### PR TITLE
fix(#5023): idempotency cache - bind key to request identity, dedup in-flight retries, bound by bytes

### DIFF
--- a/docs/5023-idempotency-cache-keying-eviction.md
+++ b/docs/5023-idempotency-cache-keying-eviction.md
@@ -1,0 +1,41 @@
+# Issue #5023 - X-Request-Id idempotency cache: wrong-response replay, skipped writes, unbounded growth
+
+## Symptom
+The HTTP idempotency cache keys solely on the raw client `X-Request-Id` header (also reused as the
+log-correlation id). Clients/proxies that propagate one id across a logical operation get:
+- wrong-response replay / silently skipped writes (different method/path/db/body, same id);
+- no in-flight dedup (concurrent retries both execute -> duplicate write);
+- caching of work done inside an open client session transaction;
+- `/begin` replay that drops the `arcadedb-session-id` header.
+Plus O(n) per-insert eviction scan and an entry-count-only bound (unbounded bytes).
+
+## Root cause
+- `AbstractServerHttpHandler` keyed the cache on the raw request id alone.
+- `IdempotencyCache.evictOldest` did a full-map scan on every overflow insert; bound was entry count only.
+
+## Fix
+- Key idempotency on a SHA-256 of `requestId \0 method \0 relativePath \0 database \0 body`.
+- Skip idempotency when the request carries an incoming `arcadedb-session-id` (session-scoped work),
+  and skip caching when the response sets a session header (e.g. `/begin`).
+- Add reserve / complete / abort with a PENDING marker so concurrent identical retries execute once.
+- Replace the O(n) eviction scan with O(1) FIFO eviction and add a total-byte bound plus a per-body
+  size cap (skip caching oversized bodies). New config keys with backward-compatible defaults.
+- Keep the existing periodic TTL sweeper untouched.
+
+## Tests
+- `IdempotencyCacheTest` additions: reserve/complete/abort contract, in-flight dedup, byte bound,
+  per-body cap, O(1) eviction correctness.
+- `IdempotencyKeyTest`: composite key distinguishes method/path/db/body; stable for identical inputs.
+
+## Impact
+`server` module only. Backward-compatible constructor and get/putSuccess retained. Two new
+`SCOPE.SERVER` config keys (`arcadedb.ha.idempotencyCacheMaxBytes` default 64 MB,
+`arcadedb.ha.idempotencyCacheMaxBodyBytes` default 1 MB). The cache is now guarded by a monitor
+(one lock per idempotent POST); non-idempotent requests never touch it.
+
+## Verification
+- `IdempotencyCacheTest` (15), `IdempotencyKeyTest` (7), `Issue5023IdempotencyKeyReplayTest` (2) pass;
+  reproduction test run 4x for stability.
+- Regression batch green: AutoCommitParameterTest, RequestIdSanitizationTest, CorrelationIdGenerationTest,
+  AbstractServerHttpHandlerErrorBodyTest/TokenTest, ExecutionResponseTest, Issue5037BeginHandlerIT,
+  HTTPAuthSessionIT, HTTPTransactionIT, Issue4141SessionManagementIT, HttpObservationIT.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1179,6 +1179,14 @@ public enum GlobalConfiguration {
       "Maximum number of entries in the HTTP idempotency cache. Oldest entry is evicted when full.",
       Integer.class, 10_000),
 
+  HA_IDEMPOTENCY_CACHE_MAX_BYTES("arcadedb.ha.idempotencyCacheMaxBytes", SCOPE.SERVER,
+      "Maximum total size in bytes of the cached response bodies in the HTTP idempotency cache. Oldest entries are evicted when exceeded.",
+      Long.class, 67_108_864L),
+
+  HA_IDEMPOTENCY_CACHE_MAX_BODY_BYTES("arcadedb.ha.idempotencyCacheMaxBodyBytes", SCOPE.SERVER,
+      "Maximum size in bytes of a single response body eligible for caching in the HTTP idempotency cache. Larger responses are not cached.",
+      Long.class, 1_048_576L),
+
   HA_PEER_ALLOWLIST_ENABLED("arcadedb.ha.peerAllowlist.enabled", SCOPE.SERVER,
       """
       Reject inbound Raft gRPC connections whose remote address does not resolve to a host in \

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -137,7 +137,9 @@ public class HttpServer implements ServerPlugin {
     this.webSocketEventBus = new WebSocketEventBus(this.server);
     final long ttlMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_TTL_MS);
     final int maxEntries = server.getConfiguration().getValueAsInteger(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_MAX_ENTRIES);
-    this.idempotencyCache = new IdempotencyCache(ttlMs, maxEntries);
+    final long maxBytes = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_MAX_BYTES);
+    final long maxBodyBytes = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_MAX_BODY_BYTES);
+    this.idempotencyCache = new IdempotencyCache(ttlMs, maxEntries, maxBytes, maxBodyBytes);
     this.idempotencyCleanupExecutor = Executors.newSingleThreadScheduledExecutor(
         r -> new Thread(r, "IdempotencyCache-cleanup"));
     this.idempotencyCleanupExecutor.scheduleAtFixedRate(idempotencyCache::cleanupExpired, 30, 30, TimeUnit.SECONDS);

--- a/server/src/main/java/com/arcadedb/server/http/IdempotencyCache.java
+++ b/server/src/main/java/com/arcadedb/server/http/IdempotencyCache.java
@@ -109,12 +109,12 @@ public class IdempotencyCache {
   public static final class Reservation {
     private final CachedEntry hit;      // non-null when a completed response is already cached
     private final CachedEntry inFlight; // non-null when another request is currently executing
-    private final boolean     reserved; // true when THIS caller now owns execution
+    private final CachedEntry owned;    // the PENDING marker installed for THIS caller; non-null iff reserved
 
-    private Reservation(final CachedEntry hit, final CachedEntry inFlight, final boolean reserved) {
+    private Reservation(final CachedEntry hit, final CachedEntry inFlight, final CachedEntry owned) {
       this.hit = hit;
       this.inFlight = inFlight;
-      this.reserved = reserved;
+      this.owned = owned;
     }
 
     /** A completed response is cached and ready to replay. */
@@ -129,7 +129,7 @@ public class IdempotencyCache {
 
     /** This caller now owns execution and must later call {@code complete} or {@code abort}. */
     public boolean isReserved() {
-      return reserved;
+      return owned != null;
     }
 
     /** The cached entry (HIT) or the pending marker to await (IN_FLIGHT); null when RESERVED. */
@@ -185,19 +185,22 @@ public class IdempotencyCache {
   public synchronized Reservation reserve(final String key) {
     if (key == null || key.isEmpty())
       // Not cacheable: let the caller execute without owning a reservation.
-      return new Reservation(null, null, false);
+      return new Reservation(null, null, null);
 
     final CachedEntry existing = cache.get(key);
     if (existing != null && !isExpired(existing)) {
       if (existing.pending)
-        return new Reservation(null, existing, false);
-      return new Reservation(existing, null, false);
+        return new Reservation(null, existing, null);
+      return new Reservation(existing, null, null);
     }
     if (existing != null)
       removeAndRelease(key);
 
-    cache.put(key, CachedEntry.newPending());
-    return new Reservation(null, null, true);
+    final CachedEntry owned = CachedEntry.newPending();
+    cache.put(key, owned);
+    // The caller receives the exact marker instance it owns, so complete/abort can verify identity and
+    // never settle a newer request's reservation if this marker was evicted/expired and replaced.
+    return new Reservation(null, null, owned);
   }
 
   /**
@@ -205,13 +208,15 @@ public class IdempotencyCache {
    * Caches it only when {@code statusCode} is 2xx and the body is within {@link #maxBodyBytes};
    * otherwise the marker is simply cleared. In-flight waiters are released either way.
    */
-  public synchronized void complete(final String key, final int statusCode, final String body, final byte[] binary,
-      final String principal) {
-    if (key == null || key.isEmpty())
+  public synchronized void complete(final String key, final Reservation reservation, final int statusCode, final String body,
+      final byte[] binary, final String principal) {
+    if (key == null || key.isEmpty() || reservation == null || reservation.owned == null)
       return;
     final CachedEntry current = cache.get(key);
-    // Only the marker we installed may be settled; if it is gone (evicted/expired) do nothing.
-    if (current == null || !current.pending)
+    // Only the exact marker this caller installed may be settled. If it was evicted/expired (and possibly
+    // replaced by a newer request's marker), current != owned and we must not touch it - otherwise we would
+    // release a different request's waiters and break the execute-once guarantee.
+    if (current != reservation.owned)
       return;
 
     final boolean cacheable = statusCode >= 200 && statusCode < 300;
@@ -222,18 +227,18 @@ public class IdempotencyCache {
       removeAndRelease(key);
 
     // Release any waiter blocked on this marker; it will re-read the completed entry (or find none).
-    current.latch.countDown();
+    reservation.owned.latch.countDown();
   }
 
   /**
    * Clears a reservation without caching anything (execution failed or produced a non-cacheable
-   * result). Releases in-flight waiters so they fall back to executing themselves.
+   * result). Releases in-flight waiters so they fall back to executing themselves. No-op unless the
+   * caller's exact pending marker is still installed.
    */
-  public synchronized void abort(final String key) {
-    if (key == null || key.isEmpty())
+  public synchronized void abort(final String key, final Reservation reservation) {
+    if (key == null || key.isEmpty() || reservation == null || reservation.owned == null)
       return;
-    final CachedEntry current = cache.get(key);
-    if (current != null && current.pending)
+    if (cache.get(key) == reservation.owned)
       removeAndRelease(key);
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/IdempotencyCache.java
+++ b/server/src/main/java/com/arcadedb/server/http/IdempotencyCache.java
@@ -262,14 +262,15 @@ public class IdempotencyCache {
     final long cutoff = System.currentTimeMillis() - ttlMs;
     final Iterator<Map.Entry<String, CachedEntry>> it = cache.entrySet().iterator();
     while (it.hasNext()) {
-      final Map.Entry<String, CachedEntry> e = it.next();
-      final CachedEntry entry = e.getValue();
-      if (entry.timestampMs < cutoff) {
-        it.remove();
-        currentBytes -= entry.sizeInBytes();
-        if (entry.latch != null)
-          entry.latch.countDown();
-      }
+      final CachedEntry entry = it.next().getValue();
+      // Insertion order equals ascending timestamp (store() always re-appends with a fresh timestamp), so
+      // the first non-expired entry means every later entry is newer too: stop scanning immediately.
+      if (entry.timestampMs >= cutoff)
+        break;
+      it.remove();
+      currentBytes -= entry.sizeInBytes();
+      if (entry.latch != null)
+        entry.latch.countDown();
     }
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/IdempotencyCache.java
+++ b/server/src/main/java/com/arcadedb/server/http/IdempotencyCache.java
@@ -19,19 +19,28 @@
 package com.arcadedb.server.http;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Server-side cache of successful HTTP responses keyed by the client-supplied
- * {@code X-Request-Id} header. When a client retries a non-idempotent request (POST) with the
- * same {@code X-Request-Id}, the server returns the cached response instead of re-executing the
- * operation. This prevents duplicate-key / double-commit violations when the original response
- * was lost in transit but the server had already committed.
+ * Server-side cache of successful HTTP responses used to make retried non-idempotent (POST) requests
+ * safe. The key is NOT the raw client {@code X-Request-Id} header: the caller must build it from the
+ * request id combined with method, path, database and body (see
+ * {@code AbstractServerHttpHandler.buildIdempotencyKey}) so two unrelated requests that happen to
+ * reuse the same correlation id are never conflated. When a client retries the SAME logical request
+ * with the same id, the server returns the cached response instead of re-executing the operation,
+ * preventing duplicate-key / double-commit violations when the original response was lost in transit.
  * <p>
- * Only successful responses (HTTP 2xx) are cached; errors are passed through so the client can
- * retry a fresh call if it chooses. Entries expire after {@link #ttlMs} and the cache is bounded
- * by {@link #maxEntries}; on overflow the oldest entry is dropped.
+ * Concurrent identical retries are de-duplicated: the first caller {@link #reserve(String) reserves}
+ * the key (installing a PENDING marker) and executes; a concurrent caller observes the marker
+ * ({@link Reservation#isInFlight()}) and can wait for the winner's result instead of executing again.
+ * <p>
+ * Only successful responses (HTTP 2xx) are cached; errors are passed through so the client can retry
+ * a fresh call if it chooses. Entries expire after {@link #ttlMs}. The cache is bounded both by the
+ * number of entries ({@link #maxEntries}) and by the total cached body bytes ({@link #maxBytes});
+ * eviction is O(1) FIFO. Individual responses larger than {@link #maxBodyBytes} are not cached.
  */
 public class IdempotencyCache {
 
@@ -43,89 +52,269 @@ public class IdempotencyCache {
     public final byte[] binary;
     public final String principal;
     public final long   timestampMs;
+    // A PENDING placeholder installed by reserve() while the winning request executes. Not a real
+    // cached response: get() never returns it and its body/binary are null.
+    final boolean        pending;
+    // Released when a pending marker is settled (completed, aborted or evicted) so an in-flight waiter
+    // stops blocking. Null for a completed entry.
+    final CountDownLatch latch;
 
     CachedEntry(final int statusCode, final String body, final byte[] binary, final String principal) {
+      this(statusCode, body, binary, principal, false, null);
+    }
+
+    private CachedEntry(final int statusCode, final String body, final byte[] binary, final String principal,
+        final boolean pending, final CountDownLatch latch) {
       this.statusCode = statusCode;
       this.body = body;
       this.binary = binary;
       this.principal = principal;
       this.timestampMs = System.currentTimeMillis();
+      this.pending = pending;
+      this.latch = latch;
     }
-  }
 
-  private final ConcurrentHashMap<String, CachedEntry> cache = new ConcurrentHashMap<>();
-  private final long                                   ttlMs;
-  private final int                                    maxEntries;
+    static CachedEntry newPending() {
+      return new CachedEntry(0, null, null, null, true, new CountDownLatch(1));
+    }
 
-  public IdempotencyCache(final long ttlMs, final int maxEntries) {
-    this.ttlMs = ttlMs;
-    this.maxEntries = maxEntries;
+    long sizeInBytes() {
+      long n = 0;
+      if (body != null)
+        n += body.length();
+      if (binary != null)
+        n += binary.length;
+      return n;
+    }
+
+    /**
+     * Blocks up to {@code timeoutMs} for a PENDING marker to be settled by the winning request.
+     * Returns true if it was settled within the timeout. Always true (no wait) for a completed entry.
+     */
+    public boolean await(final long timeoutMs) {
+      if (latch == null)
+        return true;
+      try {
+        return latch.await(timeoutMs, TimeUnit.MILLISECONDS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+    }
   }
 
   /**
-   * Returns the cached entry for {@code requestId} or {@code null} if absent or expired. Expired
-   * entries are removed as a side effect so callers don't keep paying for their TTL check.
+   * Outcome of {@link #reserve(String)}. At most one of the three predicates is true.
    */
-  public CachedEntry get(final String requestId) {
-    if (requestId == null || requestId.isEmpty())
+  public static final class Reservation {
+    private final CachedEntry hit;      // non-null when a completed response is already cached
+    private final CachedEntry inFlight; // non-null when another request is currently executing
+    private final boolean     reserved; // true when THIS caller now owns execution
+
+    private Reservation(final CachedEntry hit, final CachedEntry inFlight, final boolean reserved) {
+      this.hit = hit;
+      this.inFlight = inFlight;
+      this.reserved = reserved;
+    }
+
+    /** A completed response is cached and ready to replay. */
+    public boolean isHit() {
+      return hit != null;
+    }
+
+    /** Another request holds the reservation and is executing; the caller may {@code entry().await(..)}. */
+    public boolean isInFlight() {
+      return inFlight != null;
+    }
+
+    /** This caller now owns execution and must later call {@code complete} or {@code abort}. */
+    public boolean isReserved() {
+      return reserved;
+    }
+
+    /** The cached entry (HIT) or the pending marker to await (IN_FLIGHT); null when RESERVED. */
+    public CachedEntry entry() {
+      return hit != null ? hit : inFlight;
+    }
+  }
+
+  private final LinkedHashMap<String, CachedEntry> cache = new LinkedHashMap<>();
+  private final long                               ttlMs;
+  private final int                                maxEntries;
+  private final long                               maxBytes;
+  private final long                               maxBodyBytes;
+  private       long                               currentBytes;
+
+  public IdempotencyCache(final long ttlMs, final int maxEntries) {
+    // Backward-compatible defaults: byte bounds effectively disabled so behavior for callers that only
+    // cared about entry count is unchanged.
+    this(ttlMs, maxEntries, Long.MAX_VALUE, Long.MAX_VALUE);
+  }
+
+  public IdempotencyCache(final long ttlMs, final int maxEntries, final long maxBytes, final long maxBodyBytes) {
+    this.ttlMs = ttlMs;
+    this.maxEntries = maxEntries;
+    this.maxBytes = maxBytes;
+    this.maxBodyBytes = maxBodyBytes;
+  }
+
+  /**
+   * Returns the cached completed entry for {@code key} or {@code null} if absent, still pending, or
+   * expired. Expired entries are removed as a side effect so callers don't keep paying for their TTL
+   * check.
+   */
+  public synchronized CachedEntry get(final String key) {
+    if (key == null || key.isEmpty())
       return null;
-    final CachedEntry e = cache.get(requestId);
+    final CachedEntry e = cache.get(key);
     if (e == null)
       return null;
-    if (System.currentTimeMillis() - e.timestampMs > ttlMs) {
-      cache.remove(requestId, e);
+    if (isExpired(e)) {
+      removeAndRelease(key);
       return null;
     }
+    if (e.pending)
+      return null;
     return e;
   }
 
   /**
-   * Caches a successful response. {@code statusCode} must be 2xx; non-2xx responses are ignored.
-   * The {@code principal} is stored so that a later replay can verify the caller matches and a
-   * different user cannot replay a cached response merely by guessing a request id.
+   * Atomically looks up {@code key} and, when no live entry exists, installs a PENDING marker owned by
+   * the caller. See {@link Reservation}.
    */
-  public void putSuccess(final String requestId, final int statusCode, final String body, final byte[] binary,
-      final String principal) {
-    if (requestId == null || requestId.isEmpty())
-      return;
-    if (statusCode < 200 || statusCode >= 300)
-      return;
-    if (cache.size() >= maxEntries)
-      evictOldest();
-    cache.put(requestId, new CachedEntry(statusCode, body, binary, principal));
+  public synchronized Reservation reserve(final String key) {
+    if (key == null || key.isEmpty())
+      // Not cacheable: let the caller execute without owning a reservation.
+      return new Reservation(null, null, false);
+
+    final CachedEntry existing = cache.get(key);
+    if (existing != null && !isExpired(existing)) {
+      if (existing.pending)
+        return new Reservation(null, existing, false);
+      return new Reservation(existing, null, false);
+    }
+    if (existing != null)
+      removeAndRelease(key);
+
+    cache.put(key, CachedEntry.newPending());
+    return new Reservation(null, null, true);
   }
 
   /**
-   * Periodic maintenance: drops entries older than the TTL. Called by the server's
-   * scheduler so the cache doesn't grow unboundedly on workloads with low retry rate.
+   * Settles a reservation previously obtained from {@link #reserve(String)} with the final response.
+   * Caches it only when {@code statusCode} is 2xx and the body is within {@link #maxBodyBytes};
+   * otherwise the marker is simply cleared. In-flight waiters are released either way.
    */
-  public void cleanupExpired() {
+  public synchronized void complete(final String key, final int statusCode, final String body, final byte[] binary,
+      final String principal) {
+    if (key == null || key.isEmpty())
+      return;
+    final CachedEntry current = cache.get(key);
+    // Only the marker we installed may be settled; if it is gone (evicted/expired) do nothing.
+    if (current == null || !current.pending)
+      return;
+
+    final boolean cacheable = statusCode >= 200 && statusCode < 300;
+    final CachedEntry completed = cacheable ? new CachedEntry(statusCode, body, binary, principal) : null;
+    if (completed != null && completed.sizeInBytes() <= maxBodyBytes)
+      store(key, completed);
+    else
+      removeAndRelease(key);
+
+    // Release any waiter blocked on this marker; it will re-read the completed entry (or find none).
+    current.latch.countDown();
+  }
+
+  /**
+   * Clears a reservation without caching anything (execution failed or produced a non-cacheable
+   * result). Releases in-flight waiters so they fall back to executing themselves.
+   */
+  public synchronized void abort(final String key) {
+    if (key == null || key.isEmpty())
+      return;
+    final CachedEntry current = cache.get(key);
+    if (current != null && current.pending)
+      removeAndRelease(key);
+  }
+
+  /**
+   * Caches a successful response directly (no reservation). {@code statusCode} must be 2xx; non-2xx
+   * responses are ignored. The {@code principal} is stored so that a later replay can verify the caller
+   * matches and a different user cannot replay a cached response merely by guessing a key.
+   */
+  public synchronized void putSuccess(final String key, final int statusCode, final String body, final byte[] binary,
+      final String principal) {
+    if (key == null || key.isEmpty())
+      return;
+    if (statusCode < 200 || statusCode >= 300)
+      return;
+    final CachedEntry entry = new CachedEntry(statusCode, body, binary, principal);
+    if (entry.sizeInBytes() > maxBodyBytes)
+      return;
+    store(key, entry);
+  }
+
+  /**
+   * Periodic maintenance: drops entries older than the TTL. Called by the server's scheduler so the
+   * cache doesn't grow unboundedly on workloads with low retry rate.
+   */
+  public synchronized void cleanupExpired() {
     final long cutoff = System.currentTimeMillis() - ttlMs;
     final Iterator<Map.Entry<String, CachedEntry>> it = cache.entrySet().iterator();
     while (it.hasNext()) {
       final Map.Entry<String, CachedEntry> e = it.next();
-      if (e.getValue().timestampMs < cutoff)
+      final CachedEntry entry = e.getValue();
+      if (entry.timestampMs < cutoff) {
         it.remove();
+        currentBytes -= entry.sizeInBytes();
+        if (entry.latch != null)
+          entry.latch.countDown();
+      }
     }
   }
 
-  public int size() {
+  public synchronized int size() {
     return cache.size();
   }
 
-  private void evictOldest() {
-    // Not a perfect LRU; scans for the single oldest entry and drops it. The common case at
-    // workloads with reasonable retry rates keeps the cache well under maxEntries, so this
-    // slow path rarely runs and doesn't need to be micro-optimized.
-    String oldestKey = null;
-    long oldestTs = Long.MAX_VALUE;
-    for (final Map.Entry<String, CachedEntry> e : cache.entrySet()) {
-      if (e.getValue().timestampMs < oldestTs) {
-        oldestTs = e.getValue().timestampMs;
-        oldestKey = e.getKey();
-      }
+  public synchronized long bytes() {
+    return currentBytes;
+  }
+
+  private boolean isExpired(final CachedEntry e) {
+    return System.currentTimeMillis() - e.timestampMs > ttlMs;
+  }
+
+  // Inserts (or replaces) an entry and enforces both bounds with O(1) FIFO eviction. Callers hold the
+  // monitor.
+  private void store(final String key, final CachedEntry entry) {
+    removeAndRelease(key);
+    cache.put(key, entry);
+    currentBytes += entry.sizeInBytes();
+    evictToBounds();
+  }
+
+  // Drops eldest entries (insertion order) until both bounds are satisfied. Each removal is O(1) via the
+  // LinkedHashMap iterator, so a single insert never scans the whole map.
+  private void evictToBounds() {
+    while (cache.size() > maxEntries || currentBytes > maxBytes) {
+      final Iterator<Map.Entry<String, CachedEntry>> it = cache.entrySet().iterator();
+      if (!it.hasNext())
+        break;
+      final CachedEntry evicted = it.next().getValue();
+      it.remove();
+      currentBytes -= evicted.sizeInBytes();
+      if (evicted.latch != null)
+        evicted.latch.countDown();
     }
-    if (oldestKey != null)
-      cache.remove(oldestKey);
+  }
+
+  private void removeAndRelease(final String key) {
+    final CachedEntry removed = cache.remove(key);
+    if (removed != null) {
+      currentBytes -= removed.sizeInBytes();
+      if (removed.latch != null)
+        removed.latch.countDown();
+    }
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/IdempotencyCache.java
+++ b/server/src/main/java/com/arcadedb/server/http/IdempotencyCache.java
@@ -295,13 +295,13 @@ public class IdempotencyCache {
     evictToBounds();
   }
 
-  // Drops eldest entries (insertion order) until both bounds are satisfied. Each removal is O(1) via the
-  // LinkedHashMap iterator, so a single insert never scans the whole map.
+  // Drops eldest entries (insertion order) until both bounds are satisfied. Each removal is O(1) via a
+  // single LinkedHashMap iterator, so a single insert never scans the whole map.
   private void evictToBounds() {
-    while (cache.size() > maxEntries || currentBytes > maxBytes) {
-      final Iterator<Map.Entry<String, CachedEntry>> it = cache.entrySet().iterator();
-      if (!it.hasNext())
-        break;
+    if (cache.size() <= maxEntries && currentBytes <= maxBytes)
+      return;
+    final Iterator<Map.Entry<String, CachedEntry>> it = cache.entrySet().iterator();
+    while (it.hasNext() && (cache.size() > maxEntries || currentBytes > maxBytes)) {
       final CachedEntry evicted = it.next().getValue();
       it.remove();
       currentBytes -= evicted.sizeInBytes();

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -115,9 +115,11 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // An idempotent POST may block briefly on IdempotencyCache await() while a concurrent identical retry
     // is in flight; that must never happen on an Undertow IO thread (blocking IO threads starves the
     // server). Dispatch to a worker thread first for handlers that would otherwise run on the IO thread.
+    // A blank X-Request-Id is not treated as idempotent (matches the gating below).
+    final String dispatchRequestId = exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID);
     if (exchange.isInIoThread()
         && "POST".equalsIgnoreCase(exchange.getRequestMethod().toString())
-        && exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID) != null
+        && dispatchRequestId != null && !dispatchRequestId.isBlank()
         && exchange.getRequestHeaders().getFirst(SESSION_ID_HEADER) == null) {
       exchange.dispatch(this);
       return;
@@ -282,15 +284,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
           }
       }
 
-      // Idempotency applies only to POST requests that carry an X-Request-Id and are NOT part of an open,
-      // client-managed session transaction (a session-scoped request's outcome is not settled until the
-      // client commits, so it must never be cached/replayed).
+      // Idempotency applies only to POST requests that carry a non-blank X-Request-Id and are NOT part of
+      // an open, client-managed session transaction (a session-scoped request's outcome is not settled
+      // until the client commits, so it must never be cached/replayed). A blank id is ignored: distinct
+      // clients sending an empty header would otherwise collide on the same composite key.
+      final String rawRequestId = exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID);
       final boolean idempotentPost = "POST".equalsIgnoreCase(exchange.getRequestMethod().toString())
-          && exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID) != null
+          && rawRequestId != null && !rawRequestId.isBlank()
           && exchange.getRequestHeaders().getFirst(SESSION_ID_HEADER) == null;
 
       if (idempotentPost) {
-        final String rawRequestId = exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID);
         // Bind the key to method/path/database/body so a reused correlation id cannot replay a different
         // request's response (the core defect: same X-Request-Id across distinct writes).
         idempotencyKey = buildIdempotencyKey(rawRequestId, exchange.getRequestMethod().toString(),

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -44,6 +44,7 @@ import io.undertow.util.HttpString;
 import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -107,6 +108,17 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   @Override
   public void handleRequest(final HttpServerExchange exchange) {
     if (mustExecuteOnWorkerThread() && exchange.isInIoThread()) {
+      exchange.dispatch(this);
+      return;
+    }
+
+    // An idempotent POST may block briefly on IdempotencyCache await() while a concurrent identical retry
+    // is in flight; that must never happen on an Undertow IO thread (blocking IO threads starves the
+    // server). Dispatch to a worker thread first for handlers that would otherwise run on the IO thread.
+    if (exchange.isInIoThread()
+        && "POST".equalsIgnoreCase(exchange.getRequestMethod().toString())
+        && exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID) != null
+        && exchange.getRequestHeaders().getFirst(SESSION_ID_HEADER) == null) {
       exchange.dispatch(this);
       return;
     }
@@ -547,7 +559,12 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     if (cached.principal != null && !cached.principal.equals(currentPrincipal))
       return false;
     exchange.setStatusCode(cached.statusCode);
-    exchange.getResponseSender().send(cached.body != null ? cached.body : "");
+    // Replay a binary body faithfully; falling back to the string body would send an empty response for a
+    // cached binary export/backup and silently lose data.
+    if (cached.binary != null)
+      exchange.getResponseSender().send(ByteBuffer.wrap(cached.binary));
+    else
+      exchange.getResponseSender().send(cached.body != null ? cached.body : "");
     return true;
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -70,6 +70,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   // Bounded wait for a concurrent identical retry to observe the in-flight winner's result before it
   // gives up and executes on its own. Caps worker-thread blocking so a slow request cannot pile up retries.
   private static final long       IN_FLIGHT_WAIT_MS = 5_000L;
+  // Per-thread SHA-256 for the idempotency key: reused (reset) each call so the request hot path avoids the
+  // JCA provider lookup of MessageDigest.getInstance() per request. SHA-256 is JCA-mandated, so init cannot
+  // fail in practice; if it ever did the digest would be unusable, so we fail fast.
+  private static final ThreadLocal<MessageDigest> SHA_256_DIGEST = ThreadLocal.withInitial(() -> {
+    try {
+      return MessageDigest.getInstance("SHA-256");
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is a JCA-mandated algorithm but was not found", e);
+    }
+  });
   // Upper bound on a client-supplied X-Request-Id we echo and log, to keep a hostile value bounded.
   private static final int        MAX_REQUEST_ID_LENGTH = 128;
   // Process-wide monotonic counter used, together with a per-thread random, to mint cheap correlation ids
@@ -579,27 +589,22 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    */
   static String buildIdempotencyKey(final String requestId, final String method, final String path,
       final String database, final String body) {
-    try {
-      final MessageDigest md = MessageDigest.getInstance("SHA-256");
-      final Charset cs = DatabaseFactory.getDefaultCharset();
-      updateDigest(md, requestId, cs);
-      updateDigest(md, method, cs);
-      updateDigest(md, path, cs);
-      updateDigest(md, database, cs);
-      if (body != null)
-        md.update(body.getBytes(cs));
-      final byte[] digest = md.digest();
-      final StringBuilder sb = new StringBuilder(digest.length * 2);
-      for (final byte b : digest) {
-        sb.append(Character.forDigit((b >> 4) & 0xF, 16));
-        sb.append(Character.forDigit(b & 0xF, 16));
-      }
-      return sb.toString();
-    } catch (final NoSuchAlgorithmException e) {
-      // SHA-256 is a JCA-mandated algorithm, so this is unreachable. Fall back to a NUL-namespaced raw key
-      // that is still bound to every component, preserving correctness at the cost of a longer key.
-      return requestId + '\u0000' + method + '\u0000' + path + '\u0000' + database + '\u0000' + body;
+    final MessageDigest md = SHA_256_DIGEST.get();
+    md.reset();
+    final Charset cs = DatabaseFactory.getDefaultCharset();
+    updateDigest(md, requestId, cs);
+    updateDigest(md, method, cs);
+    updateDigest(md, path, cs);
+    updateDigest(md, database, cs);
+    if (body != null)
+      md.update(body.getBytes(cs));
+    final byte[] digest = md.digest();
+    final StringBuilder sb = new StringBuilder(digest.length * 2);
+    for (final byte b : digest) {
+      sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+      sb.append(Character.forDigit(b & 0xF, 16));
     }
+    return sb.toString();
   }
 
   private static void updateDigest(final MessageDigest md, final String value, final Charset cs) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -27,6 +27,7 @@ import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.HttpSessionManager;
 import com.arcadedb.server.http.IdempotencyCache;
 import com.arcadedb.server.security.ApiTokenConfiguration;
 import com.arcadedb.server.security.ServerSecurityException;
@@ -43,7 +44,9 @@ import io.undertow.util.HttpString;
 import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
 
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Deque;
@@ -60,6 +63,12 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   private static final String AUTHORIZATION_BEARER = "Bearer";
   // Cached once: tryFromString scans/validates the header name, wasteful to repeat on every request.
   private static final HttpString REQUEST_ID_HEADER = HttpString.tryFromString(IdempotencyCache.HEADER_REQUEST_ID);
+  // Response header set by session-establishing routes (e.g. /begin). Its presence means the response
+  // is session-scoped and must not be replayed from the idempotency cache (the session id would be lost).
+  private static final HttpString SESSION_ID_HEADER = HttpString.tryFromString(HttpSessionManager.ARCADEDB_SESSION_ID);
+  // Bounded wait for a concurrent identical retry to observe the in-flight winner's result before it
+  // gives up and executes on its own. Caps worker-thread blocking so a slow request cannot pile up retries.
+  private static final long       IN_FLIGHT_WAIT_MS = 5_000L;
   // Upper bound on a client-supplied X-Request-Id we echo and log, to keep a hostile value bounded.
   private static final int        MAX_REQUEST_ID_LENGTH = 128;
   // Process-wide monotonic counter used, together with a per-thread random, to mint cheap correlation ids
@@ -140,6 +149,12 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // catch/finally still runs: the observation is stopped (not leaked) and the request is answered
     // with an error rather than propagating an uncaught exception.
     Observation.Scope observationScope = null;
+
+    // Idempotency reservation bookkeeping, visible to the finally block: when this request owns a PENDING
+    // marker and execution throws, the finally clears it so a concurrent identical retry is released
+    // instead of blocking until the marker's TTL expires.
+    String  idempotencyKey             = null;
+    boolean idempotencyReservationOwned = false;
 
     try {
       observationScope = observation.openScope();
@@ -244,8 +259,9 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       }
 
       JSONObject payload = null;
+      String payloadAsString = null;
       if (mustExecuteOnWorkerThread()) {
-        final String payloadAsString = parseRequestPayload(exchange);
+        payloadAsString = parseRequestPayload(exchange);
         if (requiresJsonPayload() && payloadAsString != null && !payloadAsString.isBlank())
           try {
             payload = new JSONObject(payloadAsString.trim());
@@ -254,27 +270,52 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
           }
       }
 
-      final String requestId = exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID);
-      if (requestId != null && "POST".equalsIgnoreCase(exchange.getRequestMethod().toString())) {
-        final IdempotencyCache.CachedEntry cached = httpServer.getIdempotencyCache().get(requestId);
-        if (cached != null) {
-          final String currentPrincipal = user != null ? user.getName() : null;
-          if (cached.principal == null || cached.principal.equals(currentPrincipal)) {
-            exchange.setStatusCode(cached.statusCode);
-            exchange.getResponseSender().send(cached.body != null ? cached.body : "");
+      // Idempotency applies only to POST requests that carry an X-Request-Id and are NOT part of an open,
+      // client-managed session transaction (a session-scoped request's outcome is not settled until the
+      // client commits, so it must never be cached/replayed).
+      final boolean idempotentPost = "POST".equalsIgnoreCase(exchange.getRequestMethod().toString())
+          && exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID) != null
+          && exchange.getRequestHeaders().getFirst(SESSION_ID_HEADER) == null;
+
+      if (idempotentPost) {
+        final String rawRequestId = exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID);
+        // Bind the key to method/path/database/body so a reused correlation id cannot replay a different
+        // request's response (the core defect: same X-Request-Id across distinct writes).
+        idempotencyKey = buildIdempotencyKey(rawRequestId, exchange.getRequestMethod().toString(),
+            exchange.getRelativePath(), databaseTag(exchange), payloadAsString);
+        final String currentPrincipal = user != null ? user.getName() : null;
+
+        final IdempotencyCache.Reservation reservation = httpServer.getIdempotencyCache().reserve(idempotencyKey);
+        if (reservation.isHit()) {
+          if (replayCachedResponse(exchange, reservation.entry(), currentPrincipal))
             return;
-          }
-        }
+          // Principal mismatch: fall through and execute as this caller, without owning the reservation.
+        } else if (reservation.isInFlight()) {
+          // A concurrent identical retry is already executing. Wait briefly for its result rather than
+          // running the write a second time; if it does not settle in time, fall through and execute uncached.
+          if (reservation.entry().await(IN_FLIGHT_WAIT_MS)
+              && replayCachedResponse(exchange, httpServer.getIdempotencyCache().get(idempotencyKey), currentPrincipal))
+            return;
+        } else if (reservation.isReserved())
+          idempotencyReservationOwned = true;
       }
 
       final ExecutionResponse response = execute(exchange, user, payload);
       if (response != null) {
         response.send(exchange);
-        if (requestId != null && "POST".equalsIgnoreCase(exchange.getRequestMethod().toString())) {
-          final String currentPrincipal = user != null ? user.getName() : null;
-          httpServer.getIdempotencyCache().putSuccess(requestId, response.getCode(), response.getResponse(), response.getBinary(),
-              currentPrincipal);
+        if (idempotencyReservationOwned) {
+          // Do not cache a response that established a client session (e.g. /begin): replaying it would
+          // return the body without the arcadedb-session-id header, orphaning the real session.
+          if (exchange.getResponseHeaders().contains(SESSION_ID_HEADER))
+            httpServer.getIdempotencyCache().abort(idempotencyKey);
+          else
+            httpServer.getIdempotencyCache().complete(idempotencyKey, response.getCode(), response.getResponse(),
+                response.getBinary(), user != null ? user.getName() : null);
+          idempotencyReservationOwned = false;
         }
+      } else if (idempotencyReservationOwned) {
+        httpServer.getIdempotencyCache().abort(idempotencyKey);
+        idempotencyReservationOwned = false;
       }
 
     } catch (final ServerSecurityException e) {
@@ -431,6 +472,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
               .log(this, getErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(), e.getMessage());
       sendErrorResponse(exchange, 500, "Internal error", e, null);
     } finally {
+      // If execution threw after this request reserved the idempotency key, clear the PENDING marker so a
+      // concurrent identical retry is released immediately instead of blocking until the marker's TTL.
+      if (idempotencyReservationOwned) {
+        try {
+          httpServer.getIdempotencyCache().abort(idempotencyKey);
+        } catch (final Throwable t) {
+          LogManager.instance().log(this, Level.WARNING, "Error aborting idempotency reservation", t);
+        }
+      }
+
       // Finalize the optional tracing span. Each step is isolated so a failure in the optional
       // tracing layer can never skip the core cleanup or the RED timer below; closing the scope is
       // attempted independently to avoid thread-local context leaking across pooled worker threads.
@@ -481,6 +532,61 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     if (match != null)
       return match.getMatchedTemplate();
     return exchange.getRelativePath();
+  }
+
+  /**
+   * Replays a cached idempotent response onto {@code exchange}, honoring the stored principal so a
+   * different user cannot replay another caller's response merely by guessing the request id. Returns
+   * false (nothing written) when there is no usable entry or the principal does not match, so the caller
+   * can fall back to executing the request.
+   */
+  private boolean replayCachedResponse(final HttpServerExchange exchange, final IdempotencyCache.CachedEntry cached,
+      final String currentPrincipal) {
+    if (cached == null)
+      return false;
+    if (cached.principal != null && !cached.principal.equals(currentPrincipal))
+      return false;
+    exchange.setStatusCode(cached.statusCode);
+    exchange.getResponseSender().send(cached.body != null ? cached.body : "");
+    return true;
+  }
+
+  /**
+   * Builds the idempotency cache key for a POST request. The key is a SHA-256 over the client
+   * {@code X-Request-Id} joined with the HTTP method, path, database and request body, so two unrelated
+   * requests that reuse the same correlation id (a common proxy / client practice) never collide and
+   * replay each other's response. Package-private for direct unit testing.
+   */
+  static String buildIdempotencyKey(final String requestId, final String method, final String path,
+      final String database, final String body) {
+    try {
+      final MessageDigest md = MessageDigest.getInstance("SHA-256");
+      final Charset cs = DatabaseFactory.getDefaultCharset();
+      updateDigest(md, requestId, cs);
+      updateDigest(md, method, cs);
+      updateDigest(md, path, cs);
+      updateDigest(md, database, cs);
+      if (body != null)
+        md.update(body.getBytes(cs));
+      final byte[] digest = md.digest();
+      final StringBuilder sb = new StringBuilder(digest.length * 2);
+      for (final byte b : digest) {
+        sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+        sb.append(Character.forDigit(b & 0xF, 16));
+      }
+      return sb.toString();
+    } catch (final NoSuchAlgorithmException e) {
+      // SHA-256 is a JCA-mandated algorithm, so this is unreachable. Fall back to a NUL-namespaced raw key
+      // that is still bound to every component, preserving correctness at the cost of a longer key.
+      return requestId + " " + method + " " + path + " " + database + " " + body;
+    }
+  }
+
+  private static void updateDigest(final MessageDigest md, final String value, final Charset cs) {
+    if (value != null)
+      md.update(value.getBytes(cs));
+    // NUL separator delimits fields so ("a","b") and ("ab","") cannot produce the same digest.
+    md.update((byte) 0);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -165,10 +165,10 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     Observation.Scope observationScope = null;
 
     // Idempotency reservation bookkeeping, visible to the finally block: when this request owns a PENDING
-    // marker and execution throws, the finally clears it so a concurrent identical retry is released
-    // instead of blocking until the marker's TTL expires.
-    String  idempotencyKey             = null;
-    boolean idempotencyReservationOwned = false;
+    // marker and execution throws, the finally clears exactly that marker so a concurrent identical retry
+    // is released instead of blocking until the marker's TTL expires.
+    String                       idempotencyKey         = null;
+    IdempotencyCache.Reservation idempotencyReservation = null;
 
     try {
       observationScope = observation.openScope();
@@ -312,25 +312,25 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
               && replayCachedResponse(exchange, httpServer.getIdempotencyCache().get(idempotencyKey), currentPrincipal))
             return;
         } else if (reservation.isReserved())
-          idempotencyReservationOwned = true;
+          idempotencyReservation = reservation;
       }
 
       final ExecutionResponse response = execute(exchange, user, payload);
       if (response != null) {
         response.send(exchange);
-        if (idempotencyReservationOwned) {
+        if (idempotencyReservation != null) {
           // Do not cache a response that established a client session (e.g. /begin): replaying it would
           // return the body without the arcadedb-session-id header, orphaning the real session.
           if (exchange.getResponseHeaders().contains(SESSION_ID_HEADER))
-            httpServer.getIdempotencyCache().abort(idempotencyKey);
+            httpServer.getIdempotencyCache().abort(idempotencyKey, idempotencyReservation);
           else
-            httpServer.getIdempotencyCache().complete(idempotencyKey, response.getCode(), response.getResponse(),
-                response.getBinary(), user != null ? user.getName() : null);
-          idempotencyReservationOwned = false;
+            httpServer.getIdempotencyCache().complete(idempotencyKey, idempotencyReservation, response.getCode(),
+                response.getResponse(), response.getBinary(), user != null ? user.getName() : null);
+          idempotencyReservation = null;
         }
-      } else if (idempotencyReservationOwned) {
-        httpServer.getIdempotencyCache().abort(idempotencyKey);
-        idempotencyReservationOwned = false;
+      } else if (idempotencyReservation != null) {
+        httpServer.getIdempotencyCache().abort(idempotencyKey, idempotencyReservation);
+        idempotencyReservation = null;
       }
 
     } catch (final ServerSecurityException e) {
@@ -489,9 +489,9 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     } finally {
       // If execution threw after this request reserved the idempotency key, clear the PENDING marker so a
       // concurrent identical retry is released immediately instead of blocking until the marker's TTL.
-      if (idempotencyReservationOwned) {
+      if (idempotencyReservation != null) {
         try {
-          httpServer.getIdempotencyCache().abort(idempotencyKey);
+          httpServer.getIdempotencyCache().abort(idempotencyKey, idempotencyReservation);
         } catch (final Throwable t) {
           LogManager.instance().log(this, Level.WARNING, "Error aborting idempotency reservation", t);
         }
@@ -598,7 +598,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     } catch (final NoSuchAlgorithmException e) {
       // SHA-256 is a JCA-mandated algorithm, so this is unreachable. Fall back to a NUL-namespaced raw key
       // that is still bound to every component, preserving correctness at the cost of a longer key.
-      return requestId + " " + method + " " + path + " " + database + " " + body;
+      return requestId + '\u0000' + method + '\u0000' + path + '\u0000' + database + '\u0000' + body;
     }
   }
 

--- a/server/src/test/java/com/arcadedb/server/http/IdempotencyCacheTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/IdempotencyCacheTest.java
@@ -133,7 +133,7 @@ class IdempotencyCacheTest {
     assertThat(cache.get("k")).isNull();
 
     // Winner settles the reservation; the retry can now replay the completed response.
-    cache.complete("k", 200, "{\"ok\":true}", null, "alice");
+    cache.complete("k", first, 200, "{\"ok\":true}", null, "alice");
     final IdempotencyCache.Reservation third = cache.reserve("k");
     assertThat(third.isHit()).isTrue();
     assertThat(third.entry().body).isEqualTo("{\"ok\":true}");
@@ -155,7 +155,7 @@ class IdempotencyCacheTest {
       } catch (final InterruptedException ignore) {
         Thread.currentThread().interrupt();
       }
-      cache.complete("k", 200, "done", null, "alice");
+      cache.complete("k", owner, 200, "done", null, "alice");
     });
     completer.start();
 
@@ -174,7 +174,7 @@ class IdempotencyCacheTest {
     final IdempotencyCache.Reservation waiter = cache.reserve("k");
     assertThat(waiter.isInFlight()).isTrue();
 
-    cache.abort("k");
+    cache.abort("k", owner);
     // Waiter is released immediately even though nothing was cached.
     assertThat(waiter.entry().await(5_000)).isTrue();
     assertThat(cache.get("k")).isNull();
@@ -186,11 +186,36 @@ class IdempotencyCacheTest {
   @Test
   void completeIgnoresNon2xx() {
     final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
-    assertThat(cache.reserve("k").isReserved()).isTrue();
-    cache.complete("k", 500, "boom", null, "alice");
+    final IdempotencyCache.Reservation r = cache.reserve("k");
+    assertThat(r.isReserved()).isTrue();
+    cache.complete("k", r, 500, "boom", null, "alice");
     assertThat(cache.get("k")).isNull();
     // The marker is gone, so a retry may execute again.
     assertThat(cache.reserve("k").isReserved()).isTrue();
+  }
+
+  @Test
+  void staleReservationDoesNotClobberReplacement() {
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
+
+    // First request reserves, then its marker is cleared (simulating eviction/expiry).
+    final IdempotencyCache.Reservation first = cache.reserve("k");
+    assertThat(first.isReserved()).isTrue();
+    cache.abort("k", first);
+
+    // A second request reserves the same key and installs a fresh marker.
+    final IdempotencyCache.Reservation second = cache.reserve("k");
+    assertThat(second.isReserved()).isTrue();
+
+    // The slow first request finally settles: it must NOT touch the second request's marker.
+    cache.complete("k", first, 200, "stale", null, "alice");
+    assertThat(cache.get("k")).isNull();                        // second still pending, not a HIT
+    assertThat(cache.reserve("k").isInFlight()).isTrue();       // waiters still see it in flight
+
+    // The second request settles correctly and its response wins.
+    cache.complete("k", second, 200, "fresh", null, "alice");
+    assertThat(cache.get("k")).isNotNull();
+    assertThat(cache.get("k").body).isEqualTo("fresh");
   }
 
   @Test
@@ -221,9 +246,10 @@ class IdempotencyCacheTest {
   @Test
   void completeRetainsBinaryBodyForReplay() {
     final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
-    assertThat(cache.reserve("bin").isReserved()).isTrue();
+    final IdempotencyCache.Reservation r = cache.reserve("bin");
+    assertThat(r.isReserved()).isTrue();
     final byte[] data = new byte[] { 9, 8, 7, 6 };
-    cache.complete("bin", 200, null, data, "bob");
+    cache.complete("bin", r, 200, null, data, "bob");
 
     final IdempotencyCache.CachedEntry entry = cache.get("bin");
     assertThat(entry).isNotNull();

--- a/server/src/test/java/com/arcadedb/server/http/IdempotencyCacheTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/IdempotencyCacheTest.java
@@ -219,6 +219,31 @@ class IdempotencyCacheTest {
   }
 
   @Test
+  void completeRetainsBinaryBodyForReplay() {
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
+    assertThat(cache.reserve("bin").isReserved()).isTrue();
+    final byte[] data = new byte[] { 9, 8, 7, 6 };
+    cache.complete("bin", 200, null, data, "bob");
+
+    final IdempotencyCache.CachedEntry entry = cache.get("bin");
+    assertThat(entry).isNotNull();
+    assertThat(entry.binary).isEqualTo(data);
+    assertThat(entry.body).isNull();
+  }
+
+  @Test
+  void cleanupExpiredStopsAtFirstLiveEntry() throws Exception {
+    final IdempotencyCache cache = new IdempotencyCache(80, 100);
+    cache.putSuccess("old", 200, "old", null, "u");
+    Thread.sleep(100); // "old" now past its 80ms TTL
+    cache.putSuccess("fresh", 200, "fresh", null, "u");
+
+    cache.cleanupExpired();
+    assertThat(cache.get("old")).isNull();
+    assertThat(cache.get("fresh")).isNotNull();
+  }
+
+  @Test
   void reserveAfterCompleteReturnsHitWithinTtl() {
     final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
     cache.putSuccess("k", 200, "body", null, "alice");

--- a/server/src/test/java/com/arcadedb/server/http/IdempotencyCacheTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/IdempotencyCacheTest.java
@@ -111,4 +111,119 @@ class IdempotencyCacheTest {
   void headerConstant() {
     assertThat(IdempotencyCache.HEADER_REQUEST_ID).isEqualTo("X-Request-Id");
   }
+
+  @Test
+  void reserveDedupsConcurrentRetries() {
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
+
+    // First caller owns execution.
+    final IdempotencyCache.Reservation first = cache.reserve("k");
+    assertThat(first.isReserved()).isTrue();
+    assertThat(first.isHit()).isFalse();
+    assertThat(first.isInFlight()).isFalse();
+
+    // A concurrent identical retry does NOT get a reservation: it sees the in-flight marker instead, so it
+    // will not execute the write a second time.
+    final IdempotencyCache.Reservation second = cache.reserve("k");
+    assertThat(second.isReserved()).isFalse();
+    assertThat(second.isInFlight()).isTrue();
+    assertThat(second.entry()).isNotNull();
+
+    // While pending, get() must not surface the incomplete marker as a replayable response.
+    assertThat(cache.get("k")).isNull();
+
+    // Winner settles the reservation; the retry can now replay the completed response.
+    cache.complete("k", 200, "{\"ok\":true}", null, "alice");
+    final IdempotencyCache.Reservation third = cache.reserve("k");
+    assertThat(third.isHit()).isTrue();
+    assertThat(third.entry().body).isEqualTo("{\"ok\":true}");
+    assertThat(cache.get("k")).isNotNull();
+  }
+
+  @Test
+  void awaitReleasedByComplete() throws Exception {
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
+    final IdempotencyCache.Reservation owner = cache.reserve("k");
+    assertThat(owner.isReserved()).isTrue();
+
+    final IdempotencyCache.Reservation waiter = cache.reserve("k");
+    assertThat(waiter.isInFlight()).isTrue();
+
+    final Thread completer = new Thread(() -> {
+      try {
+        Thread.sleep(50);
+      } catch (final InterruptedException ignore) {
+        Thread.currentThread().interrupt();
+      }
+      cache.complete("k", 200, "done", null, "alice");
+    });
+    completer.start();
+
+    assertThat(waiter.entry().await(5_000)).isTrue();
+    completer.join();
+    assertThat(cache.get("k")).isNotNull();
+    assertThat(cache.get("k").body).isEqualTo("done");
+  }
+
+  @Test
+  void abortClearsReservationAndReleasesWaiters() {
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
+    final IdempotencyCache.Reservation owner = cache.reserve("k");
+    assertThat(owner.isReserved()).isTrue();
+
+    final IdempotencyCache.Reservation waiter = cache.reserve("k");
+    assertThat(waiter.isInFlight()).isTrue();
+
+    cache.abort("k");
+    // Waiter is released immediately even though nothing was cached.
+    assertThat(waiter.entry().await(5_000)).isTrue();
+    assertThat(cache.get("k")).isNull();
+
+    // After an abort the key is free again: a fresh retry can reserve it.
+    assertThat(cache.reserve("k").isReserved()).isTrue();
+  }
+
+  @Test
+  void completeIgnoresNon2xx() {
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
+    assertThat(cache.reserve("k").isReserved()).isTrue();
+    cache.complete("k", 500, "boom", null, "alice");
+    assertThat(cache.get("k")).isNull();
+    // The marker is gone, so a retry may execute again.
+    assertThat(cache.reserve("k").isReserved()).isTrue();
+  }
+
+  @Test
+  void byteBoundEvictsOldestEntries() {
+    // maxEntries is large; the 10-byte total budget is the binding constraint.
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 1_000, 10, 1_000);
+    cache.putSuccess("a", 200, "12345", null, "u"); // 5 bytes
+    cache.putSuccess("b", 200, "12345", null, "u"); // +5 = 10 (at limit)
+    assertThat(cache.size()).isEqualTo(2);
+    assertThat(cache.bytes()).isEqualTo(10);
+
+    cache.putSuccess("c", 200, "12345", null, "u"); // would be 15 -> evict oldest until <= 10
+    assertThat(cache.bytes()).isLessThanOrEqualTo(10);
+    assertThat(cache.get("a")).isNull();       // oldest evicted
+    assertThat(cache.get("c")).isNotNull();    // newest retained
+  }
+
+  @Test
+  void perBodyCapSkipsOversizedResponse() {
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 1_000, 1_000_000, 4);
+    cache.putSuccess("big", 200, "12345", null, "u"); // 5 bytes > 4 -> not cached
+    assertThat(cache.get("big")).isNull();
+
+    cache.putSuccess("ok", 200, "1234", null, "u");   // 4 bytes -> cached
+    assertThat(cache.get("ok")).isNotNull();
+  }
+
+  @Test
+  void reserveAfterCompleteReturnsHitWithinTtl() {
+    final IdempotencyCache cache = new IdempotencyCache(60_000, 100);
+    cache.putSuccess("k", 200, "body", null, "alice");
+    final IdempotencyCache.Reservation r = cache.reserve("k");
+    assertThat(r.isHit()).isTrue();
+    assertThat(r.isReserved()).isFalse();
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/http/Issue5023IdempotencyKeyReplayTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5023IdempotencyKeyReplayTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end regression for issue #5023. The idempotency cache used to key solely on the client
+ * {@code X-Request-Id}, so a second, DIFFERENT write that happened to reuse the same correlation id had
+ * the first request's response replayed and its write silently skipped. It also must still de-duplicate a
+ * genuine retry of the SAME request so a double-commit does not occur.
+ * <p>
+ * Assertions compare the response bodies (which carry the inserted record @rid) rather than reading back
+ * through the embedded database, so they are not subject to HTTP-commit / embedded-read visibility timing.
+ * A distinct INSERT returns a distinct @rid, so a replayed response is byte-identical to the original.
+ */
+class Issue5023IdempotencyKeyReplayTest extends BaseGraphServerTest {
+
+  private static final String DATABASE_NAME = "graph";
+
+  @Test
+  void sameRequestIdDifferentCommandStillExecutes() throws Exception {
+    // Uses the pre-existing "Person" type (created in BaseGraphServerTest.populateDatabase).
+    testEachServer(serverIndex -> {
+      // First write with X-Request-Id: abc
+      final String body1 = postCommand(serverIndex, "abc", "INSERT INTO Person SET marker = 'idem5023', n = 1");
+
+      // Second write reuses the SAME X-Request-Id but is a DIFFERENT command. Before the fix this replayed
+      // the first response (body-identical) and never executed the second write.
+      final String body2 = postCommand(serverIndex, "abc", "INSERT INTO Person SET marker = 'idem5023', n = 2");
+
+      // Both executed independently -> distinct inserted records -> distinct response bodies.
+      assertThat(body2).isNotEqualTo(body1);
+      assertThat(body1).contains("\"n\":1");
+      assertThat(body2).contains("\"n\":2");
+    });
+  }
+
+  @Test
+  void sameRequestIdSameCommandIsDeduplicated() throws Exception {
+    testEachServer(serverIndex -> {
+      // Two identical retries of the same logical request (same id, same body): the second call must replay
+      // the cached response instead of executing a second insert, so the bodies (including the @rid) match.
+      final String body1 = postCommand(serverIndex, "retry-1", "INSERT INTO Person SET marker = 'idem5023dup'");
+      final String body2 = postCommand(serverIndex, "retry-1", "INSERT INTO Person SET marker = 'idem5023dup'");
+
+      assertThat(body2).isEqualTo(body1);
+    });
+  }
+
+  private String postCommand(final int serverIndex, final String requestId, final String command) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/" + DATABASE_NAME).openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    connection.setRequestProperty(IdempotencyCache.HEADER_REQUEST_ID, requestId);
+
+    final JSONObject payload = new JSONObject();
+    payload.put("language", "sql");
+    payload.put("command", command);
+    payload.put("autoCommit", true);
+    formatPayload(connection, payload);
+    connection.connect();
+    try {
+      final String response = readResponse(connection);
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      return response;
+    } finally {
+      connection.disconnect();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/IdempotencyKeyTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/IdempotencyKeyTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for {@code AbstractServerHttpHandler.buildIdempotencyKey}. The headline defect of
+ * issue #5023 is that the idempotency cache keyed on the raw {@code X-Request-Id} alone, so two unrelated
+ * requests reusing the same correlation id replayed each other's response and silently skipped writes.
+ * The key must be bound to method, path, database and body.
+ */
+class IdempotencyKeyTest {
+
+  @Test
+  void sameRequestIdDifferentDatabaseProducesDifferentKey() {
+    final String kA = AbstractServerHttpHandler.buildIdempotencyKey("abc", "POST", "/api/v1/command/dbA", "dbA",
+        "{\"command\":\"INSERT INTO V SET n=1\"}");
+    final String kB = AbstractServerHttpHandler.buildIdempotencyKey("abc", "POST", "/api/v1/command/dbB", "dbB",
+        "{\"command\":\"INSERT INTO V SET n=1\"}");
+    assertThat(kA).isNotEqualTo(kB);
+  }
+
+  @Test
+  void sameRequestIdDifferentBodyProducesDifferentKey() {
+    final String k1 = AbstractServerHttpHandler.buildIdempotencyKey("abc", "POST", "/api/v1/command/dbA", "dbA",
+        "{\"command\":\"INSERT INTO V SET n=1\"}");
+    final String k2 = AbstractServerHttpHandler.buildIdempotencyKey("abc", "POST", "/api/v1/command/dbA", "dbA",
+        "{\"command\":\"INSERT INTO V SET n=2\"}");
+    assertThat(k1).isNotEqualTo(k2);
+  }
+
+  @Test
+  void sameRequestIdDifferentMethodProducesDifferentKey() {
+    final String post = AbstractServerHttpHandler.buildIdempotencyKey("abc", "POST", "/api/v1/command/dbA", "dbA", "{}");
+    final String put = AbstractServerHttpHandler.buildIdempotencyKey("abc", "PUT", "/api/v1/command/dbA", "dbA", "{}");
+    assertThat(post).isNotEqualTo(put);
+  }
+
+  @Test
+  void differentRequestIdProducesDifferentKey() {
+    final String k1 = AbstractServerHttpHandler.buildIdempotencyKey("id-1", "POST", "/api/v1/command/dbA", "dbA", "{}");
+    final String k2 = AbstractServerHttpHandler.buildIdempotencyKey("id-2", "POST", "/api/v1/command/dbA", "dbA", "{}");
+    assertThat(k1).isNotEqualTo(k2);
+  }
+
+  @Test
+  void identicalInputsProduceStableKey() {
+    final String a = AbstractServerHttpHandler.buildIdempotencyKey("abc", "POST", "/api/v1/command/dbA", "dbA",
+        "{\"command\":\"INSERT INTO V SET n=1\"}");
+    final String b = AbstractServerHttpHandler.buildIdempotencyKey("abc", "POST", "/api/v1/command/dbA", "dbA",
+        "{\"command\":\"INSERT INTO V SET n=1\"}");
+    assertThat(a).isEqualTo(b);
+    // SHA-256 hex is 64 characters.
+    assertThat(a).hasSize(64);
+  }
+
+  @Test
+  void fieldBoundaryCannotBeSpoofedByConcatenation() {
+    // Without a field separator ("ab" + "") and ("a" + "b") would hash identically; the NUL delimiter
+    // must keep them distinct.
+    final String k1 = AbstractServerHttpHandler.buildIdempotencyKey("ab", "", "", "", null);
+    final String k2 = AbstractServerHttpHandler.buildIdempotencyKey("a", "b", "", "", null);
+    assertThat(k1).isNotEqualTo(k2);
+  }
+
+  @Test
+  void nullBodyIsHandled() {
+    final String k = AbstractServerHttpHandler.buildIdempotencyKey("abc", "POST", "/api/v1/begin/dbA", "dbA", null);
+    assertThat(k).hasSize(64);
+  }
+}


### PR DESCRIPTION
Closes #5023

## Problem
Part of the 2026-07 `server` module audit. The HTTP idempotency cache had two defects (both in `IdempotencyCache` + `AbstractServerHttpHandler`):

1. **Correctness** - the cache key was the raw client `X-Request-Id` header alone, not bound to method, path, database or body. Since that header is commonly propagated by clients/proxies across a whole logical operation (and is also reused as the log-correlation id), a second, different `POST` reusing the same id had the first request's response replayed and **its write silently skipped (HTTP 200)**. It also cached work done inside an open client session transaction and replayed `/begin` without the `arcadedb-session-id` header.
2. **Memory/CPU** - `evictOldest` did a full-map O(n) scan on every overflow insert, and the bound was entry count only, so full response bodies (potentially MBs) accumulated unbounded in bytes.

## Fix
- Key idempotency on `SHA-256(requestId, method, path, database, body)` so a reused correlation id can no longer replay a different request's response or skip its write.
- Skip idempotency for session-scoped requests (incoming `arcadedb-session-id`) and for responses that establish a session (e.g. `/begin`), so a replay never drops the session header and uncommitted session work is never cached.
- Add `reserve`/`complete`/`abort` with a PENDING marker so concurrent identical retries are de-duplicated (execute-once) instead of both writing.
- Replace the O(n) eviction scan with O(1) FIFO eviction; add a total-byte bound and a per-body size cap via two new `SCOPE.SERVER` config keys (`arcadedb.ha.idempotencyCacheMaxBytes` default 64 MB, `arcadedb.ha.idempotencyCacheMaxBodyBytes` default 1 MB). The periodic TTL sweeper is retained.

Backward-compatible: the 2-arg constructor and `get`/`putSuccess` are kept; non-idempotent requests never touch the cache.

## Tests
- `IdempotencyCacheTest` (+7): reserve/complete/abort contract, in-flight dedup, await release, byte-bound eviction, per-body cap.
- `IdempotencyKeyTest` (new): composite key distinguishes method/path/database/body and is stable/field-delimited.
- `Issue5023IdempotencyKeyReplayTest` (new, end-to-end): same `X-Request-Id` + different command both execute (distinct response bodies); same id + same command is de-duplicated (identical replayed body). Run repeatedly for stability.
- Regression batch green: AutoCommitParameterTest, RequestIdSanitizationTest, CorrelationIdGenerationTest, AbstractServerHttpHandlerErrorBodyTest/TokenTest, ExecutionResponseTest, Issue5037BeginHandlerIT, HTTPAuthSessionIT, HTTPTransactionIT, Issue4141SessionManagementIT, HttpObservationIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)