### PR TITLE
fix(#5044): encode Java arrays as gRPC lists and guard null decode in value converters

### DIFF
--- a/docs/5044-grpc-value-encoders.md
+++ b/docs/5044-grpc-value-encoders.md
@@ -1,0 +1,51 @@
+# Issue #5044 - gRPC value encoder/decoder divergences
+
+## Symptom
+Three near-identical Java <-> protobuf value encoders diverge in branch coverage,
+producing silent data corruption. Highest priority (COR-8): the gRPC **client**
+encoder (`ProtoUtils.toGrpcValue`) has no array branch, so writing a vector
+(`float[]`) property sends `String.valueOf(float[])` (e.g. `"[F@6d03e736"`),
+destroying the vector.
+
+## Root cause
+- `ProtoUtils.toGrpcValue` (client) handles `Collection` but not Java arrays.
+  Primitive/object arrays (`float[]`, `double[]`, `int[]`, `long[]`, `Object[]`)
+  are not `Collection`s, so they fall through to the `String.valueOf(...)` fallback.
+- `GrpcTypeConverter.toGrpcValue` (the dead-in-production static converter that the
+  unit test validates) has the same array gap.
+- `ProtoUtils.fromGrpcValue` lacks the `if (v == null)` guard the other two decoders
+  have, so a null `GrpcValue` NPEs instead of decoding to `null` (COR-16, part).
+
+## Fix
+- `ProtoUtils.toGrpcValue`: add a generic array branch (via `java.lang.reflect.Array`)
+  that encodes any Java array - including `float[]`/`double[]` vectors - as a
+  `GrpcList`, mirroring the `Collection` branch. `byte[]` keeps its existing
+  dedicated `BYTES` branch (checked earlier).
+- `ProtoUtils.fromGrpcValue`: add the `if (v == null) return null;` guard.
+- `GrpcTypeConverter.toGrpcValue`: add the same generic array branch so the
+  matrix cell converges and the unit test validates array handling.
+
+## Tests
+- `grpc-client` `ProtoUtilsArrayEncoderTest` - `float[]`/`double[]`/`int[]`/`long[]`/
+  `Object[]` encode to `LIST` and round-trip to a numeric list; null `GrpcValue`
+  decodes to `null` without NPE.
+- `grpcw` `GrpcTypeConverterArrayEncoderTest` - `float[]`/`double[]` encode to `LIST`.
+
+## Impact
+Client-side vector writes and any array-valued property now round-trip as lists
+instead of corrupting to a string. No behavior change for existing scalar/collection
+paths. Fixes are additive branches; no existing test modified.
+
+## Deferred (out of scope for this PR - documented for the maintainer)
+- **COR-9 (LINK decode -> RID on the client).** Making `ProtoUtils.fromGrpcValue`
+  return a `RID` instead of the rid `String` would break the existing
+  `ProtoUtilsTest.fromGrpcValueLink` assertion, which codifies the current String
+  behavior. Changing an existing test is out of bounds for this workflow; left to
+  the maintainer.
+- **COR-7 (embedded-document type loss) and COR-13 (server param `logical_type=="json"`
+  BYTES).** These live on the server path (`ArcadeDbGrpcService`, ~4590 lines) and the
+  insert paths (`applyGrpcRecord`/`toPropertyArray`); verifying them properly needs an
+  end-to-end server integration harness rather than an encoder unit test.
+- **Full single-encoder consolidation.** `grpc-client` cannot depend on `grpcw`
+  (server) in compile scope, so a literally-shared encoder is architecturally
+  constrained; convergence here is by matching branches, not by deletion.

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
@@ -37,6 +37,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.arcadedb.log.LogManager;
 
+import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -353,10 +354,24 @@ public class ProtoUtils {
       return dbgEnc("toGrpcValue", value, GrpcValue.newBuilder().setListValue(lb.build()).build());
     }
 
+    // Java arrays (e.g. float[]/double[] vectors, int[], long[], Object[]) are not Collections, so
+    // without this branch they would fall through to the String.valueOf(...) fallback below and
+    // corrupt the value (e.g. "[F@6d03e736"). byte[] keeps its dedicated BYTES branch above.
+    if (value.getClass().isArray()) {
+      GrpcList.Builder lb = GrpcList.newBuilder();
+      final int len = Array.getLength(value);
+      for (int i = 0; i < len; i++)
+        lb.addValues(toGrpcValue(Array.get(value, i)));
+      return dbgEnc("toGrpcValue", value, GrpcValue.newBuilder().setListValue(lb.build()).build());
+    }
+
     return dbgEnc("toGrpcValue", value, GrpcValue.newBuilder().setStringValue(String.valueOf(value)).build());
   }
 
   public static Object fromGrpcValue(GrpcValue v) {
+
+    if (v == null)
+      return dbgDec("fromGrpcValue", v, null);
 
     switch (v.getKindCase()) {
     case BOOL_VALUE:

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsArrayEncoderTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsArrayEncoderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc.utils;
+
+import com.arcadedb.server.grpc.GrpcValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Regression tests for issue #5044 (COR-8 + COR-16, client encoder path).
+ * <p>
+ * Java arrays - in particular {@code float[]}/{@code double[]} vectors - had no branch in
+ * {@link ProtoUtils#toGrpcValue(Object)}, so they fell through to the {@code String.valueOf(...)}
+ * fallback (e.g. {@code "[F@6d03e736"}), destroying the value. They must encode to a
+ * {@code GrpcList} exactly like a {@link java.util.Collection} does.
+ * <p>
+ * {@link ProtoUtils#fromGrpcValue(GrpcValue)} also lacked the null guard the other two decoders
+ * have, so a {@code null} input threw an NPE instead of decoding to {@code null}.
+ */
+class ProtoUtilsArrayEncoderTest {
+
+  @Test
+  void floatArrayEncodesToListNotString() {
+    final float[] vector = { 0.1f, 0.2f, 0.3f };
+
+    final GrpcValue value = ProtoUtils.toGrpcValue(vector);
+
+    assertThat(value.hasListValue()).as("float[] vector must serialize to LIST_VALUE, not STRING_VALUE").isTrue();
+    assertThat(value.getListValue().getValuesCount()).isEqualTo(3);
+    assertThat(value.getListValue().getValues(0).getFloatValue()).isCloseTo(0.1f, within(0.0001f));
+    assertThat(value.getListValue().getValues(2).getFloatValue()).isCloseTo(0.3f, within(0.0001f));
+  }
+
+  @Test
+  void floatArrayRoundTripsToNumericList() {
+    final float[] vector = { 1.5f, 2.5f, 3.5f };
+
+    final Object decoded = ProtoUtils.fromGrpcValue(ProtoUtils.toGrpcValue(vector));
+
+    assertThat(decoded).isInstanceOf(List.class);
+    @SuppressWarnings("unchecked")
+    final List<Object> list = (List<Object>) decoded;
+    assertThat(list).hasSize(3);
+    assertThat((Float) list.get(0)).isCloseTo(1.5f, within(0.0001f));
+    assertThat((Float) list.get(1)).isCloseTo(2.5f, within(0.0001f));
+    assertThat((Float) list.get(2)).isCloseTo(3.5f, within(0.0001f));
+  }
+
+  @Test
+  void doubleArrayEncodesToList() {
+    final double[] vector = { 0.25, 0.5, 0.75 };
+
+    final GrpcValue value = ProtoUtils.toGrpcValue(vector);
+
+    assertThat(value.hasListValue()).as("double[] vector must serialize to LIST_VALUE").isTrue();
+    assertThat(value.getListValue().getValuesCount()).isEqualTo(3);
+    assertThat(value.getListValue().getValues(1).getDoubleValue()).isCloseTo(0.5, within(0.000001));
+  }
+
+  @Test
+  void intArrayEncodesToList() {
+    final int[] ints = { 10, 20, 30 };
+
+    final GrpcValue value = ProtoUtils.toGrpcValue(ints);
+
+    assertThat(value.hasListValue()).isTrue();
+    assertThat(value.getListValue().getValuesCount()).isEqualTo(3);
+    assertThat(value.getListValue().getValues(0).getInt32Value()).isEqualTo(10);
+    assertThat(value.getListValue().getValues(2).getInt32Value()).isEqualTo(30);
+  }
+
+  @Test
+  void longArrayEncodesToList() {
+    final long[] longs = { 1L, 9876543210L };
+
+    final GrpcValue value = ProtoUtils.toGrpcValue(longs);
+
+    assertThat(value.hasListValue()).isTrue();
+    assertThat(value.getListValue().getValuesCount()).isEqualTo(2);
+    assertThat(value.getListValue().getValues(1).getInt64Value()).isEqualTo(9876543210L);
+  }
+
+  @Test
+  void objectArrayEncodesToList() {
+    final Object[] mixed = { 1, "two", 3.0 };
+
+    final GrpcValue value = ProtoUtils.toGrpcValue(mixed);
+
+    assertThat(value.hasListValue()).isTrue();
+    assertThat(value.getListValue().getValuesCount()).isEqualTo(3);
+    assertThat(value.getListValue().getValues(0).getInt32Value()).isEqualTo(1);
+    assertThat(value.getListValue().getValues(1).getStringValue()).isEqualTo("two");
+    assertThat(value.getListValue().getValues(2).getDoubleValue()).isCloseTo(3.0, within(0.000001));
+  }
+
+  @Test
+  void byteArrayStillEncodesToBytes() {
+    // byte[] keeps its dedicated BYTES branch (checked before the generic array branch).
+    final byte[] bytes = { 1, 2, 3 };
+
+    final GrpcValue value = ProtoUtils.toGrpcValue(bytes);
+
+    assertThat(value.hasBytesValue()).as("byte[] must remain BYTES_VALUE, not LIST_VALUE").isTrue();
+    assertThat(value.getBytesValue().toByteArray()).isEqualTo(bytes);
+  }
+
+  @Test
+  void fromGrpcValueNullReturnsNullWithoutNpe() {
+    // COR-16: fromGrpcValue lacked the null guard the other two decoders have.
+    assertThat(ProtoUtils.fromGrpcValue(null)).isNull();
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.RID;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 
+import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.math.BigInteger;
@@ -201,6 +202,17 @@ class GrpcTypeConverter {
       final GrpcList.Builder lb = GrpcList.newBuilder();
       for (final Object item : list)
         lb.addValues(toGrpcValue(item));
+      return b.setListValue(lb.build()).build();
+    }
+
+    // Java arrays (e.g. float[]/double[] vectors, int[], long[], Object[]) are not Lists, so without
+    // this branch they would fall through to the String.valueOf(...) fallback below and corrupt the
+    // value (e.g. "[F@6d03e736"). byte[] keeps its dedicated BYTES branch above.
+    if (o.getClass().isArray()) {
+      final GrpcList.Builder lb = GrpcList.newBuilder();
+      final int len = Array.getLength(o);
+      for (int i = 0; i < len; i++)
+        lb.addValues(toGrpcValue(Array.get(o, i)));
       return b.setListValue(lb.build()).build();
     }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTypeConverterArrayEncoderTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTypeConverterArrayEncoderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Regression tests for issue #5044 (COR-8, static converter path).
+ * <p>
+ * {@link GrpcTypeConverter#toGrpcValue(Object)} handled {@link java.util.List} but not Java arrays,
+ * so a {@code float[]}/{@code double[]} vector fell through to the {@code String.valueOf(...)}
+ * fallback. Arrays must encode to a {@code GrpcList}, matching the live server encoder.
+ */
+class GrpcTypeConverterArrayEncoderTest {
+
+  @Test
+  void floatArrayEncodesToListNotString() {
+    final float[] vector = { 0.1f, 0.2f, 0.3f };
+
+    final GrpcValue value = GrpcTypeConverter.toGrpcValue(vector);
+
+    assertThat(value.hasListValue()).as("float[] vector must serialize to LIST_VALUE, not STRING_VALUE").isTrue();
+    assertThat(value.getListValue().getValuesCount()).isEqualTo(3);
+    assertThat(value.getListValue().getValues(0).getFloatValue()).isCloseTo(0.1f, within(0.0001f));
+    assertThat(value.getListValue().getValues(2).getFloatValue()).isCloseTo(0.3f, within(0.0001f));
+  }
+
+  @Test
+  void doubleArrayEncodesToList() {
+    final double[] vector = { 0.25, 0.5, 0.75 };
+
+    final GrpcValue value = GrpcTypeConverter.toGrpcValue(vector);
+
+    assertThat(value.hasListValue()).as("double[] vector must serialize to LIST_VALUE").isTrue();
+    assertThat(value.getListValue().getValuesCount()).isEqualTo(3);
+    assertThat(value.getListValue().getValues(1).getDoubleValue()).isCloseTo(0.5, within(0.000001));
+  }
+
+  @Test
+  void intArrayEncodesToList() {
+    final int[] ints = { 10, 20, 30 };
+
+    final GrpcValue value = GrpcTypeConverter.toGrpcValue(ints);
+
+    assertThat(value.hasListValue()).isTrue();
+    assertThat(value.getListValue().getValuesCount()).isEqualTo(3);
+    assertThat(value.getListValue().getValues(0).getInt32Value()).isEqualTo(10);
+  }
+
+  @Test
+  void byteArrayStillEncodesToBytes() {
+    final byte[] bytes = { 1, 2, 3 };
+
+    final GrpcValue value = GrpcTypeConverter.toGrpcValue(bytes);
+
+    assertThat(value.hasBytesValue()).as("byte[] must remain BYTES_VALUE, not LIST_VALUE").isTrue();
+    assertThat(value.getBytesValue().toByteArray()).isEqualTo(bytes);
+  }
+}


### PR DESCRIPTION
Closes #5044

## Summary

Fixes the highest-priority silent-data-corruption defect from the 2026-07 gRPC audit (COR-8) plus the missing client null-decode guard (part of COR-16).

The client encoder `ProtoUtils.toGrpcValue` and the static `GrpcTypeConverter.toGrpcValue` both handled `Collection`/`List` but had **no branch for Java arrays**. Because a `float[]`/`double[]` vector (and `int[]`, `long[]`, `Object[]`) is not a `Collection`, it fell through to the `String.valueOf(...)` fallback and was serialized as its object identity string (e.g. `"[F@6d03e736"`), destroying the value on write.

This adds a generic array branch to both encoders (via `java.lang.reflect.Array`) that encodes any Java array as a `GrpcList`, mirroring the existing `Collection`/`List` branch. `byte[]` keeps its dedicated `BYTES` branch, which is checked earlier. It also adds the missing `if (v == null) return null;` guard to `ProtoUtils.fromGrpcValue`, matching the other two decoders, so a null `GrpcValue` decodes to `null` instead of throwing an NPE.

## Scope note

Issue #5044 folds several audit findings. This PR addresses the concrete, cleanly unit-testable data-corruption defects on the client and dead-static encoders. The following are deferred and documented in `docs/5044-grpc-value-encoders.md`:

- **COR-9 (LINK decode -> RID on the client)** would require changing the existing `ProtoUtilsTest.fromGrpcValueLink` assertion, which codifies the current String behavior; changing existing tests is out of bounds for this workflow.
- **COR-7 (embedded-type loss) / COR-13 (server param `logical_type=="json"` BYTES)** live on the server path (`ArcadeDbGrpcService`) and need an end-to-end server integration harness rather than an encoder unit test.
- **Full single-encoder consolidation** is architecturally constrained: `grpc-client` cannot depend on `grpcw` in compile scope, so convergence here is by matching branches.

## Test plan

- [x] New `ProtoUtilsArrayEncoderTest` (grpc-client): `float[]`/`double[]`/`int[]`/`long[]`/`Object[]` encode to `LIST` and round-trip to a numeric list; `byte[]` stays `BYTES`; null `GrpcValue` decodes to `null` without NPE. 8/8 pass.
- [x] New `GrpcTypeConverterArrayEncoderTest` (grpcw): `float[]`/`double[]`/`int[]` encode to `LIST`; `byte[]` stays `BYTES`. 4/4 pass.
- [x] TDD verified: both new suites fail before the fix (array -> string fallback; null -> NPE) and pass after.
- [x] Existing `ProtoUtilsTest` (39) and `GrpcTypeConverterTest` (39) still pass - no regressions, no existing test modified.