### PR TITLE
fix(#5047): gRPC streaming & pagination correctness

### DIFF
--- a/docs/5047-grpc-streaming-pagination-correctness.md
+++ b/docs/5047-grpc-streaming-pagination-correctness.md
@@ -19,7 +19,7 @@ Several correctness/efficiency defects in the gRPC streaming and pagination path
 - **STR-4 (fixed)** - `is_last_batch` was never true on exact-multiple totals. `streamCursor` and
   `streamPaged` now defer the final full batch/page by one step so the terminal batch always carries
   `is_last_batch=true` (fixes `BatchedStreamingResultSet.isLastBatch()` metadata too and removes the extra
-  round trip).
+  client-visible empty-batch round trip; PAGED still runs the server-side empty SKIP/LIMIT probe query).
 - **PERF-3 (fixed)** - `streamPaged` rebuilt `convertParameters` + a wrapping map every page. The base
   parameter map is now converted once and copied per page.
 - **STR-3 (partially fixed)** - `streamPaged` now rejects a query whose parameters collide with the reserved

--- a/docs/5047-grpc-streaming-pagination-correctness.md
+++ b/docs/5047-grpc-streaming-pagination-correctness.md
@@ -1,0 +1,49 @@
+# Issue #5047 - gRPC streaming & pagination correctness
+
+## Symptom
+Several correctness/efficiency defects in the gRPC streaming and pagination paths (audit
+`docs/2026-07-06-grpc-modules-audit.md`): CON-3, STR-1, STR-2, STR-3, STR-4, PERF-2, PERF-3.
+
+## Root cause & fix (per defect)
+
+- **PERF-2 (fixed)** - `queryStreamBatched` / `queryStreamBatchesIterator` never set `.setLanguage(...)`
+  on the `StreamQueryRequest`, so Cypher/Gremlin batched-stream queries silently ran as SQL. Added
+  `.setLanguage(langOrDefault(language))` to both builders.
+- **CON-3 (fixed)** - `StreamingResultSet.close()` drained the entire remaining stream (transferring and
+  discarding every remaining row) and had no cross-thread guard. Now it cancels the underlying
+  `BlockingClientCall` and calls `checkCrossThreadUse` like `hasNext`/`next`.
+- **STR-1 (fixed)** - `InsertError.row_index` is documented as "index within the chunk" but the server
+  reported the cumulative stream-wide `ctx.received - 1`. `insertRows` per-row errors now use the
+  chunk-relative `c.received - 1`; the bidi whole-chunk-failure path now reports `-1` (not row-attributable),
+  matching the non-bidi `insertStream` path.
+- **STR-4 (fixed)** - `is_last_batch` was never true on exact-multiple totals. `streamCursor` and
+  `streamPaged` now defer the final full batch/page by one step so the terminal batch always carries
+  `is_last_batch=true` (fixes `BatchedStreamingResultSet.isLastBatch()` metadata too and removes the extra
+  round trip).
+- **PERF-3 (fixed)** - `streamPaged` rebuilt `convertParameters` + a wrapping map every page. The base
+  parameter map is now converted once and copied per page.
+- **STR-3 (partially fixed)** - `streamPaged` now rejects a query whose parameters collide with the reserved
+  `_skip`/`_limit` names (`INVALID_ARGUMENT`) instead of silently overwriting them. The deeper snapshot-isolation
+  and projection-only `@rid`-wrapper fragility are deferred (see below).
+
+## Deferred (documented, not fixed here)
+
+- **STR-2** - bidi replay duplication under `PER_ROW`/`PER_BATCH`: on chunk failure the watermark is
+  deliberately not advanced, but rows already committed mid-chunk get re-inserted on replay. A correct fix
+  requires a semantic decision (advance the watermark for already-committed rows vs. make chunk commit atomic)
+  and touches transaction lifecycle; deferred to avoid an untested transaction-semantics change.
+- **STR-3 snapshot isolation** - PAGED mode re-executes `SELECT FROM (<q>) ORDER BY @rid SKIP/LIMIT` per page,
+  so concurrent inserts/deletes shift offsets. True snapshot consistency needs CURSOR-style single execution;
+  ArcadeDB's MVCC read semantics across a spanning transaction do not guarantee it, so this is left as a
+  documented limitation (use CURSOR mode for snapshot-consistent large reads).
+- **STR-3 `@rid` wrapper on projection-only results** - detecting projection-only queries generically requires
+  query analysis; deferred.
+
+## Tests
+- `grpc-client` `Issue5047StreamingCorrectnessIT` - PERF-2 (Cypher batched stream), STR-4 (exact-multiple
+  CURSOR + PAGED), CON-3 (close after partial read releases and stream stays usable).
+- `grpcw` `Issue5047InsertErrorRowIndexIT` - STR-1 (chunk-relative row_index) and STR-3 reserved-name rejection.
+
+## Impact
+Client-side streaming/pagination correctness in the gRPC wire protocol. No change to non-streaming paths.
+</content>

