### PR TITLE
fix(#5028): backup scheduler & retention correctness (cron OR semantics, validation, cancel race, keep newest)

### DIFF
--- a/docs/5028-backup-scheduler-retention.md
+++ b/docs/5028-backup-scheduler-retention.md
@@ -1,0 +1,29 @@
+# Issue #5028 - Backup scheduler & retention fixes
+
+## Symptom
+Four defects in the `server` backup subsystem:
+1. Cron parser ANDs day-of-month / day-of-week when both restricted (standard cron ORs them) -> backups run far less often than configured.
+2. No field range validation: out-of-range fields (hour 24, dow 7, dom 32...) parse but never match, and `getNextExecutionTime` throws `IllegalStateException` inside the reschedule chain -> all future backups silently stop. Increment `x/0` loops forever, hanging the scheduler thread at config load.
+3. Cancel vs cron-reschedule race: an in-flight `BackupTask` can resurrect a cancelled schedule, leaving duplicate schedules (double backups). Shutdown can throw `RejectedExecutionException` in the worker.
+4. Tiered retention keeps the OLDEST file per bucket and runs right after each backup, so the just-completed newest backup is deleted seconds after creation.
+   - Minor: `BackupTask.performBackup` checks `database.isTransactionActive()` on the backup thread's own thread-local tx, which is never active -> dead code / false confidence.
+
+## Root cause
+- `CronScheduleParser.getNextExecutionTime` uses AND for DOM/DOW and never tracks whether a field is restricted.
+- `parseField`/`parseValue` never bounds-check parsed values or reject non-positive increments.
+- `BackupScheduler.scheduleNextCronExecution` / `cancelBackup` have no generation token; reschedule put can win the race after a cancel. Delay computation and `executor.schedule` are unguarded.
+- `BackupRetentionManager.applyRetention` never unconditionally preserves the most recent file before tier selection.
+
+## Fix
+- CronScheduleParser: track `dayOfMonthRestricted` / `dayOfWeekRestricted`; OR them when both restricted, else AND (wildcards match everything). Validate every value is within `[min,max]`; normalize day-of-week `7` -> Sunday(0); require increment > 0; validate range order and increment token shape.
+- BackupScheduler: per-database generation token guards reschedule/cancel under a single lock; delay computation and `executor.schedule` wrapped in try/catch (impossible schedule stops only that DB with a clear SEVERE log; RejectedExecutionException on shutdown swallowed).
+- BackupRetentionManager: always add the most recent backup to the keep set before deletion.
+- BackupTask: remove the dead active-transaction check.
+
+## Tests
+- `CronScheduleParserSemanticsTest` - OR semantics, range rejection, `x/0` rejection, dow 7 = Sunday, known-good next-fire table.
+- `BackupRetentionNewestBackupTest` - newest backup always survives tiered retention.
+- `BackupSchedulerValidationTest` - invalid cron config fails fast (no schedule, no throw); cancel+reschedule leaves exactly one schedule.
+
+## Impact
+Scoped to `server` backup package. No API changes. Existing tests unchanged.

--- a/server/src/main/java/com/arcadedb/server/backup/BackupRetentionManager.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupRetentionManager.java
@@ -105,6 +105,11 @@ public class BackupRetentionManager {
     else
       filesToKeep = applyMaxFilesRetention(backupFiles, retention.getMaxFiles());
 
+    // Always keep the most recent backup so a just-completed backup is never deleted. Retention
+    // runs immediately after each backup; with tiered buckets keeping the oldest member, the newest
+    // restore point would otherwise be discarded seconds after creation.
+    filesToKeep.add(backupFiles.get(backupFiles.size() - 1).file);
+
     // Delete files not in the keep set
     int deletedCount = 0;
     int failedCount = 0;

--- a/server/src/main/java/com/arcadedb/server/backup/BackupScheduler.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupScheduler.java
@@ -41,7 +41,6 @@ public class BackupScheduler {
   private final    ArcadeDBServer                  server;
   private final    ScheduledExecutorService        executor;
   private final    Map<String, ScheduledFuture<?>> scheduledTasks;
-  private final    Map<String, CronScheduleParser> cronParsers;
   // Per-database generation token: bumped on every (re)schedule and cleared on cancel, so an
   // in-flight cron task cannot resurrect a schedule that was cancelled or superseded.
   private final    Map<String, Long>               cronGenerations = new ConcurrentHashMap<>();
@@ -63,7 +62,6 @@ public class BackupScheduler {
       return t;
     });
     this.scheduledTasks = new ConcurrentHashMap<>();
-    this.cronParsers = new ConcurrentHashMap<>();
     this.running = false;
   }
 
@@ -146,7 +144,6 @@ public class BackupScheduler {
 
     final long generation;
     synchronized (scheduleLock) {
-      cronParsers.put(databaseName, parser);
       generation = generationSequence.incrementAndGet();
       cronGenerations.put(databaseName, generation);
     }
@@ -172,7 +169,6 @@ public class BackupScheduler {
       synchronized (scheduleLock) {
         cronGenerations.remove(databaseName, generation);
         scheduledTasks.remove(databaseName);
-        cronParsers.remove(databaseName);
       }
       return;
     }
@@ -224,7 +220,6 @@ public class BackupScheduler {
         LogManager.instance().log(this, Level.INFO,
             "Cancelled scheduled backup for database '%s'", databaseName);
       }
-      cronParsers.remove(databaseName);
     }
   }
 
