### PR TITLE
fix: close exhausted multi-index cursors safely

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
@@ -35,6 +35,7 @@ public class MultiIndexCursor implements IndexCursor {
   private       int                browsed         = 0;
   private       Object[]           nextKeys;
   private       int                nextCursorIndex = -1;
+  private       Identifiable       currentRecord;
   private       List<Identifiable> cursorsNextValues;
 
   public MultiIndexCursor(final List<IndexCursor> cursors, final int limit, final boolean ascendingOrder) {
@@ -81,7 +82,7 @@ public class MultiIndexCursor implements IndexCursor {
 
   @Override
   public Identifiable getRecord() {
-    return cursors.get(nextCursorIndex).getRecord();
+    return currentRecord;
   }
 
   @Override
@@ -147,6 +148,7 @@ public class MultiIndexCursor implements IndexCursor {
     ++browsed;
 
     final Identifiable nextValue = cursorsNextValues.set(nextCursorIndex, null);
+    currentRecord = nextValue;
     if (cursors.get(nextCursorIndex).hasNext()) {
       final Identifiable next = cursors.get(nextCursorIndex).next();
       if (next != null)

--- a/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
@@ -91,8 +91,12 @@ public class MultiIndexCursor implements IndexCursor {
 
     for (int i = 0; i < cursors.size(); ++i) {
       final IndexCursor cursor = cursors.get(i);
-      if (cursor != null && (cursorsNextValues.get(i) != null || cursor.hasNext()))
+      if (cursor == null)
+        continue;
+      if (cursorsNextValues.get(i) != null || cursor.hasNext())
         return true;
+      cursor.close();
+      cursors.set(i, null);
     }
 
     return false;
@@ -112,6 +116,7 @@ public class MultiIndexCursor implements IndexCursor {
 
       final Identifiable cursorsNextValue = cursorsNextValues.get(i);
       if (cursorsNextValue == null && !cursor.hasNext()) {
+        cursor.close();
         cursors.set(i, null);
         continue;
       }
@@ -153,14 +158,21 @@ public class MultiIndexCursor implements IndexCursor {
 
   @Override
   public void close() {
-    for (final IndexCursor cursor : cursors)
-      cursor.close();
+    for (int i = 0; i < cursors.size(); ++i) {
+      final IndexCursor cursor = cursors.get(i);
+      if (cursor != null) {
+        cursor.close();
+        cursors.set(i, null);
+      }
+    }
   }
 
   @Override
   public long estimateSize() {
     long tot = 0L;
     for (final IndexCursor cursor : cursors) {
+      if (cursor == null)
+        continue;
       if (cursor.estimateSize() == -1)
         return -1;
       tot += cursor.estimateSize();
@@ -199,7 +211,10 @@ public class MultiIndexCursor implements IndexCursor {
     cursorsNextValues = new ArrayList<>(cursors.size());
     for (Iterator<IndexCursor> c = cursors.iterator(); c.hasNext(); ) {
       final IndexCursor cursor = c.next();
-      if (cursor == null || !cursor.hasNext()) {
+      if (cursor == null)
+        c.remove();
+      else if (!cursor.hasNext()) {
+        cursor.close();
         c.remove();
       } else
         cursorsNextValues.add(cursor.next());

--- a/engine/src/test/java/com/arcadedb/index/MultiIndexCursorLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/index/MultiIndexCursorLifecycleTest.java
@@ -48,6 +48,7 @@ class MultiIndexCursorLifecycleTest extends TestHelper {
     assertThat(cursor.hasNext()).isTrue();
     assertThat(cursor.next()).isEqualTo(expected);
     assertThat(cursor.hasNext()).isFalse();
+    assertThat(cursor.getRecord()).isEqualTo(expected);
     assertThat(oneEntry.closeCalls).isOne();
     assertThat(cursor.estimateSize()).isZero();
 
@@ -83,13 +84,15 @@ class MultiIndexCursorLifecycleTest extends TestHelper {
     });
 
     final IndexCursor cursor = index.iterator(true);
-    int count = 0;
+    Identifiable last = null;
+    int          count = 0;
     while (cursor.hasNext()) {
-      cursor.next();
+      last = cursor.next();
       count++;
     }
 
     assertThat(count).isEqualTo(300);
+    assertThat(cursor.getRecord()).isEqualTo(last);
     assertThatCode(cursor::close).doesNotThrowAnyException();
     assertThat(cursor.estimateSize()).isZero();
   }

--- a/engine/src/test/java/com/arcadedb/index/MultiIndexCursorLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/index/MultiIndexCursorLifecycleTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.BinaryComparator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class MultiIndexCursorLifecycleTest extends TestHelper {
+
+  @Test
+  void closesEmptyAndExhaustedChildrenExactlyOnce() {
+    final TrackingCursor empty = new TrackingCursor();
+    final RID expected = new RID(1, 42);
+    final TrackingCursor oneEntry = new TrackingCursor(expected);
+    final MultiIndexCursor cursor = new MultiIndexCursor(new ArrayList<>(List.of(empty, oneEntry)), -1, true);
+
+    assertThat(empty.closeCalls).isOne();
+    assertThat(cursor.hasNext()).isTrue();
+    assertThat(cursor.next()).isEqualTo(expected);
+    assertThat(cursor.hasNext()).isFalse();
+    assertThat(oneEntry.closeCalls).isOne();
+    assertThat(cursor.estimateSize()).isZero();
+
+    cursor.close();
+    cursor.close();
+    assertThat(empty.closeCalls).isOne();
+    assertThat(oneEntry.closeCalls).isOne();
+  }
+
+  @Test
+  void closesRemainingChildrenIdempotently() {
+    final TrackingCursor child = new TrackingCursor(new RID(1, 1), new RID(1, 2));
+    final MultiIndexCursor cursor = new MultiIndexCursor(new ArrayList<>(List.of(child)), -1, true);
+
+    cursor.close();
+    cursor.close();
+
+    assertThat(child.closeCalls).isOne();
+    assertThat(cursor.estimateSize()).isZero();
+  }
+
+  @Test
+  void closesAfterExhaustingMultipleBucketCursors() {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("MultiCursorLifecycle").withTotalBuckets(3)
+        .create();
+    type.createProperty("lookupKey", Type.INTEGER);
+    final TypeIndex index = database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "MultiCursorLifecycle",
+        "lookupKey");
+
+    database.transaction(() -> {
+      for (int i = 0; i < 300; i++)
+        database.newDocument("MultiCursorLifecycle").set("lookupKey", i).save();
+    });
+
+    final IndexCursor cursor = index.iterator(true);
+    int count = 0;
+    while (cursor.hasNext()) {
+      cursor.next();
+      count++;
+    }
+
+    assertThat(count).isEqualTo(300);
+    assertThatCode(cursor::close).doesNotThrowAnyException();
+    assertThat(cursor.estimateSize()).isZero();
+  }
+
+  private static final class TrackingCursor implements IndexCursor {
+    private final List<Identifiable> values;
+    private       int                position;
+    private       int                closeCalls;
+    private       Object[]           keys;
+
+    private TrackingCursor(final Identifiable... values) {
+      this.values = List.of(values);
+    }
+
+    @Override
+    public Object[] getKeys() {
+      return keys;
+    }
+
+    @Override
+    public Identifiable getRecord() {
+      return position == 0 ? null : values.get(position - 1);
+    }
+
+    @Override
+    public boolean hasNext() {
+      return position < values.size();
+    }
+
+    @Override
+    public Identifiable next() {
+      if (!hasNext())
+        throw new NoSuchElementException();
+      keys = new Object[] { position };
+      return values.get(position++);
+    }
+
+    @Override
+    public void close() {
+      closeCalls++;
+    }
+
+    @Override
+    public long estimateSize() {
+      return values.size() - position;
+    }
+
+    @Override
+    public BinaryComparator getComparator() {
+      return null;
+    }
+
+    @Override
+    public byte[] getBinaryKeyTypes() {
+      return new byte[0];
+    }
+
+    @Override
+    public Iterator<Identifiable> iterator() {
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Closes per-index cursors as they become exhausted and makes aggregate lifecycle operations safe
after child slots have been cleared.

- Empty children are closed during initialization.
- Exhausted children encountered by `hasNext()` or `next()` are closed and cleared.
- Aggregate `close()` is null-safe and idempotent for remaining children.
- `estimateSize()` skips cleared slots.
- `getRecord()` retains the most recently returned record after its child slot is cleared.
- Tracking-cursor regressions verify empty/exhausted children close exactly once, aggregate
  close is idempotent, and the last record remains available after exhaustion.
- A three-bucket integration regression consumes a 300-entry type index, closes it after
  exhaustion, and verifies its last record remains available and its remaining estimate is zero.

## Motivation

`MultiIndexCursor` already clears exhausted child slots during iteration, but `close()` previously
dereferenced every slot unconditionally. Fully consuming a multi-bucket cursor and then closing it
therefore raised a `NullPointerException`; exhausted child cursors could also retain resources
until a later aggregate close.

Clearing an exhausted slot also made the existing `getRecord()` delegation dereference that
cleared slot after final exhaustion. Retaining the current record preserves `IndexCursor`
current-record behavior while allowing exhausted children to be closed eagerly.

## Related issues

None found for this exact lifecycle failure.

## Additional Notes

The regression was red on `main` at
`d758998ce9854d21aadce81987cd1dc036488c49` with only the original integration test added:

```text
MultiIndexCursorLifecycleTest.closesAfterExhaustingMultipleBucketCursors
Tests run: 1, Failures: 1
Failure: NullPointerException in MultiIndexCursor.close()
```

The fix branch is based on current `main` at
`845c12e016b1485b057ce2d73d341310a9618d7a`; its current head is
`0cd68d3a227153d07275f2f143352af5c26c8ee2`. Green on that base:

```text
./mvnw -pl engine -Dtest=MultiIndexCursorLifecycleTest,TypeLSMTreeIndexTest test
Tests run: 25, Failures: 0, Errors: 0, Skipped: 0

./mvnw clean package -DskipTests
Reactor modules: 24, BUILD SUCCESS
```

The focused suite finished at 2026-07-11T21:53:09Z. The 24-module package build finished at
2026-07-11T21:56:00Z. Both used OpenJDK 21.0.11 on Linux.

This changes cursor lifecycle and current-record retention only; index contents and iteration
order are unchanged.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
