### PR TITLE
fix(#5042): reject reaped/unknown gRPC transactions instead of silent data loss

### DIFF
--- a/docs/5042-grpc-reaped-unknown-transactions.md
+++ b/docs/5042-grpc-reaped-unknown-transactions.md
@@ -1,0 +1,36 @@
+# Issue #5042 - gRPC reaped/unknown transactions cause silent data loss and partial commits
+
+## Symptom
+When a client-supplied transaction id is unknown to the server (most commonly because the idle reaper
+already rolled the transaction back after 5 minutes), the gRPC layer silently does the wrong thing:
+- Client `commit()`/`rollback()` treat a `committed=false`/`rolledBack=false` server response as success.
+- Server write RPCs (`executeCommand`, `createRecord`, `updateRecord`, `deleteRecord`) fall through to a
+  non-transactional auto-commit path for a non-blank-but-unknown txId, producing partial commits.
+- `streamQuery` ignores `transaction_id`, so streamed reads inside a client transaction cannot see the
+  transaction's uncommitted writes.
+
+## Root cause
+The protocol distinguishes "the RPC succeeded" (`success`) from "the transaction was actually committed"
+(`committed`), but the client collapses them. The server write handlers treat a missing/blank txId as
+"no external transaction -> auto-transaction", which is correct for a genuinely absent txId but wrong for a
+txId the client did supply that has since been reaped. `streamQuery` never resolves the supplied txId.
+
+## Fix (TX-2, TX-5, TX-8, CON-5)
+1. Client `commit()` throws `TransactionException` when `response.getCommitted() == false`; `rollback()`
+   throws when `response.getRolledBack() == false`.
+2. Server write RPCs reject a non-blank-but-unknown txId with `FAILED_PRECONDITION` instead of
+   auto-committing. A genuinely absent/blank txId keeps the auto-transaction path.
+3. `streamQuery` resolves the supplied txId and runs the stream on the transaction's dedicated executor
+   thread (streaming analogue of the #4260 executeQuery fix); it no longer begins/commits a throwaway read
+   tx when a tx is supplied. The client now attaches the active transaction to stream requests.
+4. CON-5: the idle reaper re-reads `lastAccessMs` immediately before `activeTransactions.remove(key,value)`
+   so a just-touched (active) transaction is not reaped in the TOCTOU window.
+
+## Tests
+- `grpcw` `Issue5042ReapedTransactionIT` - write RPCs reject unknown non-blank txId; blank still auto-commits;
+  streamQuery honors txId and sees uncommitted writes.
+- `grpc-client` `Issue5042CommitRollbackThrowIT` - reaped-tx commit()/rollback() throw; streamed query inside
+  a transaction sees the transaction's uncommitted write.
+
+## Impact
+High-severity silent data loss / partial commits closed; unknown-tx writes now fail loudly.

--- a/docs/5042-grpc-reaped-unknown-transactions.md
+++ b/docs/5042-grpc-reaped-unknown-transactions.md
@@ -18,8 +18,9 @@ txId the client did supply that has since been reaped. `streamQuery` never resol
 ## Fix (TX-2, TX-5, TX-8, CON-5)
 1. Client `commit()` throws `TransactionException` when `response.getCommitted() == false`; `rollback()`
    throws when `response.getRolledBack() == false`.
-2. Server write RPCs reject a non-blank-but-unknown txId with `FAILED_PRECONDITION` instead of
-   auto-committing. A genuinely absent/blank txId keeps the auto-transaction path.
+2. Server write RPCs (`executeCommand`, `createRecord`, `updateRecord`, `deleteRecord`) and the `lookupByRid`
+   read RPC reject a non-blank-but-unknown txId with `FAILED_PRECONDITION` instead of auto-committing /
+   serving an out-of-transaction read. A genuinely absent/blank txId keeps the auto-transaction path.
 3. `streamQuery` resolves the supplied txId and runs the stream on the transaction's dedicated executor
    thread (streaming analogue of the #4260 executeQuery fix); it no longer begins/commits a throwaway read
    tx when a tx is supplied. The client now attaches the active transaction to stream requests.
@@ -27,10 +28,23 @@ txId the client did supply that has since been reaped. `streamQuery` never resol
    so a just-touched (active) transaction is not reaped in the TOCTOU window.
 
 ## Tests
-- `grpcw` `Issue5042ReapedTransactionIT` - write RPCs reject unknown non-blank txId; blank still auto-commits;
-  streamQuery honors txId and sees uncommitted writes.
-- `grpc-client` `Issue5042CommitRollbackThrowIT` - reaped-tx commit()/rollback() throw; streamed query inside
-  a transaction sees the transaction's uncommitted write.
+- `grpcw` `Issue5042ReapedTransactionIT` - write RPCs reject unknown non-blank txId; `lookupByRid` rejects it;
+  `streamQuery` rejects it; blank still auto-commits; streamQuery honors txId and sees uncommitted writes.
+- `grpc-client` `Issue5042CommitRollbackThrowIT` (`@Tag("slow")`) - reaped-tx commit()/rollback() throw;
+  streamed query inside a transaction sees the transaction's uncommitted write.
 
 ## Impact
 High-severity silent data loss / partial commits closed; unknown-tx writes now fail loudly.
+
+## Review cycles
+- Cycle 1 (head e8ce2a4c): gemini + claude bots reviewed.
+  - Applied: server `streamQuery` `future.get()` now handles `InterruptedException` (restore interrupt +
+    `CANCELLED` terminal) instead of masking it (gemini); `lookupByRid` rejection documented + regression test
+    added; `streamQuery` unknown-txId rejection regression test added; `@Tag("slow")` on the reaper-based
+    `Issue5042CommitRollbackThrowIT`; prominent javadoc on `RemoteGrpcDatabase.rollback()` documenting the
+    backward-incompatible throw-on-reaped behavior (claude).
+  - Deferred (see `docs/review-deferred-e8ce2a4c.md`): making `rollback()` idempotent (needs modifying this
+    PR's own throw-assert test - out of the automated loop's remit); applying `RemoteGrpcConfig` projection
+    settings in `queryStream` (pre-existing, unrelated to #5042).
+  - Skipped (nitpick): aligning the `"GRPC:"` vs `"GrpcServer:"` plugin-registration label between the two
+    test classes (harmless instance label).

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -302,6 +302,19 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     }
   }
 
+  /**
+   * Rolls back the active transaction on the server.
+   *
+   * <p><b>Behavior change (issue #5042):</b> if the server reports {@code rolledBack=false} - meaning it no
+   * longer has the transaction to roll back, typically because the idle reaper already reclaimed it - this
+   * method throws a {@link TransactionException} instead of silently reporting a clean rollback. The local
+   * transaction state ({@code transactionId}/{@code sessionId}) is still cleared before the throw, so the
+   * client is left in a consistent, tx-free state.
+   *
+   * <p>This is a backward-incompatible change for callers that use {@code rollback()} in a {@code catch}/
+   * cleanup block: such callers should wrap the call in {@code try/catch} if a throw from an already-reaped
+   * transaction must not mask an earlier exception.
+   */
   @Override
   public void rollback() {
 

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -267,6 +267,12 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
           if (!response.getSuccess()) {
             throw new TransactionException("Failed to commit transaction: " + response.getMessage());
           }
+          // success=true only means the RPC completed; committed=false means the server did NOT durably
+          // commit (e.g. the transaction was already rolled back by the idle reaper). Surfacing this as a
+          // failure prevents silent data loss where the client believes its writes are durable.
+          if (!response.getCommitted()) {
+            throw new TransactionException("Transaction was not committed on the server: " + response.getMessage());
+          }
         } catch (StatusRuntimeException | StatusException e) {
           handleGrpcException(e);
         } finally {
@@ -328,6 +334,11 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
           if (!response.getSuccess()) {
             throw new TransactionException("Failed to rollback transaction: " + response.getMessage());
+          }
+          // rolledBack=false means the server had no such transaction to roll back (e.g. it was already
+          // reaped). Surface it instead of silently reporting a clean rollback.
+          if (!response.getRolledBack()) {
+            throw new TransactionException("Transaction was not rolled back on the server: " + response.getMessage());
           }
         } catch (StatusRuntimeException | StatusException e) {
           throw new TransactionException("Error on transaction rollback", e);
@@ -786,6 +797,17 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
    * provides consistency with non-streaming query methods and supports non-Record
    * results like projections and aggregations.
    */
+  /**
+   * Binds a stream request to the client's currently active transaction, if any, so the server routes the
+   * stream to that transaction's dedicated thread and it sees the transaction's own uncommitted writes.
+   * Without this a streamed read inside a transaction would run as a throwaway read and miss in-flight
+   * changes (issue #5042).
+   */
+  private void bindActiveTransaction(final StreamQueryRequest.Builder b) {
+    if (transactionId != null)
+      b.setTransaction(TransactionContext.newBuilder().setTransactionId(transactionId).setDatabase(getName()).build());
+  }
+
   public ResultSet queryStream(final String language, final String query, final RemoteGrpcConfig config,
                                final Map<String, Object> params,
                                final int batchSize, final StreamQueryRequest.RetrievalMode mode) {
@@ -801,6 +823,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     if (params != null && !params.isEmpty()) {
       b.putAllParameters(convertParamsToGrpcValue(params));
     }
+
+    bindActiveTransaction(b);
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
         () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
@@ -842,6 +866,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       b.putAllParameters(convertParamsToGrpcValue(params));
     }
 
+    bindActiveTransaction(b);
+
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
         () -> blockingStub.withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
 
@@ -862,6 +888,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     if (params != null && !params.isEmpty()) {
       b.putAllParameters(convertParamsToGrpcValue(params));
     }
+
+    bindActiveTransaction(b);
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
         () -> blockingStub.withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5042CommitRollbackThrowIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5042CommitRollbackThrowIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.TransactionException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5042: when the server-side idle reaper has already rolled back and discarded a
+ * transaction, the {@link RemoteGrpcDatabase} client must surface the failure instead of silently treating a
+ * {@code committed=false}/{@code rolledBack=false} response as success.
+ *
+ * <p>Also verifies the streaming analogue of the #4260 fix: a streamed query issued inside an
+ * externally-managed transaction sees the transaction's own uncommitted writes.
+ */
+public class Issue5042CommitRollbackThrowIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT   = 50051;
+  private static final int    HTTP_PORT   = 2480;
+  private static final String VERTEX_TYPE = "Issue5042Vertex";
+
+  // Short reaper windows so the abandoned transaction is reclaimed quickly and deterministically.
+  private static final String MAX_IDLE_MS      = "1000";
+  private static final String REAPER_PERIOD_MS = "250";
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase grpc;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+    // ContextConfiguration falls back to system properties for these plugin-specific keys.
+    System.setProperty("arcadedb.grpc.tx.maxIdleMs", MAX_IDLE_MS);
+    System.setProperty("arcadedb.grpc.tx.reaperPeriodMs", REAPER_PERIOD_MS);
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    System.clearProperty("arcadedb.grpc.tx.maxIdleMs");
+    System.clearProperty("arcadedb.grpc.tx.reaperPeriodMs");
+    super.endTest();
+  }
+
+  @BeforeEach
+  void openAndPrepare() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    grpc = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, HTTP_PORT, getDatabaseName(), "root",
+        DEFAULT_PASSWORD_FOR_TESTS);
+
+    grpc.command("sql", "CREATE VERTEX TYPE `" + VERTEX_TYPE + "` IF NOT EXISTS");
+    grpc.command("sql", "CREATE PROPERTY `" + VERTEX_TYPE + "`.svex IF NOT EXISTS STRING");
+    grpc.command("sql", "DELETE FROM `" + VERTEX_TYPE + "`");
+  }
+
+  @AfterEach
+  void closeClient() {
+    if (grpc != null) {
+      try {
+        grpc.rollback();
+      } catch (final Throwable ignore) {
+        // ignore
+      }
+      grpc.close();
+    }
+    if (grpcServer != null)
+      grpcServer.close();
+  }
+
+  @Test
+  void commitThrowsWhenTransactionWasReaped() throws InterruptedException {
+    grpc.begin();
+
+    // Simulate a long client pause (GC pause, network stall, debugger): the idle reaper rolls the
+    // transaction back and discards it while the client is not looking.
+    Thread.sleep(Long.parseLong(MAX_IDLE_MS) + 1500L);
+
+    // The server reports success=true, committed=false for the now-unknown transaction. The client must
+    // NOT treat that as a durable commit - it must throw.
+    assertThatThrownBy(() -> grpc.commit()).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  void rollbackThrowsWhenTransactionWasReaped() throws InterruptedException {
+    grpc.begin();
+
+    Thread.sleep(Long.parseLong(MAX_IDLE_MS) + 1500L);
+
+    // The server reports success=true, rolledBack=false for the now-unknown transaction. The client must
+    // surface that instead of silently reporting a clean rollback.
+    assertThatThrownBy(() -> grpc.rollback()).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  void streamedQueryInsideTransactionSeesUncommittedWrite() {
+    grpc.begin();
+    try {
+      final MutableVertex v = grpc.newVertex(VERTEX_TYPE);
+      v.set("svex", "streamed");
+      v.save();
+      assertThat(v.getIdentity()).isNotNull();
+
+      // A streamed read bound to the same open transaction must see the uncommitted vertex.
+      int seen = 0;
+      try (final ResultSet rs = grpc.queryStream("sql",
+          "SELECT FROM `" + VERTEX_TYPE + "` WHERE svex = 'streamed'", (Map<String, Object>) null, 10)) {
+        while (rs.hasNext()) {
+          rs.next();
+          seen++;
+        }
+      }
+      assertThat(seen).as("streamed query inside the transaction must see its uncommitted write").isEqualTo(1);
+
+      grpc.commit();
+    } catch (final RuntimeException re) {
+      try {
+        grpc.rollback();
+      } catch (final Throwable ignore) {
+        // ignore
+      }
+      throw re;
+    }
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5042CommitRollbackThrowIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5042CommitRollbackThrowIT.java
@@ -25,6 +25,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>Also verifies the streaming analogue of the #4260 fix: a streamed query issued inside an
  * externally-managed transaction sees the transaction's own uncommitted writes.
  */
+@Tag("slow")
 public class Issue5042CommitRollbackThrowIT extends BaseGraphServerTest {
 
   private static final int    GRPC_PORT   = 50051;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1793,6 +1793,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         });
         try {
           future.get();
+        } catch (final InterruptedException ie) {
+          // Restore the interrupt status and surface an explicit CANCELLED terminal rather than letting the
+          // outer catch mask it as a generic INTERNAL error with the interrupt flag swallowed.
+          Thread.currentThread().interrupt();
+          responseObserver.onError(
+              Status.CANCELLED.withDescription("Stream query execution was interrupted").asRuntimeException());
+          return;
         } catch (final ExecutionException ee) {
           final Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
           if (cause instanceof RuntimeException re)

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -364,6 +364,27 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   /**
+   * True when the caller explicitly supplied a non-blank transaction id that resolves to no active
+   * transaction - typically because the idle reaper already rolled it back. This is distinct from a
+   * genuinely absent/blank id, which legitimately means "no external transaction, use the auto-transaction
+   * path". A transaction-scoped write RPC must fail loudly in this case instead of silently auto-committing.
+   */
+  private static boolean isUnknownSuppliedTransaction(final String txId, final TransactionContext txCtx) {
+    return txCtx == null && txId != null && !txId.isBlank();
+  }
+
+  /**
+   * gRPC status for a write/stream RPC that carried a non-blank transaction id no longer registered on the
+   * server. FAILED_PRECONDITION signals the client that the transaction it believed it was inside is gone,
+   * so the call must not silently fall through to a per-call auto-commit and lose the atomicity the client
+   * expected.
+   */
+  private static Status unknownTransactionStatus(final String txId) {
+    return Status.FAILED_PRECONDITION.withDescription(
+        "Unknown or expired transaction id: " + txId + " (it may have been rolled back by the idle reaper)");
+  }
+
+  /**
    * Scans the registered transactions and reclaims any that have been idle past {@code txMaxIdleMs}, or (when
    * configured) older than {@code txMaxAgeMs}. Each reaped transaction is removed atomically so the sweep never
    * races a concurrent commit/rollback, then rolled back on its own dedicated thread and its executor shut down.
@@ -381,9 +402,19 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         if (!idleExpired && !ageExpired)
           continue;
 
+        // CON-5: for an idle-only reap, re-read lastAccessMs immediately before claiming the transaction so a
+        // request that touched it (via lookupActiveTransaction()) between the staleness read above and the
+        // remove below is not reaped out from under an active caller. An age-expired transaction is reaped
+        // regardless, since createdAtMs never advances on touch().
+        if (!ageExpired) {
+          final long freshIdleMs = System.currentTimeMillis() - ctx.lastAccessMs;
+          if (txMaxIdleMs <= 0 || freshIdleMs < txMaxIdleMs)
+            continue;
+        }
+
         // remove(key, value) ensures only one of the reaper / commit / rollback wins the cleanup.
         // Residual TOCTOU note: a request could lookupActiveTransaction() (touch + submit work) in the instant
-        // between the staleness read above and this remove. That window only opens for an already-idle
+        // between the re-read above and this remove. That window only opens for an already-idle
         // transaction; any command already submitted to the executor still runs to completion before the
         // asynchronous shutdown() in reapTransaction() lets the thread terminate, so no in-flight work is lost.
         if (activeTransactions.remove(entry.getKey(), ctx)) {
@@ -482,6 +513,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       final var tx = hasTx ? req.getTransaction() : null;
       final String incomingTxId = hasTx && tx != null ? tx.getTransactionId() : null;
       final TransactionContext txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
+
+      if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+        // The client supplied a transaction id that is no longer active (e.g. reaped). Reject instead of
+        // silently auto-committing this write outside the transaction the client believes it is in.
+        resp.onError(unknownTransactionStatus(incomingTxId).asException());
+        return;
+      }
 
       if (txCtx != null) {
         // External transaction - execute command on the transaction's dedicated thread
@@ -775,6 +813,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
+    if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+      // Non-blank transaction id the server no longer knows about (e.g. reaped): fail loudly instead of
+      // silently auto-committing this write outside the transaction the client believes it is in.
+      resp.onError(unknownTransactionStatus(incomingTxId).asException());
+      return;
+    }
+
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
       try {
@@ -902,6 +947,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
+    if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+      // Non-blank transaction id the server no longer knows about (e.g. reaped): fail loudly instead of
+      // silently auto-committing this write outside the transaction the client believes it is in.
+      resp.onError(unknownTransactionStatus(incomingTxId).asException());
+      return;
+    }
+
     if (txCtx != null) {
       try {
         final Future<LookupByRidResponse> future = txCtx.executor.submit(() -> lookupByRidInternal(req, txCtx.db));
@@ -947,6 +999,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
     } catch (final StatusRuntimeException e) {
       resp.onError(e);
+      return;
+    }
+
+    if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+      // Non-blank transaction id the server no longer knows about (e.g. reaped): fail loudly instead of
+      // silently auto-committing this write outside the transaction the client believes it is in.
+      resp.onError(unknownTransactionStatus(incomingTxId).asException());
       return;
     }
 
@@ -1116,6 +1175,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
     } catch (final StatusRuntimeException e) {
       resp.onError(e);
+      return;
+    }
+
+    if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+      // Non-blank transaction id the server no longer knows about (e.g. reaped): fail loudly instead of
+      // silently auto-committing this write outside the transaction the client believes it is in.
+      resp.onError(unknownTransactionStatus(incomingTxId).asException());
       return;
     }
 
@@ -1686,38 +1752,85 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     ProtocolContext.set("grpc");
     try {
-      ProjectionConfig projectionConfig = getProjectionConfigFromRequest(request);
+      final ProjectionConfig projectionConfig = getProjectionConfigFromRequest(request);
 
       final ServerCallStreamObserver<QueryResult> scso = (ServerCallStreamObserver<QueryResult>) responseObserver;
       scso.setOnCancelHandler(() -> cancelled.set(true));
 
-      db = getDatabase(request.getDatabase(), request.getCredentials());
       final int batchSize = Math.max(1, request.getBatchSize());
+      final String language = langOrDefault(request.getLanguage());
+      profileLanguage = language;
 
-      // --- TX begin if requested ---
       final boolean hasTx = request.hasTransaction();
       final var tx = hasTx ? request.getTransaction() : null;
+      final String incomingTxId = hasTx ? tx.getTransactionId() : null;
+
+      // If the client is inside an externally-managed transaction (started via BeginTransaction), route the
+      // whole stream to that transaction's dedicated executor thread. ArcadeDB transactions are thread-bound,
+      // so a stream running on the gRPC worker thread would miss the transaction's own uncommitted writes -
+      // the streaming analogue of the #4260 executeQuery fix. A non-blank id that no longer resolves (e.g.
+      // reaped) is rejected instead of silently running as a throwaway read.
+      final TransactionContext txCtx;
+      try {
+        txCtx = resolveAuthorizedTransaction(incomingTxId, request.getCredentials());
+      } catch (final StatusRuntimeException e) {
+        responseObserver.onError(e);
+        return;
+      }
+      if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+        responseObserver.onError(unknownTransactionStatus(incomingTxId).asException());
+        return;
+      }
+
+      if (txCtx != null) {
+        db = txCtx.db;
+        final Database streamDb = db;
+        // The transaction lifecycle (begin/commit/rollback) stays with the Begin/Commit/Rollback RPCs, exactly
+        // like executeQuery - do NOT begin or commit a throwaway read tx here.
+        final Future<?> future = txCtx.executor.submit(() -> {
+          dispatchStream(streamDb, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
+          return null;
+        });
+        try {
+          future.get();
+        } catch (final ExecutionException ee) {
+          final Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
+          if (cause instanceof RuntimeException re)
+            throw re;
+          if (cause instanceof Error err)
+            throw err;
+          throw new RuntimeException(cause);
+        }
+
+        if (cancelled.get()) {
+          if (serverTimedOut.get()) {
+            final long timeoutMs = GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS.getValueAsLong();
+            try {
+              scso.onError(Status.DEADLINE_EXCEEDED
+                  .withDescription("gRPC stream aborted: client transport not ready within " + timeoutMs
+                      + " ms (arcadedb.server.grpcStreamWriteTimeoutMs); slow or abandoned consumer")
+                  .asRuntimeException());
+            } catch (final StatusRuntimeException ignore) {
+              // transport may have closed concurrently; the terminal is already moot
+            }
+          }
+          return; // terminal already sent (DEADLINE_EXCEEDED) or intentionally omitted (client cancel)
+        }
+        scso.onCompleted();
+        return;
+      }
+
+      // No external transaction: run on the gRPC worker thread against a pooled database handle.
+      db = getDatabase(request.getDatabase(), request.getCredentials());
+
+      // --- TX begin if requested ---
       if (hasTx && tx.getBegin()) {
         db.begin();
         beganHere = true;
       }
 
-      final String language = langOrDefault(request.getLanguage());
-      profileLanguage = language;
-
       // --- Dispatch on mode (helpers do NOT manage transactions) ---
-      // PAGED mode uses SQL-specific SKIP/LIMIT wrapping, so fall back to CURSOR for non-SQL languages
-      switch (request.getRetrievalMode()) {
-        case MATERIALIZE_ALL -> streamMaterialized(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
-        case PAGED -> {
-          if (!"sql".equalsIgnoreCase(language))
-            streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
-          else
-            streamPaged(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
-        }
-        case CURSOR -> streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
-        default -> streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
-      }
+      dispatchStream(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
 
       // If the client cancelled mid-stream, choose rollback unless caller explicitly
       // asked to commit/rollback.
@@ -1796,6 +1909,28 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           profileLanguage != null ? profileLanguage : request.getLanguage(), request.getQuery());
       QueryProfile.popCurrent();
       ProtocolContext.clear();
+    }
+  }
+
+  /**
+   * Dispatches a stream to the retrieval-mode-specific helper. The helpers do NOT manage transactions; the
+   * caller owns begin/commit/rollback (or, for an externally-managed transaction, leaves the lifecycle to the
+   * Begin/Commit/Rollback RPCs). PAGED mode uses SQL-specific SKIP/LIMIT wrapping, so it falls back to CURSOR
+   * for non-SQL languages.
+   */
+  private void dispatchStream(final Database db, final StreamQueryRequest request, final int batchSize,
+      final ServerCallStreamObserver<QueryResult> scso, final AtomicBoolean cancelled,
+      final AtomicBoolean serverTimedOut, final ProjectionConfig projectionConfig, final String language) {
+    switch (request.getRetrievalMode()) {
+      case MATERIALIZE_ALL -> streamMaterialized(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
+      case PAGED -> {
+        if (!"sql".equalsIgnoreCase(language))
+          streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
+        else
+          streamPaged(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
+      }
+      case CURSOR -> streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
+      default -> streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
     }
   }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5042ReapedTransactionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5042ReapedTransactionIT.java
@@ -52,9 +52,13 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
  *   <li>Write RPCs ({@code executeCommand}, {@code createRecord}, {@code updateRecord},
  *       {@code deleteRecord}) reject a non-blank-but-unknown transaction id with
  *       {@code FAILED_PRECONDITION} instead of silently falling through to a per-call auto-commit.</li>
+ *   <li>The {@code lookupByRid} read RPC applies the same rejection: a non-blank-but-unknown transaction id
+ *       fails with {@code FAILED_PRECONDITION} rather than silently serving an out-of-transaction read.</li>
  *   <li>A genuinely absent/blank transaction id still takes the auto-transaction path.</li>
  *   <li>{@code streamQuery} honors the supplied transaction id and runs inside the transaction, so a
  *       streamed read sees the transaction's own uncommitted writes.</li>
+ *   <li>{@code streamQuery} rejects a non-blank-but-unknown transaction id with {@code FAILED_PRECONDITION}
+ *       instead of silently running as a throwaway read.</li>
  * </ul>
  */
 public class Issue5042ReapedTransactionIT extends BaseGraphServerTest {
@@ -181,6 +185,49 @@ public class Issue5042ReapedTransactionIT extends BaseGraphServerTest {
         .setQuery("SELECT FROM Person WHERE name IN ['reaped-write','reaped-create','reaped-update']")
         .build());
     assertThat(q.getResultsList().get(0).getRecordsList()).isEmpty();
+  }
+
+  @Test
+  void lookupByRidRejectsUnknownNonBlankTransactionId() {
+    // A non-blank transaction id the server never registered (the reaped/unknown case).
+    final String unknownTxId = "reaped-" + UUID.randomUUID();
+    final TransactionContext unknownTx = TransactionContext.newBuilder()
+        .setTransactionId(unknownTxId).setDatabase(getDatabaseName()).build();
+
+    final StatusRuntimeException lookupErr = catchThrowableOfType(StatusRuntimeException.class, () ->
+        authenticatedStub.lookupByRid(LookupByRidRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setRid("#1:0")
+            .setTransaction(unknownTx)
+            .build()));
+    assertThat(lookupErr).as("lookupByRid must reject an unknown non-blank txId").isNotNull();
+    assertThat(lookupErr.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+  }
+
+  @Test
+  void streamQueryRejectsUnknownNonBlankTransactionId() {
+    // A non-blank transaction id the server never registered (the reaped/unknown case).
+    final String unknownTxId = "reaped-" + UUID.randomUUID();
+    final TransactionContext unknownTx = TransactionContext.newBuilder()
+        .setTransactionId(unknownTxId).setDatabase(getDatabaseName()).build();
+
+    // The streamed read must fail loudly instead of silently running as a throwaway read. The error surfaces
+    // when the stream is consumed, so drive the iterator inside the assertion.
+    final StatusRuntimeException streamErr = catchThrowableOfType(StatusRuntimeException.class, () -> {
+      final Iterator<QueryResult> it = authenticatedStub.streamQuery(StreamQueryRequest.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setQuery("SELECT FROM Person")
+          .setBatchSize(10)
+          .setRetrievalMode(StreamQueryRequest.RetrievalMode.CURSOR)
+          .setTransaction(unknownTx)
+          .build());
+      while (it.hasNext())
+        it.next();
+    });
+    assertThat(streamErr).as("streamQuery must reject an unknown non-blank txId").isNotNull();
+    assertThat(streamErr.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
   }
 
   @Test

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5042ReapedTransactionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5042ReapedTransactionIT.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+/**
+ * Regression test for issue #5042: reaped/unknown gRPC transactions must not cause silent data loss or
+ * partial commits.
+ *
+ * <p>Covers the server-side guarantees:
+ * <ul>
+ *   <li>Write RPCs ({@code executeCommand}, {@code createRecord}, {@code updateRecord},
+ *       {@code deleteRecord}) reject a non-blank-but-unknown transaction id with
+ *       {@code FAILED_PRECONDITION} instead of silently falling through to a per-call auto-commit.</li>
+ *   <li>A genuinely absent/blank transaction id still takes the auto-transaction path.</li>
+ *   <li>{@code streamQuery} honors the supplied transaction id and runs inside the transaction, so a
+ *       streamed read sees the transaction's own uncommitted writes.</li>
+ * </ul>
+ */
+public class Issue5042ReapedTransactionIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  @Test
+  void writeRpcsRejectUnknownNonBlankTransactionId() {
+    // A non-blank transaction id the server never registered (the reaped/unknown case).
+    final String unknownTxId = "reaped-" + UUID.randomUUID();
+    final TransactionContext unknownTx = TransactionContext.newBuilder()
+        .setTransactionId(unknownTxId).setDatabase(getDatabaseName()).build();
+
+    // executeCommand
+    final StatusRuntimeException cmdErr = catchThrowableOfType(StatusRuntimeException.class, () ->
+        authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand("INSERT INTO Person SET name = 'reaped-write'")
+            .setTransaction(unknownTx)
+            .build()));
+    assertThat(cmdErr).as("executeCommand must reject an unknown non-blank txId").isNotNull();
+    assertThat(cmdErr.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+
+    // createRecord
+    final StatusRuntimeException createErr = catchThrowableOfType(StatusRuntimeException.class, () ->
+        authenticatedStub.createRecord(CreateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setType("Person")
+            .setRecord(GrpcRecord.newBuilder()
+                .putProperties("name", GrpcValue.newBuilder().setStringValue("reaped-create").build()).build())
+            .setTransaction(unknownTx)
+            .build()));
+    assertThat(createErr).as("createRecord must reject an unknown non-blank txId").isNotNull();
+    assertThat(createErr.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+
+    // updateRecord
+    final StatusRuntimeException updateErr = catchThrowableOfType(StatusRuntimeException.class, () ->
+        authenticatedStub.updateRecord(UpdateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setRid("#1:0")
+            .setPartial(PropertiesUpdate.newBuilder()
+                .putProperties("name", GrpcValue.newBuilder().setStringValue("reaped-update").build()).build())
+            .setTransaction(unknownTx)
+            .build()));
+    assertThat(updateErr).as("updateRecord must reject an unknown non-blank txId").isNotNull();
+    assertThat(updateErr.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+
+    // deleteRecord
+    final StatusRuntimeException deleteErr = catchThrowableOfType(StatusRuntimeException.class, () ->
+        authenticatedStub.deleteRecord(DeleteRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setRid("#1:0")
+            .setTransaction(unknownTx)
+            .build()));
+    assertThat(deleteErr).as("deleteRecord must reject an unknown non-blank txId").isNotNull();
+    assertThat(deleteErr.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+
+    // Nothing must have been persisted by any of the rejected writes.
+    final ExecuteQueryResponse q = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setQuery("SELECT FROM Person WHERE name IN ['reaped-write','reaped-create','reaped-update']")
+        .build());
+    assertThat(q.getResultsList().get(0).getRecordsList()).isEmpty();
+  }
+
+  @Test
+  void blankTransactionIdStillAutoCommits() {
+    final String name = "auto-commit-" + UUID.randomUUID();
+
+    // No transaction supplied at all: the write must auto-commit (genuinely absent txId path).
+    final ExecuteCommandResponse resp = authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setCommand("INSERT INTO Person SET name = '" + name + "'")
+        .build());
+    assertThat(resp.getSuccess()).isTrue();
+
+    final ExecuteQueryResponse q = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setQuery("SELECT FROM Person WHERE name = '" + name + "'")
+        .build());
+    assertThat(q.getResultsList().get(0).getRecordsList())
+        .as("blank/absent txId must still auto-commit the write").hasSize(1);
+  }
+
+  @Test
+  void streamQueryHonorsTransactionIdAndSeesUncommittedWrites() {
+    // Begin an externally-managed transaction.
+    final BeginTransactionResponse begin = authenticatedStub.beginTransaction(BeginTransactionRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .build());
+    final String txId = begin.getTransactionId();
+    assertThat(txId).isNotEmpty();
+
+    final TransactionContext txCtx = TransactionContext.newBuilder()
+        .setTransactionId(txId).setDatabase(getDatabaseName()).build();
+
+    try {
+      final String name = "stream-tx-" + txId;
+
+      // Write inside the transaction but DO NOT commit.
+      authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setCommand("INSERT INTO Person SET name = '" + name + "'")
+          .setTransaction(txCtx)
+          .build());
+
+      // A streamed query bound to the same transaction must see the uncommitted write.
+      final Iterator<QueryResult> it = authenticatedStub.streamQuery(StreamQueryRequest.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setQuery("SELECT FROM Person WHERE name = '" + name + "'")
+          .setBatchSize(10)
+          .setRetrievalMode(StreamQueryRequest.RetrievalMode.CURSOR)
+          .setTransaction(txCtx)
+          .build());
+
+      int seen = 0;
+      while (it.hasNext())
+        seen += it.next().getRecordsList().size();
+
+      assertThat(seen).as("streamed query inside the transaction must see its uncommitted write").isEqualTo(1);
+    } finally {
+      authenticatedStub.rollbackTransaction(RollbackTransactionRequest.newBuilder()
+          .setCredentials(credentials())
+          .setTransaction(txCtx)
+          .build());
+    }
+  }
+}


### PR DESCRIPTION
Closes #5042

## Summary

When a client-supplied gRPC transaction id is unknown to the server - most commonly because the idle reaper already rolled the transaction back after 5 minutes - the gRPC layer silently did the wrong thing, causing silent data loss and partial commits. This PR makes those cases fail loudly and makes streamed reads transaction-aware.

- **Client (`RemoteGrpcDatabase`):** `commit()` now throws `TransactionException` when the server responds `committed=false`, and `rollback()` throws when `rolledBack=false`, instead of treating an RPC-level success as a durable commit/rollback (TX-2).
- **Server write RPCs (`executeCommand`, `createRecord`, `updateRecord`, `deleteRecord`):** a non-blank-but-unknown `transaction_id` is now rejected with `FAILED_PRECONDITION` rather than falling through to a per-call auto-commit. A genuinely absent/blank txId still takes the auto-transaction path, matching `executeQuery` (TX-5).
- **`streamQuery`:** now resolves the supplied `transaction_id` and runs the stream on the transaction's dedicated executor thread, so a streamed read inside a client transaction sees the transaction's own uncommitted writes (the streaming analogue of the #4260 `executeQuery` fix). It no longer begins/commits a throwaway read tx when a transaction is supplied, and the client attaches the active transaction to stream requests (TX-8).
- **Reaper (CON-5):** re-reads `lastAccessMs` immediately before `activeTransactions.remove(key, value)` for idle-only reaps, shrinking the TOCTOU window where a just-touched (active) transaction could be reaped.

Covers audit findings TX-2, TX-5, TX-8, CON-5 from `docs/2026-07-06-grpc-modules-audit.md`.

## Test plan

- [x] `grpcw` `Issue5042ReapedTransactionIT` - write RPCs reject an unknown non-blank txId with `FAILED_PRECONDITION`; blank/absent txId still auto-commits; `streamQuery` bound to a live tx sees its uncommitted write (RED before fix, GREEN after).
- [x] `grpc-client` `Issue5042CommitRollbackThrowIT` - reaped-tx `commit()`/`rollback()` throw `TransactionException`; a streamed query inside a transaction sees the uncommitted write.
- [x] No regressions: `GrpcServerIT` (30), `Issue5040GrpcTransactionHijackIT`, `GrpcTransactionReaperIT`, `GrpcTransactionMaxAgeReaperIT`, `ArcadeDbGrpcServiceReaperTest`, `GrpcStreamMetricsIT`, `Issue4803GrpcResultBoundingIT`, `Issue4197GrpcExecuteQueryResultSetLeakIT`, insert-stream ITs; client `Issue4260ReloadInsideTransactionIT`, `Issue4562RollbackDeleteTest`, `Issue4533ConcurrentModificationTest`, `RemoteGrpcTransactionExplicitLockIT` (12), `StreamingQueryIT` (8), `BatchedStreamingResultSetIT` (18) - all pass.