### PR TITLE
Add bounded parallelism to sorted LSM index builds

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -60,7 +60,7 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   private final Path                       spillDirectory;
   private final Path                       spillWorkspace;
   private final int                        mergeFanIn;
-  private final int                        requestedWriterParallelism;
+  private final int                        requestedBuildParallelism;
   private final int                        maxEntriesPerRun;
   private final List<Entry>                entries;
   private final BuildTestHook               buildTestHook;
@@ -89,11 +89,11 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
 
   public LSMTreeIndexBulkLoader(final DatabaseInternal database, final String indexName,
       final long configuredMemoryBudgetBytes, final Path spillDirectory, final int mergeFanIn,
-      final Path spillWorkspace, final int writerParallelism) {
+      final Path spillWorkspace, final int buildParallelism) {
     if (mergeFanIn < 2)
       throw new IllegalArgumentException("mergeFanIn must be at least 2");
-    if (writerParallelism < 1)
-      throw new IllegalArgumentException("writerParallelism must be at least 1");
+    if (buildParallelism < 1)
+      throw new IllegalArgumentException("buildParallelism must be at least 1");
 
     this.database = database;
     this.indexName = indexName;
@@ -101,17 +101,17 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
     this.spillDirectory = spillDirectory;
     this.spillWorkspace = spillWorkspace;
     this.mergeFanIn = mergeFanIn;
-    this.requestedWriterParallelism = writerParallelism;
+    this.requestedBuildParallelism = buildParallelism;
     this.maxEntriesPerRun = (int) Math.max(1L,
         Math.min(Integer.MAX_VALUE, memoryBudgetBytes / ESTIMATED_BYTES_PER_ENTRY));
     this.entries = new ArrayList<>(Math.min(maxEntriesPerRun, 65_536));
     this.buildTestHook = BUILD_TEST_HOOK.get();
 
     LogManager.instance().log(this, Level.INFO,
-        "Sorted index build '%s': memoryBudget=%s maxEntriesPerRun=%,d spillParent=%s mergeFanIn=%d writerParallelism=%d",
+        "Sorted index build '%s': memoryBudget=%s maxEntriesPerRun=%,d spillParent=%s mergeFanIn=%d buildParallelism=%d",
         indexName, FileUtils.getSizeAsString(memoryBudgetBytes), maxEntriesPerRun,
         spillDirectory != null ? spillDirectory : Path.of(database.getDatabasePath()), mergeFanIn,
-        requestedWriterParallelism);
+        requestedBuildParallelism);
   }
 
   public void add(final LSMTreeIndex index, final Document record) {
@@ -146,7 +146,7 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
       final long started = System.nanoTime();
       final long mergeNanosBeforeStream = getMaterializedMergeNanos();
       final long streamStarted = System.nanoTime();
-      admittedWriterParallelism = selectWriterParallelism(requestedWriterParallelism, indexesByBucket.size(),
+      admittedWriterParallelism = selectWriterParallelism(requestedBuildParallelism, indexesByBucket.size(),
           memoryBudgetBytes, Runtime.getRuntime().availableProcessors(),
           LSMTreeIndexExternalSorter.getAvailableFileDescriptors());
 
@@ -288,7 +288,10 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
 
   public StageMetrics getStageMetrics() {
     return new StageMetrics(mergeFanIn, externalSorter != null ? externalSorter.getMergeFanIn() : mergeFanIn,
-        requestedWriterParallelism, admittedWriterParallelism, maxConcurrentWriters,
+        requestedBuildParallelism,
+        externalSorter != null ? externalSorter.getAdmittedMergeParallelism() : 1,
+        externalSorter != null ? externalSorter.getMaxConcurrentMerges() : 0,
+        admittedWriterParallelism, maxConcurrentWriters,
         externalSorter != null ? externalSorter.getInitialRunCount() : 0,
         externalSorter != null ? externalSorter.getRunCount() : 0,
         externalSorter != null ? externalSorter.getInitialRunEntries() : 0L,
@@ -366,7 +369,7 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
     try {
       if (externalSorter == null)
         externalSorter = new LSMTreeIndexExternalSorter(database, binaryKeyTypes, indexesByBucket, spillDirectory,
-            mergeFanIn, memoryBudgetBytes, spillWorkspace);
+            mergeFanIn, memoryBudgetBytes, spillWorkspace, requestedBuildParallelism);
       externalSorter.addRun(entries);
       entries.clear();
     } catch (final IOException error) {
@@ -448,7 +451,8 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   }
 
   public record StageMetrics(int requestedMergeFanIn, int admittedMergeFanIn,
-                             int requestedWriterParallelism, int admittedWriterParallelism,
+                             int requestedBuildParallelism, int admittedMergeParallelism,
+                             int maxConcurrentMerges, int admittedWriterParallelism,
                              int maxConcurrentWriters, int initialRuns, int finalRuns,
                              long initialRunEntries, long initialRunBytes, long initialRunNanos,
                              long inMemorySortNanos, int materializedMergeGenerations,

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -57,6 +57,9 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   private       byte[]                     binaryKeyTypes;
   private       Boolean                    unique;
   private       long                       totalEntries;
+  private       long                       inMemorySortNanos;
+  private       long                       finalStreamAndWriteNanos;
+  private       long                       attachmentNanos;
 
   public LSMTreeIndexBulkLoader(final DatabaseInternal database, final String indexName,
       final long configuredMemoryBudgetBytes, final Path spillDirectory, final int mergeFanIn) {
@@ -114,7 +117,9 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
     try {
       prepareSortedEntries();
       invokeBuildTestHook(BuildPhase.AFTER_SORT, null, 0);
-      final long started = System.currentTimeMillis();
+      final long started = System.nanoTime();
+      final long mergeNanosBeforeStream = getMaterializedMergeNanos();
+      final long streamStarted = System.nanoTime();
       final long written = forEachSortedGroup((first, rids) -> {
         BucketWriter writer = writers.get(first.index());
         if (writer == null) {
@@ -123,20 +128,25 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
         }
         writer.append(first.key().values, rids);
       });
+      final long streamNanos = System.nanoTime() - streamStarted;
+      finalStreamAndWriteNanos += Math.max(0L,
+          streamNanos - (getMaterializedMergeNanos() - mergeNanosBeforeStream));
       invokeBuildTestHook(BuildPhase.AFTER_ENTRY_WRITES, null, 0);
 
+      final long attachmentStarted = System.nanoTime();
       int attachedBuckets = 0;
       for (final BucketWriter writer : writers.values()) {
         writer.finishAndAttach();
         invokeBuildTestHook(BuildPhase.AFTER_BUCKET_ATTACHMENT, writer.mainIndex, ++attachedBuckets);
       }
       invokeBuildTestHook(BuildPhase.AFTER_ALL_ATTACHMENTS, null, attachedBuckets);
+      attachmentNanos += System.nanoTime() - attachmentStarted;
 
       success = true;
       final int runCount = externalSorter != null ? externalSorter.getRunCount() : 0;
       final long spillBytes = externalSorter != null ? externalSorter.getSpilledBytes() : 0L;
       final BuildOutcome outcome = new BuildOutcome(written, writers.size(), runCount, spillBytes,
-          System.currentTimeMillis() - started, memoryBudgetBytes);
+          (System.nanoTime() - started) / 1_000_000L, memoryBudgetBytes);
       LogManager.instance().log(this, Level.INFO,
           "Completed sorted index build '%s': entries=%,d bucketIndexes=%d finalRuns=%d spillBytes=%s writeMillis=%,d",
           indexName, outcome.entries(), outcome.bucketIndexes(), outcome.finalRuns(),
@@ -215,8 +225,29 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   private void prepareSortedEntries() {
     if (externalSorter != null)
       spillCurrentRun();
-    else
+    else {
+      final long started = System.nanoTime();
       entries.sort(LSMTreeIndexBulkLoader::compareEntries);
+      inMemorySortNanos += System.nanoTime() - started;
+    }
+  }
+
+  private long getMaterializedMergeNanos() {
+    return externalSorter != null ? externalSorter.getMaterializedMergeNanos() : 0L;
+  }
+
+  public StageMetrics getStageMetrics() {
+    return new StageMetrics(mergeFanIn, externalSorter != null ? externalSorter.getMergeFanIn() : mergeFanIn,
+        externalSorter != null ? externalSorter.getInitialRunCount() : 0,
+        externalSorter != null ? externalSorter.getRunCount() : 0,
+        externalSorter != null ? externalSorter.getInitialRunEntries() : 0L,
+        externalSorter != null ? externalSorter.getInitialRunBytes() : 0L,
+        externalSorter != null ? externalSorter.getInitialRunNanos() : 0L,
+        inMemorySortNanos,
+        externalSorter != null ? externalSorter.getMaterializedMergeGenerationCount() : 0,
+        externalSorter != null ? externalSorter.getMaterializedMergeEntries() : 0L,
+        externalSorter != null ? externalSorter.getMaterializedMergeBytes() : 0L,
+        getMaterializedMergeNanos(), finalStreamAndWriteNanos, attachmentNanos);
   }
 
   private LSMTreeIndexExternalSorter.EntryCursor openSortedEntries() throws IOException {
@@ -348,6 +379,13 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
 
   public record BuildOutcome(long entries, int bucketIndexes, int finalRuns, long spillBytes, long writeMillis,
                              long memoryBudgetBytes) {
+  }
+
+  public record StageMetrics(int requestedMergeFanIn, int admittedMergeFanIn, int initialRuns, int finalRuns,
+                             long initialRunEntries, long initialRunBytes, long initialRunNanos,
+                             long inMemorySortNanos, int materializedMergeGenerations,
+                             long materializedMergeEntries, long materializedMergeBytes,
+                             long materializedMergeNanos, long finalStreamAndWriteNanos, long attachmentNanos) {
   }
 
   @FunctionalInterface

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -536,9 +536,11 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
         try {
           future.get();
         } catch (final ExecutionException error) {
-          failure.compareAndSet(null, error.getCause());
+          final Throwable cause = error.getCause();
+          if (cause == null)
+            throw new IndexException("Sorted index bucket writer failed without a cause", error);
+          failure.compareAndSet(null, cause);
           checkFailure();
-          throw error;
         } catch (final InterruptedException error) {
           Thread.currentThread().interrupt();
           checkFailure();

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -494,11 +495,16 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
         thread.setDaemon(true);
         return thread;
       });
-      for (int i = 0; i < workerCount; i++) {
-        final ArrayBlockingQueue<WriteBatch> queue = new ArrayBlockingQueue<>(WRITER_QUEUE_CAPACITY);
-        queues.add(queue);
-        pendingBatches.add(new WriteBatch(false));
-        futures.add(executor.submit(() -> runWorker(queue)));
+      try {
+        for (int i = 0; i < workerCount; i++) {
+          final ArrayBlockingQueue<WriteBatch> queue = new ArrayBlockingQueue<>(WRITER_QUEUE_CAPACITY);
+          queues.add(queue);
+          pendingBatches.add(new WriteBatch(false));
+          futures.add(executor.submit(() -> runWorker(queue)));
+        }
+      } catch (final RuntimeException | Error error) {
+        executor.shutdownNow();
+        throw error;
       }
     }
 
@@ -526,8 +532,19 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
       }
 
       executor.shutdown();
-      for (final Future<?> future : futures)
-        future.get();
+      for (final Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (final ExecutionException error) {
+          failure.compareAndSet(null, error.getCause());
+          checkFailure();
+          throw error;
+        } catch (final InterruptedException error) {
+          Thread.currentThread().interrupt();
+          checkFailure();
+          throw error;
+        }
+      }
       checkFailure();
       if (!executor.awaitTermination(30L, TimeUnit.SECONDS))
         throw new IndexException("Timed out waiting for sorted index bucket writers");
@@ -546,7 +563,7 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
           final int active = activeWriters.incrementAndGet();
           maxActiveWriters.accumulateAndGet(active, Math::max);
           try {
-            for (int i = 0; i < batch.size(); i++) {
+            for (int i = 0; i < batch.size; i++) {
               if (failure.get() != null)
                 return;
               final BucketWriter writer = batch.writer(i);
@@ -558,10 +575,11 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
             activeWriters.decrementAndGet();
           }
         }
+      } catch (final InterruptedException error) {
+        failure.compareAndSet(null, error);
+        Thread.currentThread().interrupt();
       } catch (final Throwable error) {
         failure.compareAndSet(null, error);
-        if (error instanceof InterruptedException)
-          Thread.currentThread().interrupt();
       }
     }
 
@@ -633,10 +651,6 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
 
     private RID[] rids(final int index) {
       return rids[index];
-    }
-
-    private int size() {
-      return size;
     }
 
     private boolean isEmpty() {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBulkLoader.java
@@ -34,15 +34,25 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 /** Builds empty LSM indexes from a bounded, globally sorted logical entry stream. */
 public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   private static final ThreadLocal<BuildTestHook> BUILD_TEST_HOOK = new ThreadLocal<>();
 
-  private static final long ESTIMATED_BYTES_PER_ENTRY   = 3_072L;
-  private static final long MIN_MEMORY_BUDGET_BYTES     = 1L << 20;
-  private static final int  MAX_BUFFERED_RIDS_PER_GROUP = 256;
+  private static final long ESTIMATED_BYTES_PER_ENTRY    = 3_072L;
+  private static final long MIN_MEMORY_BUDGET_BYTES      = 1L << 20;
+  private static final long WRITER_WORKER_OVERHEAD_BYTES = 8L << 20;
+  private static final int  MAX_BUFFERED_RIDS_PER_GROUP  = 256;
+  private static final int  WRITER_BATCH_GROUPS          = 256;
+  private static final int  WRITER_QUEUE_CAPACITY        = 8;
 
   private final DatabaseInternal           database;
   private final String                     indexName;
@@ -50,8 +60,10 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   private final Path                       spillDirectory;
   private final Path                       spillWorkspace;
   private final int                        mergeFanIn;
+  private final int                        requestedWriterParallelism;
   private final int                        maxEntriesPerRun;
   private final List<Entry>                entries;
+  private final BuildTestHook               buildTestHook;
   private final Map<Integer, LSMTreeIndex> indexesByBucket = new LinkedHashMap<>();
   private       LSMTreeIndexExternalSorter externalSorter;
   private       byte[]                     binaryKeyTypes;
@@ -60,17 +72,28 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   private       long                       inMemorySortNanos;
   private       long                       finalStreamAndWriteNanos;
   private       long                       attachmentNanos;
+  private       int                        admittedWriterParallelism = 1;
+  private       int                        maxConcurrentWriters;
+  private final AtomicInteger              completedWriterGroups = new AtomicInteger();
 
   public LSMTreeIndexBulkLoader(final DatabaseInternal database, final String indexName,
       final long configuredMemoryBudgetBytes, final Path spillDirectory, final int mergeFanIn) {
-    this(database, indexName, configuredMemoryBudgetBytes, spillDirectory, mergeFanIn, null);
+    this(database, indexName, configuredMemoryBudgetBytes, spillDirectory, mergeFanIn, null, 1);
   }
 
   public LSMTreeIndexBulkLoader(final DatabaseInternal database, final String indexName,
       final long configuredMemoryBudgetBytes, final Path spillDirectory, final int mergeFanIn,
       final Path spillWorkspace) {
+    this(database, indexName, configuredMemoryBudgetBytes, spillDirectory, mergeFanIn, spillWorkspace, 1);
+  }
+
+  public LSMTreeIndexBulkLoader(final DatabaseInternal database, final String indexName,
+      final long configuredMemoryBudgetBytes, final Path spillDirectory, final int mergeFanIn,
+      final Path spillWorkspace, final int writerParallelism) {
     if (mergeFanIn < 2)
       throw new IllegalArgumentException("mergeFanIn must be at least 2");
+    if (writerParallelism < 1)
+      throw new IllegalArgumentException("writerParallelism must be at least 1");
 
     this.database = database;
     this.indexName = indexName;
@@ -78,14 +101,17 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
     this.spillDirectory = spillDirectory;
     this.spillWorkspace = spillWorkspace;
     this.mergeFanIn = mergeFanIn;
+    this.requestedWriterParallelism = writerParallelism;
     this.maxEntriesPerRun = (int) Math.max(1L,
         Math.min(Integer.MAX_VALUE, memoryBudgetBytes / ESTIMATED_BYTES_PER_ENTRY));
     this.entries = new ArrayList<>(Math.min(maxEntriesPerRun, 65_536));
+    this.buildTestHook = BUILD_TEST_HOOK.get();
 
     LogManager.instance().log(this, Level.INFO,
-        "Sorted index build '%s': memoryBudget=%s maxEntriesPerRun=%,d spillParent=%s mergeFanIn=%d",
+        "Sorted index build '%s': memoryBudget=%s maxEntriesPerRun=%,d spillParent=%s mergeFanIn=%d writerParallelism=%d",
         indexName, FileUtils.getSizeAsString(memoryBudgetBytes), maxEntriesPerRun,
-        spillDirectory != null ? spillDirectory : Path.of(database.getDatabasePath()), mergeFanIn);
+        spillDirectory != null ? spillDirectory : Path.of(database.getDatabasePath()), mergeFanIn,
+        requestedWriterParallelism);
   }
 
   public void add(final LSMTreeIndex index, final Document record) {
@@ -120,14 +146,21 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
       final long started = System.nanoTime();
       final long mergeNanosBeforeStream = getMaterializedMergeNanos();
       final long streamStarted = System.nanoTime();
-      final long written = forEachSortedGroup((first, rids) -> {
-        BucketWriter writer = writers.get(first.index());
-        if (writer == null) {
-          writer = new BucketWriter(first.index());
-          writers.put(first.index(), writer);
+      admittedWriterParallelism = selectWriterParallelism(requestedWriterParallelism, indexesByBucket.size(),
+          memoryBudgetBytes, Runtime.getRuntime().availableProcessors(),
+          LSMTreeIndexExternalSorter.getAvailableFileDescriptors());
+
+      final long written;
+      if (admittedWriterParallelism > 1) {
+        try (BucketWriteDispatcher dispatcher = new BucketWriteDispatcher(writers, admittedWriterParallelism)) {
+          written = forEachSortedGroup(dispatcher::append);
+          dispatcher.complete();
+          maxConcurrentWriters = dispatcher.getMaxConcurrentWriters();
         }
-        writer.append(first.key().values, rids);
-      });
+      } else {
+        written = forEachSortedGroup((first, rids) -> appendDirect(writers, first, rids));
+        maxConcurrentWriters = writers.isEmpty() ? 0 : 1;
+      }
       final long streamNanos = System.nanoTime() - streamStarted;
       finalStreamAndWriteNanos += Math.max(0L,
           streamNanos - (getMaterializedMergeNanos() - mergeNanosBeforeStream));
@@ -168,6 +201,23 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
 
   public long size() {
     return totalEntries;
+  }
+
+  private void appendDirect(final Map<LSMTreeIndex, BucketWriter> writers, final Entry first, final RID[] rids)
+      throws IOException, InterruptedException {
+    final BucketWriter writer = getOrCreateWriter(writers, first.index());
+    writer.append(first.key().values, rids);
+    invokeBuildTestHook(BuildPhase.AFTER_BUCKET_APPEND, first.index(), completedWriterGroups.incrementAndGet());
+  }
+
+  private BucketWriter getOrCreateWriter(final Map<LSMTreeIndex, BucketWriter> writers, final LSMTreeIndex index)
+      throws IOException {
+    BucketWriter writer = writers.get(index);
+    if (writer == null) {
+      writer = new BucketWriter(index);
+      writers.put(index, writer);
+    }
+    return writer;
   }
 
   private long forEachSortedGroup(final SortedGroupConsumer consumer) throws Exception {
@@ -238,6 +288,7 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
 
   public StageMetrics getStageMetrics() {
     return new StageMetrics(mergeFanIn, externalSorter != null ? externalSorter.getMergeFanIn() : mergeFanIn,
+        requestedWriterParallelism, admittedWriterParallelism, maxConcurrentWriters,
         externalSorter != null ? externalSorter.getInitialRunCount() : 0,
         externalSorter != null ? externalSorter.getRunCount() : 0,
         externalSorter != null ? externalSorter.getInitialRunEntries() : 0L,
@@ -248,6 +299,21 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
         externalSorter != null ? externalSorter.getMaterializedMergeEntries() : 0L,
         externalSorter != null ? externalSorter.getMaterializedMergeBytes() : 0L,
         getMaterializedMergeNanos(), finalStreamAndWriteNanos, attachmentNanos);
+  }
+
+  static int selectWriterParallelism(final int configured, final int bucketIndexes, final long memoryBudgetBytes,
+      final int availableProcessors, final long availableFileDescriptors) {
+    if (configured < 1)
+      throw new IllegalArgumentException("writer parallelism must be at least 1");
+    if (bucketIndexes < 1)
+      return 1;
+
+    final long cpuLimit = Math.max(1L, (long) availableProcessors - 1L);
+    final long memoryLimit = Math.max(1L, memoryBudgetBytes / WRITER_WORKER_OVERHEAD_BYTES);
+    final long descriptorLimit = availableFileDescriptors == Long.MAX_VALUE ? Integer.MAX_VALUE
+        : Math.max(1L, availableFileDescriptors / 2L);
+    return (int) Math.min(configured,
+        Math.min(bucketIndexes, Math.min(cpuLimit, Math.min(memoryLimit, descriptorLimit))));
   }
 
   private LSMTreeIndexExternalSorter.EntryCursor openSortedEntries() throws IOException {
@@ -358,15 +424,15 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
       BUILD_TEST_HOOK.set(hook);
   }
 
-  private static void invokeBuildTestHook(final BuildPhase phase, final LSMTreeIndex index,
+  private void invokeBuildTestHook(final BuildPhase phase, final LSMTreeIndex index,
       final int completedBuckets) {
-    final BuildTestHook hook = BUILD_TEST_HOOK.get();
-    if (hook != null)
-      hook.onPhase(phase, index, completedBuckets);
+    if (buildTestHook != null)
+      buildTestHook.onPhase(phase, index, completedBuckets);
   }
 
   enum BuildPhase {
     AFTER_SORT,
+    AFTER_BUCKET_APPEND,
     AFTER_ENTRY_WRITES,
     AFTER_BUCKET_ATTACHMENT,
     AFTER_ALL_ATTACHMENTS
@@ -381,7 +447,9 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
                              long memoryBudgetBytes) {
   }
 
-  public record StageMetrics(int requestedMergeFanIn, int admittedMergeFanIn, int initialRuns, int finalRuns,
+  public record StageMetrics(int requestedMergeFanIn, int admittedMergeFanIn,
+                             int requestedWriterParallelism, int admittedWriterParallelism,
+                             int maxConcurrentWriters, int initialRuns, int finalRuns,
                              long initialRunEntries, long initialRunBytes, long initialRunNanos,
                              long inMemorySortNanos, int materializedMergeGenerations,
                              long materializedMergeEntries, long materializedMergeBytes,
@@ -391,6 +459,193 @@ public final class LSMTreeIndexBulkLoader implements AutoCloseable {
   @FunctionalInterface
   private interface SortedGroupConsumer {
     void accept(Entry first, RID[] rids) throws Exception;
+  }
+
+  private final class BucketWriteDispatcher implements AutoCloseable {
+    private final Map<LSMTreeIndex, BucketWriter> writers;
+    private final List<ArrayBlockingQueue<WriteBatch>> queues;
+    private final List<WriteBatch> pendingBatches;
+    private final Map<Integer, Integer> workerByBucket = new LinkedHashMap<>();
+    private final ExecutorService executor;
+    private final List<Future<?>> futures = new ArrayList<>();
+    private final AtomicReference<Throwable> failure = new AtomicReference<>();
+    private final AtomicInteger activeWriters = new AtomicInteger();
+    private final AtomicInteger maxActiveWriters = new AtomicInteger();
+    private final WriteBatch poison = new WriteBatch(true);
+    private boolean completed;
+
+    private BucketWriteDispatcher(final Map<LSMTreeIndex, BucketWriter> writers, final int workerCount) {
+      this.writers = writers;
+      this.queues = new ArrayList<>(workerCount);
+      this.pendingBatches = new ArrayList<>(workerCount);
+
+      final List<Integer> bucketIds = new ArrayList<>(indexesByBucket.keySet());
+      bucketIds.sort(Integer::compareTo);
+      for (int i = 0; i < bucketIds.size(); i++)
+        workerByBucket.put(bucketIds.get(i), i % workerCount);
+
+      final AtomicInteger threadNumber = new AtomicInteger();
+      executor = Executors.newFixedThreadPool(workerCount, task -> {
+        final Thread thread = new Thread(task, "arcadedb-index-bucket-writer-" + threadNumber.incrementAndGet());
+        thread.setDaemon(true);
+        return thread;
+      });
+      for (int i = 0; i < workerCount; i++) {
+        final ArrayBlockingQueue<WriteBatch> queue = new ArrayBlockingQueue<>(WRITER_QUEUE_CAPACITY);
+        queues.add(queue);
+        pendingBatches.add(new WriteBatch(false));
+        futures.add(executor.submit(() -> runWorker(queue)));
+      }
+    }
+
+    private void append(final Entry first, final RID[] rids) throws Exception {
+      checkFailure();
+      final BucketWriter writer = getOrCreateWriter(writers, first.index());
+      final Integer worker = workerByBucket.get(first.index().getAssociatedBucketId());
+      if (worker == null)
+        throw new IndexException("No writer worker assigned to bucket " + first.index().getAssociatedBucketId());
+
+      WriteBatch batch = pendingBatches.get(worker);
+      batch.add(writer, first.key().values, rids);
+      if (batch.isFull()) {
+        enqueue(queues.get(worker), batch);
+        pendingBatches.set(worker, new WriteBatch(false));
+      }
+    }
+
+    private void complete() throws Exception {
+      for (int i = 0; i < queues.size(); i++) {
+        final WriteBatch pending = pendingBatches.get(i);
+        if (!pending.isEmpty())
+          enqueue(queues.get(i), pending);
+        enqueue(queues.get(i), poison);
+      }
+
+      executor.shutdown();
+      for (final Future<?> future : futures)
+        future.get();
+      checkFailure();
+      if (!executor.awaitTermination(30L, TimeUnit.SECONDS))
+        throw new IndexException("Timed out waiting for sorted index bucket writers");
+      completed = true;
+    }
+
+    private void runWorker(final ArrayBlockingQueue<WriteBatch> queue) {
+      try {
+        while (true) {
+          if (failure.get() != null)
+            return;
+          final WriteBatch batch = queue.take();
+          if (batch.isPoison())
+            return;
+
+          final int active = activeWriters.incrementAndGet();
+          maxActiveWriters.accumulateAndGet(active, Math::max);
+          try {
+            for (int i = 0; i < batch.size(); i++) {
+              if (failure.get() != null)
+                return;
+              final BucketWriter writer = batch.writer(i);
+              writer.append(batch.keys(i), batch.rids(i));
+              invokeBuildTestHook(BuildPhase.AFTER_BUCKET_APPEND, writer.mainIndex,
+                  completedWriterGroups.incrementAndGet());
+            }
+          } finally {
+            activeWriters.decrementAndGet();
+          }
+        }
+      } catch (final Throwable error) {
+        failure.compareAndSet(null, error);
+        if (error instanceof InterruptedException)
+          Thread.currentThread().interrupt();
+      }
+    }
+
+    private void enqueue(final ArrayBlockingQueue<WriteBatch> queue, final WriteBatch batch) throws Exception {
+      while (!queue.offer(batch, 100L, TimeUnit.MILLISECONDS))
+        checkFailure();
+    }
+
+    private void checkFailure() throws Exception {
+      final Throwable error = failure.get();
+      if (error == null)
+        return;
+      if (error instanceof Exception exception)
+        throw exception;
+      if (error instanceof Error fatal)
+        throw fatal;
+      throw new IndexException("Sorted index bucket writer failed", error);
+    }
+
+    private int getMaxConcurrentWriters() {
+      return maxActiveWriters.get();
+    }
+
+    @Override
+    public void close() {
+      if (!completed) {
+        for (final ArrayBlockingQueue<WriteBatch> queue : queues)
+          queue.clear();
+        executor.shutdownNow();
+      }
+      try {
+        if (!executor.awaitTermination(30L, TimeUnit.SECONDS))
+          LogManager.instance().log(LSMTreeIndexBulkLoader.this, Level.WARNING,
+              "Timed out stopping sorted index bucket writers for '%s'", indexName);
+      } catch (final InterruptedException error) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private final class WriteBatch {
+    private final BucketWriter[] writers;
+    private final Object[][] keys;
+    private final RID[][] rids;
+    private final boolean poison;
+    private int size;
+
+    private WriteBatch(final boolean poison) {
+      this.poison = poison;
+      this.writers = poison ? null : new BucketWriter[WRITER_BATCH_GROUPS];
+      this.keys = poison ? null : new Object[WRITER_BATCH_GROUPS][];
+      this.rids = poison ? null : new RID[WRITER_BATCH_GROUPS][];
+    }
+
+    private void add(final BucketWriter writer, final Object[] key, final RID[] ridValues) {
+      writers[size] = writer;
+      keys[size] = key;
+      rids[size] = ridValues;
+      size++;
+    }
+
+    private BucketWriter writer(final int index) {
+      return writers[index];
+    }
+
+    private Object[] keys(final int index) {
+      return keys[index];
+    }
+
+    private RID[] rids(final int index) {
+      return rids[index];
+    }
+
+    private int size() {
+      return size;
+    }
+
+    private boolean isEmpty() {
+      return size == 0;
+    }
+
+    private boolean isFull() {
+      return size == WRITER_BATCH_GROUPS;
+    }
+
+    private boolean isPoison() {
+      return poison;
+    }
   }
 
   private final class BucketWriter {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
@@ -108,7 +108,7 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
     return (int) Math.min(configured, Math.min(memoryLimit, Math.min(descriptorLimit, Integer.MAX_VALUE)));
   }
 
-  private static long getAvailableFileDescriptors() {
+  static long getAvailableFileDescriptors() {
     try {
       final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
       final ObjectName operatingSystem = ObjectName.getInstance(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
@@ -33,6 +33,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,6 +44,13 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 /** Creates bounded sorted spill runs and exposes a k-way merged entry stream. */
@@ -50,11 +58,13 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
   static final String DIRECTORY_PREFIX = ".arcadedb-index-sort-";
 
   private static final ThreadLocal<SpillWriteTestHook> SPILL_WRITE_TEST_HOOK = new ThreadLocal<>();
+  private static final ThreadLocal<MaterializedMergeTestHook> MATERIALIZED_MERGE_TEST_HOOK = new ThreadLocal<>();
 
   private static final int RUN_MAGIC       = 0x41584953;
   private static final int RUN_VERSION     = 1;
   private static final int BUFFER_SIZE     = 256 << 10;
   private static final int MAX_ENTRY_BYTES = 64 << 20;
+  private static final long MERGE_WORKER_OVERHEAD_BYTES = 8L << 20;
   private static final long FILE_DESCRIPTOR_RESERVE = 64L;
 
   private final DatabaseInternal                  database;
@@ -63,8 +73,13 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
   private final Map<Integer, LSMTreeIndex>         indexesByBucket;
   private final Path                              directory;
   private final int                               mergeFanIn;
+  private final int                               admittedMergeParallelism;
   private final List<RunFile>                     runs = new ArrayList<>();
   private final Binary                            writePayload = new Binary();
+  private final SpillWriteTestHook                spillWriteTestHook;
+  private final MaterializedMergeTestHook         materializedMergeTestHook;
+  private final AtomicInteger                     activeMerges = new AtomicInteger();
+  private final AtomicInteger                     maxConcurrentMerges = new AtomicInteger();
   private       int                               initialRunCount;
   private       long                              initialRunEntries;
   private       long                              initialRunBytes;
@@ -77,15 +92,22 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
 
   LSMTreeIndexExternalSorter(final DatabaseInternal database, final byte[] binaryKeyTypes,
       final Map<Integer, LSMTreeIndex> indexesByBucket, final Path spillParent, final int configuredMergeFanIn,
-      final long memoryBudgetBytes, final Path spillWorkspace) throws IOException {
+      final long memoryBudgetBytes, final Path spillWorkspace, final int configuredMergeParallelism) throws IOException {
     if (configuredMergeFanIn < 2)
       throw new IllegalArgumentException("mergeFanIn must be at least 2");
+    if (configuredMergeParallelism < 1)
+      throw new IllegalArgumentException("mergeParallelism must be at least 1");
 
     this.database = database;
     this.serializer = database.getSerializer();
     this.binaryKeyTypes = Arrays.copyOf(binaryKeyTypes, binaryKeyTypes.length);
     this.indexesByBucket = indexesByBucket;
-    this.mergeFanIn = selectMergeFanIn(configuredMergeFanIn, memoryBudgetBytes, getAvailableFileDescriptors());
+    final long availableFileDescriptors = getAvailableFileDescriptors();
+    this.mergeFanIn = selectMergeFanIn(configuredMergeFanIn, memoryBudgetBytes, availableFileDescriptors);
+    this.admittedMergeParallelism = selectMergeParallelism(configuredMergeParallelism, mergeFanIn,
+        memoryBudgetBytes, Runtime.getRuntime().availableProcessors(), availableFileDescriptors);
+    this.spillWriteTestHook = SPILL_WRITE_TEST_HOOK.get();
+    this.materializedMergeTestHook = MATERIALIZED_MERGE_TEST_HOOK.get();
 
     if (spillWorkspace != null) {
       directory = spillWorkspace.toAbsolutePath().normalize();
@@ -106,6 +128,21 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
     if (descriptorLimit < 2L)
       throw new IOException("Insufficient file descriptors for external sort merging");
     return (int) Math.min(configured, Math.min(memoryLimit, Math.min(descriptorLimit, Integer.MAX_VALUE)));
+  }
+
+  static int selectMergeParallelism(final int configured, final int mergeFanIn, final long memoryBudgetBytes,
+      final int availableProcessors, final long availableFileDescriptors) {
+    if (configured < 1)
+      throw new IllegalArgumentException("merge parallelism must be at least 1");
+    if (mergeFanIn < 2)
+      throw new IllegalArgumentException("merge fan-in must be at least 2");
+
+    final long cpuLimit = Math.max(1L, (long) availableProcessors - 1L);
+    final long bytesPerWorker = ((long) mergeFanIn + 1L) * BUFFER_SIZE + MERGE_WORKER_OVERHEAD_BYTES;
+    final long memoryLimit = Math.max(1L, memoryBudgetBytes / bytesPerWorker);
+    final long descriptorLimit = availableFileDescriptors == Long.MAX_VALUE ? Integer.MAX_VALUE
+        : Math.max(1L, availableFileDescriptors / (mergeFanIn + 1L));
+    return (int) Math.min(configured, Math.min(cpuLimit, Math.min(memoryLimit, descriptorLimit)));
   }
 
   static long getAvailableFileDescriptors() {
@@ -136,7 +173,7 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
     boolean complete = false;
     try (DataOutputStream output = openRunOutput(run, entries.size())) {
       for (final LSMTreeIndexBulkLoader.Entry entry : entries)
-        writeEntry(output, entry);
+        writeEntry(output, entry, writePayload);
       complete = true;
     } finally {
       if (!complete)
@@ -167,6 +204,14 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
 
   int getMergeFanIn() {
     return mergeFanIn;
+  }
+
+  int getAdmittedMergeParallelism() {
+    return admittedMergeParallelism;
+  }
+
+  int getMaxConcurrentMerges() {
+    return maxConcurrentMerges.get();
   }
 
   int getInitialRunCount() {
@@ -244,26 +289,109 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
   }
 
   private List<MergeResult> executeMergePlans(final List<MergePlan> plans) throws IOException {
-    final List<MergeResult> results = new ArrayList<>(plans.size());
-    for (final MergePlan plan : plans) {
-      final RunFile merged = mergeRuns(plan.sources(), plan.outputPath(), plan.entryCount());
-      results.add(new MergeResult(plan.groupIndex(), merged, Files.size(plan.outputPath()), plan.sources()));
+    if (plans.isEmpty())
+      return List.of();
+    if (admittedMergeParallelism == 1 || plans.size() == 1) {
+      final List<MergeResult> results = new ArrayList<>(plans.size());
+      for (final MergePlan plan : plans)
+        results.add(mergeRuns(plan));
+      return results;
     }
+
+    final int workers = Math.min(admittedMergeParallelism, plans.size());
+    final AtomicInteger threadNumber = new AtomicInteger();
+    final ExecutorService executor = Executors.newFixedThreadPool(workers, task -> {
+      final Thread thread = new Thread(task, "arcadedb-index-merge-" + threadNumber.incrementAndGet());
+      thread.setDaemon(true);
+      return thread;
+    });
+    final ExecutorCompletionService<MergeResult> completion = new ExecutorCompletionService<>(executor);
+    final List<Future<MergeResult>> futures = new ArrayList<>(plans.size());
+    final List<MergeResult> results = new ArrayList<>(plans.size());
+    Throwable failure = null;
+    boolean interrupted = false;
+    try {
+      for (final MergePlan plan : plans)
+        futures.add(completion.submit(() -> mergeRuns(plan)));
+      for (int i = 0; i < plans.size(); i++)
+        results.add(completion.take().get());
+    } catch (final ExecutionException error) {
+      failure = error.getCause();
+    } catch (final InterruptedException error) {
+      failure = new InterruptedIOException("Interrupted while merging external sort runs");
+      failure.initCause(error);
+      interrupted = true;
+    } catch (final RuntimeException | Error error) {
+      failure = error;
+    } finally {
+      if (failure != null) {
+        for (final Future<MergeResult> future : futures)
+          future.cancel(true);
+        executor.shutdownNow();
+      } else
+        executor.shutdown();
+
+      try {
+        if (!executor.awaitTermination(30L, TimeUnit.SECONDS)) {
+          executor.shutdownNow();
+          if (!executor.awaitTermination(30L, TimeUnit.SECONDS)) {
+            final IOException timeout = new IOException("Timed out stopping external sort merge workers");
+            if (failure == null)
+              failure = timeout;
+            else
+              failure.addSuppressed(timeout);
+          }
+        }
+      } catch (final InterruptedException error) {
+        final InterruptedIOException waitFailure = new InterruptedIOException(
+            "Interrupted while stopping external sort merge workers");
+        waitFailure.initCause(error);
+        if (failure == null)
+          failure = waitFailure;
+        else
+          failure.addSuppressed(waitFailure);
+        interrupted = true;
+        executor.shutdownNow();
+      }
+    }
+
+    if (interrupted)
+      Thread.currentThread().interrupt();
+    if (failure instanceof IOException ioError)
+      throw ioError;
+    if (failure instanceof RuntimeException runtimeError)
+      throw runtimeError;
+    if (failure instanceof Error fatalError)
+      throw fatalError;
+    if (failure != null)
+      throw new IOException("Cannot merge external sort runs", failure);
+
+    results.sort(Comparator.comparingInt(MergeResult::groupIndex));
     return results;
   }
 
-  private RunFile mergeRuns(final List<RunFile> sources, final Path outputPath, final long entryCount) throws IOException {
+  private MergeResult mergeRuns(final MergePlan plan) throws IOException {
+    final int active = activeMerges.incrementAndGet();
+    maxConcurrentMerges.accumulateAndGet(active, Math::max);
+    final Binary payload = new Binary();
+    long entriesWritten = 0L;
     boolean complete = false;
-    try (DataOutputStream output = openRunOutput(outputPath, entryCount);
-        EntryCursor cursor = new MergedCursor(sources)) {
-      while (cursor.hasNext())
-        writeEntry(output, cursor.next());
+    try (DataOutputStream output = openRunOutput(plan.outputPath(), plan.entryCount());
+        EntryCursor cursor = new MergedCursor(plan.sources())) {
+      while (cursor.hasNext()) {
+        if (Thread.currentThread().isInterrupted())
+          throw new InterruptedIOException("External sort merge worker was cancelled");
+        writeEntry(output, cursor.next(), payload);
+        invokeMaterializedMergeTestHook(plan.groupIndex(), ++entriesWritten);
+      }
       complete = true;
     } finally {
+      activeMerges.decrementAndGet();
       if (!complete)
-        Files.deleteIfExists(outputPath);
+        Files.deleteIfExists(plan.outputPath());
     }
-    return new RunFile(outputPath, entryCount);
+    final RunFile merged = new RunFile(plan.outputPath(), plan.entryCount());
+    return new MergeResult(plan.groupIndex(), merged, Files.size(plan.outputPath()), plan.sources());
   }
 
   private DataOutputStream openRunOutput(final Path path, final long entryCount) throws IOException {
@@ -286,23 +414,40 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
     }
   }
 
-  private void writeEntry(final DataOutputStream output, final LSMTreeIndexBulkLoader.Entry entry) throws IOException {
-    writePayload.clear();
+  private void writeEntry(final DataOutputStream output, final LSMTreeIndexBulkLoader.Entry entry,
+      final Binary payload) throws IOException {
+    payload.clear();
     for (int i = 0; i < binaryKeyTypes.length; i++) {
       final Object key = entry.key().values[i];
-      writePayload.putByte((byte) (key == null ? 0 : 1));
+      payload.putByte((byte) (key == null ? 0 : 1));
       if (key != null)
-        serializer.serializeValue(database, writePayload, binaryKeyTypes[i], key);
+        serializer.serializeValue(database, payload, binaryKeyTypes[i], key);
     }
-    serializer.serializeValue(database, writePayload, BinaryTypes.TYPE_COMPRESSED_RID, entry.rid());
+    serializer.serializeValue(database, payload, BinaryTypes.TYPE_COMPRESSED_RID, entry.rid());
 
     output.writeInt(entry.index().getAssociatedBucketId());
-    output.writeInt(writePayload.size());
-    output.write(writePayload.getContent(), writePayload.getContentBeginOffset(), writePayload.size());
+    output.writeInt(payload.size());
+    output.write(payload.getContent(), payload.getContentBeginOffset(), payload.size());
 
-    final SpillWriteTestHook hook = SPILL_WRITE_TEST_HOOK.get();
-    if (hook != null)
-      hook.afterEntryWritten();
+    if (spillWriteTestHook != null)
+      spillWriteTestHook.afterEntryWritten();
+  }
+
+  private void invokeMaterializedMergeTestHook(final int groupIndex, final long entriesWritten) throws IOException {
+    if (materializedMergeTestHook == null)
+      return;
+    try {
+      materializedMergeTestHook.afterEntryWritten(mergeGeneration, groupIndex, entriesWritten);
+    } catch (final InterruptedException error) {
+      Thread.currentThread().interrupt();
+      final InterruptedIOException interrupted = new InterruptedIOException("Materialized merge test hook interrupted");
+      interrupted.initCause(error);
+      throw interrupted;
+    } catch (final IOException | RuntimeException error) {
+      throw error;
+    } catch (final Exception error) {
+      throw new IOException("Materialized merge test hook failed", error);
+    }
   }
 
   static void setSpillWriteTestHook(final SpillWriteTestHook hook) {
@@ -310,6 +455,13 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
       SPILL_WRITE_TEST_HOOK.remove();
     else
       SPILL_WRITE_TEST_HOOK.set(hook);
+  }
+
+  static void setMaterializedMergeTestHook(final MaterializedMergeTestHook hook) {
+    if (hook == null)
+      MATERIALIZED_MERGE_TEST_HOOK.remove();
+    else
+      MATERIALIZED_MERGE_TEST_HOOK.set(hook);
   }
 
   @Override
@@ -503,5 +655,10 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
   @FunctionalInterface
   interface SpillWriteTestHook {
     void afterEntryWritten() throws IOException;
+  }
+
+  @FunctionalInterface
+  interface MaterializedMergeTestHook {
+    void afterEntryWritten(int generation, int groupIndex, long entriesWritten) throws Exception;
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexExternalSorter.java
@@ -65,6 +65,13 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
   private final int                               mergeFanIn;
   private final List<RunFile>                     runs = new ArrayList<>();
   private final Binary                            writePayload = new Binary();
+  private       int                               initialRunCount;
+  private       long                              initialRunEntries;
+  private       long                              initialRunBytes;
+  private       long                              initialRunNanos;
+  private       long                              materializedMergeEntries;
+  private       long                              materializedMergeBytes;
+  private       long                              materializedMergeNanos;
   private       long                              spilledBytes;
   private       int                               mergeGeneration;
 
@@ -123,6 +130,7 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
     if (entries.isEmpty())
       return;
 
+    final long started = System.nanoTime();
     entries.sort(LSMTreeIndexBulkLoader::compareEntries);
     final Path run = directory.resolve("run-%06d.bin".formatted(runs.size()));
     boolean complete = false;
@@ -135,8 +143,13 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
         Files.deleteIfExists(run);
     }
 
+    final long runBytes = Files.size(run);
     runs.add(new RunFile(run, entries.size()));
-    spilledBytes += Files.size(run);
+    initialRunCount++;
+    initialRunEntries += entries.size();
+    initialRunBytes += runBytes;
+    initialRunNanos += System.nanoTime() - started;
+    spilledBytes += runBytes;
   }
 
   EntryCursor openCursor() throws IOException {
@@ -152,34 +165,91 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
     return spilledBytes;
   }
 
+  int getMergeFanIn() {
+    return mergeFanIn;
+  }
+
+  int getInitialRunCount() {
+    return initialRunCount;
+  }
+
+  long getInitialRunEntries() {
+    return initialRunEntries;
+  }
+
+  long getInitialRunBytes() {
+    return initialRunBytes;
+  }
+
+  long getInitialRunNanos() {
+    return initialRunNanos;
+  }
+
+  int getMaterializedMergeGenerationCount() {
+    return mergeGeneration;
+  }
+
+  long getMaterializedMergeEntries() {
+    return materializedMergeEntries;
+  }
+
+  long getMaterializedMergeBytes() {
+    return materializedMergeBytes;
+  }
+
+  long getMaterializedMergeNanos() {
+    return materializedMergeNanos;
+  }
+
   private void consolidateRuns() throws IOException {
     while (runs.size() > mergeFanIn) {
-      final List<RunFile> mergedRuns = new ArrayList<>((runs.size() + mergeFanIn - 1) / mergeFanIn);
       final List<RunFile> sourceRuns = new ArrayList<>(runs);
+      final RunFile[] mergedRuns = new RunFile[(sourceRuns.size() + mergeFanIn - 1) / mergeFanIn];
+      final List<MergePlan> mergePlans = new ArrayList<>(mergedRuns.length);
 
-      for (int from = 0; from < sourceRuns.size(); from += mergeFanIn) {
+      int groupIndex = 0;
+      for (int from = 0; from < sourceRuns.size(); from += mergeFanIn, groupIndex++) {
         final int to = Math.min(sourceRuns.size(), from + mergeFanIn);
         final List<RunFile> group = sourceRuns.subList(from, to);
         if (group.size() == 1) {
-          mergedRuns.add(group.getFirst());
+          mergedRuns[groupIndex] = group.getFirst();
           continue;
         }
 
         final Path mergedPath = directory.resolve(
-            "merge-%03d-%06d.bin".formatted(mergeGeneration, mergedRuns.size()));
+            "merge-%03d-%06d.bin".formatted(mergeGeneration, groupIndex));
         final long entryCount = group.stream().mapToLong(RunFile::entries).sum();
-        final RunFile merged = mergeRuns(group, mergedPath, entryCount);
-        mergedRuns.add(merged);
-        spilledBytes += Files.size(mergedPath);
-
-        for (final RunFile source : group)
-          Files.delete(source.path());
+        mergePlans.add(new MergePlan(groupIndex, List.copyOf(group), mergedPath, entryCount));
       }
 
+      final long mergeStarted = System.nanoTime();
+      final List<MergeResult> results = executeMergePlans(mergePlans);
+      materializedMergeNanos += System.nanoTime() - mergeStarted;
+
+      for (final MergeResult result : results) {
+        mergedRuns[result.groupIndex()] = result.run();
+        materializedMergeEntries += result.run().entries();
+        materializedMergeBytes += result.bytes();
+        spilledBytes += result.bytes();
+      }
+
+      for (final MergeResult result : results)
+        for (final RunFile source : result.sources())
+          Files.delete(source.path());
+
       runs.clear();
-      runs.addAll(mergedRuns);
+      runs.addAll(Arrays.asList(mergedRuns));
       mergeGeneration++;
     }
+  }
+
+  private List<MergeResult> executeMergePlans(final List<MergePlan> plans) throws IOException {
+    final List<MergeResult> results = new ArrayList<>(plans.size());
+    for (final MergePlan plan : plans) {
+      final RunFile merged = mergeRuns(plan.sources(), plan.outputPath(), plan.entryCount());
+      results.add(new MergeResult(plan.groupIndex(), merged, Files.size(plan.outputPath()), plan.sources()));
+    }
+    return results;
   }
 
   private RunFile mergeRuns(final List<RunFile> sources, final Path outputPath, final long entryCount) throws IOException {
@@ -422,6 +492,12 @@ final class LSMTreeIndexExternalSorter implements AutoCloseable {
   }
 
   private record RunFile(Path path, long entries) {
+  }
+
+  private record MergePlan(int groupIndex, List<RunFile> sources, Path outputPath, long entryCount) {
+  }
+
+  private record MergeResult(int groupIndex, RunFile run, long bytes, List<RunFile> sources) {
   }
 
   @FunctionalInterface

--- a/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildMetrics.java
+++ b/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildMetrics.java
@@ -23,6 +23,7 @@ import com.arcadedb.serializer.json.JSONObject;
 /** Versioned, coarse-grained diagnostics for one successful sorted LSM index build. */
 record SortedIndexBuildMetrics(String logicalIndexName, boolean unique, long scannedRecords, long logicalEntries,
     long writtenEntries, int bucketIndexes, long memoryBudgetBytes, int requestedMergeFanIn, int admittedMergeFanIn,
+    int requestedWriterParallelism, int admittedWriterParallelism, int maxConcurrentWriters,
     int initialRuns, int finalRuns, int materializedMergeGenerations,
     long initialRunEntries, long initialRunBytes, long materializedMergeEntries, long materializedMergeBytes,
     long totalSpillBytes, long bucketIndexCreationNanos, long sourceScanNanos, long initialRunGenerationNanos,
@@ -35,7 +36,8 @@ record SortedIndexBuildMetrics(String logicalIndexName, boolean unique, long sca
   SortedIndexBuildMetrics completed(final long schemaRecordAndPublicationNanos, final long cleanupNanos,
       final long totalNanos) {
     return new SortedIndexBuildMetrics(logicalIndexName, unique, scannedRecords, logicalEntries, writtenEntries,
-        bucketIndexes, memoryBudgetBytes, requestedMergeFanIn, admittedMergeFanIn, initialRuns, finalRuns,
+        bucketIndexes, memoryBudgetBytes, requestedMergeFanIn, admittedMergeFanIn,
+        requestedWriterParallelism, admittedWriterParallelism, maxConcurrentWriters, initialRuns, finalRuns,
         materializedMergeGenerations, initialRunEntries, initialRunBytes, materializedMergeEntries,
         materializedMergeBytes, totalSpillBytes, bucketIndexCreationNanos, sourceScanNanos,
         initialRunGenerationNanos, inMemorySortNanos, materializedMergeNanos, finalStreamAndWriteNanos,
@@ -52,7 +54,10 @@ record SortedIndexBuildMetrics(String logicalIndexName, boolean unique, long sca
     final JSONObject resources = new JSONObject()
         .put("memory_budget_bytes", memoryBudgetBytes)
         .put("requested_merge_fan_in", requestedMergeFanIn)
-        .put("admitted_merge_fan_in", admittedMergeFanIn);
+        .put("admitted_merge_fan_in", admittedMergeFanIn)
+        .put("requested_writer_parallelism", requestedWriterParallelism)
+        .put("admitted_writer_parallelism", admittedWriterParallelism)
+        .put("max_concurrent_writers", maxConcurrentWriters);
 
     final JSONObject externalSort = new JSONObject()
         .put("enabled", initialRuns > 0)

--- a/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildMetrics.java
+++ b/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildMetrics.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.serializer.json.JSONObject;
+
+/** Versioned, coarse-grained diagnostics for one successful sorted LSM index build. */
+record SortedIndexBuildMetrics(String logicalIndexName, boolean unique, long scannedRecords, long logicalEntries,
+    long writtenEntries, int bucketIndexes, long memoryBudgetBytes, int requestedMergeFanIn, int admittedMergeFanIn,
+    int initialRuns, int finalRuns, int materializedMergeGenerations,
+    long initialRunEntries, long initialRunBytes, long materializedMergeEntries, long materializedMergeBytes,
+    long totalSpillBytes, long bucketIndexCreationNanos, long sourceScanNanos, long initialRunGenerationNanos,
+    long inMemorySortNanos, long materializedMergeNanos, long finalStreamAndWriteNanos, long attachmentNanos,
+    long pipelineNanos, long schemaRecordAndPublicationNanos, long cleanupNanos, long totalNanos) {
+
+  static final int    FORMAT_VERSION = 1;
+  static final String LOG_MARKER     = "SORTED_INDEX_BUILD_METRICS ";
+
+  SortedIndexBuildMetrics completed(final long schemaRecordAndPublicationNanos, final long cleanupNanos,
+      final long totalNanos) {
+    return new SortedIndexBuildMetrics(logicalIndexName, unique, scannedRecords, logicalEntries, writtenEntries,
+        bucketIndexes, memoryBudgetBytes, requestedMergeFanIn, admittedMergeFanIn, initialRuns, finalRuns,
+        materializedMergeGenerations, initialRunEntries, initialRunBytes, materializedMergeEntries,
+        materializedMergeBytes, totalSpillBytes, bucketIndexCreationNanos, sourceScanNanos,
+        initialRunGenerationNanos, inMemorySortNanos, materializedMergeNanos, finalStreamAndWriteNanos,
+        attachmentNanos, pipelineNanos, schemaRecordAndPublicationNanos, cleanupNanos, totalNanos);
+  }
+
+  JSONObject toJSON() {
+    final JSONObject counts = new JSONObject()
+        .put("scanned_records", scannedRecords)
+        .put("logical_entries", logicalEntries)
+        .put("written_entries", writtenEntries)
+        .put("bucket_indexes", bucketIndexes);
+
+    final JSONObject resources = new JSONObject()
+        .put("memory_budget_bytes", memoryBudgetBytes)
+        .put("requested_merge_fan_in", requestedMergeFanIn)
+        .put("admitted_merge_fan_in", admittedMergeFanIn);
+
+    final JSONObject externalSort = new JSONObject()
+        .put("enabled", initialRuns > 0)
+        .put("initial_runs", initialRuns)
+        .put("final_runs", finalRuns)
+        .put("materialized_merge_generations", materializedMergeGenerations)
+        .put("initial_run_entries", initialRunEntries)
+        .put("initial_run_bytes", initialRunBytes)
+        .put("materialized_merge_entries", materializedMergeEntries)
+        .put("materialized_merge_bytes", materializedMergeBytes)
+        .put("total_spill_bytes", totalSpillBytes)
+        .put("spill_write_amplification", initialRunBytes > 0L ? (double) totalSpillBytes / initialRunBytes : 0D);
+
+    final JSONObject timings = new JSONObject()
+        .put("bucket_index_creation_millis", millis(bucketIndexCreationNanos))
+        .put("source_scan_and_inline_run_generation_millis", millis(sourceScanNanos))
+        .put("initial_run_generation_millis", millis(initialRunGenerationNanos))
+        .put("in_memory_sort_millis", millis(inMemorySortNanos))
+        .put("materialized_merge_millis", millis(materializedMergeNanos))
+        .put("final_stream_and_compacted_write_millis", millis(finalStreamAndWriteNanos))
+        .put("attachment_and_flush_millis", millis(attachmentNanos))
+        .put("pipeline_millis", millis(pipelineNanos))
+        .put("schema_record_and_publication_millis", millis(schemaRecordAndPublicationNanos))
+        .put("cleanup_millis", millis(cleanupNanos))
+        .put("total_millis", millis(totalNanos));
+
+    return new JSONObject()
+        .put("format_version", FORMAT_VERSION)
+        .put("logical_index_name", logicalIndexName)
+        .put("unique", unique)
+        .put("counts", counts)
+        .put("resources", resources)
+        .put("external_sort", externalSort)
+        .put("timings", timings);
+  }
+
+  private static double millis(final long nanos) {
+    return nanos / 1_000_000D;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildMetrics.java
+++ b/engine/src/main/java/com/arcadedb/schema/SortedIndexBuildMetrics.java
@@ -23,7 +23,8 @@ import com.arcadedb.serializer.json.JSONObject;
 /** Versioned, coarse-grained diagnostics for one successful sorted LSM index build. */
 record SortedIndexBuildMetrics(String logicalIndexName, boolean unique, long scannedRecords, long logicalEntries,
     long writtenEntries, int bucketIndexes, long memoryBudgetBytes, int requestedMergeFanIn, int admittedMergeFanIn,
-    int requestedWriterParallelism, int admittedWriterParallelism, int maxConcurrentWriters,
+    int requestedBuildParallelism, int admittedMergeParallelism, int maxConcurrentMerges,
+    int admittedWriterParallelism, int maxConcurrentWriters,
     int initialRuns, int finalRuns, int materializedMergeGenerations,
     long initialRunEntries, long initialRunBytes, long materializedMergeEntries, long materializedMergeBytes,
     long totalSpillBytes, long bucketIndexCreationNanos, long sourceScanNanos, long initialRunGenerationNanos,
@@ -37,7 +38,8 @@ record SortedIndexBuildMetrics(String logicalIndexName, boolean unique, long sca
       final long totalNanos) {
     return new SortedIndexBuildMetrics(logicalIndexName, unique, scannedRecords, logicalEntries, writtenEntries,
         bucketIndexes, memoryBudgetBytes, requestedMergeFanIn, admittedMergeFanIn,
-        requestedWriterParallelism, admittedWriterParallelism, maxConcurrentWriters, initialRuns, finalRuns,
+        requestedBuildParallelism, admittedMergeParallelism, maxConcurrentMerges,
+        admittedWriterParallelism, maxConcurrentWriters, initialRuns, finalRuns,
         materializedMergeGenerations, initialRunEntries, initialRunBytes, materializedMergeEntries,
         materializedMergeBytes, totalSpillBytes, bucketIndexCreationNanos, sourceScanNanos,
         initialRunGenerationNanos, inMemorySortNanos, materializedMergeNanos, finalStreamAndWriteNanos,
@@ -55,7 +57,9 @@ record SortedIndexBuildMetrics(String logicalIndexName, boolean unique, long sca
         .put("memory_budget_bytes", memoryBudgetBytes)
         .put("requested_merge_fan_in", requestedMergeFanIn)
         .put("admitted_merge_fan_in", admittedMergeFanIn)
-        .put("requested_writer_parallelism", requestedWriterParallelism)
+        .put("requested_build_parallelism", requestedBuildParallelism)
+        .put("admitted_merge_parallelism", admittedMergeParallelism)
+        .put("max_concurrent_merges", maxConcurrentMerges)
         .put("admitted_writer_parallelism", admittedWriterParallelism)
         .put("max_concurrent_writers", maxConcurrentWriters);
 

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 
 /**
@@ -48,6 +49,8 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
+  private static final ThreadLocal<Consumer<SortedIndexBuildMetrics>> SORTED_BUILD_METRICS_TEST_HOOK = new ThreadLocal<>();
+
   private static final int DEFAULT_SORTED_BUILD_MERGE_FAN_IN = 8;
   private static final long MIN_SORTED_BUILD_MEMORY_BUDGET    = 1L << 20;
 
@@ -315,16 +318,19 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     final Index[] indexes = new Index[buckets.size()];
     final boolean sortedBuild = buildMode == IndexBuildMode.SORTED;
     final SortedIndexBuildRecoveryMarker[] recoveryMarker = new SortedIndexBuildRecoveryMarker[1];
+    final SortedIndexBuildMetrics[] sortedBuildMetrics = new SortedIndexBuildMetrics[1];
+    final long sortedBuildStarted = sortedBuild ? System.nanoTime() : 0L;
 
     if (sortedBuild)
       validateSortedBuildPreconditions();
 
     try {
+      final long recordFileChangesStarted = System.nanoTime();
       schema.recordFileChanges(() -> {
         if (sortedBuild) {
           recoveryMarker[0] = SortedIndexBuildRecoveryMarker.create(database, metadata.typeName, metadata.propertyNames,
               buildSpillDirectory);
-          createWithSortedBuild(schema, type, keyTypes, buckets, indexes, recoveryMarker[0]);
+          sortedBuildMetrics[0] = createWithSortedBuild(schema, type, keyTypes, buckets, indexes, recoveryMarker[0]);
         } else
           for (int idx = 0; idx < buckets.size(); ++idx) {
             final int finalIdx = idx;
@@ -339,9 +345,21 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
         return null;
       }, sortedBuild);
+      final long recordFileChangesNanos = System.nanoTime() - recordFileChangesStarted;
 
-      if (recoveryMarker[0] != null)
+      long cleanupNanos = 0L;
+      if (recoveryMarker[0] != null) {
+        final long cleanupStarted = System.nanoTime();
         recoveryMarker[0].clear();
+        cleanupNanos = System.nanoTime() - cleanupStarted;
+      }
+
+      if (sortedBuildMetrics[0] != null) {
+        final SortedIndexBuildMetrics completed = sortedBuildMetrics[0].completed(
+            Math.max(0L, recordFileChangesNanos - sortedBuildMetrics[0].pipelineNanos()), cleanupNanos,
+            System.nanoTime() - sortedBuildStarted);
+        emitSortedBuildMetrics(completed);
+      }
       return type.getIndexByProperties(metadata.propertyNames);
     } catch (final NeedRetryException e) {
       if (cleanupIndexes(schema, indexes, e)
@@ -378,13 +396,17 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
       throw new IndexException("Sorted build requires no active transaction");
   }
 
-  private void createWithSortedBuild(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
+  private SortedIndexBuildMetrics createWithSortedBuild(final LocalSchema schema, final LocalDocumentType type,
+      final Type[] keyTypes,
       final List<Bucket> buckets, final Index[] indexes, final SortedIndexBuildRecoveryMarker recoveryMarker) {
+    final long pipelineStarted = System.nanoTime();
+    final long bucketIndexCreationStarted = System.nanoTime();
     for (int idx = 0; idx < buckets.size(); ++idx) {
       final int finalIdx = idx;
       database.transaction(() -> indexes[finalIdx] = createBucketIndex(schema, type, keyTypes,
           (LocalBucket) buckets.get(finalIdx), false), false, maxAttempts, null, null);
     }
+    final long bucketIndexCreationNanos = System.nanoTime() - bucketIndexCreationStarted;
 
     final Map<Integer, LSMTreeIndex> indexesByBucket = new HashMap<>(indexes.length);
     for (final Index index : indexes) {
@@ -395,8 +417,13 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
     final String logicalIndexName = metadata.typeName + metadata.propertyNames;
     final AtomicLong scannedRecords = new AtomicLong();
+    final LSMTreeIndexBulkLoader.BuildOutcome outcome;
+    final LSMTreeIndexBulkLoader.StageMetrics stageMetrics;
+    final long logicalEntries;
+    final long sourceScanNanos;
     try (LSMTreeIndexBulkLoader bulkLoader = new LSMTreeIndexBulkLoader(database, logicalIndexName,
         buildMemoryBudgetBytes, buildSpillDirectory, buildMergeFanIn, recoveryMarker.getSpillWorkspace())) {
+      final long sourceScanStarted = System.nanoTime();
       database.transaction(() -> database.scanType(metadata.typeName, true, record -> {
           final LSMTreeIndex bucketIndex = indexesByBucket.get(record.getIdentity().getBucketId());
           if (bucketIndex == null)
@@ -413,13 +440,38 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
             throw runtimeException;
           throw new IndexException("Error collecting sorted index entry at record " + rid, exception);
         }), false, maxAttempts, null, null);
+      sourceScanNanos = System.nanoTime() - sourceScanStarted;
 
-      bulkLoader.writeCompacted();
+      outcome = bulkLoader.writeCompacted();
+      logicalEntries = bulkLoader.size();
+      stageMetrics = bulkLoader.getStageMetrics();
       publishIndexes(indexes);
     }
 
     LogManager.instance().log(this, Level.INFO,
         "Published sorted index '%s': records=%,d bucketIndexes=%d", logicalIndexName, scannedRecords.get(), indexes.length);
+    return new SortedIndexBuildMetrics(logicalIndexName, unique, scannedRecords.get(), logicalEntries,
+        outcome.entries(), indexes.length, outcome.memoryBudgetBytes(), stageMetrics.requestedMergeFanIn(),
+        stageMetrics.admittedMergeFanIn(), stageMetrics.initialRuns(), stageMetrics.finalRuns(),
+        stageMetrics.materializedMergeGenerations(), stageMetrics.initialRunEntries(), stageMetrics.initialRunBytes(),
+        stageMetrics.materializedMergeEntries(), stageMetrics.materializedMergeBytes(), outcome.spillBytes(),
+        bucketIndexCreationNanos, sourceScanNanos, stageMetrics.initialRunNanos(), stageMetrics.inMemorySortNanos(),
+        stageMetrics.materializedMergeNanos(), stageMetrics.finalStreamAndWriteNanos(), stageMetrics.attachmentNanos(),
+        System.nanoTime() - pipelineStarted, 0L, 0L, 0L);
+  }
+
+  private void emitSortedBuildMetrics(final SortedIndexBuildMetrics metrics) {
+    LogManager.instance().log(this, Level.INFO, "%s%s", SortedIndexBuildMetrics.LOG_MARKER, metrics.toJSON());
+    final Consumer<SortedIndexBuildMetrics> hook = SORTED_BUILD_METRICS_TEST_HOOK.get();
+    if (hook != null)
+      hook.accept(metrics);
+  }
+
+  static void setSortedBuildMetricsTestHook(final Consumer<SortedIndexBuildMetrics> hook) {
+    if (hook == null)
+      SORTED_BUILD_METRICS_TEST_HOOK.remove();
+    else
+      SORTED_BUILD_METRICS_TEST_HOOK.set(hook);
   }
 
   private void publishIndexes(final Index[] indexes) {

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -64,6 +64,7 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   private long           buildMemoryBudgetBytes;
   private Path           buildSpillDirectory;
   private int            buildMergeFanIn        = DEFAULT_SORTED_BUILD_MERGE_FAN_IN;
+  private int            buildParallelism       = 1;
 
   protected TypeIndexBuilder(final DatabaseInternal database, final String typeName, final String[] propertyNames) {
     super(database, TypeIndex.class);
@@ -106,6 +107,17 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     if (mergeFanIn < 2)
       throw new IllegalArgumentException("build merge fan-in must be at least 2");
     this.buildMergeFanIn = mergeFanIn;
+    return this;
+  }
+
+  /**
+   * Sets the requested bucket-writer parallelism for a sorted build. Admission is bounded by bucket count,
+   * processor headroom, memory budget, and available file descriptors. The default is one.
+   */
+  public TypeIndexBuilder withBuildParallelism(final int parallelism) {
+    if (parallelism < 1)
+      throw new IllegalArgumentException("build parallelism must be at least 1");
+    this.buildParallelism = parallelism;
     return this;
   }
 
@@ -422,7 +434,8 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     final long logicalEntries;
     final long sourceScanNanos;
     try (LSMTreeIndexBulkLoader bulkLoader = new LSMTreeIndexBulkLoader(database, logicalIndexName,
-        buildMemoryBudgetBytes, buildSpillDirectory, buildMergeFanIn, recoveryMarker.getSpillWorkspace())) {
+        buildMemoryBudgetBytes, buildSpillDirectory, buildMergeFanIn, recoveryMarker.getSpillWorkspace(),
+        buildParallelism)) {
       final long sourceScanStarted = System.nanoTime();
       database.transaction(() -> database.scanType(metadata.typeName, true, record -> {
           final LSMTreeIndex bucketIndex = indexesByBucket.get(record.getIdentity().getBucketId());
@@ -452,7 +465,9 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
         "Published sorted index '%s': records=%,d bucketIndexes=%d", logicalIndexName, scannedRecords.get(), indexes.length);
     return new SortedIndexBuildMetrics(logicalIndexName, unique, scannedRecords.get(), logicalEntries,
         outcome.entries(), indexes.length, outcome.memoryBudgetBytes(), stageMetrics.requestedMergeFanIn(),
-        stageMetrics.admittedMergeFanIn(), stageMetrics.initialRuns(), stageMetrics.finalRuns(),
+        stageMetrics.admittedMergeFanIn(), stageMetrics.requestedWriterParallelism(),
+        stageMetrics.admittedWriterParallelism(), stageMetrics.maxConcurrentWriters(),
+        stageMetrics.initialRuns(), stageMetrics.finalRuns(),
         stageMetrics.materializedMergeGenerations(), stageMetrics.initialRunEntries(), stageMetrics.initialRunBytes(),
         stageMetrics.materializedMergeEntries(), stageMetrics.materializedMergeBytes(), outcome.spillBytes(),
         bucketIndexCreationNanos, sourceScanNanos, stageMetrics.initialRunNanos(), stageMetrics.inMemorySortNanos(),

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -111,8 +111,9 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   }
 
   /**
-   * Sets the requested bucket-writer parallelism for a sorted build. Admission is bounded by bucket count,
-   * processor headroom, memory budget, and available file descriptors. The default is one.
+   * Sets requested parallelism for independent sorted-build merge groups and bucket writers. Each stage is admitted
+   * independently against its work count, processor headroom, memory budget, and available file descriptors. The final
+   * global stream remains serial. The default is one.
    */
   public TypeIndexBuilder withBuildParallelism(final int parallelism) {
     if (parallelism < 1)
@@ -465,7 +466,8 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
         "Published sorted index '%s': records=%,d bucketIndexes=%d", logicalIndexName, scannedRecords.get(), indexes.length);
     return new SortedIndexBuildMetrics(logicalIndexName, unique, scannedRecords.get(), logicalEntries,
         outcome.entries(), indexes.length, outcome.memoryBudgetBytes(), stageMetrics.requestedMergeFanIn(),
-        stageMetrics.admittedMergeFanIn(), stageMetrics.requestedWriterParallelism(),
+        stageMetrics.admittedMergeFanIn(), stageMetrics.requestedBuildParallelism(),
+        stageMetrics.admittedMergeParallelism(), stageMetrics.maxConcurrentMerges(),
         stageMetrics.admittedWriterParallelism(), stageMetrics.maxConcurrentWriters(),
         stageMetrics.initialRuns(), stageMetrics.finalRuns(),
         stageMetrics.materializedMergeGenerations(), stageMetrics.initialRunEntries(), stageMetrics.initialRunBytes(),

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBucketParallelismTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBucketParallelismTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexBuildMode;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class LSMTreeSortedBucketParallelismTest extends TestHelper {
+  @Test
+  void admitsWriterWorkersAgainstBucketsCpuHeapAndFileDescriptors() {
+    assertThat(LSMTreeIndexBulkLoader.selectWriterParallelism(8, 4, 64L << 20, 16, 100)).isEqualTo(4);
+    assertThat(LSMTreeIndexBulkLoader.selectWriterParallelism(8, 4, 8L << 20, 16, 100)).isEqualTo(1);
+    assertThat(LSMTreeIndexBulkLoader.selectWriterParallelism(8, 4, 64L << 20, 2, 100)).isEqualTo(1);
+    assertThat(LSMTreeIndexBulkLoader.selectWriterParallelism(8, 4, 64L << 20, 16, 2)).isEqualTo(1);
+    assertThat(LSMTreeIndexBulkLoader.selectWriterParallelism(8, 1, 64L << 20, 16, 100)).isEqualTo(1);
+    assertThat(LSMTreeIndexBulkLoader.selectWriterParallelism(8, 0, 64L << 20, 16, 100)).isEqualTo(1);
+    assertThatThrownBy(() -> LSMTreeIndexBulkLoader.selectWriterParallelism(0, 4, 64L << 20, 16, 100))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    final DocumentType type = database.getSchema().createDocumentType("ParallelismValidation");
+    type.createProperty("lookupKey", Type.STRING);
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("ParallelismValidation",
+        new String[] { "lookupKey" }).withBuildParallelism(0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("at least 1");
+  }
+
+  @Test
+  void writesIndependentBucketsConcurrentlyAndReopens() throws Exception {
+    final int admitted = LSMTreeIndexBulkLoader.selectWriterParallelism(4, 4, 64L << 20,
+        Runtime.getRuntime().availableProcessors(), LSMTreeIndexExternalSorter.getAvailableFileDescriptors());
+    assumeTrue(admitted > 1, "test host does not admit multiple bucket writers");
+
+    createRecords("ParallelBuckets", 4, 4_000);
+    final CountDownLatch firstTwoWriters = new CountDownLatch(2);
+    final AtomicInteger gatedCalls = new AtomicInteger();
+    final AtomicInteger active = new AtomicInteger();
+    final AtomicInteger maxActive = new AtomicInteger();
+
+    LSMTreeIndexBulkLoader.setBuildTestHook((phase, index, completed) -> {
+      if (phase != LSMTreeIndexBulkLoader.BuildPhase.AFTER_BUCKET_APPEND || gatedCalls.incrementAndGet() > 2)
+        return;
+      final int current = active.incrementAndGet();
+      maxActive.accumulateAndGet(current, Math::max);
+      firstTwoWriters.countDown();
+      try {
+        if (!firstTwoWriters.await(10L, TimeUnit.SECONDS))
+          throw new IllegalStateException("bucket writers did not overlap");
+      } catch (final InterruptedException error) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted while observing bucket writer overlap", error);
+      } finally {
+        active.decrementAndGet();
+      }
+    });
+
+    TypeIndex index;
+    try {
+      index = build("ParallelBuckets", null, 4);
+    } finally {
+      LSMTreeIndexBulkLoader.setBuildTestHook(null);
+    }
+
+    assertThat(maxActive).hasValueGreaterThan(1);
+    assertThat(count(index.iterator(true))).isEqualTo(4_000);
+    assertThat(count(index.range(true, new Object[] { key(1_000) }, true,
+        new Object[] { key(1_099) }, true))).isEqualTo(100);
+
+    reopenDatabase();
+    index = database.getSchema().getType("ParallelBuckets").getIndexByProperties("lookupKey");
+    assertThat(count(index.iterator(false))).isEqualTo(4_000);
+    assertNoBuildArtifacts(Path.of(getDatabasePath()));
+  }
+
+  @Test
+  void preservesHighMultiplicityNonUniqueGroupsAcrossRidChunksAndBuckets() throws Exception {
+    final DocumentType type = database.getSchema().buildDocumentType().withName("ParallelNonUnique")
+        .withTotalBuckets(4).create();
+    type.createProperty("lookupKey", Type.STRING);
+    database.transaction(() -> {
+      for (int i = 0; i < 12_000; i++)
+        database.newDocument("ParallelNonUnique").set("lookupKey", "shared-" + i % 3).save();
+    });
+
+    TypeIndex index = build("ParallelNonUnique", null, 4, false, 1_024);
+    assertThat(count(index.get(new Object[] { "shared-0" }))).isEqualTo(4_000);
+    assertThat(count(index.get(new Object[] { "shared-1" }))).isEqualTo(4_000);
+    assertThat(count(index.get(new Object[] { "shared-2" }))).isEqualTo(4_000);
+    assertThat(count(index.iterator(true))).isEqualTo(12_000);
+
+    reopenDatabase();
+    index = database.getSchema().getType("ParallelNonUnique").getIndexByProperties("lookupKey");
+    assertThat(count(index.get(new Object[] { "shared-0" }))).isEqualTo(4_000);
+    assertThat(count(index.iterator(false))).isEqualTo(12_000);
+  }
+
+  @Test
+  void retainsGlobalUniqueCheckBeforeParallelBucketWrites() throws Exception {
+    final Path spillParent = Path.of(getDatabasePath()).resolve("parallel-duplicate");
+    final DocumentType type = createRecords("ParallelDuplicate", 4, 4_000);
+    database.transaction(() -> {
+      database.newDocument("ParallelDuplicate").set("lookupKey", "duplicate-key").save();
+      database.newDocument("ParallelDuplicate").set("lookupKey", "duplicate-key").save();
+    });
+
+    assertThatThrownBy(() -> build("ParallelDuplicate", spillParent, 4))
+        .hasRootCauseInstanceOf(DuplicatedKeyException.class);
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+    assertNoBuildArtifacts(spillParent);
+    assertNoBuildArtifacts(Path.of(getDatabasePath()));
+
+    reopenDatabase();
+    assertThat(database.getSchema().getType("ParallelDuplicate").getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
+  void requestedParallelismFallsBackForOneBucket() throws Exception {
+    createRecords("ParallelOneBucket", 1, 1_000);
+    TypeIndex index = build("ParallelOneBucket", null, 4);
+    assertThat(count(index.iterator(true))).isEqualTo(1_000);
+
+    reopenDatabase();
+    index = database.getSchema().getType("ParallelOneBucket").getIndexByProperties("lookupKey");
+    assertThat(count(index.iterator(false))).isEqualTo(1_000);
+  }
+
+  @Test
+  void cancelsPeerWritersAndPublishesNothingAfterWorkerFailure() throws Exception {
+    final int admitted = LSMTreeIndexBulkLoader.selectWriterParallelism(4, 4, 64L << 20,
+        Runtime.getRuntime().availableProcessors(), LSMTreeIndexExternalSorter.getAvailableFileDescriptors());
+    assumeTrue(admitted > 1, "test host does not admit multiple bucket writers");
+
+    final Path spillParent = Path.of(getDatabasePath()).resolve("parallel-writer-failure");
+    final DocumentType type = createRecords("ParallelWriterFailure", 4, 4_000);
+    final AtomicInteger completed = new AtomicInteger();
+    LSMTreeIndexBulkLoader.setBuildTestHook((phase, index, batches) -> {
+      if (phase == LSMTreeIndexBulkLoader.BuildPhase.AFTER_BUCKET_APPEND && completed.incrementAndGet() == 10)
+        throw new IllegalStateException("injected bucket writer failure");
+    });
+    try {
+      assertThatThrownBy(() -> build("ParallelWriterFailure", spillParent, 4))
+          .isInstanceOf(IndexException.class)
+          .hasStackTraceContaining("injected bucket writer failure");
+    } finally {
+      LSMTreeIndexBulkLoader.setBuildTestHook(null);
+    }
+
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+    assertNoBuildArtifacts(spillParent);
+    assertNoBuildArtifacts(Path.of(getDatabasePath()));
+    reopenDatabase();
+    assertThat(database.getSchema().getType("ParallelWriterFailure").getIndexByProperties("lookupKey")).isNull();
+  }
+
+  private DocumentType createRecords(final String typeName, final int buckets, final int records) {
+    final DocumentType type = database.getSchema().buildDocumentType().withName(typeName)
+        .withTotalBuckets(buckets).create();
+    type.createProperty("lookupKey", Type.STRING);
+    database.transaction(() -> {
+      for (int i = 0; i < records; i++)
+        database.newDocument(typeName).set("lookupKey", key(i)).save();
+    });
+    return type;
+  }
+
+  private TypeIndex build(final String typeName, final Path spillParent, final int parallelism) {
+    return build(typeName, spillParent, parallelism, true, 0);
+  }
+
+  private TypeIndex build(final String typeName, final Path spillParent, final int parallelism,
+      final boolean unique, final int pageSize) {
+    final var builder = database.getSchema().buildTypeIndex(typeName, new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(64L << 20)
+        .withBuildMergeFanIn(2)
+        .withBuildParallelism(parallelism);
+    builder.withUnique(unique);
+    if (pageSize > 0)
+      builder.withPageSize(pageSize);
+    if (spillParent != null)
+      builder.withBuildSpillDirectory(spillParent);
+    return builder.create();
+  }
+
+  private static long count(final IndexCursor cursor) {
+    long count = 0L;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        count++;
+      }
+      return count;
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static void assertNoBuildArtifacts(final Path parent) throws Exception {
+    if (!Files.exists(parent))
+      return;
+    try (Stream<Path> paths = Files.walk(parent)) {
+      assertThat(paths.map(path -> path.getFileName().toString())
+          .filter(name -> name.startsWith(".arcadedb-index-sort-")
+              || name.startsWith(".arcadedb-sorted-index-build-")
+              || name.endsWith(".temp_numtidx") || name.endsWith(".temp_nuctidx"))
+          .toList()).isEmpty();
+    }
+  }
+
+  private static String key(final int value) {
+    return "key-%08d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".formatted(value);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBuildFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedBuildFailureTest.java
@@ -70,6 +70,38 @@ class LSMTreeSortedBuildFailureTest extends TestHelper {
   }
 
   @Test
+  void removesGenerationOutputsAfterMaterializedMergeFailure() throws Exception {
+    final Path spillParent = Path.of(getDatabasePath()).resolve("merge-failure");
+    createRecords("MergeFailure", 1, 1_000);
+
+    final AtomicInteger written = new AtomicInteger();
+    LSMTreeIndexExternalSorter.setSpillWriteTestHook(() -> {
+      if (written.incrementAndGet() == 1_050)
+        throw new IOException("injected materialized merge failure");
+    });
+    try {
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex("MergeFailure", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(1L << 20)
+          .withBuildSpillDirectory(spillParent)
+          .withBuildMergeFanIn(2)
+          .withUnique(false)
+          .create())
+          .isInstanceOf(IndexException.class)
+          .hasStackTraceContaining("injected materialized merge failure");
+    } finally {
+      LSMTreeIndexExternalSorter.setSpillWriteTestHook(null);
+    }
+
+    assertThat(written).hasValueGreaterThan(1_000);
+    assertThat(database.getSchema().getType("MergeFailure").getIndexByProperties("lookupKey")).isNull();
+    assertNoSortedBuildArtifacts(spillParent);
+    reopenDatabase();
+    assertThat(database.getSchema().getType("MergeFailure").getIndexByProperties("lookupKey")).isNull();
+  }
+
+  @Test
   void defersSchemaSaveAndCleansFilesAfterFirstBucketAttachment() throws Exception {
     createRecords("AttachmentFailure", 2, 2_000);
     final AtomicBoolean schemaStillUnpublished = new AtomicBoolean();

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedMergeParallelismTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeSortedMergeParallelismTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexBuildMode;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class LSMTreeSortedMergeParallelismTest extends TestHelper {
+  private static final int RECORDS = 25_000;
+  private static final long MEMORY_BUDGET = 24L << 20;
+
+  @Test
+  void admitsMergeWorkersAgainstCpuHeapAndFileDescriptors() {
+    assertThat(LSMTreeIndexExternalSorter.selectMergeParallelism(8, 2, 128L << 20, 16, 100)).isEqualTo(8);
+    assertThat(LSMTreeIndexExternalSorter.selectMergeParallelism(8, 32, 32L << 20, 16, 1_000)).isEqualTo(1);
+    assertThat(LSMTreeIndexExternalSorter.selectMergeParallelism(8, 2, 128L << 20, 2, 100)).isEqualTo(1);
+    assertThat(LSMTreeIndexExternalSorter.selectMergeParallelism(8, 8, 128L << 20, 16, 27)).isEqualTo(3);
+    assertThatThrownBy(() -> LSMTreeIndexExternalSorter.selectMergeParallelism(0, 2, 128L << 20, 16, 100))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> LSMTreeIndexExternalSorter.selectMergeParallelism(2, 1, 128L << 20, 16, 100))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void mergesIndependentGroupsConcurrentlyAndReopens() throws Exception {
+    assumeParallelMergeAdmission();
+    createUniqueRecords("ParallelMerge", RECORDS);
+    final CountDownLatch firstTwoGroups = new CountDownLatch(2);
+    final AtomicInteger active = new AtomicInteger();
+    final AtomicInteger maxActive = new AtomicInteger();
+
+    LSMTreeIndexExternalSorter.setMaterializedMergeTestHook((generation, group, written) -> {
+      if (generation != 0 || group > 1 || written != 1L)
+        return;
+      final int current = active.incrementAndGet();
+      maxActive.accumulateAndGet(current, Math::max);
+      firstTwoGroups.countDown();
+      try {
+        if (!firstTwoGroups.await(10L, TimeUnit.SECONDS))
+          throw new IOException("materialized merge groups did not overlap");
+      } finally {
+        active.decrementAndGet();
+      }
+    });
+
+    TypeIndex index;
+    try {
+      index = build("ParallelMerge", true, null);
+    } finally {
+      LSMTreeIndexExternalSorter.setMaterializedMergeTestHook(null);
+    }
+
+    assertThat(maxActive).hasValueGreaterThan(1);
+    assertUniqueOrder(index.iterator(true), true);
+    assertUniqueOrder(index.iterator(false), false);
+    assertThat(count(index.range(true, new Object[] { key(1_000) }, true,
+        new Object[] { key(1_099) }, true))).isEqualTo(100);
+    assertThat(count(index.get(new Object[] { key(RECORDS / 2) }))).isEqualTo(1);
+
+    reopenDatabase();
+    index = database.getSchema().getType("ParallelMerge").getIndexByProperties("lookupKey");
+    assertUniqueOrder(index.iterator(true), true);
+    assertUniqueOrder(index.iterator(false), false);
+    assertThat(count(index.get(new Object[] { key(RECORDS / 2) }))).isEqualTo(1);
+    assertNoBuildArtifacts(Path.of(getDatabasePath()));
+  }
+
+  @Test
+  void preservesNonUniqueGroupsAcrossParallelMergeOutputs() throws Exception {
+    assumeParallelMergeAdmission();
+    final DocumentType type = database.getSchema().createDocumentType("ParallelMergeNonUnique");
+    type.createProperty("lookupKey", Type.STRING);
+    database.transaction(() -> {
+      for (int i = 0; i < RECORDS; i++)
+        database.newDocument("ParallelMergeNonUnique").set("lookupKey", "shared-" + i % 5).save();
+    });
+
+    TypeIndex index = build("ParallelMergeNonUnique", false, null);
+    for (int i = 0; i < 5; i++)
+      assertThat(count(index.get(new Object[] { "shared-" + i }))).isEqualTo(RECORDS / 5);
+    assertThat(count(index.iterator(true))).isEqualTo(RECORDS);
+
+    reopenDatabase();
+    index = database.getSchema().getType("ParallelMergeNonUnique").getIndexByProperties("lookupKey");
+    assertThat(count(index.iterator(false))).isEqualTo(RECORDS);
+    assertThat(count(index.get(new Object[] { "shared-3" }))).isEqualTo(RECORDS / 5);
+  }
+
+  @Test
+  void retainsFinalGlobalDuplicateBoundaryAfterParallelMerges() throws Exception {
+    assumeParallelMergeAdmission();
+    final Path spillParent = Path.of(getDatabasePath()).resolve("parallel-merge-duplicate");
+    final DocumentType type = createUniqueRecords("ParallelMergeDuplicate", RECORDS);
+    database.transaction(() -> {
+      database.newDocument("ParallelMergeDuplicate").set("lookupKey", "duplicate-key").save();
+      database.newDocument("ParallelMergeDuplicate").set("lookupKey", "duplicate-key").save();
+    });
+
+    assertThatThrownBy(() -> build("ParallelMergeDuplicate", true, spillParent))
+        .hasRootCauseInstanceOf(DuplicatedKeyException.class);
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+    assertNoBuildArtifacts(spillParent);
+    assertNoBuildArtifacts(Path.of(getDatabasePath()));
+  }
+
+  @Test
+  void cancelsPeerMergesAndPublishesNothingAfterWorkerFailure() throws Exception {
+    assumeParallelMergeAdmission();
+    final Path spillParent = Path.of(getDatabasePath()).resolve("parallel-merge-failure");
+    final DocumentType type = createUniqueRecords("ParallelMergeFailure", RECORDS);
+    final CountDownLatch peerStarted = new CountDownLatch(1);
+    final CountDownLatch neverRelease = new CountDownLatch(1);
+    final AtomicBoolean peerInterrupted = new AtomicBoolean();
+
+    LSMTreeIndexExternalSorter.setMaterializedMergeTestHook((generation, group, written) -> {
+      if (generation != 0 || written != 1L)
+        return;
+      if (group == 0) {
+        if (!peerStarted.await(10L, TimeUnit.SECONDS))
+          throw new IOException("peer merge did not start");
+        throw new IOException("injected parallel merge failure");
+      }
+      if (group == 1) {
+        peerStarted.countDown();
+        try {
+          neverRelease.await();
+        } catch (final InterruptedException error) {
+          peerInterrupted.set(true);
+          throw error;
+        }
+      }
+    });
+
+    try {
+      assertThatThrownBy(() -> build("ParallelMergeFailure", false, spillParent))
+          .isInstanceOf(IndexException.class)
+          .hasStackTraceContaining("injected parallel merge failure");
+    } finally {
+      LSMTreeIndexExternalSorter.setMaterializedMergeTestHook(null);
+    }
+
+    assertThat(peerInterrupted).isTrue();
+    assertThat(type.getIndexByProperties("lookupKey")).isNull();
+    assertNoBuildArtifacts(spillParent);
+    assertNoBuildArtifacts(Path.of(getDatabasePath()));
+    reopenDatabase();
+    assertThat(database.getSchema().getType("ParallelMergeFailure").getIndexByProperties("lookupKey")).isNull();
+  }
+
+  private void assumeParallelMergeAdmission() {
+    final int admitted = LSMTreeIndexExternalSorter.selectMergeParallelism(4, 2, MEMORY_BUDGET,
+        Runtime.getRuntime().availableProcessors(), LSMTreeIndexExternalSorter.getAvailableFileDescriptors());
+    assumeTrue(admitted > 1, "test host does not admit multiple merge workers");
+  }
+
+  private DocumentType createUniqueRecords(final String typeName, final int records) {
+    final DocumentType type = database.getSchema().createDocumentType(typeName);
+    type.createProperty("lookupKey", Type.STRING);
+    database.transaction(() -> {
+      for (int i = 0; i < records; i++) {
+        final int permuted = Math.floorMod(i * 12_371, records);
+        database.newDocument(typeName).set("lookupKey", key(permuted)).save();
+      }
+    });
+    return type;
+  }
+
+  private TypeIndex build(final String typeName, final boolean unique, final Path spillParent) {
+    final var builder = database.getSchema().buildTypeIndex(typeName, new String[] { "lookupKey" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withBuildMode(IndexBuildMode.SORTED)
+        .withBuildMemoryBudget(MEMORY_BUDGET)
+        .withBuildMergeFanIn(2)
+        .withBuildParallelism(4);
+    builder.withUnique(unique);
+    if (spillParent != null)
+      builder.withBuildSpillDirectory(spillParent);
+    return builder.create();
+  }
+
+  private static long count(final IndexCursor cursor) {
+    long count = 0L;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        count++;
+      }
+      return count;
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static void assertUniqueOrder(final IndexCursor cursor, final boolean ascending) {
+    int position = 0;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        final int expected = ascending ? position : RECORDS - position - 1;
+        assertThat(cursor.getKeys()[0]).isEqualTo(key(expected));
+        position++;
+      }
+    } finally {
+      cursor.close();
+    }
+    assertThat(position).isEqualTo(RECORDS);
+  }
+
+  private static void assertNoBuildArtifacts(final Path parent) throws Exception {
+    if (!Files.exists(parent))
+      return;
+    try (Stream<Path> paths = Files.walk(parent)) {
+      assertThat(paths.map(path -> path.getFileName().toString())
+          .filter(name -> name.startsWith(".arcadedb-index-sort-")
+              || name.startsWith(".arcadedb-sorted-index-build-")
+              || name.endsWith(".temp_numtidx") || name.endsWith(".temp_nuctidx"))
+          .toList()).isEmpty();
+    }
+  }
+
+  private static String key(final int value) {
+    return "key-%08d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".formatted(value);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildMetricsTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildMetricsTest.java
@@ -66,6 +66,9 @@ class SortedIndexBuildMetricsTest extends TestHelper {
     assertThat(metrics.memoryBudgetBytes()).isEqualTo(1L << 20);
     assertThat(metrics.requestedMergeFanIn()).isEqualTo(2);
     assertThat(metrics.admittedMergeFanIn()).isEqualTo(2);
+    assertThat(metrics.requestedWriterParallelism()).isEqualTo(1);
+    assertThat(metrics.admittedWriterParallelism()).isEqualTo(1);
+    assertThat(metrics.maxConcurrentWriters()).isEqualTo(1);
     assertThat(metrics.initialRuns()).isGreaterThan(2);
     assertThat(metrics.finalRuns()).isBetween(1, 2);
     assertThat(metrics.materializedMergeGenerations()).isGreaterThan(0);
@@ -88,6 +91,9 @@ class SortedIndexBuildMetricsTest extends TestHelper {
 
     final JSONObject json = metrics.toJSON();
     assertThat(json.getInt("format_version")).isEqualTo(SortedIndexBuildMetrics.FORMAT_VERSION);
+    assertThat(json.getJSONObject("resources").getInt("requested_writer_parallelism")).isEqualTo(1);
+    assertThat(json.getJSONObject("resources").getInt("admitted_writer_parallelism")).isEqualTo(1);
+    assertThat(json.getJSONObject("resources").getInt("max_concurrent_writers")).isEqualTo(1);
     assertThat(json.getJSONObject("external_sort").getBoolean("enabled")).isTrue();
     assertThat(json.getJSONObject("external_sort").getInt("materialized_merge_generations")).isGreaterThan(0);
     assertThat(json.getJSONObject("timings").getDouble("materialized_merge_millis")).isGreaterThan(0D);
@@ -130,6 +136,38 @@ class SortedIndexBuildMetricsTest extends TestHelper {
     assertThat(metrics.materializedMergeNanos()).isZero();
     assertThat(metrics.finalStreamAndWriteNanos()).isGreaterThan(0);
     assertThat(metrics.toJSON().getJSONObject("external_sort").getBoolean("enabled")).isFalse();
+  }
+
+  @Test
+  void capturesBoundedWriterParallelism() {
+    final AtomicReference<SortedIndexBuildMetrics> captured = new AtomicReference<>();
+    TypeIndexBuilder.setSortedBuildMetricsTestHook(captured::set);
+    try {
+      final DocumentType type = database.getSchema().buildDocumentType().withName("MetricsParallel")
+          .withTotalBuckets(4).create();
+      type.createProperty("lookupKey", Type.STRING);
+      database.transaction(() -> {
+        for (int i = 0; i < 4_000; i++)
+          database.newDocument("MetricsParallel").set("lookupKey", "key-%08d".formatted(i)).save();
+      });
+
+      database.getSchema().buildTypeIndex("MetricsParallel", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(64L << 20)
+          .withBuildParallelism(4)
+          .withUnique(true)
+          .create();
+    } finally {
+      TypeIndexBuilder.setSortedBuildMetricsTestHook(null);
+    }
+
+    final SortedIndexBuildMetrics metrics = captured.get();
+    assertThat(metrics).isNotNull();
+    assertThat(metrics.requestedWriterParallelism()).isEqualTo(4);
+    assertThat(metrics.admittedWriterParallelism()).isBetween(1, 4);
+    assertThat(metrics.maxConcurrentWriters()).isBetween(1, metrics.admittedWriterParallelism());
+    assertThat(metrics.toJSON().getJSONObject("resources").getInt("requested_writer_parallelism")).isEqualTo(4);
   }
 
   private static long count(final IndexCursor cursor) {

--- a/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildMetricsTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildMetricsTest.java
@@ -66,7 +66,9 @@ class SortedIndexBuildMetricsTest extends TestHelper {
     assertThat(metrics.memoryBudgetBytes()).isEqualTo(1L << 20);
     assertThat(metrics.requestedMergeFanIn()).isEqualTo(2);
     assertThat(metrics.admittedMergeFanIn()).isEqualTo(2);
-    assertThat(metrics.requestedWriterParallelism()).isEqualTo(1);
+    assertThat(metrics.requestedBuildParallelism()).isEqualTo(1);
+    assertThat(metrics.admittedMergeParallelism()).isEqualTo(1);
+    assertThat(metrics.maxConcurrentMerges()).isEqualTo(1);
     assertThat(metrics.admittedWriterParallelism()).isEqualTo(1);
     assertThat(metrics.maxConcurrentWriters()).isEqualTo(1);
     assertThat(metrics.initialRuns()).isGreaterThan(2);
@@ -91,7 +93,9 @@ class SortedIndexBuildMetricsTest extends TestHelper {
 
     final JSONObject json = metrics.toJSON();
     assertThat(json.getInt("format_version")).isEqualTo(SortedIndexBuildMetrics.FORMAT_VERSION);
-    assertThat(json.getJSONObject("resources").getInt("requested_writer_parallelism")).isEqualTo(1);
+    assertThat(json.getJSONObject("resources").getInt("requested_build_parallelism")).isEqualTo(1);
+    assertThat(json.getJSONObject("resources").getInt("admitted_merge_parallelism")).isEqualTo(1);
+    assertThat(json.getJSONObject("resources").getInt("max_concurrent_merges")).isEqualTo(1);
     assertThat(json.getJSONObject("resources").getInt("admitted_writer_parallelism")).isEqualTo(1);
     assertThat(json.getJSONObject("resources").getInt("max_concurrent_writers")).isEqualTo(1);
     assertThat(json.getJSONObject("external_sort").getBoolean("enabled")).isTrue();
@@ -134,6 +138,7 @@ class SortedIndexBuildMetricsTest extends TestHelper {
     assertThat(metrics.initialRunGenerationNanos()).isZero();
     assertThat(metrics.inMemorySortNanos()).isGreaterThan(0);
     assertThat(metrics.materializedMergeNanos()).isZero();
+    assertThat(metrics.maxConcurrentMerges()).isZero();
     assertThat(metrics.finalStreamAndWriteNanos()).isGreaterThan(0);
     assertThat(metrics.toJSON().getJSONObject("external_sort").getBoolean("enabled")).isFalse();
   }
@@ -164,10 +169,47 @@ class SortedIndexBuildMetricsTest extends TestHelper {
 
     final SortedIndexBuildMetrics metrics = captured.get();
     assertThat(metrics).isNotNull();
-    assertThat(metrics.requestedWriterParallelism()).isEqualTo(4);
+    assertThat(metrics.requestedBuildParallelism()).isEqualTo(4);
     assertThat(metrics.admittedWriterParallelism()).isBetween(1, 4);
     assertThat(metrics.maxConcurrentWriters()).isBetween(1, metrics.admittedWriterParallelism());
-    assertThat(metrics.toJSON().getJSONObject("resources").getInt("requested_writer_parallelism")).isEqualTo(4);
+    assertThat(metrics.toJSON().getJSONObject("resources").getInt("requested_build_parallelism")).isEqualTo(4);
+  }
+
+  @Test
+  void capturesBoundedMergeParallelism() {
+    final AtomicReference<SortedIndexBuildMetrics> captured = new AtomicReference<>();
+    TypeIndexBuilder.setSortedBuildMetricsTestHook(captured::set);
+    try {
+      final DocumentType type = database.getSchema().createDocumentType("MetricsParallelMerge");
+      type.createProperty("lookupKey", Type.STRING);
+      database.transaction(() -> {
+        for (int i = 0; i < 25_000; i++)
+          database.newDocument("MetricsParallelMerge").set("lookupKey", "key-%08d".formatted(i)).save();
+      });
+
+      database.getSchema().buildTypeIndex("MetricsParallelMerge", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(24L << 20)
+          .withBuildMergeFanIn(2)
+          .withBuildParallelism(4)
+          .withUnique(true)
+          .create();
+    } finally {
+      TypeIndexBuilder.setSortedBuildMetricsTestHook(null);
+    }
+
+    final SortedIndexBuildMetrics metrics = captured.get();
+    assertThat(metrics).isNotNull();
+    assertThat(metrics.requestedBuildParallelism()).isEqualTo(4);
+    assertThat(metrics.admittedMergeParallelism()).isBetween(1, 2);
+    assertThat(metrics.maxConcurrentMerges()).isBetween(1, metrics.admittedMergeParallelism());
+    assertThat(metrics.materializedMergeGenerations()).isGreaterThan(0);
+    assertThat(metrics.admittedWriterParallelism()).isEqualTo(1);
+    final JSONObject resources = metrics.toJSON().getJSONObject("resources");
+    assertThat(resources.getInt("requested_build_parallelism")).isEqualTo(4);
+    assertThat(resources.getInt("admitted_merge_parallelism")).isEqualTo(metrics.admittedMergeParallelism());
+    assertThat(resources.getInt("max_concurrent_merges")).isEqualTo(metrics.maxConcurrentMerges());
   }
 
   private static long count(final IndexCursor cursor) {

--- a/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildMetricsTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/SortedIndexBuildMetricsTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SortedIndexBuildMetricsTest extends TestHelper {
+  @Test
+  void capturesExternalRunsMaterializedMergesAndPublication() {
+    final AtomicReference<SortedIndexBuildMetrics> captured = new AtomicReference<>();
+    TypeIndexBuilder.setSortedBuildMetricsTestHook(captured::set);
+    try {
+      final DocumentType type = database.getSchema().buildDocumentType().withName("MetricsExternal")
+          .withTotalBuckets(3).create();
+      type.createProperty("lookupKey", Type.STRING);
+      database.transaction(() -> {
+        for (int i = 0; i < 2_000; i++) {
+          final int permuted = Math.floorMod(i * 1_237, 2_000);
+          database.newDocument("MetricsExternal").set("lookupKey", "key-%08d".formatted(permuted)).save();
+        }
+      });
+
+      final TypeIndex index = database.getSchema().buildTypeIndex("MetricsExternal", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(1L << 20)
+          .withBuildMergeFanIn(2)
+          .withUnique(true)
+          .create();
+      assertThat(count(index.iterator(true))).isEqualTo(2_000);
+    } finally {
+      TypeIndexBuilder.setSortedBuildMetricsTestHook(null);
+    }
+
+    final SortedIndexBuildMetrics metrics = captured.get();
+    assertThat(metrics).isNotNull();
+    assertThat(metrics.unique()).isTrue();
+    assertThat(metrics.scannedRecords()).isEqualTo(2_000);
+    assertThat(metrics.logicalEntries()).isEqualTo(2_000);
+    assertThat(metrics.writtenEntries()).isEqualTo(2_000);
+    assertThat(metrics.bucketIndexes()).isEqualTo(3);
+    assertThat(metrics.memoryBudgetBytes()).isEqualTo(1L << 20);
+    assertThat(metrics.requestedMergeFanIn()).isEqualTo(2);
+    assertThat(metrics.admittedMergeFanIn()).isEqualTo(2);
+    assertThat(metrics.initialRuns()).isGreaterThan(2);
+    assertThat(metrics.finalRuns()).isBetween(1, 2);
+    assertThat(metrics.materializedMergeGenerations()).isGreaterThan(0);
+    assertThat(metrics.initialRunEntries()).isEqualTo(2_000);
+    assertThat(metrics.initialRunBytes()).isGreaterThan(0);
+    assertThat(metrics.materializedMergeEntries()).isGreaterThan(0);
+    assertThat(metrics.materializedMergeBytes()).isGreaterThan(0);
+    assertThat(metrics.totalSpillBytes()).isGreaterThan(metrics.initialRunBytes());
+    assertThat(metrics.bucketIndexCreationNanos()).isGreaterThan(0);
+    assertThat(metrics.sourceScanNanos()).isGreaterThan(0);
+    assertThat(metrics.initialRunGenerationNanos()).isGreaterThan(0);
+    assertThat(metrics.inMemorySortNanos()).isZero();
+    assertThat(metrics.materializedMergeNanos()).isGreaterThan(0);
+    assertThat(metrics.finalStreamAndWriteNanos()).isGreaterThan(0);
+    assertThat(metrics.attachmentNanos()).isGreaterThan(0);
+    assertThat(metrics.pipelineNanos()).isGreaterThan(0);
+    assertThat(metrics.schemaRecordAndPublicationNanos()).isGreaterThan(0);
+    assertThat(metrics.cleanupNanos()).isGreaterThan(0);
+    assertThat(metrics.totalNanos()).isGreaterThanOrEqualTo(metrics.pipelineNanos());
+
+    final JSONObject json = metrics.toJSON();
+    assertThat(json.getInt("format_version")).isEqualTo(SortedIndexBuildMetrics.FORMAT_VERSION);
+    assertThat(json.getJSONObject("external_sort").getBoolean("enabled")).isTrue();
+    assertThat(json.getJSONObject("external_sort").getInt("materialized_merge_generations")).isGreaterThan(0);
+    assertThat(json.getJSONObject("timings").getDouble("materialized_merge_millis")).isGreaterThan(0D);
+    assertThat(json.getJSONObject("timings").getDouble("schema_record_and_publication_millis")).isGreaterThan(0D);
+  }
+
+  @Test
+  void distinguishesAnInMemoryBuildFromExternalSorting() {
+    final AtomicReference<SortedIndexBuildMetrics> captured = new AtomicReference<>();
+    TypeIndexBuilder.setSortedBuildMetricsTestHook(captured::set);
+    try {
+      final DocumentType type = database.getSchema().createDocumentType("MetricsInMemory");
+      type.createProperty("lookupKey", Type.INTEGER);
+      database.transaction(() -> {
+        for (int i = 0; i < 100; i++)
+          database.newDocument("MetricsInMemory").set("lookupKey", Math.floorMod(i * 37, 100)).save();
+      });
+
+      final TypeIndex index = database.getSchema().buildTypeIndex("MetricsInMemory", new String[] { "lookupKey" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withBuildMode(IndexBuildMode.SORTED)
+          .withBuildMemoryBudget(1L << 20)
+          .withUnique(true)
+          .create();
+      assertThat(count(index.iterator(true))).isEqualTo(100);
+    } finally {
+      TypeIndexBuilder.setSortedBuildMetricsTestHook(null);
+    }
+
+    final SortedIndexBuildMetrics metrics = captured.get();
+    assertThat(metrics).isNotNull();
+    assertThat(metrics.initialRuns()).isZero();
+    assertThat(metrics.finalRuns()).isZero();
+    assertThat(metrics.materializedMergeGenerations()).isZero();
+    assertThat(metrics.initialRunBytes()).isZero();
+    assertThat(metrics.materializedMergeBytes()).isZero();
+    assertThat(metrics.totalSpillBytes()).isZero();
+    assertThat(metrics.initialRunGenerationNanos()).isZero();
+    assertThat(metrics.inMemorySortNanos()).isGreaterThan(0);
+    assertThat(metrics.materializedMergeNanos()).isZero();
+    assertThat(metrics.finalStreamAndWriteNanos()).isGreaterThan(0);
+    assertThat(metrics.toJSON().getJSONObject("external_sort").getBoolean("enabled")).isFalse();
+  }
+
+  private static long count(final IndexCursor cursor) {
+    long total = 0L;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        total++;
+      }
+      return total;
+    } finally {
+      cursor.close();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/TestSortedIndexParallelismBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/schema/TestSortedIndexParallelismBenchmark.java
@@ -70,6 +70,7 @@ class TestSortedIndexParallelismBenchmark {
     try {
       final Path sourcePath = BENCHMARK_ROOT.resolve("source");
       createSourceDatabase(sourcePath, entries, buckets);
+      assertSourceCount(sourcePath, entries);
       final Path serialBeforePath = BENCHMARK_ROOT.resolve("serial-before");
       final Path parallelPath = BENCHMARK_ROOT.resolve("parallel");
       final Path serialAfterPath = BENCHMARK_ROOT.resolve("serial-after");
@@ -85,23 +86,33 @@ class TestSortedIndexParallelismBenchmark {
 
       final double serialMeanNanos = (serialBefore.buildNanos() + serialAfter.buildNanos()) / 2D;
       final double speedup = (serialMeanNanos - parallel.buildNanos()) / serialMeanNanos * 100D;
+      final double serialMeanMergeNanos = (serialBefore.metrics().materializedMergeNanos()
+          + serialAfter.metrics().materializedMergeNanos()) / 2D;
+      final double mergeSpeedup = serialMeanMergeNanos > 0D
+          ? (serialMeanMergeNanos - parallel.metrics().materializedMergeNanos()) / serialMeanMergeNanos * 100D : 0D;
       final double serialMeanWriteNanos = (serialBefore.metrics().finalStreamAndWriteNanos()
           + serialAfter.metrics().finalStreamAndWriteNanos()) / 2D;
       final double writeSpeedup = (serialMeanWriteNanos - parallel.metrics().finalStreamAndWriteNanos())
           / serialMeanWriteNanos * 100D;
       System.out.printf(Locale.ROOT,
-          "%nSorted LSM bucket-writer parallelism benchmark%n" +
+          "%nSorted LSM build parallelism benchmark%n" +
               "entries: %,d%n" +
               "buckets: %,d%n" +
               "memory budget: %,d MiB%n" +
               "merge fan-in: %,d%n" +
               "requested parallelism: %,d%n" +
-              "admitted parallelism: %,d%n" +
+              "admitted merge parallelism: %,d%n" +
+              "observed concurrent merges: %,d%n" +
+              "admitted writer parallelism: %,d%n" +
+              "observed concurrent writers: %,d%n" +
               "serial before: %.3f s%n" +
               "parallel: %.3f s%n" +
               "serial after: %.3f s%n" +
               "serial mean: %.3f s%n" +
               "parallel speedup: %.1f%%%n" +
+              "serial materialized-merge mean: %.3f s%n" +
+              "parallel materialized merge: %.3f s%n" +
+              "materialized-merge speedup: %.1f%%%n" +
               "serial final-write mean: %.3f s%n" +
               "parallel final-write: %.3f s%n" +
               "final-write speedup: %.1f%%%n" +
@@ -110,9 +121,13 @@ class TestSortedIndexParallelismBenchmark {
               "serial before metrics: %s%n" +
               "parallel metrics: %s%n" +
               "serial after metrics: %s%n%n",
-          entries, buckets, memoryMiB, mergeFanIn, parallelism, parallel.metrics().admittedWriterParallelism(),
+          entries, buckets, memoryMiB, mergeFanIn, parallelism, parallel.metrics().admittedMergeParallelism(),
+          parallel.metrics().maxConcurrentMerges(), parallel.metrics().admittedWriterParallelism(),
+          parallel.metrics().maxConcurrentWriters(),
           serialBefore.buildNanos() / 1_000_000_000D, parallel.buildNanos() / 1_000_000_000D,
           serialAfter.buildNanos() / 1_000_000_000D, serialMeanNanos / 1_000_000_000D, speedup,
+          serialMeanMergeNanos / 1_000_000_000D,
+          parallel.metrics().materializedMergeNanos() / 1_000_000_000D, mergeSpeedup,
           serialMeanWriteNanos / 1_000_000_000D,
           parallel.metrics().finalStreamAndWriteNanos() / 1_000_000_000D, writeSpeedup,
           parallel.ascendingDigest(), parallel.descendingDigest(), serialBefore.metrics().toJSON(),
@@ -145,6 +160,14 @@ class TestSortedIndexParallelismBenchmark {
           }
         });
       }
+    }
+  }
+
+  private static void assertSourceCount(final Path path, final int expectedEntries) {
+    try (DatabaseFactory factory = new DatabaseFactory(path.toString()); Database database = factory.open()) {
+      assertThat(database.countType(TYPE_NAME, true))
+          .as("source records after benchmark fixture creation")
+          .isEqualTo(expectedEntries);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/schema/TestSortedIndexParallelismBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/schema/TestSortedIndexParallelismBenchmark.java
@@ -43,49 +43,89 @@ class TestSortedIndexParallelismBenchmark {
   private static final String BUCKET_COUNT_PROPERTY = "arcadedb.sortedParallelBenchmark.buckets";
   private static final String MEMORY_MIB_PROPERTY = "arcadedb.sortedParallelBenchmark.memoryMiB";
   private static final String MERGE_FAN_IN_PROPERTY = "arcadedb.sortedParallelBenchmark.mergeFanIn";
+  private static final String PARALLELISM_PROPERTY = "arcadedb.sortedParallelBenchmark.parallelism";
 
   private static final int DEFAULT_ENTRY_COUNT = 1_000_000;
   private static final int DEFAULT_BUCKET_COUNT = 8;
   private static final int DEFAULT_MEMORY_MIB = 64;
   private static final int DEFAULT_MERGE_FAN_IN = 8;
+  private static final int DEFAULT_PARALLELISM = 4;
   private static final int INSERT_BATCH_SIZE = 10_000;
   private static final String TYPE_NAME = "ParallelBenchmarkRecord";
   private static final String PROPERTY_NAME = "lookupKey";
   private static final Path BENCHMARK_ROOT = Path.of("target", "databases", "SortedIndexParallelismBenchmark");
 
   @Test
-  void measureSerialSortedBuildStages() throws Exception {
+  void measureSortedBuildStages() throws Exception {
     final int entries = Integer.getInteger(ENTRY_COUNT_PROPERTY, DEFAULT_ENTRY_COUNT);
     final int buckets = Integer.getInteger(BUCKET_COUNT_PROPERTY, DEFAULT_BUCKET_COUNT);
     final int memoryMiB = Integer.getInteger(MEMORY_MIB_PROPERTY, DEFAULT_MEMORY_MIB);
     final int mergeFanIn = Integer.getInteger(MERGE_FAN_IN_PROPERTY, DEFAULT_MERGE_FAN_IN);
-    if (entries < 1 || buckets < 1 || memoryMiB < 1 || mergeFanIn < 2)
-      throw new IllegalArgumentException("Benchmark entries, buckets, and memory must be positive; fan-in must be at least 2");
+    final int parallelism = Integer.getInteger(PARALLELISM_PROPERTY, DEFAULT_PARALLELISM);
+    if (entries < 1 || buckets < 1 || memoryMiB < 1 || mergeFanIn < 2 || parallelism < 1)
+      throw new IllegalArgumentException(
+          "Benchmark entries, buckets, memory, and parallelism must be positive; fan-in must be at least 2");
 
     FileUtils.deleteRecursively(BENCHMARK_ROOT.toFile());
     try {
       final Path sourcePath = BENCHMARK_ROOT.resolve("source");
       createSourceDatabase(sourcePath, entries, buckets);
-      final Path buildPath = BENCHMARK_ROOT.resolve("serial");
-      FileUtils.copyDirectory(sourcePath.toFile(), buildPath.toFile());
+      final Path serialBeforePath = BENCHMARK_ROOT.resolve("serial-before");
+      final Path parallelPath = BENCHMARK_ROOT.resolve("parallel");
+      final Path serialAfterPath = BENCHMARK_ROOT.resolve("serial-after");
+      FileUtils.copyDirectory(sourcePath.toFile(), serialBeforePath.toFile());
+      FileUtils.copyDirectory(sourcePath.toFile(), parallelPath.toFile());
+      FileUtils.copyDirectory(sourcePath.toFile(), serialAfterPath.toFile());
 
-      final BuildResult result = buildAndValidate(buildPath, entries, memoryMiB, mergeFanIn);
+      final BuildResult serialBefore = buildAndValidate(serialBeforePath, entries, memoryMiB, mergeFanIn, 1);
+      final BuildResult parallel = buildAndValidate(parallelPath, entries, memoryMiB, mergeFanIn, parallelism);
+      final BuildResult serialAfter = buildAndValidate(serialAfterPath, entries, memoryMiB, mergeFanIn, 1);
+      assertEquivalentOutput(serialBefore, parallel);
+      assertEquivalentOutput(serialAfter, parallel);
+
+      final double serialMeanNanos = (serialBefore.buildNanos() + serialAfter.buildNanos()) / 2D;
+      final double speedup = (serialMeanNanos - parallel.buildNanos()) / serialMeanNanos * 100D;
+      final double serialMeanWriteNanos = (serialBefore.metrics().finalStreamAndWriteNanos()
+          + serialAfter.metrics().finalStreamAndWriteNanos()) / 2D;
+      final double writeSpeedup = (serialMeanWriteNanos - parallel.metrics().finalStreamAndWriteNanos())
+          / serialMeanWriteNanos * 100D;
       System.out.printf(Locale.ROOT,
-          "%nSorted LSM parallelism serial baseline%n" +
+          "%nSorted LSM bucket-writer parallelism benchmark%n" +
               "entries: %,d%n" +
               "buckets: %,d%n" +
               "memory budget: %,d MiB%n" +
               "merge fan-in: %,d%n" +
-              "index phase: %.3f s%n" +
+              "requested parallelism: %,d%n" +
+              "admitted parallelism: %,d%n" +
+              "serial before: %.3f s%n" +
+              "parallel: %.3f s%n" +
+              "serial after: %.3f s%n" +
+              "serial mean: %.3f s%n" +
+              "parallel speedup: %.1f%%%n" +
+              "serial final-write mean: %.3f s%n" +
+              "parallel final-write: %.3f s%n" +
+              "final-write speedup: %.1f%%%n" +
               "ascending digest: %s%n" +
               "descending digest: %s%n" +
-              "metrics: %s%n%n",
-          entries, buckets, memoryMiB, mergeFanIn, result.buildNanos() / 1_000_000_000D,
-          result.ascendingDigest(), result.descendingDigest(), result.metrics().toJSON());
+              "serial before metrics: %s%n" +
+              "parallel metrics: %s%n" +
+              "serial after metrics: %s%n%n",
+          entries, buckets, memoryMiB, mergeFanIn, parallelism, parallel.metrics().admittedWriterParallelism(),
+          serialBefore.buildNanos() / 1_000_000_000D, parallel.buildNanos() / 1_000_000_000D,
+          serialAfter.buildNanos() / 1_000_000_000D, serialMeanNanos / 1_000_000_000D, speedup,
+          serialMeanWriteNanos / 1_000_000_000D,
+          parallel.metrics().finalStreamAndWriteNanos() / 1_000_000_000D, writeSpeedup,
+          parallel.ascendingDigest(), parallel.descendingDigest(), serialBefore.metrics().toJSON(),
+          parallel.metrics().toJSON(), serialAfter.metrics().toJSON());
     } finally {
       TypeIndexBuilder.setSortedBuildMetricsTestHook(null);
       FileUtils.deleteRecursively(BENCHMARK_ROOT.toFile());
     }
+  }
+
+  private static void assertEquivalentOutput(final BuildResult expected, final BuildResult actual) {
+    assertThat(actual.ascendingDigest()).isEqualTo(expected.ascendingDigest());
+    assertThat(actual.descendingDigest()).isEqualTo(expected.descendingDigest());
   }
 
   private void createSourceDatabase(final Path path, final int entries, final int buckets) {
@@ -109,7 +149,7 @@ class TestSortedIndexParallelismBenchmark {
   }
 
   private BuildResult buildAndValidate(final Path path, final int expectedEntries, final int memoryMiB,
-      final int mergeFanIn) throws Exception {
+      final int mergeFanIn, final int parallelism) throws Exception {
     final AtomicReference<SortedIndexBuildMetrics> captured = new AtomicReference<>();
     final long buildNanos;
     final String ascendingDigest;
@@ -124,6 +164,7 @@ class TestSortedIndexParallelismBenchmark {
             .withBuildMode(IndexBuildMode.SORTED)
             .withBuildMemoryBudget((long) memoryMiB << 20)
             .withBuildMergeFanIn(mergeFanIn)
+            .withBuildParallelism(parallelism)
             .withUnique(true)
             .create();
         buildNanos = System.nanoTime() - started;

--- a/engine/src/test/java/com/arcadedb/schema/TestSortedIndexParallelismBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/schema/TestSortedIndexParallelismBenchmark.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Sorted-only stage benchmark used to select and validate bounded parallel build work. */
+@Tag("benchmark")
+class TestSortedIndexParallelismBenchmark {
+  private static final String ENTRY_COUNT_PROPERTY = "arcadedb.sortedParallelBenchmark.entries";
+  private static final String BUCKET_COUNT_PROPERTY = "arcadedb.sortedParallelBenchmark.buckets";
+  private static final String MEMORY_MIB_PROPERTY = "arcadedb.sortedParallelBenchmark.memoryMiB";
+  private static final String MERGE_FAN_IN_PROPERTY = "arcadedb.sortedParallelBenchmark.mergeFanIn";
+
+  private static final int DEFAULT_ENTRY_COUNT = 1_000_000;
+  private static final int DEFAULT_BUCKET_COUNT = 8;
+  private static final int DEFAULT_MEMORY_MIB = 64;
+  private static final int DEFAULT_MERGE_FAN_IN = 8;
+  private static final int INSERT_BATCH_SIZE = 10_000;
+  private static final String TYPE_NAME = "ParallelBenchmarkRecord";
+  private static final String PROPERTY_NAME = "lookupKey";
+  private static final Path BENCHMARK_ROOT = Path.of("target", "databases", "SortedIndexParallelismBenchmark");
+
+  @Test
+  void measureSerialSortedBuildStages() throws Exception {
+    final int entries = Integer.getInteger(ENTRY_COUNT_PROPERTY, DEFAULT_ENTRY_COUNT);
+    final int buckets = Integer.getInteger(BUCKET_COUNT_PROPERTY, DEFAULT_BUCKET_COUNT);
+    final int memoryMiB = Integer.getInteger(MEMORY_MIB_PROPERTY, DEFAULT_MEMORY_MIB);
+    final int mergeFanIn = Integer.getInteger(MERGE_FAN_IN_PROPERTY, DEFAULT_MERGE_FAN_IN);
+    if (entries < 1 || buckets < 1 || memoryMiB < 1 || mergeFanIn < 2)
+      throw new IllegalArgumentException("Benchmark entries, buckets, and memory must be positive; fan-in must be at least 2");
+
+    FileUtils.deleteRecursively(BENCHMARK_ROOT.toFile());
+    try {
+      final Path sourcePath = BENCHMARK_ROOT.resolve("source");
+      createSourceDatabase(sourcePath, entries, buckets);
+      final Path buildPath = BENCHMARK_ROOT.resolve("serial");
+      FileUtils.copyDirectory(sourcePath.toFile(), buildPath.toFile());
+
+      final BuildResult result = buildAndValidate(buildPath, entries, memoryMiB, mergeFanIn);
+      System.out.printf(Locale.ROOT,
+          "%nSorted LSM parallelism serial baseline%n" +
+              "entries: %,d%n" +
+              "buckets: %,d%n" +
+              "memory budget: %,d MiB%n" +
+              "merge fan-in: %,d%n" +
+              "index phase: %.3f s%n" +
+              "ascending digest: %s%n" +
+              "descending digest: %s%n" +
+              "metrics: %s%n%n",
+          entries, buckets, memoryMiB, mergeFanIn, result.buildNanos() / 1_000_000_000D,
+          result.ascendingDigest(), result.descendingDigest(), result.metrics().toJSON());
+    } finally {
+      TypeIndexBuilder.setSortedBuildMetricsTestHook(null);
+      FileUtils.deleteRecursively(BENCHMARK_ROOT.toFile());
+    }
+  }
+
+  private void createSourceDatabase(final Path path, final int entries, final int buckets) {
+    try (DatabaseFactory factory = new DatabaseFactory(path.toString()); Database database = factory.create()) {
+      final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME)
+          .withTotalBuckets(buckets).create();
+      type.createProperty(PROPERTY_NAME, Type.STRING);
+      final int stride = permutationStride(entries);
+
+      for (int from = 0; from < entries; from += INSERT_BATCH_SIZE) {
+        final int batchStart = from;
+        final int batchEnd = Math.min(entries, from + INSERT_BATCH_SIZE);
+        database.transaction(() -> {
+          for (int i = batchStart; i < batchEnd; i++) {
+            final int permuted = (int) Math.floorMod((long) i * stride, entries);
+            database.newDocument(TYPE_NAME).set(PROPERTY_NAME, key(permuted)).save();
+          }
+        });
+      }
+    }
+  }
+
+  private BuildResult buildAndValidate(final Path path, final int expectedEntries, final int memoryMiB,
+      final int mergeFanIn) throws Exception {
+    final AtomicReference<SortedIndexBuildMetrics> captured = new AtomicReference<>();
+    final long buildNanos;
+    final String ascendingDigest;
+    final String descendingDigest;
+    try (DatabaseFactory factory = new DatabaseFactory(path.toString()); Database database = factory.open()) {
+      TypeIndexBuilder.setSortedBuildMetricsTestHook(captured::set);
+      final TypeIndex index;
+      try {
+        final long started = System.nanoTime();
+        index = database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { PROPERTY_NAME })
+            .withType(Schema.INDEX_TYPE.LSM_TREE)
+            .withBuildMode(IndexBuildMode.SORTED)
+            .withBuildMemoryBudget((long) memoryMiB << 20)
+            .withBuildMergeFanIn(mergeFanIn)
+            .withUnique(true)
+            .create();
+        buildNanos = System.nanoTime() - started;
+      } finally {
+        TypeIndexBuilder.setSortedBuildMetricsTestHook(null);
+      }
+
+      assertThat(captured.get()).isNotNull();
+      assertThat(captured.get().scannedRecords()).isEqualTo(expectedEntries);
+      assertThat(count(index.get(new Object[] { key(expectedEntries / 2) }))).isEqualTo(1);
+      ascendingDigest = digest(index.iterator(true), expectedEntries);
+      descendingDigest = digest(index.iterator(false), expectedEntries);
+    }
+
+    try (DatabaseFactory factory = new DatabaseFactory(path.toString()); Database database = factory.open()) {
+      final TypeIndex index = database.getSchema().getType(TYPE_NAME).getIndexByProperties(PROPERTY_NAME);
+      assertThat(digest(index.iterator(true), expectedEntries)).isEqualTo(ascendingDigest);
+      assertThat(digest(index.iterator(false), expectedEntries)).isEqualTo(descendingDigest);
+    }
+    return new BuildResult(buildNanos, ascendingDigest, descendingDigest, captured.get());
+  }
+
+  private static String digest(final IndexCursor cursor, final int expectedEntries) throws Exception {
+    final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    int count = 0;
+    try {
+      while (cursor.hasNext()) {
+        final Identifiable record = cursor.next();
+        digest.update(cursor.getKeys()[0].toString().getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) 0);
+        digest.update(record.getIdentity().toString().getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) '\n');
+        count++;
+      }
+    } finally {
+      cursor.close();
+    }
+    assertThat(count).isEqualTo(expectedEntries);
+    return HexFormat.of().formatHex(digest.digest());
+  }
+
+  private static long count(final IndexCursor cursor) {
+    long count = 0L;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        count++;
+      }
+      return count;
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static String key(final int value) {
+    return "key-%09d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".formatted(value);
+  }
+
+  private static int permutationStride(final int entries) {
+    if (entries == 1)
+      return 1;
+
+    int candidate = Math.max(1, (int) (entries * 0.6180339887498949));
+    while (greatestCommonDivisor(candidate, entries) != 1)
+      --candidate;
+    return candidate;
+  }
+
+  private static int greatestCommonDivisor(int left, int right) {
+    while (right != 0) {
+      final int remainder = left % right;
+      left = right;
+      right = remainder;
+    }
+    return left;
+  }
+
+  private record BuildResult(long buildNanos, String ascendingDigest, String descendingDigest,
+                             SortedIndexBuildMetrics metrics) {
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds opt-in, resource-admitted parallelism to the sorted `LSM_TREE` build path introduced in #5244 and extended to unique indexes in #5256.

```java
schema.buildTypeIndex(typeName, propertyNames)
    .withType(Schema.INDEX_TYPE.LSM_TREE)
    .withBuildMode(IndexBuildMode.SORTED)
    .withBuildParallelism(4)
    .create();
```

The requested parallelism applies only to work that is already independent:

- materialized external-sort merge groups within one merge generation; and
- final compacted writers for independent bucket sub-indexes.

The default remains one worker. The final global ordered stream remains serial and continues to own key ordering, RID grouping, unique-key enforcement, and publication semantics.

## Resource admission and diagnostics

Each stage independently bounds its admitted workers by:

- requested parallelism;
- available work groups or bucket writers;
- processor headroom;
- the sorted-build memory budget; and
- available file descriptors.

The existing sorted-build metrics now report requested, admitted, and observed merge/writer concurrency alongside the existing run, spill, and stage timing data. A request can therefore fall back to one worker without changing correctness or publication behavior.

## Failure and publication behavior

Parallel merge workers own disjoint input cursors, output streams, and serialization buffers. Source runs remain intact until every group in a generation succeeds. On the first failure, the dispatcher cancels peers, waits for worker termination, preserves the first cause, and removes incomplete generation output.

Parallel bucket writers own independent staged bucket-index files. A writer failure cancels and joins its peers before the existing sorted-build cleanup removes staged components and spill artifacts. Schema publication still occurs only after all bucket output succeeds.

No new writer, on-disk layout, recovery mechanism, HA behavior, or online-build path is introduced.

## Correctness and validation

Coverage includes:

- merge and writer admission against work, CPU, memory, and file-descriptor limits;
- observed overlap for admitted merge groups and bucket writers;
- unique and high-multiplicity nonunique output across buckets and RID chunks;
- preservation of the final global duplicate boundary;
- cancellation, cleanup, and no publication after worker failure;
- serial fallback for one merge group or one bucket;
- metrics, exact/range/ascending/descending reads, planner use, reopen, mutation, crash recovery, compatibility, and later compaction.

```text
Concurrency/failure/metrics gate: 19 tests, 0 failures, 0 errors
Broad sorted-build gate:           42 tests, 0 failures, 0 errors
```

A full engine run completed 9,347 tests. Every PR3 and adjacent index test passed. It reported three failures outside this patch: one 256-CPU bucket-limit test defect reproduced on untouched `main`, plus two shared-suite failures that pass in isolation.

## Performance evidence

All comparisons use the same binary, fresh fixture copies, a 4 GiB heap, full output digest checks, and reopen validation.

### 1M, eight source buckets

With a 64 MiB build budget, fan-in 8, and four requested workers:

```text
Serial mean:                4.279 s
Parallel:                   3.327 s
End-to-end improvement:      22.3%
Materialized merge:  0.777 -> 0.279 s  (64.1%)
Final write:         1.077 -> 0.792 s  (26.4%)
```

Both merge and writer stages admitted and observed four concurrent workers.

### 10M, one source bucket

A serial/parallel/serial bracket isolated materialized merge work because writer admission was one:

```text
Serial mean:               40.497 s
Parallel mean:             35.339 s
End-to-end improvement:      12.74%
Materialized merge:  7.615 -> 2.417 s  (68.26%)
```

Every accepted run produced identical ascending and descending digests. These results describe the tested fixtures and configurations, not a general throughput guarantee.

## Scope

This remains an explicit, offline, single-server sorted build. Automatic parallelism, SQL syntax, HA/replicated construction, online snapshot-plus-delta construction, and multi-index scheduling remain out of scope.

Related: #5230.
