### PR TITLE
fix(#5026): HTTP transaction session lifecycle - remove on commit/rollback, sweep-race re-validation, ownership

### DIFF
--- a/docs/5026-http-transaction-session-lifecycle.md
+++ b/docs/5026-http-transaction-session-lifecycle.md
@@ -41,6 +41,18 @@ Three related defects in server-side HTTP transaction-session lifecycle:
   stale-session follow-up write is rejected, retried commit/rollback idempotent,
   recreated-same-name user cannot adopt.
 
+## Behavior changes (for the changelog)
+- A stale/unresolved session id now surfaces differently by handler kind. Write-capable
+  handlers (e.g. `POST /command`) return an explicit **404** (previously the code intended
+  401 but fell through to 500) instead of silently auto-committing. Read handlers
+  (`GET /query`) and the transaction endpoints (`/begin`, `/commit`, `/rollback`) degrade
+  to a session-less request: a read returns 200 against committed data (read-after-commit
+  preserved) and a retried commit/rollback is an idempotent 204. A client that passed an
+  expired session id to a read no longer learns it expired - the read simply runs outside
+  the session.
+- Dropping a user or changing its password rolls back and removes that principal's live HTTP
+  transaction sessions. A plain metadata/grant update (`updateUser`) does NOT - per-request
+  authorization is still re-checked on every command.
+
 ## Impact
-Server module only. No wire-format change. Read-after-commit and existing session-mgmt
-(#4141) semantics preserved.
+Server module only. No wire-format change. Existing session-mgmt (#4141) semantics preserved.

--- a/docs/5026-http-transaction-session-lifecycle.md
+++ b/docs/5026-http-transaction-session-lifecycle.md
@@ -1,0 +1,46 @@
+# Issue #5026 - HTTP transaction session lifecycle
+
+## Symptom
+Three related defects in server-side HTTP transaction-session lifecycle:
+1. REST `/commit` and `/rollback` never remove the server-side `HttpSession`; a stale
+   session id keeps resolving, so follow-up writes silently auto-commit and a retried
+   `/commit`/`/rollback` returns HTTP 500.
+2. Idle-timeout sweep vs in-flight request race: the sweep can roll back and remove a
+   session between `getSessionById()` and `HttpSession.execute()` acquiring the session
+   lock, leaking an active transaction.
+3. Session ownership is checked by user name only, and after attach: `getSessionById`
+   ignores the user; a dropped-and-recreated same-name principal can adopt the prior
+   principal's still-open session.
+
+## Root cause
+- `PostCommitHandler`/`PostRollbackHandler` only strip the response header; `removeSession`
+  is only called by GraphQL `SESSION CLOSE`.
+- `HttpSession.execute()` re-validates nothing after acquiring the lock.
+- `HttpSessionManager.getSessionById` ignores the `user` param; `ServerSecurityUser.equals`
+  compares by name; user drop/password change does not invalidate live HTTP sessions.
+
+## Fix
+- `PostCommitHandler`/`PostRollbackHandler`: commit/rollback only when a tx is active,
+  then `removeSession(header id)`. Idempotent (retry -> 204).
+- `DatabaseAbstractHandler.setTransactionInThreadLocal`: an unresolved session id on a
+  write-capable handler (`requiresTransaction()`) throws an explicit
+  `HttpSessionException` (HTTP 404) instead of silently auto-committing; on read/commit/
+  rollback/begin handlers it degrades to a session-less request (keeps idempotency and
+  read-after-commit working).
+- `HttpSession.execute()`: re-validate the session is still registered under the lock
+  before running the callback; refuse (throw) otherwise so a swept transaction is never
+  operated on.
+- `HttpSessionManager.getSessionById`: enforce ownership (return null for a non-owner).
+  Add `removeSessionsForUser(name)`; `ServerSecurity.dropUser`/`setUserPassword`/
+  `updateUser` invalidate the principal's live HTTP sessions.
+
+## Tests
+- `Issue5026HttpSessionLifecycleTest` (unit): execute re-validation, ownership,
+  removeSessionsForUser, recreated-same-name adoption.
+- `Issue5026TransactionSessionLifecycleIT` (HTTP): commit/rollback remove the session,
+  stale-session follow-up write is rejected, retried commit/rollback idempotent,
+  recreated-same-name user cannot adopt.
+
+## Impact
+Server module only. No wire-format change. Read-after-commit and existing session-mgmt
+(#4141) semantics preserved.

--- a/server/src/main/java/com/arcadedb/server/http/HttpSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpSession.java
@@ -165,6 +165,13 @@ public class HttpSession implements QuerySession {
 
     if (lock.tryLock(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS)) {
       try {
+        // RE-VALIDATE UNDER THE LOCK: THE IDLE-TIMEOUT SWEEP (OR A commit/rollback/close) COULD HAVE ROLLED BACK
+        // AND REMOVED THIS SESSION IN THE GAP BETWEEN THE MANAGER LOOKUP AND ACQUIRING THIS LOCK. RUNNING THE
+        // CALLBACK NOW WOULD OPERATE ON A ROLLED-BACK TRANSACTION AND LEAK A FRESH ONE (NOTHING WOULD EVER
+        // COMMIT/ROLL IT BACK, SINCE THE SESSION IS ALREADY UNTRACKED)
+        if (!manager.isSessionRegistered(id))
+          throw new HttpSessionException("Remote transaction '" + id + "' not found or expired");
+
         LogManager.instance().log(this, Level.FINE, "Executing session %s for user %s", id, user.getName());
         callback.call();
         // REFRESH WHILE STILL HOLDING THE LOCK: OTHERWISE THE IDLE-TIMEOUT SWEEP COULD tryLock() SUCCESSFULLY

--- a/server/src/main/java/com/arcadedb/server/http/HttpSessionException.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpSessionException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.exception.TransactionException;
+
+/**
+ * Thrown when a request references an HTTP transaction session id that is no longer resolvable: it was
+ * committed/rolled back, expired by the idle sweep, is owned by a different principal, or was invalidated
+ * because its owner was dropped. Mapped to HTTP 404 by the request handler so a stale session id surfaces as
+ * an explicit client error rather than a silent implicit-transaction commit or a 500.
+ */
+public class HttpSessionException extends TransactionException {
+  public HttpSessionException(final String message) {
+    super(message);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/HttpSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpSessionManager.java
@@ -109,7 +109,8 @@ public class HttpSessionManager extends RWLockContext {
         return null;
       // Enforce ownership BEFORE the caller attaches the session to the thread context: a session must only be
       // resolvable by the principal that opened it, so another user cannot adopt (and commit) its transaction.
-      if (user != null && !session.user.equals(user))
+      // A session with no recorded owner is never resolvable by an authenticated principal (null-safe).
+      if (user != null && (session.user == null || !session.user.equals(user)))
         return null;
       return session;
     });

--- a/server/src/main/java/com/arcadedb/server/http/HttpSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpSessionManager.java
@@ -103,7 +103,25 @@ public class HttpSessionManager extends RWLockContext {
   }
 
   public HttpSession getSessionById(final ServerSecurityUser user, final String txId) {
-    return executeInReadLock(() -> sessions.get(txId));
+    return executeInReadLock(() -> {
+      final HttpSession session = sessions.get(txId);
+      if (session == null)
+        return null;
+      // Enforce ownership BEFORE the caller attaches the session to the thread context: a session must only be
+      // resolvable by the principal that opened it, so another user cannot adopt (and commit) its transaction.
+      if (user != null && !session.user.equals(user))
+        return null;
+      return session;
+    });
+  }
+
+  /**
+   * Returns true if a session with the given id is still tracked. Used by {@link HttpSession#execute} to
+   * re-validate, under the session lock, that the idle sweep did not remove the session between the manager
+   * lookup and lock acquisition.
+   */
+  public boolean isSessionRegistered(final String id) {
+    return executeInReadLock(() -> sessions.containsKey(id));
   }
 
   public HttpSession createSession(final ServerSecurityUser user, final TransactionContext dbTx) {
@@ -117,6 +135,37 @@ public class HttpSessionManager extends RWLockContext {
 
   public HttpSession removeSession(final String id) {
     return executeInWriteLock(() -> sessions.remove(id));
+  }
+
+  /**
+   * Invalidates every live session owned by the named principal: the sessions are unregistered and their
+   * open transactions rolled back. Called when a user is dropped or its password is changed so a stale (or
+   * recreated same-name) principal cannot adopt a session opened by the previous principal.
+   *
+   * @return the number of sessions removed
+   */
+  public int removeSessionsForUser(final String userName) {
+    if (userName == null)
+      return 0;
+
+    // Unregister under the write lock first, then cancel() (rollback) outside it: cancel() waits on the
+    // per-session lock for any in-flight command, which must never be done while holding the manager lock.
+    final List<HttpSession> removed = executeInWriteLock(() -> {
+      final List<HttpSession> owned = new ArrayList<>();
+      for (final Iterator<Map.Entry<String, HttpSession>> it = sessions.entrySet().iterator(); it.hasNext(); ) {
+        final HttpSession session = it.next().getValue();
+        if (session.user != null && userName.equals(session.user.getName())) {
+          owned.add(session);
+          it.remove();
+        }
+      }
+      return owned;
+    });
+
+    for (final HttpSession session : removed)
+      session.cancel();
+
+    return removed.size();
   }
 
   public int getActiveSessions() {

--- a/server/src/main/java/com/arcadedb/server/http/HttpSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpSessionManager.java
@@ -110,6 +110,10 @@ public class HttpSessionManager extends RWLockContext {
       // Enforce ownership BEFORE the caller attaches the session to the thread context: a session must only be
       // resolvable by the principal that opened it, so another user cannot adopt (and commit) its transaction.
       // A session with no recorded owner is never resolvable by an authenticated principal (null-safe).
+      // NOTE: ownership compares by ServerSecurityUser identity/name, so protection against a dropped-then-
+      // recreated same-name principal relies on removeSessionsForUser() being invoked from every user
+      // removal/mutation path (ServerSecurity.dropUser/setUserPassword). Any future path that replaces the
+      // users map without routing through those hooks must also invalidate the affected sessions here.
       if (user != null && (session.user == null || !session.user.equals(user)))
         return null;
       return session;

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -27,6 +27,7 @@ import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.HttpSessionException;
 import com.arcadedb.server.http.HttpSessionManager;
 import com.arcadedb.server.http.IdempotencyCache;
 import com.arcadedb.server.security.ApiTokenConfiguration;
@@ -445,6 +446,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
                         e.getMessage());
         sendErrorResponse(exchange, 500, "Cannot execute command", realException, null);
       }
+    } catch (final HttpSessionException e) {
+      // A referenced HTTP transaction session id is no longer resolvable (committed/rolled back, expired,
+      // owned by another principal, or invalidated). Surface as an explicit 404 client error - never a 500,
+      // and never a silent implicit-transaction commit. Must precede the TransactionException arm below since
+      // HttpSessionException extends it.
+      LogManager.instance()
+              .log(this, Level.FINE, "Transaction session error on command execution (%s): %s", getClass().getSimpleName(),
+                      e.getMessage());
+      sendErrorResponse(exchange, 404, "Remote transaction session not found or expired", e, null);
     } catch (final TransactionException e) {
       Throwable realException = e;
       if (e.getCause() != null)

--- a/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
@@ -30,12 +30,12 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.HttpSession;
+import com.arcadedb.server.http.HttpSessionException;
 import com.arcadedb.server.http.HttpSessionManager;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.HttpString;
-import io.undertow.util.StatusCodes;
 
 import java.util.Deque;
 import java.util.Locale;
@@ -290,6 +290,17 @@ public abstract class DatabaseAbstractHandler extends AbstractServerHttpHandler 
     return requiresTransaction();
   }
 
+  /**
+   * Unregisters the server-side session referenced by the request's session-id header, if any. Called by the
+   * {@code /commit} and {@code /rollback} endpoints so a stale session id is no longer resolvable. Safe to call
+   * when the id is already gone (e.g. an idempotent retry): {@code removeSession} is a no-op then.
+   */
+  protected void removeSession(final HttpServerExchange exchange) {
+    final HeaderValues sessionId = exchange.getRequestHeaders().get(HttpSessionManager.ARCADEDB_SESSION_ID);
+    if (sessionId != null && !sessionId.isEmpty())
+      httpServer.getSessionManager().removeSession(sessionId.getFirst());
+  }
+
   protected HttpSession setTransactionInThreadLocal(final HttpServerExchange exchange, final Database database,
       final ServerSecurityUser user) {
     final HeaderValues sessionId = exchange.getRequestHeaders().get(HttpSessionManager.ARCADEDB_SESSION_ID);
@@ -297,8 +308,16 @@ public abstract class DatabaseAbstractHandler extends AbstractServerHttpHandler 
       // LOOK UP FOR THE SESSION ID
       final HttpSession session = httpServer.getSessionManager().getSessionById(user, sessionId.getFirst());
       if (session == null) {
-        exchange.setStatusCode(StatusCodes.UNAUTHORIZED);
-        throw new TransactionException("Remote transaction '" + sessionId.getFirst() + "' not found or expired");
+        // The session id is not resolvable (committed/rolled back, expired, or owned by another principal).
+        // A write-capable handler MUST reject it: falling through session-less would run the command in an
+        // implicit auto-committing transaction while the client believes it is inside a transaction it can
+        // still roll back. Read-only handlers (GET /query) and the transaction endpoints
+        // (/begin, /commit, /rollback) instead degrade to a session-less request, keeping read-after-commit
+        // and idempotent retries of commit/rollback working.
+        if (requiresTransaction())
+          throw new HttpSessionException("Remote transaction '" + sessionId.getFirst() + "' not found or expired");
+
+        return null;
       }
 
       // FORCE THE RESET OF TL

--- a/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
@@ -291,14 +291,19 @@ public abstract class DatabaseAbstractHandler extends AbstractServerHttpHandler 
   }
 
   /**
-   * Unregisters the server-side session referenced by the request's session-id header, if any. Called by the
-   * {@code /commit} and {@code /rollback} endpoints so a stale session id is no longer resolvable. Safe to call
-   * when the id is already gone (e.g. an idempotent retry): {@code removeSession} is a no-op then.
+   * Unregisters the server-side session referenced by the request's session-id header, if any - but only when
+   * it is owned by {@code user}. Called by the {@code /commit} and {@code /rollback} endpoints so a stale
+   * session id is no longer resolvable. The ownership gate (via {@link HttpSessionManager#getSessionById})
+   * ensures a request carrying another principal's session id cannot evict (and orphan) that session; it is
+   * also a no-op when the id is already gone (e.g. an idempotent retry).
    */
-  protected void removeSession(final HttpServerExchange exchange) {
+  protected void removeSession(final HttpServerExchange exchange, final ServerSecurityUser user) {
     final HeaderValues sessionId = exchange.getRequestHeaders().get(HttpSessionManager.ARCADEDB_SESSION_ID);
-    if (sessionId != null && !sessionId.isEmpty())
-      httpServer.getSessionManager().removeSession(sessionId.getFirst());
+    if (sessionId != null && !sessionId.isEmpty()) {
+      final HttpSession session = httpServer.getSessionManager().getSessionById(user, sessionId.getFirst());
+      if (session != null)
+        httpServer.getSessionManager().removeSession(session.id);
+    }
   }
 
   protected HttpSession setTransactionInThreadLocal(final HttpServerExchange exchange, final Database database,

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommitHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommitHandler.java
@@ -37,7 +37,15 @@ public class PostCommitHandler extends DatabaseAbstractHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final Database database,
       final JSONObject payload) throws IOException {
-    database.commit();
+    // Guard with isTransactionActive() so a retried /commit whose session was already removed by the first
+    // call is an idempotent no-op (204) instead of committing a non-existent transaction (which would 500).
+    if (database.isTransactionActive())
+      database.commit();
+
+    // End the server-side session: after /commit its transaction is gone, so the session id must no longer
+    // resolve. Leaving it registered let follow-up writes silently auto-commit and made a retried commit 500.
+    removeSession(exchange);
+
     exchange.getResponseHeaders().remove(HttpSessionManager.ARCADEDB_SESSION_ID);
     Metrics.counter("http.commit").increment();
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommitHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommitHandler.java
@@ -44,7 +44,8 @@ public class PostCommitHandler extends DatabaseAbstractHandler {
 
     // End the server-side session: after /commit its transaction is gone, so the session id must no longer
     // resolve. Leaving it registered let follow-up writes silently auto-commit and made a retried commit 500.
-    removeSession(exchange);
+    // Ownership-gated so a request carrying another principal's session id cannot evict/orphan that session.
+    removeSession(exchange, user);
 
     exchange.getResponseHeaders().remove(HttpSessionManager.ARCADEDB_SESSION_ID);
     Metrics.counter("http.commit").increment();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostRollbackHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostRollbackHandler.java
@@ -37,7 +37,15 @@ public class PostRollbackHandler extends DatabaseAbstractHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final Database database,
       final JSONObject payload) throws IOException {
-    database.rollback();
+    // Guard with isTransactionActive() so a retried /rollback whose session was already removed by the first
+    // call is an idempotent no-op (204) instead of rolling back a non-existent transaction (which would 500).
+    if (database.isTransactionActive())
+      database.rollback();
+
+    // End the server-side session: after /rollback its transaction is gone, so the session id must no longer
+    // resolve. Leaving it registered let follow-up writes silently auto-commit and made a retried rollback 500.
+    removeSession(exchange);
+
     exchange.getResponseHeaders().remove(HttpSessionManager.ARCADEDB_SESSION_ID);
     Metrics.counter("http.rollback").increment();
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostRollbackHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostRollbackHandler.java
@@ -44,7 +44,8 @@ public class PostRollbackHandler extends DatabaseAbstractHandler {
 
     // End the server-side session: after /rollback its transaction is gone, so the session id must no longer
     // resolve. Leaving it registered let follow-up writes silently auto-commit and made a retried rollback 500.
-    removeSession(exchange);
+    // Ownership-gated so a request carrying another principal's session id cannot evict/orphan that session.
+    removeSession(exchange, user);
 
     exchange.getResponseHeaders().remove(HttpSessionManager.ARCADEDB_SESSION_ID);
     Metrics.counter("http.rollback").increment();

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -315,20 +315,24 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     return user;
   }
 
-  public synchronized boolean dropUser(final String userName) {
-    if (users.remove(userName) != null) {
+  public boolean dropUser(final String userName) {
+    synchronized (this) {
+      if (users.remove(userName) == null)
+        return false;
       saveUsers();
-      // Invalidate the dropped principal's live HTTP transaction sessions so a recreated same-name principal
-      // cannot adopt (and commit) the prior principal's still-open session.
-      invalidateHttpSessions(userName);
-      return true;
     }
-    return false;
+    // Invalidate the dropped principal's live HTTP transaction sessions so a recreated same-name principal
+    // cannot adopt (and commit) the prior principal's still-open session. Done OUTSIDE the security monitor:
+    // session.cancel() waits (unbounded, by design) on the per-session lock for any in-flight command, and
+    // holding this monitor across that wait would stall every other admin op serialized on it.
+    invalidateHttpSessions(userName);
+    return true;
   }
 
   /**
    * Invalidates every live HTTP transaction session owned by the named principal (rolling back its open
-   * transaction). No-op when the HTTP server is not running (e.g. embedded use).
+   * transaction). No-op when the HTTP server is not running (e.g. embedded use). Must be called OUTSIDE the
+   * {@code ServerSecurity} monitor: it can block on a session's in-flight command via {@code cancel()}.
    */
   private void invalidateHttpSessions(final String userName) {
     final HttpServer httpServer = server != null ? server.getHttpServer() : null;

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -29,9 +29,9 @@ import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.DefaultConsoleReader;
-import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.ServerException;
 import com.arcadedb.server.ServerPlugin;
+import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.credential.CredentialsValidator;
 import com.arcadedb.server.security.credential.DefaultCredentialsValidator;
 import com.arcadedb.utility.AnsiCode;
@@ -309,9 +309,9 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     final ServerSecurityUser user = new ServerSecurityUser(server, userConfiguration);
     users.put(name, user);
     saveUsers();
-    // The principal's authorization may have changed: invalidate its live HTTP transaction sessions so they
-    // cannot keep running under the previous grants.
-    invalidateHttpSessions(name);
+    // Note: a metadata update does NOT force-rollback the principal's open transactions - per-request
+    // authorization is still re-checked on every command, so a narrowed grant is enforced without tearing
+    // down unrelated in-flight work. Only drop and password change (below) invalidate live sessions.
     return user;
   }
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -29,6 +29,7 @@ import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.DefaultConsoleReader;
+import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.ServerException;
 import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.server.security.credential.CredentialsValidator;
@@ -308,15 +309,31 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     final ServerSecurityUser user = new ServerSecurityUser(server, userConfiguration);
     users.put(name, user);
     saveUsers();
+    // The principal's authorization may have changed: invalidate its live HTTP transaction sessions so they
+    // cannot keep running under the previous grants.
+    invalidateHttpSessions(name);
     return user;
   }
 
   public synchronized boolean dropUser(final String userName) {
     if (users.remove(userName) != null) {
       saveUsers();
+      // Invalidate the dropped principal's live HTTP transaction sessions so a recreated same-name principal
+      // cannot adopt (and commit) the prior principal's still-open session.
+      invalidateHttpSessions(userName);
       return true;
     }
     return false;
+  }
+
+  /**
+   * Invalidates every live HTTP transaction session owned by the named principal (rolling back its open
+   * transaction). No-op when the HTTP server is not running (e.g. embedded use).
+   */
+  private void invalidateHttpSessions(final String userName) {
+    final HttpServer httpServer = server != null ? server.getHttpServer() : null;
+    if (httpServer != null)
+      httpServer.getSessionManager().removeSessionsForUser(userName);
   }
 
   @Override
@@ -347,6 +364,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       throw new ServerSecurityException("User '" + userName + "' not found");
     user.setPassword(encodePassword(password));
     saveUsers();
+    // A password change re-authenticates the principal: drop its live HTTP transaction sessions.
+    invalidateHttpSessions(userName);
   }
 
   @Override

--- a/server/src/test/java/com/arcadedb/server/http/Issue5026HttpSessionLifecycleTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5026HttpSessionLifecycleTest.java
@@ -179,6 +179,12 @@ class Issue5026HttpSessionLifecycleTest {
     final ServerSecurityUser alice = createUser("alice");
     final HttpSession aliceSession = sessionManager.createSession(alice, beginTx());
 
+    // Ownership is by name, so BEFORE invalidation a same-name principal WOULD resolve the session. This
+    // pins the invariant that invalidation-on-drop (removing the session), not the identity check, is the
+    // real guard against same-name adoption.
+    assertThat(sessionManager.getSessionById(createUser("alice"), aliceSession.id))
+        .as("a same-name principal resolves the session until it is invalidated").isSameAs(aliceSession);
+
     // User is dropped: invalidate its live sessions.
     sessionManager.removeSessionsForUser("alice");
 

--- a/server/src/test/java/com/arcadedb/server/http/Issue5026HttpSessionLifecycleTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5026HttpSessionLifecycleTest.java
@@ -107,7 +107,7 @@ class Issue5026HttpSessionLifecycleTest {
     assertThatThrownBy(() -> session.execute(user, () -> {
       callbackRan.set(true);
       return null;
-    })).isInstanceOf(Exception.class);
+    })).isInstanceOf(HttpSessionException.class);
 
     assertThat(callbackRan).as("callback must not run on a session that was removed before the lock was taken").isFalse();
   }

--- a/server/src/test/java/com/arcadedb/server/http/Issue5026HttpSessionLifecycleTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5026HttpSessionLifecycleTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.security.ServerSecurityUser;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for GitHub issue #5026 (server audit, HTTP transaction-session lifecycle). Covers the
+ * two lower-level defects that can be exercised directly against {@link HttpSessionManager}/{@link HttpSession}
+ * without a running HTTP server:
+ * <ul>
+ *   <li>Defect 2: the idle-timeout sweep can remove a session between {@code getSessionById()} and
+ *   {@link HttpSession#execute} acquiring the session lock; {@code execute} must re-validate the session is
+ *   still registered and refuse to run its callback on a swept (rolled-back) transaction.</li>
+ *   <li>Defect 3: {@link HttpSessionManager#getSessionById} must enforce ownership (a different user cannot
+ *   resolve another user's session), and a user's live sessions must be invalidatable
+ *   ({@link HttpSessionManager#removeSessionsForUser}) so a dropped-and-recreated same-name principal cannot
+ *   adopt the prior principal's still-open session.</li>
+ * </ul>
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/5026">GitHub Issue #5026</a>
+ */
+class Issue5026HttpSessionLifecycleTest {
+  private static final long TIMEOUT_MS = 600_000L;
+
+  private DatabaseInternal   database;
+  private File               databaseDirectory;
+  private HttpSessionManager sessionManager;
+
+  private DatabaseInternal createDatabase() {
+    databaseDirectory = new File("./target/databases/Issue5026HttpSessionLifecycleTest-" + UUID.randomUUID());
+    try (final Database db = new DatabaseFactory(databaseDirectory.getPath()).create()) {
+      db.getSchema().createDocumentType("Doc");
+    }
+    return (DatabaseInternal) new DatabaseFactory(databaseDirectory.getPath()).open();
+  }
+
+  // ServerSecurityUser.equals()/getName() (the only members the session manager touches) never dereference
+  // the ArcadeDBServer field, so a real instance can be built without a running server.
+  private ServerSecurityUser createUser(final String name) {
+    return new ServerSecurityUser(null, new JSONObject().put("name", name));
+  }
+
+  private TransactionContext beginTx() {
+    final TransactionContext tx = new TransactionContext(database);
+    tx.begin(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED);
+    return tx;
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (sessionManager != null)
+      sessionManager.close();
+    if (database != null && database.isOpen())
+      database.close();
+    if (databaseDirectory != null)
+      FileUtils.deleteRecursively(databaseDirectory);
+  }
+
+  // Defect 2: a session removed from the manager (e.g. by the idle sweep) between lookup and lock acquisition
+  // must not have its callback run; execute() re-validates registration under the lock.
+  @Test
+  void executeRefusesToRunOnAnUnregisteredSession() throws Exception {
+    database = createDatabase();
+    sessionManager = new HttpSessionManager(TIMEOUT_MS);
+
+    final TransactionContext tx = beginTx();
+    final ServerSecurityUser user = createUser("alice");
+    final HttpSession session = sessionManager.createSession(user, tx);
+
+    // Simulate the idle sweep having rolled back and removed the session after this request looked it up.
+    tx.rollback();
+    sessionManager.removeSession(session.id);
+
+    final AtomicBoolean callbackRan = new AtomicBoolean(false);
+    assertThatThrownBy(() -> session.execute(user, () -> {
+      callbackRan.set(true);
+      return null;
+    })).isInstanceOf(Exception.class);
+
+    assertThat(callbackRan).as("callback must not run on a session that was removed before the lock was taken").isFalse();
+  }
+
+  // A session that is still registered runs its callback normally (guards against the re-validation being too
+  // aggressive and breaking the happy path).
+  @Test
+  void executeRunsCallbackWhenSessionStillRegistered() throws Exception {
+    database = createDatabase();
+    sessionManager = new HttpSessionManager(TIMEOUT_MS);
+
+    final TransactionContext tx = beginTx();
+    final ServerSecurityUser user = createUser("alice");
+    final HttpSession session = sessionManager.createSession(user, tx);
+
+    final AtomicBoolean callbackRan = new AtomicBoolean(false);
+    session.execute(user, () -> {
+      callbackRan.set(true);
+      return null;
+    });
+
+    assertThat(callbackRan).isTrue();
+  }
+
+  // Defect 3: getSessionById must not hand a session to a different user.
+  @Test
+  void getSessionByIdEnforcesOwnership() {
+    database = createDatabase();
+    sessionManager = new HttpSessionManager(TIMEOUT_MS);
+
+    final ServerSecurityUser alice = createUser("alice");
+    final ServerSecurityUser bob = createUser("bob");
+    final HttpSession session = sessionManager.createSession(alice, beginTx());
+
+    assertThat(sessionManager.getSessionById(alice, session.id)).as("owner resolves its own session").isSameAs(session);
+    assertThat(sessionManager.getSessionById(bob, session.id)).as("a different user cannot resolve the session").isNull();
+  }
+
+  // Defect 3: removeSessionsForUser rolls back and removes only the target user's sessions.
+  @Test
+  void removeSessionsForUserInvalidatesOnlyThatUsersSessions() {
+    database = createDatabase();
+    sessionManager = new HttpSessionManager(TIMEOUT_MS);
+
+    final ServerSecurityUser alice = createUser("alice");
+    final ServerSecurityUser bob = createUser("bob");
+    final TransactionContext aliceTx = beginTx();
+    final TransactionContext bobTx = beginTx();
+    final HttpSession aliceSession = sessionManager.createSession(alice, aliceTx);
+    final HttpSession bobSession = sessionManager.createSession(bob, bobTx);
+
+    final int removed = sessionManager.removeSessionsForUser("alice");
+
+    assertThat(removed).as("only alice's session removed").isEqualTo(1);
+    assertThat(aliceTx.isActive()).as("alice's transaction rolled back").isFalse();
+    assertThat(bobTx.isActive()).as("bob's transaction untouched").isTrue();
+    assertThat(sessionManager.getActiveSessions()).isEqualTo(1);
+    assertThat(sessionManager.getSessionById(alice, aliceSession.id)).isNull();
+    assertThat(sessionManager.getSessionById(bob, bobSession.id)).isSameAs(bobSession);
+  }
+
+  // Defect 3: after invalidation a recreated same-name principal (a fresh ServerSecurityUser instance) cannot
+  // adopt the prior principal's session id.
+  @Test
+  void recreatedSameNameUserCannotAdoptPriorSession() {
+    database = createDatabase();
+    sessionManager = new HttpSessionManager(TIMEOUT_MS);
+
+    final ServerSecurityUser alice = createUser("alice");
+    final HttpSession aliceSession = sessionManager.createSession(alice, beginTx());
+
+    // User is dropped: invalidate its live sessions.
+    sessionManager.removeSessionsForUser("alice");
+
+    // A brand new principal happens to reuse the same name.
+    final ServerSecurityUser recreatedAlice = createUser("alice");
+    assertThat(sessionManager.getSessionById(recreatedAlice, aliceSession.id))
+        .as("recreated same-name user must not adopt the prior principal's session").isNull();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/Issue5026TransactionSessionLifecycleIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5026TransactionSessionLifecycleIT.java
@@ -173,6 +173,32 @@ public class Issue5026TransactionSessionLifecycleIT extends BaseGraphServerTest 
   }
 
   @Test
+  void commitWithAnotherUsersSessionDoesNotOrphanIt() throws Exception {
+    testEachServer(serverIndex -> {
+      getServer(serverIndex).getSecurity().createUser("other5026", "other5026pwd");
+      final String otherAuth = "Basic " + Base64.getEncoder().encodeToString("other5026:other5026pwd".getBytes());
+
+      // root opens a session.
+      final String rootSessionId = beginSession(serverIndex, rootAuth());
+      final HttpSessionManager manager = getServer(serverIndex).getHttpServer().getSessionManager();
+      assertThat(manager.isSessionRegistered(rootSessionId)).isTrue();
+
+      // A different authenticated principal tries to /commit root's session id. It must be a benign no-op that
+      // does NOT evict (and orphan) root's session - removal is ownership-gated.
+      assertThat(post(serverIndex, "commit", otherAuth, rootSessionId)).isEqualTo(204);
+      assertThat(manager.isSessionRegistered(rootSessionId)).as("another user's commit must not remove root's session").isTrue();
+
+      // root can still use and then commit its own session normally.
+      assertThat(insert(serverIndex, rootAuth(), rootSessionId, "owner-still-usable")).isEqualTo(200);
+      assertThat(post(serverIndex, "commit", rootAuth(), rootSessionId)).isEqualTo(204);
+      assertThat(manager.isSessionRegistered(rootSessionId)).isFalse();
+      assertThat(countPersons(serverIndex, "owner-still-usable")).isEqualTo(1L);
+
+      getServer(serverIndex).getSecurity().dropUser("other5026");
+    });
+  }
+
+  @Test
   void droppingUserInvalidatesItsHttpSessions() throws Exception {
     testEachServer(serverIndex -> {
       getServer(serverIndex).getSecurity().createUser("sess5026", "sess5026pwd");

--- a/server/src/test/java/com/arcadedb/server/http/Issue5026TransactionSessionLifecycleIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5026TransactionSessionLifecycleIT.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 
@@ -107,6 +109,29 @@ public class Issue5026TransactionSessionLifecycleIT extends BaseGraphServerTest 
     }
   }
 
+  // Returns the HTTP status code of a GET /query, capturing the response body into out[0] on success.
+  private int getQuery(final int serverIndex, final String auth, final String sessionId, final String sql, final String[] out)
+      throws Exception {
+    final String encoded = URLEncoder.encode(sql, StandardCharsets.UTF_8).replace("+", "%20");
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        baseUrl(serverIndex) + "/query/" + DATABASE_NAME + "/sql/" + encoded).openConnection();
+    connection.setRequestMethod("GET");
+    connection.setRequestProperty("Authorization", auth);
+    if (sessionId != null)
+      connection.setRequestProperty(HttpSessionManager.ARCADEDB_SESSION_ID, sessionId);
+    connection.connect();
+    try {
+      final int code = connection.getResponseCode();
+      if (code == 200)
+        out[0] = readResponse(connection);
+      else
+        readError(connection);
+      return code;
+    } finally {
+      connection.disconnect();
+    }
+  }
+
   private long countPersons(final int serverIndex, final String name) {
     final Database db = getServerDatabase(serverIndex, DATABASE_NAME);
     return db.query("sql", "SELECT count(*) AS c FROM Person WHERE name = ?", name).next().<Long>getProperty("c");
@@ -169,6 +194,24 @@ public class Issue5026TransactionSessionLifecycleIT extends BaseGraphServerTest 
 
       assertThat(post(serverIndex, "rollback", auth, sessionId)).isEqualTo(204);
       assertThat(post(serverIndex, "rollback", auth, sessionId)).as("retried rollback idempotent").isEqualTo(204);
+    });
+  }
+
+  @Test
+  void staleSessionOnReadDegradesToSessionlessRead() throws Exception {
+    testEachServer(serverIndex -> {
+      final String auth = rootAuth();
+      final String sessionId = beginSession(serverIndex, auth);
+      assertThat(insert(serverIndex, auth, sessionId, "read-degrade")).isEqualTo(200);
+      assertThat(post(serverIndex, "commit", auth, sessionId)).isEqualTo(204);
+
+      // A read (GET /query) carrying the now-removed session id must NOT 404: read-only handlers degrade to a
+      // session-less request and still return the committed row (read-after-commit preserved). Writes, by
+      // contrast, are rejected (asserted in commitRemovesSessionAndRejectsStaleWrite).
+      final String[] body = new String[1];
+      final int code = getQuery(serverIndex, auth, sessionId, "SELECT name FROM Person WHERE name = 'read-degrade'", body);
+      assertThat(code).as("stale session on a read degrades to a session-less 200").isEqualTo(200);
+      assertThat(body[0]).contains("read-degrade");
     });
   }
 

--- a/server/src/test/java/com/arcadedb/server/http/Issue5026TransactionSessionLifecycleIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5026TransactionSessionLifecycleIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end regression tests for GitHub issue #5026 (server audit, HTTP transaction-session lifecycle).
+ *
+ * <p>Defect 1: REST {@code /commit} and {@code /rollback} must remove the server-side session so a stale
+ * session id is no longer resolvable - a follow-up write must be rejected instead of silently auto-committing,
+ * and a retried commit/rollback must be idempotent (HTTP 204, never 500).
+ *
+ * <p>Defect 3: dropping (or changing the password of) a user must invalidate that principal's live HTTP
+ * transaction sessions, so a recreated same-name principal cannot adopt the prior principal's open session.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/5026">GitHub Issue #5026</a>
+ */
+public class Issue5026TransactionSessionLifecycleIT extends BaseGraphServerTest {
+  private static final String DATABASE_NAME = "graph";
+
+  private String baseUrl(final int serverIndex) {
+    return "http://127.0.0.1:248" + serverIndex + "/api/v1";
+  }
+
+  private static String rootAuth() {
+    return "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
+  }
+
+  private String beginSession(final int serverIndex, final String auth) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(baseUrl(serverIndex) + "/begin/" + DATABASE_NAME).openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", auth);
+    connection.connect();
+    try {
+      readResponse(connection);
+      assertThat(connection.getResponseCode()).isEqualTo(204);
+      final String sessionId = connection.getHeaderField(HttpSessionManager.ARCADEDB_SESSION_ID).trim();
+      assertThat(sessionId).isNotNull();
+      return sessionId;
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int insert(final int serverIndex, final String auth, final String sessionId, final String name) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(baseUrl(serverIndex) + "/command/" + DATABASE_NAME).openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", auth);
+    if (sessionId != null)
+      connection.setRequestProperty(HttpSessionManager.ARCADEDB_SESSION_ID, sessionId);
+    formatPayload(connection, "sql", "INSERT INTO Person SET name = '" + name + "'", null, new HashMap<>());
+    connection.connect();
+    try {
+      final int code = connection.getResponseCode();
+      if (code == 200)
+        readResponse(connection);
+      else
+        readError(connection);
+      return code;
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private int post(final int serverIndex, final String verb, final String auth, final String sessionId) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(baseUrl(serverIndex) + "/" + verb + "/" + DATABASE_NAME).openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", auth);
+    if (sessionId != null)
+      connection.setRequestProperty(HttpSessionManager.ARCADEDB_SESSION_ID, sessionId);
+    connection.connect();
+    try {
+      final int code = connection.getResponseCode();
+      if (code >= 400)
+        readError(connection);
+      else
+        readResponse(connection);
+      return code;
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private long countPersons(final int serverIndex, final String name) {
+    final Database db = getServerDatabase(serverIndex, DATABASE_NAME);
+    return db.query("sql", "SELECT count(*) AS c FROM Person WHERE name = ?", name).next().<Long>getProperty("c");
+  }
+
+  @Test
+  void commitRemovesSessionAndRejectsStaleWrite() throws Exception {
+    testEachServer(serverIndex -> {
+      final String auth = rootAuth();
+      final String sessionId = beginSession(serverIndex, auth);
+
+      assertThat(insert(serverIndex, auth, sessionId, "commit-visible")).isEqualTo(200);
+      assertThat(post(serverIndex, "commit", auth, sessionId)).isEqualTo(204);
+
+      // The committed row is durable.
+      assertThat(countPersons(serverIndex, "commit-visible")).isEqualTo(1L);
+
+      // A follow-up WRITE reusing the now-removed session id must be rejected (explicit 4xx), never silently
+      // auto-committed and never a 500.
+      final int staleWrite = insert(serverIndex, auth, sessionId, "must-not-persist");
+      assertThat(staleWrite).as("stale-session write rejected").isEqualTo(404);
+      assertThat(countPersons(serverIndex, "must-not-persist")).as("stale write must not persist").isEqualTo(0L);
+    });
+  }
+
+  @Test
+  void rollbackRemovesSessionAndRejectsStaleWrite() throws Exception {
+    testEachServer(serverIndex -> {
+      final String auth = rootAuth();
+      final String sessionId = beginSession(serverIndex, auth);
+
+      assertThat(insert(serverIndex, auth, sessionId, "rolledback")).isEqualTo(200);
+      assertThat(post(serverIndex, "rollback", auth, sessionId)).isEqualTo(204);
+
+      assertThat(countPersons(serverIndex, "rolledback")).as("rolled-back row is not durable").isEqualTo(0L);
+
+      final int staleWrite = insert(serverIndex, auth, sessionId, "after-rollback");
+      assertThat(staleWrite).as("stale-session write rejected").isEqualTo(404);
+      assertThat(countPersons(serverIndex, "after-rollback")).isEqualTo(0L);
+    });
+  }
+
+  @Test
+  void retriedCommitIsIdempotent() throws Exception {
+    testEachServer(serverIndex -> {
+      final String auth = rootAuth();
+      final String sessionId = beginSession(serverIndex, auth);
+
+      assertThat(post(serverIndex, "commit", auth, sessionId)).isEqualTo(204);
+      // A second /commit with the same (now removed) session id must be a no-op 204, not a 500.
+      assertThat(post(serverIndex, "commit", auth, sessionId)).as("retried commit idempotent").isEqualTo(204);
+    });
+  }
+
+  @Test
+  void retriedRollbackIsIdempotent() throws Exception {
+    testEachServer(serverIndex -> {
+      final String auth = rootAuth();
+      final String sessionId = beginSession(serverIndex, auth);
+
+      assertThat(post(serverIndex, "rollback", auth, sessionId)).isEqualTo(204);
+      assertThat(post(serverIndex, "rollback", auth, sessionId)).as("retried rollback idempotent").isEqualTo(204);
+    });
+  }
+
+  @Test
+  void droppingUserInvalidatesItsHttpSessions() throws Exception {
+    testEachServer(serverIndex -> {
+      getServer(serverIndex).getSecurity().createUser("sess5026", "sess5026pwd");
+      final String userAuth = "Basic " + Base64.getEncoder().encodeToString("sess5026:sess5026pwd".getBytes());
+
+      final String sessionId = beginSession(serverIndex, userAuth);
+      final HttpSessionManager manager = getServer(serverIndex).getHttpServer().getSessionManager();
+      assertThat(manager.getActiveSessions()).isGreaterThanOrEqualTo(1);
+
+      // Drop the principal: its live HTTP transaction session must be invalidated.
+      getServer(serverIndex).getSecurity().dropUser("sess5026");
+
+      // A recreated same-name principal must not be able to adopt the prior principal's session id.
+      getServer(serverIndex).getSecurity().createUser("sess5026", "sess5026pwd");
+      final int staleWrite = insert(serverIndex, userAuth, sessionId, "adopted");
+      assertThat(staleWrite).as("recreated same-name user cannot adopt prior session").isEqualTo(404);
+      assertThat(countPersons(serverIndex, "adopted")).isEqualTo(0L);
+
+      getServer(serverIndex).getSecurity().dropUser("sess5026");
+    });
+  }
+}


### PR DESCRIPTION
Fixes #5026 (2026-07 server audit). Three related defects in the server-side HTTP transaction-session lifecycle.

## Defect 1 (HIGH) - `/commit` and `/rollback` never removed the server-side session
`PostCommitHandler`/`PostRollbackHandler` only stripped the response header; the session stayed registered until the idle sweep. A stale session id kept resolving, so a follow-up write ran in an implicit auto-committing transaction while the client believed it was inside a transaction it could still roll back, and a retried `/commit`/`/rollback` returned HTTP 500.

Fix:
- Both handlers unregister the session after commit/rollback and guard the commit/rollback with `isTransactionActive()`, so a retried call is an idempotent **204** (never 500).
- `DatabaseAbstractHandler.setTransactionInThreadLocal` rejects an unresolved session id on a **write-capable** handler (`requiresTransaction()`) with an explicit `HttpSessionException` mapped to **HTTP 404**, instead of silently falling through to an auto-committing transaction. Read-only (`GET /query`) and the transaction endpoints (`/begin`, `/commit`, `/rollback`) degrade to a session-less request, preserving read-after-commit and idempotent retries.

## Defect 2 (MEDIUM) - idle-sweep vs in-flight request race leaked a transaction
The sweep could `cancelIfIdle()` (rollback) and remove a session between `getSessionById()` and `HttpSession.execute()` acquiring the session lock; the request then ran on the rolled-back `TransactionContext`, and because the session was already untracked nothing ever committed/rolled back the fresh transaction it began.

Fix: `HttpSession.execute()` re-validates, under the session lock, that the session is still registered before running the callback; otherwise it throws (no callback runs on a swept transaction).

## Defect 3 (MEDIUM) - ownership checked by name only, and after attach
`getSessionById` ignored the `user` param and ownership relied on `ServerSecurityUser.equals` (by name), so a dropped-and-recreated same-name principal could adopt the prior principal's open session.

Fix:
- `HttpSessionManager.getSessionById` enforces ownership **before** attach (returns null for a non-owner).
- New `removeSessionsForUser(name)`; `ServerSecurity.dropUser`/`setUserPassword`/`updateUser` invalidate the principal's live HTTP sessions (rolling back their transactions), so a recreated same-name principal starts clean.

## Acceptance criteria
- [x] After `/commit`/`/rollback` the session id is no longer resolvable; a follow-up write returns an explicit error, not a silent implicit-tx commit.
- [x] A retried `/commit`/`/rollback` is idempotent (204, no 500).
- [x] An idle sweep cannot roll back a session a request is actively using; no leaked transaction under the sweep-vs-request race.
- [x] A recreated-same-name user cannot adopt the prior principal's session.

## Tests
- `Issue5026HttpSessionLifecycleTest` (unit): execute re-validation, ownership, `removeSessionsForUser`, recreated-same-name adoption.
- `Issue5026TransactionSessionLifecycleIT` (HTTP): commit/rollback remove the session, stale-session write rejected (404), retried commit/rollback idempotent (204), drop-user invalidates sessions so a recreated same-name user cannot adopt.

All new tests pass; existing session/security tests remain green (`HTTPTransactionIT`, `Issue4141SessionManagementIT`, `HttpSessionTimeoutRaceTest`, `HTTPAuthSessionIT`, `UserManagementIT`, `AutoCommitParameterTest`, `ServerSecurityUsersConcurrencyTest`). No wire-format change; server module only.