### PR TITLE
fix(#5041): gRPC insert-stream transaction lifecycle (TX-3/TX-4/TX-6, CON-1/CON-4)

### DIFF
--- a/docs/5041-grpc-insert-stream-tx-lifecycle.md
+++ b/docs/5041-grpc-insert-stream-tx-lifecycle.md
@@ -34,11 +34,22 @@ half-close semantics.
 - **CON-1** capture `Context.current()` at observer creation and wrap every submitted runnable with
   `grpcContext.wrap(...)`.
 
+## Review follow-ups
+- `close()` also drops this database's `DatabaseContext` entry for the current thread, but ONLY when a
+  transaction was captured (so it never unbinds an unrelated request's context on a foreign pooled
+  thread on the `tx == null` path).
+- `insertBidirectional` shuts down its per-stream executor on all terminal paths (COMMIT, unexpected
+  exception, duplicate START) so its thread cannot leak.
+- `insertBidirectional.onNext`'s task is extracted into a `Runnable` for readability.
+
 ## Tests
 `grpcw/.../Issue5041InsertStreamTxLifecycleIT`:
 - TX-3: stream error mid-way leaves no active transaction bound to the thread.
 - TX-4: an unrelated `DatabaseContext.init()` on the same thread cannot roll back the stream's tx.
 - TX-6: bidirectional half-close without COMMIT commits nothing.
+- CON-1: bidirectional insert authenticated only via `USER_CONTEXT_KEY` (no payload credentials) is
+  rejected without the context and commits with it (self-validating). CON-4 is a genuine guard-vs-submit
+  race, verified by reasoning.
 
 ## Impact
 Only `grpcw` `ArcadeDbGrpcService`. No wire/proto changes. Behavior preserved for payload-credential

--- a/docs/5041-grpc-insert-stream-tx-lifecycle.md
+++ b/docs/5041-grpc-insert-stream-tx-lifecycle.md
@@ -1,0 +1,45 @@
+# Issue #5041 - gRPC insert-stream transaction lifecycle
+
+## Symptom
+`InsertContext` in `ArcadeDbGrpcService` mismanages ArcadeDB's thread-bound transactions across gRPC
+callbacks, causing silent data loss, transaction leaks that corrupt unrelated requests, and wrong
+half-close semantics.
+
+## Root cause (findings from the 2026-07 gRPC audit)
+- **TX-3** `InsertContext.close()` is an empty no-op, so `closeQuietly()` on every error/cancel path
+  never rolls back the transaction begun in the ctor. The orphaned, still-active transaction stays
+  bound to the pooled gRPC thread; the next unrelated request reusing that thread silently joins it.
+- **TX-4** `insertStream` runs its callbacks on shared gRPC pool threads and leaves the live
+  transaction parked in the thread-local `DatabaseContext` between callbacks. An unrelated request on
+  the same pool thread calls `DatabaseContext.init()`, which rolls back the parked transaction -
+  silently discarding the stream's rows.
+- **TX-6** `insertBidirectional.onCompleted` (half-close without an explicit COMMIT) calls
+  `flushCommit(false)`, which actually COMMITS for `PER_ROW`/`PER_BATCH` (`db.commit(); db.begin()`)
+  and leaks the open tx for `PER_STREAM` - contradicting the comment's stated "rollback" intent.
+- **CON-4** `insertBidirectional.onNext` submits to `streamExecutor` without guarding against a
+  `RejectedExecutionException` thrown when a racing cancel shut the executor down (`onCompleted`
+  already guards this).
+- **CON-1** `insertBidirectional` submits work to `streamExecutor` without propagating
+  `io.grpc.Context`, so header/Bearer-only auth (`USER_CONTEXT_KEY`) is invisible on the worker thread.
+
+## Fix
+- **TX-3** `close()` now rebinds the captured transaction to the current thread and rolls it back if
+  still active (via the existing `abortTransaction()`), then clears the handle.
+- **TX-4** new `unbindFromCurrentThread()` detaches the captured transaction from the thread-local
+  `DatabaseContext` (without rolling it back) at the end of each `insertStream.onNext`;
+  `bindToCurrentThread()` re-attaches it on the next callback.
+- **TX-6** half-close without COMMIT now calls `abortTransaction()` (explicit rollback) for all modes.
+- **CON-4** the `onNext` submit is wrapped in the same `try/catch (RejectedExecutionException)` guard
+  as `onCompleted`.
+- **CON-1** capture `Context.current()` at observer creation and wrap every submitted runnable with
+  `grpcContext.wrap(...)`.
+
+## Tests
+`grpcw/.../Issue5041InsertStreamTxLifecycleIT`:
+- TX-3: stream error mid-way leaves no active transaction bound to the thread.
+- TX-4: an unrelated `DatabaseContext.init()` on the same thread cannot roll back the stream's tx.
+- TX-6: bidirectional half-close without COMMIT commits nothing.
+
+## Impact
+Only `grpcw` `ArcadeDbGrpcService`. No wire/proto changes. Behavior preserved for payload-credential
+clients and the existing #4644/#4198/#4806 insert-stream regression tests.

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -3760,17 +3760,23 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
      * reusing that thread would silently join the orphaned transaction. Rebind the transaction onto
      * this thread first (it may have been detached by {@link #unbindFromCurrentThread()} or begun on
      * another callback thread) so the rollback releases its locks. Idempotent: after a successful
-     * {@link #flushCommit(boolean)} the transaction handle is already {@code null} and only the
-     * thread-local cleanup below runs.
+     * {@link #flushCommit(boolean)} the transaction handle is already {@code null} and this is a
+     * no-op.
      * <p>
-     * Always drop this database's {@link DatabaseContext} entry for the current thread afterwards so
-     * stale per-thread state (currentUser, querySession, temporary buffers) is not left parked on a
-     * pooled gRPC thread that a later unrelated request reuses.
+     * When a transaction WAS captured, {@link #bindToCurrentThread()} above binds it to the current
+     * thread, so the current thread's {@link DatabaseContext} entry is provably ours: drop it to
+     * release the stale per-thread state (currentUser, querySession, temporary buffers) left on the
+     * pooled gRPC thread. We deliberately do NOT remove the context on the {@code tx == null} path:
+     * {@code close()} can then be running on a different pooled callback thread (e.g. the
+     * {@code streamFailed} branch of {@code insertStream.onCompleted}), where the entry may belong to
+     * an unrelated request - the same "don't touch a foreign pooled thread's transaction" caution the
+     * surrounding code observes.
      */
     @Override
     public void close() {
+      final boolean hadTransaction = tx != null;
       try {
-        if (tx != null) {
+        if (hadTransaction) {
           bindToCurrentThread();
           abortTransaction();
         }
@@ -3778,7 +3784,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // best-effort cleanup: the engine may already have terminated the transaction
       } finally {
         tx = null;
-        DatabaseContext.INSTANCE.removeContext(db.getDatabasePath());
+        if (hadTransaction)
+          DatabaseContext.INSTANCE.removeContext(db.getDatabasePath());
       }
     }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2709,13 +2709,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         if (cancelled.get())
           return;
 
-        // Submit all message processing to the single-threaded executor to ensure the transaction
-        // ThreadLocal context is preserved. Issue #5041 (CON-1): wrap the task with the captured
-        // gRPC Context so header/Bearer auth survives the thread hop. Issue #5041 (CON-4): guard the
-        // submit against a RejectedExecutionException thrown when a racing cancel shut the executor
-        // down between the cancelled check above and this submit (onCompleted already guards this).
-        try {
-          streamExecutor.submit(grpcContext.wrap(() -> {
+        // Process every message on the single-threaded executor so the transaction ThreadLocal
+        // context is preserved. Issue #5041 (CON-1): the task is wrapped with the captured gRPC
+        // Context at submit time so header/Bearer auth survives the thread hop.
+        final Runnable task = () -> {
           if (cancelled.get())
             return;
 
@@ -2840,10 +2837,15 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             // thread does not leak after the error is delivered to the client.
             streamExecutor.shutdown();
           }
-          }));
+        };
+
+        // Issue #5041 (CON-4): guard the submit against a RejectedExecutionException thrown when a
+        // racing cancel shut the executor down between the cancelled check above and this submit
+        // (onCompleted already guards this).
+        try {
+          streamExecutor.submit(grpcContext.wrap(task));
         } catch (final RejectedExecutionException ignore) {
-          // Issue #5041 (CON-4): a racing cancel shut the executor down after the cancelled check
-          // above; drop the message instead of throwing out of the callback.
+          // a racing cancel shut the executor down; drop the message instead of throwing out of the callback
         }
       }
 
@@ -2863,6 +2865,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           streamExecutor.submit(grpcContext.wrap(() -> {
             final InsertContext ctx = ref.getAndSet(null);
             if (ctx != null) {
+              // Rebind before rolling back for symmetry with close(): the transaction was begun on
+              // this same single-thread executor so it is already bound here, but rebinding keeps the
+              // rollback correct even if that ever changes.
+              ctx.bindToCurrentThread();
               ctx.abortTransaction();
               sessionWatermark.remove(ctx.sessionId);
               ctx.closeQuietly();

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2726,6 +2726,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                 if (!started.compareAndSet(false, true)) {
                   out.onError(
                       Status.FAILED_PRECONDITION.withDescription("insertBidirectional: START already received").asException());
+                  // Issue #5041: this is a terminal error - clean up any in-flight context (rolling
+                  // back its transaction) and stop the per-stream executor so its thread does not leak.
+                  final InsertContext existing = ref.getAndSet(null);
+                  if (existing != null) {
+                    sessionWatermark.remove(existing.sessionId);
+                    existing.closeQuietly();
+                  }
+                  streamExecutor.shutdown();
                   return;
                 }
 
@@ -2809,6 +2817,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                   sessionWatermark.remove(ctx.sessionId);
                   ctx.closeQuietly();
                   ref.set(null);
+                  // Issue #5041: COMMIT (success or failure) is terminal - stop the per-stream
+                  // executor so its thread does not leak when the client does not half-close.
+                  streamExecutor.shutdown();
                 }
               }
 
@@ -2825,6 +2836,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               sessionWatermark.remove(ctx.sessionId);
               ctx.closeQuietly();
             }
+            // Issue #5041: an unexpected failure is terminal - stop the per-stream executor so its
+            // thread does not leak after the error is delivered to the client.
+            streamExecutor.shutdown();
           }
           }));
         } catch (final RejectedExecutionException ignore) {
@@ -3740,19 +3754,25 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
      * reusing that thread would silently join the orphaned transaction. Rebind the transaction onto
      * this thread first (it may have been detached by {@link #unbindFromCurrentThread()} or begun on
      * another callback thread) so the rollback releases its locks. Idempotent: after a successful
-     * {@link #flushCommit(boolean)} the handle is already {@code null} and this is a no-op.
+     * {@link #flushCommit(boolean)} the transaction handle is already {@code null} and only the
+     * thread-local cleanup below runs.
+     * <p>
+     * Always drop this database's {@link DatabaseContext} entry for the current thread afterwards so
+     * stale per-thread state (currentUser, querySession, temporary buffers) is not left parked on a
+     * pooled gRPC thread that a later unrelated request reuses.
      */
     @Override
     public void close() {
-      if (tx == null)
-        return;
       try {
-        bindToCurrentThread();
-        abortTransaction();
+        if (tx != null) {
+          bindToCurrentThread();
+          abortTransaction();
+        }
       } catch (final RuntimeException ignore) {
         // best-effort cleanup: the engine may already have terminated the transaction
       } finally {
         tx = null;
+        DatabaseContext.INSTANCE.removeContext(db.getDatabasePath());
       }
     }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -66,6 +66,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
+import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -2279,6 +2280,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             totals.updated = 0;
           }
         } finally {
+          // Issue #5041 (TX-4): detach the transaction from this (shared) pool thread before
+          // returning, so it is not left parked in the thread-local DatabaseContext between
+          // callbacks where an unrelated request reusing the thread would roll it back. onNext /
+          // onCompleted re-bind it via bindToCurrentThread().
+          final InsertContext parkedCtx = ctxRef.get();
+          if (parkedCtx != null)
+            parkedCtx.unbindFromCurrentThread();
           if (!cancelled.get())
             call.request(1);
         }
@@ -2653,6 +2661,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final AtomicBoolean cancelled = new AtomicBoolean(false);
     final AtomicBoolean started = new AtomicBoolean(false);
 
+    // Issue #5041 (CON-1): capture the gRPC Context here, on the inbound thread where the auth
+    // interceptor has attached it, so the header/Bearer-authenticated user (USER_CONTEXT_KEY) is
+    // visible to resolvedUsername() on the single-thread executor below. Without this the executor
+    // thread runs under Context.ROOT and header-only auth resolves to null.
+    final Context grpcContext = Context.current();
+
     // Single-threaded executor ensures all database operations for this stream happen on the same thread.
     // This is critical because ArcadeDB transactions are ThreadLocal - if begin() and commit() happen
     // on different threads, the transaction context is lost.
@@ -2672,13 +2686,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       cancelled.set(true);
       out.markTerminated();
       try {
-        streamExecutor.submit(() -> {
+        streamExecutor.submit(grpcContext.wrap(() -> {
           final InsertContext ctx = ref.getAndSet(null);
           if (ctx != null) {
             sessionWatermark.remove(ctx.sessionId);
             ctx.closeQuietly();
           }
-        });
+        }));
       } catch (RejectedExecutionException ignore) {
         // Executor already shut down - cleanup was already done
       }
@@ -2695,9 +2709,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         if (cancelled.get())
           return;
 
-        // Submit all message processing to the single-threaded executor
-        // to ensure transaction ThreadLocal context is preserved
-        streamExecutor.submit(() -> {
+        // Submit all message processing to the single-threaded executor to ensure the transaction
+        // ThreadLocal context is preserved. Issue #5041 (CON-1): wrap the task with the captured
+        // gRPC Context so header/Bearer auth survives the thread hop. Issue #5041 (CON-4): guard the
+        // submit against a RejectedExecutionException thrown when a racing cancel shut the executor
+        // down between the cancelled check above and this submit (onCompleted already guards this).
+        try {
+          streamExecutor.submit(grpcContext.wrap(() -> {
           if (cancelled.get())
             return;
 
@@ -2808,7 +2826,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               ctx.closeQuietly();
             }
           }
-        });
+          }));
+        } catch (final RejectedExecutionException ignore) {
+          // Issue #5041 (CON-4): a racing cancel shut the executor down after the cancelled check
+          // above; drop the message instead of throwing out of the callback.
+        }
       }
 
       @Override
