### PR TITLE
fix(#5262): root test databases under target/ via TestHelper

### DIFF
--- a/.github/scripts/check-test-database-paths.sh
+++ b/.github/scripts/check-test-database-paths.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Fails when a test constructs a DatabaseFactory on a repo-relative "databases/" path.
+# Fails when a test would put its database on a repo-relative "databases/" path.
 #
 # Such a database is written outside target/, so `mvn clean` cannot remove it. If a run dies
 # before its teardown (kill -9, surefire fork timeout, OOM), the leftover directory makes every
@@ -8,25 +8,78 @@
 # `rm -rf` recovers. Tests must place their database under target/ - extend TestHelper, which
 # does that plus pre-test cleanup, or pass an explicit target/-rooted path.
 #
+# Two complementary checks:
+#
+#   static  - grep test sources for repo-relative "databases/" string literals. Catches the path
+#             whether it is inlined in the constructor or held in a String constant/local.
+#
+#   runtime - after a test run, assert no module has grown a top-level databases/ directory.
+#             This is the backstop: a server test derives its path from SERVER_ROOT_PATH rather
+#             than a literal, so no grep can see it - only the resulting directory can.
+#
+# Usage:
+#   check-test-database-paths.sh            # static only (cheap, safe to run pre-build)
+#   check-test-database-paths.sh --runtime  # runtime only (run AFTER the test phase)
+#   check-test-database-paths.sh --all      # both
+#
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
-# Matches: new DatabaseFactory("databases/...  and  new DatabaseFactory("./databases/...
-PATTERN='new[[:space:]]+DatabaseFactory\([[:space:]]*"\.?/?databases/'
+mode="${1:---static}"
+status=0
 
-violations=$(grep -rEln --include='*.java' "${PATTERN}" -- */src/test/java || true)
+# A string literal that *starts* at a repo-relative databases/ dir: "databases/, "./databases/, "../databases/
+#
+# Deliberately does NOT match "/databases/, which is the suffix half of the correct server idiom
+# `new DatabaseFactory(rootPath + "/databases/" + name)`. Whether that one lands outside target/
+# depends on SERVER_ROOT_PATH, which no grep can resolve - the runtime check below covers it.
+LITERAL='"(\.\.?/)?databases/'
 
-if [ -n "${violations}" ]; then
-  echo "ERROR: test sources construct a DatabaseFactory on a repo-relative 'databases/' path."
-  echo "These databases live outside target/, so 'mvn clean' cannot remove them and a leftover"
-  echo "directory from a crashed run permanently wedges the test class."
-  echo
-  echo "Fix: extend com.arcadedb.TestHelper, or root the path under target/databases/."
-  echo
-  echo "Offending files:"
-  echo "${violations}" | sed 's/^/  - /'
-  exit 1
-fi
+run_static() {
+  local violations
+  violations=$(grep -rEl --include='*.java' "${LITERAL}" -- */src/test/java || true)
 
-echo "OK: no test constructs a DatabaseFactory on a repo-relative 'databases/' path."
+  if [ -n "${violations}" ]; then
+    echo "ERROR: test sources reference a repo-relative 'databases/' path."
+    echo "These databases live outside target/, so 'mvn clean' cannot remove them and a leftover"
+    echo "directory from a crashed run permanently wedges the test class."
+    echo
+    echo "Fix: extend com.arcadedb.TestHelper, or root the path under target/databases/."
+    echo
+    echo "Offending files:"
+    grep -rEn --include='*.java' "${LITERAL}" -- */src/test/java | sed 's/^/  /'
+    status=1
+  else
+    echo "OK (static): no test source references a repo-relative 'databases/' path."
+  fi
+}
+
+run_runtime() {
+  local leaked
+  leaked=$(find . -maxdepth 2 -type d -name databases -not -path './.git/*' || true)
+
+  if [ -n "${leaked}" ]; then
+    echo "ERROR: the test run left a repo-relative 'databases/' directory behind."
+    echo "The database was written outside target/, so 'mvn clean' cannot remove it."
+    echo
+    echo "A server test most likely started ArcadeDBServer without setting SERVER_ROOT_PATH, which"
+    echo "defaults the database directory to ./databases. Set it to ./target, as the other server"
+    echo "tests do:  GlobalConfiguration.SERVER_ROOT_PATH.setValue(\"./target\");"
+    echo
+    echo "Leaked directories:"
+    echo "${leaked}" | sed 's/^/  - /'
+    status=1
+  else
+    echo "OK (runtime): the test run left no repo-relative 'databases/' directory behind."
+  fi
+}
+
+case "${mode}" in
+  --static)  run_static ;;
+  --runtime) run_runtime ;;
+  --all)     run_static; run_runtime ;;
+  *) echo "usage: $0 [--static|--runtime|--all]" >&2; exit 2 ;;
+esac
+
+exit "${status}"

