### PR TITLE
fix: read a key's compacted leaf pages newest-first

### DIFF
--- a/docs/5266-fulltext-index-misses-records.md
+++ b/docs/5266-fulltext-index-misses-records.md
@@ -1,0 +1,62 @@
+# 5266 - FULL_TEXT index misses records
+
+## Status
+
+Issue #5266 as reported (fresh `CREATE INDEX` over 204k pre-existing records, no writes in between)
+**could not be reproduced** on `main`. This change fixes a *different*, confirmed index-correctness
+defect found while investigating, which produces the same user-visible symptom. It does not close
+#5266.
+
+## What was ruled out for #5266
+
+A harness built the FULL_TEXT index over pre-existing records and compared, for every token, the index
+result against a plain scan, and `countEntries()` against the expected posting count. No loss on `main`
+in any of: 204k records / 917k postings / 158k-token vocabulary; vertex type with ~350-byte records;
+`CREATE INDEX` inside an outer transaction (the server/HTTP path); page size 1024 and 65536;
+`indexCompactionRAM` = 1MB (forcing multi-chunk, multi-series compaction); four successive compaction
+rounds; database reopen; a token present in every record (posting list spanning many leaves).
+
+The reporter is on 26.7.2. Several compacted-LSM read fixes landed after that tag (#5210, #5214, #4943),
+and 26.7.2 demonstrably behaves differently: the same workload with a small index page size throws
+`UnsupportedOperationException: Root index page overflow` there, and not on `main`. #5266 may already be
+fixed; the reporter has been asked for their dataset or a reproducer, and to retest on `main`.
+
+## Symptom (the defect fixed here)
+
+A value removed from a key and then added back under that same key **permanently disappears** from the
+index, while a plain scan still returns the record. Easiest to hit with a heavily duplicated full-text
+token, because a common token's posting list is what overflows a compacted leaf page.
+
+## Root cause
+
+`LSMTreeIndexAbstract.lookupInPageAndAddInResultset` resolves deletions with a **forward-poisoning**
+`deletedRIDs` set: a tombstone only suppresses RIDs encountered *after* it. The whole reader therefore
+walks newest to oldest - mutable pages (`LSMTreeIndexMutable:358`), compacted series
+(`LSMTreeIndexCompacted:530`), and values within a page (`LSMTreeIndexAbstract:663`).
+
+The one exception was the per-key leaf-page loop at `LSMTreeIndexCompacted:580`. A key whose values
+overflow one leaf is written oldest-chunk-first onto ascending pages, each with its own root entry.
+That loop iterated the root entries in order, i.e. **oldest chunk first**, so a tombstone sitting in an
+early chunk poisoned `deletedRIDs` and then suppressed the live re-add sitting in a later chunk.
+
+The remove and the re-add must land in separate transactions to be reachable: within one transaction a
+REMOVE followed by an ADD on the same (key, rid) collapses to a single ADD in the transaction overlay,
+so no tombstone is written at all.
+
+## Fix
+
+- `LSMTreeIndexCompacted:580` - iterate the key's leaf pages newest-first, matching every other level of
+  the reader. The preceding-leaf read (which holds the oldest chunks) already ran last and stays last.
+- `LSMTreeIndexMutable.onAfterLoad()` - propagate `storeTermFrequency` to the compacted sub-index when it
+  is re-attached. The flag is not persisted in the page header, so a sub-index materialised by the
+  component factory defaults to `false`; a mismatch desynchronises the posting value stream (the
+  tf/docLength varints are not consumed) and silently decodes the rest of the entry as garbage.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/index/CompactedTombstoneLeafOrderTest.java` - 3000 documents share the
+token `data` (1024-byte pages, so its posting list provably spans many compacted leaves); a third of them
+have the token removed in one transaction and added back in the next; after compaction the index must
+return all 3000. Fails without the fix (1000 documents missing - exactly the ones touched), passes with it.
+
+Regression run: 551 tests / 90 classes across the index, LSM, compaction and full-text suites - 0 failures.

--- a/docs/5266-fulltext-index-misses-records.md
+++ b/docs/5266-fulltext-index-misses-records.md
@@ -60,3 +60,27 @@ have the token removed in one transaction and added back in the next; after comp
 return all 3000. Fails without the fix (1000 documents missing - exactly the ones touched), passes with it.
 
 Regression run: 551 tests / 90 classes across the index, LSM, compaction and full-text suites - 0 failures.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5270 (related to #5266, does not close it)
+
+## Review cycles
+
+- **cycle 1** (`651046d`) - gemini: defensive null check on `subIndex` after `getFileById`. Declined: the NPE
+  risk is pre-existing and unchanged by the diff (the next line already dereferences it), and the whole block
+  is inside a `catch (Exception)` that logs SEVERE and drops the index, so the proposed `IndexException` is
+  handled identically. claude: no bugs; four non-blocking notes. Applied the `Record` import; added a note to
+  the PR body on `limit` truncation now taking the newest values (strictly safer - the old order could
+  early-exit before a later chunk's tombstone and return a deleted value). Declined `@Tag("slow")` (test runs
+  0.53-0.80s) and declined moving the tracking doc (25 `docs/<issue>-<name>.md` files are already tracked, so
+  it is an established convention).
+- **cycle 2** (`984fea2`) - claude: "No bugs or security concerns found"; three optional polish items.
+  Reported honestly that the `storeTermFrequency` guard has no failing test and cannot have one:
+  `LocalSchema.getFileById` returns the already-registered component, so the flag is already correct in every
+  reachable in-process path. Kept it as an explicit local invariant rather than relying on the
+  `initComponents()` / `readConfiguration()` ordering coincidence.
+
+## Final state
+
+clean-approval - both bots reviewed, no blocking findings. Merge is the maintainer's call.

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -576,9 +576,14 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
           --pageInSeries;
 
         if (resultInRootPage.valueBeginPositions != null && resultInRootPage.valueBeginPositions.length > 1) {
+          // Newest leaf first. A key whose values overflow one leaf is written oldest-chunk-first onto ascending pages, so
+          // walking the root entries in order would visit the oldest chunk first. That inverts the deletion semantics of
+          // lookupInPageAndAddInResultset, whose deletedRIDs set only suppresses RIDs encountered AFTER the tombstone: a
+          // tombstone in an early chunk would then kill the live re-add sitting in a later chunk. Every other level of this
+          // reader (mutable pages, series, values within a page) already walks newest to oldest for the same reason.
           final List<RID> pages = readAllValuesFromResult(rootPageBuffer, resultInRootPage);
-          for (RID page : pages) {
-            final int pageNum = (int) page.getPosition();
+          for (int p = pages.size() - 1; p > -1; --p) {
+            final int pageNum = (int) pages.get(p).getPosition();
             if (pageNum < 1)
               continue;
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -132,6 +132,10 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
         subIndex = (LSMTreeIndexCompacted) database.getSchema().getFileById(subIndexFileId);
         subIndex.mainIndex = mainIndex;
         subIndex.binaryKeyTypes = binaryKeyTypes;
+        // The flag is not persisted in the page header: a sub-index materialised by the component factory defaults to false. It
+        // must match this index, because it decides whether the tf/docLength varints trailing every posting are consumed when a
+        // value is read back. A mismatch desynchronises the value stream and silently decodes the rest of the entry as garbage.
+        subIndex.setStoreTermFrequency(isStoreTermFrequency());
       }
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE,

--- a/engine/src/test/java/com/arcadedb/index/CompactedTombstoneLeafOrderTest.java
+++ b/engine/src/test/java/com/arcadedb/index/CompactedTombstoneLeafOrderTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
 import com.arcadedb.schema.Schema;
 import org.junit.jupiter.api.Test;
 
@@ -87,7 +88,7 @@ class CompactedTombstoneLeafOrderTest extends TestHelper {
 
     final List<RID> touched = new ArrayList<>();
     database.transaction(() -> {
-      final Iterator<com.arcadedb.database.Record> it = database.iterateType("Doc", false);
+      final Iterator<Record> it = database.iterateType("Doc", false);
       int n = 0;
       while (it.hasNext()) {
         final RID rid = it.next().getIdentity();
@@ -118,7 +119,7 @@ class CompactedTombstoneLeafOrderTest extends TestHelper {
 
     final Set<RID> expected = new HashSet<>();
     database.transaction(() -> {
-      final Iterator<com.arcadedb.database.Record> it = database.iterateType("Doc", false);
+      final Iterator<Record> it = database.iterateType("Doc", false);
       while (it.hasNext()) {
         final Document doc = (Document) it.next();
         if (doc.getString("words").contains("data"))

--- a/engine/src/test/java/com/arcadedb/index/CompactedTombstoneLeafOrderTest.java
+++ b/engine/src/test/java/com/arcadedb/index/CompactedTombstoneLeafOrderTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A key whose values overflow one compacted leaf page is written oldest-chunk-first onto ascending pages, each carrying its own
+ * root entry. The reader must walk those leaves NEWEST first, because {@code lookupInPageAndAddInResultset} resolves deletions
+ * with a forward-poisoning {@code deletedRIDs} set: a tombstone only suppresses RIDs seen after it. Walking oldest-first let a
+ * tombstone in an early chunk kill the live re-add sitting in a later chunk, so a value removed and then added back under the
+ * same key vanished from the index while a plain scan still returned the record. The defect is in the shared compacted read
+ * path; a heavily duplicated full-text token is the easiest way to overflow a leaf.
+ * <p>
+ * The remove and the re-add must land in SEPARATE transactions: within one transaction a REMOVE followed by an ADD on the same
+ * (key, rid) collapses to a single ADD in the transaction overlay, so no tombstone is ever written.
+ */
+class CompactedTombstoneLeafOrderTest extends TestHelper {
+
+  private static final int DOCS = 3_000;
+
+  /** Small pages so the shared token's posting list provably overflows a leaf and spans many compacted pages. */
+  private static final int PAGE_SIZE = 1024;
+
+  /**
+   * Ensures the compacted sub-index is in play. This page count always crosses {@code INDEX_COMPACTION_MIN_PAGES_SCHEDULE}, so a
+   * background compaction is already scheduled or running: wait for it, then compact once more so the merge is complete no
+   * matter who ran it.
+   */
+  private void compact(final String indexName) {
+    database.async().waitCompletion();
+    for (final IndexInternal bucketIndex : ((TypeIndex) database.getSchema().getIndexByName(indexName)).getIndexesOnBuckets())
+      try {
+        for (int attempt = 0; attempt < 200 && !bucketIndex.scheduleCompaction(); ++attempt)
+          Thread.sleep(25); // a background compaction owns the status; let it finish
+        bucketIndex.compact();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+  }
+
+  @Test
+  void fullTextFindsTokenRemovedThenAddedBack() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("Doc").withTotalBuckets(1).create();
+      database.getSchema().getType("Doc").createProperty("words", String.class);
+      database.getSchema().buildTypeIndex("Doc", new String[] { "words" })
+          .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType().withPageSize(PAGE_SIZE).create();
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < DOCS; i++)
+        database.newDocument("Doc").set("words", "data tok" + i).save();
+    });
+
+    final List<RID> touched = new ArrayList<>();
+    database.transaction(() -> {
+      final Iterator<com.arcadedb.database.Record> it = database.iterateType("Doc", false);
+      int n = 0;
+      while (it.hasNext()) {
+        final RID rid = it.next().getIdentity();
+        if (n++ % 3 == 0)
+          touched.add(rid);
+      }
+    });
+
+    // Drop the shared token: writes a tombstone for ('data', rid).
+    database.transaction(() -> {
+      for (final RID rid : touched) {
+        final MutableDocument doc = rid.asDocument().modify();
+        doc.set("words", doc.getString("words").replace("data ", ""));
+        doc.save();
+      }
+    });
+
+    // Add it back: a live re-add for the same ('data', rid), landing in a later chunk than its tombstone.
+    database.transaction(() -> {
+      for (final RID rid : touched) {
+        final MutableDocument doc = rid.asDocument().modify();
+        doc.set("words", "data " + doc.getString("words"));
+        doc.save();
+      }
+    });
+
+    compact("Doc[words]");
+
+    final Set<RID> expected = new HashSet<>();
+    database.transaction(() -> {
+      final Iterator<com.arcadedb.database.Record> it = database.iterateType("Doc", false);
+      while (it.hasNext()) {
+        final Document doc = (Document) it.next();
+        if (doc.getString("words").contains("data"))
+          expected.add(doc.getIdentity());
+      }
+    });
+    assertThat(expected).hasSize(DOCS);
+
+    final Set<RID> found = new HashSet<>();
+    database.transaction(() -> {
+      final IndexCursor cursor = ((TypeIndex) database.getSchema().getIndexByName("Doc[words]")).getIndexesOnBuckets()[0]
+          .get(new Object[] { "data" });
+      while (cursor.hasNext())
+        found.add(cursor.next().getIdentity());
+    });
+
+    assertThat(found).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
Related to #5266. **This does not close #5266** - see "Scope" below.

## Summary

A value removed from a key and then added back under that same key **permanently disappears** from the index, while a plain scan still returns the record. It is easiest to hit with a heavily duplicated full-text token, because a common token's posting list is what overflows a compacted leaf page.

`LSMTreeIndexAbstract.lookupInPageAndAddInResultset` resolves deletions with a **forward-poisoning** `deletedRIDs` set: a tombstone only suppresses RIDs encountered *after* it. The whole reader therefore walks newest to oldest - mutable pages (`LSMTreeIndexMutable:358`), compacted series (`LSMTreeIndexCompacted:530`), and values within a page (`LSMTreeIndexAbstract:663`).

The one exception was the per-key leaf-page loop at `LSMTreeIndexCompacted:580`. A key whose values overflow one leaf is written oldest-chunk-first onto ascending pages, each with its own root entry. That loop iterated the root entries **in order**, i.e. oldest chunk first, so a tombstone in an early chunk poisoned `deletedRIDs` and then suppressed the live re-add sitting in a later chunk.

The remove and the re-add must land in separate transactions to be reachable: within one transaction a REMOVE followed by an ADD on the same `(key, rid)` collapses to a single ADD in the transaction overlay, so no tombstone is written at all. That is why this survived existing coverage.

## Changes

- `LSMTreeIndexCompacted:580` - iterate the key's leaf pages newest-first, matching every other level of the reader. The preceding-leaf read (which holds the oldest chunks) already ran last and stays last.
- `LSMTreeIndexMutable.onAfterLoad()` - propagate `storeTermFrequency` to the compacted sub-index when it is re-attached. The flag is not persisted in the page header, so a sub-index materialised by the component factory defaults to `false`; a mismatch desynchronises the posting value stream (the tf/docLength varints are not consumed) and silently decodes the rest of the entry as garbage.

## Scope: this is not (yet) a fix for #5266

#5266 as reported - a fresh `CREATE INDEX` over 204k pre-existing records, no writes in between - **could not be reproduced on `main`**. A harness compared, for every token, the index result against a plain scan, and `countEntries()` against the expected posting count. No loss in any of: 204k records / 917k postings / 158k-token vocabulary; vertex type with ~350-byte records; `CREATE INDEX` inside an outer transaction (the server/HTTP path); page size 1024 and 65536; `indexCompactionRAM` = 1MB (forcing multi-chunk, multi-series compaction); four successive compaction rounds; database reopen; a token present in every record.

The reporter is on 26.7.2. Several compacted-LSM read fixes landed after that tag (#5210, #5214, #4943), and 26.7.2 demonstrably behaves differently - the same workload with a small index page size throws `UnsupportedOperationException: Root index page overflow` there, and not on `main`. #5266 may already be fixed; the reporter has been asked for their dataset and to retest against `main`.

This PR fixes a distinct, confirmed defect found while investigating, which produces the same user-visible symptom.

### Note on `limit`

With the reversal, a lookup passing `limit > -1` on an overflowing non-unique key now truncates to the **newest** values rather than the oldest. This is strictly an improvement, not just a semantic shift: under the old oldest-first order such a lookup could early-exit *before* reaching the later chunk that holds a tombstone, and therefore return a value that had actually been deleted. Newest-first cannot do that. The result is a `Set`, so caller-visible ordering is unaffected.

## Test plan

- [x] New `CompactedTombstoneLeafOrderTest`: 3000 documents share the token `data` (1024-byte pages, so its posting list provably spans many compacted leaves); a third have the token removed in one transaction and added back in the next; after compaction the index must return all 3000.
- [x] Verified it **fails without the fix** - exactly 1000 documents missing, precisely the ones touched - and passes with it.
- [x] Regression run: 551 tests / 90 classes across the index, LSM, compaction and full-text suites - 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