--- a/docs/5047-grpc-streaming-pagination-correctness.md
+++ b/docs/5047-grpc-streaming-pagination-correctness.md
@@ -46,4 +46,3 @@ Several correctness/efficiency defects in the gRPC streaming and pagination path
 
 ## Impact
 Client-side streaming/pagination correctness in the gRPC wire protocol. No change to non-streaming paths.
-</content>

--- a/docs/5047-grpc-streaming-pagination-correctness.md
+++ b/docs/5047-grpc-streaming-pagination-correctness.md
@@ -46,3 +46,20 @@ Several correctness/efficiency defects in the gRPC streaming and pagination path
 
 ## Impact
 Client-side streaming/pagination correctness in the gRPC wire protocol. No change to non-streaming paths.
+
+## PR & review history
+- PR: https://github.com/ArcadeData/arcadedb/pull/5199
+- Cycle 1 (`8fd2a8008`): initial fixes. Gemini review COMMENTED (no actionable comments); Claude review
+  non-blocking with 5 polish suggestions.
+- Cycle 2 (`ef5adedae`): applied review items - removed stray doc marker, softened the CON-3 comment,
+  aligned the two ITs on the `GrpcServer:` plugin name, tightened the reserved-name assertion. Claude
+  re-review: "No blocking issues found" (4 non-blocking observations).
+- Cycle 3 (`bc0e14ba2`): applied 2 more non-blocking items - `streamExhausted` made `volatile`, doc wording
+  clarified (PAGED still runs the server-side empty probe). Claude re-review: "Nothing here blocks merge."
+- Final state: clean-approval (both bots non-blocking; merge left to the developer).
+
+## Recommended follow-ups (from review, out of scope here)
+- Add a `chunk_seq` field to `InsertError` in `arcadedb-server.proto` so aggregated (multi-chunk) non-bidi
+  insert errors remain attributable to a chunk now that `row_index` is chunk-relative.
+- Optional: a bidi test asserting `row_index=-1` on a whole-chunk failure, and `@Tag("slow")` on the CON-3
+  IT if its 1000 sequential single-row commands prove slow in CI.

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -870,6 +870,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     stats.queries.incrementAndGet();
 
     final StreamQueryRequest.Builder b = StreamQueryRequest.newBuilder().setDatabase(getName()).setQuery(query)