--- a/.github/scripts/check-test-database-paths.sh
+++ b/.github/scripts/check-test-database-paths.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Fails when a test constructs a DatabaseFactory on a repo-relative "databases/" path.
+#
+# Such a database is written outside target/, so `mvn clean` cannot remove it. If a run dies
+# before its teardown (kill -9, surefire fork timeout, OOM), the leftover directory makes every
+# subsequent run of that class fail with "Database ... already exists", and only a manual
+# `rm -rf` recovers. Tests must place their database under target/ - extend TestHelper, which
+# does that plus pre-test cleanup, or pass an explicit target/-rooted path.
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Matches: new DatabaseFactory("databases/...  and  new DatabaseFactory("./databases/...
+PATTERN='new[[:space:]]+DatabaseFactory\([[:space:]]*"\.?/?databases/'
+
+violations=$(grep -rEln --include='*.java' "${PATTERN}" -- */src/test/java || true)
+
+if [ -n "${violations}" ]; then
+  echo "ERROR: test sources construct a DatabaseFactory on a repo-relative 'databases/' path."
+  echo "These databases live outside target/, so 'mvn clean' cannot remove them and a leftover"
+  echo "directory from a crashed run permanently wedges the test class."
+  echo
+  echo "Fix: extend com.arcadedb.TestHelper, or root the path under target/databases/."
+  echo
+  echo "Offending files:"
+  echo "${violations}" | sed 's/^/  - /'
+  exit 1
+fi
+
+echo "OK: no test constructs a DatabaseFactory on a repo-relative 'databases/' path."

--- a/.github/scripts/check-test-database-paths.sh
+++ b/.github/scripts/check-test-database-paths.sh
@@ -12,6 +12,9 @@
 #
 #   static  - grep test sources for repo-relative "databases/" string literals. Catches the path
 #             whether it is inlined in the constructor or held in a String constant/local.
+#             It matches the literal anywhere in the file, so a "databases/..." string inside a
+#             comment or a log message trips it too. That is deliberate: a false alarm you can
+#             silence by rewording beats a leak that wedges someone's test class next month.
 #
 #   runtime - after a test run, assert no module has grown a top-level databases/ directory.
 #             This is the backstop: a server test derives its path from SERVER_ROOT_PATH rather
@@ -57,7 +60,8 @@ run_static() {
 
 run_runtime() {
   local leaked
-  leaked=$(find . -maxdepth 2 -type d -name databases -not -path './.git/*' || true)
+  # <module>/databases is a leak; anything under a target/ dir is the goal state, not a leak.
+  leaked=$(find . -maxdepth 2 -type d -name databases -not -path './.git/*' -not -path '*/target/*' || true)
 
   if [ -n "${leaked}" ]; then
     echo "ERROR: the test run left a repo-relative 'databases/' directory behind."

--- a/.github/scripts/check-test-database-paths.sh
+++ b/.github/scripts/check-test-database-paths.sh
@@ -43,7 +43,7 @@ run_static() {
   local violations
   violations=$(grep -rEl --include='*.java' "${LITERAL}" -- */src/test/java || true)
 
-  if [ -n "${violations}" ]; then
+  if [[ -n "${violations}" ]]; then
     echo "ERROR: test sources reference a repo-relative 'databases/' path."
     echo "These databases live outside target/, so 'mvn clean' cannot remove them and a leftover"
     echo "directory from a crashed run permanently wedges the test class."
@@ -63,7 +63,7 @@ run_runtime() {
   # <module>/databases is a leak; anything under a target/ dir is the goal state, not a leak.
   leaked=$(find . -maxdepth 2 -type d -name databases -not -path './.git/*' -not -path '*/target/*' || true)
 
-  if [ -n "${leaked}" ]; then
+  if [[ -n "${leaked}" ]]; then
     echo "ERROR: the test run left a repo-relative 'databases/' directory behind."
     echo "The database was written outside target/, so 'mvn clean' cannot remove it."
     echo
@@ -72,7 +72,9 @@ run_runtime() {
     echo "tests do:  GlobalConfiguration.SERVER_ROOT_PATH.setValue(\"./target\");"
     echo
     echo "Leaked directories:"
-    echo "${leaked}" | sed 's/^/  - /'
+    while IFS= read -r dir; do
+      echo "  - ${dir}"
+    done <<< "${leaked}"
     status=1
   else
     echo "OK (runtime): the test run left no repo-relative 'databases/' directory behind."

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -112,6 +112,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # A test that derives its path from SERVER_ROOT_PATH cannot be caught by the static grep in
+      # the setup job - only the directory it leaves behind proves it wrote outside target/.
+      - name: Check no test leaked a databases/ directory
+        run: ./.github/scripts/check-test-database-paths.sh --runtime
+
       - name: Unit Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -164,6 +164,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check no test leaked a databases/ directory
+        run: ./.github/scripts/check-test-database-paths.sh --runtime
+
       - name: Unit Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
@@ -210,6 +213,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # The server ITs derive their database dir from SERVER_ROOT_PATH, which the static grep cannot
+      # resolve. This job is where that pattern actually runs, so the backstop matters most here.
+      - name: Check no test leaked a databases/ directory
+        run: ./.github/scripts/check-test-database-paths.sh --runtime
+
       - name: IT Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
@@ -255,6 +263,9 @@ jobs:
         run: ./mvnw verify -DskipTests -Pintegration -Pcoverage  --batch-mode --errors --fail-never --show-version -pl ha-raft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check no test leaked a databases/ directory
+        run: ./.github/scripts/check-test-database-paths.sh --runtime
 
       - name: HA IT Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Ensure SHA pinned actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@3db98c0363e2fa5df3e1c4c471777a7c10b24cc9 # v5.0.5
+      - name: Check test database paths
+        run: ./.github/scripts/check-test-database-paths.sh
       - name: Run pre-commit
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -240,8 +240,6 @@ class ConsoleTest {
   void importNeo4jConsoleOK() throws Exception {
     final String DATABASE_PATH = "testNeo4j";
 
-    FileUtils.deleteRecursively(new File("databases/" + DATABASE_PATH));
-
     final Console newConsole = new Console();
     newConsole.parse("create database " + DATABASE_PATH + ";import database file://src/test/resources/neo4j-export-mini.neo");
     newConsole.close();
@@ -281,8 +279,6 @@ class ConsoleTest {
   @Test
   void importCSVConsoleOK() throws Exception {
     final String DATABASE_PATH = "testCSV";
-
-    FileUtils.deleteRecursively(new File("databases/" + DATABASE_PATH));
 
     final Console newConsole = new Console();
     newConsole.parse("create database " + DATABASE_PATH + "");

--- a/docs/5262-testhelper-database-lifecycle.md
+++ b/docs/5262-testhelper-database-lifecycle.md
@@ -111,7 +111,20 @@ structurally incapable of catching:
 
 ## Tests
 
-No test logic, assertion, query or expected value was changed - this is a pure lifecycle refactor.
-The migration is itself validated by the existing suites: the tests must keep passing while now
-running against a `target/`-rooted database, with `TestHelper`'s stricter teardown
+The migration is validated by the existing suites: the tests must keep passing while now running
+against a `target/`-rooted database, with `TestHelper`'s stricter teardown
 (`checkActiveDatabases()` + `CHECK DATABASE`) newly applied to all 48 engine classes.
+
+No assertion, query or expected value was changed. Two edits are *not* pure moves, and are called
+out here so "lifecycle-only" is not read too literally:
+
+1. `RecordRecyclingTest`: `databaseFactory.getActiveDatabaseInstances()` ->
+   `DatabaseFactory.getActiveDatabaseInstances()`. The same static method, now called through the
+   class because the local variable was removed.
+2. `OrderByTest` and `TestInsertAndSelectWithThreadBucketSelectionStrategy`: `beginTest()` now calls
+   `database.getSchema().setDateTimeFormat(...)` in addition to setting the global
+   `DATE_TIME_FORMAT`. This is a genuine addition, and it is required: `TestHelper` builds the
+   database in its **constructor**, before any subclass code runs, and `LocalSchema` captures
+   `DATE_TIME_FORMAT` at construction and persists it into `schema.json`. Setting only the global
+   from `beginTest()` would arrive too late for the already-built schema, so the format has to be
+   written onto the schema itself to survive the `reopenDatabase()` these tests perform.

--- a/docs/5262-testhelper-database-lifecycle.md
+++ b/docs/5262-testhelper-database-lifecycle.md
@@ -81,6 +81,36 @@ utilities, not JUnit tests). They are repointed under `target/` instead:
   `databases/` directory. This is the backstop for the case no grep can see - a server test whose
   path is *derived* from `SERVER_ROOT_PATH` rather than written as a literal.
 
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5264
+
+## Review cycles
+
+| # | Head | What changed | Outcome |
+|---|---|---|---|
+| 1 | `863febdd` | Initial: 48 engine classes onto `TestHelper`, 9 non-engine repointed under `target/`, static guard | Claude: guard too narrow, six classes still leak via `String DB_PATH`. Gemini: a `@Nested` class creates its DB with no pre-clean |
+| 2 | `e3beea4e` | Guard matches the *literal*, not the call site; added the runtime backstop; fixed the 6 exposed classes, 5 server tests leaking via a derived path, `ConsoleTest` dead cleanup, 4 nested classes onto `TestHelper.createDatabase` | Claude: 3 polish items, none blocking |
+| 3 | `130e8173` | Runtime guard excludes `*/target/*`; documented the static grep's false-alarm bias. Declined the `reopenDatabase()` DRY suggestion (see below) | Claude: runtime backstop missing from the jobs that need it most |
+| 4 | `4a9a5108` | Runtime guard added to `slow-unit-tests`, `integration-tests`, `ha-integration-tests`; documented the second semantic change | Claude: no blockers |
+
+### Declined
+
+**Reuse `TestHelper.reopenDatabase()` in `RecordRecyclingTest.createAndDeleteGraph()`.** Not
+equivalent. `reopenDatabase()` closes and reopens with no window in between, but the test must
+delete the statistics file *between* the close and the open - that gap is the point of the test,
+which exercises recovery when the stats file is missing. Reusing the helper would reopen before the
+delete and stop exercising that path. Explained on the PR; no pushback.
+
+### Known follow-up (not in scope)
+
+`OpenCypherCollectUnwindTest` and `OpenCypherPatternPredicateTest` have `@Nested` classes that
+cannot fold into the outer `TestHelper` database (the outer seed data would change their
+expectations). They keep their own lifecycle, so the outer database is now created, seeded,
+integrity-checked and dropped once per nested test. Correct but wasteful. The clean fix is to pull
+the nested classes out into top-level `TestHelper` subclasses, which is a bigger refactor than this
+issue warrants.
+
 ## Review follow-up (cycle 1)
 
 The first version of the guard only matched the inline-constructor form, so it reported `OK` while

--- a/docs/5262-testhelper-database-lifecycle.md
+++ b/docs/5262-testhelper-database-lifecycle.md
@@ -94,6 +94,32 @@ https://github.com/ArcadeData/arcadedb/pull/5264
 | 3 | `130e8173` | Runtime guard excludes `*/target/*`; documented the static grep's false-alarm bias. Declined the `reopenDatabase()` DRY suggestion (see below) | Claude: runtime backstop missing from the jobs that need it most |
 | 4 | `4a9a5108` | Runtime guard added to `slow-unit-tests`, `integration-tests`, `ha-integration-tests`; documented the second semantic change | Claude: no blockers |
 
+### The runtime guard caught a real leak on its first CI run
+
+`integration-tests` failed at the guard step with `leaked ./server/databases`.
+
+`TestLinkedPropertiesSchemaReloadIT` starts an `ArcadeDBServer` without setting `SERVER_ROOT_PATH`,
+so `SERVER_DATABASE_DIRECTORY` resolves to `./databases` and **the server** writes its database into
+the repo tree. The test never calls `new DatabaseFactory(...)` at all, so no grep over test sources
+could ever have found it. This is exactly the blind spot the runtime layer exists to cover, and it
+only surfaced because the check is wired into `integration-tests` - had it stayed only in
+`unit-tests`, this would have shipped as a silent hole in the very thing the PR claims to fix.
+
+Fixed with the same one-line `SERVER_ROOT_PATH` set.
+
+**Verified against `main` as a control, on the same machine:**
+
+| run | IT failures | failing classes | leaked `server/databases`? |
+|---|---|---|---|
+| `main` (control) | 5 | RemoteDatabaseIT, BackupHttpErrorHandlingIT, HttpRedMetricsIT, StudioProductionModeIT | **yes - `testLocalDateTimeOrderBy`** |
+| branch, run 1 | 6 | the same 4 + QueryRedMetricsIT | no |
+| branch, run 2 | 5 | **the same 4 - identical to `main`** | no |
+
+So: the branch reproduces `main`'s exact failure set (those 4 are pre-existing on this machine),
+`QueryRedMetricsIT` is an order-dependent flake - it asserts against the JVM-global Micrometer
+`Metrics.globalRegistry`, has zero references to `SERVER_ROOT_PATH` or `databases`, and passes in
+isolation - and only `main` leaks a database directory. The fix holds.
+
 ### Declined
 
 **Reuse `TestHelper.reopenDatabase()` in `RecordRecyclingTest.createAndDeleteGraph()`.** Not

--- a/docs/5262-testhelper-database-lifecycle.md
+++ b/docs/5262-testhelper-database-lifecycle.md
@@ -69,10 +69,45 @@ utilities, not JUnit tests). They are repointed under `target/` instead:
 
 ## Regression guard
 
-`.github/scripts/check-test-database-paths.sh` fails the build when any file under
-`*/src/test/java` constructs a `DatabaseFactory` on a repo-relative `databases/` path. It is wired
-into the `setup` job of `.github/workflows/mvn-test.yml`, so it gates every PR before the test jobs
-run. Verified failing on the pre-fix tree (57 files listed) and passing after.
+`.github/scripts/check-test-database-paths.sh` has two complementary checks:
+
+- **static** (`--static`, in the `setup` job): greps test sources for a string literal rooted at a
+  repo-relative `databases/` dir - `"databases/`, `"./databases/` or `"../databases/`. Matching the
+  literal rather than the `new DatabaseFactory(...)` call site means it also catches the
+  `private static final String DB_PATH = "databases/..."` form. It deliberately does *not* match
+  `"/databases/`, which is the suffix half of the correct server idiom
+  `new DatabaseFactory(rootPath + "/databases/" + name)`.
+- **runtime** (`--runtime`, after the unit-test job): asserts no module grew a top-level
+  `databases/` directory. This is the backstop for the case no grep can see - a server test whose
+  path is *derived* from `SERVER_ROOT_PATH` rather than written as a literal.
+
+## Review follow-up (cycle 1)
+
+The first version of the guard only matched the inline-constructor form, so it reported `OK` while
+six classes still put databases on repo-relative paths via a `String` constant. Broadening it to
+match the literal exposed them, and the runtime check exposed a seventh case the static grep is
+structurally incapable of catching:
+
+- `engine`: `LSMVectorIndexPersistenceTest`, `LSMVectorIndexChunkedWriteTest`, `ContiguousPageIOTest`
+  (`DB_PATH` constants) and three `@Test` methods in `LSMVectorIndexTest` (local `dbPath`) repointed
+  under `target/`. These already self-heal, so they only needed the path change.
+- `integration`: `GloVeReopenVerificationTest` used `"../databases/glovedb"` - repo *root*, one level
+  above the module. Repointed to `target/databases/glovedb`, pairing it with `GloVeTest`.
+- `console`: two `deleteRecursively(new File("databases/" + DATABASE_PATH))` calls in `ConsoleTest`
+  were dead cleanup of a legacy location. The console writes to `./target/databases/`, which the
+  test's own setup already wipes wholesale. Removed.
+- `server`: `SelectOrderTest`, `CompositeIndexTest`, `BatchInsertUpdateTest`, `RemoteDateIT` and
+  `RemoteCollectionTemporalIT` call `IntegrationUtils.setRootPath(...)` without setting
+  `SERVER_ROOT_PATH` first. `ServerPathUtils.setRootPath` only honours an already-set value and
+  otherwise returns `"."`, so `rootPath + "/databases/"` resolved to the repo-relative
+  `server/databases/`. Confirmed empirically: a full `mvn -pl server test` left
+  `server/databases/SelectOrderTest` behind. All five now set `SERVER_ROOT_PATH` to `./target` in
+  their `@BeforeEach`, and `SelectOrderTest`'s database was verified to land in
+  `server/target/databases/` afterwards.
+- `OpenCypherCollectUnwindTest`: four `@Nested` classes created their database with a bare
+  `new DatabaseFactory(...).create()` and no pre-clean, so a crashed run wedged them until
+  `mvn clean`. They now use `TestHelper.createDatabase(...)`, which drops-if-exists then creates.
+  (Gemini flagged one of the four; the same defect was present in three more.)
 
 ## Tests
 

--- a/docs/5262-testhelper-database-lifecycle.md
+++ b/docs/5262-testhelper-database-lifecycle.md
@@ -1,0 +1,82 @@
+# #5262 - Tests hand-roll their database lifecycle on repo-relative `./databases/` paths
+
+## Symptom
+
+57 test classes across `engine`, `server`, `integration` and `gremlin` built their own
+`DatabaseFactory` on a repo-relative `./databases/<name>` path and hand-rolled the create/drop
+lifecycle instead of extending `TestHelper`.
+
+Two consequences:
+
+1. A leftover directory poisons every subsequent run of that class - `LocalDatabase.create()`
+   throws `Database './databases/x' already exists`. Any path that skips teardown (JVM crash,
+   `kill -9`, surefire fork timeout, OOM, a failure inside `drop()` itself) wedges the class.
+2. `mvn clean` cannot recover, because the databases live outside `target/`. The only cure was a
+   manual `rm -rf`.
+
+Reproduction (pre-fix):
+
+```bash
+cd engine
+mkdir -p databases/test-issue5213 && echo '{}' > databases/test-issue5213/schema.json
+mvn test -Dtest=Issue5213NestedCallScopeTest    # 5 errors, and no mvn clean fixes it
+```
+
+## Root cause
+
+The tests only did one of the four things a database-backed test needs. `TestHelper` already does
+all four:
+
+| | hand-rolled | `TestHelper` |
+|---|---|---|
+| clean **before** test | no | `FileUtils.deleteRecursively` in ctor |
+| drop **after** test | yes | `afterTest()` |
+| path under `target/` (so `mvn clean` works) | no (`./databases/x`) | `target/databases/<ClassName>` |
+| assert no `Database` instance leaked | no | `checkActiveDatabases()` |
+| database integrity check | no | `checkDatabaseIntegrity()` |
+
+## Fix
+
+**48 `engine` classes** migrated onto `TestHelper`: the `@BeforeEach`/`@AfterEach` pair and the
+private `Database` field are deleted, the class `extends TestHelper`, and seeding moves into the
+`beginTest()` hook. The inherited `database` field and the default
+`target/databases/<SimpleClassName>` path are used throughout.
+
+```java
+class FooTest extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (:A {id: 1})");   // was @BeforeEach
+  }
+  // @Test methods unchanged
+}
+```
+
+**9 classes outside `engine` cannot extend `TestHelper`** (the `server` and `gremlin` test modules
+do not depend on the engine test-jar, and three of the `integration` classes are `main()`
+utilities, not JUnit tests). They are repointed under `target/` instead:
+
+- `server`: `AsyncInsertTest`, `RemoteQueriesIT`, `RemoteSafeCloseDatabaseIT` now set
+  `GlobalConfiguration.SERVER_ROOT_PATH` to `./target` - the convention already used by the other
+  server tests. `SERVER_DATABASE_DIRECTORY` defaults to `${arcadedb.server.rootPath}/databases`, so
+  this relocates both the pre-created database and the server's own database directory in one move.
+  In `AsyncInsertTest` and `RemoteQueriesIT` this also let a vestigial `./databases/<name>` drop
+  block be deleted: the database it guarded is already wiped by the existing
+  `deleteRecursively(rootPath + "/databases")`.
+- `integration`: `SQLLocalExporterTest`, `SQLLocalImporterIT`, `GloVeTest`, `SimpleGloVeTest`,
+  `FastTextDatabase` repointed to `target/databases/...`.
+- `gremlin`: `CypherEngineComparisonBenchmark` repointed to `target/databases/...`.
+
+## Regression guard
+
+`.github/scripts/check-test-database-paths.sh` fails the build when any file under
+`*/src/test/java` constructs a `DatabaseFactory` on a repo-relative `databases/` path. It is wired
+into the `setup` job of `.github/workflows/mvn-test.yml`, so it gates every PR before the test jobs
+run. Verified failing on the pre-fix tree (57 files listed) and passing after.
+
+## Tests
+
+No test logic, assertion, query or expected value was changed - this is a pure lifecycle refactor.
+The migration is itself validated by the existing suites: the tests must keep passing while now
+running against a `target/`-rooted database, with `TestHelper`'s stricter teardown
+(`checkActiveDatabases()` + `CHECK DATABASE`) newly applied to all 48 engine classes.

--- a/engine/src/test/java/com/arcadedb/engine/RandomDeleteTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/RandomDeleteTest.java
@@ -18,8 +18,8 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.graph.MutableVertex;
@@ -33,7 +33,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RandomDeleteTest {
+class RandomDeleteTest extends TestHelper {
   private final static int    TOT_RECORDS = 100_000;
   private final static String TYPE        = "Product";
   private static final int    CYCLES      = 3;
@@ -41,50 +41,42 @@ class RandomDeleteTest {
   @Test
   @Tag("slow")
   void smallRecords() {
-    try (DatabaseFactory databaseFactory = new DatabaseFactory("databases/randomDeleteTest")) {
-      if (databaseFactory.exists())
-        databaseFactory.open().drop();
+    final Database db = database;
 
-      try (Database db = databaseFactory.create()) {
-        db.getSchema().createVertexType(TYPE, 1);
+    db.getSchema().createVertexType(TYPE, 1);
 
-        final List<RID> rids = new ArrayList<>(TOT_RECORDS);
-        db.transaction(() -> {
-          insert(db, rids);
-          assertThat(db.countType(TYPE, true)).isEqualTo(TOT_RECORDS);
+    final List<RID> rids = new ArrayList<>(TOT_RECORDS);
+    db.transaction(() -> {
+      insert(db, rids);
+      assertThat(db.countType(TYPE, true)).isEqualTo(TOT_RECORDS);
 
-          // DELETE FROM 1 TO N
-          for (int i = 0; i < TOT_RECORDS; i++)
-            db.deleteRecord(rids.get(i).asVertex());
+      // DELETE FROM 1 TO N
+      for (int i = 0; i < TOT_RECORDS; i++)
+        db.deleteRecord(rids.get(i).asVertex());
 
-          assertThat(db.countType(TYPE, true)).isEqualTo(0);
-        });
+      assertThat(db.countType(TYPE, true)).isEqualTo(0);
+    });
 
-        db.transaction(() -> {
-          // DELETE RANDOMLY X TIMES
-          for (int cycle = 0; cycle < CYCLES; cycle++) {
-            insert(db, rids);
-            checkRecords(db, rids);
+    db.transaction(() -> {
+      // DELETE RANDOMLY X TIMES
+      for (int cycle = 0; cycle < CYCLES; cycle++) {
+        insert(db, rids);
+        checkRecords(db, rids);
 
-            for (int deleted = 0; deleted < TOT_RECORDS; ) {
-              final int i = ThreadLocalRandom.current().nextInt(TOT_RECORDS);
-              final RID rid = rids.get(i);
-              if (rid != null) {
-                db.deleteRecord(rid.asVertex());
-                rids.set(i, null);
-                ++deleted;
-              }
-            }
+        for (int deleted = 0; deleted < TOT_RECORDS; ) {
+          final int i = ThreadLocalRandom.current().nextInt(TOT_RECORDS);
+          final RID rid = rids.get(i);
+          if (rid != null) {
+            db.deleteRecord(rid.asVertex());
+            rids.set(i, null);
+            ++deleted;
           }
-
-          assertThat(db.countType(TYPE, true)).isEqualTo(0);
-
-        });
-      } finally {
-        if (databaseFactory.exists())
-          databaseFactory.open().drop();
+        }
       }
-    }
+
+      assertThat(db.countType(TYPE, true)).isEqualTo(0);
+
+    });
   }
 
   private void checkRecords(Database db, List<RID> rids) {

--- a/engine/src/test/java/com/arcadedb/engine/RecordRecyclingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/RecordRecyclingTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.engine;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
@@ -36,7 +37,7 @@ import static com.arcadedb.schema.LocalSchema.STATISTICS_FILE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("slow")
-class RecordRecyclingTest {
+class RecordRecyclingTest extends TestHelper {
   private final static int    TOT_RECORDS  = 100_000;
   private final static String VERTEX_TYPE  = "Product";
   private final static String EDGE_TYPE    = "LinkedTo";
@@ -48,79 +49,68 @@ class RecordRecyclingTest {
   void createAndDeleteGraph() {
     GlobalConfiguration.BUCKET_REUSE_SPACE_MODE.setValue("high");
 
-    try (DatabaseFactory databaseFactory = new DatabaseFactory("databases/RecordRecyclingTest")) {
-      if (databaseFactory.exists())
-        databaseFactory.open().drop();
+    database.getSchema().createVertexType(VERTEX_TYPE, 1);
+    database.getSchema().createEdgeType(EDGE_TYPE, 1);
 
-      final Database database = databaseFactory.create();
-      database.getSchema().createVertexType(VERTEX_TYPE, 1);
-      database.getSchema().createEdgeType(EDGE_TYPE, 1);
-      database.close();
+    RID maxVertexRID = null;
+    RID maxEdgeRID = null;
 
-      RID maxVertexRID = null;
-      RID maxEdgeRID = null;
+    for (int i = 0; i < CYCLES; i++) {
+      final Database db = database;
 
-      for (int i = 0; i < CYCLES; i++) {
-        final Database db = databaseFactory.open();
+      try {
+        db.transaction(() -> {
+          final MutableVertex root = db.newVertex(VERTEX_TYPE)//
+              .set("id", 0)//
+              .save();
 
-        try {
-          db.transaction(() -> {
-            final MutableVertex root = db.newVertex(VERTEX_TYPE)//
-                .set("id", 0)//
+          for (int k = 1; k < TOT_RECORDS; k++) {
+            final MutableVertex v = db.newVertex(VERTEX_TYPE)//
+                .set("id", k)//
                 .save();
 
-            for (int k = 1; k < TOT_RECORDS; k++) {
-              final MutableVertex v = db.newVertex(VERTEX_TYPE)//
-                  .set("id", k)//
-                  .save();
+            root.newEdge(EDGE_TYPE, v, "something", k);
+          }
+        });
 
-              root.newEdge(EDGE_TYPE, v, "something", k);
-            }
-          });
+        // CHECK RECORDS HAVE BEEN RECYCLED MORE THAN 80% OF THE SPACE
+        final RID maxVertex =
+            db.query("sql", "select from " + VERTEX_TYPE + " order by @rid desc").next().getIdentity().get();
+        if (maxVertexRID != null)
+          assertThat(maxVertex.getPosition()).isLessThan((long) (maxVertexRID.getPosition() * 1.2));
+        maxVertexRID = maxVertex;
 
-          // CHECK RECORDS HAVE BEEN RECYCLED MORE THAN 80% OF THE SPACE
-          final RID maxVertex =
-              db.query("sql", "select from " + VERTEX_TYPE + " order by @rid desc").next().getIdentity().get();
-          if (maxVertexRID != null)
-            assertThat(maxVertex.getPosition()).isLessThan((long) (maxVertexRID.getPosition() * 1.2));
-          maxVertexRID = maxVertex;
+        final RID maxEdge =
+            db.query("sql", "select from " + EDGE_TYPE + " order by @rid desc").next().getIdentity().get();
+        if (maxEdgeRID != null)
+          assertThat(maxEdge.getPosition()).isLessThan((long) (maxEdgeRID.getPosition() * 1.2));
+        maxEdgeRID = maxEdge;
 
-          final RID maxEdge =
-              db.query("sql", "select from " + EDGE_TYPE + " order by @rid desc").next().getIdentity().get();
-          if (maxEdgeRID != null)
-            assertThat(maxEdge.getPosition()).isLessThan((long) (maxEdgeRID.getPosition() * 1.2));
-          maxEdgeRID = maxEdge;
+        db.transaction(() -> {
+          assertThat(db.countType(VERTEX_TYPE, true)).isEqualTo(TOT_RECORDS);
+          assertThat(db.countType(EDGE_TYPE, true)).isEqualTo(TOT_RECORDS - 1);
 
-          db.transaction(() -> {
-            assertThat(db.countType(VERTEX_TYPE, true)).isEqualTo(TOT_RECORDS);
-            assertThat(db.countType(EDGE_TYPE, true)).isEqualTo(TOT_RECORDS - 1);
+          db.command("sql", "delete from " + VERTEX_TYPE);
 
-            db.command("sql", "delete from " + VERTEX_TYPE);
+          assertThat(db.countType(VERTEX_TYPE, true)).isEqualTo(0);
+          assertThat(db.countType(EDGE_TYPE, true)).isEqualTo(0);
 
-            assertThat(db.countType(VERTEX_TYPE, true)).isEqualTo(0);
-            assertThat(db.countType(EDGE_TYPE, true)).isEqualTo(0);
+          assertThat(db.countBucket(db.getSchema().getBucketById(1).getName())).isEqualTo(0);
+          assertThat(db.countBucket(db.getSchema().getBucketById(2).getName())).isEqualTo(0);
+          assertThat(db.countBucket(db.getSchema().getBucketById(3).getName())).isEqualTo(0);
+          assertThat(db.countBucket(db.getSchema().getBucketById(4).getName())).isEqualTo(0);
+        });
 
-            assertThat(db.countBucket(db.getSchema().getBucketById(1).getName())).isEqualTo(0);
-            assertThat(db.countBucket(db.getSchema().getBucketById(2).getName())).isEqualTo(0);
-            assertThat(db.countBucket(db.getSchema().getBucketById(3).getName())).isEqualTo(0);
-            assertThat(db.countBucket(db.getSchema().getBucketById(4).getName())).isEqualTo(0);
-          });
+        final ResultSet result = db.command("sql", "check database");
+        // System.out.println(result.nextIfAvailable().toJSON());
+      } finally {
+        db.close();
+        new File(factory.getDatabasePath() + File.separator + STATISTICS_FILE_NAME).delete();
+        assertThat(DatabaseFactory.getActiveDatabaseInstances()).isEmpty();
 
-          final ResultSet result = db.command("sql", "check database");
-          // System.out.println(result.nextIfAvailable().toJSON());
-        } finally {
-          db.close();
-          new File(databaseFactory.getDatabasePath() + File.separator + STATISTICS_FILE_NAME).delete();
-          assertThat(databaseFactory.getActiveDatabaseInstances()).isEmpty();
-        }
+        // REOPEN FOR THE NEXT CYCLE AND TO LET THE TEST TEARDOWN DROP THE DATABASE
+        database = factory.open();
       }
-
-      if (databaseFactory.exists())
-        databaseFactory.open().drop();
-
-    } finally {
-
-      GlobalConfiguration.BUCKET_REUSE_SPACE_MODE.reset();
     }
   }
 
@@ -137,86 +127,76 @@ class RecordRecyclingTest {
   void edgeLinkedLists() {
     GlobalConfiguration.BUCKET_REUSE_SPACE_MODE.setValue("high");
 
-    try (DatabaseFactory databaseFactory = new DatabaseFactory("databases/RecordRecyclingTest")) {
-      if (databaseFactory.exists())
-        databaseFactory.open().drop();
+    final Database db = database;
 
-      try (Database db = databaseFactory.create()) {
-        db.getSchema().buildVertexType().withName(VERTEX_TYPE).withTotalBuckets(1).create();
-        db.getSchema().buildEdgeType().withName(EDGE_TYPE).withTotalBuckets(1).create();
+    db.getSchema().buildVertexType().withName(VERTEX_TYPE).withTotalBuckets(1).create();
+    db.getSchema().buildEdgeType().withName(EDGE_TYPE).withTotalBuckets(1).create();
+
+    db.transaction(() -> {
+      final MutableVertex root = db.newVertex(VERTEX_TYPE)//
+          .set("id", 0)//
+          .save();
+    });
+
+    String largeContent = "";
+    for (int i = 0; i < 100; i++)
+      largeContent += i;
+
+    for (int i = 0; i < CYCLES; i++) {
+      String finalLargeContent = largeContent;
+
+      db.transaction(() -> {
+        Vertex root = db.select().fromType(VERTEX_TYPE).limit(1).vertices().next();
+
+        for (int k = 1; k < TOT_VERTICES; k++) {
+          final MutableVertex v = db.newVertex(VERTEX_TYPE)//
+              .set("id", k)//
+              .set("largeContent", finalLargeContent)//
+              .save();
+
+          root.newEdge(EDGE_TYPE, v, "something", k);
+        }
+      });
+
+      // UPDATE ALL THE VERTICES WITH A LARGE CONTENT TO FORCE REALLOCATION ON AVAILABLE PAGES
+      db.transaction(() -> {
+        String largeContent2 = finalLargeContent;
+        for (int j = 0; j < 100; j++)
+          largeContent2 += j;
+
+        for (Vertex v : db.select().fromType(VERTEX_TYPE).vertices().toList()) {
+          v.modify().set("largeContent2", largeContent2).save();
+        }
+      });
+
+      for (int k = 1; k < TOT_VERTICES; ) {
+        final int deleteRecords = TOT_VERTICES - k > 20 ? 20 : 1;
+        // DELETE THE VERTEX IN 2 DIFFERENT WAYS
+        if (k % 2 == 0)
+          deleteFirstConnectedVertex(db, deleteRecords);
+        else
+          deleteLastVertex(db, deleteRecords);
+
+        k += deleteRecords;
+
+        final int idx = k;
 
         db.transaction(() -> {
-          final MutableVertex root = db.newVertex(VERTEX_TYPE)//
-              .set("id", 0)//
-              .save();
-        });
+          final SelectIterator<Vertex> cursor = db.select().fromType(VERTEX_TYPE).vertices();
 
-        String largeContent = "";
-        for (int i = 0; i < 100; i++)
-          largeContent += i;
-
-        for (int i = 0; i < CYCLES; i++) {
-          String finalLargeContent = largeContent;
-
-          db.transaction(() -> {
-            Vertex root = db.select().fromType(VERTEX_TYPE).limit(1).vertices().next();
-
-            for (int k = 1; k < TOT_VERTICES; k++) {
-              final MutableVertex v = db.newVertex(VERTEX_TYPE)//
-                  .set("id", k)//
-                  .set("largeContent", finalLargeContent)//
-                  .save();
-
-              root.newEdge(EDGE_TYPE, v, "something", k);
-            }
-          });
-
-          // UPDATE ALL THE VERTICES WITH A LARGE CONTENT TO FORCE REALLOCATION ON AVAILABLE PAGES
-          db.transaction(() -> {
-            String largeContent2 = finalLargeContent;
-            for (int j = 0; j < 100; j++)
-              largeContent2 += j;
-
-            for (Vertex v : db.select().fromType(VERTEX_TYPE).vertices().toList()) {
-              v.modify().set("largeContent2", largeContent2).save();
-            }
-          });
-
-          for (int k = 1; k < TOT_VERTICES; ) {
-            final int deleteRecords = TOT_VERTICES - k > 20 ? 20 : 1;
-            // DELETE THE VERTEX IN 2 DIFFERENT WAYS
-            if (k % 2 == 0)
-              deleteFirstConnectedVertex(db, deleteRecords);
-            else
-              deleteLastVertex(db, deleteRecords);
-
-            k += deleteRecords;
-
-            final int idx = k;
-
-            db.transaction(() -> {
-              final SelectIterator<Vertex> cursor = db.select().fromType(VERTEX_TYPE).vertices();
-
-              int loaded = 0;
-              while (cursor.hasNext()) {
-                ++loaded;
-                cursor.next().toJSON();  // CHECK FULL LOADING
-              }
-
-              assertThat(loaded).isEqualTo(TOT_VERTICES - idx + 1);
-            });
+          int loaded = 0;
+          while (cursor.hasNext()) {
+            ++loaded;
+            cursor.next().toJSON();  // CHECK FULL LOADING
           }
-        }
 
-        final ResultSet result = db.command("sql", "check database");
-        assertThat((Collection) result.next().getProperty("corruptedRecords")).isEmpty();
-      } finally {
-        if (databaseFactory.exists())
-          databaseFactory.open().drop();
+          assertThat(loaded).isEqualTo(TOT_VERTICES - idx + 1);
+        });
       }
-    } finally {
-      GlobalConfiguration.BUCKET_REUSE_SPACE_MODE.reset();
     }
+
+    final ResultSet result = db.command("sql", "check database");
+    assertThat((Collection) result.next().getProperty("corruptedRecords")).isEmpty();
   }
 
   private void deleteLastVertex(Database db, int deleteRecords) {

--- a/engine/src/test/java/com/arcadedb/engine/TestInsertAndSelectWithThreadBucketSelectionStrategy.java
+++ b/engine/src/test/java/com/arcadedb/engine/TestInsertAndSelectWithThreadBucketSelectionStrategy.java
@@ -19,15 +19,12 @@
 package com.arcadedb.engine;
 
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.bucketselectionstrategy.ThreadBucketSelectionStrategy;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -35,89 +32,74 @@ import java.time.format.DateTimeFormatter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class TestInsertAndSelectWithThreadBucketSelectionStrategy {
+class TestInsertAndSelectWithThreadBucketSelectionStrategy extends TestHelper {
 
-  @BeforeEach
-  void setUp() {
-    GlobalConfiguration.DATE_TIME_FORMAT.setValue("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
+  @Override
+  protected void beginTest() {
+    final String dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS";
+    GlobalConfiguration.DATE_TIME_FORMAT.setValue(dateTimeFormat);
+    database.getSchema().setDateTimeFormat(dateTimeFormat);
 
-  }
+    database.transaction(() -> {
+      DocumentType dtProducts = database.getSchema().createDocumentType("Product");
+      dtProducts.createProperty("name", Type.STRING);
+      dtProducts.createProperty("type", Type.STRING);
+      dtProducts.createProperty("start", Type.DATETIME_MICROS);
+      dtProducts.createProperty("stop", Type.DATETIME_MICROS);
+      dtProducts.createProperty("v", Type.STRING);
+      dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+      dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "type", "start", "stop");
+      dtProducts.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
+    });
 
-  @AfterEach
-  void tearDown() {
-    GlobalConfiguration.resetAll();
-
+    // REOPEN THE DATABASE TO RELOAD THE SCHEMA FROM DISK
+    reopenDatabase();
   }
 
   @Test
   void insertAndSelectWithThreadBucketSelectionStrategy() {
-    try (DatabaseFactory databaseFactory = new DatabaseFactory("databases/test")) {
-      if (databaseFactory.exists())
-        databaseFactory.open().drop();
+    String name1, name2, type, version1, version2;
 
-      try (Database db = databaseFactory.create()) {
-        db.transaction(() -> {
-          DocumentType dtProducts = db.getSchema().createDocumentType("Product");
-          dtProducts.createProperty("name", Type.STRING);
-          dtProducts.createProperty("type", Type.STRING);
-          dtProducts.createProperty("start", Type.DATETIME_MICROS);
-          dtProducts.createProperty("stop", Type.DATETIME_MICROS);
-          dtProducts.createProperty("v", Type.STRING);
-          dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-          dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "type", "start", "stop");
-          dtProducts.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
-        });
+    final LocalDateTime queryStart, queryStop, validityStart, validityStop;
+    name1 = "CS_OPER_MPL_ORBREF_20180707T231257_20190711T045744_0001.EEF";
+    name2 = "CS_OPER_MPL_ORBREF_20180707T231257_20190711T045744_0002.EEF";
+    type = "MPL_ORBREF";
+    version1 = "0001";
+    version2 = "0002";
+    validityStart = LocalDateTime.parse("2018-07-07T23:12:57.000000",
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
+    validityStop = LocalDateTime.parse("2019-07-11T04:57:44.000000",
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
+    try {
+      database.begin();
+      String sqlString = "UPDATE Product SET name = ?, type = ?, start = ?, stop = ?, v = ? UPSERT WHERE name = ?";
+      try (ResultSet resultSet = database.command("sql", sqlString, name1, type, validityStart, validityStop, version1,
+          name1)) {
+        assertThat((long) resultSet.nextIfAvailable().getProperty("count", 0)).isEqualTo(1);
       }
-
-      try (final Database database = databaseFactory.open()) {
-        try {
-          String name1, name2, type, version1, version2;
-
-          final LocalDateTime queryStart, queryStop, validityStart, validityStop;
-          name1 = "CS_OPER_MPL_ORBREF_20180707T231257_20190711T045744_0001.EEF";
-          name2 = "CS_OPER_MPL_ORBREF_20180707T231257_20190711T045744_0002.EEF";
-          type = "MPL_ORBREF";
-          version1 = "0001";
-          version2 = "0002";
-          validityStart = LocalDateTime.parse("2018-07-07T23:12:57.000000",
-              DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
-          validityStop = LocalDateTime.parse("2019-07-11T04:57:44.000000",
-              DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
-          try {
-            database.begin();
-            String sqlString = "UPDATE Product SET name = ?, type = ?, start = ?, stop = ?, v = ? UPSERT WHERE name = ?";
-            try (ResultSet resultSet = database.command("sql", sqlString, name1, type, validityStart, validityStop, version1,
-                name1)) {
-              assertThat((long) resultSet.nextIfAvailable().getProperty("count", 0)).isEqualTo(1);
-            }
 //            database.commit();
 //            database.begin();
-            try (ResultSet resultSet = database.command("sql", sqlString, name2, type, validityStart, validityStop, version2,
-                name2)) {
-              assertThat((long) resultSet.nextIfAvailable().getProperty("count", 0)).isEqualTo(1);
-            }
-            database.commit();
-          } catch (Exception e) {
-            e.printStackTrace();
-            if (database.isTransactionActive()) {
-              database.rollback();
-            }
-          }
-          queryStart = LocalDateTime.parse("2019-05-05T00:12:38.236835",
-              DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
-          queryStop = LocalDateTime.parse("2019-05-05T00:10:37.288211",
-              DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
-          String sqlString = "SELECT name, start, stop FROM Product WHERE type = ? AND start <= ? AND stop >= ? ORDER BY start DESC, stop DESC, v DESC LIMIT 1";
-          int total = 0;
-          try (ResultSet resultSet = database.query("sql", sqlString, type, queryStart, queryStop)) {
-            assertThat(resultSet.hasNext()).isTrue();
-            ++total;
-          }
-          assertThat(total).isEqualTo(1);
-        } finally {
-          database.drop();
-        }
+      try (ResultSet resultSet = database.command("sql", sqlString, name2, type, validityStart, validityStop, version2,
+          name2)) {
+        assertThat((long) resultSet.nextIfAvailable().getProperty("count", 0)).isEqualTo(1);
+      }
+      database.commit();
+    } catch (Exception e) {
+      e.printStackTrace();
+      if (database.isTransactionActive()) {
+        database.rollback();
       }
     }
+    queryStart = LocalDateTime.parse("2019-05-05T00:12:38.236835",
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
+    queryStop = LocalDateTime.parse("2019-05-05T00:10:37.288211",
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
+    String sqlString = "SELECT name, start, stop FROM Product WHERE type = ? AND start <= ? AND stop >= ? ORDER BY start DESC, stop DESC, v DESC LIMIT 1";
+    int total = 0;
+    try (ResultSet resultSet = database.query("sql", sqlString, type, queryStart, queryStop)) {
+      assertThat(resultSet.hasNext()).isTrue();
+      ++total;
+    }
+    assertThat(total).isEqualTo(1);
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/TestInsertAndSelectWithThreadBucketSelectionStrategy.java
+++ b/engine/src/test/java/com/arcadedb/engine/TestInsertAndSelectWithThreadBucketSelectionStrategy.java
@@ -58,9 +58,16 @@ class TestInsertAndSelectWithThreadBucketSelectionStrategy extends TestHelper {
 
   @Test
   void insertAndSelectWithThreadBucketSelectionStrategy() {
-    String name1, name2, type, version1, version2;
+    String name1;
+    String name2;
+    String type;
+    String version1;
+    String version2;
 
-    final LocalDateTime queryStart, queryStop, validityStart, validityStop;
+    final LocalDateTime queryStart;
+    final LocalDateTime queryStop;
+    final LocalDateTime validityStart;
+    final LocalDateTime validityStop;
     name1 = "CS_OPER_MPL_ORBREF_20180707T231257_20190711T045744_0001.EEF";
     name2 = "CS_OPER_MPL_ORBREF_20180707T231257_20190711T045744_0002.EEF";
     type = "MPL_ORBREF";

--- a/engine/src/test/java/com/arcadedb/index/vector/ContiguousPageIOTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/ContiguousPageIOTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Verifies that data written at specific positions can be read back correctly.
  */
 class ContiguousPageIOTest {
-  private static final String DB_PATH = "databases/test-contiguous-io";
+  private static final String DB_PATH = "target/databases/test-contiguous-io";
 
   @AfterEach
   void cleanup() {

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexChunkedWriteTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexChunkedWriteTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * LSM vector chunked-write regression tests: mid-page boundary, mixed-type chunks, and corrupted content-size clamping.
  */
 class LSMVectorIndexChunkedWriteTest {
-  private static final String DB_PATH = "databases/test-lsm-vector-chunked-write";
+  private static final String DB_PATH = "target/databases/test-lsm-vector-chunked-write";
 
   @AfterEach
   void cleanup() {

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexPersistenceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexPersistenceTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests that LSM vector indexes persist correctly to schema.json and can be loaded after database restart.
  */
 class LSMVectorIndexPersistenceTest {
-  private static final String DB_PATH = "databases/test-vector-persistence";
+  private static final String DB_PATH = "target/databases/test-vector-persistence";
 
   @AfterEach
   void cleanup() {

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
@@ -1768,7 +1768,7 @@ class LSMVectorIndexTest extends TestHelper {
    */
   @Test
   void vectorIndexGraphFileNotClosedBug() throws Exception {
-    final String dbPath = "databases/test-graph-file-not-closed";
+    final String dbPath = "target/databases/test-graph-file-not-closed";
     final File dbDir = new File(dbPath);
 
     // Clean up any existing database
@@ -1907,7 +1907,7 @@ class LSMVectorIndexTest extends TestHelper {
    */
   @Test
   void graphFileDiscoveryAfterReload() throws Exception {
-    final String dbPath = "databases/test-graph-file-discovery";
+    final String dbPath = "target/databases/test-graph-file-discovery";
     final File dbDir = new File(dbPath);
 
     // Clean up any existing database
@@ -2011,7 +2011,7 @@ class LSMVectorIndexTest extends TestHelper {
    */
   // @Test - Disabled due to separate JVector bug
   void testGraphPersistenceMultipleCycles_Disabled() throws Exception {
-    final String dbPath = "databases/test-graph-persistence-cycles";
+    final String dbPath = "target/databases/test-graph-persistence-cycles";
     final File dbDir = new File(dbPath);
 
     // Clean up

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionSecurityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionSecurityTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -35,21 +32,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 /**
  * Tests for security boundary conditions in Cypher functions.
  */
-class CypherFunctionSecurityTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-function-security").create();
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null) {
-      database.drop();
-    }
-  }
-
+class CypherFunctionSecurityTest extends TestHelper {
   @Test
   void utilSleepMaxDuration() {
     final ResultSet rs = database.query("opencypher", "RETURN util.sleep(999999999999) AS result");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherReduceAndShortestPathTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherReduceAndShortestPathTest.java
@@ -18,15 +18,12 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
@@ -41,13 +38,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class CypherReduceAndShortestPathTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-reduce-shortestpath").create();
-
+class CypherReduceAndShortestPathTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Create schema for graph tests
     database.getSchema().createVertexType("Person");
     database.getSchema().createEdgeType("KNOWS");
@@ -72,12 +65,6 @@ class CypherReduceAndShortestPathTest {
       bob.newEdge("KNOWS", eve, true, (Object[]) null).save();
       alice.newEdge("KNOWS", frank, true, (Object[]) null).save();
     });
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null)
-      database.drop();
   }
 
   // ============================================================================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathEdgeFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathEdgeFilterTest.java
@@ -18,13 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.graph.MutableVertex;
-import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -41,13 +37,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class CypherShortestPathEdgeFilterTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-shortestpath-edgefilter").create();
-
+class CypherShortestPathEdgeFilterTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("Node");
     database.getSchema().createEdgeType("LINK");
 
@@ -65,12 +57,6 @@ class CypherShortestPathEdgeFilterTest {
       n1.newEdge("LINK", n4, true, new Object[] { "w", 2 }).save();
       n4.newEdge("LINK", n3, true, new Object[] { "w", 2 }).save();
     });
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null)
-      database.drop();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/HeadCollectTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/HeadCollectTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -38,12 +35,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * detect aggregations wrapped in non-aggregation functions, causing the query planner to use
  * WithStep instead of GroupByAggregationStep.
  */
-class HeadCollectTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-head-collect").create();
+class HeadCollectTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("CHUNK");
     database.getSchema().createVertexType("DOCUMENT");
     database.getSchema().createEdgeType("BELONGS_TO");
@@ -60,13 +54,6 @@ class HeadCollectTest {
         (chunk1)-[:BELONGS_TO]->(doc1), \
         (chunk2)-[:BELONGS_TO]->(doc1), \
         (chunk3)-[:BELONGS_TO]->(doc2)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null) {
-      database.drop();
-    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4305Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4305Test.java
@@ -18,15 +18,12 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -47,23 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue4305Test {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/issue4305");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null && database.isOpen())
-      database.drop();
-  }
-
+class Issue4305Test extends TestHelper {
   @Test
   void propertyNamedLatStaysNumeric() {
     database.command("opencypher", "CREATE (:City {lat: 1.0, lon: 2.0})");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4353Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4353Test.java
@@ -18,14 +18,11 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -39,15 +36,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue4353Test {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-issue-4353");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
+class Issue4353Test extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("Worker");
     database.getSchema().createEdgeType("REPORTS_TO");
 
@@ -61,12 +52,6 @@ class Issue4353Test {
         (a)-[:REPORTS_TO]->(b), \
         (b)-[:REPORTS_TO]->(c), \
         (c)-[:REPORTS_TO]->(d)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5107MatchCreateIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5107MatchCreateIndexTest.java
@@ -18,13 +18,10 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -48,13 +45,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public class Issue5107MatchCreateIndexTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-issue5107").create();
-
+public class Issue5107MatchCreateIndexTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.transaction(() -> {
       final var personType = database.getSchema().createVertexType("Person");
       personType.createProperty("id", Integer.class);
@@ -75,14 +68,6 @@ public class Issue5107MatchCreateIndexTest {
         database.command("opencypher",
             "CREATE (p:Person {name: 'Person" + i + "', id: " + i + ", age: " + (20 + (i % 50)) + ", city: 'c" + i + "'})");
     });
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null) {
-      database.drop();
-      database = null;
-    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5136MatchMultipleCreateOptimizerTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5136MatchMultipleCreateOptimizerTest.java
@@ -18,13 +18,10 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -44,13 +41,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public class Issue5136MatchMultipleCreateOptimizerTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-issue5136").create();
-
+public class Issue5136MatchMultipleCreateOptimizerTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.transaction(() -> {
       final var personType = database.getSchema().createVertexType("Person");
       personType.createProperty("id", Integer.class);
@@ -71,14 +64,6 @@ public class Issue5136MatchMultipleCreateOptimizerTest {
         database.command("opencypher",
             "CREATE (p:Person {name: 'Person" + i + "', id: " + i + ", age: " + (20 + (i % 50)) + ", city: 'c" + i + "'})");
     });
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null) {
-      database.drop();
-      database = null;
-    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5140CountInPatternComprehensionWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5140CountInPatternComprehensionWhereTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -37,12 +34,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5140CountInPatternComprehensionWhereTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-5140-count-pc-where").create();
+class Issue5140CountInPatternComprehensionWhereTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("CB");
     database.getSchema().createEdgeType("E");
 
@@ -57,12 +51,6 @@ class Issue5140CountInPatternComprehensionWhereTest {
         (a)-[:E {weight: 1}]->(b), \
         (a)-[:E {weight: 2}]->(c), \
         (b)-[:E {weight: 3}]->(d)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5145AllPatternComprehensionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5145AllPatternComprehensionTest.java
@@ -18,14 +18,11 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -47,27 +44,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5145AllPatternComprehensionTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-issue5145").create();
-    database.getSchema().createVertexType("User");
-    database.getSchema().createEdgeType("FRIEND");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null && database.isOpen())
-      database.drop();
-  }
-
+class Issue5145AllPatternComprehensionTest extends TestHelper {
   private static final String FLAG_QUERY =
       "MATCH (u:User {active: true}) " +
       "WITH u, [(u)-[:FRIEND]->(f:User) | f.active] AS actives " +
       "WHERE size(actives) > 0 AND all(a IN actives WHERE a = false) " +
       "SET u.flagged = true";
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("User");
+    database.getSchema().createEdgeType("FRIEND");
+  }
 
   private long flaggedCount() {
     return ((Number) database.query("opencypher",

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5163DivisionByZeroTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5163DivisionByZeroTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,20 +36,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5163DivisionByZeroTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-issue5163").create();
+class Issue5163DivisionByZeroTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("U");
     database.transaction(() -> database.newVertex("U").set("id", 1).set("zero", 0).set("zeroD", 0.0).save());
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null)
-      database.drop();
   }
 
   private void assertFails(final String cypher) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5164IntegerOverflowTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5164IntegerOverflowTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,24 +38,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5164IntegerOverflowTest {
+class Issue5164IntegerOverflowTest extends TestHelper {
   private static final long MAX = Long.MAX_VALUE;
   private static final long MIN = Long.MIN_VALUE;
 
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-issue5164").create();
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("U");
     database.transaction(() -> database.newVertex("U")
         .set("id", 1).set("max", MAX).set("min", MIN).set("neg", -1L).set("two", 2L).save());
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null)
-      database.drop();
   }
 
   private void assertOverflow(final String cypher) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5179PatternComprehensionScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5179PatternComprehensionScopeTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,19 +35,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5179PatternComprehensionScopeTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-issue5179").create();
+class Issue5179PatternComprehensionScopeTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.command("opencypher", "CREATE (a:A {v:1}), (b:B {v:10}), (a)-[:R]->(b)");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null && database.isOpen())
-      database.drop();
   }
 
   /** The reporter's failing query: pattern-comprehension-local {@code n} referenced in any() WHERE. */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5180TrailingCommaListLiteralTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5180TrailingCommaListLiteralTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -37,20 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5180TrailingCommaListLiteralTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-5180-trailing-comma-list").create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
-  }
-
+class Issue5180TrailingCommaListLiteralTest extends TestHelper {
   @Test
   void trailingCommaInListLiteralIsAccepted() {
     try (final ResultSet rs = database.query("opencypher", "RETURN [1, 2,] AS x")) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5207Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5207Test.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -35,23 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Regression test for issue #5207: nullIf() on a node property returned the value instead of null
  * because the stored property (Integer) was compared to the literal (Long) with type-strict equality.
  */
-class Issue5207Test {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-issue-5207");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
-  }
-
+class Issue5207Test extends TestHelper {
   @Test
   void nullIfOnPropertyValueMatchesLiteral() {
     database.command("opencypher", "CREATE (:A {v:1}), (:A {v:2})");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5213NestedCallScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5213NestedCallScopeTest.java
@@ -18,13 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandParsingException;
-import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,19 +35,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5213NestedCallScopeTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-issue5213").create();
+class Issue5213NestedCallScopeTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.command("opencypher", "CREATE (a:C1 {id: 1}), (b:C2 {v: 21}), (a)-[:R]->(b)");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null && database.isOpen())
-      database.drop();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5226CallMatchEdgeLabelTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5226CallMatchEdgeLabelTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,19 +36,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5226CallMatchEdgeLabelTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-issue5226").create();
+class Issue5226CallMatchEdgeLabelTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.command("opencypher", "CREATE (a:A {v: 1}), (b:B {v: 2}), (a)-[:EdgeLabel]->(b)");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null && database.isOpen())
-      database.drop();
   }
 
   private long count(final String cypher) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5228CallMatchEdgeLabelEntityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5228CallMatchEdgeLabelEntityTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,20 +41,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5228CallMatchEdgeLabelEntityTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-issue5228").create();
+class Issue5228CallMatchEdgeLabelEntityTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Two vertices (A, B) and one edge whose type name is "EdgeLabel"; zero vertices are labeled EdgeLabel.
     database.command("opencypher", "CREATE (a:A {v: 1}), (b:B {v: 2}), (a)-[:EdgeLabel]->(b)");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null && database.isOpen())
-      database.drop();
   }
 
   private int rowCount(final String cypher) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherAdvancedFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherAdvancedFunctionTest.java
@@ -18,14 +18,11 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -36,15 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for advanced Cypher functions: Path, List, String, and Type Conversion functions.
  */
-class OpenCypherAdvancedFunctionTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-advanced-functions");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
+class OpenCypherAdvancedFunctionTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("Person");
     database.getSchema().createEdgeType("KNOWS");
 
@@ -57,13 +48,6 @@ class OpenCypherAdvancedFunctionTest {
         (charlie:Person {name: 'Charlie', age: 35}), \
         (alice)-[:KNOWS {since: 2020}]->(bob), \
         (bob)-[:KNOWS {since: 2021}]->(charlie)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null) {
-      database.drop();
-    }
   }
 
   // ==================== String Functions ====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCollectUnwindTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCollectUnwindTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher;
 
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
@@ -49,12 +50,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * COLLECT collects values into a list.
  * UNWIND expands a list into individual rows.
  */
-class OpenCypherCollectUnwindTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-collect-unwind").create();
+class OpenCypherCollectUnwindTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("Person");
     database.getSchema().createVertexType("City");
     database.getSchema().createEdgeType("LIVES_IN");
@@ -71,13 +69,6 @@ class OpenCypherCollectUnwindTest {
             (alice)-[:LIVES_IN]->(nyc),
             (bob)-[:LIVES_IN]->(nyc),
             (charlie)-[:LIVES_IN]->(la)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null) {
-      database.drop();
-    }
   }
 
   // ===== COLLECT Tests =====
@@ -1265,7 +1256,7 @@ class OpenCypherCollectUnwindTest {
 
     @BeforeEach
     void setUp() {
-      database = new DatabaseFactory("./databases/test-issue-3154").create();
+      database = new DatabaseFactory("./target/databases/test-issue-3154").create();
       database.getSchema().createVertexType("CHUNK");
       database.getSchema().createVertexType("CHUNK_EMBEDDING");
       database.getSchema().createVertexType("USER_RIGHTS");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCollectUnwindTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCollectUnwindTest.java
@@ -539,7 +539,7 @@ class OpenCypherCollectUnwindTest extends TestHelper {
 
     @BeforeEach
     void setUp() {
-      tagDatabase = new DatabaseFactory("./target/databases/testopencypher-issue3758").create();
+      tagDatabase = TestHelper.createDatabase("./target/databases/testopencypher-issue3758");
 
       tagDatabase.getSchema().createVertexType("Question");
       tagDatabase.getSchema().createVertexType("Tag");
@@ -716,7 +716,7 @@ class OpenCypherCollectUnwindTest extends TestHelper {
 
     @BeforeEach
     void setUp() {
-      database = new DatabaseFactory("./target/databases/issue-3129").create();
+      database = TestHelper.createDatabase("./target/databases/issue-3129");
       database.getSchema().createVertexType("CHUNK");
     }
 
@@ -836,7 +836,7 @@ class OpenCypherCollectUnwindTest extends TestHelper {
 
     @BeforeEach
     void setUp() {
-      database = new DatabaseFactory("./target/databases/issue-3138").create();
+      database = TestHelper.createDatabase("./target/databases/issue-3138");
       database.getSchema().createVertexType("Source");
       database.getSchema().createVertexType("Target");
       database.getSchema().createEdgeType("in");
@@ -1256,7 +1256,7 @@ class OpenCypherCollectUnwindTest extends TestHelper {
 
     @BeforeEach
     void setUp() {
-      database = new DatabaseFactory("./target/databases/test-issue-3154").create();
+      database = TestHelper.createDatabase("./target/databases/test-issue-3154");
       database.getSchema().createVertexType("CHUNK");
       database.getSchema().createVertexType("CHUNK_EMBEDDING");
       database.getSchema().createVertexType("USER_RIGHTS");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCustomFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCustomFunctionTest.java
@@ -18,13 +18,10 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.ResultSet;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,22 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for custom function support in OpenCypher queries.
  * Tests SQL, JavaScript, and Cypher-defined functions callable from Cypher expressions.
  */
-class OpenCypherCustomFunctionTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/testcustomfunc").create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null) {
-      database.drop();
-      database = null;
-    }
-  }
-
+class OpenCypherCustomFunctionTest extends TestHelper {
   // Phase 1: SQL Function Tests
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherExpressionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherExpressionTest.java
@@ -18,13 +18,10 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -41,13 +38,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class OpenCypherExpressionTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-expression").create();
-
+class OpenCypherExpressionTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Create schema
     database.getSchema().createVertexType("Person");
 
@@ -71,12 +64,6 @@ class OpenCypherExpressionTest {
           .set("salary", 60000)
           .save();
     });
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null)
-      database.drop();
   }
 
   // ============================================================================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherFunctionTest.java
@@ -18,13 +18,12 @@
  */
 package com.arcadedb.query.opencypher;
 
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -40,13 +39,9 @@ import static org.assertj.core.api.Assertions.within;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class OpenCypherFunctionTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-function").create();
-
+class OpenCypherFunctionTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Create schema
     database.getSchema().createVertexType("Person");
     database.getSchema().createVertexType("Company");
@@ -81,13 +76,6 @@ class OpenCypherFunctionTest {
       bob.newEdge("WORKS_AT", arcadedb, "since", 2022).save();
       charlie.newEdge("KNOWS", alice, "since", 2019).save();
     });
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null) {
-      database.drop();
-    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherGroupByTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherGroupByTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -31,19 +28,14 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-;
-
 /**
  * Tests for implicit GROUP BY in Cypher.
  * When a RETURN clause contains both aggregation functions and non-aggregated expressions,
  * the non-aggregated expressions become grouping keys.
  */
-class OpenCypherGroupByTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-group-by").create();
+class OpenCypherGroupByTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("Person");
     database.getSchema().createVertexType("Product");
     database.getSchema().createEdgeType("PURCHASED");
@@ -59,13 +51,6 @@ class OpenCypherGroupByTest {
         (charlie:Person {name: 'Charlie', age: 35, city: 'LA'}), \
         (david:Person {name: 'David', age: 40, city: 'LA'}), \
         (eve:Person {name: 'Eve', age: 28, city: 'SF'})""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null) {
-      database.drop();
-    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherListPredicateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherListPredicateTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -35,20 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for Cypher list predicate functions: all(), any(), none(), single().
  * Regression test for https://github.com/ArcadeData/arcadedb/issues/3334
  */
-class OpenCypherListPredicateTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-list-predicates").create();
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null)
-      database.drop();
-  }
-
+class OpenCypherListPredicateTest extends TestHelper {
   @Test
   void allPredicates() {
     // Exact query from the issue

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherNewFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherNewFunctionsTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,20 +31,7 @@ import static org.assertj.core.api.Assertions.within;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class OpenCypherNewFunctionsTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-new-functions").create();
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null)
-      database.drop();
-  }
-
+class OpenCypherNewFunctionsTest extends TestHelper {
   // ============ isNaN() tests ============
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherOptimizerVerificationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherOptimizerVerificationTest.java
@@ -18,29 +18,20 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-;
 
 /**
  * Cypher Verification test for Cost-Based Query Optimizer.
  * Ensures that optimizations are correctly applied by checking EXPLAIN output.
  */
-public class OpenCypherOptimizerVerificationTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-optimizer-verification").create();
-
+public class OpenCypherOptimizerVerificationTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Create schema with properties
     database.transaction(() -> {
       final var personType = database.getSchema().createVertexType("Person");
@@ -94,14 +85,6 @@ public class OpenCypherOptimizerVerificationTest {
       database.getSchema().getOrCreateVertexType("Company")
         .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
     });
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null) {
-      database.drop();
-      database = null;
-    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehension5146Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehension5146Test.java
@@ -18,12 +18,8 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
-import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -36,12 +32,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class OpenCypherPatternComprehension5146Test {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-pc-5146").create();
+class OpenCypherPatternComprehension5146Test extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.command("opencypher",
         """
         CREATE
@@ -52,12 +45,6 @@ class OpenCypherPatternComprehension5146Test {
           (src)-[:QE {w: 1}]->(t2),
           (src)-[:QE {w: 2}]->(t3),
           (src)-[:QE {w: 3}]->(t4)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionIssue5111Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionIssue5111Test.java
@@ -18,12 +18,8 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
-import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -39,12 +35,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class OpenCypherPatternComprehensionIssue5111Test {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-pc-issue-5111").create();
+class OpenCypherPatternComprehensionIssue5111Test extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("Person");
     database.getSchema().createEdgeType("R");
 
@@ -58,12 +51,6 @@ class OpenCypherPatternComprehensionIssue5111Test {
         (dave:Person {name: 'Dave'}), \
         (alice)-[:R {w: 3}]->(bob), \
         (alice)-[:R {w: 5}]->(dave)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionRelPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionRelPropertyTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -39,12 +36,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class OpenCypherPatternComprehensionRelPropertyTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-pc-rel-property").create();
+class OpenCypherPatternComprehensionRelPropertyTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("VZ");
     database.getSchema().createEdgeType("VE");
 
@@ -61,12 +55,6 @@ class OpenCypherPatternComprehensionRelPropertyTest {
         (b)-[:VE {w: 2}]->(c), \
         (a)-[:VE {w: 3}]->(d), \
         (d)-[:VE {w: 4}]->(c)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternPredicateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternPredicateTest.java
@@ -18,8 +18,8 @@
  */
 package com.arcadedb.query.opencypher;
 
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -34,19 +34,14 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-;
-
 /**
  * Tests for pattern predicates in WHERE clauses.
  * Pattern predicates test whether a pattern exists in the graph.
  * Examples: WHERE (n)-[:KNOWS]->(), WHERE NOT (a)-[:LIKES]->(b)
  */
-class OpenCypherPatternPredicateTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    database = new DatabaseFactory("./databases/test-pattern-predicate").create();
+class OpenCypherPatternPredicateTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("Person");
     database.getSchema().createEdgeType("KNOWS");
     database.getSchema().createEdgeType("LIKES");
@@ -66,13 +61,6 @@ class OpenCypherPatternPredicateTest {
         (alice)-[:KNOWS]->(bob), \
         (alice)-[:KNOWS]->(charlie), \
         (bob)-[:LIKES]->(alice)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null) {
-      database.drop();
-    }
   }
 
   @Test
@@ -221,33 +209,33 @@ class OpenCypherPatternPredicateTest {
   /** See issue #3331 */
   @Nested
   class PatternComprehensionReturnTypeRegression {
-    private Database database;
+    private Database db;
 
     @BeforeEach
     void setUp() {
-      database = new DatabaseFactory("./target/databases/test-issue3331").create();
-      database.getSchema().createVertexType("Person");
-      database.getSchema().createEdgeType("KNOWS");
+      db = TestHelper.createDatabase("./target/databases/test-issue3331");
+      db.getSchema().createVertexType("Person");
+      db.getSchema().createEdgeType("KNOWS");
     }
 
     @AfterEach
     void tearDown() {
-      if (database != null) {
-        database.drop();
-        database = null;
+      if (db != null) {
+        db.drop();
+        db = null;
       }
     }
 
     @Test
     void patternComprehensionFromIssue() {
       // Exact scenario from issue #3331
-      database.transaction(() ->
-        database.command("opencypher",
+      db.transaction(() ->
+        db.command("opencypher",
             """
             CREATE (a:Person {name:'A'})-[:KNOWS]->(:Person {name:'B'}), \
             (a)-[:KNOWS]->(:Person {name:'C'})"""));
 
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (a:Person {name: 'A'}) \
           RETURN [(a)-->(friend) WHERE friend.name <> 'B' | friend.name] AS result""")) {
@@ -264,13 +252,13 @@ class OpenCypherPatternPredicateTest {
     @Test
     void patternComprehensionNoFilter() {
       // Pattern comprehension without WHERE clause
-      database.transaction(() ->
-        database.command("opencypher",
+      db.transaction(() ->
+        db.command("opencypher",
             """
             CREATE (a:Person {name:'A'})-[:KNOWS]->(:Person {name:'B'}), \
             (a)-[:KNOWS]->(:Person {name:'C'})"""));
 
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (a:Person {name: 'A'}) \
           RETURN [(a)-->(friend) | friend.name] AS result""")) {
@@ -287,13 +275,13 @@ class OpenCypherPatternPredicateTest {
     @Test
     void patternComprehensionWithRelType() {
       // Pattern comprehension with specific relationship type
-      database.transaction(() ->
-        database.command("opencypher",
+      db.transaction(() ->
+        db.command("opencypher",
             """
             CREATE (a:Person {name:'A'})-[:KNOWS]->(:Person {name:'B'}), \
             (a)-[:LIKES]->(:Person {name:'C'})"""));
 
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (a:Person {name: 'A'}) \
           RETURN [(a)-[:KNOWS]->(friend) | friend.name] AS result""")) {
@@ -310,11 +298,11 @@ class OpenCypherPatternPredicateTest {
     @Test
     void patternComprehensionEmptyResult() {
       // Pattern comprehension that matches nothing
-      database.transaction(() ->
-        database.command("opencypher",
+      db.transaction(() ->
+        db.command("opencypher",
             "CREATE (:Person {name:'A'})"));
 
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (a:Person {name: 'A'}) \
           RETURN [(a)-->(friend) | friend.name] AS result""")) {
@@ -335,13 +323,13 @@ class OpenCypherPatternPredicateTest {
      */
     @Test
     void patternComprehensionTwoHopAnonymousMiddleNode() {
-      database.transaction(() ->
-          database.command("opencypher",
+      db.transaction(() ->
+          db.command("opencypher",
               """
               CREATE (p:Person {probe: true}), (m:Person {gid: 2}), (t:Person {gid: 3}), \
               (p)-[:KNOWS]->(m), (m)-[:KNOWS]->(t)"""));
 
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (p:Person {probe: true}) \
           RETURN [(p)-[:KNOWS]->(:Person)-[:KNOWS]->(target:Person) | target.gid] AS targets""")) {
@@ -358,13 +346,13 @@ class OpenCypherPatternPredicateTest {
     /** See issue #5007: a 2-hop pattern comprehension with a named middle node must keep working. */
     @Test
     void patternComprehensionTwoHopNamedMiddleNode() {
-      database.transaction(() ->
-          database.command("opencypher",
+      db.transaction(() ->
+          db.command("opencypher",
               """
               CREATE (p:Person {probe: true}), (m:Person {gid: 2}), (t:Person {gid: 3}), \
               (p)-[:KNOWS]->(m), (m)-[:KNOWS]->(t)"""));
 
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (p:Person {probe: true}) \
           RETURN [(p)-[:KNOWS]->(mid:Person)-[:KNOWS]->(target:Person) | target.gid] AS targets""")) {
@@ -382,32 +370,32 @@ class OpenCypherPatternPredicateTest {
   /** See issue #3938: existential pattern predicate must filter by target-node properties too. */
   @Nested
   class ExistentialPatternPredicateTargetPropertiesRegression {
-    private Database database;
+    private Database db;
 
     @BeforeEach
     void setUp() {
-      database = new DatabaseFactory("./target/databases/test-issue3938").create();
-      database.getSchema().createVertexType("Person");
-      database.getSchema().createVertexType("Country");
-      database.getSchema().createEdgeType("LIVING_IN");
+      db = TestHelper.createDatabase("./target/databases/test-issue3938");
+      db.getSchema().createVertexType("Person");
+      db.getSchema().createVertexType("Country");
+      db.getSchema().createEdgeType("LIVING_IN");
 
-      database.transaction(() -> {
-        database.command("opencypher",
+      db.transaction(() -> {
+        db.command("opencypher",
             """
             CREATE (:Country {name: 'Germany'}), \
             (:Country {name: 'United Kingdom'}), \
             (:Person {name: 'Alice'}), \
             (:Person {name: 'Bob'}), \
             (:Person {name: 'Charlie'})""");
-        database.command("opencypher",
+        db.command("opencypher",
             """
             MATCH (p:Person {name: 'Alice'}), (c:Country {name: 'Germany'}) \
             CREATE (p)-[:LIVING_IN]->(c)""");
-        database.command("opencypher",
+        db.command("opencypher",
             """
             MATCH (p:Person {name: 'Bob'}), (c:Country {name: 'United Kingdom'}) \
             CREATE (p)-[:LIVING_IN]->(c)""");
-        database.command("opencypher",
+        db.command("opencypher",
             """
             MATCH (p:Person {name: 'Charlie'}), (c:Country {name: 'Germany'}) \
             CREATE (p)-[:LIVING_IN]->(c)""");
@@ -416,16 +404,16 @@ class OpenCypherPatternPredicateTest {
 
     @AfterEach
     void tearDown() {
-      if (database != null) {
-        database.drop();
-        database = null;
+      if (db != null) {
+        db.drop();
+        db = null;
       }
     }
 
     @Test
     void patternPredicateFiltersByTargetNodeProperties() {
       // Only people living in Germany must pass the predicate.
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (p:Person) \
           WHERE (p)-[:LIVING_IN]->(:Country {name: 'Germany'}) \
@@ -440,7 +428,7 @@ class OpenCypherPatternPredicateTest {
     @Test
     void patternPredicateFiltersByTargetNodePropertiesAnonymousEnd() {
       // Anonymous end node with property constraint only.
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (p:Person) \
           WHERE (p)-[:LIVING_IN]->({name: 'Germany'}) \
@@ -455,7 +443,7 @@ class OpenCypherPatternPredicateTest {
     @Test
     void patternPredicateFilteredRowDoesNotLeakIntoDownstreamMatch() {
       // The predicate must cut Bob off, so a later MATCH cannot reintroduce United Kingdom.
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (p:Person) \
           WHERE (p)-[:LIVING_IN]->(:Country {name: 'Germany'}) \
@@ -474,7 +462,7 @@ class OpenCypherPatternPredicateTest {
     @Test
     void negatedPatternPredicateHonorsTargetNodeProperties() {
       // Only people NOT living in Germany must pass.
-      try (final ResultSet rs = database.query("opencypher",
+      try (final ResultSet rs = db.query("opencypher",
           """
           MATCH (p:Person) \
           WHERE NOT (p)-[:LIVING_IN]->(:Country {name: 'Germany'}) \
@@ -493,7 +481,7 @@ class OpenCypherPatternPredicateTest {
 
     @BeforeEach
     void setUp() {
-      db = new DatabaseFactory("./databases/test-inline-rel-predicate").create();
+      db = TestHelper.createDatabase("./target/databases/test-inline-rel-predicate");
       db.getSchema().createVertexType("Person");
       db.getSchema().createEdgeType("KNOWS");
       db.command("opencypher",
@@ -507,8 +495,10 @@ class OpenCypherPatternPredicateTest {
 
     @AfterEach
     void tearDown() {
-      if (db != null)
+      if (db != null) {
         db.drop();
+        db = null;
+      }
     }
 
     @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherStDevTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherStDevTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,23 +33,12 @@ import static org.assertj.core.api.Assertions.within;
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
-class OpenCypherStDevTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-stdev").create();
+class OpenCypherStDevTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     database.getSchema().createVertexType("Val");
     database.transaction(() ->
       database.command("opencypher", "CREATE (:Val {v: 10.0}), (:Val {v: 20.0}), (:Val {v: 30.0})"));
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null) {
-      database.drop();
-      database = null;
-    }
   }
 
   @Test
@@ -102,7 +88,7 @@ class OpenCypherStDevTest {
 
     // Drop and recreate with single value
     database.drop();
-    database = new DatabaseFactory("./databases/test-stdev").create();
+    database = factory.create();
     database.getSchema().createVertexType("Val");
     database.transaction(() ->
       database.command("opencypher", "CREATE (:Val {v: 42.0})"));

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherTimestampTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherTimestampTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher;
 
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.query.opencypher.temporal.CypherLocalDateTime;
@@ -25,8 +26,6 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -42,20 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class OpenCypherTimestampTest {
-  private Database database;
-
-  @BeforeEach
-  void setup() {
-    database = new DatabaseFactory("./databases/test-timestamp").create();
-  }
-
-  @AfterEach
-  void teardown() {
-    if (database != null)
-      database.drop();
-  }
-
+class OpenCypherTimestampTest extends TestHelper {
   @Test
   void timestampReturnsLong() {
     final long before = System.currentTimeMillis();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/Issue4577And4578Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/Issue4577And4578Test.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -43,22 +40,7 @@ import static org.assertj.core.api.Assertions.within;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue4577And4578Test {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-issue-4577-4578");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
-  }
+class Issue4577And4578Test extends TestHelper {
 
   // ==================== #4578 ====================
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherAggregatingFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherAggregatingFunctionsComprehensiveTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -35,16 +32,9 @@ import static org.assertj.core.api.Assertions.within;
  * Comprehensive tests for OpenCypher Aggregating functions based on Neo4j Cypher documentation.
  * Tests cover: avg(), collect(), count(), max(), min(), percentileCont(), percentileDisc(), stDev(), stDevP(), sum()
  */
-class OpenCypherAggregatingFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-aggregating-functions");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-
+class OpenCypherAggregatingFunctionsComprehensiveTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Create test graph matching Neo4j documentation
     database.getSchema().createVertexType("Person");
     database.getSchema().createVertexType("Movie");
@@ -66,12 +56,6 @@ class OpenCypherAggregatingFunctionsComprehensiveTest {
         (keanu)-[:KNOWS]->(kathryn), \
         (carrie)-[:KNOWS]->(guy), \
         (liam)-[:KNOWS]->(guy)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   // ==================== avg() Tests ====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherListFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherListFunctionsComprehensiveTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -35,16 +32,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Comprehensive tests for OpenCypher List functions based on Neo4j Cypher documentation.
  * Tests cover all 21 list functions including coll.* functions, keys(), labels(), nodes(), range(), reduce(), relationships(), reverse(), tail(), and to*List() functions.
  */
-class OpenCypherListFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-list-functions");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-
+class OpenCypherListFunctionsComprehensiveTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Create test graph matching Neo4j documentation
     database.getSchema().createVertexType("Developer");
     database.getSchema().createVertexType("Administrator");
@@ -65,12 +55,6 @@ class OpenCypherListFunctionsComprehensiveTest {
         (bob)-[:KNOWS]->(daniel), \
         (charlie)-[:KNOWS]->(daniel), \
         (bob)-[:MARRIED]->(eskil)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   // ==================== coll.distinct() Tests ====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherLoadCsvFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherLoadCsvFunctionsComprehensiveTest.java
@@ -18,14 +18,12 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedWriter;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -38,36 +36,32 @@ import static org.assertj.core.api.Assertions.assertThat;
  * These functions are only useful when run on a query that uses LOAD CSV.
  * In all other contexts they always return null.
  */
-class OpenCypherLoadCsvFunctionsComprehensiveTest {
+class OpenCypherLoadCsvFunctionsComprehensiveTest extends TestHelper {
 
-  private Database database;
   private Path testCsvFile;
 
-  @BeforeEach
-  void setUp() throws Exception {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-load-csv-functions");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-
+  @Override
+  protected void beginTest() {
     // Create test CSV file with headers
-    testCsvFile = Files.createTempFile("test-load-csv", ".csv");
-    try (BufferedWriter writer = Files.newBufferedWriter(testCsvFile)) {
-      writer.write("name,age,city");
-      writer.newLine();
-      writer.write("Alice,30,Paris");
-      writer.newLine();
-      writer.write("Bob,25,London");
-      writer.newLine();
-      writer.write("Charlie,35,Berlin");
-      writer.newLine();
+    try {
+      testCsvFile = Files.createTempFile("test-load-csv", ".csv");
+      try (BufferedWriter writer = Files.newBufferedWriter(testCsvFile)) {
+        writer.write("name,age,city");
+        writer.newLine();
+        writer.write("Alice,30,Paris");
+        writer.newLine();
+        writer.write("Bob,25,London");
+        writer.newLine();
+        writer.write("Charlie,35,Berlin");
+        writer.newLine();
+      }
+    } catch (final IOException e) {
+      throw new RuntimeException("Error on creating the test CSV file", e);
     }
   }
 
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
+  @Override
+  protected void endTest() {
     if (testCsvFile != null) {
       try {
         Files.deleteIfExists(testCsvFile);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherMathLogarithmicFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherMathLogarithmicFunctionsComprehensiveTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,22 +30,7 @@ import static org.assertj.core.api.Assertions.within;
  * Comprehensive tests for OpenCypher Mathematical Logarithmic functions based on Neo4j Cypher documentation.
  * Tests cover: e(), exp(), log(), log10(), sqrt()
  */
-class OpenCypherMathLogarithmicFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-math-log");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
-  }
+class OpenCypherMathLogarithmicFunctionsComprehensiveTest extends TestHelper {
 
   // ==================== e() Tests ====================
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherMathNumericFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherMathNumericFunctionsComprehensiveTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,22 +30,7 @@ import static org.assertj.core.api.Assertions.within;
  * Comprehensive tests for OpenCypher Mathematical Numeric functions based on Neo4j Cypher documentation.
  * Tests cover: abs(), ceil(), floor(), isNaN(), rand(), round(), sign()
  */
-class OpenCypherMathNumericFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-math-numeric");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
-  }
+class OpenCypherMathNumericFunctionsComprehensiveTest extends TestHelper {
 
   // ==================== abs() Tests ====================
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherMathTrigonometricFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherMathTrigonometricFunctionsComprehensiveTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,22 +30,7 @@ import static org.assertj.core.api.Assertions.within;
  * Comprehensive tests for OpenCypher Mathematical Trigonometric functions based on Neo4j Cypher documentation.
  * Tests cover: acos(), asin(), atan(), atan2(), cos(), cosh(), cot(), coth(), degrees(), haversin(), pi(), radians(), sin(), sinh(), tan(), tanh()
  */
-class OpenCypherMathTrigonometricFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-math-trig");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
-  }
+class OpenCypherMathTrigonometricFunctionsComprehensiveTest extends TestHelper {
 
   // ==================== acos() Tests ====================
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherPredicateFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherPredicateFunctionsComprehensiveTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,16 +29,9 @@ import org.assertj.core.api.Assertions;
  * Comprehensive tests for OpenCypher Predicate functions based on Neo4j Cypher documentation.
  * Tests cover: all(), allReduce(), any(), exists(), isEmpty(), none(), single()
  */
-class OpenCypherPredicateFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-predicate-functions");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-
+class OpenCypherPredicateFunctionsComprehensiveTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Create test graph matching Neo4j documentation
     database.getSchema().createVertexType("Person");
     database.getSchema().createVertexType("Movie");
@@ -66,12 +56,6 @@ class OpenCypherPredicateFunctionsComprehensiveTest {
         (liam)-[:KNOWS {since: 2009}]->(guy), \
         (keanu)-[:ACTED_IN]->(theMatrix), \
         (carrie)-[:ACTED_IN]->(theMatrix)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   // ==================== all() Tests ====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherScalarFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherScalarFunctionsComprehensiveTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -38,16 +35,9 @@ import org.assertj.core.api.Assertions;
  * startNode(), timestamp(), toBoolean(), toBooleanOrNull(), toFloat(), toFloatOrNull(),
  * toInteger(), toIntegerOrNull(), type(), valueType()
  */
-class OpenCypherScalarFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-scalar-functions");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-
+class OpenCypherScalarFunctionsComprehensiveTest extends TestHelper {
+  @Override
+  protected void beginTest() {
     // Create test graph matching Neo4j documentation
     database.getSchema().createVertexType("Developer");
     database.getSchema().createVertexType("Administrator");
@@ -69,12 +59,6 @@ class OpenCypherScalarFunctionsComprehensiveTest {
         (bob)-[:KNOWS]->(daniel), \
         (charlie)-[:KNOWS]->(daniel), \
         (bob)-[:MARRIED]->(eskil)""");
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
   }
 
   // ==================== char_length() Tests ====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherSpatialFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherSpatialFunctionsComprehensiveTest.java
@@ -18,12 +18,9 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,22 +31,7 @@ import static org.assertj.core.api.Assertions.within;
  * Comprehensive tests for OpenCypher Spatial functions based on Neo4j Cypher documentation.
  * Tests cover all spatial functions: point(), point.distance(), point.withinBBox()
  */
-class OpenCypherSpatialFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-spatial-functions");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
-  }
+class OpenCypherSpatialFunctionsComprehensiveTest extends TestHelper {
 
   // ==================== point() Tests - WGS 84 2D ====================
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherStringFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherStringFunctionsComprehensiveTest.java
@@ -18,11 +18,8 @@
  */
 package com.arcadedb.query.opencypher.functions;
 
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -35,22 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Comprehensive tests for OpenCypher String functions based on Neo4j Cypher documentation.
  * Tests cover all 18 string functions with their various parameters and edge cases.
  */
-class OpenCypherStringFunctionsComprehensiveTest {
-  private Database database;
-
-  @BeforeEach
-  void setUp() {
-    final DatabaseFactory factory = new DatabaseFactory("./databases/test-cypher-string-functions");
-    if (factory.exists())
-      factory.open().drop();
-    database = factory.create();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (database != null)
-      database.drop();
-  }
+class OpenCypherStringFunctionsComprehensiveTest extends TestHelper {
 
   // ==================== btrim() Tests ====================
 

--- a/engine/src/test/java/com/arcadedb/query/sql/OrderByTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/OrderByTest.java
@@ -19,16 +19,13 @@
 package com.arcadedb.query.sql;
 
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -39,41 +36,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * From Issue https://github.com/ArcadeData/arcadedb/issues/839
  */
-class OrderByTest {
+class OrderByTest extends TestHelper {
 
-  @BeforeEach
-  void setUp() {
-    GlobalConfiguration.DATE_TIME_FORMAT.setValue("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
+  @Override
+  protected void beginTest() {
+    final String dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS";
+    GlobalConfiguration.DATE_TIME_FORMAT.setValue(dateTimeFormat);
+    database.getSchema().setDateTimeFormat(dateTimeFormat);
 
-  }
+    database.transaction(() -> {
+      DocumentType dtProduct = database.getSchema().createDocumentType("Product");
+      dtProduct.createProperty("name", Type.STRING);
+      dtProduct.createProperty("type", Type.STRING);
+      dtProduct.createProperty("start", Type.DATETIME_MICROS);
+      dtProduct.createProperty("stop", Type.DATETIME_MICROS);
+      dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+      dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "type", "start", "stop");
+    });
 
-  @AfterEach
-  void tearDown() {
-    GlobalConfiguration.resetAll();
+    // REOPEN THE DATABASE TO RELOAD THE SCHEMA FROM DISK
+    reopenDatabase();
   }
 
   @Test
   void localDateTimeOrderBy() {
-    DatabaseFactory databaseFactory = new DatabaseFactory("databases/OrderByTest");
-
-    if (databaseFactory.exists())
-      databaseFactory.open().drop();
-
-    try (Database db = databaseFactory.create()) {
-      db.transaction(() -> {
-        DocumentType dtProduct = db.getSchema().createDocumentType("Product");
-        dtProduct.createProperty("name", Type.STRING);
-        dtProduct.createProperty("type", Type.STRING);
-        dtProduct.createProperty("start", Type.DATETIME_MICROS);
-        dtProduct.createProperty("stop", Type.DATETIME_MICROS);
-        dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-        dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "type", "start", "stop");
-      });
-    }
-
-
-    final Database database = databaseFactory.open();
-
     database.transaction(() -> {
       String name;
       String type;

--- a/gremlin/src/test/java/performance/CypherEngineComparisonBenchmark.java
+++ b/gremlin/src/test/java/performance/CypherEngineComparisonBenchmark.java
@@ -89,8 +89,8 @@ class CypherEngineComparisonBenchmark {
     // Use Java engine for Gremlin (secure, not Groovy)
     GlobalConfiguration.GREMLIN_ENGINE.setValue("java");
 
-    FileUtils.deleteRecursively(new File("./databases/test-comparison-benchmark"));
-    database = new DatabaseFactory("./databases/test-comparison-benchmark").create();
+    FileUtils.deleteRecursively(new File("target/databases/test-comparison-benchmark"));
+    database = new DatabaseFactory("target/databases/test-comparison-benchmark").create();
 
     // Create schema with properties
     database.transaction(() -> {

--- a/integration/src/test/java/com/arcadedb/integration/exporter/SQLLocalExporterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/SQLLocalExporterTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLLocalExporterTest {
 
-  public static final String DATABASE_PATH = "databases/importedFromOrientDB";
+  public static final String DATABASE_PATH = "target/databases/importedFromOrientDB";
 
   @BeforeEach
   @AfterEach
@@ -52,7 +52,7 @@ public class SQLLocalExporterTest {
   void importAndExportDatabase() {
     final URL inputFile = OrientDBImporterIT.class.getClassLoader().getResource("orientdb-export-small.gz");
 
-    try (final Database database = new DatabaseFactory("databases/importedFromOrientDB").create()) {
+    try (final Database database = new DatabaseFactory(DATABASE_PATH).create()) {
       database.getConfiguration()
           .setValue(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE,
               ((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue()) * 10);
@@ -80,7 +80,7 @@ public class SQLLocalExporterTest {
   void importAndExportPartialDatabase() {
     final URL inputFile = OrientDBImporterIT.class.getClassLoader().getResource("orientdb-export-small.gz");
 
-    try (final Database database = new DatabaseFactory("databases/importedFromOrientDB").create()) {
+    try (final Database database = new DatabaseFactory(DATABASE_PATH).create()) {
       database.getConfiguration()
           .setValue(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE,
               ((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue()) * 10);
@@ -108,7 +108,7 @@ public class SQLLocalExporterTest {
   @Test
   void exportAndReimportSmallDatabase() {
     // Test case for issue #1839 - exported database cannot be imported
-    final String dbPath = "databases/testExportImport";
+    final String dbPath = "target/databases/testExportImport";
     FileUtils.deleteRecursively(new File(dbPath));
 
     try (final Database database = new DatabaseFactory(dbPath).create()) {
@@ -151,7 +151,7 @@ public class SQLLocalExporterTest {
     }
 
     // Now try to import it into a new database
-    final String dbPath2 = "databases/testExportImport2";
+    final String dbPath2 = "target/databases/testExportImport2";
     FileUtils.deleteRecursively(new File(dbPath2));
 
     try (final Database database2 = new DatabaseFactory(dbPath2).create()) {

--- a/integration/src/test/java/com/arcadedb/integration/importer/SQLLocalImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/SQLLocalImporterIT.java
@@ -35,9 +35,9 @@ class SQLLocalImporterIT {
   void importOrientDB() {
     final URL inputFile = OrientDBImporterIT.class.getClassLoader().getResource("orientdb-export-small.gz");
 
-    FileUtils.deleteRecursively(new File("databases/importedFromOrientDB"));
+    FileUtils.deleteRecursively(new File("target/databases/importedFromOrientDB"));
 
-    try (final Database database = new DatabaseFactory("databases/importedFromOrientDB").create()) {
+    try (final Database database = new DatabaseFactory("target/databases/importedFromOrientDB").create()) {
       database.getConfiguration()
           .setValue(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE, ((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue()) * 10);
 
@@ -49,6 +49,6 @@ class SQLLocalImporterIT {
     }
 
     TestHelper.checkActiveDatabases();
-    FileUtils.deleteRecursively(new File("databases/importedFromOrientDB"));
+    FileUtils.deleteRecursively(new File("target/databases/importedFromOrientDB"));
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/vector/FastTextDatabase.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/vector/FastTextDatabase.java
@@ -71,7 +71,7 @@ public class FastTextDatabase {
 
     final Database database;
 
-    final DatabaseFactory factory = new DatabaseFactory("databases/textdb");
+    final DatabaseFactory factory = new DatabaseFactory("target/databases/textdb");
 
     // TODO: REMOVE THIS
 //    if (factory.exists())

--- a/integration/src/test/java/com/arcadedb/integration/importer/vector/GloVeReopenVerificationTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/vector/GloVeReopenVerificationTest.java
@@ -38,7 +38,7 @@ class GloVeReopenVerificationTest {
 
   @Test
   void gloVeDatabaseReopensCorrectly() {
-    final DatabaseFactory factory = new DatabaseFactory("../databases/glovedb");
+    final DatabaseFactory factory = new DatabaseFactory("target/databases/glovedb");
 
     // Skip test if database doesn't exist
     if (!factory.exists()) {

--- a/integration/src/test/java/com/arcadedb/integration/importer/vector/GloVeTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/vector/GloVeTest.java
@@ -67,7 +67,7 @@ public class GloVeTest {
 
     final Database database;
 
-    final DatabaseFactory factory = new DatabaseFactory("databases/glovedb");
+    final DatabaseFactory factory = new DatabaseFactory("target/databases/glovedb");
 
     // TODO: REMOVE THIS
 //    if (factory.exists())

--- a/integration/src/test/java/com/arcadedb/integration/importer/vector/SimpleGloVeTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/vector/SimpleGloVeTest.java
@@ -56,7 +56,7 @@ public class SimpleGloVeTest {
 
   public SimpleGloVeTest() {
 
-    final DatabaseFactory factory = new DatabaseFactory("databases/glovedb");
+    final DatabaseFactory factory = new DatabaseFactory("target/databases/glovedb");
     final Database database;
 
     try {

--- a/server/src/test/java/com/arcadedb/server/AsyncInsertTest.java
+++ b/server/src/test/java/com/arcadedb/server/AsyncInsertTest.java
@@ -156,10 +156,7 @@ class AsyncInsertTest {
 
   @BeforeEach
   void beginTests() {
-    try (DatabaseFactory databaseFactory = new DatabaseFactory("./databases/" + DATABASE_NAME)) {
-      if (databaseFactory.exists())
-        databaseFactory.open().drop();
-    }
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
 
     final ContextConfiguration serverConfiguration = new ContextConfiguration();
     final String rootPath = IntegrationUtils.setRootPath(serverConfiguration);

--- a/server/src/test/java/com/arcadedb/server/BatchInsertUpdateTest.java
+++ b/server/src/test/java/com/arcadedb/server/BatchInsertUpdateTest.java
@@ -207,6 +207,7 @@ class BatchInsertUpdateTest {
 
   @BeforeEach
   void beginTests() {
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
     final ContextConfiguration serverConfiguration = new ContextConfiguration();
     final String rootPath = IntegrationUtils.setRootPath(serverConfiguration);
     FileUtils.deleteRecursively(new File(rootPath + "/databases"));

--- a/server/src/test/java/com/arcadedb/server/CompositeIndexTest.java
+++ b/server/src/test/java/com/arcadedb/server/CompositeIndexTest.java
@@ -134,6 +134,7 @@ class CompositeIndexTest {
 
   @BeforeEach
   void beginTests() {
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
     final ContextConfiguration serverConfiguration = new ContextConfiguration();
     final String rootPath = IntegrationUtils.setRootPath(serverConfiguration);
     FileUtils.deleteRecursively(new File(rootPath + "/databases"));

--- a/server/src/test/java/com/arcadedb/server/RemoteCollectionTemporalIT.java
+++ b/server/src/test/java/com/arcadedb/server/RemoteCollectionTemporalIT.java
@@ -146,6 +146,7 @@ class RemoteCollectionTemporalIT {
 
   @BeforeEach
   void beginTest() {
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
     final ContextConfiguration serverConfiguration = new ContextConfiguration();
     final String rootPath = IntegrationUtils.setRootPath(serverConfiguration);
     final DatabaseFactory databaseFactory = new DatabaseFactory(rootPath + "/databases/remotecolltemporal");

--- a/server/src/test/java/com/arcadedb/server/RemoteDateIT.java
+++ b/server/src/test/java/com/arcadedb/server/RemoteDateIT.java
@@ -158,6 +158,7 @@ class RemoteDateIT {
 
   @BeforeEach
   void beginTest() {
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
     final ContextConfiguration serverConfiguration = new ContextConfiguration();
     final String rootPath = IntegrationUtils.setRootPath(serverConfiguration);
     DatabaseFactory databaseFactory = new DatabaseFactory(rootPath + "/databases/remotedate");

--- a/server/src/test/java/com/arcadedb/server/RemoteQueriesIT.java
+++ b/server/src/test/java/com/arcadedb/server/RemoteQueriesIT.java
@@ -218,10 +218,7 @@ class RemoteQueriesIT {
 
   @BeforeEach
   void beginTests() {
-    try (DatabaseFactory databaseFactory = new DatabaseFactory("./databases/" + DATABASE_NAME)) {
-      if (databaseFactory.exists())
-        databaseFactory.open().drop();
-    }
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
 
     final ContextConfiguration serverConfiguration = new ContextConfiguration();
     final String rootPath = IntegrationUtils.setRootPath(serverConfiguration);

--- a/server/src/test/java/com/arcadedb/server/RemoteSafeCloseDatabaseIT.java
+++ b/server/src/test/java/com/arcadedb/server/RemoteSafeCloseDatabaseIT.java
@@ -40,7 +40,12 @@ class RemoteSafeCloseDatabaseIT {
   void createDatabaseThenStartAndStopServer() {
     final String DATABASE_NAME = "test";
     final int PARALLEL_LEVEL = 6;
-    try (DatabaseFactory databaseFactory = new DatabaseFactory("databases/" + DATABASE_NAME)) {
+
+    // The server resolves its database directory from SERVER_ROOT_PATH, so the database has to be
+    // created under the same root the server will later read it from.
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
+
+    try (DatabaseFactory databaseFactory = new DatabaseFactory("./target/databases/" + DATABASE_NAME)) {
       if (databaseFactory.exists()) {
         databaseFactory.open().drop();
       }

--- a/server/src/test/java/com/arcadedb/server/SelectOrderTest.java
+++ b/server/src/test/java/com/arcadedb/server/SelectOrderTest.java
@@ -320,6 +320,7 @@ class SelectOrderTest {
 
   @BeforeEach
   void beginTests() {
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
     final ContextConfiguration serverConfiguration = new ContextConfiguration();
     final String rootPath = IntegrationUtils.setRootPath(serverConfiguration);
     FileUtils.deleteRecursively(new File(rootPath + "/databases"));

--- a/server/src/test/java/com/arcadedb/server/TestLinkedPropertiesSchemaReloadIT.java
+++ b/server/src/test/java/com/arcadedb/server/TestLinkedPropertiesSchemaReloadIT.java
@@ -141,6 +141,7 @@ public class TestLinkedPropertiesSchemaReloadIT {
   private void testSchema() {
     boolean AUTO_TRANS = false;
 
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
     GlobalConfiguration.SERVER_ROOT_PASSWORD.setValue(DEFAULT_PASSWORD_FOR_TESTS);
     ContextConfiguration config = new ContextConfiguration();
     ArcadeDBServer server = null;


### PR DESCRIPTION
Closes #5262

## Summary

57 test classes across `engine`, `server`, `integration` and `gremlin` constructed their own `DatabaseFactory` on a repo-relative `./databases/<name>` path and hand-rolled the create/drop lifecycle. Any run that skipped teardown (`kill -9`, a surefire fork timeout, an OOM, or a failure inside `drop()` itself) left the directory behind, which made every subsequent run of that class fail with `Database './databases/x' already exists`. Because the databases lived outside `target/`, `mvn clean` could not recover - the only cure was a manual `rm -rf` that a developer had to know to do.

The 48 `engine` classes now extend `TestHelper`, which already does all four things these tests need: cleans before the test, drops after, roots the database at `target/databases/<ClassName>`, asserts no `Database` instance leaked, and runs a `CHECK DATABASE` integrity check. Seeding moves from `@BeforeEach` into the `beginTest()` hook.

The 9 classes outside `engine` cannot extend `TestHelper` - the `server` and `gremlin` test modules do not depend on the engine test-jar, and three of the `integration` classes are `main()` utilities rather than JUnit tests - so they are repointed under `target/` directly. The three server tests set `SERVER_ROOT_PATH` to `./target`, the convention already used by the other server tests; since `SERVER_DATABASE_DIRECTORY` defaults to `${arcadedb.server.rootPath}/databases`, that one change relocates both the pre-created database and the server's own database directory.

Net **-698 lines**.

## Scope grew during review

Review found the first version of the guard was too narrow, and closing that hole exposed more of the same bug. This PR therefore goes past the 55 classes the issue lists:

- **6 more engine/integration classes** put databases on repo-relative paths via a `String` constant rather than an inline literal, so the original guard reported OK while they still leaked: `LSMVectorIndexPersistenceTest`, `LSMVectorIndexChunkedWriteTest`, `ContiguousPageIOTest`, three `LSMVectorIndexTest` methods, and `GloVeReopenVerificationTest` (which used `"../databases/glovedb"` - the repo *root*, a level above the module).
- **5 more server tests** leak through a path that is *derived*, not written: `SelectOrderTest`, `CompositeIndexTest`, `BatchInsertUpdateTest`, `RemoteDateIT`, `RemoteCollectionTemporalIT` call `IntegrationUtils.setRootPath(...)` without setting `SERVER_ROOT_PATH` first. `ServerPathUtils.setRootPath` only honours an already-set value and otherwise returns `"."`, so `rootPath + "/databases/"` resolved to `server/databases/`. Confirmed empirically: a full `mvn -pl server test` on the pre-fix tree left `server/databases/SelectOrderTest` on disk. No grep can catch this class of leak.
- **`OpenCypherCollectUnwindTest`**: four `@Nested` classes created their database with a bare `new DatabaseFactory(...).create()` and no pre-clean. Now use `TestHelper.createDatabase(...)` (drop-if-exists, then create).
- **`ConsoleTest`**: two `deleteRecursively(new File("databases/" + ...))` calls were dead cleanup of a legacy location the console no longer writes to. Removed.

The issue's own verification criterion - no module has a `databases/` directory after a run - is not reachable without these.

## Regression guard

`.github/scripts/check-test-database-paths.sh`, two layers:

- **static** (`setup` job): greps test sources for a literal rooted at a repo-relative `databases/` dir. Matching the *literal* rather than the `new DatabaseFactory(...)` call site is what catches the `String DB_PATH = "databases/..."` form. Deliberately does not match `"/databases/`, the suffix half of the correct `rootPath + "/databases/" + name` idiom.
- **runtime** (after **all four** test jobs - `unit-tests`, `slow-unit-tests`, `integration-tests`, `ha-integration-tests`): asserts no module grew a top-level `databases/` directory. This is the backstop for the `SERVER_ROOT_PATH`-derived case that no grep can resolve, and the server ITs that exhibit that pattern run in `integration-tests`.

## What changed beyond lifecycle

No assertion, query or expected value was changed. Two edits are **not** pure moves:

1. `RecordRecyclingTest`: `databaseFactory.getActiveDatabaseInstances()` -> `DatabaseFactory.getActiveDatabaseInstances()`. Same static method, called through the class because the local variable was removed.
2. `OrderByTest` and `TestInsertAndSelectWithThreadBucketSelectionStrategy`: `beginTest()` now also calls `database.getSchema().setDateTimeFormat(...)`. Required, not cosmetic: `TestHelper` builds the database in its **constructor**, before any subclass code runs, and `LocalSchema` captures `DATE_TIME_FORMAT` at construction and persists it into `schema.json`. Setting only the global from `beginTest()` arrives too late for the already-built schema, so the format must be written onto the schema to survive the `reopenDatabase()` these tests perform.

## Test plan

- [x] Guard fails on the pre-fix tree listing exactly the offending files, and passes after
- [x] Runtime guard verified both directions: a planted reactor-root `./target/databases` control is correctly ignored; a real `<module>/databases` is caught
- [x] All 48 migrated `engine` classes green: **966 tests, 0 failures** - including every class where `TestHelper`'s newly-applied `CHECK DATABASE` teardown could have surprised
- [x] Newly-scoped classes green: vector-index (33), `OpenCypherCollectUnwindTest` (77), `ConsoleTest` (30), `SelectOrderTest`/`CompositeIndexTest`/`BatchInsertUpdateTest`, `GloVeReopenVerificationTest`
- [x] Affected ITs green: `RemoteQueriesIT`, `RemoteSafeCloseDatabaseIT`, `SQLLocalImporterIT`, `RemoteDateIT`, `RemoteCollectionTemporalIT`
- [x] `SelectOrderTest`'s database verified to land in `server/target/databases/` after the fix
- [x] `engine`, `console`, `server`, `integration`, `gremlin` all compile
- [x] **Bug reproduction:** planting a leftover `schema.json` (simulating a crashed run) no longer wedges the class - 5/5 pass, where the pre-fix equivalent errored on all 5 and no `mvn clean` could fix it

🤖 Generated with [Claude Code](https://claude.com/claude-code)