### PR TITLE
fix(#5045): gRPC temporal (DATE/DATETIME) type fidelity on client decode

### DIFF
--- a/docs/5045-grpc-temporal-type-fidelity.md
+++ b/docs/5045-grpc-temporal-type-fidelity.md
@@ -1,0 +1,26 @@
+# Issue #5045 - gRPC temporal (DATE/DATETIME) type fidelity
+
+## Symptom
+Temporal values do not round-trip faithfully over gRPC:
+- **COR-5**: the client (`ProtoUtils.fromGrpcValue`) maps every `TIMESTAMP_VALUE` to `tsToMillis(...)`, returning a bare `Long` epoch-millis. Sub-millisecond precision (DATETIME_MICROS/NANOS) is lost and the temporal type identity is gone.
+- **COR-6**: DATE/DATETIME encode is UTC-anchored but the client decode returned a raw epoch-millis Long, so consumers had to re-apply a timezone to reconstruct a date, risking an off-by-one day.
+- **COR-12**: the server `DATETIME_SECOND/MICROS/NANOS` STRING branch in `convertWithSchemaType` did `new Date(Long.parseLong(s))`, so an ISO-8601 string throws `NumberFormatException` and `java.util.Date` caps sub-millisecond precision.
+
+## Root cause
+- Client `fromGrpcValue` ignored the `logical_type` tag the server always sets (`"date"` / `"datetime"`) and collapsed the proto Timestamp to epoch-millis.
+- The high-precision STRING branch on the server only accepted numeric epoch-millis strings and used `java.util.Date`.
+
+## Fix
+- `grpc-client` `ProtoUtils.fromGrpcValue` TIMESTAMP_VALUE: reconstruct the temporal type from `logical_type` symmetrically with the encode side (UTC-anchored):
+  - `"date"` -> `LocalDate.ofEpochDay(floorDiv(seconds, 86400))`
+  - `"datetime"` -> `LocalDateTime.ofEpochSecond(seconds, nanos, UTC)` (preserves micros/nanos)
+  - no `logical_type` -> unchanged legacy `Long` epoch-millis (keeps `ProtoUtilsTest.fromGrpcValueTimestamp` green and backward-compatible).
+- `grpcw` `ArcadeDbGrpcService.convertWithSchemaType` DATETIME_SECOND/MICROS/NANOS STRING branch: numeric string -> `Instant.ofEpochMilli(...)`; otherwise `DateUtils.dateTimeToTimestamp(db, s, NANOS)` -> `Instant.ofEpochSecond(0, nanos)` so ISO-8601 is accepted and sub-millisecond precision survives (engine truncates to the column precision).
+
+## Tests
+- `ProtoUtilsTemporalDecodeTest` (grpc-client unit): date/datetime/micros/nanos decode to the right temporal type and value; bare timestamp still decodes to Long.
+- `Issue5045GrpcTemporalFidelityIT` (grpc-client IT): full round-trip through `RemoteGrpcDatabase` for DATE, DATETIME, DATETIME_MICROS, DATETIME_NANOS asserting temporal type + exact value on the client.
+- `Issue5045GrpcDatetimeStringPrecisionIT` (grpcw IT): sending an ISO-8601 string to a DATETIME_NANOS column no longer throws and preserves nanosecond precision.
+
+## Impact
+Silent precision loss and type-identity loss on temporal reads over gRPC are fixed. Backward compatible: timestamps without a `logical_type` still decode to `Long`. Out of scope (noted for follow-up): explicit proto representations for `LocalTime`/TIME, zoned datetime offset retention, and `Duration`.

--- a/docs/5045-grpc-temporal-type-fidelity.md
+++ b/docs/5045-grpc-temporal-type-fidelity.md
@@ -23,4 +23,7 @@ Temporal values do not round-trip faithfully over gRPC:
 - `Issue5045GrpcDatetimeStringPrecisionIT` (grpcw IT): sending an ISO-8601 string to a DATETIME_NANOS column no longer throws and preserves nanosecond precision.
 
 ## Impact
-Silent precision loss and type-identity loss on temporal reads over gRPC are fixed. Backward compatible: timestamps without a `logical_type` still decode to `Long`. Out of scope (noted for follow-up): explicit proto representations for `LocalTime`/TIME, zoned datetime offset retention, and `Duration`.
+Silent precision loss and type-identity loss on temporal reads over gRPC are fixed. Out of scope (noted for follow-up): explicit proto representations for `LocalTime`/TIME, zoned datetime offset retention, and `Duration`.
+
+## Compatibility note (surface in release notes)
+Because the server always sets a `logical_type` on temporal values, this is a wire-decode behavior change for real server responses, not only the untagged-timestamp edge case: `grpc-client` reads of DATE/DATETIME columns that previously returned a bare `Long` epoch-millis now return `LocalDate` / `LocalDateTime`. Any downstream consumer that read a temporal column and expected a `Long` (or did epoch-millis arithmetic on it) must be updated. Timestamps with no `logical_type` still decode to `Long` (unchanged). On the encode side `java.util.Date`, `Instant`, and `ZonedDateTime` all carry `logical_type "datetime"`, so all three now round-trip to a `LocalDateTime` at UTC; instant/zone identity is not preserved (tracked as the out-of-scope proto-gap follow-up above).

--- a/docs/5045-grpc-temporal-type-fidelity.md
+++ b/docs/5045-grpc-temporal-type-fidelity.md
@@ -25,5 +25,16 @@ Temporal values do not round-trip faithfully over gRPC:
 ## Impact
 Silent precision loss and type-identity loss on temporal reads over gRPC are fixed. Out of scope (noted for follow-up): explicit proto representations for `LocalTime`/TIME, zoned datetime offset retention, and `Duration`.
 
+## PR
+https://github.com/ArcadeData/arcadedb/pull/5196
+
+## Review cycles
+- **c599135** (initial): gemini-code-assist COMMENTED (LGTM, no feedback); claude[bot] non-blocking ("core fix is sound"). Suggested a pre-epoch date test and a release-note callout.
+- **e37d876** (cycle 2): added `preEpochDateRoundTripsAsLocalDate` IT + compatibility note. claude[bot] re-reviewed, non-blocking; only substantive ask was deciding/documenting malformed-string behavior.
+- **2844277** (cycle 3): added `malformedStringSurfacesAnErrorInsteadOfSilentlyStoringNull` IT proving a malformed datetime string surfaces a loud gRPC error (not a silent null). claude[bot] re-reviewed: **LGTM pending release-note callout**; remaining points out-of-scope / pre-existing / non-blocking.
+- **a200031** (cycle 4): added cross-referencing comments tying the shared UTC-anchored temporal encode/decode contract across `ProtoUtils` (grpc-client) and `GrpcTypeConverter` (grpcw) so they cannot silently diverge (claude point 3, non-blocking).
+
+Final state: max review cycles (4) reached. Both bots LGTM. The only open item is a maintainer-owned release-note/changelog callout for the wire-decode behavior change (temporals now decode to `LocalDate`/`LocalDateTime` instead of `Long`); it is documented below and is not a code change. Deferred/skipped review items are tracked locally in `docs/review-deferred-c599135.md` (not committed, per repo convention).
+
 ## Compatibility note (surface in release notes)
 Because the server always sets a `logical_type` on temporal values, this is a wire-decode behavior change for real server responses, not only the untagged-timestamp edge case: `grpc-client` reads of DATE/DATETIME columns that previously returned a bare `Long` epoch-millis now return `LocalDate` / `LocalDateTime`. Any downstream consumer that read a temporal column and expected a `Long` (or did epoch-millis arithmetic on it) must be updated. Timestamps with no `logical_type` still decode to `Long` (unchanged). On the encode side `java.util.Date`, `Instant`, and `ZonedDateTime` all carry `logical_type "datetime"`, so all three now round-trip to a `LocalDateTime` at UTC; instant/zone identity is not preserved (tracked as the out-of-scope proto-gap follow-up above).

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
@@ -405,6 +405,9 @@ public class ProtoUtils {
       // symmetrically with the encode side (UTC-anchored), instead of collapsing every Timestamp
       // to a bare Long epoch-millis - which lost sub-millisecond precision (DATETIME_MICROS/NANOS)
       // and the temporal type identity, and forced consumers to re-apply a timezone (off-by-one risk).
+      // The UTC-anchored temporal encoding (epochDay * 86400 for "date"; toInstant(UTC) for
+      // "datetime") is shared with the server encoder GrpcTypeConverter.toGrpcValue in the grpcw
+      // module and this class's own toGrpcValue above; keep all three in sync when changing it.
       final Timestamp ts = v.getTimestampValue();
       final String logical = v.getLogicalType();
       if ("date".equalsIgnoreCase(logical))

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
@@ -400,8 +400,22 @@ public class ProtoUtils {
       }
       return dbgDec("fromGrpcValue", v, v.getBytesValue().toByteArray());
 
-    case TIMESTAMP_VALUE:
-      return dbgDec("fromGrpcValue", v, tsToMillis(v.getTimestampValue())); // or Instant
+    case TIMESTAMP_VALUE: {
+      // Issue #5045: reconstruct the temporal type from the logical_type tag the server sets,
+      // symmetrically with the encode side (UTC-anchored), instead of collapsing every Timestamp
+      // to a bare Long epoch-millis - which lost sub-millisecond precision (DATETIME_MICROS/NANOS)
+      // and the temporal type identity, and forced consumers to re-apply a timezone (off-by-one risk).
+      final Timestamp ts = v.getTimestampValue();
+      final String logical = v.getLogicalType();
+      if ("date".equalsIgnoreCase(logical))
+        // Encode: epochDay * 86400 seconds. Inverse recovers the exact LocalDate at UTC.
+        return dbgDec("fromGrpcValue", v, LocalDate.ofEpochDay(Math.floorDiv(ts.getSeconds(), 86_400L)));
+      if ("datetime".equalsIgnoreCase(logical))
+        // Encode: LocalDateTime/Instant.toInstant(UTC). Inverse preserves micros/nanos at UTC.
+        return dbgDec("fromGrpcValue", v, LocalDateTime.ofEpochSecond(ts.getSeconds(), ts.getNanos(), ZoneOffset.UTC));
+      // No logical_type: keep the legacy epoch-millis Long behavior (backward compatible).
+      return dbgDec("fromGrpcValue", v, tsToMillis(ts));
+    }
     case LIST_VALUE: {
       var out = new ArrayList<>();
       for (GrpcValue e : v.getListValue().getValuesList())

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5045GrpcTemporalFidelityIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5045GrpcTemporalFidelityIT.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5045 (COR-5 / COR-6): temporal values must round-trip over gRPC as
+ * temporal types with their precision intact, instead of decoding to a bare {@code Long}
+ * epoch-millis (losing sub-millisecond precision and the temporal type identity, and forcing the
+ * caller to re-apply a timezone).
+ * <p>
+ * The client {@code ProtoUtils.fromGrpcValue} now reconstructs the temporal type from the
+ * {@code logical_type} tag the server sets, symmetrically with the UTC-anchored encode side.
+ */
+public class Issue5045GrpcTemporalFidelityIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT   = 50051;
+  private static final int    HTTP_PORT   = 2480;
+  private static final String VERTEX_TYPE = "Temporal5045";
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase grpc;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void openAndPrepare() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    grpc = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, HTTP_PORT, getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+    grpc.command("sql", "CREATE VERTEX TYPE `" + VERTEX_TYPE + "` IF NOT EXISTS");
+    grpc.command("sql", "CREATE PROPERTY `" + VERTEX_TYPE + "`.d IF NOT EXISTS DATE");
+    grpc.command("sql", "CREATE PROPERTY `" + VERTEX_TYPE + "`.dt IF NOT EXISTS DATETIME");
+    grpc.command("sql", "CREATE PROPERTY `" + VERTEX_TYPE + "`.dtMicros IF NOT EXISTS DATETIME_MICROS");
+    grpc.command("sql", "CREATE PROPERTY `" + VERTEX_TYPE + "`.dtNanos IF NOT EXISTS DATETIME_NANOS");
+    grpc.command("sql", "DELETE FROM `" + VERTEX_TYPE + "`");
+  }
+
+  @AfterEach
+  void closeClient() {
+    if (grpc != null) {
+      try {
+        grpc.rollback();
+      } catch (final Throwable ignore) {
+        // ignore
+      }
+      grpc.close();
+    }
+    if (grpcServer != null)
+      grpcServer.close();
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Test
+  void dateRoundTripsAsLocalDate() {
+    final LocalDate target = LocalDate.of(2026, 7, 6);
+
+    grpc.begin();
+    final MutableVertex v = grpc.newVertex(VERTEX_TYPE);
+    v.set("d", target);
+    v.save();
+    grpc.commit();
+
+    try (final ResultSet rs = grpc.query("sql", "SELECT d FROM `" + VERTEX_TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Object raw = rs.next().getProperty("d");
+      assertThat(raw).as("DATE must decode to a LocalDate, not a Long").isInstanceOf(LocalDate.class);
+      assertThat((LocalDate) raw).isEqualTo(target);
+    }
+  }
+
+  @Test
+  void datetimeRoundTripsAsLocalDateTime() {
+    final LocalDateTime target = LocalDateTime.of(2026, 5, 9, 12, 34, 56, 123_000_000);
+
+    grpc.begin();
+    final MutableVertex v = grpc.newVertex(VERTEX_TYPE);
+    v.set("dt", target);
+    v.save();
+    grpc.commit();
+
+    try (final ResultSet rs = grpc.query("sql", "SELECT dt FROM `" + VERTEX_TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Object raw = rs.next().getProperty("dt");
+      assertThat(raw).as("DATETIME must decode to a LocalDateTime, not a Long").isInstanceOf(LocalDateTime.class);
+      assertThat((LocalDateTime) raw).isEqualTo(target);
+    }
+  }
+
+  @Test
+  void datetimeMicrosRoundTripsPreservingMicros() {
+    final LocalDateTime target = LocalDateTime.of(2026, 5, 9, 12, 34, 56, 123_456_000);
+
+    grpc.begin();
+    final MutableVertex v = grpc.newVertex(VERTEX_TYPE);
+    v.set("dtMicros", target);
+    v.save();
+    grpc.commit();
+
+    try (final ResultSet rs = grpc.query("sql", "SELECT dtMicros FROM `" + VERTEX_TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Object raw = rs.next().getProperty("dtMicros");
+      assertThat(raw).as("DATETIME_MICROS must decode to a LocalDateTime").isInstanceOf(LocalDateTime.class);
+      assertThat(((LocalDateTime) raw).getNano()).as("microsecond precision preserved").isEqualTo(123_456_000);
+      assertThat((LocalDateTime) raw).isEqualTo(target);
+    }
+  }
+
+  @Test
+  void datetimeNanosRoundTripsPreservingNanos() {
+    final LocalDateTime target = LocalDateTime.of(2026, 5, 9, 12, 34, 56, 123_456_789);
+
+    grpc.begin();
+    final MutableVertex v = grpc.newVertex(VERTEX_TYPE);
+    v.set("dtNanos", target);
+    v.save();
+    grpc.commit();
+
+    try (final ResultSet rs = grpc.query("sql", "SELECT dtNanos FROM `" + VERTEX_TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Object raw = rs.next().getProperty("dtNanos");
+      assertThat(raw).as("DATETIME_NANOS must decode to a LocalDateTime").isInstanceOf(LocalDateTime.class);
+      assertThat(((LocalDateTime) raw).getNano()).as("nanosecond precision preserved").isEqualTo(123_456_789);
+      assertThat((LocalDateTime) raw).isEqualTo(target);
+    }
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5045GrpcTemporalFidelityIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5045GrpcTemporalFidelityIT.java
@@ -109,6 +109,26 @@ public class Issue5045GrpcTemporalFidelityIT extends BaseGraphServerTest {
   }
 
   @Test
+  void preEpochDateRoundTripsAsLocalDate() {
+    // Guards the floorDiv() path on the decode side: a pre-epoch date has a negative epoch-day,
+    // so plain integer division would round toward zero and land on the wrong day.
+    final LocalDate target = LocalDate.of(1969, 12, 31);
+
+    grpc.begin();
+    final MutableVertex v = grpc.newVertex(VERTEX_TYPE);
+    v.set("d", target);
+    v.save();
+    grpc.commit();
+
+    try (final ResultSet rs = grpc.query("sql", "SELECT d FROM `" + VERTEX_TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Object raw = rs.next().getProperty("d");
+      assertThat(raw).as("pre-epoch DATE must decode to a LocalDate").isInstanceOf(LocalDate.class);
+      assertThat((LocalDate) raw).isEqualTo(target);
+    }
+  }
+
+  @Test
   void datetimeRoundTripsAsLocalDateTime() {
     final LocalDateTime target = LocalDateTime.of(2026, 5, 9, 12, 34, 56, 123_000_000);
 

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsTemporalDecodeTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsTemporalDecodeTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc.utils;
+
+import com.arcadedb.server.grpc.GrpcValue;
+import com.google.protobuf.Timestamp;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5045 (COR-5 / COR-6): the client must reconstruct the correct temporal type from the
+ * {@code logical_type} tag the server sets on a proto Timestamp, preserving sub-millisecond
+ * precision and reading the value back at the same UTC anchor used on encode - instead of
+ * collapsing every Timestamp to a bare {@code Long} epoch-millis (losing micros/nanos and the
+ * temporal type identity).
+ */
+class ProtoUtilsTemporalDecodeTest {
+
+  @Test
+  void dateLogicalTypeDecodesToLocalDate() {
+    final LocalDate expected = LocalDate.of(2026, 7, 6);
+    // Server encodes a LocalDate as midnight-UTC: epochDay * 86400 seconds, nanos 0, logical_type "date".
+    final long seconds = expected.toEpochDay() * 86_400L;
+    final GrpcValue v = GrpcValue.newBuilder()
+        .setTimestampValue(Timestamp.newBuilder().setSeconds(seconds).setNanos(0).build())
+        .setLogicalType("date")
+        .build();
+
+    final Object decoded = ProtoUtils.fromGrpcValue(v);
+    assertThat(decoded).isInstanceOf(LocalDate.class);
+    assertThat((LocalDate) decoded).isEqualTo(expected);
+  }
+
+  @Test
+  void datetimeLogicalTypeDecodesToLocalDateTimePreservingMillis() {
+    final LocalDateTime expected = LocalDateTime.of(2026, 1, 1, 0, 0, 0, 123_000_000);
+    final GrpcValue v = GrpcValue.newBuilder()
+        .setTimestampValue(Timestamp.newBuilder()
+            .setSeconds(expected.toEpochSecond(ZoneOffset.UTC))
+            .setNanos(expected.getNano())
+            .build())
+        .setLogicalType("datetime")
+        .build();
+
+    final Object decoded = ProtoUtils.fromGrpcValue(v);
+    assertThat(decoded).isInstanceOf(LocalDateTime.class);
+    assertThat((LocalDateTime) decoded).isEqualTo(expected);
+  }
+
+  @Test
+  void datetimeLogicalTypePreservesMicros() {
+    final LocalDateTime expected = LocalDateTime.of(2026, 1, 1, 0, 0, 0, 123_456_000);
+    final GrpcValue v = GrpcValue.newBuilder()
+        .setTimestampValue(Timestamp.newBuilder()
+            .setSeconds(expected.toEpochSecond(ZoneOffset.UTC))
+            .setNanos(expected.getNano())
+            .build())
+        .setLogicalType("datetime")
+        .build();
+
+    final Object decoded = ProtoUtils.fromGrpcValue(v);
+    assertThat(decoded).isInstanceOf(LocalDateTime.class);
+    assertThat(((LocalDateTime) decoded).getNano()).isEqualTo(123_456_000);
+    assertThat((LocalDateTime) decoded).isEqualTo(expected);
+  }
+
+  @Test
+  void datetimeLogicalTypePreservesNanos() {
+    final LocalDateTime expected = LocalDateTime.of(2026, 5, 9, 12, 34, 56, 123_456_789);
+    final GrpcValue v = GrpcValue.newBuilder()
+        .setTimestampValue(Timestamp.newBuilder()
+            .setSeconds(expected.toEpochSecond(ZoneOffset.UTC))
+            .setNanos(expected.getNano())
+            .build())
+        .setLogicalType("datetime")
+        .build();
+
+    final Object decoded = ProtoUtils.fromGrpcValue(v);
+    assertThat(decoded).isInstanceOf(LocalDateTime.class);
+    assertThat(((LocalDateTime) decoded).getNano()).isEqualTo(123_456_789);
+    assertThat((LocalDateTime) decoded).isEqualTo(expected);
+  }
+
+  @Test
+  void bareTimestampWithoutLogicalTypeStillDecodesToLongForBackwardCompatibility() {
+    // A Timestamp with no logical_type keeps the legacy epoch-millis Long behavior so existing
+    // consumers (and ProtoUtilsTest.fromGrpcValueTimestamp) are unaffected.
+    final GrpcValue v = GrpcValue.newBuilder()
+        .setTimestampValue(Timestamp.newBuilder().setSeconds(1_234_567_890L).setNanos(123_456_789).build())
+        .build();
+
+    final Object decoded = ProtoUtils.fromGrpcValue(v);
+    assertThat(decoded).isInstanceOf(Long.class);
+    assertThat((Long) decoded).isEqualTo(1_234_567_890_123L);
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsTest.java
@@ -481,8 +481,12 @@ class ProtoUtilsTest {
     final GrpcValue grpcValue = ProtoUtils.toGrpcValue(date);
     final Object result = ProtoUtils.fromGrpcValue(grpcValue);
 
-    assertThat(result).isInstanceOf(Long.class);
-    assertThat((Long) result).isEqualTo(1234567890000L);
+    // Issue #5045: a Date carries logical_type "datetime", so it now round-trips to a temporal
+    // (LocalDateTime at the same UTC instant) instead of a bare Long epoch-millis. The previous
+    // Long assertion documented the COR-5 type-loss defect this issue fixes.
+    assertThat(result).isInstanceOf(LocalDateTime.class);
+    assertThat((LocalDateTime) result)
+        .isEqualTo(LocalDateTime.ofEpochSecond(1234567890L, 0, ZoneOffset.UTC));
   }
 
   private void assertRoundTrip(final Object original) {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -4625,7 +4625,20 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         return switch (v.getKindCase()) {
           case TIMESTAMP_VALUE -> GrpcTypeConverter.tsToInstant(v.getTimestampValue());
           case INT64_VALUE -> new Date(v.getInt64Value()); // epoch ms expected
-          case STRING_VALUE -> new Date(Long.parseLong(v.getStringValue()));
+          case STRING_VALUE -> {
+            // Issue #5045 (COR-12): mirror the DATE/DATETIME branch. A numeric string is epoch
+            // milliseconds (backward compatible); anything else is parsed as ISO-8601 (or a
+            // schema-configured format) instead of throwing NumberFormatException. Return an Instant
+            // (not java.util.Date) so sub-millisecond precision survives - Type.convert() truncates
+            // to the column's declared precision.
+            final String s = v.getStringValue();
+            try {
+              yield Instant.ofEpochMilli(Long.parseLong(s));
+            } catch (final NumberFormatException ignored) {
+              final Long nanos = DateUtils.dateTimeToTimestamp(db, s, ChronoUnit.NANOS);
+              yield nanos != null ? Instant.ofEpochSecond(0L, nanos) : null;
+            }
+          }
           default -> null;
         };
       }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
@@ -164,6 +164,9 @@ class GrpcTypeConverter {
     // Without these branches the read path falls through to String.valueOf(o), emitting
     // string_value at LocalDateTime#toString precision rather than timestamp_value at the
     // column's declared precision.
+    // Issue #5045: this UTC-anchored temporal encoding (epochDay * 86400 for "date";
+    // toInstant(UTC) for "datetime") is the inverse of the client decoder
+    // ProtoUtils.fromGrpcValue in the grpc-client module; keep the two in sync when changing it.
     if (o instanceof LocalDate ld) {
       final long seconds = ld.atStartOfDay(ZoneOffset.UTC).toEpochSecond();
       return b.setTimestampValue(Timestamp.newBuilder().setSeconds(seconds).setNanos(0).build())

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5045GrpcDatetimeStringPrecisionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5045GrpcDatetimeStringPrecisionIT.java
@@ -34,11 +34,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.grpc.StatusRuntimeException;
+
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #5045 (COR-12): the {@code DATETIME_SECOND/MICROS/NANOS} STRING branch
@@ -185,6 +188,39 @@ public class Issue5045GrpcDatetimeStringPrecisionIT extends BaseGraphServerTest 
 
     // DATETIME_MICROS truncates to microsecond precision: 123_456_789 -> 123_456_000.
     assertThat(readBackNanos("MicrosStr5045")).isEqualTo(123_456_000);
+  }
+
+  @Test
+  void malformedStringSurfacesAnErrorInsteadOfSilentlyStoringNull() {
+    // Documents the decision for point 2 of the #5196 review: a string that is neither numeric nor a
+    // parseable datetime is surfaced as a loud gRPC error (DateUtils.parseIsoDateTime throws
+    // DateTimeParseException, which propagates), not silently coerced to null and stored.
+    executeCommand("CREATE DOCUMENT TYPE NanosBad5045 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY NanosBad5045.t IF NOT EXISTS DATETIME_NANOS");
+
+    final GrpcRecord record = GrpcRecord.newBuilder()
+        .setType("NanosBad5045")
+        .putProperties("t", GrpcValue.newBuilder().setStringValue("not-a-datetime").build())
+        .build();
+
+    assertThatThrownBy(() -> authenticatedStub.createRecord(
+        CreateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setType("NanosBad5045")
+            .setRecord(record)
+            .build()))
+        .isInstanceOf(StatusRuntimeException.class);
+
+    // Nothing was persisted.
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(
+        ExecuteQueryRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setQuery("SELECT count(*) AS c FROM NanosBad5045")
+            .build());
+    final GrpcValue count = response.getResultsList().get(0).getRecordsList().get(0).getPropertiesMap().get("c");
+    assertThat(((Number) GrpcTypeConverter.fromGrpcValue(count)).longValue()).isZero();
   }
 
   @Test

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5045GrpcDatetimeStringPrecisionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5045GrpcDatetimeStringPrecisionIT.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5045 (COR-12): the {@code DATETIME_SECOND/MICROS/NANOS} STRING branch
+ * in {@code convertWithSchemaType} previously did {@code new Date(Long.parseLong(s))}, which threw
+ * {@link NumberFormatException} on an ISO-8601 string and capped high-precision columns at
+ * millisecond precision.
+ * <p>
+ * The fix parses ISO-8601 (numeric strings stay epoch-millis for backward compatibility) and keeps
+ * sub-millisecond precision via {@link java.time.Instant}, letting {@code Type.convert()} truncate
+ * to the column's declared precision.
+ */
+public class Issue5045GrpcDatetimeStringPrecisionIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  // 2026-05-09T12:34:56.123456789 - distinct millis, micros and nanos digits
+  private static final LocalDateTime TEST_TIME    = LocalDateTime.of(2026, 5, 9, 12, 34, 56, 123_456_789);
+  private static final long          TEST_SECONDS = TEST_TIME.toEpochSecond(ZoneOffset.UTC);
+
+  private ManagedChannel channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    GlobalConfiguration.QUERY_PARALLEL_SCAN.setValue(false);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder()
+        .setUsername("root")
+        .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+        .build();
+  }
+
+  private void executeCommand(final String command) {
+    authenticatedStub.executeCommand(
+        ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand(command)
+            .build());
+  }
+
+  private int readBackNanos(final String type) {
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(
+        ExecuteQueryRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setQuery("SELECT t FROM " + type)
+            .build());
+
+    assertThat(response.getResultsList()).as("query must return at least one result group").isNotEmpty();
+    assertThat(response.getResultsList().get(0).getRecordsList()).as("result group must contain records").isNotEmpty();
+
+    final GrpcRecord record = response.getResultsList().get(0).getRecordsList().get(0);
+    assertThat(record.getPropertiesMap()).as("'t' property must be present").containsKey("t");
+    final GrpcValue tValue = record.getPropertiesMap().get("t");
+    assertThat(tValue.hasTimestampValue()).as("datetime property must come back as a Timestamp").isTrue();
+    assertThat(tValue.getTimestampValue().getSeconds()).isEqualTo(TEST_SECONDS);
+    return tValue.getTimestampValue().getNanos();
+  }
+
+  @Test
+  void isoStringPreservesNanosForDatetimeNanos() {
+    executeCommand("CREATE DOCUMENT TYPE NanosStr5045 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY NanosStr5045.t IF NOT EXISTS DATETIME_NANOS");
+
+    // ISO-8601 string with nanosecond precision. Before the fix this threw NumberFormatException.
+    final GrpcRecord record = GrpcRecord.newBuilder()
+        .setType("NanosStr5045")
+        .putProperties("t", GrpcValue.newBuilder().setStringValue("2026-05-09T12:34:56.123456789").build())
+        .build();
+
+    final CreateRecordResponse createResp = authenticatedStub.createRecord(
+        CreateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setType("NanosStr5045")
+            .setRecord(record)
+            .build());
+    assertThat(createResp.getRid()).isNotEmpty();
+
+    assertThat(readBackNanos("NanosStr5045")).isEqualTo(123_456_789);
+  }
+
+  @Test
+  void isoStringPreservesMicrosForDatetimeMicros() {
+    executeCommand("CREATE DOCUMENT TYPE MicrosStr5045 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY MicrosStr5045.t IF NOT EXISTS DATETIME_MICROS");
+
+    final GrpcRecord record = GrpcRecord.newBuilder()
+        .setType("MicrosStr5045")
+        .putProperties("t", GrpcValue.newBuilder().setStringValue("2026-05-09T12:34:56.123456789").build())
+        .build();
+
+    final CreateRecordResponse createResp = authenticatedStub.createRecord(
+        CreateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setType("MicrosStr5045")
+            .setRecord(record)
+            .build());
+    assertThat(createResp.getRid()).isNotEmpty();
+
+    // DATETIME_MICROS truncates to microsecond precision: 123_456_789 -> 123_456_000.
+    assertThat(readBackNanos("MicrosStr5045")).isEqualTo(123_456_000);
+  }
+
+  @Test
+  void numericStringStaysEpochMillisForDatetimeNanos() {
+    executeCommand("CREATE DOCUMENT TYPE NanosEpoch5045 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY NanosEpoch5045.t IF NOT EXISTS DATETIME_NANOS");
+
+    // A numeric string remains epoch milliseconds for backward compatibility.
+    final long epochMillis = TEST_SECONDS * 1000L + 123L;
+    final GrpcRecord record = GrpcRecord.newBuilder()
+        .setType("NanosEpoch5045")
+        .putProperties("t", GrpcValue.newBuilder().setStringValue(Long.toString(epochMillis)).build())
+        .build();
+
+    final CreateRecordResponse createResp = authenticatedStub.createRecord(
+        CreateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setType("NanosEpoch5045")
+            .setRecord(record)
+            .build());
+    assertThat(createResp.getRid()).isNotEmpty();
+
+    // Epoch-millis input carries only millisecond precision.
+    assertThat(readBackNanos("NanosEpoch5045")).isEqualTo(123_000_000);
+  }
+}


### PR DESCRIPTION
Closes #5045

## Summary
Temporal values (DATE / DATETIME with second/milli/micro/nano precision) did not round-trip faithfully over gRPC. The client collapsed every proto Timestamp to a bare `Long` epoch-millis on decode (losing sub-millisecond precision and the temporal type identity, and forcing callers to re-apply a timezone), and one server decode branch threw on ISO-8601 strings. This is the gRPC continuation of the #4181 / #4805 / #4358 / #4149 datetime family - the server-side nanos fixes stopped at the wire and were undone by the client.

- **COR-5 / COR-6 (client decode)** - `grpc-client` `ProtoUtils.fromGrpcValue` now reconstructs the temporal type from the `logical_type` tag the server always sets, symmetrically with the UTC-anchored encode side:
  - `"date"` -> `LocalDate.ofEpochDay(floorDiv(seconds, 86400))`
  - `"datetime"` -> `LocalDateTime.ofEpochSecond(seconds, nanos, UTC)` (preserves micros/nanos)
  - no `logical_type` -> unchanged legacy `Long` epoch-millis, so existing consumers and `ProtoUtilsTest.fromGrpcValueTimestamp` stay green.
- **COR-12 (server high-precision string branch)** - `grpcw` `ArcadeDbGrpcService.convertWithSchemaType` DATETIME_SECOND/MICROS/NANOS STRING branch now accepts ISO-8601 (numeric strings stay epoch-millis for backward compatibility) and keeps sub-millisecond precision via `Instant` instead of throwing `NumberFormatException` / capping at millis with `java.util.Date`.

One existing assertion (`ProtoUtilsTest.roundTripDate`) documented the COR-5 type-loss defect (a `Date` decoding to `Long`); it was updated to assert the corrected contract (a temporal at the same UTC instant).

Out of scope, noted for follow-up: explicit proto representations for `LocalTime`/TIME, zoned-datetime offset retention, and `Duration`.

## Test plan
- [x] `ProtoUtilsTemporalDecodeTest` (grpc-client unit) - date/datetime/micros/nanos decode to the right temporal type + value; bare timestamp still decodes to `Long`.
- [x] `Issue5045GrpcTemporalFidelityIT` (grpc-client IT) - full round-trip through `RemoteGrpcDatabase` for DATE, DATETIME, DATETIME_MICROS, DATETIME_NANOS asserting temporal type + exact value on the client.
- [x] `Issue5045GrpcDatetimeStringPrecisionIT` (grpcw IT) - ISO-8601 string into DATETIME_NANOS/MICROS no longer throws and preserves precision; numeric string stays epoch-millis.
- [x] Regression: `Issue4358GrpcDateTimeIT`, `Issue4805GrpcDatetimePrecisionIT`, `Issue4181GrpcDateCorruptionIT`, `ProtoUtilsTest`, `RemoteGrpcDatabaseRegressionTest`, `RemoteGrpcDatabaseCoverageIT`, `TimeSeriesGrpcInsertMaterializationIT` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)