@@ -2818,21 +2840,20 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       @Override
       public void onCompleted() {
-        // Define your policy for half-close without COMMIT:
+        // Issue #5041 (TX-6): half-close WITHOUT an explicit COMMIT must roll back. The previous
+        // flushCommit(false) actually COMMITTED the buffered rows for PER_ROW/PER_BATCH
+        // (db.commit();db.begin()) and left the open transaction leaked for PER_STREAM, contradicting
+        // the "commit only on explicit COMMIT" contract. abortTransaction() rolls back the still-open
+        // transaction (a no-op if a prior per-batch commit already terminated it) for every mode.
         try {
-          streamExecutor.submit(() -> {
+          streamExecutor.submit(grpcContext.wrap(() -> {
             final InsertContext ctx = ref.getAndSet(null);
             if (ctx != null) {
-              try {
-                // Safer default is rollback; if you prefer auto-commit on close, call
-                // flushCommit(true)
-                ctx.flushCommit(false); // or ctx.rollbackQuietly() if you have a helper
-              } catch (Exception ignore) {
-              }
+              ctx.abortTransaction();
               sessionWatermark.remove(ctx.sessionId);
               ctx.closeQuietly();
             }
-          });
+          }));
         } catch (RejectedExecutionException ignore) {
           // Executor already shut down
         }
@@ -3599,6 +3620,25 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     }
 
     /**
+     * Issue #5041 (TX-4): detach the captured transaction from the current thread's
+     * {@link DatabaseContext} WITHOUT rolling it back, so a still-open insert-stream transaction is
+     * never left parked on a shared gRPC pool thread between callbacks. Left parked, an unrelated
+     * request that reuses the same pool thread calls {@link DatabaseContext#init(DatabaseInternal)},
+     * which rolls back whatever transaction it finds bound to the thread - silently discarding this
+     * stream's rows. {@link #bindToCurrentThread()} re-attaches the transaction on the next callback.
+     * The captured {@code tx} handle keeps the transaction (and its buffered rows) alive across the
+     * detach. No-op when there is no captured transaction or it is not bound to this thread.
+     */
+    void unbindFromCurrentThread() {
+      if (tx == null)
+        return;
+
+      final DatabaseContext.DatabaseContextTL tl = DatabaseContext.INSTANCE.getContextIfExists(db.getDatabasePath());
+      if (tl != null && tl.getLastTransaction() == tx)
+        DatabaseContext.INSTANCE.removeContext(db.getDatabasePath());
+    }
+
+    /**
      * Issue #4644: snapshot the transaction (and its security user) currently bound to this thread so
      * it can be re-bound on the next callback thread by {@link #bindToCurrentThread()}.
      */
