### PR TITLE
fix(#5032): harden ServerQueryProfiler counter, array publication, ring-buffer overflow and hot-path regex

### DIFF
--- a/docs/5032-serverqueryprofiler-racy-counter.md
+++ b/docs/5032-serverqueryprofiler-racy-counter.md
@@ -1,0 +1,25 @@
+# Issue #5032 - ServerQueryProfiler: racy counter, array publication, ring-buffer overflow, per-call regex
+
+## Symptom
+`ServerQueryProfiler` (server module) records queries on an unsynchronized hot path from Undertow workers but has three defects:
+1. `totalRecorded++` on a plain `int` loses updates under concurrency; plain array stores lack happens-before to the `synchronized` readers.
+2. `writeIndex.getAndIncrement() % MAX_ENTRIES` on an `AtomicInteger` goes negative once the counter overflows `Integer.MAX_VALUE`, throwing `ArrayIndexOutOfBoundsException` and killing recording.
+3. `normalizeQuery` compiles the `\s+` regex on every call during aggregation.
+
+## Root cause
+- Non-atomic counter and non-published array in a concurrent producer / synchronized consumer design.
+- Signed 32-bit modulo of an overflowing counter.
+- Regex not hoisted to a constant.
+
+## Fix
+- Replace the separate `totalRecorded` int with a derived count from an `AtomicLong writeIndex` (one increment per record => exact count, no lost updates).
+- Store entries in an `AtomicReferenceArray` so each element write is published to the synchronized readers.
+- Compute the slot with `Math.floorMod(seq, MAX_ENTRIES)` on the `long` sequence so it is always non-negative.
+- Hoist `static final Pattern WHITESPACE = Pattern.compile("\\s+")` and reuse it in `normalizeQuery`.
+
+## Tests (added to ServerQueryProfilerTest)
+- `concurrentRecordingCountsExactly` - N threads x M records, asserts exact `totalQueries` (fails before fix due to lost updates).
+- `ringBufferIndexDoesNotOverflow` - seeds `writeIndex` near `Integer.MAX_VALUE` via reflection (type-agnostic), asserts recording does not throw AIOOBE (fails before fix).
+
+## Impact
+Server monitor profiler only. No behavior change for correct single-threaded use; fixes accuracy under concurrency, long-running robustness, and removes a hot-path allocation.

--- a/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
@@ -39,13 +39,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 public class ServerQueryProfiler {
-  private static final int DEFAULT_TIMEOUT_SECONDS = 60;
-  private static final int MAX_ENTRIES             = 10_000;
-  private static final int MAX_PROFILER_FILES      = 50;
+  private static final int     DEFAULT_TIMEOUT_SECONDS = 60;
+  private static final int     MAX_ENTRIES             = 10_000;
+  private static final int     MAX_PROFILER_FILES      = 50;
+  private static final Pattern WHITESPACE              = Pattern.compile("\\s+");
 
   private final ArcadeDBServer server;
 
@@ -55,9 +58,13 @@ public class ServerQueryProfiler {
   private int     timeoutSeconds;
   private Timer   autoStopTimer;
 
-  private final ProfiledQueryEntry[] entries = new ProfiledQueryEntry[MAX_ENTRIES];
-  private final AtomicInteger        writeIndex = new AtomicInteger(0);
-  private int                        totalRecorded;
+  // The recording hot path (recordQuery) is intentionally unsynchronized and can run concurrently on
+  // many Undertow workers. Visibility to the synchronized readers (stop/buildResults) is established
+  // through the AtomicReferenceArray element writes and the AtomicLong counter. writeIndex is a long
+  // so the ring-buffer slot (floorMod) never goes negative even after 2^31 records, and it doubles as
+  // the exact grand total of recorded queries (one atomic increment per record, no lost updates).
+  private final AtomicReferenceArray<ProfiledQueryEntry> entries    = new AtomicReferenceArray<>(MAX_ENTRIES);
+  private final AtomicLong                               writeIndex = new AtomicLong(0);
 
   private JSONObject snapshotStartProfiler;
   private JSONObject snapshotStartDatabases;
@@ -83,9 +90,8 @@ public class ServerQueryProfiler {
       return;
 
     // Clear previous data
-    Arrays.fill(entries, null);
+    clearEntries();
     writeIndex.set(0);
-    totalRecorded = 0;
     lastResults = null;
     stopTimeMs = 0;
     timeoutSeconds = timeoutSec > 0 ? timeoutSec : DEFAULT_TIMEOUT_SECONDS;
@@ -122,7 +128,7 @@ public class ServerQueryProfiler {
     snapshotStopProfiler = Profiler.INSTANCE.toJSON();
     snapshotStopDatabases = captureDatabaseStats();
 
-    LogManager.instance().log(this, Level.INFO, "Query profiler stopped (%d queries recorded)", totalRecorded);
+    LogManager.instance().log(this, Level.INFO, "Query profiler stopped (%d queries recorded)", writeIndex.get());
 
     lastResults = buildResults();
     persistResults(lastResults);
@@ -132,9 +138,8 @@ public class ServerQueryProfiler {
   public synchronized void reset() {
     recording = false;
     cancelAutoStopTimer();
-    Arrays.fill(entries, null);
+    clearEntries();
     writeIndex.set(0);
-    totalRecorded = 0;
     startTimeMs = 0;
     stopTimeMs = 0;
     snapshotStartProfiler = null;
@@ -160,9 +165,9 @@ public class ServerQueryProfiler {
     final ProfiledQueryEntry entry = new ProfiledQueryEntry(database, language, queryText,
         System.currentTimeMillis(), deserializationNanos, engineNanos, serializationNanos, executionPlan);
 
-    final int idx = writeIndex.getAndIncrement() % MAX_ENTRIES;
-    entries[idx] = entry;
-    totalRecorded++;
+    // floorMod on the long sequence stays non-negative even after the counter passes Integer.MAX_VALUE.
+    final int idx = (int) Math.floorMod(writeIndex.getAndIncrement(), MAX_ENTRIES);
+    entries.set(idx, entry);
   }
 
   public void recordQuery(final String database, final String language, final String queryText,
@@ -226,7 +231,7 @@ public class ServerQueryProfiler {
     result.put("stopTime", stopTimeMs > 0 ? stopTimeMs : System.currentTimeMillis());
     result.put("durationMs", (stopTimeMs > 0 ? stopTimeMs : System.currentTimeMillis()) - startTimeMs);
     result.put("timeoutSeconds", timeoutSeconds);
-    result.put("totalQueries", totalRecorded);
+    result.put("totalQueries", writeIndex.get());
 
     // Names of databases that have at least one recorded query in this window.
     // The Studio summary cards use this to scope DB-specific deltas (queries, commands,
@@ -263,9 +268,9 @@ public class ServerQueryProfiler {
 
   private Set<String> collectProfiledDatabaseNames() {
     final LinkedHashSet<String> names = new LinkedHashSet<>();
-    final int count = Math.min(totalRecorded, MAX_ENTRIES);
+    final int count = (int) Math.min(writeIndex.get(), MAX_ENTRIES);
     for (int i = 0; i < count; i++) {
-      final ProfiledQueryEntry entry = entries[i];
+      final ProfiledQueryEntry entry = entries.get(i);
       if (entry != null && entry.database != null)
         names.add(entry.database);
     }
@@ -275,9 +280,9 @@ public class ServerQueryProfiler {
   private JSONArray aggregateQueries() {
     final Map<String, List<ProfiledQueryEntry>> groups = new HashMap<>();
 
-    final int count = Math.min(totalRecorded, MAX_ENTRIES);
+    final int count = (int) Math.min(writeIndex.get(), MAX_ENTRIES);
     for (int i = 0; i < count; i++) {
-      final ProfiledQueryEntry entry = entries[i];
+      final ProfiledQueryEntry entry = entries.get(i);
       if (entry == null)
         continue;
       final String key = entry.database + "|" + entry.language + "|" + normalizeQuery(entry.queryText);
@@ -469,7 +474,12 @@ public class ServerQueryProfiler {
   }
 
   public static String normalizeQuery(final String query) {
-    return query.replaceAll("\\s+", " ").trim();
+    return WHITESPACE.matcher(query).replaceAll(" ").trim();
+  }
+
+  private void clearEntries() {
+    for (int i = 0; i < MAX_ENTRIES; i++)
+      entries.set(i, null);
   }
 
   private static long sumNanos(final long[] values) {

--- a/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
+++ b/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
@@ -464,8 +464,11 @@ class ServerQueryProfilerTest extends StaticBaseServerTest {
     final Field writeIndexField = ServerQueryProfiler.class.getDeclaredField("writeIndex");
     writeIndexField.setAccessible(true);
     final Object writeIndex = writeIndexField.get(profiler);
+    // Seed each counter type at its own overflow boundary: a long wraps at Long.MAX_VALUE, while the
+    // pre-fix int counter wrapped at Integer.MAX_VALUE. Either way the next getAndIncrement produces a
+    // negative sequence value and, without an overflow-safe modulo, a negative array index.
     if (writeIndex instanceof AtomicLong al)
-      al.set(Integer.MAX_VALUE);
+      al.set(Long.MAX_VALUE);
     else if (writeIndex instanceof AtomicInteger ai)
       ai.set(Integer.MAX_VALUE);
     else

--- a/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
+++ b/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
@@ -34,10 +34,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class ServerQueryProfilerTest extends StaticBaseServerTest {
   private ArcadeDBServer server;
@@ -405,6 +413,72 @@ class ServerQueryProfilerTest extends StaticBaseServerTest {
     for (int i = 0; i < profiledDbs.length(); i++)
       names.add(profiledDbs.getString(i));
     assertThat(names).containsExactlyInAnyOrder("dbA", "dbB", "dbC");
+  }
+
+  @Test
+  void concurrentRecordingCountsExactly() throws InterruptedException {
+    // recordQuery() is an unsynchronized hot path called from many Undertow workers. The total
+    // count must be exact under concurrency: a plain int++ loses updates. The number of records
+    // exceeds MAX_ENTRIES (10_000) so the ring buffer wraps, but the grand total must still be exact.
+    final ServerQueryProfiler profiler = server.getQueryProfiler();
+    profiler.start();
+
+    final int threads = 8;
+    final int perThread = 2_000;
+    final ExecutorService pool = Executors.newFixedThreadPool(threads);
+    final CountDownLatch startGate = new CountDownLatch(1);
+    final CountDownLatch doneGate = new CountDownLatch(threads);
+
+    for (int t = 0; t < threads; t++) {
+      pool.submit(() -> {
+        try {
+          startGate.await();
+          for (int i = 0; i < perThread; i++)
+            profiler.recordQuery("testdb", "sql", "SELECT FROM Person", 1_000_000L, null);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          doneGate.countDown();
+        }
+      });
+    }
+
+    startGate.countDown();
+    assertThat(doneGate.await(60, TimeUnit.SECONDS)).isTrue();
+    pool.shutdownNow();
+
+    final JSONObject results = profiler.stop();
+    assertThat(results.getInt("totalQueries")).isEqualTo(threads * perThread);
+  }
+
+  @Test
+  void ringBufferIndexDoesNotOverflow() throws Exception {
+    // The ring-buffer slot is writeIndex % MAX_ENTRIES. Once the counter overflows Integer.MAX_VALUE
+    // a signed int modulo goes negative, producing a negative array index and an
+    // ArrayIndexOutOfBoundsException that kills recording. Seed the counter near the overflow point
+    // and assert recording keeps working. Reflection is type-agnostic so this test both reproduces
+    // the bug (AtomicInteger) and validates the fix (overflow-safe counter).
+    final ServerQueryProfiler profiler = server.getQueryProfiler();
+    profiler.start();
+
+    final Field writeIndexField = ServerQueryProfiler.class.getDeclaredField("writeIndex");
+    writeIndexField.setAccessible(true);
+    final Object writeIndex = writeIndexField.get(profiler);
+    if (writeIndex instanceof AtomicLong al)
+      al.set(Integer.MAX_VALUE);
+    else if (writeIndex instanceof AtomicInteger ai)
+      ai.set(Integer.MAX_VALUE);
+    else
+      throw new IllegalStateException("Unexpected writeIndex type: " + writeIndex.getClass());
+
+    assertThatCode(() -> {
+      // The first record uses index MAX_VALUE % MAX_ENTRIES (still positive); the next records
+      // cross the overflow boundary and previously produced negative indices.
+      for (int i = 0; i < 10; i++)
+        profiler.recordQuery("testdb", "sql", "SELECT FROM Person", 1_000_000L, null);
+    }).doesNotThrowAnyException();
+
+    assertThat(profiler.stop()).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
Fixes #5032 (2026-07 `server` module audit).

## Problem
`ServerQueryProfiler` records queries on an intentionally unsynchronized hot path (Undertow workers on every command/query when recording is on) while readers (`stop`/`buildResults`) aggregate under a monitor lock. Three defects:

1. **Racy counter + unpublished array (MEDIUM concurrency).** `totalRecorded++` on a plain `int` lost updates under concurrency (undercounted `totalQueries`), and plain array stores into `entries[]` had no happens-before to the synchronized readers, so entries recorded just before `stop()` could be missed.
2. **Ring-buffer index overflow (MEDIUM robustness).** `writeIndex.getAndIncrement() % MAX_ENTRIES` on an `AtomicInteger` goes negative once the counter passes `Integer.MAX_VALUE` (long-lived server with the profiler on), yielding a negative array index and an `ArrayIndexOutOfBoundsException` that kills recording.
3. **Per-call regex compilation (LOW performance).** `normalizeQuery` compiled `\s+` on every aggregation call.

## Fix
- Removed the separate `totalRecorded` field; the count is now derived from an `AtomicLong writeIndex` (one atomic increment per record => exact grand total, no lost updates).
- Store entries in an `AtomicReferenceArray<ProfiledQueryEntry>` so each element write is published to the synchronized readers.
- Compute the slot with `Math.floorMod(writeIndex.getAndIncrement(), MAX_ENTRIES)` on the `long` sequence, which stays non-negative past `Integer.MAX_VALUE`.
- Hoisted `static final Pattern WHITESPACE = Pattern.compile("\\s+")` and reuse it in `normalizeQuery`.

No public API or behavior change for correct single-threaded use.

## Tests
Two regression tests added to `ServerQueryProfilerTest` (verified: **fail before**, **pass after**):
- `concurrentRecordingCountsExactly` - 8 threads x 2,000 records (crosses the 10,000 ring-buffer wrap); asserts `totalQueries` is exactly 16,000.
- `ringBufferIndexDoesNotOverflow` - seeds `writeIndex` at `Integer.MAX_VALUE` (type-agnostic reflection) and asserts recording does not throw `ArrayIndexOutOfBoundsException`.

Full class (20 tests) passes: `mvn -pl server -am test -Dtest=ServerQueryProfilerTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)