### PR TITLE
Add bounded sorted builds for non-unique LSM indexes

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentIndexer.java
@@ -36,6 +36,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class DocumentIndexer {
@@ -98,6 +99,13 @@ public class DocumentIndexer {
   }
 
   public void addToIndex(final Index entry, final RID rid, final Document record) {
+    forEachIndexKey(entry, record, keyValues -> entry.put(keyValues, new RID[] { rid }));
+  }
+
+  /**
+   * Expands a document into the same logical keys used by normal index maintenance without mutating the index.
+   */
+  public void forEachIndexKey(final Index entry, final Document record, final Consumer<Object[]> keyConsumer) {
     final List<String> keyNames = entry.getPropertyNames();
 
     // Detect a collection modifier ("by item" for LIST, "by key"/"by value" for MAP) on each property.
@@ -110,22 +118,22 @@ public class DocumentIndexer {
         // Full-text combined index over several BY ITEM properties (issue #5181): a full-text index is an inverted per-field
         // index, not a compound key, so each BY ITEM property is indexed as the UNION of its own list items (the lists may be
         // different and of different lengths). No element-wise zip and no shared-root requirement.
-        addFullTextByItemToIndex(entry, rid, record, propertyNamesArray, expansions);
+        forEachFullTextByItemKey(record, propertyNamesArray, expansions, keyConsumer);
       else
         // Multiple BY ITEM properties sharing the same root list - one compound entry per list element (issue #5181)
-        addMultiListItemsToIndex(entry, rid, record, propertyNamesArray, expansions);
+        forEachMultiListItemKey(record, propertyNamesArray, expansions, keyConsumer);
     } else if (expansion == KeyExpansion.NONE) {
       // Standard indexing - single entry per document
       final Object[] keyValues = new Object[keyNames.size()];
       for (int i = 0; i < keyValues.length; ++i)
         keyValues[i] = getPropertyValue(record, propertyNamesArray[i]);
-      entry.put(keyValues, new RID[] { rid });
+      keyConsumer.accept(keyValues);
     } else if (expansion == KeyExpansion.LIST_ITEM) {
       // List indexing - one entry per list element
-      addListItemsToIndex(entry, rid, record, propertyNamesArray, expansionIndex);
+      forEachListItemKey(record, propertyNamesArray, expansionIndex, keyConsumer);
     } else {
       // Map indexing - one entry per key or per value
-      addMapEntriesToIndex(entry, rid, record, propertyNamesArray, expansionIndex, expansion);
+      forEachMapEntryKey(record, propertyNamesArray, expansionIndex, expansion, keyConsumer);
     }
   }
 
@@ -177,13 +185,13 @@ public class DocumentIndexer {
     return count;
   }
 
-  private void addMapEntriesToIndex(final Index entry, final RID rid, final Document record,
-      final String[] propertyNames, final int mapPropertyIndex, final KeyExpansion expansion) {
+  private void forEachMapEntryKey(final Document record, final String[] propertyNames, final int mapPropertyIndex,
+      final KeyExpansion expansion, final Consumer<Object[]> keyConsumer) {
     for (final Object element : mapElements(record, propertyNames[mapPropertyIndex], expansion)) {
       final Object[] keyValues = new Object[propertyNames.length];
       for (int i = 0; i < keyValues.length; ++i)
         keyValues[i] = i == mapPropertyIndex ? element : getPropertyValue(record, propertyNames[i]);
-      entry.put(keyValues, new RID[] { rid });
+      keyConsumer.accept(keyValues);
     }
   }
 
@@ -208,8 +216,8 @@ public class DocumentIndexer {
     return elements;
   }
 
-  private void addListItemsToIndex(final Index entry, final RID rid, final Document record,
-      final String[] propertyNames, final int listPropertyIndex) {
+  private void forEachListItemKey(final Document record, final String[] propertyNames, final int listPropertyIndex,
+      final Consumer<Object[]> keyConsumer) {
     final String propertyName = propertyNames[listPropertyIndex];
 
     // Check if this is a nested property path (e.g., "tags.id")
@@ -277,9 +285,8 @@ public class DocumentIndexer {
       }
 
       // Only index if we have a valid key value
-      if (keyValues[listPropertyIndex] != null) {
-        entry.put(keyValues, new RID[] { rid });
-      }
+      if (keyValues[listPropertyIndex] != null)
+        keyConsumer.accept(keyValues);
     }
   }
 
@@ -289,10 +296,10 @@ public class DocumentIndexer {
    * compound key is produced per element, zipping the nested value of every list property from the SAME element (element-wise, not
    * cross-product). Non-list properties are resolved as scalars from the record.
    */
-  private void addMultiListItemsToIndex(final Index entry, final RID rid, final Document record,
-      final String[] propertyNames, final KeyExpansion[] expansions) {
+  private void forEachMultiListItemKey(final Document record, final String[] propertyNames,
+      final KeyExpansion[] expansions, final Consumer<Object[]> keyConsumer) {
     for (final Object[] keyValues : buildMultiListItemTuples(record, propertyNames, expansions))
-      entry.put(keyValues, new RID[] { rid });
+      keyConsumer.accept(keyValues);
   }
 
   private static boolean isFullText(final Index entry) {
@@ -306,11 +313,11 @@ public class DocumentIndexer {
    * position carries the union of that property's own list items and every plain position carries its scalar value. Unlike the
    * compound path, the {@code BY ITEM} properties may reference different lists of different lengths.
    */
-  private void addFullTextByItemToIndex(final Index entry, final RID rid, final Document record,
-      final String[] propertyNames, final KeyExpansion[] expansions) {
+  private void forEachFullTextByItemKey(final Document record, final String[] propertyNames,
+      final KeyExpansion[] expansions, final Consumer<Object[]> keyConsumer) {
     final Object[] keyValues = buildFullTextByItemKey(record, propertyNames, expansions);
     if (!isAllEmpty(keyValues))
-      entry.put(keyValues, new RID[] { rid });
+      keyConsumer.accept(keyValues);
   }
 
   /**
@@ -588,7 +595,7 @@ public class DocumentIndexer {
 
       if (countListExpansions(expansions) > 1) {
         if (isFullText(index))
-          // Full-text combined BY ITEM index (issue #5181): diff the per-field item unions (see addFullTextByItemToIndex).
+          // Full-text combined BY ITEM index (issue #5181): diff the per-field item unions.
           anyIndexModified |= updateFullTextByItemInIndex(index, rid, originalRecord, modifiedRecord, propertyNamesArray, expansions);
         else
           // Multi-BY ITEM index: diff the compound tuples produced from the shared list (issue #5181)

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -624,6 +624,11 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
   }
 
   protected LSMTreeIndexMutable splitIndex(final int startingFromPage, final LSMTreeIndexCompacted compactedIndex) {
+    return splitIndex(startingFromPage, compactedIndex, true);
+  }
+
+  protected LSMTreeIndexMutable splitIndex(final int startingFromPage, final LSMTreeIndexCompacted compactedIndex,
+      final boolean saveSchema) {
     checkIsValid();
     final DatabaseInternal database = getDatabase();
     if (database.isTransactionActive())
@@ -704,10 +709,9 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
         newMutableIndex.removeTempSuffix();
 
         mutable = newMutableIndex;
+        updateCaseInsensitiveKeys();
 
-        ((LocalSchema) database.getSchema()).setMigratedFileId(fileId, newMutableIndex.getFileId());
-
-        database.getSchema().getEmbedded().saveConfiguration();
+        ((LocalSchema) database.getSchema()).setMigratedFileId(fileId, newMutableIndex.getFileId(), saveSchema);
         return newMutableIndex;
       });
 
@@ -789,6 +793,10 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
       throw new NeedRetryException("Error on building index '" + name + "' because not available");
 
     return total.get();
+  }
+
+  Object[] normalizeKeysForBulkBuild(final Object[] keys) {
+    return convertKeys(keys);
   }
 
   protected RWLockContext getLock() {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -263,6 +263,13 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   }
 
   private long resolveMemoryBudget(final long configuredMemoryBudgetBytes) {
+    final Runtime runtime = Runtime.getRuntime();
+    return resolveMemoryBudget(configuredMemoryBudgetBytes, runtime.maxMemory(), runtime.totalMemory(),
+        runtime.freeMemory());
+  }
+
+  static long resolveMemoryBudget(final long configuredMemoryBudgetBytes, final long maxMemoryBytes,
+      final long totalMemoryBytes, final long freeMemoryBytes) {
     if (configuredMemoryBudgetBytes < 0L)
       throw new IllegalArgumentException("memory budget cannot be negative");
     if (configuredMemoryBudgetBytes > 0L) {
@@ -271,9 +278,9 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
       return configuredMemoryBudgetBytes;
     }
 
-    final Runtime runtime = Runtime.getRuntime();
-    final long usedHeap = runtime.totalMemory() - runtime.freeMemory();
-    final long availableHeap = Math.max(0L, runtime.maxMemory() - usedHeap);
+    final long usedHeap = Math.max(0L, totalMemoryBytes - freeMemoryBytes);
+    final long effectiveMaxMemory = maxMemoryBytes == Long.MAX_VALUE ? totalMemoryBytes : maxMemoryBytes;
+    final long availableHeap = Math.max(0L, effectiveMaxMemory - usedHeap);
     return Math.max(MIN_MEMORY_BUDGET_BYTES, availableHeap / 4L);
   }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -144,9 +144,10 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
     } catch (final InterruptedException error) {
       Thread.currentThread().interrupt();
       throw new IndexException("Sorted build for '" + indexName + "' was interrupted", error);
+    } catch (final IndexException error) {
+      throw error;
     } catch (final Exception error) {
-      throw error instanceof IndexException indexError ? indexError
-          : new IndexException("Cannot build sorted index '" + indexName + "'", error);
+      throw new IndexException("Cannot build sorted index '" + indexName + "'", error);
     } finally {
       if (!success)
         for (final BucketWriter writer : writers.values())
@@ -228,6 +229,7 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
 
       @Override
       public void close() {
+        // The in-memory cursor owns no closeable resources.
       }
     };
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -90,11 +90,10 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
 
     database.getIndexer().forEachIndexKey(index, record, rawKeys -> {
       final Object[] normalizedKeys = index.normalizeKeysForBulkBuild(rawKeys);
+      index.getMutableIndex().checkForNulls(normalizedKeys);
       final boolean containsNull = LSMTreeIndexAbstract.isKeyNull(normalizedKeys);
       if (containsNull && index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.SKIP)
         return;
-      if (containsNull && index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.ERROR)
-        index.getMutableIndex().checkForNulls(normalizedKeys);
 
       registerIndex(index);
       entries.add(new Entry(index, new TransactionIndexContext.ComparableKey(normalizedKeys), rid));

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.TransactionIndexContext;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.FileUtils;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+/** Builds empty non-unique LSM indexes from a bounded, globally sorted logical entry stream. */
+public final class LSMTreeIndexBulkLoader implements AutoCloseable {
+  private static final ThreadLocal<BuildTestHook> BUILD_TEST_HOOK = new ThreadLocal<>();
+
+  private static final long ESTIMATED_BYTES_PER_ENTRY   = 3_072L;
+  private static final long MIN_MEMORY_BUDGET_BYTES     = 1L << 20;
+  private static final int  MAX_BUFFERED_RIDS_PER_GROUP = 256;
+
+  private final DatabaseInternal           database;
+  private final String                     indexName;
+  private final long                       memoryBudgetBytes;
+  private final Path                       spillDirectory;
+  private final Path                       spillWorkspace;
+  private final int                        mergeFanIn;
+  private final int                        maxEntriesPerRun;
+  private final List<Entry>                entries;
+  private final Map<Integer, LSMTreeIndex> indexesByBucket = new LinkedHashMap<>();
+  private       LSMTreeIndexExternalSorter externalSorter;
+  private       byte[]                     binaryKeyTypes;
+  private       long                       totalEntries;
+
+  public LSMTreeIndexBulkLoader(final DatabaseInternal database, final String indexName,
+      final long configuredMemoryBudgetBytes, final Path spillDirectory, final int mergeFanIn) {
+    this(database, indexName, configuredMemoryBudgetBytes, spillDirectory, mergeFanIn, null);
+  }
+
+  public LSMTreeIndexBulkLoader(final DatabaseInternal database, final String indexName,
+      final long configuredMemoryBudgetBytes, final Path spillDirectory, final int mergeFanIn,
+      final Path spillWorkspace) {
+    if (mergeFanIn < 2)
+      throw new IllegalArgumentException("mergeFanIn must be at least 2");
+
+    this.database = database;
+    this.indexName = indexName;
+    this.memoryBudgetBytes = resolveMemoryBudget(configuredMemoryBudgetBytes);
+    this.spillDirectory = spillDirectory;
+    this.spillWorkspace = spillWorkspace;
+    this.mergeFanIn = mergeFanIn;
+    this.maxEntriesPerRun = (int) Math.max(1L,
+        Math.min(Integer.MAX_VALUE, memoryBudgetBytes / ESTIMATED_BYTES_PER_ENTRY));
+    this.entries = new ArrayList<>(Math.min(maxEntriesPerRun, 65_536));
+
+    LogManager.instance().log(this, Level.INFO,
+        "Sorted index build '%s': memoryBudget=%s maxEntriesPerRun=%,d spillParent=%s mergeFanIn=%d",
+        indexName, FileUtils.getSizeAsString(memoryBudgetBytes), maxEntriesPerRun,
+        spillDirectory != null ? spillDirectory : Path.of(database.getDatabasePath()), mergeFanIn);
+  }
+
+  public void add(final LSMTreeIndex index, final Document record) {
+    final RID rid = record.getIdentity();
+    if (rid == null)
+      throw new IndexException("Cannot bulk-index a non-persistent record in '" + indexName + "'");
+
+    database.getIndexer().forEachIndexKey(index, record, rawKeys -> {
+      final Object[] normalizedKeys = index.normalizeKeysForBulkBuild(rawKeys);
+      final boolean containsNull = LSMTreeIndexAbstract.isKeyNull(normalizedKeys);
+      if (containsNull && index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.SKIP)
+        return;
+      if (containsNull && index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.ERROR)
+        index.getMutableIndex().checkForNulls(normalizedKeys);
+
+      registerIndex(index);
+      entries.add(new Entry(index, new TransactionIndexContext.ComparableKey(normalizedKeys), rid));
+      totalEntries++;
+      if (entries.size() >= maxEntriesPerRun)
+        spillCurrentRun();
+    });
+  }
+
+  public BuildOutcome writeCompacted() {
+    if (database.isTransactionActive())
+      throw new IndexException("Sorted build for '" + indexName + "' requires no active transaction");
+
+    final Map<LSMTreeIndex, BucketWriter> writers = new LinkedHashMap<>();
+    boolean success = false;
+    try {
+      prepareSortedEntries();
+      invokeBuildTestHook(BuildPhase.AFTER_SORT, null, 0);
+      final long started = System.currentTimeMillis();
+      final long written = forEachSortedGroup((first, rids) -> {
+        BucketWriter writer = writers.get(first.index());
+        if (writer == null) {
+          writer = new BucketWriter(first.index());
+          writers.put(first.index(), writer);
+        }
+        writer.append(first.key().values, rids);
+      });
+      invokeBuildTestHook(BuildPhase.AFTER_ENTRY_WRITES, null, 0);
+
+      int attachedBuckets = 0;
+      for (final BucketWriter writer : writers.values()) {
+        writer.finishAndAttach();
+        invokeBuildTestHook(BuildPhase.AFTER_BUCKET_ATTACHMENT, writer.mainIndex, ++attachedBuckets);
+      }
+      invokeBuildTestHook(BuildPhase.AFTER_ALL_ATTACHMENTS, null, attachedBuckets);
+
+      success = true;
+      final int runCount = externalSorter != null ? externalSorter.getRunCount() : 0;
+      final long spillBytes = externalSorter != null ? externalSorter.getSpilledBytes() : 0L;
+      final BuildOutcome outcome = new BuildOutcome(written, writers.size(), runCount, spillBytes,
+          System.currentTimeMillis() - started, memoryBudgetBytes);
+      LogManager.instance().log(this, Level.INFO,
+          "Completed sorted index build '%s': entries=%,d bucketIndexes=%d finalRuns=%d spillBytes=%s writeMillis=%,d",
+          indexName, outcome.entries(), outcome.bucketIndexes(), outcome.finalRuns(),
+          FileUtils.getSizeAsString(outcome.spillBytes()), outcome.writeMillis());
+      return outcome;
+    } catch (final InterruptedException error) {
+      Thread.currentThread().interrupt();
+      throw new IndexException("Sorted build for '" + indexName + "' was interrupted", error);
+    } catch (final Exception error) {
+      throw error instanceof IndexException indexError ? indexError
+          : new IndexException("Cannot build sorted index '" + indexName + "'", error);
+    } finally {
+      if (!success)
+        for (final BucketWriter writer : writers.values())
+          writer.abort();
+    }
+  }
+
+  public long size() {
+    return totalEntries;
+  }
+
+  private long forEachSortedGroup(final SortedGroupConsumer consumer) throws Exception {
+    long processed = 0L;
+    try (LSMTreeIndexExternalSorter.EntryCursor cursor = openSortedEntries()) {
+      final RID[] ridBuffer = new RID[MAX_BUFFERED_RIDS_PER_GROUP];
+      Entry groupFirst = null;
+      RID previousRid = null;
+      int bufferedRids = 0;
+
+      while (cursor.hasNext()) {
+        final Entry current = cursor.next();
+        if (groupFirst == null || current.index() != groupFirst.index()
+            || current.key().compareTo(groupFirst.key()) != 0) {
+          if (groupFirst != null)
+            processed += flushRidBuffer(consumer, groupFirst, ridBuffer, bufferedRids);
+          groupFirst = current;
+          previousRid = null;
+          bufferedRids = 0;
+        }
+
+        if (current.rid().equals(previousRid))
+          continue;
+
+        ridBuffer[bufferedRids++] = current.rid();
+        previousRid = current.rid();
+        if (bufferedRids == ridBuffer.length) {
+          processed += flushRidBuffer(consumer, groupFirst, ridBuffer, bufferedRids);
+          bufferedRids = 0;
+        }
+      }
+
+      if (groupFirst != null)
+        processed += flushRidBuffer(consumer, groupFirst, ridBuffer, bufferedRids);
+    }
+    return processed;
+  }
+
+  private static int flushRidBuffer(final SortedGroupConsumer consumer, final Entry first, final RID[] buffer,
+      final int size) throws Exception {
+    if (size == 0)
+      return 0;
+    consumer.accept(first, Arrays.copyOf(buffer, size));
+    return size;
+  }
+
+  private void prepareSortedEntries() {
+    if (externalSorter != null)
+      spillCurrentRun();
+    else
+      entries.sort(LSMTreeIndexBulkLoader::compareEntries);
+  }
+
+  private LSMTreeIndexExternalSorter.EntryCursor openSortedEntries() throws IOException {
+    if (externalSorter != null)
+      return externalSorter.openCursor();
+
+    return new LSMTreeIndexExternalSorter.EntryCursor() {
+      private int position;
+
+      @Override
+      public boolean hasNext() {
+        return position < entries.size();
+      }
+
+      @Override
+      public Entry next() {
+        return entries.get(position++);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void registerIndex(final LSMTreeIndex index) {
+    final byte[] indexKeyTypes = index.getBinaryKeyTypes();
+    if (binaryKeyTypes == null)
+      binaryKeyTypes = Arrays.copyOf(indexKeyTypes, indexKeyTypes.length);
+    else if (!Arrays.equals(binaryKeyTypes, indexKeyTypes))
+      throw new IndexException("Bucket index '" + index.getName() + "' has incompatible key types for sorted build '"
+          + indexName + "'");
+
+    final LSMTreeIndex previous = indexesByBucket.putIfAbsent(index.getAssociatedBucketId(), index);
+    if (previous != null && previous != index)
+      throw new IndexException("Multiple indexes are associated with bucket " + index.getAssociatedBucketId());
+  }
+
+  private void spillCurrentRun() {
+    if (entries.isEmpty())
+      return;
+
+    try {
+      if (externalSorter == null)
+        externalSorter = new LSMTreeIndexExternalSorter(database, binaryKeyTypes, indexesByBucket, spillDirectory,
+            mergeFanIn, memoryBudgetBytes, spillWorkspace);
+      externalSorter.addRun(entries);
+      entries.clear();
+    } catch (final IOException error) {
+      throw new IndexException("Cannot spill external sort run for index '" + indexName + "'", error);
+    }
+  }
+
+  private long resolveMemoryBudget(final long configuredMemoryBudgetBytes) {
+    if (configuredMemoryBudgetBytes < 0L)
+      throw new IllegalArgumentException("memory budget cannot be negative");
+    if (configuredMemoryBudgetBytes > 0L) {
+      if (configuredMemoryBudgetBytes < MIN_MEMORY_BUDGET_BYTES)
+        throw new IllegalArgumentException("memory budget must be at least " + MIN_MEMORY_BUDGET_BYTES + " bytes");
+      return configuredMemoryBudgetBytes;
+    }
+
+    final Runtime runtime = Runtime.getRuntime();
+    final long usedHeap = runtime.totalMemory() - runtime.freeMemory();
+    final long availableHeap = Math.max(0L, runtime.maxMemory() - usedHeap);
+    return Math.max(MIN_MEMORY_BUDGET_BYTES, availableHeap / 4L);
+  }
+
+  @Override
+  public void close() {
+    entries.clear();
+    if (externalSorter != null)
+      try {
+        externalSorter.close();
+      } catch (final IOException error) {
+        throw new IndexException("Cannot remove external sort files for index '" + indexName + "'", error);
+      } finally {
+        externalSorter = null;
+      }
+  }
+
+  static int compareEntries(final Entry left, final Entry right) {
+    final int keyComparison = left.key().compareTo(right.key());
+    return keyComparison != 0 ? keyComparison : left.rid().compareTo(right.rid());
+  }
+
+  static record Entry(LSMTreeIndex index, TransactionIndexContext.ComparableKey key, RID rid) {
+  }
+
+  static void setBuildTestHook(final BuildTestHook hook) {
+    if (hook == null)
+      BUILD_TEST_HOOK.remove();
+    else
+      BUILD_TEST_HOOK.set(hook);
+  }
+
+  private static void invokeBuildTestHook(final BuildPhase phase, final LSMTreeIndex index,
+      final int completedBuckets) {
+    final BuildTestHook hook = BUILD_TEST_HOOK.get();
+    if (hook != null)
+      hook.onPhase(phase, index, completedBuckets);
+  }
+
+  enum BuildPhase {
+    AFTER_SORT,
+    AFTER_ENTRY_WRITES,
+    AFTER_BUCKET_ATTACHMENT,
+    AFTER_ALL_ATTACHMENTS
+  }
+
+  @FunctionalInterface
+  interface BuildTestHook {
+    void onPhase(BuildPhase phase, LSMTreeIndex index, int completedBuckets);
+  }
+
+  public record BuildOutcome(long entries, int bucketIndexes, int finalRuns, long spillBytes, long writeMillis,
+                             long memoryBudgetBytes) {
+  }
+
+  @FunctionalInterface
+  private interface SortedGroupConsumer {
+    void accept(Entry first, RID[] rids) throws Exception;
+  }
+
+  private final class BucketWriter {
+    private final LSMTreeIndex                       mainIndex;
+    private final LSMTreeIndexCompacted              compactedIndex;
+    private final LSMTreeIndexCompactedStreamWriter  streamWriter;
+    private       boolean                            attached;
+
+    private BucketWriter(final LSMTreeIndex mainIndex) throws IOException {
+      this.mainIndex = mainIndex;
+      this.compactedIndex = mainIndex.getMutableIndex().createNewForCompaction();
+      try {
+        database.getSchema().getEmbedded().registerFile(compactedIndex);
+        this.streamWriter = new LSMTreeIndexCompactedStreamWriter(mainIndex, compactedIndex);
+      } catch (final RuntimeException error) {
+        try {
+          database.getFileManager().dropFile(compactedIndex.getFileId());
+        } catch (final Throwable cleanupError) {
+          error.addSuppressed(cleanupError);
+        }
+        throw error;
+      }
+    }
+
+    private void append(final Object[] keys, final RID[] rids) throws IOException, InterruptedException {
+      streamWriter.appendBounded(keys, rids,
+          LSMTreeIndexCompactedStreamWriter.DEFAULT_MAX_DATA_PAGES_PER_SERIES);
+    }
+
+    private void finishAndAttach() throws IOException, InterruptedException {
+      streamWriter.finishIfActive();
+      database.getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+      mainIndex.splitIndex(mainIndex.getMutableIndex().getTotalPages(), compactedIndex, false);
+      attached = true;
+    }
+
+    private void abort() {
+      if (attached)
+        return;
+      try {
+        database.getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+        database.transaction(() -> {
+          try {
+            database.getPageManager().deleteFile(database, compactedIndex.getFileId());
+            database.getFileManager().dropFile(compactedIndex.getFileId());
+            database.getSchema().getEmbedded().removeFile(compactedIndex.getFileId());
+          } catch (final IOException error) {
+            throw new IndexException("Cannot remove failed sorted index file '" + compactedIndex.getName() + "'", error);
+          }
+        }, false, 1, null, null);
+      } catch (final Throwable error) {
+        LogManager.instance().log(this, Level.WARNING, "Cannot clean failed sorted index file '%s'", error,
+            compactedIndex.getName());
+      }
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -29,6 +29,7 @@ import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.index.IndexCursorEntry;
+import com.arcadedb.index.IndexException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.RidHashSet;
@@ -95,6 +96,14 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     if (keys == null)
       throw new IllegalArgumentException("Keys parameter is null");
 
+    return appendDuringCompactionConverted(keyValueContent, currentPage, currentPageBuffer, compactedPageNumberOfSeries,
+        keys, convertKeysForCompaction(keys), rids);
+  }
+
+  List<MutablePage> appendDuringCompactionConverted(final Binary keyValueContent, MutablePage currentPage,
+      final TrackableBinary currentPageBuffer, final AtomicInteger compactedPageNumberOfSeries, final Object[] keys,
+      final Object[] convertedKeys, final RID[] rids)
+      throws IOException, InterruptedException {
     final List<MutablePage> newPages = new ArrayList<>();
 
     TrackableBinary pageBuffer = currentPageBuffer;
@@ -115,8 +124,6 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     int count = getCount(currentPage);
 
     int pageNum = currentPage.getPageId().getPageNumber();
-
-    final Object[] convertedKeys = convertKeys(keys, binaryKeyTypes);
 
     int keyValueFreePosition = getValuesFreePosition(currentPage);
     int freeSpaceInPage = keyValueFreePosition - (getHeaderSize(pageNum) + (count * INT_SERIALIZED_SIZE) + INT_SERIALIZED_SIZE);
@@ -167,7 +174,8 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       keyValueFreePosition -= keyValueContent.size();
 
       // WRITE KEY/VALUE PAIR CONTENT
-      pageBuffer.putByteArray(keyValueFreePosition, keyValueContent.toByteArray());
+      pageBuffer.putByteArray(keyValueFreePosition, keyValueContent.getContent(), keyValueContent.getContentBeginOffset(),
+          keyValueContent.size());
 
       final int startPos = getHeaderSize(pageNum) + (count * INT_SERIALIZED_SIZE);
       pageBuffer.putInt(startPos, keyValueFreePosition);
@@ -206,6 +214,54 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     } while (true);
 
     return newPages;
+  }
+
+  int availableSpaceForEntries(final MutablePage page) {
+    final int count = getCount(page);
+    return getValuesFreePosition(page)
+        - (getHeaderSize(page.getPageId().getPageNumber()) + count * INT_SERIALIZED_SIZE);
+  }
+
+  int requiredSpaceForEntry(final MutablePage page, final Object[] keys, final RID[] rids) {
+    return requiredSpaceForEntry(new Binary(), page, keys, convertKeysForCompaction(keys), rids);
+  }
+
+  int requiredSpaceForEntry(final Binary scratch, final MutablePage page, final Object[] keys,
+      final Object[] convertedKeys, final RID[] rids) {
+    final int pageNumber = page.getPageId().getPageNumber();
+    final int pageUsableSpace = page.getMaxContentSize() - getHeaderSize(pageNumber);
+    final int written = writeEntryMultipleValues(scratch, convertedKeys, rids, pageUsableSpace, pageUsableSpace,
+        page.getPageId());
+    if (written != rids.length)
+      throw new IndexException("Key/value group for " + Arrays.toString(keys) + " does not fit in one compacted page");
+    return INT_SERIALIZED_SIZE + scratch.size();
+  }
+
+  boolean canAppendWholeEntry(final MutablePage page, final Object[] keys, final RID[] rids) {
+    return requiredSpaceForEntry(page, keys, rids) <= availableSpaceForEntries(page);
+  }
+
+  int valuesFittingInEmptyLeaf(final MutablePage referencePage, final Object[] keys, final RID[] rids) {
+    return valuesFittingInEmptyLeaf(new Binary(), referencePage, keys, convertKeysForCompaction(keys), rids);
+  }
+
+  int valuesFittingInEmptyLeaf(final Binary scratch, final MutablePage referencePage, final Object[] keys,
+      final Object[] convertedKeys, final RID[] rids) {
+    final int pageUsableSpace = referencePage.getMaxContentSize() - getHeaderSize(1);
+    final int written = writeEntryMultipleValues(scratch, convertedKeys, rids,
+        pageUsableSpace - INT_SERIALIZED_SIZE, pageUsableSpace, referencePage.getPageId());
+    if (written < 1)
+      throw new IndexException(
+          "Key/value group for " + Arrays.toString(keys) + " does not fit in an empty compacted leaf page");
+    return written;
+  }
+
+  int requiredSpaceForSerializedEntry(final Binary serializedEntry) {
+    return INT_SERIALIZED_SIZE + serializedEntry.size();
+  }
+
+  Object[] convertKeysForCompaction(final Object[] keys) {
+    return convertKeys(keys, binaryKeyTypes);
   }
 
   protected LookupResult compareKey(final Binary currentPageBuffer, final int startIndexArray, final Object[] convertedKeys,

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -440,9 +440,10 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
 
       if (resultInRootPage.found) {
         if (ascendingOrder && !unique) {
-          // Start at the first matching leaf, plus its possible shared predecessor for files written before the overflow
-          // safeguard. A non-matching predecessor advances to the next page in the page-level lookup below. Unique indexes
-          // are exempt: a unique key holds a single value that never overflows a page, so the shared-leaf layout cannot occur.
+          // Start at the first matching leaf plus its possible shared predecessor. Legacy files can contain a key that began
+          // on its predecessor and then overflowed; the bounded writer can also place a complete leading RID chunk there
+          // before later chunks move to matching leaves. A non-matching predecessor advances to the next page below. Unique
+          // indexes are exempt: a unique key holds one value and cannot span leaves.
           final int firstMatchingRootEntry = resultInRootPage.valueBeginPositions != null
               ? resultInRootPage.keyIndex - resultInRootPage.valueBeginPositions.length + 1
               : resultInRootPage.keyIndex;
@@ -479,9 +480,14 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       } else {
         startingPageNumber = firstPageNumber;
         posInPage = result.keyIndex;
-        if (ascendingOrder)
+        if (ascendingOrder) {
+          // Binary search may land in the middle of a repeated-key run. This matters when a bounded write starts a
+          // high-cardinality key on its predecessor leaf: starting at the middle drops the earlier RID chunks on that leaf.
+          // Position immediately before the first matching entry so the series cursor emits the complete run.
+          if (result.found && !unique)
+            posInPage = findFirstEntryOfSameKey(firstPageBuffer, convertedFromKeys, getHeaderSize(firstPageNumber), posInPage);
           --posInPage;
-        else
+        } else
           ++posInPage;
       }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.TrackableBinary;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.log.LogManager;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+/** Writes an ordered key/RID stream into the compacted LSM series format used by normal compaction. */
+final class LSMTreeIndexCompactedStreamWriter {
+  private static final RID[] ROOT_SENTINEL = new RID[] { new RID(0, 0) };
+
+  private final LSMTreeIndex          mainIndex;
+  private final LSMTreeIndexMutable   mutableIndex;
+  private final LSMTreeIndexCompacted compactedIndex;
+  private final DatabaseInternal      database;
+  private final Binary                keyValueContent = new Binary();
+
+  private MutablePage     rootPage;
+  private TrackableBinary rootPageBuffer;
+  private MutablePage     lastPage;
+  private TrackableBinary lastPageBuffer;
+  private AtomicInteger   pageNumberInSeries;
+  private Object[]        lastPageMaxKey;
+  private List<MutablePage> newPagesInSeries;
+
+  LSMTreeIndexCompactedStreamWriter(final LSMTreeIndex mainIndex, final LSMTreeIndexCompacted compactedIndex) {
+    this.mainIndex = mainIndex;
+    this.mutableIndex = mainIndex.getMutableIndex();
+    this.compactedIndex = compactedIndex;
+    this.database = mutableIndex.getDatabase();
+  }
+
+  MutablePage startSeries() {
+    if (rootPage != null)
+      throw new IllegalStateException("A compacted series is already active for index '" + mainIndex.getName() + "'");
+
+    rootPage = compactedIndex.createNewPage(0);
+    rootPageBuffer = rootPage.getTrackable();
+    lastPage = null;
+    lastPageBuffer = null;
+    pageNumberInSeries = new AtomicInteger(1);
+    lastPageMaxKey = null;
+    newPagesInSeries = new ArrayList<>();
+    return rootPage;
+  }
+
+  void append(final Object[] keys, final RID[] rids) throws IOException, InterruptedException {
+    if (rootPage == null)
+      throw new IllegalStateException("No compacted series is active for index '" + mainIndex.getName() + "'");
+
+    final List<MutablePage> newPages = compactedIndex.appendDuringCompaction(keyValueContent, lastPage, lastPageBuffer,
+        pageNumberInSeries, keys, rids);
+
+    if (!newPages.isEmpty()) {
+      lastPage = newPages.getLast();
+      lastPageBuffer = lastPage.getTrackable();
+
+      for (final MutablePage newPage : newPages) {
+        final int newPageNumber = newPage.getPageId().getPageNumber();
+        final List<MutablePage> newRootPages = compactedIndex.appendDuringCompaction(keyValueContent, rootPage,
+            rootPageBuffer, pageNumberInSeries, keys, new RID[] { new RID(0, newPageNumber) });
+
+        LogManager.instance().log(mainIndex, Level.FINE,
+            "- Creating a new entry in index '%s' root page %s->%d (entry in page=%d threadId=%d)", null, mutableIndex,
+            Arrays.toString(keys), newPageNumber, mutableIndex.getCount(rootPage) - 1, Thread.currentThread().threadId());
+
+        if (!newRootPages.isEmpty())
+          throw new UnsupportedOperationException("Root index page overflow");
+      }
+      newPagesInSeries.addAll(newPages);
+    }
+
+    lastPageMaxKey = keys;
+  }
+
+  void finishSeries() throws IOException, InterruptedException {
+    if (rootPage == null)
+      throw new IllegalStateException("No compacted series is active for index '" + mainIndex.getName() + "'");
+
+    if (lastPageMaxKey != null) {
+      final List<MutablePage> overflow = compactedIndex.appendDuringCompaction(keyValueContent, rootPage, rootPageBuffer,
+          pageNumberInSeries, lastPageMaxKey, ROOT_SENTINEL);
+      if (!overflow.isEmpty())
+        throw new UnsupportedOperationException("Root index page overflow");
+
+      LogManager.instance().log(mainIndex, Level.FINE,
+          "- Creating last entry in index '%s' root page %s (entriesInRootPage=%d threadId=%d)", null, mutableIndex,
+          Arrays.toString(lastPageMaxKey), compactedIndex.getCount(rootPage), Thread.currentThread().threadId());
+    }
+
+    final List<MutablePage> modifiedPages = new ArrayList<>(newPagesInSeries);
+    modifiedPages.add(database.getPageManager().updatePageVersion(rootPage, true));
+    database.getPageManager().writePages(modifiedPages, false);
+
+    rootPage = null;
+    rootPageBuffer = null;
+    lastPage = null;
+    lastPageBuffer = null;
+    pageNumberInSeries = null;
+    lastPageMaxKey = null;
+    newPagesInSeries = null;
+  }
+
+  int getRootEntryCount() {
+    return rootPage != null ? compactedIndex.getCount(rootPage) : 0;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.TrackableBinary;
 import com.arcadedb.engine.MutablePage;
+import com.arcadedb.index.IndexException;
 import com.arcadedb.log.LogManager;
 
 import java.io.IOException;
@@ -34,13 +35,17 @@ import java.util.logging.Level;
 
 /** Writes an ordered key/RID stream into the compacted LSM series format used by normal compaction. */
 final class LSMTreeIndexCompactedStreamWriter {
-  private static final RID[] ROOT_SENTINEL = new RID[] { new RID(0, 0) };
+  static final int DEFAULT_MAX_DATA_PAGES_PER_SERIES = 1_024;
+
+  private static final RID[] ROOT_SENTINEL               = new RID[] { new RID(0, 0) };
+  private static final int   MAX_RIDS_PER_BOUNDED_APPEND = 256;
 
   private final LSMTreeIndex          mainIndex;
   private final LSMTreeIndexMutable   mutableIndex;
   private final LSMTreeIndexCompacted compactedIndex;
   private final DatabaseInternal      database;
   private final Binary                keyValueContent = new Binary();
+  private final Binary                sizingContent   = new Binary();
 
   private MutablePage     rootPage;
   private TrackableBinary rootPageBuffer;
@@ -48,6 +53,7 @@ final class LSMTreeIndexCompactedStreamWriter {
   private TrackableBinary lastPageBuffer;
   private AtomicInteger   pageNumberInSeries;
   private Object[]        lastPageMaxKey;
+  private Object[]        lastPageMaxConvertedKey;
   private List<MutablePage> newPagesInSeries;
 
   LSMTreeIndexCompactedStreamWriter(final LSMTreeIndex mainIndex, final LSMTreeIndexCompacted compactedIndex) {
@@ -67,16 +73,22 @@ final class LSMTreeIndexCompactedStreamWriter {
     lastPageBuffer = null;
     pageNumberInSeries = new AtomicInteger(1);
     lastPageMaxKey = null;
+    lastPageMaxConvertedKey = null;
     newPagesInSeries = new ArrayList<>();
     return rootPage;
   }
 
   void append(final Object[] keys, final RID[] rids) throws IOException, InterruptedException {
+    appendConverted(keys, compactedIndex.convertKeysForCompaction(keys), rids);
+  }
+
+  private void appendConverted(final Object[] keys, final Object[] convertedKeys, final RID[] rids)
+      throws IOException, InterruptedException {
     if (rootPage == null)
       throw new IllegalStateException("No compacted series is active for index '" + mainIndex.getName() + "'");
 
-    final List<MutablePage> newPages = compactedIndex.appendDuringCompaction(keyValueContent, lastPage, lastPageBuffer,
-        pageNumberInSeries, keys, rids);
+    final List<MutablePage> newPages = compactedIndex.appendDuringCompactionConverted(keyValueContent, lastPage,
+        lastPageBuffer, pageNumberInSeries, keys, convertedKeys, rids);
 
     if (!newPages.isEmpty()) {
       lastPage = newPages.getLast();
@@ -84,8 +96,8 @@ final class LSMTreeIndexCompactedStreamWriter {
 
       for (final MutablePage newPage : newPages) {
         final int newPageNumber = newPage.getPageId().getPageNumber();
-        final List<MutablePage> newRootPages = compactedIndex.appendDuringCompaction(keyValueContent, rootPage,
-            rootPageBuffer, pageNumberInSeries, keys, new RID[] { new RID(0, newPageNumber) });
+        final List<MutablePage> newRootPages = compactedIndex.appendDuringCompactionConverted(keyValueContent, rootPage,
+            rootPageBuffer, pageNumberInSeries, keys, convertedKeys, new RID[] { new RID(0, newPageNumber) });
 
         LogManager.instance().log(mainIndex, Level.FINE,
             "- Creating a new entry in index '%s' root page %s->%d (entry in page=%d threadId=%d)", null, mutableIndex,
@@ -98,6 +110,54 @@ final class LSMTreeIndexCompactedStreamWriter {
     }
 
     lastPageMaxKey = keys;
+    lastPageMaxConvertedKey = convertedKeys;
+  }
+
+  void appendBounded(final Object[] keys, final RID[] rids, final int maxDataPagesPerSeries)
+      throws IOException, InterruptedException {
+    if (maxDataPagesPerSeries < 1)
+      throw new IllegalArgumentException("maxDataPagesPerSeries must be at least 1");
+
+    final Object[] convertedKeys = compactedIndex.convertKeysForCompaction(keys);
+    int from = 0;
+    while (from < rids.length) {
+      if (rootPage == null)
+        startSeries();
+
+      final int requestedTo = Math.min(rids.length, from + MAX_RIDS_PER_BOUNDED_APPEND);
+      RID[] chunk = from == 0 && requestedTo == rids.length ? rids : Arrays.copyOfRange(rids, from, requestedTo);
+      final int fitting = compactedIndex.valuesFittingInEmptyLeaf(sizingContent, rootPage, keys, convertedKeys, chunk);
+      if (fitting < chunk.length)
+        chunk = Arrays.copyOf(chunk, fitting);
+      final int requiredLeafSpace = compactedIndex.requiredSpaceForSerializedEntry(sizingContent);
+
+      final boolean startsNewLeaf = lastPage == null
+          || requiredLeafSpace > compactedIndex.availableSpaceForEntries(lastPage);
+      int requiredRootSpace = compactedIndex.requiredSpaceForEntry(sizingContent, rootPage, keys, convertedKeys,
+          ROOT_SENTINEL);
+      if (startsNewLeaf)
+        requiredRootSpace += compactedIndex.requiredSpaceForEntry(sizingContent, rootPage, keys, convertedKeys,
+            new RID[] { new RID(0, compactedIndex.getTotalPages()) });
+
+      if ((startsNewLeaf && newPagesInSeries.size() >= maxDataPagesPerSeries)
+          || requiredRootSpace > compactedIndex.availableSpaceForEntries(rootPage)) {
+        finishSeries();
+        startSeries();
+        requiredRootSpace = compactedIndex.requiredSpaceForEntry(sizingContent, rootPage, keys, convertedKeys,
+            ROOT_SENTINEL)
+            + compactedIndex.requiredSpaceForEntry(sizingContent, rootPage, keys, convertedKeys,
+            new RID[] { new RID(0, compactedIndex.getTotalPages()) });
+        if (requiredRootSpace > compactedIndex.availableSpaceForEntries(rootPage))
+          throw new IndexException(
+              "Root entry for key " + Arrays.toString(keys) + " does not fit in an empty compacted series");
+      }
+
+      final int pagesBefore = newPagesInSeries.size();
+      appendConverted(keys, convertedKeys, chunk);
+      if (newPagesInSeries.size() - pagesBefore > 1)
+        throw new IndexException("A bounded compacted append unexpectedly created multiple data pages");
+      from += chunk.length;
+    }
   }
 
   void finishSeries() throws IOException, InterruptedException {
@@ -105,8 +165,8 @@ final class LSMTreeIndexCompactedStreamWriter {
       throw new IllegalStateException("No compacted series is active for index '" + mainIndex.getName() + "'");
 
     if (lastPageMaxKey != null) {
-      final List<MutablePage> overflow = compactedIndex.appendDuringCompaction(keyValueContent, rootPage, rootPageBuffer,
-          pageNumberInSeries, lastPageMaxKey, ROOT_SENTINEL);
+      final List<MutablePage> overflow = compactedIndex.appendDuringCompactionConverted(keyValueContent, rootPage,
+          rootPageBuffer, pageNumberInSeries, lastPageMaxKey, lastPageMaxConvertedKey, ROOT_SENTINEL);
       if (!overflow.isEmpty())
         throw new UnsupportedOperationException("Root index page overflow");
 
@@ -125,7 +185,13 @@ final class LSMTreeIndexCompactedStreamWriter {
     lastPageBuffer = null;
     pageNumberInSeries = null;
     lastPageMaxKey = null;
+    lastPageMaxConvertedKey = null;
     newPagesInSeries = null;
+  }
+
+  void finishIfActive() throws IOException, InterruptedException {
+    if (rootPage != null)
+      finishSeries();
   }
 
   int getRootEntryCount() {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
@@ -33,7 +33,16 @@ import java.util.*;
 import java.util.logging.Level;
 
 public class LSMTreeIndexCompactor {
+  private static final ThreadLocal<CompactionTestHook> COMPACTION_TEST_HOOK = new ThreadLocal<>();
+
   private boolean debug = false;
+
+  static void setCompactionTestHook(final CompactionTestHook hook) {
+    if (hook == null)
+      COMPACTION_TEST_HOOK.remove();
+    else
+      COMPACTION_TEST_HOOK.set(hook);
+  }
 
   public LSMTreeIndexCompactor setDebug(final boolean debug) {
     this.debug = debug;
@@ -272,7 +281,8 @@ public class LSMTreeIndexCompactor {
           final RID[] ridsArray = new RID[rids.size()];
           rids.toArray(ridsArray);
 
-          streamWriter.append(minorKey, ridsArray);
+          streamWriter.appendBounded(minorKey, ridsArray,
+              LSMTreeIndexCompactedStreamWriter.DEFAULT_MAX_DATA_PAGES_PER_SERIES);
 
           ++totalKeys;
           totalValues += rids.size();
@@ -286,6 +296,10 @@ public class LSMTreeIndexCompactor {
       }
 
       streamWriter.finishSeries();
+
+      final CompactionTestHook testHook = COMPACTION_TEST_HOOK.get();
+      if (testHook != null)
+        testHook.afterSeriesWritten(compactedIndex);
 
       compactedPages += pagesToCompact;
 
@@ -317,5 +331,10 @@ public class LSMTreeIndexCompactor {
     }
 
     return true;
+  }
+
+  @FunctionalInterface
+  interface CompactionTestHook {
+    void afterSeriesWritten(LSMTreeIndexCompacted compactedIndex) throws IOException;
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
@@ -19,12 +19,9 @@
 package com.arcadedb.index.lsm;
 
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
-import com.arcadedb.database.TrackableBinary;
 import com.arcadedb.engine.ImmutablePage;
-import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.BinaryComparator;
@@ -33,7 +30,6 @@ import com.arcadedb.utility.FileUtils;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 public class LSMTreeIndexCompactor {
@@ -122,7 +118,7 @@ public class LSMTreeIndexCompactor {
     long totalMergedKeys = 0;
     long totalMergedValues = 0;
 
-    final Binary keyValueContent = new Binary();
+    final LSMTreeIndexCompactedStreamWriter streamWriter = new LSMTreeIndexCompactedStreamWriter(mainIndex, compactedIndex);
 
     int pagesToCompact;
     int compactedPages = 0;
@@ -160,17 +156,12 @@ public class LSMTreeIndexCompactor {
       } else
         pagesToCompact = lastImmutablePage - pageIndex + 1;
 
-      // CREATE ROOT PAGE
-      final MutablePage rootPage = compactedIndex.createNewPage(0);
-      final TrackableBinary rootPageBuffer = rootPage.getTrackable();
-      Object[] lastPageMaxKey = null;
+      final var rootPage = streamWriter.startSeries();
 
       LogManager.instance()
           .log(mainIndex, Level.FINE, "- This turn compacting %d pages using root page %s v.%d (threadId=%d)", null,
               pagesToCompact, rootPage.getPageId(),
               rootPage.getVersion(), Thread.currentThread().threadId());
-
-      final AtomicInteger compactedPageNumberInSeries = new AtomicInteger(1);
 
       final LSMTreeIndexUnderlyingPageCursor[] iterators = new LSMTreeIndexUnderlyingPageCursor[pagesToCompact];
       for (int i = 0; i < pagesToCompact; ++i)
@@ -192,12 +183,7 @@ public class LSMTreeIndexCompactor {
       final BinarySerializer serializer = database.getSerializer();
       final BinaryComparator comparator = serializer.getComparator();
 
-      MutablePage lastPage = null;
-      TrackableBinary currentPageBuffer = null;
-
       final Set<RID> rids = new LinkedHashSet<>();
-
-      final List<MutablePage> allNewPages = new ArrayList<>();
 
       for (boolean moreItems = true; moreItems; ++iterations) {
         moreItems = false;
@@ -286,41 +272,7 @@ public class LSMTreeIndexCompactor {
           final RID[] ridsArray = new RID[rids.size()];
           rids.toArray(ridsArray);
 
-          final List<MutablePage> newPages = compactedIndex.appendDuringCompaction(keyValueContent, lastPage, currentPageBuffer,
-              compactedPageNumberInSeries, minorKey,
-              ridsArray);
-
-          if (!newPages.isEmpty()) {
-            lastPage = newPages.getLast();
-            currentPageBuffer = lastPage.getTrackable();
-
-            for (MutablePage newPage : newPages) {
-              // NEW PAGE: STORE THE MIN KEY IN THE ROOT PAGE
-              final int newPageNum = newPage.getPageId().getPageNumber();
-
-              final List<MutablePage> newRootPages = compactedIndex.appendDuringCompaction(keyValueContent, rootPage,
-                  rootPageBuffer,
-                  compactedPageNumberInSeries,
-                  minorKey, new RID[] { new RID(0, newPageNum) });
-
-              LogManager.instance()
-                  .log(mainIndex, Level.FINE,
-                      "- Creating a new entry in index '%s' root page %s->%d (entry in page=%d threadId=%d)", null, mutableIndex,
-                      Arrays.toString(minorKey), newPageNum, mutableIndex.getCount(rootPage) - 1,
-                      Thread.currentThread().threadId());
-
-              if (!newRootPages.isEmpty()) {
-                // TODO: MANAGE A LINKED LIST OF ROOT PAGES INSTEAD
-                throw new UnsupportedOperationException("Root index page overflow");
-              }
-
-              allNewPages.addAll(newPages);
-            }
-          }
-
-          // UPDATE LAST PAGE'S KEY
-          if (minorKey != null)
-            lastPageMaxKey = minorKey;
+          streamWriter.append(minorKey, ridsArray);
 
           ++totalKeys;
           totalValues += rids.size();
@@ -329,25 +281,11 @@ public class LSMTreeIndexCompactor {
             LogManager.instance()
                 .log(mainIndex, Level.FINE, "- Keys %d values %d - iterations %d (entriesInRootPage=%d, threadId=%d)", null,
                     totalKeys, totalValues,
-                    iterations, compactedIndex.getCount(rootPage), Thread.currentThread().threadId());
+                    iterations, streamWriter.getRootEntryCount(), Thread.currentThread().threadId());
         }
       }
 
-      if (rootPage != null && lastPageMaxKey != null) {
-        // WRITE THE MAX KEY
-        compactedIndex.appendDuringCompaction(keyValueContent, rootPage, rootPageBuffer, compactedPageNumberInSeries,
-            lastPageMaxKey,
-            new RID[] { new RID(0, 0) });
-        LogManager.instance()
-            .log(mainIndex, Level.FINE, "- Creating last entry in index '%s' root page %s (entriesInRootPage=%d, threadId=%d)",
-                null, mutableIndex,
-                Arrays.toString(lastPageMaxKey), compactedIndex.getCount(rootPage), Thread.currentThread().threadId());
-      }
-
-      final List<MutablePage> modifiedPages = new ArrayList<>(allNewPages);
-      modifiedPages.add(database.getPageManager().updatePageVersion(rootPage, true));
-
-      database.getPageManager().writePages(modifiedPages, false);
+      streamWriter.finishSeries();
 
       compactedPages += pagesToCompact;
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
@@ -24,8 +24,9 @@ import com.arcadedb.database.RID;
 import com.arcadedb.database.TransactionIndexContext;
 import com.arcadedb.serializer.BinarySerializer;
 import com.arcadedb.serializer.BinaryTypes;
-import com.sun.management.UnixOperatingSystemMXBean;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -101,11 +102,19 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
   }
 
   private static long getAvailableFileDescriptors() {
-    if (ManagementFactory.getOperatingSystemMXBean() instanceof UnixOperatingSystemMXBean unix) {
-      final long maximum = unix.getMaxFileDescriptorCount();
-      final long open = unix.getOpenFileDescriptorCount();
-      if (maximum > 0L && open >= 0L)
-        return Math.max(0L, maximum - open - FILE_DESCRIPTOR_RESERVE);
+    try {
+      final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+      final ObjectName operatingSystem = ObjectName.getInstance(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);
+      final Object maximumValue = server.getAttribute(operatingSystem, "MaxFileDescriptorCount");
+      final Object openValue = server.getAttribute(operatingSystem, "OpenFileDescriptorCount");
+      if (maximumValue instanceof Number maximumNumber && openValue instanceof Number openNumber) {
+        final long maximum = maximumNumber.longValue();
+        final long open = openNumber.longValue();
+        if (maximum > 0L && open >= 0L)
+          return Math.max(0L, maximum - open - FILE_DESCRIPTOR_RESERVE);
+      }
+    } catch (final Exception | LinkageError ignored) {
+      // Descriptor metrics are optional on non-Unix or non-HotSpot runtimes.
     }
     return Long.MAX_VALUE;
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.TransactionIndexContext;
+import com.arcadedb.serializer.BinarySerializer;
+import com.arcadedb.serializer.BinaryTypes;
+import com.sun.management.UnixOperatingSystemMXBean;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.stream.Stream;
+
+/** Creates bounded sorted spill runs and exposes a k-way merged entry stream. */
+final class LSMTreeIndexExternalSorter implements AutoCloseable {
+  static final String DIRECTORY_PREFIX = ".arcadedb-index-sort-";
+
+  private static final ThreadLocal<SpillWriteTestHook> SPILL_WRITE_TEST_HOOK = new ThreadLocal<>();
+
+  private static final int RUN_MAGIC       = 0x41584953;
+  private static final int RUN_VERSION     = 1;
+  private static final int BUFFER_SIZE     = 256 << 10;
+  private static final int MAX_ENTRY_BYTES = 64 << 20;
+  private static final long FILE_DESCRIPTOR_RESERVE = 64L;
+
+  private final DatabaseInternal                  database;
+  private final BinarySerializer                  serializer;
+  private final byte[]                            binaryKeyTypes;
+  private final Map<Integer, LSMTreeIndex>         indexesByBucket;
+  private final Path                              directory;
+  private final int                               mergeFanIn;
+  private final List<RunFile>                     runs = new ArrayList<>();
+  private final Binary                            writePayload = new Binary();
+  private       long                              spilledBytes;
+  private       int                               mergeGeneration;
+
+  LSMTreeIndexExternalSorter(final DatabaseInternal database, final byte[] binaryKeyTypes,
+      final Map<Integer, LSMTreeIndex> indexesByBucket, final Path spillParent, final int configuredMergeFanIn,
+      final long memoryBudgetBytes, final Path spillWorkspace) throws IOException {
+    if (configuredMergeFanIn < 2)
+      throw new IllegalArgumentException("mergeFanIn must be at least 2");
+
+    this.database = database;
+    this.serializer = database.getSerializer();
+    this.binaryKeyTypes = Arrays.copyOf(binaryKeyTypes, binaryKeyTypes.length);
+    this.indexesByBucket = indexesByBucket;
+    this.mergeFanIn = selectMergeFanIn(configuredMergeFanIn, memoryBudgetBytes, getAvailableFileDescriptors());
+
+    if (spillWorkspace != null) {
+      directory = spillWorkspace.toAbsolutePath().normalize();
+      Files.createDirectories(directory.getParent());
+      Files.createDirectory(directory);
+    } else {
+      final Path parent = spillParent != null ? spillParent : Path.of(database.getDatabasePath());
+      Files.createDirectories(parent);
+      directory = Files.createTempDirectory(parent, DIRECTORY_PREFIX);
+    }
+  }
+
+  static int selectMergeFanIn(final int configured, final long memoryBudgetBytes,
+      final long availableFileDescriptors) throws IOException {
+    final long memoryLimit = Math.max(2L, memoryBudgetBytes / (2L * BUFFER_SIZE));
+    final long descriptorLimit = availableFileDescriptors == Long.MAX_VALUE ? Integer.MAX_VALUE
+        : availableFileDescriptors - 1L;
+    if (descriptorLimit < 2L)
+      throw new IOException("Insufficient file descriptors for external sort merging");
+    return (int) Math.min(configured, Math.min(memoryLimit, Math.min(descriptorLimit, Integer.MAX_VALUE)));
+  }
+
+  private static long getAvailableFileDescriptors() {
+    if (ManagementFactory.getOperatingSystemMXBean() instanceof UnixOperatingSystemMXBean unix) {
+      final long maximum = unix.getMaxFileDescriptorCount();
+      final long open = unix.getOpenFileDescriptorCount();
+      if (maximum > 0L && open >= 0L)
+        return Math.max(0L, maximum - open - FILE_DESCRIPTOR_RESERVE);
+    }
+    return Long.MAX_VALUE;
+  }
+
+  void addRun(final List<LSMTreeIndexBulkLoader.Entry> entries) throws IOException {
+    if (entries.isEmpty())
+      return;
+
+    entries.sort(LSMTreeIndexBulkLoader::compareEntries);
+    final Path run = directory.resolve("run-%06d.bin".formatted(runs.size()));
+    boolean complete = false;
+    try (DataOutputStream output = openRunOutput(run, entries.size())) {
+      for (final LSMTreeIndexBulkLoader.Entry entry : entries)
+        writeEntry(output, entry);
+      complete = true;
+    } finally {
+      if (!complete)
+        Files.deleteIfExists(run);
+    }
+
+    runs.add(new RunFile(run, entries.size()));
+    spilledBytes += Files.size(run);
+  }
+
+  EntryCursor openCursor() throws IOException {
+    consolidateRuns();
+    return new MergedCursor(List.copyOf(runs));
+  }
+
+  int getRunCount() {
+    return runs.size();
+  }
+
+  long getSpilledBytes() {
+    return spilledBytes;
+  }
+
+  private void consolidateRuns() throws IOException {
+    while (runs.size() > mergeFanIn) {
+      final List<RunFile> mergedRuns = new ArrayList<>((runs.size() + mergeFanIn - 1) / mergeFanIn);
+      final List<RunFile> sourceRuns = new ArrayList<>(runs);
+
+      for (int from = 0; from < sourceRuns.size(); from += mergeFanIn) {
+        final int to = Math.min(sourceRuns.size(), from + mergeFanIn);
+        final List<RunFile> group = sourceRuns.subList(from, to);
+        if (group.size() == 1) {
+          mergedRuns.add(group.getFirst());
+          continue;
+        }
+
+        final Path mergedPath = directory.resolve(
+            "merge-%03d-%06d.bin".formatted(mergeGeneration, mergedRuns.size()));
+        final long entryCount = group.stream().mapToLong(RunFile::entries).sum();
+        final RunFile merged = mergeRuns(group, mergedPath, entryCount);
+        mergedRuns.add(merged);
+        spilledBytes += Files.size(mergedPath);
+
+        for (final RunFile source : group)
+          Files.delete(source.path());
+      }
+
+      runs.clear();
+      runs.addAll(mergedRuns);
+      mergeGeneration++;
+    }
+  }
+
+  private RunFile mergeRuns(final List<RunFile> sources, final Path outputPath, final long entryCount) throws IOException {
+    boolean complete = false;
+    try (DataOutputStream output = openRunOutput(outputPath, entryCount);
+        EntryCursor cursor = new MergedCursor(sources)) {
+      while (cursor.hasNext())
+        writeEntry(output, cursor.next());
+      complete = true;
+    } finally {
+      if (!complete)
+        Files.deleteIfExists(outputPath);
+    }
+    return new RunFile(outputPath, entryCount);
+  }
+
+  private DataOutputStream openRunOutput(final Path path, final long entryCount) throws IOException {
+    final DataOutputStream output = new DataOutputStream(new BufferedOutputStream(
+        Files.newOutputStream(path, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE), BUFFER_SIZE));
+    try {
+      output.writeInt(RUN_MAGIC);
+      output.writeInt(RUN_VERSION);
+      output.writeInt(binaryKeyTypes.length);
+      output.write(binaryKeyTypes);
+      output.writeLong(entryCount);
+      return output;
+    } catch (final IOException | RuntimeException error) {
+      try {
+        output.close();
+      } catch (final IOException closeError) {
+        error.addSuppressed(closeError);
+      }
+      throw error;
+    }
+  }
+
+  private void writeEntry(final DataOutputStream output, final LSMTreeIndexBulkLoader.Entry entry) throws IOException {
+    writePayload.clear();
+    for (int i = 0; i < binaryKeyTypes.length; i++) {
+      final Object key = entry.key().values[i];
+      writePayload.putByte((byte) (key == null ? 0 : 1));
+      if (key != null)
+        serializer.serializeValue(database, writePayload, binaryKeyTypes[i], key);
+    }
+    serializer.serializeValue(database, writePayload, BinaryTypes.TYPE_COMPRESSED_RID, entry.rid());
+
+    output.writeInt(entry.index().getAssociatedBucketId());
+    output.writeInt(writePayload.size());
+    output.write(writePayload.getContent(), writePayload.getContentBeginOffset(), writePayload.size());
+
+    final SpillWriteTestHook hook = SPILL_WRITE_TEST_HOOK.get();
+    if (hook != null)
+      hook.afterEntryWritten();
+  }
+
+  static void setSpillWriteTestHook(final SpillWriteTestHook hook) {
+    if (hook == null)
+      SPILL_WRITE_TEST_HOOK.remove();
+    else
+      SPILL_WRITE_TEST_HOOK.set(hook);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!Files.exists(directory))
+      return;
+
+    final List<Path> paths;
+    try (Stream<Path> walk = Files.walk(directory)) {
+      paths = walk.sorted(Comparator.reverseOrder()).toList();
+    }
+
+    IOException failure = null;
+    for (final Path path : paths)
+      try {
+        Files.deleteIfExists(path);
+      } catch (final IOException error) {
+        if (failure == null)
+          failure = error;
+        else
+          failure.addSuppressed(error);
+      }
+    if (failure != null)
+      throw failure;
+  }
+
+  interface EntryCursor extends AutoCloseable {
+    boolean hasNext();
+
+    LSMTreeIndexBulkLoader.Entry next() throws IOException;
+
+    @Override
+    void close() throws IOException;
+  }
+
+  private final class MergedCursor implements EntryCursor {
+    private final PriorityQueue<RunReader> readers = new PriorityQueue<>((left, right) ->
+        LSMTreeIndexBulkLoader.compareEntries(left.current, right.current));
+    private boolean closed;
+
+    private MergedCursor(final List<RunFile> sourceRuns) throws IOException {
+      try {
+        for (final RunFile run : sourceRuns) {
+          final RunReader reader = new RunReader(run);
+          if (reader.current != null)
+            readers.add(reader);
+          else
+            reader.close();
+        }
+      } catch (final IOException | RuntimeException error) {
+        try {
+          close();
+        } catch (final IOException closeError) {
+          error.addSuppressed(closeError);
+        }
+        throw error;
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return !readers.isEmpty();
+    }
+
+    @Override
+    public LSMTreeIndexBulkLoader.Entry next() throws IOException {
+      final RunReader reader = readers.remove();
+      final LSMTreeIndexBulkLoader.Entry result = reader.current;
+      try {
+        reader.advance();
+      } catch (final IOException | RuntimeException error) {
+        try {
+          reader.close();
+        } catch (final IOException closeError) {
+          error.addSuppressed(closeError);
+        }
+        throw error;
+      }
+
+      if (reader.current != null)
+        readers.add(reader);
+      else
+        reader.close();
+      return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (closed)
+        return;
+      closed = true;
+
+      IOException failure = null;
+      for (final RunReader reader : readers)
+        try {
+          reader.close();
+        } catch (final IOException error) {
+          if (failure == null)
+            failure = error;
+          else
+            failure.addSuppressed(error);
+        }
+      readers.clear();
+      if (failure != null)
+        throw failure;
+    }
+  }
+
+  private final class RunReader implements AutoCloseable {
+    private final DataInputStream input;
+    private       long            remaining;
+    private       LSMTreeIndexBulkLoader.Entry current;
+
+    private RunReader(final RunFile run) throws IOException {
+      input = new DataInputStream(new BufferedInputStream(Files.newInputStream(run.path()), BUFFER_SIZE));
+      try {
+        if (input.readInt() != RUN_MAGIC)
+          throw new IOException("Invalid external sort run header in " + run.path());
+        if (input.readInt() != RUN_VERSION)
+          throw new IOException("Unsupported external sort run version in " + run.path());
+
+        final int keyCount = input.readInt();
+        if (keyCount != binaryKeyTypes.length)
+          throw new IOException("External sort run key count " + keyCount + " does not match " + binaryKeyTypes.length);
+        final byte[] runKeyTypes = input.readNBytes(keyCount);
+        if (!Arrays.equals(runKeyTypes, binaryKeyTypes))
+          throw new IOException("External sort run key types do not match the target index");
+
+        remaining = input.readLong();
+        if (remaining < 0 || remaining != run.entries())
+          throw new IOException("Invalid external sort run entry count " + remaining + " in " + run.path());
+        advance();
+      } catch (final IOException | RuntimeException error) {
+        try {
+          input.close();
+        } catch (final IOException closeError) {
+          error.addSuppressed(closeError);
+        }
+        throw error;
+      }
+    }
+
+    private void advance() throws IOException {
+      if (remaining == 0) {
+        current = null;
+        return;
+      }
+
+      try {
+        final int bucketId = input.readInt();
+        final int length = input.readInt();
+        if (length < 1 || length > MAX_ENTRY_BYTES)
+          throw new IOException("Invalid external sort entry length " + length);
+
+        final byte[] bytes = input.readNBytes(length);
+        if (bytes.length != length)
+          throw new EOFException("Truncated external sort entry: expected " + length + " bytes, found " + bytes.length);
+
+        final LSMTreeIndex index = indexesByBucket.get(bucketId);
+        if (index == null)
+          throw new IOException("External sort run references unknown bucket " + bucketId);
+
+        final Binary payload = new Binary(bytes);
+        final Object[] keys = new Object[binaryKeyTypes.length];
+        for (int i = 0; i < binaryKeyTypes.length; i++)
+          if (payload.getByte() != 0)
+            keys[i] = serializer.deserializeValue(database, payload, binaryKeyTypes[i], null);
+        final RID rid = (RID) serializer.deserializeValue(database, payload, BinaryTypes.TYPE_COMPRESSED_RID, null);
+        current = new LSMTreeIndexBulkLoader.Entry(index, new TransactionIndexContext.ComparableKey(keys), rid);
+        remaining--;
+      } catch (final EOFException error) {
+        throw new EOFException("Truncated external sort run with " + remaining + " entries remaining: " + error.getMessage());
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      input.close();
+    }
+  }
+
+  private record RunFile(Path path, long entries) {
+  }
+
+  @FunctionalInterface
+  interface SpillWriteTestHook {
+    void afterEntryWritten() throws IOException;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuildMode.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuildMode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+/** Selects how an index is populated when it is created over existing records. */
+public enum IndexBuildMode {
+  /** Uses the established record-at-a-time mutable LSM build. */
+  DEFAULT,
+
+  /** Uses a bounded external sort and writes the ordered stream into compacted LSM pages. */
+  SORTED
+}

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -190,6 +190,8 @@ public class LocalSchema implements Schema {
     indexMap.clear();
     dictionary = null;
 
+    SortedIndexBuildRecoveryMarker.recoverInterruptedBuilds(database, mode);
+
     final Collection<ComponentFile> filesToOpen = database.getFileManager().getFiles();
 
     // REGISTER THE DICTIONARY FIRST
@@ -334,6 +336,15 @@ public class LocalSchema implements Schema {
 
       files.set(fileId, null);
     }
+
+    final Integer replacementFileId = migratedFileIds.get(fileId);
+    for (final Map.Entry<Integer, Integer> migration : migratedFileIds.entrySet())
+      if (migration.getValue() == fileId) {
+        if (replacementFileId != null)
+          migratedFileIds.replace(migration.getKey(), fileId, replacementFileId);
+        else
+          migratedFileIds.remove(migration.getKey(), fileId);
+      }
 
     database.getTransaction().removeFile(fileId);
   }
@@ -2075,9 +2086,14 @@ public class LocalSchema implements Schema {
   }
 
   public void setMigratedFileId(final int oldFileId, final int newFileId) {
+    setMigratedFileId(oldFileId, newFileId, true);
+  }
+
+  public void setMigratedFileId(final int oldFileId, final int newFileId, final boolean saveConfiguration) {
     LogManager.instance().log(this, Level.FINE, "Migrating file id %d to %d", null, oldFileId, newFileId);
     migratedFileIds.put(oldFileId, newFileId);
-    saveConfiguration();
+    if (saveConfiguration)
+      saveConfiguration();
   }
 
   public Integer getMigratedFileId(final int oldFileId) {
@@ -2125,6 +2141,11 @@ public class LocalSchema implements Schema {
   }
 
   protected <RET> RET recordFileChanges(final Callable<Object> callback) {
+    return recordFileChanges(callback, false);
+  }
+
+  protected <RET> RET recordFileChanges(final Callable<Object> callback,
+      final boolean deferIntermediateSchemaSaves) {
     if (readingFromFile || !loadInRamCompleted) {
       try {
         return (RET) callback.call();
@@ -2136,10 +2157,17 @@ public class LocalSchema implements Schema {
     final long prevGeneration = dirtyGeneration.get();
     dirtyGeneration.updateAndGet(cur -> Math.max(cur, savedGeneration + 1));
 
+    final boolean suspendIntermediateSaves = deferIntermediateSchemaSaves && !multipleUpdate;
+    if (suspendIntermediateSaves)
+      multipleUpdate = true;
+
     boolean executed = false;
     try {
       final RET result = database.getWrappedDatabaseInstance().recordFileChanges(callback);
       executed = true;
+
+      if (suspendIntermediateSaves)
+        multipleUpdate = false;
       saveConfiguration();
 
       // INVALIDATE EXECUTION PLAN IN CASE TYPE OR INDEX CONCUR IN THE GENERATED PLANS
@@ -2153,6 +2181,8 @@ public class LocalSchema implements Schema {
       return result;
 
     } finally {
+      if (suspendIntermediateSaves)
+        multipleUpdate = false;
       if (!executed && prevGeneration <= savedGeneration)
         // ROLLBACK THE DIRTY STATUS - restore only if we were the ones who made it dirty
         savedGeneration = dirtyGeneration.get();
@@ -2172,6 +2202,24 @@ public class LocalSchema implements Schema {
       final TypeIndex propIndex,
       final int batchSize,
       final IndexMetadata metadata) {
+    return createBucketIndex(type, keyTypes, bucket, typeName, indexType, unique, pageSize, nullStrategy, callback,
+        propertyNames, propIndex, batchSize, metadata, true);
+  }
+
+  protected Index createBucketIndex(final LocalDocumentType type,
+      final Type[] keyTypes,
+      final Bucket bucket,
+      final String typeName,
+      final INDEX_TYPE indexType,
+      final boolean unique,
+      final int pageSize,
+      final NULL_STRATEGY nullStrategy,
+      final Index.BuildIndexCallback callback,
+      final String[] propertyNames,
+      final TypeIndex propIndex,
+      final int batchSize,
+      final IndexMetadata metadata,
+      final boolean build) {
     database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
 
     if (bucket == null)
@@ -2209,13 +2257,18 @@ public class LocalSchema implements Schema {
 
       indexMap.put(indexName, index);
 
+      if (!build && !index.setStatus(new IndexInternal.INDEX_STATUS[] { IndexInternal.INDEX_STATUS.AVAILABLE },
+          IndexInternal.INDEX_STATUS.UNAVAILABLE))
+        throw new IndexException("Cannot prepare empty index '" + indexName + "' for sorted population");
+
       type.addIndexInternal(index, bucket.getFileId(), propertyNames, propIndex);
 
       // Re-set metadata after addIndexInternal populated propertyNames, to propagate
       // caseInsensitiveKeys to the underlying mutable/compacted indexes.
       index.setMetadata(index.getMetadata());
 
-      index.build(batchSize, callback);
+      if (build)
+        index.build(batchSize, callback);
 
       return index;
 

--- a/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildRecoveryMarker.java
+++ b/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildRecoveryMarker.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.stream.Stream;
+
+/** Durable cleanup manifest for sorted builds whose component pages are written outside the WAL. */
+final class SortedIndexBuildRecoveryMarker {
+  static final String FILE_PREFIX = ".arcadedb-sorted-index-build-";
+  static final String FILE_SUFFIX = ".json";
+  private static final String SORT_DIRECTORY_PREFIX = ".arcadedb-index-sort-";
+
+  private final Path markerPath;
+  private final Path spillWorkspace;
+  private final Set<Integer> baselineFileIds;
+
+  private SortedIndexBuildRecoveryMarker(final Path markerPath, final Path spillWorkspace,
+      final Set<Integer> baselineFileIds) {
+    this.markerPath = markerPath;
+    this.spillWorkspace = spillWorkspace;
+    this.baselineFileIds = Set.copyOf(baselineFileIds);
+  }
+
+  static SortedIndexBuildRecoveryMarker create(final DatabaseInternal database, final String typeName,
+      final List<String> propertyNames, final Path configuredSpillParent) {
+    final String buildId = UUID.randomUUID().toString();
+    final Path databasePath = Path.of(database.getDatabasePath()).toAbsolutePath().normalize();
+    final Path spillParent = (configuredSpillParent != null ? configuredSpillParent : databasePath)
+        .toAbsolutePath().normalize();
+    final Path spillWorkspace = spillParent.resolve(SORT_DIRECTORY_PREFIX + buildId);
+
+    final JSONArray baselineFileIds = new JSONArray();
+    final Set<Integer> baselineFileIdSet = new HashSet<>();
+    for (final ComponentFile file : database.getFileManager().getFiles())
+      if (file != null) {
+        baselineFileIds.put(file.getFileId());
+        baselineFileIdSet.add(file.getFileId());
+      }
+
+    final JSONObject marker = new JSONObject();
+    marker.put("version", 1);
+    marker.put("typeName", typeName);
+    marker.put("propertyNames", new JSONArray(propertyNames));
+    marker.put("startedUtc", Instant.now().toString());
+    marker.put("baselineFileIds", baselineFileIds);
+    marker.put("spillWorkspace", spillWorkspace.toString());
+
+    final Path markerPath = databasePath.resolve(FILE_PREFIX + buildId + FILE_SUFFIX);
+    try {
+      Files.createDirectories(spillParent);
+      Files.writeString(markerPath, marker.toString(), StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW,
+          StandardOpenOption.WRITE);
+      forceFile(markerPath);
+      forceDirectory(databasePath);
+      return new SortedIndexBuildRecoveryMarker(markerPath, spillWorkspace, baselineFileIdSet);
+    } catch (final IOException error) {
+      throw new IndexException("Cannot create sorted index build cleanup manifest " + markerPath, error);
+    }
+  }
+
+  Path getSpillWorkspace() {
+    return spillWorkspace;
+  }
+
+  boolean baselineRestored(final DatabaseInternal database) {
+    for (final ComponentFile file : database.getFileManager().getFiles())
+      if (file != null && !baselineFileIds.contains(file.getFileId()))
+        return false;
+    return true;
+  }
+
+  void clear() {
+    try {
+      removeRecursively(spillWorkspace);
+      if (Files.deleteIfExists(markerPath))
+        forceDirectory(markerPath.getParent());
+    } catch (final IOException error) {
+      throw new IndexException("Cannot remove sorted index build cleanup manifest " + markerPath, error);
+    }
+  }
+
+  static void recoverInterruptedBuilds(final DatabaseInternal database, final ComponentFile.MODE mode) throws IOException {
+    final Path databasePath = Path.of(database.getDatabasePath()).toAbsolutePath().normalize();
+    final List<Path> markers;
+    try (Stream<Path> files = Files.list(databasePath)) {
+      markers = files.filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().startsWith(FILE_PREFIX))
+          .filter(path -> path.getFileName().toString().endsWith(FILE_SUFFIX))
+          .sorted()
+          .toList();
+    }
+    if (markers.isEmpty())
+      return;
+    if (mode != ComponentFile.MODE.READ_WRITE)
+      throw new IOException("Database contains an interrupted sorted index build; reopen it read-write to perform cleanup");
+
+    for (final Path markerPath : markers)
+      recoverMarker(database, databasePath, markerPath);
+    forceDirectory(databasePath);
+  }
+
+  private static void recoverMarker(final DatabaseInternal database, final Path databasePath, final Path markerPath)
+      throws IOException {
+    final JSONObject marker = new JSONObject(Files.readString(markerPath, StandardCharsets.UTF_8));
+    if (marker.getInt("version") != 1)
+      throw new IOException("Unsupported sorted index build cleanup manifest version in " + markerPath);
+
+    final String typeName = marker.getString("typeName");
+    final List<String> propertyNames = marker.getJSONArray("propertyNames").toListOfStrings();
+    final boolean published = isPublished(databasePath, typeName, propertyNames);
+
+    int removedFiles = 0;
+    if (!published) {
+      final Set<Integer> baselineFileIds = new HashSet<>();
+      final JSONArray ids = marker.getJSONArray("baselineFileIds");
+      for (int i = 0; i < ids.length(); i++)
+        baselineFileIds.add(ids.getInt(i));
+
+      final List<ComponentFile> currentFiles = new ArrayList<>(database.getFileManager().getFiles());
+      for (final ComponentFile file : currentFiles)
+        if (file != null && !baselineFileIds.contains(file.getFileId())) {
+          LogManager.instance().log(database, Level.WARNING,
+              "Removing component '%s' (fileId=%d) left by an interrupted sorted index build", null,
+              file.getFileName(), file.getFileId());
+          database.getFileManager().dropFile(file.getFileId());
+          removedFiles++;
+        }
+    }
+
+    final Path spillWorkspace = Path.of(marker.getString("spillWorkspace")).toAbsolutePath().normalize();
+    validateSpillWorkspace(spillWorkspace, markerPath);
+    removeRecursively(spillWorkspace);
+    Files.deleteIfExists(markerPath);
+
+    LogManager.instance().log(database, Level.WARNING,
+        "Recovered interrupted sorted index build for %s%s (published=%s removedFiles=%d)", null, typeName,
+        propertyNames, published, removedFiles);
+  }
+
+  private static boolean isPublished(final Path databasePath, final String typeName, final List<String> propertyNames) {
+    final Path schemaPath = databasePath.resolve(LocalSchema.SCHEMA_FILE_NAME);
+    if (!Files.isRegularFile(schemaPath))
+      return false;
+
+    try {
+      final JSONObject root = new JSONObject(Files.readString(schemaPath, StandardCharsets.UTF_8));
+      final JSONObject types = root.getJSONObject("types", null);
+      final JSONObject type = types != null ? types.getJSONObject(typeName, null) : null;
+      final JSONObject indexes = type != null ? type.getJSONObject("indexes", null) : null;
+      if (indexes == null)
+        return false;
+
+      for (final String indexName : indexes.keySet()) {
+        final JSONArray properties = indexes.getJSONObject(indexName).getJSONArray("properties");
+        if (propertyNames.equals(properties.toListOfStrings()))
+          return true;
+      }
+    } catch (final Exception ignore) {
+      // A missing or corrupt current schema falls back to the previous schema during normal load.
+    }
+    return false;
+  }
+
+  private static void validateSpillWorkspace(final Path spillWorkspace, final Path markerPath) throws IOException {
+    final Path fileName = spillWorkspace.getFileName();
+    if (fileName == null || !fileName.toString().startsWith(SORT_DIRECTORY_PREFIX))
+      throw new IOException("Invalid spill workspace in sorted index build cleanup manifest " + markerPath);
+  }
+
+  private static void removeRecursively(final Path root) throws IOException {
+    if (!Files.exists(root))
+      return;
+    final List<Path> paths;
+    try (Stream<Path> walk = Files.walk(root)) {
+      paths = walk.sorted((left, right) -> right.compareTo(left)).toList();
+    }
+    for (final Path path : paths)
+      Files.deleteIfExists(path);
+  }
+
+  private static void forceFile(final Path path) throws IOException {
+    try (FileChannel channel = FileChannel.open(path, StandardOpenOption.WRITE)) {
+      channel.force(true);
+    }
+  }
+
+  private static void forceDirectory(final Path path) {
+    try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      channel.force(true);
+    } catch (final IOException | UnsupportedOperationException ignore) {
+      // The manifest itself is forced; directory fsync is best effort where supported.
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildRecoveryMarker.java
+++ b/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildRecoveryMarker.java
@@ -175,10 +175,22 @@ final class SortedIndexBuildRecoveryMarker {
 
   private static boolean isPublished(final Path databasePath, final String typeName, final List<String> propertyNames) {
     final Path schemaPath = databasePath.resolve(LocalSchema.SCHEMA_FILE_NAME);
+    final Boolean current = isPublishedInSchema(schemaPath, typeName, propertyNames);
+    if (current != null)
+      return current;
+
+    final Path previousSchemaPath = databasePath.resolve(LocalSchema.SCHEMA_PREV_FILE_NAME);
+    return Boolean.TRUE.equals(isPublishedInSchema(previousSchemaPath, typeName, propertyNames));
+  }
+
+  private static Boolean isPublishedInSchema(final Path schemaPath, final String typeName,
+      final List<String> propertyNames) {
     if (!Files.isRegularFile(schemaPath))
-      return false;
+      return null;
 
     try {
+      if (Files.size(schemaPath) == 0L)
+        return null;
       final JSONObject root = new JSONObject(Files.readString(schemaPath, StandardCharsets.UTF_8));
       final JSONObject types = root.getJSONObject("types", null);
       final JSONObject type = types != null ? types.getJSONObject(typeName, null) : null;
@@ -191,10 +203,11 @@ final class SortedIndexBuildRecoveryMarker {
         if (propertyNames.equals(properties.toListOfStrings()))
           return true;
       }
+      return false;
     } catch (final Exception ignore) {
-      // A missing or corrupt current schema falls back to the previous schema during normal load.
+      // Match LocalSchema loading: an absent, empty, or corrupt primary schema falls back to schema.prev.json.
+      return null;
     }
-    return false;
   }
 
   private static void validateSpillWorkspace(final Path spillWorkspace, final Path markerPath) throws IOException {

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -28,10 +28,19 @@ import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexBulkLoader;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.security.SecurityDatabaseUser;
 
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
 
 /**
  * Builder class for type indexes.
@@ -39,12 +48,19 @@ import java.util.List;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
+  private static final int DEFAULT_SORTED_BUILD_MERGE_FAN_IN = 8;
+  private static final long MIN_SORTED_BUILD_MEMORY_BUDGET    = 1L << 20;
+
   public IndexMetadata metadata;
   // When set, lets {@link #create()} accept properties that aren't declared on the type yet:
   // the index is materialised with this Type as the key serialisation, while the property
   // stays "free-form" on the document type so writes don't get coerced. Used by the OpenCypher
   // engine, where {@code CREATE INDEX} can run on an empty/typeless property (issue #4222).
   private Type[] defaultKeyTypesForUndeclaredProperties;
+  private IndexBuildMode buildMode              = IndexBuildMode.DEFAULT;
+  private long           buildMemoryBudgetBytes;
+  private Path           buildSpillDirectory;
+  private int            buildMergeFanIn        = DEFAULT_SORTED_BUILD_MERGE_FAN_IN;
 
   protected TypeIndexBuilder(final DatabaseInternal database, final String typeName, final String[] propertyNames) {
     super(database, TypeIndex.class);
@@ -63,6 +79,33 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     return this;
   }
 
+  public TypeIndexBuilder withBuildMode(final IndexBuildMode buildMode) {
+    this.buildMode = Objects.requireNonNull(buildMode, "buildMode");
+    return this;
+  }
+
+  /** Sets the approximate heap budget for one sorted run. Zero keeps automatic heap-based sizing. */
+  public TypeIndexBuilder withBuildMemoryBudget(final long bytes) {
+    if (bytes < 0L)
+      throw new IllegalArgumentException("build memory budget cannot be negative");
+    if (bytes > 0L && bytes < MIN_SORTED_BUILD_MEMORY_BUDGET)
+      throw new IllegalArgumentException("build memory budget must be at least " + MIN_SORTED_BUILD_MEMORY_BUDGET + " bytes");
+    this.buildMemoryBudgetBytes = bytes;
+    return this;
+  }
+
+  public TypeIndexBuilder withBuildSpillDirectory(final Path directory) {
+    this.buildSpillDirectory = Objects.requireNonNull(directory, "directory");
+    return this;
+  }
+
+  public TypeIndexBuilder withBuildMergeFanIn(final int mergeFanIn) {
+    if (mergeFanIn < 2)
+      throw new IllegalArgumentException("build merge fan-in must be at least 2");
+    this.buildMergeFanIn = mergeFanIn;
+    return this;
+  }
+
   /**
    * Sets the index type. For LSM_VECTOR indexes, returns an LSMVectorIndexBuilder
    * to enable vector-specific configuration methods. For FULL_TEXT indexes, returns
@@ -74,6 +117,8 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
    */
   @Override
   public TypeIndexBuilder withType(final Schema.INDEX_TYPE indexType) {
+    if (buildMode == IndexBuildMode.SORTED && indexType != Schema.INDEX_TYPE.LSM_TREE)
+      throw new IllegalArgumentException("Sorted build currently supports only LSM_TREE indexes");
     if (indexType == Schema.INDEX_TYPE.LSM_VECTOR && !(this instanceof TypeLSMVectorIndexBuilder))
       return new TypeLSMVectorIndexBuilder(this);
     if (indexType == Schema.INDEX_TYPE.LSM_SPARSE_VECTOR && !(this instanceof TypeLSMSparseVectorIndexBuilder))
@@ -268,35 +313,45 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
     final List<Bucket> buckets = type.getBuckets(true);
     final Index[] indexes = new Index[buckets.size()];
+    final boolean sortedBuild = buildMode == IndexBuildMode.SORTED;
+    final SortedIndexBuildRecoveryMarker[] recoveryMarker = new SortedIndexBuildRecoveryMarker[1];
+
+    if (sortedBuild)
+      validateSortedBuildPreconditions();
 
     try {
       schema.recordFileChanges(() -> {
-        for (int idx = 0; idx < buckets.size(); ++idx) {
-          final int finalIdx = idx;
-          database.transaction(() -> {
+        if (sortedBuild) {
+          recoveryMarker[0] = SortedIndexBuildRecoveryMarker.create(database, metadata.typeName, metadata.propertyNames,
+              buildSpillDirectory);
+          createWithSortedBuild(schema, type, keyTypes, buckets, indexes, recoveryMarker[0]);
+        } else
+          for (int idx = 0; idx < buckets.size(); ++idx) {
+            final int finalIdx = idx;
+            database.transaction(() -> {
 
-            final LocalBucket bucket = (LocalBucket) buckets.get(finalIdx);
+              final LocalBucket bucket = (LocalBucket) buckets.get(finalIdx);
 
-            indexes[finalIdx] = createBucketIndex(schema, type, keyTypes, bucket);
+              indexes[finalIdx] = createBucketIndex(schema, type, keyTypes, bucket);
 
-          }, false, maxAttempts, null, error -> {
-            for (int j = 0; j < indexes.length; j++) {
-              final IndexInternal indexToRemove = (IndexInternal) indexes[j];
-              if (indexToRemove != null)
-                indexToRemove.drop();
-            }
-          });
-        }
+            }, false, maxAttempts, null, null);
+          }
 
         return null;
-      });
+      }, sortedBuild);
 
+      if (recoveryMarker[0] != null)
+        recoveryMarker[0].clear();
       return type.getIndexByProperties(metadata.propertyNames);
     } catch (final NeedRetryException e) {
-      schema.dropIndex(metadata.typeName + metadata.propertyNames);
+      if (cleanupIndexes(schema, indexes, e)
+          && (recoveryMarker[0] == null || recoveryMarker[0].baselineRestored(database)))
+        clearRecoveryMarker(recoveryMarker[0], e);
       throw e;
     } catch (final Throwable e) {
-      schema.dropIndex(metadata.typeName + metadata.propertyNames);
+      if (cleanupIndexes(schema, indexes, e)
+          && (recoveryMarker[0] == null || recoveryMarker[0].baselineRestored(database)))
+        clearRecoveryMarker(recoveryMarker[0], e);
       throw new IndexException("Error on creating index on type '" + metadata.typeName + "', properties " + metadata.propertyNames,
           e);
     }
@@ -304,9 +359,100 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
   protected Index createBucketIndex(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
       final LocalBucket bucket) {
+    return createBucketIndex(schema, type, keyTypes, bucket, true);
+  }
+
+  protected Index createBucketIndex(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
+      final LocalBucket bucket, final boolean build) {
     return schema.createBucketIndex(type, keyTypes, bucket, metadata.typeName, indexType, unique, pageSize, nullStrategy, callback,
         metadata.propertyNames.toArray(new String[0]), null, batchSize,
-        metadata);
+        metadata, build);
+  }
+
+  private void validateSortedBuildPreconditions() {
+    if (indexType != Schema.INDEX_TYPE.LSM_TREE)
+      throw new IndexException("Sorted build currently supports only LSM_TREE indexes");
+    if (unique)
+      throw new IndexException("Sorted build currently supports only non-unique indexes");
+    if (database.isReplicated() || database.getWrappedDatabaseInstance().isReplicated())
+      throw new IndexException("Sorted build is not supported on replicated databases");
+    if (database.isTransactionActive())
+      throw new IndexException("Sorted build requires no active transaction");
+  }
+
+  private void createWithSortedBuild(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
+      final List<Bucket> buckets, final Index[] indexes, final SortedIndexBuildRecoveryMarker recoveryMarker) {
+    for (int idx = 0; idx < buckets.size(); ++idx) {
+      final int finalIdx = idx;
+      database.transaction(() -> indexes[finalIdx] = createBucketIndex(schema, type, keyTypes,
+          (LocalBucket) buckets.get(finalIdx), false), false, maxAttempts, null, null);
+    }
+
+    final Map<Integer, LSMTreeIndex> indexesByBucket = new HashMap<>(indexes.length);
+    for (final Index index : indexes) {
+      if (!(index instanceof LSMTreeIndex lsmIndex))
+        throw new IndexException("Sorted build requires LSM bucket indexes, found " + index.getClass().getName());
+      indexesByBucket.put(index.getAssociatedBucketId(), lsmIndex);
+    }
+
+    final String logicalIndexName = metadata.typeName + metadata.propertyNames;
+    final AtomicLong scannedRecords = new AtomicLong();
+    try (LSMTreeIndexBulkLoader bulkLoader = new LSMTreeIndexBulkLoader(database, logicalIndexName,
+        buildMemoryBudgetBytes, buildSpillDirectory, buildMergeFanIn, recoveryMarker.getSpillWorkspace())) {
+      database.transaction(() -> database.scanType(metadata.typeName, true, record -> {
+          final LSMTreeIndex bucketIndex = indexesByBucket.get(record.getIdentity().getBucketId());
+          if (bucketIndex == null)
+            throw new IndexException("No empty bucket index found for record " + record.getIdentity() + " while building '"
+                + logicalIndexName + "'");
+
+          bulkLoader.add(bucketIndex, record);
+          final long total = scannedRecords.incrementAndGet();
+          if (callback != null)
+            callback.onDocumentIndexed(record, total);
+          return true;
+        }, (rid, exception) -> {
+          if (exception instanceof RuntimeException runtimeException)
+            throw runtimeException;
+          throw new IndexException("Error collecting sorted index entry at record " + rid, exception);
+        }), false, maxAttempts, null, null);
+
+      bulkLoader.writeCompacted();
+      publishIndexes(indexes);
+    }
+
+    LogManager.instance().log(this, Level.INFO,
+        "Published sorted index '%s': records=%,d bucketIndexes=%d", logicalIndexName, scannedRecords.get(), indexes.length);
+  }
+
+  private void publishIndexes(final Index[] indexes) {
+    for (final Index index : indexes)
+      if (!((IndexInternal) index).setStatus(new IndexInternal.INDEX_STATUS[] { IndexInternal.INDEX_STATUS.UNAVAILABLE },
+          IndexInternal.INDEX_STATUS.AVAILABLE))
+        throw new IndexException("Cannot publish sorted index bucket '" + index.getName() + "'");
+  }
+
+  private boolean cleanupIndexes(final LocalSchema schema, final Index[] indexes, final Throwable originalError) {
+    boolean cleaned = true;
+    for (final Index index : indexes)
+      if (index != null)
+        try {
+          if (schema.existsIndex(index.getName()))
+            schema.dropIndex(index.getName());
+        } catch (final Throwable cleanupError) {
+          cleaned = false;
+          originalError.addSuppressed(cleanupError);
+        }
+    return cleaned;
+  }
+
+  private void clearRecoveryMarker(final SortedIndexBuildRecoveryMarker recoveryMarker, final Throwable originalError) {
+    if (recoveryMarker == null)
+      return;
+    try {
+      recoveryMarker.clear();
+    } catch (final Throwable cleanupError) {
+      originalError.addSuppressed(cleanupError);
+    }
   }
 
   public TypeIndexBuilder withCollations(final List<String> collations) {

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeCompactionCorrectnessTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeCompactionCorrectnessTest.java
@@ -112,6 +112,29 @@ class LSMTreeCompactionCorrectnessTest extends TestHelper {
     return rids;
   }
 
+  @Test
+  void caseInsensitiveFlagsSurviveCompactionFileSwap() {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("email", String.class);
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "email" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withCollations(List.of("CI"))
+        .withUnique(false)
+        .withPageSize(1_024)
+        .create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < 1_000; i++)
+        database.newDocument(TYPE_NAME).set("email", i % 2 == 0 ? "MixedCase" : "mixedcase").save();
+    });
+    assertThat(lookup("MIXEDCASE")).hasSize(1_000);
+
+    compactAll();
+
+    assertThat(lookup("MIXEDCASE")).hasSize(1_000);
+  }
+
   // ---- #4942: compaction must not lose a re-inserted key/RID (ADD, REMOVE, ADD of the same key+RID) ----
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeSortedNonUniqueBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeSortedNonUniqueBuildTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexBuildMode;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LSMTreeSortedNonUniqueBuildTest extends TestHelper {
+  @Test
+  void buildsExternalRunsAcrossBucketsAndSupportsReopenAndMutation() throws Exception {
+    final Path spillParent = Path.of(getDatabasePath()).resolve("sorted-spill");
+    final DocumentType type = database.getSchema().buildDocumentType().withName("SortedExternal").withTotalBuckets(3).create();
+    type.createProperty("lookupKey", Type.STRING);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 2_000; i++) {
+        final int permuted = Math.floorMod(i * 1_237, 2_000);
+        database.newDocument("SortedExternal").set("lookupKey", String.format("key-%05d-padding", permuted)).save();
+      }
+    });
+
+    TypeIndex index = database.getSchema().buildTypeIndex("SortedExternal", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(1L << 20)
+        .withBuildSpillDirectory(spillParent)
+        .withBuildMergeFanIn(4)
+        .withUnique(false)
+        .withPageSize(1_024)
+        .create();
+
+    assertOrdered(index, 2_000);
+    assertThat(count(index.get(new Object[] { "key-01234-padding" }))).isEqualTo(1);
+    assertNoSpillDirectories(spillParent);
+
+    reopenDatabase();
+    index = database.getSchema().getType("SortedExternal").getIndexByProperties("lookupKey");
+    assertOrdered(index, 2_000);
+
+    final RID[] added = new RID[1];
+    database.transaction(() -> added[0] = database.newDocument("SortedExternal").set("lookupKey", "key-new")
+        .save().getIdentity());
+    assertThat(count(index.get(new Object[] { "key-new" }))).isEqualTo(1);
+    database.transaction(() -> database.lookupByRID(added[0], true).asDocument().delete());
+    assertThat(count(index.get(new Object[] { "key-new" }))).isZero();
+  }
+
+  @Test
+  void preservesListExpansionAndCollapsesRepeatedRidKeys() {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("SortedList").withTotalBuckets(2).create();
+    type.createProperty("tags", Type.LIST);
+
+    database.transaction(() -> {
+      database.newDocument("SortedList").set("tags", Arrays.asList("java", "database", "java")).save();
+      database.newDocument("SortedList").set("tags", Arrays.asList("python", "database")).save();
+      database.newDocument("SortedList").set("tags", Arrays.asList("java", "systems")).save();
+    });
+
+    final TypeIndex index = database.getSchema().buildTypeIndex("SortedList", new String[] { "tags by item" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(1L << 20)
+        .withBuildMergeFanIn(2)
+        .withUnique(false)
+        .create();
+
+    assertThat(count(index.get(new Object[] { "java" }))).isEqualTo(2);
+    assertThat(count(index.get(new Object[] { "database" }))).isEqualTo(2);
+  }
+
+  @Test
+  void buildsOneHighCardinalityKeyAcrossRunsBucketsAndRidChunks() throws Exception {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("SortedHighCardinality")
+        .withTotalBuckets(3).create();
+    type.createProperty("lookupKey", Type.STRING);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 2_000; i++)
+        database.newDocument("SortedHighCardinality").set("lookupKey", "shared-key").save();
+    });
+
+    TypeIndex index = database.getSchema().buildTypeIndex("SortedHighCardinality", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(1L << 20)
+        .withBuildMergeFanIn(3)
+        .withUnique(false)
+        .withPageSize(1_024)
+        .create();
+
+    assertThat(count(index.get(new Object[] { "shared-key" }))).isEqualTo(2_000);
+    assertThat(count(index.iterator(true))).isEqualTo(2_000);
+
+    reopenDatabase();
+    index = database.getSchema().getType("SortedHighCardinality").getIndexByProperties("lookupKey");
+    assertThat(count(index.get(new Object[] { "shared-key" }))).isEqualTo(2_000);
+    assertThat(count(index.iterator(false))).isEqualTo(2_000);
+  }
+
+  @Test
+  void preservesCompositeCollationAndNullSkippingAcrossSpillRuns() throws Exception {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("SortedComposite")
+        .withTotalBuckets(2).create();
+    type.createProperty("groupName", Type.STRING);
+    type.createProperty("ordinal", Type.INTEGER);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 1_000; i++) {
+        final boolean nullKey = i % 50 == 0;
+        final String group = nullKey ? null : "Group-%02d".formatted(i % 20);
+        database.newDocument("SortedComposite")
+            .set("groupName", group != null && i % 2 == 0 ? group.toUpperCase() : group)
+            .set("ordinal", nullKey ? null : i % 10)
+            .save();
+      }
+    });
+
+    TypeIndex index = database.getSchema().buildTypeIndex("SortedComposite",
+            new String[] { "groupName", "ordinal" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(1L << 20)
+        .withBuildMergeFanIn(2)
+        .withCollations(List.of("CI", "DEFAULT"))
+        .withUnique(false)
+        .create();
+
+    assertThat(count(index.iterator(true))).isEqualTo(980);
+    assertThat(count(index.get(new Object[] { "GROUP-01", 1 }))).isEqualTo(50);
+    assertThat(count(index.get(new Object[] { null, null }))).isZero();
+
+    reopenDatabase();
+    index = database.getSchema().getType("SortedComposite").getIndexByProperties("groupName", "ordinal");
+    assertThat(count(index.iterator(false))).isEqualTo(980);
+    assertThat(count(index.get(new Object[] { "group-01", 1 }))).isEqualTo(50);
+  }
+
+  @Test
+  void rejectsUnsupportedUniqueBuildBeforeCreatingFiles() {
+    final DocumentType type = database.getSchema().createDocumentType("SortedUnique");
+    type.createProperty("lookupKey", Type.STRING);
+    database.transaction(() -> database.newDocument("SortedUnique").set("lookupKey", "one").save());
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedUnique", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withUnique(true)
+        .create())
+        .isInstanceOf(IndexException.class)
+        .hasMessageContaining("non-unique");
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
+  void rejectsUnsupportedIndexTypeAndActiveTransaction() {
+    final DocumentType type = database.getSchema().createDocumentType("SortedPreconditions");
+    type.createProperty("lookupKey", Type.STRING);
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedPreconditions", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.HASH)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withUnique(false)
+        .create())
+        .isInstanceOf(IndexException.class)
+        .hasMessageContaining("only LSM_TREE");
+
+    database.begin();
+    try {
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedPreconditions", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withUnique(false)
+          .create())
+          .isInstanceOf(IndexException.class)
+          .hasMessageContaining("no active transaction");
+    } finally {
+      database.rollback();
+    }
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
+  void publishesEmptyIndexAndAcceptsLaterWrites() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("SortedEmpty");
+    type.createProperty("lookupKey", Type.STRING);
+
+    TypeIndex index = database.getSchema().buildTypeIndex("SortedEmpty", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withUnique(false)
+        .create();
+    assertThat(count(index.iterator(true))).isZero();
+
+    database.transaction(() -> database.newDocument("SortedEmpty").set("lookupKey", "later").save());
+    assertThat(count(index.get(new Object[] { "later" }))).isEqualTo(1);
+    reopenDatabase();
+    index = database.getSchema().getType("SortedEmpty").getIndexByProperties("lookupKey");
+    assertThat(count(index.get(new Object[] { "later" }))).isEqualTo(1);
+  }
+
+  @Test
+  void cleansSchemaAndSpillFilesAfterLateScanFailure() throws Exception {
+    final Path spillParent = Path.of(getDatabasePath()).resolve("failed-spill");
+    final DocumentType type = database.getSchema().buildDocumentType().withName("SortedFailure").withTotalBuckets(2).create();
+    type.createProperty("lookupKey", Type.INTEGER);
+    database.transaction(() -> {
+      for (int i = 0; i < 1_000; i++)
+        database.newDocument("SortedFailure").set("lookupKey", i).save();
+    });
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedFailure", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(1L << 20)
+        .withBuildSpillDirectory(spillParent)
+        .withBuildMergeFanIn(2)
+        .withUnique(false)
+        .withCallback((document, total) -> {
+          if (total == 500L)
+            throw new IllegalStateException("injected late scan failure");
+        })
+        .create())
+        .isInstanceOf(IndexException.class)
+        .hasRootCauseMessage("injected late scan failure");
+
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+    assertNoSpillDirectories(spillParent);
+    reopenDatabase();
+    assertThat(database.getSchema().getType("SortedFailure").getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
+  void supportsMultipleCompactedSeriesAndLaterNormalCompaction() throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    final DocumentType type = database.getSchema().createDocumentType("SortedMultiSeries");
+    type.createProperty("lookupKey", Type.STRING);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 20_000; i++) {
+        final int permuted = Math.floorMod(i * 12_347, 20_000);
+        database.newDocument("SortedMultiSeries").set("lookupKey", paddedKey("key", permuted)).save();
+      }
+    });
+
+    TypeIndex index = database.getSchema().buildTypeIndex("SortedMultiSeries", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(128L << 20)
+        .withUnique(false)
+        .withPageSize(1_024)
+        .create();
+
+    final LSMTreeIndex bucketIndex = (LSMTreeIndex) index.getIndexesOnBuckets()[0];
+    assertThat(bucketIndex.getMutableIndex().getSubIndex().newIterators(true, null, null).size()).isGreaterThan(1);
+    assertOrdered(index, 20_000);
+    assertDescending(index, 20_000);
+    assertThat(count(index.range(true, new Object[] { paddedKey("key", 9_990) }, true,
+        new Object[] { paddedKey("key", 10_010) }, true))).isEqualTo(21);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 2_000; i++)
+        database.newDocument("SortedMultiSeries").set("lookupKey", paddedKey("z-live", i)).save();
+    });
+    assertThat(((IndexInternal) index).scheduleCompaction()).isTrue();
+    assertThat(((IndexInternal) index).compact()).isTrue();
+    assertOrdered(index, 22_000);
+    assertDescending(index, 22_000);
+
+    reopenDatabase();
+    index = database.getSchema().getType("SortedMultiSeries").getIndexByProperties("lookupKey");
+    assertOrdered(index, 22_000);
+    assertThat(count(index.get(new Object[] { paddedKey("z-live", 1_234) }))).isEqualTo(1);
+  }
+
+  private static long count(final IndexCursor cursor) {
+    long total = 0L;
+    while (cursor.hasNext()) {
+      cursor.next();
+      total++;
+    }
+    return total;
+  }
+
+  private static void assertOrdered(final TypeIndex index, final int expected) {
+    final IndexCursor cursor = index.iterator(true);
+    String previous = null;
+    int count = 0;
+    while (cursor.hasNext()) {
+      cursor.next();
+      final String current = (String) cursor.getKeys()[0];
+      if (previous != null)
+        assertThat(current).isGreaterThanOrEqualTo(previous);
+      previous = current;
+      count++;
+    }
+    assertThat(count).isEqualTo(expected);
+  }
+
+  private static void assertDescending(final TypeIndex index, final int expected) {
+    final IndexCursor cursor = index.iterator(false);
+    String previous = null;
+    int count = 0;
+    while (cursor.hasNext()) {
+      cursor.next();
+      final String current = (String) cursor.getKeys()[0];
+      if (previous != null)
+        assertThat(current).isLessThanOrEqualTo(previous);
+      previous = current;
+      count++;
+    }
+    assertThat(count).isEqualTo(expected);
+  }
+
+  private static String paddedKey(final String prefix, final int value) {
+    return "%s-%08d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".formatted(prefix, value);
+  }
+
+  private static void assertNoSpillDirectories(final Path parent) throws Exception {
+    if (!Files.exists(parent))
+      return;
+    try (var paths = Files.list(parent)) {
+      assertThat(paths.filter(path -> path.getFileName().toString().startsWith(".arcadedb-index-sort-")).toList()).isEmpty();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeSortedNonUniqueBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeSortedNonUniqueBuildTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
 import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.IndexBuildMode;
 import com.arcadedb.schema.Schema;
@@ -164,6 +165,62 @@ class LSMTreeSortedNonUniqueBuildTest extends TestHelper {
     index = database.getSchema().getType("SortedComposite").getIndexByProperties("groupName", "ordinal");
     assertThat(count(index.iterator(false))).isEqualTo(980);
     assertThat(count(index.get(new Object[] { "group-01", 1 }))).isEqualTo(50);
+  }
+
+  @Test
+  void indexesPartialNullCompositeKeysWithSkipStrategy() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("SortedPartialNullSkip");
+    type.createProperty("groupName", Type.STRING);
+    type.createProperty("ordinal", Type.INTEGER);
+
+    database.transaction(() -> {
+      database.newDocument("SortedPartialNullSkip").set("groupName", null).set("ordinal", 5).save();
+      database.newDocument("SortedPartialNullSkip").set("groupName", "group").set("ordinal", null).save();
+      database.newDocument("SortedPartialNullSkip").set("groupName", null).set("ordinal", null).save();
+      database.newDocument("SortedPartialNullSkip").set("groupName", "group").set("ordinal", 7).save();
+    });
+
+    TypeIndex index = database.getSchema().buildTypeIndex("SortedPartialNullSkip",
+            new String[] { "groupName", "ordinal" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.SKIP)
+        .withUnique(false)
+        .create();
+
+    assertThat(count(index.iterator(true))).isEqualTo(3);
+    assertThat(count(index.get(new Object[] { null, 5 }))).isEqualTo(1);
+    assertThat(count(index.get(new Object[] { "group", null }))).isEqualTo(1);
+    assertThat(count(index.get(new Object[] { null, null }))).isZero();
+
+    reopenDatabase();
+    index = database.getSchema().getType("SortedPartialNullSkip").getIndexByProperties("groupName", "ordinal");
+    assertThat(count(index.get(new Object[] { null, 5 }))).isEqualTo(1);
+    assertThat(count(index.get(new Object[] { "group", null }))).isEqualTo(1);
+  }
+
+  @Test
+  void rejectsPartialNullCompositeKeysWithErrorStrategy() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("SortedPartialNullError");
+    type.createProperty("groupName", Type.STRING);
+    type.createProperty("ordinal", Type.INTEGER);
+    database.transaction(() -> database.newDocument("SortedPartialNullError")
+        .set("groupName", null).set("ordinal", 5).save());
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedPartialNullError",
+            new String[] { "groupName", "ordinal" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR)
+        .withUnique(false)
+        .create())
+        .isInstanceOf(IndexException.class)
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage("Indexed key SortedPartialNullError[groupName, ordinal] cannot be NULL ([null, 5])");
+
+    assertThat(type.getIndexByProperties("groupName", "ordinal")).isNull();
+    reopenDatabase();
+    assertThat(database.getSchema().getType("SortedPartialNullError").getIndexByProperties("groupName", "ordinal")).isNull();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/LegacySharedLeafIndexCompatibilityTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LegacySharedLeafIndexCompatibilityTest.java
@@ -18,9 +18,14 @@
  */
 package com.arcadedb.index;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.lsm.LSMTreeIndex;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -35,10 +40,11 @@ import java.util.zip.ZipInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies exact lookup compatibility with compacted files written before the shared-leaf writer safeguard.
+ * Verifies exact lookup compatibility with compacted files whose first RID chunk shares the preceding key's leaf.
  *
  * <p>The synthetic fixture contains 30,000 records with the same composite key. It was generated with the safeguard
- * temporarily disabled; an unpatched reader returns only 28,857 records from its compacted index.</p>
+ * temporarily disabled; an unpatched reader returns only 28,857 records from its compacted index. Current bounded
+ * compaction can also produce a read-safe shared leaf when a complete leading chunk fits after the preceding key.</p>
  */
 class LegacySharedLeafIndexCompatibilityTest {
   private static final int EXPECTED_DUPLICATES = 30_000;
@@ -103,5 +109,57 @@ class LegacySharedLeafIndexCompatibilityTest {
         assertCounts(reopened);
       }
     }
+  }
+
+  @Test
+  @Tag("slow")
+  void boundedCompactionReadsHighCardinalityKeyFromSharedPrecedingLeafAtDefaultPageSize() throws Exception {
+    final int duplicates = 100_000;
+    final Path databasePath = tempDir.resolve("current-bounded-writer");
+
+    try (DatabaseFactory factory = new DatabaseFactory(databasePath.toString())) {
+      try (Database database = factory.create()) {
+        final DocumentType type = database.getSchema().buildDocumentType().withName("SharedLeaf")
+            .withTotalBuckets(1).create();
+        type.createProperty("lookupKey", String.class);
+        final TypeIndex typeIndex = database.getSchema().buildTypeIndex("SharedLeaf", new String[] { "lookupKey" })
+            .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
+        final LSMTreeIndex bucketIndex = (LSMTreeIndex) typeIndex.getIndexesOnBuckets()[0];
+
+        database.transaction(() -> {
+          for (int i = 0; i < 32; i++)
+            database.newDocument("SharedLeaf").set("lookupKey", "a-small-%02d".formatted(i)).save();
+        });
+        for (int batch = 0; batch < 100; batch++)
+          database.transaction(() -> {
+            for (int i = 0; i < duplicates / 100; i++)
+              database.newDocument("SharedLeaf").set("lookupKey", "z-shared").save();
+          });
+
+        database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+        assertThat(bucketIndex.scheduleCompaction()).as("high-cardinality index is eligible for compaction").isTrue();
+        assertThat(bucketIndex.compact()).as("high-cardinality index was compacted").isTrue();
+        assertThat(bucketIndex.getMutableIndex().getSubIndex().getTotalPages())
+            .as("default-size compacted output spans a root and multiple leaves").isGreaterThan(2);
+
+        assertCurrentSharedLeafCounts(typeIndex, duplicates);
+      }
+
+      try (Database reopened = factory.open()) {
+        final TypeIndex index = reopened.getSchema().getType("SharedLeaf").getIndexByProperties("lookupKey");
+        assertCurrentSharedLeafCounts(index, duplicates);
+      }
+    }
+  }
+
+  private void assertCurrentSharedLeafCounts(final TypeIndex index, final int expected) {
+    final Object[] key = { "z-shared" };
+    final long pointCount = count(index.get(key));
+    final long ascendingCount = count(index.range(true, key, true, key, true));
+    final long descendingCount = count(index.range(false, key, true, key, true));
+    assertThat(pointCount).as("point lookup includes the leading shared-leaf chunk").isEqualTo(expected);
+    assertThat(ascendingCount).as("ascending exact range count (point=%d, descending=%d)", pointCount, descendingCount)
+        .isEqualTo(expected);
+    assertThat(descendingCount).as("descending exact range count").isEqualTo(expected);
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeCompactionAtomicityTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeCompactionAtomicityTest.java
@@ -16,31 +16,32 @@
  * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.arcadedb.index;
+package com.arcadedb.index.lsm;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.TestHelper;
-import com.arcadedb.index.lsm.LSMTreeIndex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * #4946: a failed compaction must be atomic. Leaf pages are flushed eagerly during the merge with no WAL;
- * if compact() throws after some were written (root-page overflow, I/O error, interrupt), the orphans used
+ * if compact() throws after some were written (I/O error, interrupt), the orphans used
  * to stay counted in the in-RAM page count - invisible at first (page 0's series counter was never bumped)
  * but PUBLISHED by the NEXT successful round, whose setCompactedTotalPages() writes getTotalPages(): stale
  * duplicates re-exposing tombstoned entries and a malformed partial series walked by positional logic. And
  * when the FIRST compaction failed (no sub-index yet), the freshly registered compacted file was never
  * linked nor dropped, so every failed round leaked another file.
  * <p>
- * The deterministic failure used here is the real "Root index page overflow" path: with 1KB pages, a round
- * that produces more compacted leaf pages than one root page can reference throws AFTER those leaf pages
- * were flushed - exactly the mid-merge failure the issue describes.
+ * The deterministic failure hook throws after a complete compacted series has been written but before the
+ * mutable/compacted file swap publishes it. This exercises the same rollback boundary without depending on
+ * root-page overflow, which the bounded compacted writer now prevents.
  */
 class LSMTreeCompactionAtomicityTest extends TestHelper {
 
@@ -58,8 +59,7 @@ class LSMTreeCompactionAtomicityTest extends TestHelper {
 
     final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
     type.createProperty("email", String.class);
-    // Small pages: a handful of entries seals immutable pages, and a round with many leaf pages overflows
-    // the single root page deterministically.
+    // Small pages make each injected failure leave several unpublished compacted pages to roll back.
     database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "email" })
         .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).withPageSize(1024).create();
     return (LSMTreeIndex) database.getSchema().getType(TYPE_NAME).getAllIndexes(false).iterator().next().getIndexesOnBuckets()[0];
@@ -87,24 +87,31 @@ class LSMTreeCompactionAtomicityTest extends TestHelper {
     });
   }
 
-  private void compactExpectingRootOverflow(final LSMTreeIndex index) throws Exception {
-    assertThat(index.scheduleCompaction()).as("compaction scheduled").isTrue();
-    assertThatThrownBy(index::compact)
-        .as("the oversized round must fail with the real mid-merge root-overflow error")
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("Root index page overflow");
+  private void compactWithInjectedFailure(final LSMTreeIndex index) throws Exception {
+    LSMTreeIndexCompactor.setCompactionTestHook(compactedIndex -> {
+      throw new IOException("injected failure after compacted series write");
+    });
+    try {
+      assertThat(index.scheduleCompaction()).as("compaction scheduled").isTrue();
+      assertThatThrownBy(index::compact)
+          .as("the compaction must fail after writing an unpublished compacted series")
+          .isInstanceOf(IOException.class)
+          .hasMessageContaining("injected failure after compacted series write");
+    } finally {
+      LSMTreeIndexCompactor.setCompactionTestHook(null);
+    }
   }
 
   @Test
   void failedFirstCompactionDropsTempFileAndDoesNotLeakPerRound() throws Exception {
     final LSMTreeIndex index = createType();
-    // Enough long keys that the FIRST round produces more leaf pages than one root page can reference.
+    // Enough long keys that the FIRST round writes several compacted pages before the injected failure.
     insert(0, 3_000, 60);
 
     assertThat(index.getMutableIndex().getSubIndex()).as("no sub-index before the first compaction").isNull();
     final long filesBefore = registeredFiles();
 
-    compactExpectingRootOverflow(index);
+    compactWithInjectedFailure(index);
 
     assertThat(index.getMutableIndex().getSubIndex())
         .as("the failed first compaction must not link the compacted index").isNull();
@@ -114,7 +121,7 @@ class LSMTreeCompactionAtomicityTest extends TestHelper {
     assertThat(tempFilesOnDisk()).as("no temp compacted file may remain on disk (#4946)").isNullOrEmpty();
 
     // The issue's leak: every further failed round used to register (and orphan) ANOTHER file.
-    compactExpectingRootOverflow(index);
+    compactWithInjectedFailure(index);
     assertThat(registeredFiles())
         .as("repeated failed compactions must not leak one file per round (#4946)")
         .isEqualTo(filesBefore);
@@ -137,9 +144,9 @@ class LSMTreeCompactionAtomicityTest extends TestHelper {
 
     final int pagesBeforeFailedRound = index.getMutableIndex().getSubIndex().getTotalPages();
 
-    // Round 2: oversized - fails mid-merge AFTER flushing orphan leaf pages into the sub-index file.
+    // Round 2 fails after writing another complete but still unpublished compacted series.
     insert(120, 3_120, 60);
-    compactExpectingRootOverflow(index);
+    compactWithInjectedFailure(index);
 
     assertThat(index.getMutableIndex().getSubIndex().getTotalPages())
         .as("the failed round must roll the in-RAM page count back, or the next successful round's "

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoaderAdmissionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoaderAdmissionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LSMTreeIndexBulkLoaderAdmissionTest {
+  @Test
+  void usesAvailableMaximumHeapForAutomaticBudget() {
+    assertThat(LSMTreeIndexBulkLoader.resolveMemoryBudget(0L, 4L << 30, 1L << 30, 512L << 20))
+        .isEqualTo(896L << 20);
+  }
+
+  @Test
+  void usesCommittedHeapWhenMaximumIsUnlimited() {
+    assertThat(LSMTreeIndexBulkLoader.resolveMemoryBudget(0L, Long.MAX_VALUE, 512L << 20, 128L << 20))
+        .isEqualTo(32L << 20);
+  }
+
+  @Test
+  void retainsMinimumBudgetWhenNoHeapIsCurrentlyAvailable() {
+    assertThat(LSMTreeIndexBulkLoader.resolveMemoryBudget(0L, Long.MAX_VALUE, 2L << 20, 0L))
+        .isEqualTo(1L << 20);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorterAdmissionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorterAdmissionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LSMTreeIndexExternalSorterAdmissionTest {
+  @Test
+  void capsFanInByMemoryBudget() throws Exception {
+    assertThat(LSMTreeIndexExternalSorter.selectMergeFanIn(128, 1L << 20, 1_000)).isEqualTo(2);
+  }
+
+  @Test
+  void retainsOperatorCapWhenResourcesAllowIt() throws Exception {
+    assertThat(LSMTreeIndexExternalSorter.selectMergeFanIn(8, 1L << 30, 1_000)).isEqualTo(8);
+  }
+
+  @Test
+  void rejectsInsufficientFileDescriptors() {
+    assertThatThrownBy(() -> LSMTreeIndexExternalSorter.selectMergeFanIn(8, 1L << 30, 2))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Insufficient file descriptors");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBuildCrashTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBuildCrashTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexBuildMode;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LSMTreeSortedBuildCrashTest {
+  private static final int CRASH_EXIT_CODE = 73;
+
+  @TempDir
+  Path tempDirectory;
+
+  @Test
+  void crashAfterAttachmentLeavesSchemaUnpublishedAndAllowsRetry() throws Exception {
+    final Path databasePath = tempDirectory.resolve("crash-after-attachment");
+    final ChildResult prepared = runChild("prepare", databasePath);
+    assertThat(prepared.exitCode()).as(prepared.output()).isZero();
+
+    final ChildResult crashed = runChild("crash", databasePath);
+    assertThat(crashed.exitCode()).as(crashed.output()).isEqualTo(CRASH_EXIT_CODE);
+
+    assertThatThrownBy(() -> {
+      try (DatabaseFactory factory = new DatabaseFactory(databasePath.toString())) {
+        factory.open(ComponentFile.MODE.READ_ONLY);
+      }
+    }).hasRootCauseMessage("Database contains an interrupted sorted index build; reopen it read-write to perform cleanup");
+
+    try (DatabaseFactory factory = new DatabaseFactory(databasePath.toString()); Database database = factory.open()) {
+      assertThat(database.getSchema().getType("CrashBuild").getIndexByProperties("lookupKey")).isNull();
+      assertThat(database.getSchema().getIndexes()).isEmpty();
+      assertThat(database.countType("CrashBuild", false)).isEqualTo(2_000L);
+
+      final TypeIndex index = database.getSchema().buildTypeIndex("CrashBuild", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(16L << 20)
+          .withUnique(false)
+          .create();
+      assertThat(count(index.iterator(true))).isEqualTo(2_000);
+    }
+
+    try (DatabaseFactory factory = new DatabaseFactory(databasePath.toString()); Database database = factory.open()) {
+      final TypeIndex index = database.getSchema().getType("CrashBuild").getIndexByProperties("lookupKey");
+      assertThat(index).isNotNull();
+      assertThat(count(index.iterator(false))).isEqualTo(2_000);
+    }
+  }
+
+  @Test
+  void crashAfterExternalSortRemovesSpillWorkspaceAndStagedFiles() throws Exception {
+    final Path databasePath = tempDirectory.resolve("crash-after-sort");
+    assertThat(runChild("prepare", databasePath).exitCode()).isZero();
+    assertThat(runChild("crash-after-sort", databasePath).exitCode()).isEqualTo(CRASH_EXIT_CODE);
+    assertThat(buildArtifacts(databasePath)).isNotEmpty();
+
+    try (DatabaseFactory factory = new DatabaseFactory(databasePath.toString()); Database database = factory.open()) {
+      assertThat(database.getSchema().getType("CrashBuild").getIndexByProperties("lookupKey")).isNull();
+      assertThat(database.getSchema().getIndexes()).isEmpty();
+      assertThat(database.countType("CrashBuild", false)).isEqualTo(2_000L);
+    }
+    assertThat(buildArtifacts(databasePath)).isEmpty();
+  }
+
+  public static void main(final String[] args) {
+    if (args.length != 2)
+      throw new IllegalArgumentException("Expected mode and database path");
+
+    if ("prepare".equals(args[0])) {
+      prepare(args[1]);
+      return;
+    }
+    if ("crash".equals(args[0]) || "crash-after-sort".equals(args[0])) {
+      crash(args[0], args[1]);
+      return;
+    }
+    throw new IllegalArgumentException("Unknown mode " + args[0]);
+  }
+
+  private static void prepare(final String databasePath) {
+    try (DatabaseFactory factory = new DatabaseFactory(databasePath); Database database = factory.create()) {
+      final DocumentType type = database.getSchema().buildDocumentType().withName("CrashBuild").withTotalBuckets(2).create();
+      type.createProperty("lookupKey", Type.INTEGER);
+      database.transaction(() -> {
+        for (int i = 0; i < 2_000; i++)
+          database.newDocument("CrashBuild").set("lookupKey", i).save();
+      });
+    }
+  }
+
+  private static void crash(final String mode, final String databasePath) {
+    LSMTreeIndexBulkLoader.setBuildTestHook((phase, index, completedBuckets) -> {
+      if (("crash".equals(mode)
+          && phase == LSMTreeIndexBulkLoader.BuildPhase.AFTER_BUCKET_ATTACHMENT && completedBuckets == 1)
+          || ("crash-after-sort".equals(mode) && phase == LSMTreeIndexBulkLoader.BuildPhase.AFTER_SORT))
+        Runtime.getRuntime().halt(CRASH_EXIT_CODE);
+    });
+
+    try (DatabaseFactory factory = new DatabaseFactory(databasePath); Database database = factory.open()) {
+      database.getSchema().buildTypeIndex("CrashBuild", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget("crash-after-sort".equals(mode) ? 1L << 20 : 16L << 20)
+          .withUnique(false)
+          .create();
+    }
+    throw new AssertionError("Sorted build completed without triggering crash hook");
+  }
+
+  private ChildResult runChild(final String mode, final Path databasePath) throws IOException, InterruptedException {
+    final Process process = startChild(mode, databasePath);
+    final String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertThat(process.waitFor(30, TimeUnit.SECONDS)).as(output).isTrue();
+    return new ChildResult(process.exitValue(), output);
+  }
+
+  private Process startChild(final String mode, final Path databasePath) throws IOException {
+    final String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+    final String classpath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+    final List<String> command = new ArrayList<>();
+    command.add(java);
+    command.add("-Xms128m");
+    command.add("-Xmx512m");
+    command.add("--add-exports");
+    command.add("java.management/sun.management=ALL-UNNAMED");
+    command.add("--add-opens");
+    command.add("java.base/java.util.concurrent.atomic=ALL-UNNAMED");
+    command.add("--add-opens");
+    command.add("java.base/java.nio.channels.spi=ALL-UNNAMED");
+    command.add("--add-modules");
+    command.add("jdk.incubator.vector");
+    command.add("--enable-native-access=ALL-UNNAMED");
+    command.add("-cp");
+    command.add(classpath);
+    command.add(LSMTreeSortedBuildCrashTest.class.getName());
+    command.add(mode);
+    command.add(databasePath.toString());
+    return new ProcessBuilder(command).redirectErrorStream(true).start();
+  }
+
+  private static int count(final IndexCursor cursor) {
+    int count = 0;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        count++;
+      }
+      return count;
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static List<Path> buildArtifacts(final Path databasePath) throws IOException {
+    try (Stream<Path> paths = Files.list(databasePath)) {
+      return paths.filter(path -> {
+        final String name = path.getFileName().toString();
+        return name.startsWith(".arcadedb-sorted-index-build-") || name.startsWith(".arcadedb-index-sort-");
+      }).toList();
+    }
+  }
+
+  private record ChildResult(int exitCode, String output) {
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBuildFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBuildFailureTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexBuildMode;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LSMTreeSortedBuildFailureTest extends TestHelper {
+  @Test
+  void removesPartialRunAndSchemaEntriesAfterSpillWriteFailure() throws Exception {
+    final Path spillParent = Path.of(getDatabasePath()).resolve("spill-failure");
+    createRecords("SpillFailure", 1, 1_000);
+
+    final AtomicInteger written = new AtomicInteger();
+    LSMTreeIndexExternalSorter.setSpillWriteTestHook(() -> {
+      if (written.incrementAndGet() == 50)
+        throw new IOException("injected spill exhaustion");
+    });
+    try {
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SpillFailure", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(1L << 20)
+          .withBuildSpillDirectory(spillParent)
+          .withBuildMergeFanIn(2)
+          .withUnique(false)
+          .create())
+          .isInstanceOf(IndexException.class)
+          .hasStackTraceContaining("injected spill exhaustion");
+    } finally {
+      LSMTreeIndexExternalSorter.setSpillWriteTestHook(null);
+    }
+
+    assertThat(database.getSchema().getType("SpillFailure").getIndexByProperties("lookupKey")).isNull();
+    assertNoSortedBuildArtifacts(spillParent);
+    reopenDatabase();
+    assertThat(database.getSchema().getType("SpillFailure").getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
+  void defersSchemaSaveAndCleansFilesAfterFirstBucketAttachment() throws Exception {
+    createRecords("AttachmentFailure", 2, 2_000);
+    final AtomicBoolean schemaStillUnpublished = new AtomicBoolean();
+
+    LSMTreeIndexBulkLoader.setBuildTestHook((phase, index, completedBuckets) -> {
+      if (phase == LSMTreeIndexBulkLoader.BuildPhase.AFTER_BUCKET_ATTACHMENT && completedBuckets == 1) {
+        try {
+          final JSONObject schema = new JSONObject(
+              Files.readString(Path.of(database.getDatabasePath()).resolve("schema.json")));
+          final JSONObject type = schema.getJSONObject("types").getJSONObject("AttachmentFailure");
+          schemaStillUnpublished.set(!type.has("indexes") || type.getJSONObject("indexes").keySet().isEmpty());
+        } catch (final IOException error) {
+          throw new IllegalStateException("Cannot inspect schema publication boundary", error);
+        }
+        throw new IllegalStateException("injected failure after first attachment");
+      }
+    });
+    try {
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex("AttachmentFailure", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(16L << 20)
+          .withUnique(false)
+          .create())
+          .isInstanceOf(IndexException.class)
+          .hasStackTraceContaining("injected failure after first attachment");
+    } finally {
+      LSMTreeIndexBulkLoader.setBuildTestHook(null);
+    }
+
+    assertThat(schemaStillUnpublished).isTrue();
+    assertThat(database.getSchema().getType("AttachmentFailure").getIndexByProperties("lookupKey")).isNull();
+    assertNoIndexFiles();
+    reopenDatabase();
+    assertThat(database.getSchema().getType("AttachmentFailure").getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
+  void removesUnattachedCompactedFileAfterEntryWriteFailure() throws Exception {
+    createRecords("EntryWriteFailure", 1, 2_000);
+    LSMTreeIndexBulkLoader.setBuildTestHook((phase, index, completedBuckets) -> {
+      if (phase == LSMTreeIndexBulkLoader.BuildPhase.AFTER_ENTRY_WRITES)
+        throw new IllegalStateException("injected failure after entry writes");
+    });
+    try {
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex("EntryWriteFailure", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(16L << 20)
+          .withUnique(false)
+          .create())
+          .isInstanceOf(IndexException.class)
+          .hasStackTraceContaining("injected failure after entry writes");
+    } finally {
+      LSMTreeIndexBulkLoader.setBuildTestHook(null);
+    }
+
+    assertThat(database.getSchema().getType("EntryWriteFailure").getIndexByProperties("lookupKey")).isNull();
+    assertNoIndexFiles();
+  }
+
+  private void createRecords(final String typeName, final int buckets, final int records) {
+    final DocumentType type = database.getSchema().buildDocumentType().withName(typeName).withTotalBuckets(buckets).create();
+    type.createProperty("lookupKey", Type.INTEGER);
+    database.transaction(() -> {
+      for (int i = 0; i < records; i++)
+        database.newDocument(typeName).set("lookupKey", i).save();
+    });
+  }
+
+  private static void assertNoSortedBuildArtifacts(final Path parent) throws IOException {
+    if (!Files.exists(parent))
+      return;
+    try (Stream<Path> paths = Files.list(parent)) {
+      assertThat(paths.filter(path -> path.getFileName().toString()
+          .startsWith(LSMTreeIndexExternalSorter.DIRECTORY_PREFIX)).toList()).isEmpty();
+    }
+  }
+
+  private void assertNoIndexFiles() throws IOException {
+    try (Stream<Path> files = Files.list(Path.of(database.getDatabasePath()))) {
+      assertThat(files.filter(Files::isRegularFile).map(path -> path.getFileName().toString())
+          .filter(name -> name.endsWith(".numtidx") || name.endsWith(".nuctidx")
+              || name.endsWith(".temp_numtidx") || name.endsWith(".temp_nuctidx"))
+          .toList()).isEmpty();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildRecoveryMarkerTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildRecoveryMarkerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -41,6 +42,9 @@ class SortedIndexBuildRecoveryMarkerTest extends TestHelper {
         database.newDocument("PublishedBuild").set("lookupKey", i).save();
     });
 
+    SortedIndexBuildRecoveryMarker.create((DatabaseInternal) database, "PublishedBuild", List.of("lookupKey"), null);
+    assertThat(recoveryMarkers()).hasSize(1);
+
     TypeIndex index = database.getSchema().buildTypeIndex("PublishedBuild", new String[] { "lookupKey" })
         .withType(Schema.INDEX_TYPE.LSM_TREE)
         .withBuildMode(IndexBuildMode.SORTED)
@@ -49,11 +53,42 @@ class SortedIndexBuildRecoveryMarkerTest extends TestHelper {
         .create();
     assertThat(count(index.iterator(true))).isEqualTo(500);
 
-    SortedIndexBuildRecoveryMarker.create((DatabaseInternal) database, "PublishedBuild", List.of("lookupKey"), null);
-    assertThat(recoveryMarkers()).hasSize(1);
-
     reopenDatabase();
     index = database.getSchema().getType("PublishedBuild").getIndexByProperties("lookupKey");
+    assertThat(index).isNotNull();
+    assertThat(count(index.iterator(false))).isEqualTo(500);
+    assertThat(recoveryMarkers()).isEmpty();
+  }
+
+  @Test
+  void usesPreviousSchemaToPreservePublishedIndexWhenPrimarySchemaIsCorrupt() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("PreviousSchemaBuild");
+    type.createProperty("lookupKey", Type.INTEGER);
+    database.transaction(() -> {
+      for (int i = 0; i < 500; i++)
+        database.newDocument("PreviousSchemaBuild").set("lookupKey", i).save();
+    });
+
+    SortedIndexBuildRecoveryMarker.create((DatabaseInternal) database, "PreviousSchemaBuild", List.of("lookupKey"), null);
+    TypeIndex index = database.getSchema().buildTypeIndex("PreviousSchemaBuild", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(4L << 20)
+        .withUnique(false)
+        .create();
+    assertThat(count(index.iterator(true))).isEqualTo(500);
+
+    database.getSchema().getEmbedded().saveConfiguration();
+    final Path databasePath = Path.of(database.getDatabasePath());
+    assertThat(databasePath.resolve(LocalSchema.SCHEMA_PREV_FILE_NAME)).isRegularFile();
+
+    database.close();
+    database = null;
+    Files.writeString(databasePath.resolve(LocalSchema.SCHEMA_FILE_NAME), "{broken",
+        StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+    database = factory.open();
+
+    index = database.getSchema().getType("PreviousSchemaBuild").getIndexByProperties("lookupKey");
     assertThat(index).isNotNull();
     assertThat(count(index.iterator(false))).isEqualTo(500);
     assertThat(recoveryMarkers()).isEmpty();

--- a/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildRecoveryMarkerTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildRecoveryMarkerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.TypeIndex;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SortedIndexBuildRecoveryMarkerTest extends TestHelper {
+  @Test
+  void preservesPublishedIndexWhenManifestClearWasInterrupted() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("PublishedBuild");
+    type.createProperty("lookupKey", Type.INTEGER);
+    database.transaction(() -> {
+      for (int i = 0; i < 500; i++)
+        database.newDocument("PublishedBuild").set("lookupKey", i).save();
+    });
+
+    TypeIndex index = database.getSchema().buildTypeIndex("PublishedBuild", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(4L << 20)
+        .withUnique(false)
+        .create();
+    assertThat(count(index.iterator(true))).isEqualTo(500);
+
+    SortedIndexBuildRecoveryMarker.create((DatabaseInternal) database, "PublishedBuild", List.of("lookupKey"), null);
+    assertThat(recoveryMarkers()).hasSize(1);
+
+    reopenDatabase();
+    index = database.getSchema().getType("PublishedBuild").getIndexByProperties("lookupKey");
+    assertThat(index).isNotNull();
+    assertThat(count(index.iterator(false))).isEqualTo(500);
+    assertThat(recoveryMarkers()).isEmpty();
+  }
+
+  private List<Path> recoveryMarkers() throws Exception {
+    try (Stream<Path> files = Files.list(Path.of(database.getDatabasePath()))) {
+      return files.filter(path -> path.getFileName().toString().startsWith(SortedIndexBuildRecoveryMarker.FILE_PREFIX))
+          .toList();
+    }
+  }
+
+  private static int count(final IndexCursor cursor) {
+    int count = 0;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        count++;
+      }
+      return count;
+    } finally {
+      cursor.close();
+    }
+  }
+}

--- a/engine/src/test/java/performance/TestSortedIndexBuildBenchmark.java
+++ b/engine/src/test/java/performance/TestSortedIndexBuildBenchmark.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package performance;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexBuildMode;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.TypeIndexBuilder;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Compares the normal record-at-a-time LSM index build with the bounded sorted build over identical physical input.
+ * Both the raw normal-build time and its subsequent compaction are reported because the sorted build already returns
+ * compacted output. The sorted build runs first so the normal path receives any JVM warmup advantage. Dataset creation,
+ * copying, and validation are excluded from the reported index timings.
+ * <p>
+ * Run explicitly with:
+ * {@code JAVA_TOOL_OPTIONS=-Xmx4g ./mvnw -pl engine -Dtest=TestSortedIndexBuildBenchmark -Dgroups=benchmark test}.
+ * Override the deterministic ten-million-record default with
+ * {@code -Darcadedb.sortedBuildBenchmark.entries=5000000}.
+ */
+@Tag("benchmark")
+class TestSortedIndexBuildBenchmark {
+  private static final String ENTRY_COUNT_PROPERTY    = "arcadedb.sortedBuildBenchmark.entries";
+  private static final String VALUES_PER_KEY_PROPERTY = "arcadedb.sortedBuildBenchmark.valuesPerKey";
+  private static final int    DEFAULT_ENTRY_COUNT     = 10_000_000;
+  private static final int    DEFAULT_VALUES_PER_KEY  = 1;
+  private static final int    INSERT_BATCH_SIZE       = 10_000;
+  private static final long   SORTED_MEMORY_BUDGET    = 1L << 30;
+  private static final int    SORTED_MERGE_FAN_IN     = 8;
+  private static final String TYPE_NAME               = "BenchmarkRecord";
+  private static final String PROPERTY_NAME           = "lookupKey";
+  private static final Path   BENCHMARK_ROOT          = Path.of("target", "databases", "SortedIndexBuildBenchmark");
+
+  @Test
+  void compareDefaultAndSortedBuilds() throws Exception {
+    final int entries = Integer.getInteger(ENTRY_COUNT_PROPERTY, DEFAULT_ENTRY_COUNT);
+    final int valuesPerKey = Integer.getInteger(VALUES_PER_KEY_PROPERTY, DEFAULT_VALUES_PER_KEY);
+    if (entries < 1)
+      throw new IllegalArgumentException(ENTRY_COUNT_PROPERTY + " must be positive");
+    if (valuesPerKey < 1 || valuesPerKey > entries)
+      throw new IllegalArgumentException(VALUES_PER_KEY_PROPERTY + " must be between 1 and the entry count");
+
+    FileUtils.deleteRecursively(BENCHMARK_ROOT.toFile());
+    try {
+      final Path sourcePath = BENCHMARK_ROOT.resolve("source");
+      createSourceDatabase(sourcePath, entries, valuesPerKey);
+
+      // Run SORTED first so DEFAULT, the slower control, receives any shared JVM warmup advantage.
+      final Path sortedPath = BENCHMARK_ROOT.resolve("sorted");
+      FileUtils.copyDirectory(sourcePath.toFile(), sortedPath.toFile());
+      final BuildResult sorted = buildAndMeasure(sortedPath, IndexBuildMode.SORTED, entries, valuesPerKey);
+
+      final Path defaultPath = BENCHMARK_ROOT.resolve("default");
+      FileUtils.copyDirectory(sourcePath.toFile(), defaultPath.toFile());
+      final BuildResult normal = buildAndMeasure(defaultPath, IndexBuildMode.DEFAULT, entries, valuesPerKey);
+
+      final double rawBuildRatio = normal.buildNanos() / (double) sorted.buildNanos();
+      final double compactedSpeedup = normal.totalToCompactedNanos() / (double) sorted.totalToCompactedNanos();
+      System.out.printf(Locale.ROOT,
+          "%nSorted LSM index build benchmark%n" +
+              "entries: %,d%n" +
+              "distinct keys: %,d%n" +
+              "values per key: %,d%n" +
+              "permutation stride: %,d%n" +
+              "max heap: %.2f GiB%n" +
+              "DEFAULT build: %.3f s%n" +
+              "DEFAULT compaction: %.3f s%n" +
+              "DEFAULT total to compacted output: %.3f s%n" +
+              "SORTED build to compacted output: %.3f s%n" +
+              "raw DEFAULT/SORTED build ratio: %.2fx%n" +
+              "compacted-output speedup: %.2fx%n%n",
+          entries, (entries + valuesPerKey - 1L) / valuesPerKey, valuesPerKey, permutationStride(entries),
+          Runtime.getRuntime().maxMemory() / (double) (1L << 30), seconds(normal.buildNanos()),
+          seconds(normal.compactionNanos()), seconds(normal.totalToCompactedNanos()),
+          seconds(sorted.totalToCompactedNanos()), rawBuildRatio, compactedSpeedup);
+
+      assertThat(sorted.entries()).isEqualTo(entries);
+      assertThat(normal.entries()).isEqualTo(entries);
+      if (entries >= DEFAULT_ENTRY_COUNT)
+        assertThat(sorted.totalToCompactedNanos())
+            .as("SORTED should reach equivalent compacted output before DEFAULT at %,d entries", entries)
+            .isLessThan(normal.totalToCompactedNanos());
+    } finally {
+      FileUtils.deleteRecursively(BENCHMARK_ROOT.toFile());
+    }
+  }
+
+  private void createSourceDatabase(final Path path, final int entries, final int valuesPerKey) {
+    try (DatabaseFactory factory = new DatabaseFactory(path.toString()); Database database = factory.create()) {
+      final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+      type.createProperty(PROPERTY_NAME, Type.STRING);
+      final int stride = permutationStride(entries);
+
+      for (int from = 0; from < entries; from += INSERT_BATCH_SIZE) {
+        final int batchStart = from;
+        final int batchEnd = Math.min(entries, from + INSERT_BATCH_SIZE);
+        database.transaction(() -> {
+          for (int i = batchStart; i < batchEnd; i++) {
+            final int permuted = (int) Math.floorMod((long) i * stride, entries);
+            database.newDocument(TYPE_NAME).set(PROPERTY_NAME, key(permuted / valuesPerKey)).save();
+          }
+        });
+      }
+    }
+  }
+
+  private BuildResult buildAndMeasure(final Path path, final IndexBuildMode mode, final int expectedEntries,
+      final int valuesPerKey) throws Exception {
+    try (DatabaseFactory factory = new DatabaseFactory(path.toString()); Database database = factory.open()) {
+      final AtomicLong scannedEntries = new AtomicLong();
+      final TypeIndexBuilder builder = database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { PROPERTY_NAME });
+      builder.withType(Schema.INDEX_TYPE.LSM_TREE);
+      builder.withBuildMode(mode);
+      builder.withUnique(false);
+      builder.withCallback((document, total) -> scannedEntries.set(total));
+      if (mode == IndexBuildMode.SORTED)
+        builder.withBuildMemoryBudget(SORTED_MEMORY_BUDGET).withBuildMergeFanIn(SORTED_MERGE_FAN_IN);
+
+      final long started = System.nanoTime();
+      final TypeIndex index = builder.create();
+      final long buildNanos = System.nanoTime() - started;
+
+      assertThat(scannedEntries.get()).as("%s scanned entry count", mode).isEqualTo(expectedEntries);
+
+      long compactionNanos = 0L;
+      if (mode == IndexBuildMode.DEFAULT) {
+        database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+        database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1_024);
+        final long compactionStarted = System.nanoTime();
+        assertThat(index.scheduleCompaction()).as("DEFAULT index is eligible for compaction").isTrue();
+        assertThat(index.compact()).as("DEFAULT index compaction completed").isTrue();
+        compactionNanos = System.nanoTime() - compactionStarted;
+      }
+
+      final LSMTreeIndex bucketIndex = (LSMTreeIndex) index.getIndexesOnBuckets()[0];
+      assertThat(bucketIndex.getMutableIndex().getSubIndex()).as("%s compacted output", mode).isNotNull();
+      assertThat(count(index.get(new Object[] { key(0) }))).as("%s point lookup", mode).isEqualTo(valuesPerKey);
+      return new BuildResult(buildNanos, compactionNanos, scannedEntries.get());
+    }
+  }
+
+  private static long count(final IndexCursor cursor) {
+    long count = 0L;
+    while (cursor.hasNext()) {
+      cursor.next();
+      count++;
+    }
+    return count;
+  }
+
+  private static String key(final int value) {
+    return "key-%09d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".formatted(value);
+  }
+
+  private static int permutationStride(final int entries) {
+    if (entries == 1)
+      return 1;
+
+    int candidate = Math.max(1, (int) (entries * 0.6180339887498949));
+    while (greatestCommonDivisor(candidate, entries) != 1)
+      --candidate;
+    return candidate;
+  }
+
+  private static int greatestCommonDivisor(int left, int right) {
+    while (right != 0) {
+      final int remainder = left % right;
+      left = right;
+      right = remainder;
+    }
+    return left;
+  }
+
+  private static double seconds(final long nanos) {
+    return nanos / 1_000_000_000.0;
+  }
+
+  private record BuildResult(long buildNanos, long compactionNanos, long entries) {
+    long totalToCompactedNanos() {
+      return buildNanos + compactionNanos;
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds an explicit, opt-in sorted build mode for creating a non-unique `LSM_TREE` index over existing
records.

```java
schema.buildTypeIndex(typeName, propertyNames)
    .withType(Schema.INDEX_TYPE.LSM_TREE)
    .withBuildMode(IndexBuildMode.SORTED)
    .withBuildMemoryBudget(1L << 30)
    .withBuildMergeFanIn(8)
    .withUnique(false)
    .create();
```

Existing callers retain the established record-at-a-time build through `IndexBuildMode.DEFAULT`.
The new mode:

- projects logical keys through `DocumentIndexer`, preserving scalar, list, map, composite, null,
  and collation behavior;
- creates bounded in-memory sorted runs and spills them when the configured or automatic heap
  budget is reached;
- admits merge fan-in against both memory and file-descriptor headroom;
- globally merges normalized `(key, RID)` entries;
- collapses repeated emission of the same `(key, RID)` pair and bounds high-cardinality RID groups;
- writes the ordered stream through the same bounded compacted-series writer used by normal LSM
  compaction;
- keeps every bucket index unavailable until all bucket output is complete, then publishes the
  type index through one schema-save boundary;
- removes owned spill and component files after ordinary failures and interrupted-process
  recovery.

The initial contribution is restricted to non-unique `LSM_TREE` indexes on a non-replicated,
single-server database with no active caller transaction. Existing online writes and HA behavior
are unchanged because unsupported explicit requests fail before index files are created.

## Motivation

The established builder inserts existing records through the mutable LSM path. As an ordered index
grows, that repeatedly performs lookup and page-maintenance work against the growing structure.
For large initial indexes, a bounded external sort followed by sequential compacted-page assembly
avoids that growth-dependent insertion path while retaining ordered lookup and range semantics.

This is the first contribution slice discussed in #5230: external sorting plus non-unique
`LSM_TREE` output through the compaction append path, opt-in and single-server only. Unique
enforcement and bounded parallelism are intentionally left for follow-up contributions.

## Publication and recovery

The implementation does not add `BUILDING` or `READY_TO_PUBLISH` states to schema metadata. Empty
bucket indexes and compacted output remain unavailable in memory, intermediate schema saves are
deferred, and the completed index is attached by the final schema save.

Hard-process testing did expose one additional storage requirement. After `Runtime.halt()` between
bucket attachment and publication, reopening the database discovered newly registered component
files even though the logical index had never been published. The build therefore creates a small,
fsynced cleanup manifest before component creation. It contains only the baseline component IDs and
the owned spill workspace.

On read-write reopen:

- if the schema does not contain the completed index, files created after the baseline and the
  owned spill workspace are removed;
- if the final schema save completed before the process stopped, the published index is preserved
  and only the manifest/workspace is cleared.

Read-only reopen refuses an interrupted build because cleanup requires writes. This manifest is
cleanup ownership, not a durable schema build-state machine.

## Explicit-mode behavior

`IndexBuildMode.SORTED` is an explicit operator request. If its preconditions cannot be honored,
the builder fails before creating files rather than silently switching to a potentially much
slower build path. A future `AUTO` mode could provide warning plus fallback while preserving the
meaning of the explicit mode.

## Validation

The branch is based on `origin/main` at `6ff2148e4f93`; the reviewed head is `5f95009a`.

Focused coverage includes:

- in-memory and multi-generation external-sort builds;
- one key spanning buckets, spill runs, more than 256 RID chunks, and reopen;
- scalar, list, composite, case-insensitive, and null-skipping keys;
- partial-null composite keys under both `NULL_STRATEGY.SKIP` and `NULL_STRATEGY.ERROR`, including
  reopen;
- a default-page-size shared-leaf regression with preceding keys and 100,000 records sharing one
  key, covering point, ascending, descending, and reopen behavior;
- exact, range, ascending, descending, and SQL-planner reads;
- empty index publication and future insert/delete;
- later normal compaction and reopen;
- memory/file-descriptor merge admission;
- spill-write, scan, compacted-write, and bucket-attachment failures;
- hard process stops after external sorting and after partial bucket attachment;
- preservation of a published index when manifest clearing is interrupted;
- compacted-series capacity boundaries and ordinary compaction atomicity.

Green on OpenJDK 21.0.11 and Linux:

```text
./mvnw -pl engine \
  -DexcludedGroups=slow,benchmark \
  -Dsurefire.excludes='**/*$*,**/ScriptExecutionTest.java' test

Tests run: 9,127, Failures: 0, Errors: 0, Skipped: 23

./mvnw package -DskipTests

Reactor modules: 25, BUILD SUCCESS
```

The `slow` group was excluded because one upstream asynchronous test is pathological on this
256-CPU host. The new benchmark is tagged `benchmark` and excluded from routine validation by
design. `ScriptExecutionTest` was excluded because its 256-bucket configuration exceeds the engine
maximum of 32; that failure was reproduced unchanged on untouched `origin/main`.

After the review fixes and rebase, a 41-test focused matrix covering the sorted path, crash/failure
recovery, compaction, duplicate handling, and shared-leaf behavior also passed.

## Repeatable DEFAULT-vs-SORTED benchmark

The committed benchmark builds the same deterministic copied physical input through both paths and
reports raw DEFAULT construction separately from its subsequent compaction because SORTED already
returns compacted output. It is opt-in under `@Tag("benchmark")`:

```text
JAVA_TOOL_OPTIONS=-Xmx4g ./mvnw -pl engine \
  -Dtest=TestSortedIndexBuildBenchmark -Dgroups=benchmark test
```

The default 10,000,000-distinct-key run remains configurable with
`-Darcadedb.sortedBuildBenchmark.entries=<count>`. On this host with a 4 GiB heap:

```text
DEFAULT build:                       31.636 s
DEFAULT compaction:                 339.231 s
DEFAULT total to compacted output:  370.868 s
SORTED build to compacted output:    38.585 s
raw DEFAULT/SORTED build ratio:         0.82x
compacted-output speedup:               9.61x
total benchmark test time:               7:20
```

Raw DEFAULT creation alone was faster at this scale. The reported speedup compares equivalent
compacted outputs rather than conflating the mutable DEFAULT result with SORTED's compacted result.

## 10M exact-path result

Two builds used the public API above on the same one-bucket fixture containing 10,000,000 distinct
URI strings, with a 4 GiB heap, 1 GiB build budget, fan-in 32, 29 final runs, and approximately
504.06 MiB spill output:

```text
Index phase: 25.890 s
Index phase: 25.044 s
Mean:        25.467 s
Spread:       3.32%
```

Both runs produced 10,000,000 entries and identical ascending and descending SHA-256 digests.
Exact lookups, inclusive/exclusive ranges in both directions, planner use, reopen, future
non-unique insertion/deletion, and post-write reopen passed. No database lock, cleanup manifest,
or spill artifact remained.

These measurements describe this fixture and configuration; they are not presented as a general
throughput guarantee.

## Scope left for follow-up work

- unique sorted builds with global duplicate enforcement;
- bounded per-bucket and merge-group parallelism;
- an automatic warning-and-fallback mode;
- SQL syntax;
- HA/replicated operation;
- online snapshot-plus-delta construction;
- construction of multiple indexes from one source scan.

## Checklist

- [x] Existing build behavior remains the default
- [x] The new path is explicit and fails before file creation when unsupported
- [x] Unit tests cover success, failure, and hard-crash recovery
- [x] Full engine regression suite passed
- [x] All 25 package modules passed
