### PR TITLE
fix(#5257): enforce CALL subquery scope on CREATE/MERGE patterns

### DIFF
--- a/docs/5257-call-subquery-rel-scope-validation.md
+++ b/docs/5257-call-subquery-rel-scope-validation.md
@@ -60,3 +60,30 @@ Queries that previously "succeeded" while writing orphan vertices now fail fast 
 
 A `WITH` *inside* a subquery body that drops an imported variable, followed by a `CREATE` re-using that
 name, is still not flagged (Neo4j errors). Tracked separately - the reported bug is the un-imported case.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5260
+
+## Review cycles
+
+### Cycle 1 - 4b87c0cd
+
+- `gemini-code-assist`: COMMENTED, "I have no additional feedback to provide."
+- `claude[bot]`: non-blocking notes, no blocking objections.
+
+Applied:
+- Added `createSingleNodeWithUnimportedOuterVariableThrows` - pins the intended breadth of the guard
+  (it covers single-node `CREATE`, not only relationship patterns).
+- `countRelationships` in the test now gates on `schema.existsType(...)` instead of swallowing every
+  exception, so an unexpected failure can no longer masquerade as a passing assertion.
+- Clarified in the `importedNamesFromLeadingWith` javadoc that it tracks the names still bound after
+  the `WITH`, not the source variables they were computed from.
+- Dropped the copied `@author` tag from the new test rather than mis-attributing it.
+- Retitled the PR to say "CREATE/MERGE patterns" instead of "relationship patterns".
+
+Not applied:
+- "Add a CHANGELOG / release-notes entry for the compatibility change." No CHANGELOG file exists in the
+  repo, so there is no place to put it. The behaviour change (previously-lenient subqueries now fail
+  fast) is described in the PR body and here instead; flagging it for the release notes is the
+  maintainer's call.

--- a/docs/5257-call-subquery-rel-scope-validation.md
+++ b/docs/5257-call-subquery-rel-scope-validation.md
@@ -56,10 +56,17 @@ This also closes the same hole for nested subqueries, since `shadowed` is inheri
 Queries that previously "succeeded" while writing orphan vertices now fail fast with
 `UndefinedVariable`. That is the intended, spec-aligned behaviour and matches Neo4j/Memgraph.
 
-## Known related gap (not addressed)
+## Known related gaps (not addressed)
 
-A `WITH` *inside* a subquery body that drops an imported variable, followed by a `CREATE` re-using that
-name, is still not flagged (Neo4j errors). Tracked separately - the reported bug is the un-imported case.
+Both are pre-existing holes in the same validator, not regressions from this change:
+
+1. A `WITH` *inside* a subquery body that drops an imported variable, followed by a `CREATE` re-using
+   that name, is still not flagged (Neo4j errors). `shadowed` is computed once at branch entry and does
+   not track mid-body scope narrowing.
+2. `FOREACH` bodies are not scope-validated at all (`case FOREACH` is a bare `break`), so
+   `FOREACH (x IN [1] | CREATE (a)-[:R]->(b))` inside a subquery still bypasses the check.
+
+The reported bug is the un-imported case, which is what this change fixes.
 
 ## PR
 
@@ -87,3 +94,17 @@ Not applied:
   repo, so there is no place to put it. The behaviour change (previously-lenient subqueries now fail
   fast) is described in the PR body and here instead; flagging it for the release notes is the
   maintainer's call.
+
+### Cycle 2 - 0a3884a3
+
+- `claude[bot]`: **LGTM**. Traced the `shadowed` propagation through the bare-`CALL`, partial-`WITH`,
+  nested-`CALL` and `CALL (*)` paths and confirmed it holds; called the positive controls the valuable
+  part of the test suite. Remaining points were non-blocking, and three were explicitly
+  "no change requested" (`UndefinedVariable` token reuse is consistent with the #5213 SET/DELETE checks;
+  the old-style casts match the neighbouring `checkExpressionScope`; the fixed test-DB path matches
+  module convention). The one substantive note - `FOREACH` bodies bypass the check - is a pre-existing
+  validator gap and is now recorded under "Known related gaps" above.
+- `gemini-code-assist`: did not re-review this SHA (it re-reviews inconsistently); it had no feedback on
+  cycle 1.
+
+Final state: clean approval.

--- a/docs/5257-call-subquery-rel-scope-validation.md
+++ b/docs/5257-call-subquery-rel-scope-validation.md
@@ -1,0 +1,62 @@
+# #5257 - CREATE/MERGE relationship patterns bypass CALL subquery scope validation
+
+## Symptom
+
+Inside a `CALL { ... }` subquery, `CREATE`/`MERGE` relationship patterns referencing outer variables
+that were never imported are silently accepted:
+
+```cypher
+MATCH (a:A {id: 1}), (b:B {id: 2})
+CALL {
+  CREATE (a)-[:R]->(b)
+  RETURN 1 AS ok
+}
+RETURN ok
+```
+
+The query succeeds, reports `relationshipsCreated: 1`, but `MATCH (:A)-[r:R]->(:B) RETURN count(r)`
+returns 0. `SET`, `DELETE` and label updates correctly raise `UndefinedVariable` in the same position.
+
+## Root cause
+
+`CypherSemanticValidator.validateVariableScope` seeds a `CALL { ... }` body with an empty scope when
+nothing is imported (`validateSubqueryBranchScope`). `case SET`/`case DELETE` check their variables
+against that scope, but `case CREATE`/`case MERGE` never check pattern variables - they call
+`addBoundVarsFromPattern` unconditionally, which *declares* `a` and `b` as fresh variables.
+
+At runtime `CreateStep.createPath` / `MergeStep.createNewPath` look the variable up in the seed row,
+find nothing, and fall back to `createVertex(...)`, minting brand-new anonymous `Vertex`-typed nodes.
+The edge is then created between those orphans and `stats.incRelationshipsCreated()` fires. Hence:
+success + counter + no relationship between the intended endpoints (and two orphan vertices).
+
+Neo4j and Memgraph both reject these queries.
+
+## Fix
+
+Thread a `shadowed` set through `validateVariableScope`: names visible in an enclosing scope that were
+*not* imported into the current `CALL` subquery. `CREATE` and `MERGE` now reject any pattern variable
+(node, relationship or path) that is absent from the current scope but present in `shadowed`.
+
+`shadowed` is computed at subquery entry as `(outerScope + inheritedShadowed) - importedNames`, where
+`importedNames` is:
+- the explicit scope list for `CALL (a, b) { ... }`,
+- the whole outer scope for `CALL (*) { ... }`,
+- the outer names that survive a leading importing `WITH` (so `CALL { WITH a CREATE (a)-[:R]->(b) }`
+  still flags `b`),
+- empty for a bare `CALL { ... }`.
+
+This also closes the same hole for nested subqueries, since `shadowed` is inherited downwards.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue5257CallSubqueryRelationshipScopeTest.java`
+
+## Impact
+
+Queries that previously "succeeded" while writing orphan vertices now fail fast with
+`UndefinedVariable`. That is the intended, spec-aligned behaviour and matches Neo4j/Memgraph.
+
+## Known related gap (not addressed)
+
+A `WITH` *inside* a subquery body that drops an imported variable, followed by a `CREATE` re-using that
+name, is still not flagged (Neo4j errors). Tracked separately - the reported bug is the un-imported case.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -327,7 +327,7 @@ public class CypherSemanticValidator {
   // ==============================
 
   private void validateVariableScope(final CypherStatement statement) {
-    validateVariableScope(statement, new HashSet<>());
+    validateVariableScope(statement, new HashSet<>(), Set.of());
   }
 
   /**
@@ -335,8 +335,14 @@ public class CypherSemanticValidator {
    * visible when the statement begins. Top-level statements start with an empty scope; a CALL
    * subquery body starts with only the variables it imports (explicit {@code CALL (v) { ... }} scope
    * list, {@code CALL (*)}, or an importing {@code WITH}).
+   * <p>
+   * {@code shadowed} holds the names declared in an enclosing scope that this subquery body did NOT
+   * import. Such a name is not a free identifier the body may re-declare: a CREATE/MERGE pattern that
+   * binds it would silently mint a fresh anonymous vertex instead of writing against the outer entity,
+   * so it is rejected as undefined.
    */
-  private void validateVariableScope(final CypherStatement statement, final Set<String> scope) {
+  private void validateVariableScope(final CypherStatement statement, final Set<String> scope,
+      final Set<String> shadowed) {
     final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
     if (clausesInOrder == null || clausesInOrder.isEmpty())
       return; // Can't validate scope without clause ordering
@@ -363,12 +369,14 @@ public class CypherSemanticValidator {
               for (final RelationshipPattern rel : path.getRelationships())
                 if (rel.hasProperties())
                   checkPropertyValuesScope(rel.getProperties(), scope);
+              checkPatternVarsNotShadowed(path, scope, shadowed);
               addBoundVarsFromPattern(path, scope);
             }
           break;
         case MERGE:
           final MergeClause mergeClause = entry.getTypedClause();
           if (mergeClause != null) {
+            checkPatternVarsNotShadowed(mergeClause.getPathPattern(), scope, shadowed);
             addBoundVarsFromPattern(mergeClause.getPathPattern(), scope);
             // Validate ON CREATE SET / ON MATCH SET variables
             validateSetClauseScope(mergeClause.getOnCreateSet(), scope);
@@ -546,7 +554,7 @@ public class CypherSemanticValidator {
           final SubqueryClause subqueryClause = entry.getTypedClause();
           if (subqueryClause != null && subqueryClause.getInnerStatement() != null) {
             // Validate the subquery body: outer variables are visible only if imported (issue #5213).
-            validateSubqueryScope(subqueryClause, scope);
+            validateSubqueryScope(subqueryClause, scope, shadowed);
             final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
             if (innerReturn != null)
               for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems()) {
@@ -574,7 +582,8 @@ public class CypherSemanticValidator {
    * Referencing an outer variable that is not imported raises an undefined-variable error, matching
    * Neo4j (issue #5213).
    */
-  private void validateSubqueryScope(final SubqueryClause clause, final Set<String> outerScope) {
+  private void validateSubqueryScope(final SubqueryClause clause, final Set<String> outerScope,
+      final Set<String> outerShadowed) {
     final List<String> scopeVariables = clause.getScopeVariables();
 
     // Explicit scope list applies uniformly to every UNION branch of the body.
@@ -595,23 +604,56 @@ public class CypherSemanticValidator {
     final CypherStatement inner = clause.getInnerStatement();
     if (inner instanceof UnionStatement union) {
       for (final CypherStatement branch : union.getQueries())
-        validateSubqueryBranchScope(branch, outerScope, explicitSeed);
+        validateSubqueryBranchScope(branch, outerScope, outerShadowed, explicitSeed);
     } else
-      validateSubqueryBranchScope(inner, outerScope, explicitSeed);
+      validateSubqueryBranchScope(inner, outerScope, outerShadowed, explicitSeed);
   }
 
   private void validateSubqueryBranchScope(final CypherStatement branch, final Set<String> outerScope,
-      final Set<String> explicitSeed) {
+      final Set<String> outerShadowed, final Set<String> explicitSeed) {
     final Set<String> seed;
-    if (explicitSeed != null)
+    final Set<String> imported;
+    if (explicitSeed != null) {
       seed = new HashSet<>(explicitSeed);
-    else if (startsWithImportingWith(branch))
+      imported = explicitSeed;
+    } else if (startsWithImportingWith(branch)) {
       // The importing WITH may reference outer variables; it then resets the scope to its projections,
       // so exposing the whole outer scope here does not leak variables past the WITH.
       seed = new HashSet<>(outerScope);
-    else
+      imported = importedNamesFromLeadingWith(branch, outerScope);
+    } else {
       seed = new HashSet<>();
-    validateVariableScope(branch, seed);
+      imported = Set.of();
+    }
+
+    // Outer names the body did not import are shadowed: they may not be re-bound by a write pattern.
+    final Set<String> shadowed = new HashSet<>(outerScope);
+    shadowed.addAll(outerShadowed);
+    shadowed.removeAll(imported);
+
+    validateVariableScope(branch, seed, shadowed);
+  }
+
+  /**
+   * Returns the outer names that survive the leading importing {@code WITH} of a subquery body, i.e.
+   * the variables actually imported. {@code WITH *} imports the whole outer scope; a re-aliased item
+   * ({@code WITH a AS x}) does not import {@code a}, since {@code a} is no longer visible afterwards.
+   */
+  private static Set<String> importedNamesFromLeadingWith(final CypherStatement branch, final Set<String> outerScope) {
+    final WithClause withClause = branch.getClausesInOrder().get(0).getTypedClause();
+    final Set<String> imported = new HashSet<>();
+    for (final ReturnClause.ReturnItem item : withClause.getItems()) {
+      final Expression expr = item.getExpression();
+      if (expr instanceof StarExpression ||
+          (expr instanceof VariableExpression && "*".equals(((VariableExpression) expr).getVariableName())))
+        return new HashSet<>(outerScope);
+      final String name = item.getAlias() != null ?
+          item.getAlias() :
+          (expr instanceof VariableExpression ? ((VariableExpression) expr).getVariableName() : null);
+      if (name != null && outerScope.contains(name))
+        imported.add(name);
+    }
+    return imported;
   }
 
   private static boolean startsWithImportingWith(final CypherStatement statement) {
@@ -619,6 +661,29 @@ public class CypherSemanticValidator {
     if (clauses == null || clauses.isEmpty())
       return false;
     return clauses.get(0).getType() == ClauseEntry.ClauseType.WITH;
+  }
+
+  /**
+   * Rejects a CREATE/MERGE pattern variable that is not visible in the current scope but is declared in
+   * an enclosing one without having been imported. Binding it here would create a fresh anonymous entity
+   * rather than write against the outer one, which is a silent data-loss bug (issue #5257).
+   */
+  private void checkPatternVarsNotShadowed(final PathPattern path, final Set<String> scope, final Set<String> shadowed) {
+    if (shadowed.isEmpty() || path == null)
+      return;
+
+    if (path.hasPathVariable())
+      checkVarNotShadowed(path.getPathVariable(), scope, shadowed);
+    for (final NodePattern node : path.getNodes())
+      checkVarNotShadowed(node.getVariable(), scope, shadowed);
+    for (final RelationshipPattern rel : path.getRelationships())
+      checkVarNotShadowed(rel.getVariable(), scope, shadowed);
+  }
+
+  private void checkVarNotShadowed(final String var, final Set<String> scope, final Set<String> shadowed) {
+    if (var != null && isValidVariableName(var) && !scope.contains(var) && shadowed.contains(var))
+      throw new CommandSemanticException("UndefinedVariable: Variable '" + var
+          + "' not defined: it is declared in an outer scope but not imported into the CALL subquery");
   }
 
   private void checkExpressionScope(final Expression expr, final Set<String> scope) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -635,9 +635,12 @@ public class CypherSemanticValidator {
   }
 
   /**
-   * Returns the outer names that survive the leading importing {@code WITH} of a subquery body, i.e.
-   * the variables actually imported. {@code WITH *} imports the whole outer scope; a re-aliased item
-   * ({@code WITH a AS x}) does not import {@code a}, since {@code a} is no longer visible afterwards.
+   * Returns the outer names that survive the leading importing {@code WITH} of a subquery body, i.e. the
+   * variables actually imported. {@code WITH *} imports the whole outer scope.
+   * <p>
+   * This tracks the <i>names still bound after the WITH</i>, not the source variables they were computed
+   * from, because that is what the shadowing check needs: a re-aliased item ({@code WITH a AS x}) leaves
+   * {@code a} unbound, so {@code a} stays shadowed and a later {@code CREATE (a)} in the body is rejected.
    */
   private static Set<String> importedNamesFromLeadingWith(final CypherStatement branch, final Set<String> outerScope) {
     final WithClause withClause = branch.getClausesInOrder().get(0).getTypedClause();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5257CallSubqueryRelationshipScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5257CallSubqueryRelationshipScopeTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5257: {@code CREATE} and {@code MERGE} relationship patterns inside a
+ * {@code CALL} subquery must obey the same variable-scope rules as {@code SET} and {@code DELETE}.
+ * Referencing an outer variable that was never imported used to silently mint fresh anonymous
+ * vertices, persist the edge between those orphans, and still report {@code relationshipsCreated: 1}.
+ * Neo4j and Memgraph both reject such queries.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5257CallSubqueryRelationshipScopeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./databases/test-issue5257").create();
+    database.command("opencypher", "CREATE (:A {id: 1}), (:B {id: 2})");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  /** The reporter's case 1: CREATE of a relationship between two unimported outer variables. */
+  @Test
+  void createRelationshipWithUnimportedOuterVariablesThrows() {
+    assertThatThrownBy(() -> database.command("opencypher",
+        """
+        MATCH (a:A {id: 1}), (b:B {id: 2}) \
+        CALL { \
+          CREATE (a)-[:R]->(b) \
+          RETURN 1 AS ok \
+        } \
+        RETURN ok"""))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("UndefinedVariable")
+        .hasMessageContaining("a");
+
+    assertNoOrphanWrites("R");
+  }
+
+  /** The reporter's case 2: MERGE has the same false-success behaviour. */
+  @Test
+  void mergeRelationshipWithUnimportedOuterVariablesThrows() {
+    assertThatThrownBy(() -> database.command("opencypher",
+        """
+        MATCH (a:A {id: 1}), (b:B {id: 2}) \
+        CALL { \
+          MERGE (a)-[:MR]->(b) \
+          RETURN 1 AS ok \
+        } \
+        RETURN ok"""))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("UndefinedVariable")
+        .hasMessageContaining("a");
+
+    assertNoOrphanWrites("MR");
+  }
+
+  /** A partially importing WITH must still flag the endpoint it did not import. */
+  @Test
+  void createRelationshipWithPartiallyImportedOuterVariablesThrows() {
+    assertThatThrownBy(() -> database.command("opencypher",
+        """
+        MATCH (a:A {id: 1}), (b:B {id: 2}) \
+        CALL { \
+          WITH a \
+          CREATE (a)-[:R]->(b) \
+          RETURN 1 AS ok \
+        } \
+        RETURN ok"""))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("UndefinedVariable")
+        .hasMessageContaining("b");
+
+    assertNoOrphanWrites("R");
+  }
+
+  /** A relationship variable bound in the outer scope but not imported must also be rejected. */
+  @Test
+  void createWithUnimportedOuterRelationshipVariableThrows() {
+    database.command("opencypher", "MATCH (a:A {id: 1}), (b:B {id: 2}) CREATE (a)-[:R]->(b)");
+
+    assertThatThrownBy(() -> database.command("opencypher",
+        """
+        MATCH (a:A)-[r:R]->(b:B) \
+        CALL { \
+          CREATE (x:X)-[r:R2]->(y:Y) \
+          RETURN 1 AS ok \
+        } \
+        RETURN ok"""))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("UndefinedVariable")
+        .hasMessageContaining("r");
+  }
+
+  /** Nested subqueries inherit the shadowed names of every enclosing scope. */
+  @Test
+  void nestedCallCreateRelationshipWithUnimportedOuterVariablesThrows() {
+    assertThatThrownBy(() -> database.command("opencypher",
+        """
+        MATCH (a:A {id: 1}), (b:B {id: 2}) \
+        CALL (a, b) { \
+          CALL { \
+            CREATE (a)-[:R]->(b) \
+            RETURN 1 AS ok \
+          } \
+          RETURN ok \
+        } \
+        RETURN ok"""))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("UndefinedVariable");
+
+    assertNoOrphanWrites("R");
+  }
+
+  /** Control: an importing WITH makes the relationship CREATE valid and it really persists. */
+  @Test
+  void createRelationshipWithImportingWithPersists() {
+    final ResultSet rs = database.command("opencypher",
+        """
+        MATCH (a:A {id: 1}), (b:B {id: 2}) \
+        CALL { \
+          WITH a, b \
+          CREATE (a)-[:CR]->(b) \
+          RETURN 1 AS ok \
+        } \
+        RETURN ok""");
+    assertThat(rs.hasNext()).isTrue();
+    rs.close();
+
+    assertThat(countRelationships("CR")).isEqualTo(1);
+    assertThat(countVertices()).isEqualTo(2);
+  }
+
+  /** Control: an explicit scope list makes the relationship MERGE valid and it really persists. */
+  @Test
+  void mergeRelationshipWithExplicitScopeListPersists() {
+    final ResultSet rs = database.command("opencypher",
+        """
+        MATCH (a:A {id: 1}), (b:B {id: 2}) \
+        CALL (a, b) { \
+          MERGE (a)-[:MR]->(b) \
+          RETURN 1 AS ok \
+        } \
+        RETURN ok""");
+    assertThat(rs.hasNext()).isTrue();
+    rs.close();
+
+    assertThat(countRelationships("MR")).isEqualTo(1);
+    assertThat(countVertices()).isEqualTo(2);
+  }
+
+  /** Control: a subquery that declares its own pattern variables stays valid. */
+  @Test
+  void selfContainedCreateInsideSubqueryPersists() {
+    final ResultSet rs = database.command("opencypher",
+        """
+        MATCH (a:A {id: 1}) \
+        CALL { \
+          CREATE (x:X {id: 10})-[:XR]->(y:Y {id: 11}) \
+          RETURN 1 AS ok \
+        } \
+        RETURN ok""");
+    assertThat(rs.hasNext()).isTrue();
+    rs.close();
+
+    assertThat(countRelationships("XR")).isEqualTo(1);
+  }
+
+  /** Control: top-level CREATE of a fresh relationship pattern is unaffected. */
+  @Test
+  void topLevelCreateRelationshipPersists() {
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:A {id: 1}), (b:B {id: 2}) CREATE (a)-[:TR]->(b) RETURN 1 AS ok");
+    assertThat(rs.hasNext()).isTrue();
+    rs.close();
+
+    assertThat(countRelationships("TR")).isEqualTo(1);
+    assertThat(countVertices()).isEqualTo(2);
+  }
+
+  private void assertNoOrphanWrites(final String relType) {
+    assertThat(countRelationships(relType)).isZero();
+    assertThat(countVertices()).isEqualTo(2);
+  }
+
+  private long countRelationships(final String relType) {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH ()-[r:" + relType + "]->() RETURN count(r) AS cnt")) {
+      return rs.hasNext() ? ((Number) rs.next().getProperty("cnt")).longValue() : 0;
+    } catch (final Exception e) {
+      // The relationship type may not exist at all: that is the strongest form of "nothing created".
+      return 0;
+    }
+  }
+
+  private long countVertices() {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n) RETURN count(n) AS cnt")) {
+      return ((Number) rs.next().getProperty("cnt")).longValue();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5257CallSubqueryRelationshipScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5257CallSubqueryRelationshipScopeTest.java
@@ -30,13 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Regression tests for issue #5257: {@code CREATE} and {@code MERGE} relationship patterns inside a
- * {@code CALL} subquery must obey the same variable-scope rules as {@code SET} and {@code DELETE}.
- * Referencing an outer variable that was never imported used to silently mint fresh anonymous
- * vertices, persist the edge between those orphans, and still report {@code relationshipsCreated: 1}.
- * Neo4j and Memgraph both reject such queries.
- *
- * @author Luca Garulli (l.garulli@arcadedata.com)
+ * Regression tests for issue #5257: {@code CREATE} and {@code MERGE} patterns inside a {@code CALL}
+ * subquery must obey the same variable-scope rules as {@code SET} and {@code DELETE}. Binding an outer
+ * variable that was never imported used to silently mint fresh anonymous vertices, persist the edge
+ * between those orphans, and still report {@code relationshipsCreated: 1}. Neo4j and Memgraph both
+ * reject such queries.
  */
 class Issue5257CallSubqueryRelationshipScopeTest {
   private Database database;
@@ -124,6 +122,26 @@ class Issue5257CallSubqueryRelationshipScopeTest {
         .isInstanceOf(CommandParsingException.class)
         .hasMessageContaining("UndefinedVariable")
         .hasMessageContaining("r");
+  }
+
+  /**
+   * The guard is not limited to relationship patterns: a single-node CREATE re-binding an unimported
+   * outer variable is the same shadowing violation and must be rejected too.
+   */
+  @Test
+  void createSingleNodeWithUnimportedOuterVariableThrows() {
+    assertThatThrownBy(() -> database.command("opencypher",
+        """
+        MATCH (a:A {id: 1}) \
+        CALL { \
+          CREATE (a:Shadow) \
+          RETURN 1 AS ok \
+        } \
+        RETURN ok"""))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("a");
+
+    assertThat(countVertices()).isEqualTo(2);
   }
 
   /** Nested subqueries inherit the shadowed names of every enclosing scope. */
@@ -218,12 +236,13 @@ class Issue5257CallSubqueryRelationshipScopeTest {
   }
 
   private long countRelationships(final String relType) {
+    // An absent type is the strongest form of "nothing was created"; querying it would throw.
+    if (!database.getSchema().existsType(relType))
+      return 0;
+
     try (final ResultSet rs = database.query("opencypher",
         "MATCH ()-[r:" + relType + "]->() RETURN count(r) AS cnt")) {
       return rs.hasNext() ? ((Number) rs.next().getProperty("cnt")).longValue() : 0;
-    } catch (final Exception e) {
-      // The relationship type may not exist at all: that is the strongest form of "nothing created".
-      return 0;
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5257CallSubqueryRelationshipScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5257CallSubqueryRelationshipScopeTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,19 +33,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * between those orphans, and still report {@code relationshipsCreated: 1}. Neo4j and Memgraph both
  * reject such queries.
  */
-class Issue5257CallSubqueryRelationshipScopeTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-issue5257").create();
+class Issue5257CallSubqueryRelationshipScopeTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.command("opencypher", "CREATE (:A {id: 1}), (:B {id: 2})");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null && database.isOpen())
-      database.drop();
   }
 
   /** The reporter's case 1: CREATE of a relationship between two unimported outer variables. */


### PR DESCRIPTION
Closes #5257

## Summary

`CREATE` and `MERGE` relationship patterns inside a `CALL { ... }` subquery never validated their pattern variables against the subquery scope. `CypherSemanticValidator` checks `SET` and `DELETE` variables against the (empty, when nothing is imported) subquery scope, but the `CREATE`/`MERGE` cases went straight to `addBoundVarsFromPattern`, which *declares* the names as fresh bindings. At runtime `CreateStep`/`MergeStep` then failed to resolve those names in the seed row and fell back to minting brand-new anonymous `Vertex` nodes, persisted the edge between those orphans, and still incremented `relationshipsCreated`. Net effect: the query returned successfully, reported `relationshipsCreated: 1`, and no relationship existed between the intended endpoints. Neo4j and Memgraph both reject these queries.

The fix threads a `shadowed` set through variable-scope validation: the names declared in an enclosing scope that the subquery body did *not* import. `CREATE` and `MERGE` now reject any pattern variable (node, relationship or path) that is absent from the current scope but present in `shadowed`. `shadowed` is computed at subquery entry as `(outerScope + inheritedShadowed) - importedNames`, where `importedNames` comes from the explicit scope list (`CALL (a, b) {...}`), the whole outer scope (`CALL (*) {...}`), the outer names surviving a leading importing `WITH`, or nothing at all for a bare `CALL {...}`. Because it is inherited downwards, nested subqueries are covered too.

## Test plan

- [x] New regression test `Issue5257CallSubqueryRelationshipScopeTest` (9 tests, engine module):
  - [x] reporter's case 1 - `CALL { CREATE (a)-[:R]->(b) }` with unimported `a`/`b` now raises `UndefinedVariable`
  - [x] reporter's case 2 - same for `MERGE`
  - [x] partially importing `WITH a` still flags the un-imported `b`
  - [x] an un-imported outer *relationship* variable is flagged
  - [x] nested `CALL` inherits the shadowed names
  - [x] controls: importing `WITH a, b`, explicit scope list `CALL (a, b)`, a self-contained subquery `CREATE`, and a top-level `CREATE` all still persist the relationship (and create no orphan vertices)
- [x] Full OpenCypher suite green: `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**'` - 7267 run, 0 failures, 0 errors

## Known related gap (not addressed here)

A `WITH` *inside* a subquery body that drops an already-imported variable, followed by a `CREATE` re-using that name, is still not flagged (Neo4j errors). The reported bug is the un-imported case; that variant is noted in the tracking doc.