@@ -3691,8 +3731,29 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           .setFailed(c.failed).addAllErrors(c.errors).setStartedAt(ts(startedAtMs)).setFinishedAt(ts(now)).build();
     }
 
+    /**
+     * Issue #5041 (TX-3): roll back any still-active captured transaction. Previously this was an
+     * empty no-op, so {@link #closeQuietly()} on every error/cancel path (insertStream.onError, the
+     * cancel handler, insertBidirectional cleanup, bulkInsert try-with-resources) left the
+     * transaction begun in the ctor active and bound to a pooled gRPC thread. It is not tracked in
+     * {@code activeTransactions}, so the reaper cannot reclaim it either; the next unrelated request
+     * reusing that thread would silently join the orphaned transaction. Rebind the transaction onto
+     * this thread first (it may have been detached by {@link #unbindFromCurrentThread()} or begun on
+     * another callback thread) so the rollback releases its locks. Idempotent: after a successful
+     * {@link #flushCommit(boolean)} the handle is already {@code null} and this is a no-op.
+     */
     @Override
     public void close() {
+      if (tx == null)
+        return;
+      try {
+        bindToCurrentThread();
+        abortTransaction();
+      } catch (final RuntimeException ignore) {
+        // best-effort cleanup: the engine may already have terminated the transaction
+      } finally {
+        tx = null;
+      }
     }
 
     void closeQuietly() {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2859,17 +2859,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // Issue #5041 (TX-6): half-close WITHOUT an explicit COMMIT must roll back. The previous
         // flushCommit(false) actually COMMITTED the buffered rows for PER_ROW/PER_BATCH
         // (db.commit();db.begin()) and left the open transaction leaked for PER_STREAM, contradicting
-        // the "commit only on explicit COMMIT" contract. abortTransaction() rolls back the still-open
-        // transaction (a no-op if a prior per-batch commit already terminated it) for every mode.
+        // the "commit only on explicit COMMIT" contract. closeQuietly() -> close() rebinds and rolls
+        // back the still-open transaction (a no-op if a prior per-batch commit already terminated it)
+        // for every mode, then drops the thread-local context - a single rollback path.
         try {
           streamExecutor.submit(grpcContext.wrap(() -> {
             final InsertContext ctx = ref.getAndSet(null);
             if (ctx != null) {
-              // Rebind before rolling back for symmetry with close(): the transaction was begun on
-              // this same single-thread executor so it is already bound here, but rebinding keeps the
-              // rollback correct even if that ever changes.
-              ctx.bindToCurrentThread();
-              ctx.abortTransaction();
               sessionWatermark.remove(ctx.sessionId);
               ctx.closeQuietly();
             }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5041InsertStreamTxLifecycleIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5041InsertStreamTxLifecycleIT.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.Context;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -219,6 +221,67 @@ public class Issue5041InsertStreamTxLifecycleIT extends BaseGraphServerTest {
     }
   }
 
+  /**
+   * CON-1: a bidirectional insert authenticated ONLY through the gRPC context ({@code USER_CONTEXT_KEY},
+   * as set by the auth interceptor for header/Bearer clients) - with NO credentials in the request
+   * payload - must work. The stream executor runs on a different thread than the inbound callback, so
+   * the captured {@code io.grpc.Context} has to be propagated for {@code resolvedUsername()} to see the
+   * user. Self-validating: the first stream (no context, no credentials) must be rejected, proving auth
+   * is actually enforced; the second (context user, still no credentials) must commit.
+   */
+  @Test
+  void bidirectionalHeaderOnlyAuthIsPropagatedToStreamExecutor() throws Exception {
+    final String typeName = "Issue5041Con1_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final InsertRequest start = InsertRequest.newBuilder().setStart(Start.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              // deliberately NO credentials: the only identity source is the gRPC context
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM)
+              .build())
+          .build()).build();
+
+      // (a) No context and no credentials: START must be rejected (auth is enforced).
+      final BidiResponseObserver respA = new BidiResponseObserver();
+      final StreamObserver<InsertRequest> reqA = service.insertBidirectional(respA);
+      reqA.onNext(start);
+      assertThat(respA.terminalLatch.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(respA.error.get()).as("unauthenticated START must be rejected").isNotNull();
+      assertThat(respA.sessionId.get()).isEmpty();
+
+      // (b) Same payload (no credentials) but the handler is invoked within a gRPC context carrying
+      // the authenticated user, exactly as the auth interceptor would set up for a header/Bearer client.
+      final BidiResponseObserver respB = new BidiResponseObserver();
+      final Context authContext = Context.current().withValue(GrpcAuthInterceptor.USER_CONTEXT_KEY, "root");
+      final AtomicReference<StreamObserver<InsertRequest>> reqBHolder = new AtomicReference<>();
+      authContext.run(() -> reqBHolder.set(service.insertBidirectional(respB)));
+      final StreamObserver<InsertRequest> reqB = reqBHolder.get();
+
+      reqB.onNext(start);
+      assertThat(respB.startedLatch.await(30, TimeUnit.SECONDS)).as("context-authenticated START must succeed").isTrue();
+
+      final InsertChunk.Builder chunk = InsertChunk.newBuilder().setSessionId(respB.sessionId.get()).setChunkSeq(1);
+      for (int i = 0; i < 5; i++)
+        chunk.addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+      reqB.onNext(InsertRequest.newBuilder().setChunk(chunk.build()).build());
+      assertThat(respB.batchAckLatch.await(30, TimeUnit.SECONDS)).isTrue();
+
+      reqB.onNext(InsertRequest.newBuilder().setCommit(Commit.newBuilder().setSessionId(respB.sessionId.get()).setCommit(true).build()).build());
+      assertThat(respB.terminalLatch.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(respB.committed.get()).as("context-authenticated stream must commit").isTrue();
+      assertThat(countRows(typeName)).isEqualTo(5L);
+    } finally {
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
   private static Thread awaitBidiWorker() throws InterruptedException {
     for (int i = 0; i < 300; i++) {
       for (final Thread t : Thread.getAllStackTraces().keySet())
@@ -255,10 +318,12 @@ public class Issue5041InsertStreamTxLifecycleIT extends BaseGraphServerTest {
    * handler that latches on the Started/BatchAck responses and records whether a Committed arrived.
    */
   private static final class BidiResponseObserver extends ServerCallStreamObserver<InsertResponse> {
-    final CountDownLatch                startedLatch  = new CountDownLatch(1);
-    final CountDownLatch                batchAckLatch = new CountDownLatch(1);
-    final AtomicReference<String>       sessionId     = new AtomicReference<>("");
-    final java.util.concurrent.atomic.AtomicBoolean committed = new java.util.concurrent.atomic.AtomicBoolean(false);
+    final CountDownLatch          startedLatch  = new CountDownLatch(1);
+    final CountDownLatch          batchAckLatch = new CountDownLatch(1);
+    final CountDownLatch          terminalLatch = new CountDownLatch(1);
+    final AtomicReference<String> sessionId     = new AtomicReference<>("");
+    final AtomicBoolean           committed     = new AtomicBoolean(false);
+    final AtomicReference<Throwable> error      = new AtomicReference<>();
 
     @Override public void onNext(final InsertResponse value) {
       switch (value.getMsgCase()) {
@@ -268,8 +333,8 @@ public class Issue5041InsertStreamTxLifecycleIT extends BaseGraphServerTest {
         default -> { }
       }
     }
-    @Override public void onError(final Throwable t) { }
-    @Override public void onCompleted() { }
+    @Override public void onError(final Throwable t) { error.set(t); terminalLatch.countDown(); }
+    @Override public void onCompleted() { terminalLatch.countDown(); }
 
     @Override public boolean isCancelled() { return false; }
     @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5041InsertStreamTxLifecycleIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5041InsertStreamTxLifecycleIT.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5041: the gRPC insert-stream machinery ({@code InsertContext} in
+ * {@code ArcadeDbGrpcService}) mismanages ArcadeDB's thread-bound transactions across gRPC callbacks.
+ *
+ * <ul>
+ *   <li><b>TX-3</b>: {@code InsertContext.close()} was an empty no-op, so {@code closeQuietly()} on an
+ *       error/cancel path never rolled back the transaction begun in the ctor. The orphaned, still
+ *       active transaction stayed bound to the callback thread and corrupted the next request that
+ *       reused it.</li>
+ *   <li><b>TX-4</b>: {@code insertStream} left the live transaction parked in the thread-local
+ *       {@code DatabaseContext} between callbacks. An unrelated request reusing that pool thread calls
+ *       {@code DatabaseContext.init()}, which rolls back the parked transaction, silently discarding
+ *       the stream's rows.</li>
+ *   <li><b>TX-6</b>: {@code insertBidirectional} half-close without an explicit COMMIT called
+ *       {@code flushCommit(false)}, which actually COMMITS the buffered rows for PER_BATCH/PER_ROW
+ *       instead of rolling them back.</li>
+ * </ul>
+ */
+public class Issue5041InsertStreamTxLifecycleIT extends BaseGraphServerTest {
+
+  // The insert-stream handlers are driven in-process by constructing ArcadeDbGrpcService directly, so
+  // no gRPC port needs to be bound: the GrpcServerPlugin is intentionally NOT enabled here (binding a
+  // fixed port across several server-restarting test methods races with itself).
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private GrpcValue stringValue(final String s) {
+    return GrpcValue.newBuilder().setStringValue(s).build();
+  }
+
+  private InsertChunk perStreamChunk(final String typeName, final int rows) {
+    final InsertChunk.Builder chunk = InsertChunk.newBuilder()
+        .setSessionId("issue-5041")
+        .setChunkSeq(0)
+        .setOptions(InsertOptions.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setTargetClass(typeName)
+            .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+            .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM)
+            .build());
+    for (int i = 0; i < rows; i++)
+      chunk.addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+    return chunk.build();
+  }
+
+  private long countRows(final String typeName) {
+    return getServer(0).getDatabase(getDatabaseName())
+        .query("sql", "SELECT count(*) AS total FROM " + typeName).next().<Long>getProperty("total");
+  }
+
+  /**
+   * TX-3: a client error mid-stream must roll back the just-begun transaction so it does not stay
+   * active and bound to the callback thread. Before the fix, {@code close()} did nothing and the
+   * transaction stayed active on the thread; after the fix, {@code close()} rolls it back.
+   */
+  @Test
+  void streamErrorRollsBackAndLeavesNoActiveTransaction() throws Exception {
+    final String typeName = "Issue5041Tx3_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    final ExecutorService pool = Executors.newSingleThreadExecutor(r -> new Thread(r, "issue5041-tx3-pool"));
+    try {
+      final Database db = getServer(0).getDatabase(getDatabaseName());
+      final RecordingResponseObserver resp = new RecordingResponseObserver();
+      final StreamObserver<InsertChunk> req = service.insertStream(resp);
+
+      // All callbacks run on ONE pool thread, modelling a reused gRPC pool thread.
+      pool.submit(() -> req.onNext(perStreamChunk(typeName, 20))).get(30, TimeUnit.SECONDS);
+
+      // Client aborts mid-stream: onError must clean up the transaction.
+      pool.submit(() -> req.onError(new RuntimeException("client aborted"))).get(30, TimeUnit.SECONDS);
+
+      // On the SAME pool thread the orphaned transaction must be gone: no active transaction leaked.
+      final boolean stillActive = pool.submit(db::isTransactionActive).get(30, TimeUnit.SECONDS);
+      assertThat(stillActive).as("no active transaction may be left bound to the pool thread after onError").isFalse();
+
+      // And the aborted stream's rows must not have been committed.
+      assertThat(countRows(typeName)).isZero();
+    } finally {
+      pool.shutdownNow();
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  /**
+   * TX-4: an unrelated request reusing the same pool thread calls {@code DatabaseContext.init()},
+   * which rolls back whatever transaction is parked in the thread-local. Before the fix the insert
+   * stream left its transaction parked there, so the unrelated init() silently discarded its rows
+   * (deferred commit found a rolled-back transaction). After the fix the stream unbinds its
+   * transaction from the thread between callbacks, so the unrelated init() cannot touch it.
+   */
+  @Test
+  void unrelatedInitOnSharedThreadDoesNotDiscardStreamRows() throws Exception {
+    final String typeName = "Issue5041Tx4_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    final ExecutorService pool = Executors.newSingleThreadExecutor(r -> new Thread(r, "issue5041-tx4-pool"));
+    try {
+      final Database db = getServer(0).getDatabase(getDatabaseName());
+      final RecordingResponseObserver resp = new RecordingResponseObserver();
+      final StreamObserver<InsertChunk> req = service.insertStream(resp);
+
+      // Chunk 1 begins the PER_STREAM transaction and inserts the rows (commit deferred to onCompleted).
+      pool.submit(() -> req.onNext(perStreamChunk(typeName, 30))).get(30, TimeUnit.SECONDS);
+
+      // An unrelated request reuses this pool thread: getDatabase() -> DatabaseContext.init() rolls
+      // back any transaction parked in the thread-local for this database.
+      pool.submit(() -> DatabaseContext.INSTANCE.init((DatabaseInternal) db)).get(30, TimeUnit.SECONDS);
+
+      // Half-close: deferred PER_STREAM commit.
+      pool.submit(req::onCompleted).get(30, TimeUnit.SECONDS);
+
+      final InsertSummary summary = resp.summaryRef.get();
+      assertThat(summary).isNotNull();
+      assertThat(summary.getInserted()).as("all streamed rows must survive the unrelated init() and commit").isEqualTo(30);
+      assertThat(summary.getFailed()).isZero();
+      assertThat(countRows(typeName)).isEqualTo(30L);
+    } finally {
+      pool.shutdownNow();
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  /**
+   * TX-6: a bidirectional half-close WITHOUT an explicit COMMIT must roll back the buffered rows.
+   * Before the fix the handler called {@code flushCommit(false)}, which COMMITS for PER_BATCH, so the
+   * rows were silently persisted even though the client never sent a Commit.
+   */
+  @Test
+  void bidirectionalHalfCloseWithoutCommitCommitsNothing() throws Exception {
+    final String typeName = "Issue5041Tx6_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BidiResponseObserver resp = new BidiResponseObserver();
+      final StreamObserver<InsertRequest> req = service.insertBidirectional(resp);
+
+      // START: PER_BATCH with the default server batch size (1000), so a small chunk is buffered but
+      // not committed by insertRows; only an explicit COMMIT (or the buggy flushCommit(false)) commits.
+      req.onNext(InsertRequest.newBuilder().setStart(Start.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setCredentials(credentials())
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .setTransactionMode(InsertOptions.TransactionMode.PER_BATCH)
+              .build())
+          .build()).build());
+      assertThat(resp.startedLatch.await(30, TimeUnit.SECONDS)).isTrue();
+
+      // Capture the dedicated single-thread worker so we can wait for its terminal cleanup to run.
+      final Thread worker = awaitBidiWorker();
+      assertThat(worker).as("bidirectional stream worker thread").isNotNull();
+
+      final InsertChunk.Builder chunk = InsertChunk.newBuilder().setSessionId(resp.sessionId.get()).setChunkSeq(1);
+      for (int i = 0; i < 10; i++)
+        chunk.addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+      req.onNext(InsertRequest.newBuilder().setChunk(chunk.build()).build());
+      assertThat(resp.batchAckLatch.await(30, TimeUnit.SECONDS)).isTrue();
+
+      // Half-close WITHOUT sending a Commit message.
+      req.onCompleted();
+
+      // The worker thread terminates only after the terminal cleanup task has fully run (shutdown()
+      // drains the queue first), giving a deterministic happens-before for the assertions below.
+      worker.join(30_000);
+      assertThat(worker.isAlive()).isFalse();
+
+      assertThat(resp.committed.get()).as("no Committed response on a half-close without COMMIT").isFalse();
+      assertThat(countRows(typeName)).as("half-close without COMMIT must commit nothing").isZero();
+    } finally {
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  private static Thread awaitBidiWorker() throws InterruptedException {
+    for (int i = 0; i < 300; i++) {
+      for (final Thread t : Thread.getAllStackTraces().keySet())
+        if (t.isAlive() && t.getName().startsWith("grpc-bidi-stream-"))
+          return t;
+      Thread.sleep(10);
+    }
+    return null;
+  }
+
+  /**
+   * Minimal {@link ServerCallStreamObserver} double for the client-streaming {@code insertStream}
+   * handler that captures the single {@link InsertSummary} it emits.
+   */
+  private static final class RecordingResponseObserver extends ServerCallStreamObserver<InsertSummary> {
+    final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+
+    @Override public void onNext(final InsertSummary value) { summaryRef.set(value); }
+    @Override public void onError(final Throwable t) { }
+    @Override public void onCompleted() { }
+
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+
+  /**
+   * Minimal {@link ServerCallStreamObserver} double for the bidirectional {@code insertBidirectional}
+   * handler that latches on the Started/BatchAck responses and records whether a Committed arrived.
+   */
+  private static final class BidiResponseObserver extends ServerCallStreamObserver<InsertResponse> {
+    final CountDownLatch                startedLatch  = new CountDownLatch(1);
+    final CountDownLatch                batchAckLatch = new CountDownLatch(1);
+    final AtomicReference<String>       sessionId     = new AtomicReference<>("");
+    final java.util.concurrent.atomic.AtomicBoolean committed = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+    @Override public void onNext(final InsertResponse value) {
+      switch (value.getMsgCase()) {
+        case STARTED -> { sessionId.set(value.getStarted().getSessionId()); startedLatch.countDown(); }
+        case BATCH_ACK -> batchAckLatch.countDown();
+        case COMMITTED -> committed.set(true);
+        default -> { }
+      }
+    }
+    @Override public void onError(final Throwable t) { }
+    @Override public void onCompleted() { }
+
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5041. `InsertContext` in `ArcadeDbGrpcService` mismanaged ArcadeDB's **thread-bound** transactions across gRPC callbacks, causing silent data loss, transaction leaks that corrupt unrelated requests, and wrong half-close semantics. Findings from the 2026-07 gRPC modules audit.

## Changes (`grpcw/.../ArcadeDbGrpcService.java`)

- **TX-3** - `InsertContext.close()` was an empty no-op, so `closeQuietly()` on every error/cancel path (`insertStream.onError`, the cancel handler, `insertBidirectional` cleanup, `bulkInsert` try-with-resources) never rolled back the transaction begun in the ctor. The orphaned, still-active transaction stayed bound to the pooled gRPC thread (and is not in `activeTransactions`, so the reaper cannot reclaim it either), so the next unrelated request reusing that thread silently joined it. `close()` now rebinds the captured transaction and rolls it back if still active.
- **TX-4** - `insertStream` left the live transaction parked in the thread-local `DatabaseContext` between callbacks. An unrelated request reusing that pool thread calls `DatabaseContext.init()`, which rolls back the parked transaction, silently discarding the stream's rows. New `unbindFromCurrentThread()` detaches the transaction (without rolling it back) at the end of each `onNext`; `bindToCurrentThread()` re-attaches it on the next callback.
- **TX-6** - `insertBidirectional` half-close **without** an explicit `Commit` called `flushCommit(false)`, which actually **commits** for `PER_ROW`/`PER_BATCH` (`db.commit(); db.begin()`) and leaks the open tx for `PER_STREAM`. It now rolls back via `abortTransaction()` for every mode, matching the "commit only on explicit COMMIT" contract.
- **CON-4** - the `insertBidirectional.onNext` submit is now guarded against a `RejectedExecutionException` thrown when a racing cancel shut the executor down between the `cancelled` check and the submit (symmetric with the existing `onCompleted` guard).
- **CON-1** - the captured `io.grpc.Context` is now propagated to the stream executor so header/Bearer auth (`USER_CONTEXT_KEY`) survives the thread hop.

## Tests

New `Issue5041InsertStreamTxLifecycleIT` drives the handlers in-process (mirroring `Issue4644InsertStreamThreadHopIT`) and covers:
- **TX-3**: a stream error mid-way leaves no active transaction bound to the pool thread.
- **TX-4**: an unrelated `DatabaseContext.init()` on the same thread cannot roll back the stream's transaction; all rows survive and commit.
- **TX-6**: a bidirectional half-close without COMMIT commits nothing.

All three fail before the fix and pass after. Verified no regressions in `Issue4644/4198/4806/4214/4656` insert-stream ITs and `ArcadeDbGrpcServiceCoverageIT` (35), `ArcadeDbGrpcServiceExtendedTest` (26), `GrpcServerIT` (30).

## Notes

- No wire/proto changes. Behavior is preserved for payload-credential clients.
- Scoped entirely to the `grpcw` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)