### PR TITLE
Add unique enforcement to sorted LSM index builds

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.TransactionIndexContext;
+import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.FileUtils;
@@ -35,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
-/** Builds empty non-unique LSM indexes from a bounded, globally sorted logical entry stream. */
+/** Builds empty LSM indexes from a bounded, globally sorted logical entry stream. */
 public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   private static final ThreadLocal<BuildTestHook> BUILD_TEST_HOOK = new ThreadLocal<>();
 
@@ -54,6 +55,7 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   private final Map<Integer, LSMTreeIndex> indexesByBucket = new LinkedHashMap<>();
   private       LSMTreeIndexExternalSorter externalSorter;
   private       byte[]                     binaryKeyTypes;
+  private       Boolean                    unique;
   private       long                       totalEntries;
 
   public LSMTreeIndexBulkLoader(final DatabaseInternal database, final String indexName,
@@ -163,11 +165,19 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
     try (LSMTreeIndexExternalSorter.EntryCursor cursor = openSortedEntries()) {
       final RID[] ridBuffer = new RID[MAX_BUFFERED_RIDS_PER_GROUP];
       Entry groupFirst = null;
+      Entry previousEntry = null;
       RID previousRid = null;
       int bufferedRids = 0;
 
       while (cursor.hasNext()) {
         final Entry current = cursor.next();
+        if (Boolean.TRUE.equals(unique) && previousEntry != null
+            && current.key().compareTo(previousEntry.key()) == 0
+            && !LSMTreeIndexAbstract.isKeyNull(current.key().values)
+            && !current.rid().equals(previousEntry.rid()))
+          throw new DuplicatedKeyException(indexName, Arrays.toString(current.key().values), previousEntry.rid());
+        previousEntry = current;
+
         if (groupFirst == null || current.index() != groupFirst.index()
             || current.key().compareTo(groupFirst.key()) != 0) {
           if (groupFirst != null)
@@ -234,6 +244,12 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   }
 
   private void registerIndex(final LSMTreeIndex index) {
+    if (unique == null)
+      unique = index.isUnique();
+    else if (unique != index.isUnique())
+      throw new IndexException("Bucket index '" + index.getName() + "' has incompatible uniqueness for sorted build '"
+          + indexName + "'");
+
     final byte[] indexKeyTypes = index.getBinaryKeyTypes();
     if (binaryKeyTypes == null)
       binaryKeyTypes = Arrays.copyOf(indexKeyTypes, indexKeyTypes.length);

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -372,8 +372,6 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   private void validateSortedBuildPreconditions() {
     if (indexType != Schema.INDEX_TYPE.LSM_TREE)
       throw new IndexException("Sorted build currently supports only LSM_TREE indexes");
-    if (unique)
-      throw new IndexException("Sorted build currently supports only non-unique indexes");
     if (database.isReplicated() || database.getWrappedDatabaseInstance().isReplicated())
       throw new IndexException("Sorted build is not supported on replicated databases");
     if (database.isTransactionActive())

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeSortedNonUniqueBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeSortedNonUniqueBuildTest.java
@@ -223,23 +223,6 @@ class LSMTreeSortedNonUniqueBuildTest extends TestHelper {
     assertThat(database.getSchema().getType("SortedPartialNullError").getIndexByProperties("groupName", "ordinal")).isNull();
   }
 
-  @Test
-  void rejectsUnsupportedUniqueBuildBeforeCreatingFiles() {
-    final DocumentType type = database.getSchema().createDocumentType("SortedUnique");
-    type.createProperty("lookupKey", Type.STRING);
-    database.transaction(() -> database.newDocument("SortedUnique").set("lookupKey", "one").save());
-
-    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedUnique", new String[] { "lookupKey" })
-        .withType(Schema.INDEX_TYPE.LSM_TREE)
-        .withBuildMode(IndexBuildMode.SORTED)
-        .withUnique(true)
-        .create())
-        .isInstanceOf(IndexException.class)
-        .hasMessageContaining("non-unique");
-    assertThat(type.getIndexByProperties("lookupKey")).isNull();
-  }
-
-  @Test
   void rejectsUnsupportedIndexTypeAndActiveTransaction() {
     final DocumentType type = database.getSchema().createDocumentType("SortedPreconditions");
     type.createProperty("lookupKey", Type.STRING);

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeSortedUniqueBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeSortedUniqueBuildTest.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexBuildMode;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LSMTreeSortedUniqueBuildTest extends TestHelper {
+  @Test
+  void buildsAcrossBucketsAndSpillRunsThenSupportsPlannerCompactionReopenAndMutation() throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    final Path spillParent = Path.of(getDatabasePath()).resolve("unique-success-spill");
+    final DocumentType type = database.getSchema().buildDocumentType().withName("SortedUniqueSuccess")
+        .withTotalBuckets(3).create();
+    type.createProperty("lookupKey", Type.STRING);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 2_000; i++) {
+        final int permuted = Math.floorMod(i * 1_237, 2_000);
+        database.newDocument("SortedUniqueSuccess").set("lookupKey", paddedKey("key", permuted)).save();
+      }
+    });
+
+    TypeIndex index = database.getSchema().buildTypeIndex("SortedUniqueSuccess", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(1L << 20)
+        .withBuildSpillDirectory(spillParent)
+        .withBuildMergeFanIn(2)
+        .withPageSize(1_024)
+        .withUnique(true)
+        .create();
+
+    assertThat(index.isUnique()).isTrue();
+    assertOrdered(index, 2_000);
+    assertThat(count(index.iterator(false))).isEqualTo(2_000);
+    assertThat(count(index.get(new Object[] { paddedKey("key", 1_234) }))).isEqualTo(1);
+    assertThat(count(index.range(true, new Object[] { paddedKey("key", 990) }, true,
+        new Object[] { paddedKey("key", 1_010) }, true))).isEqualTo(21);
+    assertPlannerUses(index, "SortedUniqueSuccess", paddedKey("key", 1_234));
+    assertNoBuildArtifacts(spillParent);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 500; i++)
+        database.newDocument("SortedUniqueSuccess").set("lookupKey", paddedKey("live", i)).save();
+    });
+    assertThat(((IndexInternal) index).scheduleCompaction()).isTrue();
+    assertThat(((IndexInternal) index).compact()).isTrue();
+    assertThat(count(index.iterator(true))).isEqualTo(2_500);
+
+    reopenDatabase();
+    index = database.getSchema().getType("SortedUniqueSuccess").getIndexByProperties("lookupKey");
+    assertThat(index.isUnique()).isTrue();
+    assertThat(count(index.get(new Object[] { paddedKey("live", 250) }))).isEqualTo(1);
+    assertThatThrownBy(() -> database.transaction(() -> database.newDocument("SortedUniqueSuccess")
+        .set("lookupKey", paddedKey("key", 1_234)).save()))
+        .isInstanceOf(DuplicatedKeyException.class);
+
+    final RID[] reusable = new RID[1];
+    database.transaction(() -> reusable[0] = database.newDocument("SortedUniqueSuccess")
+        .set("lookupKey", "reusable-key").save().getIdentity());
+    database.transaction(() -> database.lookupByRID(reusable[0], true).asDocument().delete());
+    database.transaction(() -> database.newDocument("SortedUniqueSuccess").set("lookupKey", "reusable-key").save());
+    assertThat(count(index.get(new Object[] { "reusable-key" }))).isEqualTo(1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "0000-duplicate", "key-00400", "zzzz-duplicate" })
+  void rejectsDuplicateAtAnySortedPositionAndPublishesNothing(final String duplicateKey) throws Exception {
+    final Path spillParent = Path.of(getDatabasePath()).resolve("position-spill");
+    final DocumentType type = database.getSchema().createDocumentType("SortedUniquePosition");
+    type.createProperty("lookupKey", Type.STRING);
+    database.transaction(() -> {
+      for (int i = 0; i < 800; i++)
+        database.newDocument("SortedUniquePosition").set("lookupKey", "key-%05d".formatted(i)).save();
+      database.newDocument("SortedUniquePosition").set("lookupKey", duplicateKey).save();
+      database.newDocument("SortedUniquePosition").set("lookupKey", duplicateKey).save();
+    });
+
+    assertThatThrownBy(() -> buildUnique("SortedUniquePosition", spillParent, 2))
+        .hasRootCauseInstanceOf(DuplicatedKeyException.class);
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+    assertThat(database.getSchema().getIndexes()).isEmpty();
+    assertNoBuildArtifacts(spillParent);
+    assertNoBuildArtifactsInDatabase();
+
+    reopenDatabase();
+    assertThat(database.getSchema().getType("SortedUniquePosition").getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
+  void rejectsCrossBucketDuplicateAfterMultipleMergeGenerationsAndAllowsRetry() throws Exception {
+    final Path spillParent = Path.of(getDatabasePath()).resolve("cross-bucket-spill");
+    final DocumentType type = database.getSchema().buildDocumentType().withName("SortedUniqueCrossBucket")
+        .withTotalBuckets(2).create();
+    type.createProperty("lookupKey", Type.STRING);
+    final RID[] duplicates = new RID[2];
+    database.transaction(() -> {
+      for (int i = 0; i < 2_000; i++)
+        database.newDocument("SortedUniqueCrossBucket").set("lookupKey", "key-%05d".formatted(i)).save();
+      duplicates[0] = database.newDocument("SortedUniqueCrossBucket").set("lookupKey", "zzzz-duplicate")
+          .save().getIdentity();
+      duplicates[1] = database.newDocument("SortedUniqueCrossBucket").set("lookupKey", "zzzz-duplicate")
+          .save().getIdentity();
+    });
+    assertThat(duplicates[0].getBucketId()).isNotEqualTo(duplicates[1].getBucketId());
+
+    assertThatThrownBy(() -> buildUnique("SortedUniqueCrossBucket", spillParent, 2))
+        .hasRootCauseInstanceOf(DuplicatedKeyException.class);
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+    assertNoBuildArtifacts(spillParent);
+    assertNoBuildArtifactsInDatabase();
+
+    reopenDatabase();
+    database.transaction(() -> database.lookupByRID(duplicates[1], true).asDocument().delete());
+    final TypeIndex index = buildUnique("SortedUniqueCrossBucket", spillParent, 2);
+    assertThat(count(index.iterator(true))).isEqualTo(2_001);
+    assertThat(count(index.get(new Object[] { "zzzz-duplicate" }))).isEqualTo(1);
+  }
+
+  @Test
+  void collapsesRepeatedListEntryForSameRidButRejectsAnotherRid() {
+    final DocumentType type = database.getSchema().createDocumentType("SortedUniqueList");
+    type.createProperty("tags", Type.LIST);
+    final List<String> repeatedTags = new ArrayList<>(Collections.nCopies(400, "alpha"));
+    repeatedTags.add("beta");
+    database.transaction(() -> {
+      database.newDocument("SortedUniqueList").set("tags", repeatedTags).save();
+      database.newDocument("SortedUniqueList").set("tags", List.of("gamma")).save();
+    });
+
+    final TypeIndex index = database.getSchema().buildTypeIndex("SortedUniqueList", new String[] { "tags by item" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(1L << 20)
+        .withBuildMergeFanIn(2)
+        .withUnique(true)
+        .create();
+    assertThat(count(index.get(new Object[] { "alpha" }))).isEqualTo(1);
+    assertThat(count(index.iterator(true))).isEqualTo(3);
+    assertThatThrownBy(() -> database.transaction(() -> database.newDocument("SortedUniqueList")
+        .set("tags", List.of("alpha")).save()))
+        .isInstanceOf(DuplicatedKeyException.class);
+  }
+
+  @Test
+  void rejectsCaseInsensitiveCompositeDuplicate() throws Exception {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("SortedUniqueComposite")
+        .withTotalBuckets(2).create();
+    type.createProperty("code", Type.STRING);
+    type.createProperty("ordinal", Type.INTEGER);
+    database.transaction(() -> {
+      database.newDocument("SortedUniqueComposite").set("code", "Alpha").set("ordinal", 7).save();
+      database.newDocument("SortedUniqueComposite").set("code", "ALPHA").set("ordinal", 7).save();
+    });
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedUniqueComposite",
+            new String[] { "code", "ordinal" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withCollations(List.of("CI", "DEFAULT"))
+        .withUnique(true)
+        .create())
+        .hasRootCauseInstanceOf(DuplicatedKeyException.class);
+    assertThat(type.getIndexByProperties("code", "ordinal")).isNull();
+    assertNoBuildArtifactsInDatabase();
+  }
+
+  @Test
+  void indexesPartialNullCompositeKeysWithSkipStrategyAndEnforcesFutureUniqueness() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("SortedUniquePartialNullSkip");
+    type.createProperty("groupName", Type.STRING);
+    type.createProperty("ordinal", Type.INTEGER);
+
+    database.transaction(() -> {
+      database.newDocument("SortedUniquePartialNullSkip").set("groupName", null).set("ordinal", 5).save();
+      database.newDocument("SortedUniquePartialNullSkip").set("groupName", "group").set("ordinal", null).save();
+      database.newDocument("SortedUniquePartialNullSkip").set("groupName", null).set("ordinal", null).save();
+      database.newDocument("SortedUniquePartialNullSkip").set("groupName", "group").set("ordinal", 7).save();
+    });
+
+    TypeIndex index = database.getSchema().buildTypeIndex("SortedUniquePartialNullSkip",
+            new String[] { "groupName", "ordinal" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.SKIP)
+        .withUnique(true)
+        .create();
+
+    assertThat(count(index.iterator(true))).isEqualTo(3);
+    assertThat(count(index.get(new Object[] { null, 5 }))).isEqualTo(1);
+    assertThat(count(index.get(new Object[] { "group", null }))).isEqualTo(1);
+    assertThat(count(index.get(new Object[] { null, null }))).isZero();
+
+    reopenDatabase();
+    index = database.getSchema().getType("SortedUniquePartialNullSkip")
+        .getIndexByProperties("groupName", "ordinal");
+    assertThat(count(index.get(new Object[] { null, 5 }))).isEqualTo(1);
+    assertThat(count(index.get(new Object[] { "group", null }))).isEqualTo(1);
+    assertThatThrownBy(() -> database.transaction(() -> database.newDocument("SortedUniquePartialNullSkip")
+        .set("groupName", null).set("ordinal", 5).save()))
+        .isInstanceOf(DuplicatedKeyException.class);
+  }
+
+  @Test
+  void rejectsInitialDuplicatePartialNullCompositeKeyWithSkipStrategy() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("SortedUniquePartialNullDuplicate");
+    type.createProperty("groupName", Type.STRING);
+    type.createProperty("ordinal", Type.INTEGER);
+    database.transaction(() -> {
+      database.newDocument("SortedUniquePartialNullDuplicate").set("groupName", null).set("ordinal", 5).save();
+      database.newDocument("SortedUniquePartialNullDuplicate").set("groupName", null).set("ordinal", 5).save();
+    });
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedUniquePartialNullDuplicate",
+            new String[] { "groupName", "ordinal" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.SKIP)
+        .withUnique(true)
+        .create())
+        .hasRootCauseInstanceOf(DuplicatedKeyException.class);
+    assertThat(type.getIndexByProperties("groupName", "ordinal")).isNull();
+    assertNoBuildArtifactsInDatabase();
+
+    reopenDatabase();
+    assertThat(database.getSchema().getType("SortedUniquePartialNullDuplicate")
+        .getIndexByProperties("groupName", "ordinal")).isNull();
+  }
+
+  @Test
+  void rejectsPartialNullCompositeKeysWithErrorStrategy() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("SortedUniquePartialNullError");
+    type.createProperty("groupName", Type.STRING);
+    type.createProperty("ordinal", Type.INTEGER);
+    database.transaction(() -> database.newDocument("SortedUniquePartialNullError")
+        .set("groupName", null).set("ordinal", 5).save());
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("SortedUniquePartialNullError",
+            new String[] { "groupName", "ordinal" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR)
+        .withUnique(true)
+        .create())
+        .isInstanceOf(IndexException.class)
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(
+            "Indexed key SortedUniquePartialNullError[groupName, ordinal] cannot be NULL ([null, 5])");
+    assertThat(type.getIndexByProperties("groupName", "ordinal")).isNull();
+    assertNoBuildArtifactsInDatabase();
+
+    reopenDatabase();
+    assertThat(database.getSchema().getType("SortedUniquePartialNullError")
+        .getIndexByProperties("groupName", "ordinal")).isNull();
+  }
+
+  @Test
+  void honorsIndexSkipAndErrorNullStrategies() {
+    final TypeIndex indexedNulls = createUniqueNullIndex("UniqueNullIndex", LSMTreeIndexAbstract.NULL_STRATEGY.INDEX);
+    assertThat(countNullKeys(indexedNulls.iterator(true))).isEqualTo(2);
+    assertThat(count(indexedNulls.iterator(true))).isEqualTo(3);
+
+    final TypeIndex skippedNulls = createUniqueNullIndex("UniqueNullSkip", LSMTreeIndexAbstract.NULL_STRATEGY.SKIP);
+    assertThat(countNullKeys(skippedNulls.iterator(true))).isZero();
+    assertThat(count(skippedNulls.iterator(true))).isEqualTo(1);
+
+    final DocumentType errorType = createNullRecords("UniqueNullError");
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("UniqueNullError", new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR)
+        .withUnique(true)
+        .create())
+        .hasRootCauseInstanceOf(IllegalArgumentException.class);
+    assertThat(errorType.getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
+  void publishesEmptyUniqueIndexAndEnforcesLaterWrites() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("SortedUniqueEmpty");
+    type.createProperty("lookupKey", Type.STRING);
+    TypeIndex index = buildUnique("SortedUniqueEmpty", null, 8);
+    assertThat(index.isUnique()).isTrue();
+    assertThat(count(index.iterator(true))).isZero();
+
+    database.transaction(() -> database.newDocument("SortedUniqueEmpty").set("lookupKey", "later").save());
+    assertThatThrownBy(() -> database.transaction(() -> database.newDocument("SortedUniqueEmpty")
+        .set("lookupKey", "later").save()))
+        .isInstanceOf(DuplicatedKeyException.class);
+    reopenDatabase();
+    index = database.getSchema().getType("SortedUniqueEmpty").getIndexByProperties("lookupKey");
+    assertThat(index.isUnique()).isTrue();
+    assertThat(count(index.get(new Object[] { "later" }))).isEqualTo(1);
+  }
+
+  private TypeIndex createUniqueNullIndex(final String typeName, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
+    createNullRecords(typeName);
+    return database.getSchema().buildTypeIndex(typeName, new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withNullStrategy(nullStrategy)
+        .withUnique(true)
+        .create();
+  }
+
+  private DocumentType createNullRecords(final String typeName) {
+    final DocumentType type = database.getSchema().createDocumentType(typeName);
+    type.createProperty("lookupKey", Type.STRING);
+    database.transaction(() -> {
+      database.newDocument(typeName).set("lookupKey", (Object) null).save();
+      database.newDocument(typeName).set("lookupKey", (Object) null).save();
+      database.newDocument(typeName).set("lookupKey", "value").save();
+    });
+    return type;
+  }
+
+  private TypeIndex buildUnique(final String typeName, final Path spillParent, final int fanIn) {
+    final var builder = database.getSchema().buildTypeIndex(typeName, new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(1L << 20)
+        .withBuildMergeFanIn(fanIn);
+    if (spillParent != null)
+      builder.withBuildSpillDirectory(spillParent);
+    return builder.withUnique(true).create();
+  }
+
+  private void assertPlannerUses(final TypeIndex index, final String typeName, final String key) {
+    try (var result = database.query("sql", "SELECT FROM " + typeName + " WHERE lookupKey = ?", key)) {
+      final String plan = result.getExecutionPlan().orElseThrow().prettyPrint(0, 2);
+      assertThat(plan).contains("FETCH FROM INDEX").contains(index.getName());
+      assertThat(result.stream()).hasSize(1);
+    }
+  }
+
+  private static long count(final IndexCursor cursor) {
+    long total = 0L;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        total++;
+      }
+      return total;
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static long countNullKeys(final IndexCursor cursor) {
+    long total = 0L;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        if (cursor.getKeys()[0] == null)
+          total++;
+      }
+      return total;
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static void assertOrdered(final TypeIndex index, final int expected) {
+    final IndexCursor cursor = index.iterator(true);
+    String previous = null;
+    int count = 0;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        final String current = (String) cursor.getKeys()[0];
+        if (previous != null)
+          assertThat(current).isGreaterThan(previous);
+        previous = current;
+        count++;
+      }
+    } finally {
+      cursor.close();
+    }
+    assertThat(count).isEqualTo(expected);
+  }
+
+  private void assertNoBuildArtifactsInDatabase() throws Exception {
+    try (Stream<Path> files = Files.list(Path.of(database.getDatabasePath()))) {
+      assertThat(files.map(path -> path.getFileName().toString())
+          .filter(name -> name.endsWith(".numtidx") || name.endsWith(".nuctidx")
+              || name.endsWith(".temp_numtidx") || name.endsWith(".temp_nuctidx")
+              || name.startsWith(".arcadedb-sorted-index-build-")
+              || name.startsWith(".arcadedb-index-sort-"))
+          .toList()).isEmpty();
+    }
+  }
+
+  private static void assertNoBuildArtifacts(final Path parent) throws Exception {
+    if (parent == null || !Files.exists(parent))
+      return;
+    try (Stream<Path> paths = Files.list(parent)) {
+      assertThat(paths.filter(path -> path.getFileName().toString().startsWith(".arcadedb-index-sort-")).toList()).isEmpty();
+    }
+  }
+
+  private static String paddedKey(final String prefix, final int value) {
+    return "%s-%08d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".formatted(prefix, value);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBuildCrashTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBuildCrashTest.java
@@ -99,6 +99,29 @@ class LSMTreeSortedBuildCrashTest {
     assertThat(buildArtifacts(databasePath)).isEmpty();
   }
 
+  @Test
+  void uniqueBuildCrashAfterAttachmentLeavesNothingPublishedAndAllowsRetry() throws Exception {
+    final Path databasePath = tempDirectory.resolve("unique-crash-after-attachment");
+    assertThat(runChild("prepare", databasePath).exitCode()).isZero();
+    assertThat(runChild("crash-unique", databasePath).exitCode()).isEqualTo(CRASH_EXIT_CODE);
+
+    try (DatabaseFactory factory = new DatabaseFactory(databasePath.toString()); Database database = factory.open()) {
+      assertThat(database.getSchema().getType("CrashBuild").getIndexByProperties("lookupKey")).isNull();
+      assertThat(database.getSchema().getIndexes()).isEmpty();
+
+      final TypeIndex index = database.getSchema().buildTypeIndex("CrashBuild", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(16L << 20)
+          .withUnique(true)
+          .create();
+      assertThat(index.isUnique()).isTrue();
+      assertThat(count(index.iterator(true))).isEqualTo(2_000);
+    }
+
+    assertThat(buildArtifacts(databasePath)).isEmpty();
+  }
+
   public static void main(final String[] args) {
     if (args.length != 2)
       throw new IllegalArgumentException("Expected mode and database path");
@@ -107,7 +130,7 @@ class LSMTreeSortedBuildCrashTest {
       prepare(args[1]);
       return;
     }
-    if ("crash".equals(args[0]) || "crash-after-sort".equals(args[0])) {
+    if ("crash".equals(args[0]) || "crash-after-sort".equals(args[0]) || "crash-unique".equals(args[0])) {
       crash(args[0], args[1]);
       return;
     }
@@ -127,7 +150,7 @@ class LSMTreeSortedBuildCrashTest {
 
   private static void crash(final String mode, final String databasePath) {
     LSMTreeIndexBulkLoader.setBuildTestHook((phase, index, completedBuckets) -> {
-      if (("crash".equals(mode)
+      if ((("crash".equals(mode) || "crash-unique".equals(mode))
           && phase == LSMTreeIndexBulkLoader.BuildPhase.AFTER_BUCKET_ATTACHMENT && completedBuckets == 1)
           || ("crash-after-sort".equals(mode) && phase == LSMTreeIndexBulkLoader.BuildPhase.AFTER_SORT))
         Runtime.getRuntime().halt(CRASH_EXIT_CODE);
@@ -138,7 +161,7 @@ class LSMTreeSortedBuildCrashTest {
           .withType(Schema.INDEX_TYPE.LSM_TREE)
           .withBuildMode(IndexBuildMode.SORTED)
           .withBuildMemoryBudget("crash-after-sort".equals(mode) ? 1L << 20 : 16L << 20)
-          .withUnique(false)
+          .withUnique("crash-unique".equals(mode))
           .create();
     }
     throw new AssertionError("Sorted build completed without triggering crash hook");


### PR DESCRIPTION
## What does this PR do?

Extends the opt-in sorted `LSM_TREE` build path introduced in #5244 to unique indexes.

```java
schema.buildTypeIndex(typeName, propertyNames)
    .withType(Schema.INDEX_TYPE.LSM_TREE)
    .withBuildMode(IndexBuildMode.SORTED)
    .withUnique(true)
    .create();
```

The external-sort cursor is already globally ordered by normalized key and RID across every bucket
sub-index. This extension uses that stream as the uniqueness boundary:

- adjacent equal logical keys with different RIDs throw `DuplicatedKeyException`, except for
  ArcadeDB's established all-null-key exemption;
- repeated emission of the identical `(key, RID)` remains collapsed by existing grouping;
- with `SKIP`, partial-null composite keys remain indexed and uniqueness-constrained while all-null
  keys are skipped; with `ERROR`, any null component rejects the build;
- duplicate detection is global across bucket indexes and merge generations;
- no second sort, hash set, pre-pass, writer, publication mechanism, or public tuning option is
  introduced.

The only additional build state is the previous normalized key and RID.

## Failure and publication behavior

A late duplicate can be discovered after staged compacted pages have been written, but it still
publishes nothing. The cleanup ownership from #5244 removes staged components, spill runs, and the
recovery manifest, and a normal read-write reopen permits a corrected retry.

The initial boundary remains unchanged: explicit mode, `LSM_TREE`, single-server/non-replicated
operation, no active caller transaction, and one final schema publication after all bucket output
succeeds.

## Correctness and validation

Focused coverage includes:

- successful multi-bucket builds with multiple runs and merge generations;
- exact/range/ascending/descending reads, planner use, compaction, reopen, mutation, deletion, and
  key reuse;
- duplicates near the beginning, middle, and end, including cross-bucket duplicates;
- cleanup, reopen, correction, and retry after duplicate failure;
- repeated list expansion of one `(key, RID)` and case-insensitive composite collisions;
- `INDEX`, `SKIP`, and `ERROR` null strategies, including initial and future partial-null duplicate
  rejection;
- empty indexes, hard-process termination, recovery, and absence of residual artifacts.

The branch is based directly on merged #5244 commit `492239ae`; the PR head is `e46903ee`.

```text
Unique-path tests:       12 tests, 0 failures, 0 errors
Combined focused gate:   90 tests, 0 failures, 0 errors
Full package reactor:    25 modules, BUILD SUCCESS
```

The clean broad engine suite previously passed 9,139 tests with zero failures or errors and 23
skips on the pre-merge stack. `git range-diff` confirms the PR 2 patch is unchanged after replaying
it onto the accepted squash merge; the current-base focused and package gates above were rerun.

## Scale evidence

The 10M fixture used distinct URI keys, a 4 GiB heap, a 1 GiB build budget, fan-in 32, and about
504 MiB of spill output.

```text
Unique index phases:  25.915 s, 26.353 s
Unique mean:          26.134 s
#5244 non-unique mean: 25.467 s
Measured overhead:      2.62%
```

Both runs produced 10,000,000 entries with identical ascending and descending digests. Exact and
range reads, planner use, reopen, future duplicate rejection, and artifact cleanup passed.

A selected 50M build using the default-policy fan-in of 8 deliberately exercised two materialized
merge generations. Its index phase was 226.820 seconds, with 7.53 GiB cumulative spill and
4,467,712 KiB maximum RSS. Build, reopen, and post-rejected-write validation each contained all
50,000,000 entries with matching digests and clean artifact state.

These measurements describe the tested fixtures and configurations, not a general throughput
guarantee.

## Follow-up scope

Parallel merge groups and per-bucket writers, automatic fallback, SQL syntax, HA/replicated
operation, online snapshot-plus-delta construction, and multi-index construction remain separate
work.

A pre-existing `TypeIndex.get(null)` behavior with `NULL_STRATEGY.INDEX` was independently
reproduced on untouched upstream code: multiple null records are accepted, but exact lookup returns
only one. This retrieval defect is intentionally not changed here.