@@ -257,7 +252,6 @@ public class BackupScheduler {
       for (final ScheduledFuture<?> future : tasksToCancel)
         future.cancel(false);
       scheduledTasks.clear();
-      cronParsers.clear();
       cronGenerations.clear();
     }
 

--- a/server/src/main/java/com/arcadedb/server/backup/BackupScheduler.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupScheduler.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 /**
@@ -41,6 +42,12 @@ public class BackupScheduler {
   private final    ScheduledExecutorService        executor;
   private final    Map<String, ScheduledFuture<?>> scheduledTasks;
   private final    Map<String, CronScheduleParser> cronParsers;
+  // Per-database generation token: bumped on every (re)schedule and cleared on cancel, so an
+  // in-flight cron task cannot resurrect a schedule that was cancelled or superseded.
+  private final    Map<String, Long>               cronGenerations = new ConcurrentHashMap<>();
+  private final    AtomicLong                      generationSequence = new AtomicLong();
+  // Serializes schedule install / cancel so a reschedule cannot race a concurrent cancel.
+  private final    Object                          scheduleLock = new Object();
   private final    String                          backupDirectory;
   private final    BackupRetentionManager          retentionManager;
   private volatile boolean                         running;
@@ -127,44 +134,79 @@ public class BackupScheduler {
     LogManager.instance().log(this, Level.INFO,
         "Scheduling backup for database '%s' with CRON expression: %s", databaseName, cronExpression);
 
+    final CronScheduleParser parser;
     try {
-      final CronScheduleParser parser = new CronScheduleParser(cronExpression);
-      cronParsers.put(databaseName, parser);
-
-      // Schedule the first execution
-      scheduleNextCronExecution(databaseName, task, parser);
-
+      // Constructing the parser validates the CRON expression (field ranges, increments, ...).
+      parser = new CronScheduleParser(cronExpression);
     } catch (final IllegalArgumentException e) {
       LogManager.instance().log(this, Level.SEVERE,
           "Invalid CRON expression for database '%s': %s", databaseName, e.getMessage());
+      return;
     }
+
+    final long generation;
+    synchronized (scheduleLock) {
+      cronParsers.put(databaseName, parser);
+      generation = generationSequence.incrementAndGet();
+      cronGenerations.put(databaseName, generation);
+    }
+
+    // Schedule the first execution
+    scheduleNextCronExecution(databaseName, task, parser, generation);
   }
 
   private void scheduleNextCronExecution(final String databaseName, final BackupTask task,
-                                         final CronScheduleParser parser) {
+                                         final CronScheduleParser parser, final long generation) {
     if (!running)
       return;
 
-    final long delayMillis = parser.getDelayMillis(LocalDateTime.now());
+    final long delayMillis;
+    try {
+      delayMillis = parser.getDelayMillis(LocalDateTime.now());
+    } catch (final RuntimeException e) {
+      // An impossible schedule (e.g. Feb 30th) must stop only THIS database's chain, not throw
+      // inside the executor task and break rescheduling for everything.
+      LogManager.instance().log(this, Level.SEVERE,
+          "Cannot compute next execution time for database '%s' (CRON '%s'): %s. Automatic backups stopped for this database.",
+          databaseName, parser.getExpression(), e.getMessage());
+      synchronized (scheduleLock) {
+        cronGenerations.remove(databaseName, generation);
+        scheduledTasks.remove(databaseName);
+        cronParsers.remove(databaseName);
+      }
+      return;
+    }
 
     LogManager.instance().log(this, Level.FINE,
         "Next backup for database '%s' scheduled in %d ms", databaseName, delayMillis);
 
-    final ScheduledFuture<?> future = executor.schedule(() -> {
-      try {
-        task.run();
-      } finally {
-        // Schedule the next execution only if still running and parser is still registered
-        // Use atomic get to avoid race condition between containsKey and get
-        if (running) {
-          final CronScheduleParser currentParser = cronParsers.get(databaseName);
-          if (currentParser != null)
-            scheduleNextCronExecution(databaseName, task, currentParser);
-        }
-      }
-    }, delayMillis, TimeUnit.MILLISECONDS);
+    synchronized (scheduleLock) {
+      // Only install if this generation is still current (not cancelled or superseded).
+      final Long current = cronGenerations.get(databaseName);
+      if (!running || current == null || current != generation)
+        return;
 
-    scheduledTasks.put(databaseName, future);
+      try {
+        final ScheduledFuture<?> future = executor.schedule(() -> {
+          try {
+            task.run();
+          } finally {
+            // Reschedule only if this task still owns the current generation.
+            if (running) {
+              final Long g = cronGenerations.get(databaseName);
+              if (g != null && g == generation)
+                scheduleNextCronExecution(databaseName, task, parser, generation);
+            }
+          }
+        }, delayMillis, TimeUnit.MILLISECONDS);
+
+        scheduledTasks.put(databaseName, future);
+      } catch (final RejectedExecutionException e) {
+        // Executor is shutting down; nothing left to schedule.
+        LogManager.instance().log(this, Level.FINE,
+            "Backup scheduler shutting down, skipped rescheduling for database '%s'", databaseName);
+      }
+    }
   }
 
   /**
@@ -173,13 +215,17 @@ public class BackupScheduler {
    * @param databaseName The name of the database
    */
   public void cancelBackup(final String databaseName) {
-    final ScheduledFuture<?> future = scheduledTasks.remove(databaseName);
-    if (future != null) {
-      future.cancel(false);
-      LogManager.instance().log(this, Level.INFO,
-          "Cancelled scheduled backup for database '%s'", databaseName);
+    synchronized (scheduleLock) {
+      // Invalidate any in-flight reschedule for this database first.
+      cronGenerations.remove(databaseName);
+      final ScheduledFuture<?> future = scheduledTasks.remove(databaseName);
+      if (future != null) {
+        future.cancel(false);
+        LogManager.instance().log(this, Level.INFO,
+            "Cancelled scheduled backup for database '%s'", databaseName);
+      }
+      cronParsers.remove(databaseName);
     }
-    cronParsers.remove(databaseName);
   }
 
   /**
@@ -206,11 +252,14 @@ public class BackupScheduler {
     running = false;
 
     // Cancel all scheduled tasks - create copy to avoid ConcurrentModificationException
-    final List<ScheduledFuture<?>> tasksToCancel = new ArrayList<>(scheduledTasks.values());
-    for (final ScheduledFuture<?> future : tasksToCancel)
-      future.cancel(false);
-    scheduledTasks.clear();
-    cronParsers.clear();
+    synchronized (scheduleLock) {
+      final List<ScheduledFuture<?>> tasksToCancel = new ArrayList<>(scheduledTasks.values());
+      for (final ScheduledFuture<?> future : tasksToCancel)
+        future.cancel(false);
+      scheduledTasks.clear();
+      cronParsers.clear();
+      cronGenerations.clear();
+    }
 
     // Shutdown the executor
     executor.shutdown();

--- a/server/src/main/java/com/arcadedb/server/backup/BackupTask.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupTask.java
@@ -19,7 +19,6 @@
 package com.arcadedb.server.backup;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.event.ServerEventLog;
@@ -166,22 +165,11 @@ public class BackupTask implements Runnable {
    * Performs the actual backup using the integration Backup class.
    * <p>
    * Note: The backup mechanism in ArcadeDB reads from immutable pages and handles
-   * consistency internally. The transaction check is a safety warning but does not
-   * block new transactions - the backup is designed to be non-blocking.
+   * consistency internally, so it is safe to run concurrently with active transactions on other
+   * threads - uncommitted changes are simply not included.
    */
   private String performBackup() throws Exception {
     final Database database = server.getDatabase(databaseName);
-
-    // Check for active transaction - warn but don't block
-    // ArcadeDB backup is designed to work on immutable pages, so this is informational
-    if (database.isTransactionActive()) {
-      final DatabaseInternal dbInternal = (DatabaseInternal) database;
-      if (dbInternal.getTransaction().hasChanges()) {
-        LogManager.instance().log(this, Level.WARNING,
-            "Backup for database '%s' starting with active transaction - uncommitted changes will not be included",
-            databaseName);
-      }
-    }
 
     // Generate backup filename
     final String timestamp = LocalDateTime.now().format(BACKUP_TIMESTAMP_FORMAT);

--- a/server/src/main/java/com/arcadedb/server/backup/CronScheduleParser.java
+++ b/server/src/main/java/com/arcadedb/server/backup/CronScheduleParser.java
@@ -52,6 +52,11 @@ public class CronScheduleParser {
   private final BitSet months;      // 1-12
   private final BitSet daysOfWeek;  // 0-6 (Sunday=0)
 
+  // Standard CRON ORs day-of-month and day-of-week when BOTH are restricted; when only one is
+  // restricted the wildcard field is ignored. These flags record whether each field is restricted.
+  private final boolean dayOfMonthRestricted;
+  private final boolean dayOfWeekRestricted;
+
   private final String expression;
 
   public CronScheduleParser(final String expression) {
@@ -63,27 +68,35 @@ public class CronScheduleParser {
     this.months = new BitSet(13);
     this.daysOfWeek = new BitSet(7);
 
-    parse(expression);
-  }
-
-  private void parse(final String expression) {
     final String[] fields = expression.trim().split("\\s+");
 
     if (fields.length != 6)
       throw new IllegalArgumentException(
           "Invalid CRON expression: expected 6 fields (second minute hour day-of-month month day-of-week), got " + fields.length);
 
-    parseField(fields[FIELD_SECOND], seconds, 0, 59, null);
-    parseField(fields[FIELD_MINUTE], minutes, 0, 59, null);
-    parseField(fields[FIELD_HOUR], hours, 0, 23, null);
-    parseField(fields[FIELD_DAY_OF_MONTH], daysOfMonth, 1, 31, null);
-    parseField(fields[FIELD_MONTH], months, 1, 12, new String[]{"JAN", "FEB", "MAR", "APR", "MAY", "JUN",
-        "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"});
-    parseField(fields[FIELD_DAY_OF_WEEK], daysOfWeek, 0, 6, new String[]{"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"});
+    this.dayOfMonthRestricted = !isWildcard(fields[FIELD_DAY_OF_MONTH]);
+    this.dayOfWeekRestricted = !isWildcard(fields[FIELD_DAY_OF_WEEK]);
+
+    parse(fields);
   }
 
-  private void parseField(final String field, final BitSet bitSet, final int min, final int max, final String[] names) {
-    if ("*".equals(field) || "?".equals(field)) {
+  private static boolean isWildcard(final String field) {
+    return "*".equals(field) || "?".equals(field);
+  }
+
+  private void parse(final String[] fields) {
+    parseField(fields[FIELD_SECOND], seconds, 0, 59, null, false);
+    parseField(fields[FIELD_MINUTE], minutes, 0, 59, null, false);
+    parseField(fields[FIELD_HOUR], hours, 0, 23, null, false);
+    parseField(fields[FIELD_DAY_OF_MONTH], daysOfMonth, 1, 31, null, false);
+    parseField(fields[FIELD_MONTH], months, 1, 12, new String[]{"JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+        "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"}, false);
+    parseField(fields[FIELD_DAY_OF_WEEK], daysOfWeek, 0, 6, new String[]{"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}, true);
+  }
+
+  private void parseField(final String field, final BitSet bitSet, final int min, final int max, final String[] names,
+      final boolean dayOfWeek) {
+    if (isWildcard(field)) {
       bitSet.set(min, max + 1);
       return;
     }
@@ -91,15 +104,20 @@ public class CronScheduleParser {
     // Handle lists (comma-separated)
     if (field.contains(",")) {
       for (final String part : field.split(","))
-        parseField(part, bitSet, min, max, names);
+        parseField(part, bitSet, min, max, names, dayOfWeek);
       return;
     }
 
     // Handle increments (e.g., 0/15)
     if (field.contains("/")) {
-      final String[] parts = field.split("/");
-      final int start = "*".equals(parts[0]) ? min : parseValue(parts[0], min, names);
-      final int increment = Integer.parseInt(parts[1]);
+      final String[] parts = field.split("/", -1);
+      if (parts.length != 2)
+        throw new IllegalArgumentException("Invalid CRON increment '" + field + "' in expression '" + expression + "'");
+      final int start = "*".equals(parts[0]) ? min : parseValue(parts[0], min, max, names, dayOfWeek);
+      final int increment = parseInt(parts[1], "increment");
+      if (increment <= 0)
+        throw new IllegalArgumentException(
+            "Invalid CRON increment '" + increment + "' in expression '" + expression + "': must be greater than 0");
       for (int i = start; i <= max; i += increment)
         bitSet.set(i);
       return;
@@ -108,24 +126,51 @@ public class CronScheduleParser {
     // Handle ranges (e.g., 1-5)
     if (field.contains("-")) {
       final String[] parts = field.split("-");
-      final int rangeStart = parseValue(parts[0], min, names);
-      final int rangeEnd = parseValue(parts[1], min, names);
+      if (parts.length != 2)
+        throw new IllegalArgumentException("Invalid CRON range '" + field + "' in expression '" + expression + "'");
+      final int rangeStart = parseValue(parts[0], min, max, names, dayOfWeek);
+      final int rangeEnd = parseValue(parts[1], min, max, names, dayOfWeek);
+      if (rangeStart > rangeEnd)
+        throw new IllegalArgumentException(
+            "Invalid CRON range '" + field + "' in expression '" + expression + "': start is greater than end");
       bitSet.set(rangeStart, rangeEnd + 1);
       return;
     }
 
     // Single value
-    bitSet.set(parseValue(field, min, names));
+    bitSet.set(parseValue(field, min, max, names, dayOfWeek));
   }
 
-  private int parseValue(final String value, final int offset, final String[] names) {
+  private int parseValue(final String value, final int min, final int max, final String[] names, final boolean dayOfWeek) {
+    int result = -1;
     if (names != null) {
       final String upper = value.toUpperCase();
       for (int i = 0; i < names.length; i++)
-        if (names[i].equals(upper))
-          return i + offset;
+        if (names[i].equals(upper)) {
+          result = i + min;
+          break;
+        }
     }
-    return Integer.parseInt(value);
+    if (result < 0)
+      result = parseInt(value, "value");
+
+    // Accept 7 as an alias for Sunday (0), a very common convention.
+    if (dayOfWeek && result == 7)
+      result = 0;
+
+    if (result < min || result > max)
+      throw new IllegalArgumentException(
+          "Invalid CRON value '" + value + "' in expression '" + expression + "': out of range [" + min + "-" + max + "]");
+
+    return result;
+  }
+
+  private int parseInt(final String value, final String what) {
+    try {
+      return Integer.parseInt(value.trim());
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid CRON " + what + " '" + value + "' in expression '" + expression + "'");
+    }
   }
 
   /**
@@ -149,15 +194,16 @@ public class CronScheduleParser {
         continue;
       }
 
-      // Check day of month
-      if (!daysOfMonth.get(next.getDayOfMonth())) {
-        next = next.plusDays(1).withHour(0).withMinute(0).withSecond(0);
-        continue;
-      }
-
-      // Check day of week (convert Java DayOfWeek 1-7 to cron 0-6)
+      // Check day-of-month and day-of-week together. Standard CRON ORs the two fields when both
+      // are restricted; when only one is restricted the wildcard field is ignored (its BitSet is
+      // fully set, so the AND below reduces to the restricted field).
       final int cronDayOfWeek = next.getDayOfWeek().getValue() % 7; // Sunday=7 becomes 0
-      if (!daysOfWeek.get(cronDayOfWeek)) {
+      final boolean domMatches = daysOfMonth.get(next.getDayOfMonth());
+      final boolean dowMatches = daysOfWeek.get(cronDayOfWeek);
+      final boolean dayMatches = (dayOfMonthRestricted && dayOfWeekRestricted)
+          ? (domMatches || dowMatches)
+          : (domMatches && dowMatches);
+      if (!dayMatches) {
         next = next.plusDays(1).withHour(0).withMinute(0).withSecond(0);
         continue;
       }

--- a/server/src/main/java/com/arcadedb/server/backup/CronScheduleParser.java
+++ b/server/src/main/java/com/arcadedb/server/backup/CronScheduleParser.java
@@ -66,7 +66,7 @@ public class CronScheduleParser {
     this.hours = new BitSet(24);
     this.daysOfMonth = new BitSet(32);
     this.months = new BitSet(13);
-    this.daysOfWeek = new BitSet(7);
+    this.daysOfWeek = new BitSet(8); // 0-7, where both 0 and 7 mean Sunday
 
     final String[] fields = expression.trim().split("\\s+");
 
@@ -85,17 +85,22 @@ public class CronScheduleParser {
   }
 
   private void parse(final String[] fields) {
-    parseField(fields[FIELD_SECOND], seconds, 0, 59, null, false);
-    parseField(fields[FIELD_MINUTE], minutes, 0, 59, null, false);
-    parseField(fields[FIELD_HOUR], hours, 0, 23, null, false);
-    parseField(fields[FIELD_DAY_OF_MONTH], daysOfMonth, 1, 31, null, false);
+    parseField(fields[FIELD_SECOND], seconds, 0, 59, null);
+    parseField(fields[FIELD_MINUTE], minutes, 0, 59, null);
+    parseField(fields[FIELD_HOUR], hours, 0, 23, null);
+    parseField(fields[FIELD_DAY_OF_MONTH], daysOfMonth, 1, 31, null);
     parseField(fields[FIELD_MONTH], months, 1, 12, new String[]{"JAN", "FEB", "MAR", "APR", "MAY", "JUN",
-        "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"}, false);
-    parseField(fields[FIELD_DAY_OF_WEEK], daysOfWeek, 0, 6, new String[]{"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}, true);
+        "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"});
+    // Day-of-week accepts 0-7 where both 0 and 7 mean Sunday, so ranges such as "1-7" (Mon-Sun) and
+    // the lone value "7" are valid. Bit 7 is folded onto bit 0 after the whole field is parsed.
+    parseField(fields[FIELD_DAY_OF_WEEK], daysOfWeek, 0, 7, new String[]{"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"});
+    if (daysOfWeek.get(7)) {
+      daysOfWeek.set(0);
+      daysOfWeek.clear(7);
+    }
   }
 
-  private void parseField(final String field, final BitSet bitSet, final int min, final int max, final String[] names,
-      final boolean dayOfWeek) {
+  private void parseField(final String field, final BitSet bitSet, final int min, final int max, final String[] names) {
     if (isWildcard(field)) {
       bitSet.set(min, max + 1);
       return;
@@ -104,7 +109,7 @@ public class CronScheduleParser {
     // Handle lists (comma-separated)
     if (field.contains(",")) {
       for (final String part : field.split(","))
-        parseField(part, bitSet, min, max, names, dayOfWeek);
+        parseField(part, bitSet, min, max, names);
       return;
     }
 
@@ -113,7 +118,7 @@ public class CronScheduleParser {
       final String[] parts = field.split("/", -1);
       if (parts.length != 2)
         throw new IllegalArgumentException("Invalid CRON increment '" + field + "' in expression '" + expression + "'");
-      final int start = "*".equals(parts[0]) ? min : parseValue(parts[0], min, max, names, dayOfWeek);
+      final int start = "*".equals(parts[0]) ? min : parseValue(parts[0], min, max, names);
       final int increment = parseInt(parts[1], "increment");
       if (increment <= 0)
         throw new IllegalArgumentException(
@@ -128,8 +133,8 @@ public class CronScheduleParser {
       final String[] parts = field.split("-");
       if (parts.length != 2)
         throw new IllegalArgumentException("Invalid CRON range '" + field + "' in expression '" + expression + "'");
-      final int rangeStart = parseValue(parts[0], min, max, names, dayOfWeek);
-      final int rangeEnd = parseValue(parts[1], min, max, names, dayOfWeek);
+      final int rangeStart = parseValue(parts[0], min, max, names);
+      final int rangeEnd = parseValue(parts[1], min, max, names);
       if (rangeStart > rangeEnd)
         throw new IllegalArgumentException(
             "Invalid CRON range '" + field + "' in expression '" + expression + "': start is greater than end");
@@ -138,10 +143,10 @@ public class CronScheduleParser {
     }
 
     // Single value
-    bitSet.set(parseValue(field, min, max, names, dayOfWeek));
+    bitSet.set(parseValue(field, min, max, names));
   }
 
-  private int parseValue(final String value, final int min, final int max, final String[] names, final boolean dayOfWeek) {
+  private int parseValue(final String value, final int min, final int max, final String[] names) {
     int result = -1;
     if (names != null) {
       final String upper = value.toUpperCase();
@@ -153,10 +158,6 @@ public class CronScheduleParser {
     }
     if (result < 0)
       result = parseInt(value, "value");
-
-    // Accept 7 as an alias for Sunday (0), a very common convention.
-    if (dayOfWeek && result == 7)
-      result = 0;
 
     if (result < min || result > max)
       throw new IllegalArgumentException(

--- a/server/src/test/java/com/arcadedb/server/backup/BackupRetentionNewestBackupTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupRetentionNewestBackupTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5028 defect 4: tiered retention must never delete the most recent
+ * backup, otherwise the just-completed backup is discarded seconds after creation.
+ */
+class BackupRetentionNewestBackupTest {
+  private static final DateTimeFormatter BACKUP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+  private static final String            DATABASE_NAME = "testdb";
+
+  @TempDir
+  Path tempDir;
+
+  private BackupRetentionManager retentionManager;
+  private File                   dbBackupDir;
+
+  @BeforeEach
+  void setUp() {
+    retentionManager = new BackupRetentionManager(tempDir.toString());
+    dbBackupDir = new File(tempDir.toFile(), DATABASE_NAME);
+    dbBackupDir.mkdirs();
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(tempDir.toFile());
+  }
+
+  /**
+   * Three backups on the same day at different hours, with a daily-only tier of 1. The daily tier
+   * keeps the OLDEST member of the day bucket, so without the fix the two newer backups (including
+   * the newest restore point) would be deleted immediately. The newest must always survive.
+   */
+  @Test
+  void newestBackupSurvivesTieredDailyRetention() throws Exception {
+    final LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
+
+    final File oldest = createBackupFile(now.minusHours(2));
+    final File middle = createBackupFile(now.minusHours(1));
+    final File newest = createBackupFile(now);
+
+    final DatabaseBackupConfig config = new DatabaseBackupConfig(DATABASE_NAME);
+    final DatabaseBackupConfig.RetentionConfig retention = new DatabaseBackupConfig.RetentionConfig();
+    final DatabaseBackupConfig.TieredConfig tiered = new DatabaseBackupConfig.TieredConfig();
+    tiered.setHourly(0);
+    tiered.setDaily(1);
+    tiered.setWeekly(0);
+    tiered.setMonthly(0);
+    tiered.setYearly(0);
+    retention.setTiered(tiered);
+    config.setRetention(retention);
+
+    retentionManager.registerDatabase(DATABASE_NAME, config);
+
+    retentionManager.applyRetention(DATABASE_NAME);
+
+    // The newest backup must never be deleted, regardless of tier bucketing.
+    assertThat(newest.exists()).as("newest backup must survive retention").isTrue();
+    // The daily tier still keeps its (oldest) bucket member.
+    assertThat(oldest.exists()).as("oldest daily-tier member kept").isTrue();
+    // The middle one is the only expendable file.
+    assertThat(middle.exists()).as("middle backup pruned").isFalse();
+  }
+
+  private File createBackupFile(final LocalDateTime timestamp) throws IOException {
+    final String filename = DATABASE_NAME + "-backup-" + timestamp.format(BACKUP_FORMAT) + ".zip";
+    final File file = new File(dbBackupDir, filename);
+    Files.write(file.toPath(), "test backup content".getBytes());
+    return file;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/backup/BackupRetentionNewestBackupTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupRetentionNewestBackupTest.java
@@ -66,7 +66,9 @@ class BackupRetentionNewestBackupTest {
    */
   @Test
   void newestBackupSurvivesTieredDailyRetention() throws Exception {
-    final LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
+    // Fixed date at noon so all three files always fall in the same day bucket (a floating
+    // LocalDateTime.now() near midnight could split them across two days and skew the assertions).
+    final LocalDateTime now = LocalDateTime.of(2026, 7, 15, 12, 0, 0);
 
     final File oldest = createBackupFile(now.minusHours(2));
     final File middle = createBackupFile(now.minusHours(1));

--- a/server/src/test/java/com/arcadedb/server/backup/BackupSchedulerValidationTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupSchedulerValidationTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression tests for issue #5028 defects 2 and 3: an invalid CRON config must fail fast (no
+ * schedule, no propagated exception) instead of silently stopping backups, and a cancel followed by
+ * a reschedule must not leave a duplicate schedule.
+ */
+class BackupSchedulerValidationTest {
+
+  @TempDir
+  Path tempDir;
+
+  private BackupScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler = new BackupScheduler(null, tempDir.toString(), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (scheduler != null && scheduler.isRunning())
+      scheduler.stop();
+  }
+
+  /**
+   * A CRON expression with an out-of-range field (hour 24) can never match. Before the fix this
+   * scheduled a task whose first delay computation threw and killed the reschedule chain (or
+   * propagated an unchecked exception to the caller). After the fix it must be rejected up front:
+   * no exception escapes and nothing is scheduled.
+   */
+  @Test
+  void invalidCronRangeFailsFastWithoutScheduling() {
+    scheduler.start();
+
+    final DatabaseBackupConfig config = createCronConfig("testdb", "0 0 24 * * *");
+
+    assertThatCode(() -> scheduler.scheduleBackup("testdb", config)).doesNotThrowAnyException();
+    assertThat(scheduler.getScheduledCount()).isEqualTo(0);
+  }
+
+  @Test
+  void zeroIncrementCronFailsFastWithoutScheduling() {
+    scheduler.start();
+
+    final DatabaseBackupConfig config = createCronConfig("testdb", "0 0/0 * * * *");
+
+    assertThatCode(() -> scheduler.scheduleBackup("testdb", config)).doesNotThrowAnyException();
+    assertThat(scheduler.getScheduledCount()).isEqualTo(0);
+  }
+
+  /**
+   * Cancelling then rescheduling the same database must leave exactly one active schedule, never a
+   * resurrected duplicate.
+   */
+  @Test
+  void cancelThenRescheduleLeavesSingleSchedule() {
+    scheduler.start();
+
+    scheduler.scheduleBackup("testdb", createCronConfig("testdb", "0 0 3 * * *"));
+    assertThat(scheduler.getScheduledCount()).isEqualTo(1);
+
+    scheduler.cancelBackup("testdb");
+    assertThat(scheduler.getScheduledCount()).isEqualTo(0);
+
+    scheduler.scheduleBackup("testdb", createCronConfig("testdb", "0 0 4 * * *"));
+    assertThat(scheduler.getScheduledCount()).isEqualTo(1);
+  }
+
+  /**
+   * Repeated schedule/cancel cycles must never accumulate more than a single schedule per database.
+   */
+  @Test
+  void repeatedScheduleCancelDoesNotAccumulate() {
+    scheduler.start();
+
+    for (int i = 0; i < 20; i++) {
+      scheduler.scheduleBackup("testdb", createCronConfig("testdb", "0 0 2 * * *"));
+      assertThat(scheduler.getScheduledCount()).isEqualTo(1);
+      scheduler.cancelBackup("testdb");
+      assertThat(scheduler.getScheduledCount()).isEqualTo(0);
+    }
+  }
+
+  private DatabaseBackupConfig createCronConfig(final String databaseName, final String cronExpression) {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig(databaseName);
+
+    final DatabaseBackupConfig.ScheduleConfig schedule = new DatabaseBackupConfig.ScheduleConfig();
+    schedule.setType(DatabaseBackupConfig.ScheduleConfig.Type.CRON);
+    schedule.setCronExpression(cronExpression);
+    config.setSchedule(schedule);
+
+    return config;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/backup/CronScheduleParserSemanticsTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/CronScheduleParserSemanticsTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
+
+/**
+ * Regression tests for issue #5028: correct CRON day-of-month / day-of-week semantics and field
+ * range validation.
+ */
+class CronScheduleParserSemanticsTest {
+
+  /**
+   * Defect 1: when both day-of-month and day-of-week are restricted, standard CRON ORs them.
+   * "0 0 2 1 * MON" must fire on the 1st of the month OR on any Monday, whichever comes first.
+   */
+  @Test
+  void domAndDowBothRestrictedUsesOrSemantics() {
+    final CronScheduleParser parser = new CronScheduleParser("0 0 2 1 * MON");
+
+    // 15th Jan 2024 is a Monday; the next Monday (22nd) comes well before the next 1st (Feb 1st).
+    final LocalDateTime from = LocalDateTime.of(2024, 1, 15, 10, 0, 0);
+    final LocalDateTime next = parser.getNextExecutionTime(from);
+
+    // OR semantics -> next Monday 22nd Jan at 02:00 (NOT April 1st, which is the AND result).
+    assertThat(next).isEqualTo(LocalDateTime.of(2024, 1, 22, 2, 0, 0));
+  }
+
+  @Test
+  void domOrDowFiresOnFirstOfMonthEvenWhenNotMatchingDow() {
+    // Fires on day 15 OR on Wednesday. From a Monday, the nearest match is the DOM=15 side.
+    final CronScheduleParser parser = new CronScheduleParser("0 0 0 15 * WED");
+
+    final LocalDateTime from = LocalDateTime.of(2024, 1, 8, 10, 0, 0); // Monday 8th Jan
+    final LocalDateTime next = parser.getNextExecutionTime(from);
+
+    // Wednesday 10th Jan 2024 comes before the 15th -> DOW side wins here.
+    assertThat(next).isEqualTo(LocalDateTime.of(2024, 1, 10, 0, 0, 0));
+  }
+
+  /**
+   * Defect 2: out-of-range fields must be rejected at parse time with a clear error rather than
+   * parsing silently and never matching.
+   */
+  @Test
+  void rejectsHour24() {
+    assertThatThrownBy(() -> new CronScheduleParser("0 0 24 * * *"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("24");
+  }
+
+  @Test
+  void rejectsMinute60() {
+    assertThatThrownBy(() -> new CronScheduleParser("0 60 * * * *"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void rejectsDayOfMonth32() {
+    assertThatThrownBy(() -> new CronScheduleParser("0 0 0 32 * *"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void rejectsMonth13() {
+    assertThatThrownBy(() -> new CronScheduleParser("0 0 0 1 13 *"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void rejectsDayOfWeek8() {
+    assertThatThrownBy(() -> new CronScheduleParser("0 0 0 * * 8"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * Defect 2: increment of zero must be rejected instead of looping forever (i += 0).
+   */
+  @Test
+  void rejectsZeroIncrement() {
+    assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+        assertThatThrownBy(() -> new CronScheduleParser("0 0/0 * * * *"))
+            .isInstanceOf(IllegalArgumentException.class));
+  }
+
+  @Test
+  void rejectsNegativeIncrement() {
+    assertThatThrownBy(() -> new CronScheduleParser("0 0/-1 * * * *"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * Day-of-week 7 is a very common way to express Sunday; it must be accepted as Sunday(0)
+   * rather than silently never matching.
+   */
+  @Test
+  void dayOfWeek7IsSunday() {
+    final CronScheduleParser parser = new CronScheduleParser("0 0 4 * * 7");
+
+    // 15th Jan 2024 is a Monday; next Sunday is 21st Jan.
+    final LocalDateTime from = LocalDateTime.of(2024, 1, 15, 10, 0, 0);
+    final LocalDateTime next = parser.getNextExecutionTime(from);
+
+    assertThat(next).isEqualTo(LocalDateTime.of(2024, 1, 21, 4, 0, 0));
+  }
+
+  /**
+   * A small table of known-good expressions and their expected next fire time.
+   */
+  @Test
+  void knownGoodNextFireTimes() {
+    final LocalDateTime base = LocalDateTime.of(2024, 3, 10, 12, 30, 15); // Sunday
+
+    assertThat(new CronScheduleParser("0 0 0 * * *").getNextExecutionTime(base))
+        .isEqualTo(LocalDateTime.of(2024, 3, 11, 0, 0, 0)); // next midnight
+
+    assertThat(new CronScheduleParser("0 0 * * * *").getNextExecutionTime(base))
+        .isEqualTo(LocalDateTime.of(2024, 3, 10, 13, 0, 0)); // next top of hour
+
+    assertThat(new CronScheduleParser("0 0/15 * * * *").getNextExecutionTime(base))
+        .isEqualTo(LocalDateTime.of(2024, 3, 10, 12, 45, 0)); // next quarter hour
+
+    assertThat(new CronScheduleParser("0 0 0 1 * *").getNextExecutionTime(base))
+        .isEqualTo(LocalDateTime.of(2024, 4, 1, 0, 0, 0)); // first of next month
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/backup/CronScheduleParserSemanticsTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/CronScheduleParserSemanticsTest.java
@@ -129,6 +129,23 @@ class CronScheduleParserSemanticsTest {
   }
 
   /**
+   * A day-of-week range that ends in 7 (Sunday) must be accepted: "1-7" means Monday through Sunday,
+   * i.e. every day. Folding 7 to 0 at value level would wrongly reject this as start &gt; end.
+   */
+  @Test
+  void dayOfWeekRangeEndingInSevenMeansEveryDay() {
+    final CronScheduleParser parser = new CronScheduleParser("0 0 0 * * 1-7");
+
+    // From any day, the next fire is simply the next midnight (every day matches).
+    final LocalDateTime from = LocalDateTime.of(2024, 1, 15, 10, 0, 0); // Monday
+    assertThat(parser.getNextExecutionTime(from)).isEqualTo(LocalDateTime.of(2024, 1, 16, 0, 0, 0));
+
+    // Sunday is included via the 7 endpoint.
+    final LocalDateTime saturday = LocalDateTime.of(2024, 1, 20, 10, 0, 0);
+    assertThat(parser.getNextExecutionTime(saturday)).isEqualTo(LocalDateTime.of(2024, 1, 21, 0, 0, 0));
+  }
+
+  /**
    * A small table of known-good expressions and their expected next fire time.
    */
   @Test


### PR DESCRIPTION
## What does this PR do?

Fixes the four scheduling and retention defects in the `server` backup subsystem reported in the 2026-07 server audit (#5028):

1. **Cron OR semantics** - `CronScheduleParser` now ORs day-of-month and day-of-week when both fields are restricted (standard cron), instead of ANDing them. Before, `0 0 2 1 * MON` fired only when the 1st of the month was a Monday.
2. **Field validation / fail-fast** - every field value is bounds-checked at parse time, day-of-week `7` is normalized to Sunday(0), non-positive increments (`x/0`) and malformed range/increment tokens are rejected. An invalid expression now fails fast with a clear message instead of silently never matching (or looping forever on `x/0`).
3. **Cancel vs cron-reschedule race** - reschedule/cancel are guarded by a per-database generation token under a single lock, so an in-flight `BackupTask` can no longer resurrect a cancelled or superseded schedule (no duplicate/double backups). The next-execution computation and `executor.schedule` are wrapped so an impossible schedule stops only that database (clear SEVERE log) and a shutdown `RejectedExecutionException` is swallowed.
4. **Retention keeps newest** - `BackupRetentionManager` always keeps the most recent backup before applying tier selection, so tiered retention can never delete the just-completed newest backup.

Also removes the dead active-transaction check in `BackupTask.performBackup` that inspected the backup thread's own thread-local transaction (never active), which gave false confidence.

## Motivation

These are correctness / data-protection defects: mis-scheduled or silently-stopped backups, and retention that discards the newest restore point.

## Related issues

Fixes #5028

## Additional Notes

- Regression tests added under `server/src/test/java/.../backup/`: `CronScheduleParserSemanticsTest`, `BackupRetentionNewestBackupTest`, `BackupSchedulerValidationTest`. They fail on the pre-fix source (verified: 10 failures + 1 error) and pass with the fix.
- No public API changes; existing backup tests are unchanged and still green (124 tests in the backup package pass).

## Checklist

- [x] I have run the build using `mvn clean package` command (scoped to the `server` module and affected tests)
- [x] My unit tests cover both failure and success scenarios