+        .setLanguage(langOrDefault(language))
         .setCredentials(buildCredentials()).setBatchSize(batchSize > 0 ? batchSize : 100).setRetrievalMode(mode);
 
     if (params != null && !params.isEmpty()) {
@@ -893,6 +894,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     stats.queries.incrementAndGet();
 
     final StreamQueryRequest.Builder b = StreamQueryRequest.newBuilder().setDatabase(getName()).setQuery(query)
+        .setLanguage(langOrDefault(language))
         .setCredentials(buildCredentials()).setBatchSize(batchSize > 0 ? batchSize : 100).setRetrievalMode(mode);
 
     if (params != null && !params.isEmpty()) {

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/StreamingResultSet.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/StreamingResultSet.java
@@ -145,17 +145,21 @@ class StreamingResultSet implements ResultSet {
 
   @Override
   public void close() {
+    // Detect a close racing against the owning thread's iteration: BlockingClientCall is not thread-safe,
+    // so a cleanup/timeout thread closing while the owner is in hasNext/next would corrupt its state.
+    db.checkCrossThreadUse("streamQuery.close");
+
+    if (streamExhausted)
+      return;
 
     try {
-      // Drain any remaining results
-      while (stream.hasNext()) {
-        stream.read();
-      }
+      // Cancel the underlying call instead of draining. Draining a partially-read result would transfer and
+      // decode every remaining row, keeping the server cursor/worker busy for the whole result set.
+      stream.cancel("ResultSet closed by client", null);
     } catch (Exception e) {
-      LogManager.instance().log(this, Level.FINE, "Exception while draining stream during close: %s", e.getMessage());
+      LogManager.instance().log(this, Level.FINE, "Exception while cancelling stream during close: %s", e.getMessage());
+    } finally {
+      streamExhausted = true;
     }
-
-    // BlockingClientCall doesn't implement AutoCloseable
-    // No need to cast or check instanceof
   }
 }

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/StreamingResultSet.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/StreamingResultSet.java
@@ -45,7 +45,9 @@ class StreamingResultSet implements ResultSet {
   private final RemoteGrpcDatabase                 db;
   private final AtomicLong                         totalProcessed  = new AtomicLong(0);
   protected     Iterator<Result>                   currentBatch    = Collections.emptyIterator();
-  private       boolean                            streamExhausted = false;
+  // volatile: close() may run on a different thread than the iterating owner (checkCrossThreadUse only
+  // warns, it does not prevent it), so publish this flag with a happens-before edge to the reader in hasNext.
+  private volatile boolean                         streamExhausted = false;
   private       Result                             nextResult      = null;
 
   StreamingResultSet(BlockingClientCall<?, QueryResult> stream, RemoteGrpcDatabase db) {

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/StreamingResultSet.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/StreamingResultSet.java
@@ -145,8 +145,9 @@ class StreamingResultSet implements ResultSet {
 
   @Override
   public void close() {
-    // Detect a close racing against the owning thread's iteration: BlockingClientCall is not thread-safe,
-    // so a cleanup/timeout thread closing while the owner is in hasNext/next would corrupt its state.
+    // Diagnostic breadcrumb (logs a WARNING only) if close races the owning thread's iteration, consistent
+    // with hasNext/next. The actual thread-safety fix is below: cancelling the call is documented as safe
+    // from any thread, unlike the previous drain loop that shared the non-thread-safe BlockingClientCall.
     db.checkCrossThreadUse("streamQuery.close");
 
     if (streamExhausted)

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5047StreamingCorrectnessIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5047StreamingCorrectnessIT.java
@@ -63,7 +63,7 @@ class Issue5047StreamingCorrectnessIT extends BaseGraphServerTest {
   @Override
   public void setTestConfiguration() {
     super.setTestConfiguration();
-    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
   }
 
   @BeforeAll
@@ -209,7 +209,7 @@ class Issue5047StreamingCorrectnessIT extends BaseGraphServerTest {
         while (rs.hasNext())
           rs.next();
       }
-    }).isInstanceOf(Exception.class);
+    }).hasMessageContaining("_skip").hasMessageContaining("_limit");
   }
 
   @Test

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5047StreamingCorrectnessIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue5047StreamingCorrectnessIT.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.grpc.StreamQueryRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5047 (gRPC streaming & pagination correctness):
+ * <ul>
+ *   <li><b>PERF-2</b> - {@code queryStreamBatched} / {@code queryStreamBatchesIterator} must honor the
+ *       requested query {@code language} instead of silently running as SQL.</li>
+ *   <li><b>STR-4</b> - {@code is_last_batch} must be reported {@code true} on exact-multiple totals in both
+ *       CURSOR and PAGED retrieval modes.</li>
+ *   <li><b>STR-3</b> - PAGED mode must reject queries whose parameters collide with the reserved
+ *       {@code _skip}/{@code _limit} names instead of silently overwriting them.</li>
+ *   <li><b>CON-3</b> - closing a partially-read stream must release resources and leave the connection
+ *       usable (the stream is cancelled, not drained).</li>
+ * </ul>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Issue5047StreamingCorrectnessIT extends BaseGraphServerTest {
+
+  private static final String TYPE     = "Issue5047Stream";
+  private static final int    GRPC_PORT = 50051;
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase database;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeAll
+  void setupServer() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+  }
+
+  @AfterAll
+  void teardownServer() {
+    if (grpcServer != null)
+      grpcServer.close();
+  }
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+    database = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, 2480, getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("sql", "CREATE VERTEX TYPE `" + TYPE + "` IF NOT EXISTS BUCKETS 8");
+    database.command("sql", "CREATE PROPERTY `" + TYPE + "`.id IF NOT EXISTS LONG");
+    database.command("sql", "CREATE INDEX IF NOT EXISTS ON `" + TYPE + "` (id) UNIQUE");
+    database.command("sql", "DELETE FROM `" + TYPE + "`");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    if (database != null) {
+      try {
+        database.rollback();
+      } catch (Throwable ignore) {
+      }
+      database.close();
+    }
+    super.endTest();
+  }
+
+  private void insertRows(final int count) {
+    database.begin();
+    for (int i = 0; i < count; i++)
+      database.command("sql", "INSERT INTO `" + TYPE + "` SET id = :id", Map.of("id", (long) i));
+    database.commit();
+  }
+
+  @Test
+  @DisplayName("PERF-2: queryStreamBatched honors the requested Cypher language")
+  void queryStreamBatched_honorsCypherLanguage() {
+    insertRows(20);
+
+    // This is a Cypher query; if the stream request dropped the language it would run as SQL and fail to
+    // parse (or return nothing meaningful). With the language preserved it returns all 20 rows.
+    final List<Result> results = new ArrayList<>();
+    try (ResultSet rs = database.queryStreamBatched("cypher", "MATCH (n:`" + TYPE + "`) RETURN n.id AS id",
+        Map.of(), 10, StreamQueryRequest.RetrievalMode.CURSOR)) {
+      while (rs.hasNext())
+        results.add(rs.next());
+    }
+
+    assertThat(results).hasSize(20);
+    assertThat(results).allSatisfy(r -> assertThat(r.<Long>getProperty("id")).isNotNull());
+  }
+
+  @Test
+  @DisplayName("PERF-2: queryStreamBatchesIterator honors the requested Cypher language")
+  void queryStreamBatchesIterator_honorsCypherLanguage() {
+    insertRows(15);
+
+    int total = 0;
+    final var it = database.queryStreamBatchesIterator("cypher", "MATCH (n:`" + TYPE + "`) RETURN n.id AS id",
+        Map.of(), 10, StreamQueryRequest.RetrievalMode.CURSOR);
+    while (it.hasNext())
+      total += it.next().results().size();
+
+    assertThat(total).isEqualTo(15);
+  }
+
+  @Test
+  @DisplayName("STR-4: CURSOR mode marks is_last_batch on an exact-multiple total")
+  void cursorMode_isLastBatchOnExactMultiple() {
+    insertRows(20); // exactly 2 x batchSize(10)
+
+    int total = 0;
+    try (ResultSet rs = database.queryStreamBatched("sql", "SELECT FROM `" + TYPE + "`", Map.of(), 10,
+        StreamQueryRequest.RetrievalMode.CURSOR)) {
+      final BatchedStreamingResultSet batched = (BatchedStreamingResultSet) rs;
+      while (rs.hasNext()) {
+        rs.next();
+        total++;
+      }
+      assertThat(total).isEqualTo(20);
+      // The terminal batch must carry is_last_batch=true even though the total is an exact multiple of the
+      // batch size; before the fix the last full batch went out with is_last_batch=false.
+      assertThat(batched.isLastBatch()).isTrue();
+    }
+  }
+
+  @Test
+  @DisplayName("STR-4: PAGED mode marks is_last_batch on an exact-multiple total")
+  void pagedMode_isLastBatchOnExactMultiple() {
+    insertRows(20); // exactly 2 x batchSize(10)
+
+    int total = 0;
+    try (ResultSet rs = database.queryStreamBatched("sql", "SELECT FROM `" + TYPE + "`", Map.of(), 10,
+        StreamQueryRequest.RetrievalMode.PAGED)) {
+      final BatchedStreamingResultSet batched = (BatchedStreamingResultSet) rs;
+      while (rs.hasNext()) {
+        rs.next();
+        total++;
+      }
+      assertThat(total).isEqualTo(20);
+      assertThat(batched.isLastBatch()).isTrue();
+    }
+  }
+
+  @Test
+  @DisplayName("STR-4: PAGED mode with a partial last page still streams all rows")
+  void pagedMode_partialLastPage() {
+    insertRows(25); // 2 full pages + a partial page of 5
+
+    int total = 0;
+    try (ResultSet rs = database.queryStreamBatched("sql", "SELECT FROM `" + TYPE + "`", Map.of(), 10,
+        StreamQueryRequest.RetrievalMode.PAGED)) {
+      while (rs.hasNext()) {
+        rs.next();
+        total++;
+      }
+    }
+    assertThat(total).isEqualTo(25);
+  }
+
+  @Test
+  @DisplayName("STR-3: PAGED mode rejects a query that reuses the reserved _skip/_limit parameter names")
+  void pagedMode_rejectsReservedParameterName() {
+    insertRows(5);
+
+    // The caller binds a parameter literally named "_skip", which PAGED reserves for its SKIP wrapper. The
+    // server must reject the request instead of silently overwriting the caller's value.
+    assertThatThrownBy(() -> {
+      try (ResultSet rs = database.queryStreamBatched("sql", "SELECT FROM `" + TYPE + "` WHERE id >= :_skip",
+          Map.of("_skip", 0L), 10, StreamQueryRequest.RetrievalMode.PAGED)) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).isInstanceOf(Exception.class);
+  }
+
+  @Test
+  @DisplayName("CON-3: closing a partially-read stream releases resources and keeps the connection usable")
+  void close_afterPartialRead_releasesAndStaysUsable() {
+    insertRows(1000);
+
+    int read = 0;
+    try (ResultSet rs = database.queryStream("sql", "SELECT FROM `" + TYPE + "`", 50)) {
+      while (rs.hasNext() && read < 5) {
+        rs.next();
+        read++;
+      }
+      // close() runs here via try-with-resources: it must cancel the underlying call, not drain 995 rows.
+    }
+    assertThat(read).isEqualTo(5);
+
+    // The connection must remain fully usable after the partial-read close.
+    try (ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM `" + TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Long>getProperty("c")).isEqualTo(1000L);
+    }
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1958,6 +1958,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     QueryResult.Builder batch = QueryResult.newBuilder();
     int inBatch = 0;
+    // A completed full batch is held back one step: it is emitted (non-terminal) only once the next row
+    // proves more data follows; otherwise it is the terminal batch and is marked is_last_batch=true at the
+    // end. This keeps is_last_batch correct when the total row count is an exact multiple of batchSize
+    // (previously the final full batch went out with is_last_batch=false and no terminal followed).
+    QueryResult pending = null;
 
     try (ResultSet rs = db.query(language, request.getQuery(),
         GrpcTypeConverter.convertParameters(request.getParametersMap()))) {
@@ -1974,49 +1979,42 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
         Result r = rs.next();
 
+        // Another row follows, so any held-back full batch is definitely not the last: flush it now.
+        if (pending != null) {
+          safeOnNext(scso, cancelled, pending);
+          pending = null;
+        }
+
         if (r.isElement()) {
-
-          Record rec = r.getElement().get();
-
-          batch.addRecords(convertToGrpcRecord(rec, db));
-
-          inBatch++;
-          running++;
-
-          if (inBatch >= batchSize) {
-            safeOnNext(scso, cancelled,
-                batch.setTotalRecordsInBatch(inBatch).setRunningTotalEmitted(running).setIsLastBatch(false).build());
-            batch = QueryResult.newBuilder();
-            inBatch = 0;
-          }
+          batch.addRecords(convertToGrpcRecord(r.getElement().get(), db));
         } else {
-
           GrpcRecord.Builder rb = GrpcRecord.newBuilder();
-
-          for (String p : r.getPropertyNames()) {
+          for (String p : r.getPropertyNames())
             rb.putProperties(p, convertPropToGrpcValue(p, r, projectionConfig)); // overload below
-          }
-
           batch.addRecords(rb.build());
+        }
 
-          inBatch++;
-          running++;
+        inBatch++;
+        running++;
 
-          if (inBatch >= batchSize) {
-
-            safeOnNext(scso, cancelled,
-                batch.setTotalRecordsInBatch(inBatch).setRunningTotalEmitted(running).setIsLastBatch(false).build());
-
-            batch = QueryResult.newBuilder();
-            inBatch = 0;
-          }
+        if (inBatch >= batchSize) {
+          pending = batch.setTotalRecordsInBatch(inBatch).setRunningTotalEmitted(running).setIsLastBatch(false).build();
+          batch = QueryResult.newBuilder();
+          inBatch = 0;
         }
       }
     }
 
-    if (!cancelled.get() && inBatch > 0) {
+    if (cancelled.get())
+      return;
+
+    if (inBatch > 0) {
+      // Trailing partial batch is the terminal batch.
       safeOnNext(scso, cancelled,
           batch.setTotalRecordsInBatch(inBatch).setRunningTotalEmitted(running).setIsLastBatch(true).build());
+    } else if (pending != null) {
+      // Exact-multiple boundary: the last full batch is the terminal batch.
+      safeOnNext(scso, cancelled, pending.toBuilder().setIsLastBatch(true).build());
     }
   }
 
@@ -2098,9 +2096,25 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                            ServerCallStreamObserver<QueryResult> scso,
                            AtomicBoolean cancelled, AtomicBoolean serverTimedOut, ProjectionConfig projectionConfig, String language) {
 
+    // PERF-3: convert the request parameters once - only the per-page _skip/_limit change between pages, so
+    // rebuilding convertParameters() and a wrapping map on every page is wasted work.
+    final Map<String, Object> baseParams = GrpcTypeConverter.convertParameters(request.getParametersMap());
+
+    // PAGED wraps the query with reserved :_skip / :_limit bind parameters. If the caller already binds those
+    // names, the wrapper would silently overwrite them and corrupt paging: reject with a clear error instead.
+    if (baseParams.containsKey("_skip") || baseParams.containsKey("_limit"))
+      throw Status.INVALID_ARGUMENT
+          .withDescription(
+              "PAGED retrieval mode reserves the parameter names '_skip' and '_limit'; rename the conflicting query parameter or use CURSOR retrieval mode")
+          .asRuntimeException();
+
     final String pagedSql = wrapWithSkipLimit(request.getQuery()); // see helper below
     int offset = 0;
     long running = 0L;
+    // A full page is held back one step so the terminal page carries is_last_batch=true even when the total
+    // row count is an exact multiple of batchSize (previously the last full page went out with
+    // is_last_batch=false and the empty probe page returned without a terminal). Mirrors streamCursor.
+    QueryResult pending = null;
 
     while (true) {
       if (cancelled.get())
@@ -2111,7 +2125,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       if (cancelled.get())
         return;
 
-      Map<String, Object> params = new HashMap<>(GrpcTypeConverter.convertParameters(request.getParametersMap()));
+      final Map<String, Object> params = new HashMap<>(baseParams);
       params.put("_skip", offset);
       params.put("_limit", batchSize);
 
@@ -2143,17 +2157,31 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         }
       }
 
-      if (count == 0)
+      if (count == 0) {
+        // No more rows. A held-back full page (exact-multiple boundary) is the terminal page.
+        if (pending != null)
+          safeOnNext(scso, cancelled, pending.toBuilder().setIsLastBatch(true).build());
         return; // no more rows
+      }
+
+      // This page has rows, so any held-back full page is definitely not the last: flush it now.
+      if (pending != null) {
+        safeOnNext(scso, cancelled, pending);
+        pending = null;
+      }
 
       running += count;
-      boolean last = count < batchSize;
+      final boolean last = count < batchSize;
+      final QueryResult page = b.setTotalRecordsInBatch(count).setRunningTotalEmitted(running).setIsLastBatch(last).build();
 
-      safeOnNext(scso, cancelled,
-          b.setTotalRecordsInBatch(count).setRunningTotalEmitted(running).setIsLastBatch(last).build());
-
-      if (last)
+      if (last) {
+        // Partial page - definitely the last one.
+        safeOnNext(scso, cancelled, page);
         return;
+      }
+
+      // Full page - might be terminal if the next page turns out to be empty; hold it back.
+      pending = page;
       offset += batchSize;
     }
   }
@@ -2931,7 +2959,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
                   perChunk.failed = c.getRowsCount();
 
-                  perChunk.errors.add(InsertError.newBuilder().setRowIndex(Math.max(0, ctx.received - 1)).setCode(
+                  // A whole-chunk exception is transaction-level, not attributable to a single row, so report
+                  // row_index=-1 ("not applicable") per the InsertError contract, matching the non-bidi
+                  // insertStream path. Per-row failures are already reported chunk-relative inside insertRows.
+                  perChunk.errors.add(InsertError.newBuilder().setRowIndex(-1).setCode(
                           "DB_ERROR")
                       .setMessage(String.valueOf(e.getMessage())).build());
                   ctx.totals.add(perChunk);
@@ -3185,7 +3216,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
               c.failed++;
 
-              c.errors.add(InsertError.newBuilder().setRowIndex(ctx.received - 1).setCode("MISSING_ENDPOINTS")
+              c.errors.add(InsertError.newBuilder().setRowIndex(c.received - 1).setCode("MISSING_ENDPOINTS")
                   .setMessage("Edge requires 'out' and 'in'").build());
             } else {
               final var outV = ctx.db.lookupByRID(new RID(outRid), false).asVertex(false);
@@ -3213,7 +3244,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       } catch (DuplicatedKeyException dup) {
         switch (ctx.opts.getConflictMode()) {
           case CONFLICT_IGNORE -> c.ignored++;
-          case CONFLICT_ABORT, UNRECOGNIZED -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
+          case CONFLICT_ABORT, UNRECOGNIZED -> c.err(c.received - 1, "CONFLICT", dup.getMessage(), "");
           // A concurrent stream inserted this key after our check; the unique index proves it exists
           // now, so retry as an update instead of losing the row. Not exercised by
           // Issue4656InsertStreamConflictUpdateIT: the race needs two concurrent streams hitting the
@@ -3225,19 +3256,19 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               else
                 // The match vanished between the conflict and the retry (transient MVCC window): report
                 // it as a retriable CONFLICT rather than guessing.
-                c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
+                c.err(c.received - 1, "CONFLICT", dup.getMessage(), "");
             } catch (DuplicatedKeyException retryDup) {
               // A third writer can race the retry too: still a retriable conflict.
-              c.err(ctx.received - 1, "CONFLICT", retryDup.getMessage(), "");
+              c.err(c.received - 1, "CONFLICT", retryDup.getMessage(), "");
             } catch (Exception retryEx) {
               // Anything else (IO error, etc.) is a real failure - do not mask it as a CONFLICT.
-              c.err(ctx.received - 1, "DB_ERROR", retryEx.getMessage(), "");
+              c.err(c.received - 1, "DB_ERROR", retryEx.getMessage(), "");
             }
           }
-          case CONFLICT_ERROR -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
+          case CONFLICT_ERROR -> c.err(c.received - 1, "CONFLICT", dup.getMessage(), "");
         }
       } catch (Exception e) {
-        c.err(ctx.received - 1, "DB_ERROR", e.getMessage(), "");
+        c.err(c.received - 1, "DB_ERROR", e.getMessage(), "");
       }
 
       inBatch++;

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5047InsertErrorRowIndexIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5047InsertErrorRowIndexIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5047 (STR-1): {@code InsertError.row_index} is documented as the index within
+ * the chunk, but the server reported the cumulative stream-wide {@code ctx.received - 1}. This drives a
+ * two-chunk {@code insertStream} where the failing row is at chunk-relative index 1 (but cumulative index 3),
+ * and asserts the reported {@code row_index} is the chunk-relative 1.
+ */
+public class Issue5047InsertErrorRowIndexIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                 channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub         asyncAuthenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+    asyncAuthenticatedStub = ArcadeDbServiceGrpc.newStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private GrpcValue stringValue(final String s) {
+    return GrpcValue.newBuilder().setStringValue(s).build();
+  }
+
+  @Test
+  void insertErrorRowIndexIsChunkRelative() throws Exception {
+    final String vType = "Issue5047V_" + System.currentTimeMillis();
+    final String eType = "Issue5047E_" + System.currentTimeMillis();
+
+    // Two vertices to use as edge endpoints, plus an edge type.
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("CREATE VERTEX TYPE " + vType).build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("CREATE EDGE TYPE " + eType).build());
+
+    final ExecuteCommandResponse v0 = authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setReturnRows(true)
+        .setCommand("CREATE VERTEX " + vType).build());
+    final ExecuteCommandResponse v1 = authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setReturnRows(true)
+        .setCommand("CREATE VERTEX " + vType).build());
+
+    final String rid0 = ridOf(v0);
+    final String rid1 = ridOf(v1);
+    assertThat(rid0).as("vertex 0 rid").isNotNull();
+    assertThat(rid1).as("vertex 1 rid").isNotNull();
+
+    try {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+
+      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
+        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
+        @Override public void onError(final Throwable t) { done.countDown(); }
+        @Override public void onCompleted() { done.countDown(); }
+      });
+
+      // PER_STREAM commits once at the end, so a per-row MISSING_ENDPOINTS error does not roll the whole
+      // stream back; it is recorded row-by-row inside insertRows with a chunk-relative row_index.
+      final InsertOptions options = InsertOptions.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setTargetClass(eType)
+          .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM)
+          .build();
+
+      // Chunk 0 (seq 0): two valid edges -> ctx.received advances to 2.
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-5047")
+          .setChunkSeq(0)
+          .setOptions(options)
+          .addRows(edge(eType, rid0, rid1))
+          .addRows(edge(eType, rid0, rid1))
+          .build());
+
+      // Chunk 1 (seq 1, last): valid, INVALID (no out/in), valid. The invalid row is at chunk-relative
+      // index 1 but cumulative index 3.
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-5047")
+          .setChunkSeq(1)
+          .setLast(true)
+          .addRows(edge(eType, rid0, rid1))
+          .addRows(GrpcRecord.newBuilder().setType(eType).build()) // missing out/in
+          .addRows(edge(eType, rid0, rid1))
+          .build());
+
+      req.onCompleted();
+
+      assertThat(done.await(30, TimeUnit.SECONDS)).as("InsertStream should terminate within 30s").isTrue();
+      final InsertSummary summary = summaryRef.get();
+      assertThat(summary).as("client must receive an InsertSummary").isNotNull();
+
+      assertThat(summary.getErrorsList())
+          .as("exactly one per-row MISSING_ENDPOINTS error").hasSize(1);
+      final InsertError error = summary.getErrors(0);
+      assertThat(error.getCode()).isEqualTo("MISSING_ENDPOINTS");
+      assertThat(error.getRowIndex())
+          .as("row_index must be chunk-relative (1), not the cumulative stream index (3)")
+          .isEqualTo(1L);
+    } finally {
+      authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+          .setDatabase(getDatabaseName()).setCredentials(credentials())
+          .setCommand("DROP TYPE " + eType + " IF EXISTS UNSAFE").build());
+      authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+          .setDatabase(getDatabaseName()).setCredentials(credentials())
+          .setCommand("DROP TYPE " + vType + " IF EXISTS UNSAFE").build());
+    }
+  }
+
+  private GrpcRecord edge(final String type, final String out, final String in) {
+    return GrpcRecord.newBuilder().setType(type)
+        .putProperties("out", stringValue(out))
+        .putProperties("in", stringValue(in))
+        .build();
+  }
+
+  private static String ridOf(final ExecuteCommandResponse resp) {
+    for (final GrpcRecord rec : resp.getRecordsList())
+      if (rec.getRid() != null && !rec.getRid().isEmpty())
+        return rec.getRid();
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #5047

## Summary

Fixes several correctness/efficiency defects in the gRPC streaming and pagination paths, from the 2026-07 gRPC modules audit. Six defects are fixed; two deeper ones are documented as deferred (they require semantic decisions / carry transaction-lifecycle risk).

**Fixed**

- **PERF-2 (High)** - `queryStreamBatched` / `queryStreamBatchesIterator` never set `.setLanguage(...)` on the `StreamQueryRequest`, so Cypher/Gremlin batched-stream queries silently executed as SQL. Both builders now set `langOrDefault(language)`.
- **CON-3 (Medium)** - `StreamingResultSet.close()` drained the entire remaining stream (transferring and decoding every remaining row, pinning the server cursor) and had no cross-thread guard. It now cancels the underlying `BlockingClientCall` and calls `checkCrossThreadUse`.
- **STR-1 (Medium)** - `InsertError.row_index` is documented as "index within the chunk" but the server reported the cumulative stream-wide `ctx.received - 1`. `insertRows` per-row errors now use the chunk-relative `c.received - 1`; the bidi whole-chunk-failure path reports `-1` (not row-attributable), matching the non-bidi path.
- **STR-4 (Low)** - `is_last_batch` was never `true` on exact-multiple totals. `streamCursor` and `streamPaged` now hold the final full batch/page back one step so the terminal batch always carries `is_last_batch=true` (also fixes `BatchedStreamingResultSet.isLastBatch()` metadata and removes an extra round trip).
- **PERF-3 (Medium)** - `streamPaged` rebuilt `convertParameters` + a wrapping map on every page; the base parameter map is now converted once and copied per page.
- **STR-3 (partial, Medium)** - `streamPaged` now rejects queries whose parameters collide with the reserved `_skip`/`_limit` names (`INVALID_ARGUMENT`) instead of silently overwriting them.

**Deferred (documented in the tracking doc)**

- **STR-2** - bidi replay duplication under `PER_ROW`/`PER_BATCH`: needs a semantic decision (advance the watermark for already-committed rows vs. atomic-per-chunk commit) and touches transaction lifecycle.
- **STR-3 snapshot isolation** and the projection-only `@rid`-wrapper fragility: true snapshot consistency needs CURSOR-style single execution; documented as a limitation (use CURSOR mode for snapshot-consistent large reads).

## Test plan

- [x] `grpc-client` `Issue5047StreamingCorrectnessIT` - PERF-2 (Cypher batched stream, both APIs), STR-4 (exact-multiple CURSOR + PAGED, partial last page), STR-3 (reserved-name rejection), CON-3 (partial-read close stays usable). 7/7 pass.
- [x] `grpcw` `Issue5047InsertErrorRowIndexIT` - STR-1 (two-chunk stream, failing row at chunk-relative index 1 / cumulative 3, asserts row_index==1). 1/1 pass.
- [x] Regression: `StreamingQueryIT`, `StreamingResultSetTest`, `BatchedStreamingResultSetIT` (32/32); insert-stream ITs `Issue4806/4198/4214/4656/4644` (23/23); `GrpcStreamMetricsIT`, `Issue4803GrpcResultBoundingIT`, `Issue4197...` (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)