### PR TITLE
feat(mcp): expose schema as a Resource at arcadedb://{database}/schema (#4865)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-mcp-schema-resource-4865.md
+++ b/docs/superpowers/plans/2026-07-14-mcp-schema-resource-4865.md
@@ -1,0 +1,1335 @@
+# MCP Schema Resource (#4865) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose each accessible database's schema as an MCP Resource at `arcadedb://{database}/schema` over both the HTTP and stdio transports, and collapse the duplicated JSON-RPC dispatch of the two transports onto a single shared `MCPDispatcher`.
+
+**Architecture:** Three layers. `GetSchemaTool` is refactored so its schema walk becomes a reusable `buildSchema(Database, String)` helper. A new `MCPResources` class holds all Resources logic (URI parsing, access filtering, list/read). A new `MCPDispatcher` becomes the single source of truth for the JSON-RPC method surface (protocol version, tool list, instructions, gating, method switch, envelope helpers), and `MCPHttpHandler` / `MCPStdioServer` shrink to thin transport adapters over it.
+
+**Tech Stack:** Java 21, Maven, JUnit 5 (Jupiter), AssertJ, `com.arcadedb.serializer.json.JSONObject` / `JSONArray`, Undertow (HTTP transport). All changes are confined to the `server` module.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-mcp-schema-resource-4865-design.md`
+**Issue:** [#4865](https://github.com/ArcadeData/arcadedb/issues/4865) | **Epic:** [#4859](https://github.com/ArcadeData/arcadedb/issues/4859) (Wave 1)
+
+## Global Constraints
+
+- **Java 21+.** Use `switch` expressions and `record` where the surrounding code already does.
+- **No fully qualified names in code.** Import the class and use the bare name.
+- **`final` on variables and parameters** wherever possible. This is the house style throughout the MCP package.
+- **Single-statement `if` bodies take no curly braces.** Match the existing MCP code exactly.
+- **JSON is `com.arcadedb.serializer.json.JSONObject` / `JSONArray`.** Never `org.json`, never Jackson. Use the two-argument getters (`getString(key, default)`) to avoid null checks.
+- **No new dependencies.**
+- **No `System.out`** left behind. `MCPStdioServer` writes to an injected `PrintStream`, never `System.out` directly.
+- **Comments state behavioral invariants only.** No issue numbers, no "this line does X", no attribution.
+- **Do not add Claude as an author** of any source file or commit.
+- **Do not run `git push`** and do not open a PR. Commit locally only; the maintainer reviews before pushing.
+- **Existing MCP tests are the regression net for the dispatcher extraction.** They must stay green *unedited*, with exactly two intentional exceptions, both in Task 5. Any other existing test that needs editing is a signal the refactor broke behavior: stop and investigate rather than adjusting the assertion.
+- **Apache 2.0 license header** at the top of every new `.java` file. Copy it verbatim from an existing file in the same package.
+- **Tool count stays at 11.** This issue adds a protocol primitive, not a tool. `assertThat(tools.length()).isEqualTo(11)` must remain true.
+
+**Build/test commands.** All work is in the `server` module. If the reactor artifacts are stale, run once from the repo root:
+
+```bash
+mvn -DskipTests install
+```
+
+Then, from the repo root, run a single test class with:
+
+```bash
+mvn -pl server test -Dtest=MCPResourcesTest
+```
+
+---
+
+### Task 1: Extract `buildSchema` from `GetSchemaTool`
+
+Pure refactor. No behavior change. This is what makes the tool-output-equals-resource-content criterion true by construction later, because there will be exactly one implementation of the schema walk.
+
+**Files:**
+- Modify: `server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java:53-128`
+- Test: `server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java` (existing `getSchema` test is the regression net; no edit)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public static JSONObject GetSchemaTool.buildSchema(final Database database, final String databaseName)`, returning `{"database": <name>, "types": [...]}`. Consumed by Task 2.
+
+- [ ] **Step 1: Run the existing test to establish the green baseline**
+
+Run: `mvn -pl server test -Dtest=MCPServerPluginTest#getSchema`
+Expected: PASS. If this is already red, stop: the baseline is broken and this refactor cannot be validated.
+
+- [ ] **Step 2: Extract the schema walk into `buildSchema`**
+
+In `GetSchemaTool.java`, replace the whole `execute` method (lines 53-128) with the two methods below. The body of `buildSchema` is the *existing* code from lines 62-127, moved verbatim; only the method wrapper is new.
+
+```java
+  public static JSONObject execute(final ArcadeDBServer server, final ServerSecurityUser user, final JSONObject args,
+      final MCPConfiguration config) {
+    if (!config.isAllowReads())
+      throw new SecurityException("Read operations are not allowed by MCP configuration");
+
+    final String databaseName = args.getString("database");
+
+    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+
+    return buildSchema(database, databaseName);
+  }
+
+  /**
+   * Builds the JSON schema document for a database. The single source of truth for schema shaping: the get_schema
+   * tool and the arcadedb://{database}/schema resource both render from here, so their content cannot drift apart.
+   * Performs no permission or authorization check; the caller is responsible for both.
+   */
+  public static JSONObject buildSchema(final Database database, final String databaseName) {
+    final Schema schema = database.getSchema();
+    final JSONArray types = new JSONArray();
+
+    for (final DocumentType type : schema.getTypes()) {
+      final JSONObject typeJson = new JSONObject();
+      typeJson.put("name", type.getName());
+
+      if (type instanceof VertexType)
+        typeJson.put("category", "vertex");
+      else if (type instanceof EdgeType)
+        typeJson.put("category", "edge");
+      else
+        typeJson.put("category", "document");
+
+      // Parent types
+      final JSONArray parents = new JSONArray();
+      for (final DocumentType superType : type.getSuperTypes())
+        parents.put(superType.getName());
+      if (parents.length() > 0)
+        typeJson.put("parentTypes", parents);
+
+      // Properties
+      final JSONArray properties = new JSONArray();
+      for (final Property prop : type.getProperties()) {
+        final JSONObject propJson = new JSONObject();
+        propJson.put("name", prop.getName());
+        propJson.put("type", prop.getType().name());
+        if (prop.isMandatory())
+          propJson.put("mandatory", true);
+        if (prop.isReadonly())
+          propJson.put("readonly", true);
+        if (prop.isNotNull())
+          propJson.put("notNull", true);
+        if (prop.getDefaultValue() != null)
+          propJson.put("default", prop.getDefaultValue());
+        if (prop.getMin() != null)
+          propJson.put("min", prop.getMin());
+        if (prop.getMax() != null)
+          propJson.put("max", prop.getMax());
+        if (prop.getOfType() != null)
+          propJson.put("ofType", prop.getOfType());
+        properties.put(propJson);
+      }
+      if (properties.length() > 0)
+        typeJson.put("properties", properties);
+
+      // Indexes
+      final JSONArray indexes = new JSONArray();
+      for (final TypeIndex index : type.getAllIndexes(false)) {
+        final JSONObject indexJson = new JSONObject();
+        indexJson.put("name", index.getName());
+        indexJson.put("type", index.getType().name());
+        indexJson.put("properties", new JSONArray(index.getPropertyNames()));
+        indexJson.put("unique", index.isUnique());
+        indexes.put(indexJson);
+      }
+      if (indexes.length() > 0)
+        typeJson.put("indexes", indexes);
+
+      types.put(typeJson);
+    }
+
+    final JSONObject result = new JSONObject();
+    result.put("database", databaseName);
+    result.put("types", types);
+    return result;
+  }
+```
+
+The imports at the top of the file are unchanged: every type used by `buildSchema` was already imported.
+
+- [ ] **Step 3: Run the test to verify no behavior changed**
+
+Run: `mvn -pl server test -Dtest=MCPServerPluginTest#getSchema`
+Expected: PASS, unchanged. The test was not edited, so a pass means the extraction is behavior-preserving.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java
+git commit -m "refactor(mcp): extract reusable buildSchema from GetSchemaTool"
+```
+
+---
+
+### Task 2: `MCPResources` and `MCPResourceNotFoundException`
+
+All Resources logic, transport-free and independently testable. Neither transport learns anything about URIs.
+
+**Files:**
+- Create: `server/src/main/java/com/arcadedb/server/mcp/MCPResourceNotFoundException.java`
+- Create: `server/src/main/java/com/arcadedb/server/mcp/MCPResources.java`
+- Test: `server/src/test/java/com/arcadedb/server/mcp/MCPResourcesTest.java` (create)
+
+**Interfaces:**
+- Consumes: `GetSchemaTool.buildSchema(Database, String)` from Task 1.
+- Produces, all consumed by Task 3:
+  - `MCPResources.list(ArcadeDBServer, ServerSecurityUser, MCPConfiguration)` returns `{"resources": [...]}`; never throws for permission reasons, returns an empty array when reads are disabled.
+  - `MCPResources.read(ArcadeDBServer, ServerSecurityUser, MCPConfiguration, String uri)` returns `{"contents": [{uri, mimeType, text}]}`; throws `SecurityException` when reads are disabled and `MCPResourceNotFoundException` for an unknown database, an unauthorized database, or a malformed URI.
+  - `MCPResources.schemaURI(String databaseName)` returns `arcadedb://<db>/schema`.
+  - `MCPResources.parseSchemaURI(String uri)` returns the database name, or `null` when the URI does not match.
+  - `MCPResourceNotFoundException extends RuntimeException`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/src/test/java/com/arcadedb/server/mcp/MCPResourcesTest.java`.
+
+`BaseGraphServerTest` provisions a database named `graph` and the constant `DEFAULT_PASSWORD_FOR_TESTS`. `MCPConfiguration` here is the live server instance, shared across the class, so `@BeforeEach` resets `allowReads` to `true` and the two denial tests flip it locally.
+
+```java
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.mcp.tools.GetSchemaTool;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MCPResourcesTest extends BaseGraphServerTest {
+
+  private MCPConfiguration   config;
+  private ServerSecurityUser user;
+
+  @BeforeEach
+  void setupMCP() {
+    config = getServer(0).getMCPConfiguration();
+    config.setEnabled(true);
+    config.setAllowReads(true);
+    user = getServer(0).getSecurity().authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
+  }
+
+  @Test
+  void listExposesOneSchemaResourcePerDatabase() {
+    final JSONArray resources = MCPResources.list(getServer(0), user, config).getJSONArray("resources");
+
+    JSONObject graphResource = null;
+    for (int i = 0; i < resources.length(); i++)
+      if ("arcadedb://graph/schema".equals(resources.getJSONObject(i).getString("uri")))
+        graphResource = resources.getJSONObject(i);
+
+    assertThat(graphResource).isNotNull();
+    assertThat(graphResource.getString("name")).isEqualTo("graph schema");
+    assertThat(graphResource.getString("mimeType")).isEqualTo("application/json");
+    assertThat(graphResource.getString("description")).contains("graph");
+  }
+
+  @Test
+  void listIsEmptyWhenReadsDisabled() {
+    config.setAllowReads(false);
+
+    final JSONArray resources = MCPResources.list(getServer(0), user, config).getJSONArray("resources");
+
+    assertThat(resources.length()).isZero();
+  }
+
+  @Test
+  void readReturnsSchemaIdenticalToGetSchemaTool() {
+    final JSONObject resource = MCPResources.read(getServer(0), user, config, "arcadedb://graph/schema");
+
+    final JSONArray contents = resource.getJSONArray("contents");
+    assertThat(contents.length()).isEqualTo(1);
+    assertThat(contents.getJSONObject(0).getString("uri")).isEqualTo("arcadedb://graph/schema");
+    assertThat(contents.getJSONObject(0).getString("mimeType")).isEqualTo("application/json");
+
+    final JSONObject toolResult = GetSchemaTool.execute(getServer(0), user, new JSONObject().put("database", "graph"), config);
+
+    assertThat(contents.getJSONObject(0).getString("text")).isEqualTo(toolResult.toString());
+  }
+
+  @Test
+  void readRejectsUnknownDatabase() {
+    assertThatThrownBy(() -> MCPResources.read(getServer(0), user, config, "arcadedb://nosuchdb/schema"))
+        .isInstanceOf(MCPResourceNotFoundException.class)
+        .hasMessageContaining("Resource not found");
+  }
+
+  @Test
+  void readRejectsMalformedURI() {
+    // Wrong scheme, wrong suffix, empty database, embedded slash, and a URI too short to hold a database name.
+    for (final String uri : new String[] { "http://graph/schema", "arcadedb://graph/tables", "arcadedb:///schema",
+        "arcadedb://a/b/schema", "arcadedb://schema", "graph", "" })
+      assertThatThrownBy(() -> MCPResources.read(getServer(0), user, config, uri))
+          .isInstanceOf(MCPResourceNotFoundException.class);
+  }
+
+  @Test
+  void readDeniedWhenReadsDisabled() {
+    config.setAllowReads(false);
+
+    assertThatThrownBy(() -> MCPResources.read(getServer(0), user, config, "arcadedb://graph/schema"))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not allowed");
+  }
+
+  @Test
+  void parseSchemaURIPreservesCaseAndUnderscores() {
+    // java.net.URI would lowercase the authority and reject the underscore, silently resolving this to nothing.
+    assertThat(MCPResources.parseSchemaURI("arcadedb://My_DB/schema")).isEqualTo("My_DB");
+    assertThat(MCPResources.parseSchemaURI("arcadedb://graph/schema")).isEqualTo("graph");
+    assertThat(MCPResources.parseSchemaURI("arcadedb://schema")).isNull();
+    assertThat(MCPResources.parseSchemaURI(null)).isNull();
+  }
+
+  @Test
+  void schemaURIRoundTripsThroughParse() {
+    assertThat(MCPResources.parseSchemaURI(MCPResources.schemaURI("My_DB"))).isEqualTo("My_DB");
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -pl server test -Dtest=MCPResourcesTest`
+Expected: FAIL at compilation, with "cannot find symbol: class MCPResources" and "cannot find symbol: class MCPResourceNotFoundException".
+
+- [ ] **Step 3: Write `MCPResourceNotFoundException`**
+
+Create `server/src/main/java/com/arcadedb/server/mcp/MCPResourceNotFoundException.java`. Copy the Apache 2.0 header verbatim from `MCPConfiguration.java`.
+
+```java
+package com.arcadedb.server.mcp;
+
+/**
+ * Raised when an MCP resource URI does not resolve. Unknown databases, databases the user cannot access, and
+ * malformed URIs all raise this same exception, so that resources/read cannot be used to probe which databases exist.
+ */
+public class MCPResourceNotFoundException extends RuntimeException {
+
+  public MCPResourceNotFoundException(final String message) {
+    super(message);
+  }
+}
+```
+
+- [ ] **Step 4: Write `MCPResources`**
+
+Create `server/src/main/java/com/arcadedb/server/mcp/MCPResources.java`. Copy the Apache 2.0 header verbatim from `MCPConfiguration.java`.
+
+```java
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.mcp.tools.GetSchemaTool;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import java.util.TreeSet;
+
+/**
+ * MCP Resources surface. Exposes each database's schema at arcadedb://{database}/schema.
+ */
+public class MCPResources {
+  public static final String URI_SCHEME    = "arcadedb://";
+  public static final String SCHEMA_SUFFIX = "/schema";
+  public static final String MIME_TYPE     = "application/json";
+
+  private MCPResources() {
+  }
+
+  /**
+   * Enumerates the schema resources the user may read. A discovery call issued unprompted by most clients at session
+   * start, so a denial is expressed as an empty list rather than an error, and databases the user cannot access are
+   * omitted rather than reported.
+   */
+  public static JSONObject list(final ArcadeDBServer server, final ServerSecurityUser user, final MCPConfiguration config) {
+    final JSONArray resources = new JSONArray();
+
+    if (config.isAllowReads())
+      for (final String databaseName : new TreeSet<>(server.getDatabaseNames())) {
+        if (!user.canAccessToDatabase(databaseName))
+          continue;
+
+        resources.put(new JSONObject()
+            .put("uri", schemaURI(databaseName))
+            .put("name", databaseName + " schema")
+            .put("description", "Schema of the ArcadeDB database '" + databaseName
+                + "': types (vertex, edge, document), properties, indexes, inheritance.")
+            .put("mimeType", MIME_TYPE));
+      }
+
+    return new JSONObject().put("resources", resources);
+  }
+
+  /**
+   * Reads a schema resource. An unknown database, an unauthorized database, and a malformed URI are indistinguishable
+   * to the caller, so that this method cannot be used to probe which databases exist.
+   */
+  public static JSONObject read(final ArcadeDBServer server, final ServerSecurityUser user, final MCPConfiguration config,
+      final String uri) {
+    if (!config.isAllowReads())
+      throw new SecurityException("Read operations are not allowed by MCP configuration");
+
+    final String databaseName = parseSchemaURI(uri);
+    if (databaseName == null || !server.existsDatabase(databaseName) || !user.canAccessToDatabase(databaseName))
+      throw new MCPResourceNotFoundException("Resource not found: " + uri);
+
+    final Database database = server.getDatabase(databaseName);
+    final JSONObject schema = GetSchemaTool.buildSchema(database, databaseName);
+
+    final JSONArray contents = new JSONArray();
+    contents.put(new JSONObject()
+        .put("uri", uri)
+        .put("mimeType", MIME_TYPE)
+        .put("text", schema.toString()));
+
+    return new JSONObject().put("contents", contents);
+  }
+
+  public static String schemaURI(final String databaseName) {
+    return URI_SCHEME + databaseName + SCHEMA_SUFFIX;
+  }
+
+  /**
+   * Returns the database name in arcadedb://{database}/schema, or null when the URI does not match that shape.
+   * Parsed with string operations rather than java.net.URI on purpose: URI applies hostname rules to the authority,
+   * lowercasing it and rejecting the underscores that an ArcadeDB database name may legally contain, so
+   * arcadedb://My_DB/schema would otherwise resolve to nothing. A database name cannot contain '/', because it is a
+   * directory name on disk, so this parse round-trips exactly against what list() emits.
+   */
+  public static String parseSchemaURI(final String uri) {
+    if (uri == null || !uri.startsWith(URI_SCHEME) || !uri.endsWith(SCHEMA_SUFFIX))
+      return null;
+    if (uri.length() <= URI_SCHEME.length() + SCHEMA_SUFFIX.length())
+      return null;
+
+    final String databaseName = uri.substring(URI_SCHEME.length(), uri.length() - SCHEMA_SUFFIX.length());
+    if (databaseName.indexOf('/') >= 0)
+      return null;
+
+    return databaseName;
+  }
+}
+```
+
+The length guard on line 3 of `parseSchemaURI` is load-bearing, not defensive padding: `arcadedb://schema` both starts with the scheme and ends with the suffix, and without the guard the `substring` call would throw `StringIndexOutOfBoundsException` instead of returning `null`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `mvn -pl server test -Dtest=MCPResourcesTest`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/mcp/MCPResources.java \
+        server/src/main/java/com/arcadedb/server/mcp/MCPResourceNotFoundException.java \
+        server/src/test/java/com/arcadedb/server/mcp/MCPResourcesTest.java
+git commit -m "feat(mcp): add MCPResources with arcadedb://{database}/schema resource"
+```
+
+---
+
+### Task 3: `MCPDispatcher`, and rewire `MCPHttpHandler` onto it
+
+The dispatcher becomes the single source of truth for the JSON-RPC method surface. This task moves the HTTP handler's logic into it wholesale, then reduces `MCPHttpHandler` to a transport adapter. Stdio is not touched yet; it still carries its own copy and must keep working.
+
+The existing `MCPServerPluginTest` is the regression net. It must pass **unedited** at the end of this task.
+
+**Files:**
+- Create: `server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java`
+- Modify: `server/src/main/java/com/arcadedb/server/mcp/MCPHttpHandler.java` (full rewrite)
+- Test: `server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java` (unedited in this task)
+
+**Interfaces:**
+- Consumes: `MCPResources.list/read`, `MCPResourceNotFoundException` from Task 2.
+- Produces, consumed by Task 4:
+  - `new MCPDispatcher(ArcadeDBServer server, MCPConfiguration config, String transport)`
+  - `MCPResponse MCPDispatcher.dispatch(JSONObject request, ServerSecurityUser user)`, where `request` is nullable, meaning an empty body.
+  - `record MCPDispatcher.MCPResponse(int httpStatus, JSONObject json)`, where a `null` `json` means "notification, send no reply".
+
+- [ ] **Step 1: Write `MCPDispatcher`**
+
+Create `server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java`. Copy the Apache 2.0 header verbatim from `MCPHttpHandler.java`.
+
+The `TOOLS_LIST` static block, the `tools/call` switch, `formatArgs`, `sanitizeForLog`, `formatResult`, and `toolError` are all moved verbatim from `MCPHttpHandler`. The gating checks, `initialize`, and the resources arms are the new parts.
+
+```java
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.Constants;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.mcp.tools.ExecuteCommandTool;
+import com.arcadedb.server.mcp.tools.FullTextSearchTool;
+import com.arcadedb.server.mcp.tools.GetSchemaTool;
+import com.arcadedb.server.mcp.tools.GetServerSettingsTool;
+import com.arcadedb.server.mcp.tools.ListDatabasesTool;
+import com.arcadedb.server.mcp.tools.ProfilerStartTool;
+import com.arcadedb.server.mcp.tools.ProfilerStatusTool;
+import com.arcadedb.server.mcp.tools.ProfilerStopTool;
+import com.arcadedb.server.mcp.tools.QueryTool;
+import com.arcadedb.server.mcp.tools.ServerStatusTool;
+import com.arcadedb.server.mcp.tools.SetServerSettingTool;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import java.util.logging.Level;
+
+/**
+ * Transport-neutral MCP JSON-RPC dispatcher. Owns the protocol surface (version, tool list, instructions, gating,
+ * method routing, envelope shaping); the HTTP and stdio transports own only their I/O and their own parse errors.
+ */
+public class MCPDispatcher {
+  public static final  String    MCP_PROTOCOL_VERSION = "2025-03-26";
+  private static final JSONArray TOOLS_LIST;
+
+  private static final String INSTRUCTIONS =
+      """
+      You are connected to an ArcadeDB multi-model database server. Follow these rules:
+      1. ALWAYS call list_databases first when you do not know the target database name. Never guess it.
+      2. Prefer Cypher (language: 'cypher') for graph queries unless SQL is explicitly requested.
+      3. Use the 'query' tool for read-only operations (SELECT, MATCH, RETURN) and 'execute_command' for writes (CREATE, INSERT, UPDATE, DELETE, MERGE).
+      4. Call get_schema before writing queries against an unfamiliar database to understand its types and properties. If your client supports MCP Resources, prefer reading arcadedb://{database}/schema instead: it carries the same content without spending a tool call.
+      5. If a query returns no results, verify the type/property names with get_schema before concluding the data does not exist.""";
+
+  static {
+    TOOLS_LIST = new JSONArray();
+    TOOLS_LIST.put(ListDatabasesTool.getDefinition());
+    TOOLS_LIST.put(GetSchemaTool.getDefinition());
+    TOOLS_LIST.put(QueryTool.getDefinition());
+    TOOLS_LIST.put(ExecuteCommandTool.getDefinition());
+    TOOLS_LIST.put(FullTextSearchTool.getDefinition());
+    TOOLS_LIST.put(ServerStatusTool.getDefinition());
+    TOOLS_LIST.put(ProfilerStartTool.getDefinition());
+    TOOLS_LIST.put(ProfilerStopTool.getDefinition());
+    TOOLS_LIST.put(ProfilerStatusTool.getDefinition());
+    TOOLS_LIST.put(GetServerSettingsTool.getDefinition());
+    TOOLS_LIST.put(SetServerSettingTool.getDefinition());
+  }
+
+  /**
+   * A transport-neutral reply. A null json means a JSON-RPC notification, for which no reply is sent at all;
+   * the httpStatus is meaningful only to the HTTP transport and is ignored by stdio.
+   */
+  public record MCPResponse(int httpStatus, JSONObject json) {
+  }
+
+  private final ArcadeDBServer   server;
+  private final MCPConfiguration config;
+  private final String           transport;
+
+  public MCPDispatcher(final ArcadeDBServer server, final MCPConfiguration config, final String transport) {
+    this.server = server;
+    this.config = config;
+    this.transport = transport;
+  }
+
+  /**
+   * Routes one parsed JSON-RPC request. A null request means an empty body. Authentication is checked before
+   * anything else, so that server state is not disclosed to unauthenticated callers.
+   */
+  public MCPResponse dispatch(final JSONObject request, final ServerSecurityUser user) {
+    if (user == null)
+      return error(null, -32600, "Authentication required", 401);
+
+    if (!config.isEnabled())
+      return error(null, -32600, "MCP server is disabled", 503);
+
+    if (request == null)
+      return error(null, -32700, "Parse error: empty request body", 200);
+
+    final Object id = request.opt("id");
+
+    if (!config.isUserAllowed(user.getName()))
+      return error(id, -32600, "User not authorized for MCP access", 403);
+
+    final String method = request.getString("method", "");
+    final JSONObject params = request.getJSONObject("params", new JSONObject());
+
+    LogManager.instance().log(this, Level.INFO, "MCP[%s] %s (user=%s)", transport, method, user.getName());
+
+    return switch (method) {
+      case "initialize" -> result(id, initialize());
+      case "notifications/initialized" -> new MCPResponse(204, null);
+      case "tools/list" -> result(id, new JSONObject().put("tools", TOOLS_LIST));
+      case "tools/call" -> toolsCall(id, params, user);
+      case "resources/list" -> resourcesList(id, user);
+      case "resources/read" -> resourcesRead(id, params, user);
+      case "ping" -> result(id, new JSONObject());
+      default -> error(id, -32601, "Method not found: " + method, 200);
+    };
+  }
+
+  private JSONObject initialize() {
+    final JSONObject result = new JSONObject();
+    result.put("protocolVersion", MCP_PROTOCOL_VERSION);
+
+    final JSONObject serverInfo = new JSONObject();
+    serverInfo.put("name", "arcadedb");
+    serverInfo.put("version", Constants.getVersion());
+    result.put("serverInfo", serverInfo);
+
+    final JSONObject capabilities = new JSONObject();
+    capabilities.put("tools", new JSONObject().put("listChanged", false));
+    capabilities.put("resources", new JSONObject().put("listChanged", false).put("subscribe", false));
+    result.put("capabilities", capabilities);
+
+    result.put("instructions", INSTRUCTIONS);
+
+    return result;
+  }
+
+  private MCPResponse resourcesList(final Object id, final ServerSecurityUser user) {
+    try {
+      return result(id, MCPResources.list(server, user, config));
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "MCP[%s] resources/list -> error: %s", transport, e.getMessage());
+      return error(id, -32603, "Internal error: " + e.getMessage(), 200);
+    }
+  }
+
+  private MCPResponse resourcesRead(final Object id, final JSONObject params, final ServerSecurityUser user) {
+    final String uri = params.getString("uri", "");
+
+    LogManager.instance().log(this, Level.INFO, "MCP[%s] resources/read '%s' (user=%s)", transport, uri, user.getName());
+
+    try {
+      return result(id, MCPResources.read(server, user, config, uri));
+    } catch (final SecurityException e) {
+      LogManager.instance().log(this, Level.INFO, "MCP[%s] resources/read -> permission denied: %s", transport, e.getMessage());
+      return error(id, -32600, e.getMessage(), 200);
+    } catch (final MCPResourceNotFoundException e) {
+      return error(id, -32002, e.getMessage(), 200);
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "MCP[%s] resources/read -> error: %s", transport, e.getMessage());
+      return error(id, -32603, "Internal error: " + e.getMessage(), 200);
+    }
+  }
+
+  private MCPResponse toolsCall(final Object id, final JSONObject params, final ServerSecurityUser user) {
+    final String toolName = params.getString("name", "");
+    final JSONObject args = params.getJSONObject("arguments", new JSONObject());
+
+    LogManager.instance()
+        .log(this, Level.INFO, "MCP[%s] tools/call '%s' %s (user=%s)", transport, toolName, formatArgs(args), user.getName());
+
+    try {
+      final JSONObject toolResult = switch (toolName) {
+        case "list_databases" -> ListDatabasesTool.execute(server, user, args, config);
+        case "get_schema" -> GetSchemaTool.execute(server, user, args, config);
+        case "query" -> QueryTool.execute(server, user, args, config);
+        case "execute_command" -> ExecuteCommandTool.execute(server, user, args, config);
+        case "full_text_search" -> FullTextSearchTool.execute(server, user, args, config);
+        case "server_status" -> ServerStatusTool.execute(server, user, args, config);
+        case "profiler_start" -> ProfilerStartTool.execute(server, user, args, config);
+        case "profiler_stop" -> ProfilerStopTool.execute(server, user, args, config);
+        case "profiler_status" -> ProfilerStatusTool.execute(server, user, args, config);
+        case "get_server_settings" -> GetServerSettingsTool.execute(server, user, args, config);
+        case "set_server_setting" -> SetServerSettingTool.execute(server, user, args, config);
+        default -> throw new IllegalArgumentException("Unknown tool: " + toolName);
+      };
+
+      LogManager.instance()
+          .log(this, Level.INFO, "MCP[%s] tools/call '%s' -> %s", transport, toolName, formatResult(toolName, toolResult));
+
+      final JSONObject result = new JSONObject();
+      final JSONArray content = new JSONArray();
+      content.put(new JSONObject()
+          .put("type", "text")
+          .put("text", toolResult.toString()));
+      result.put("content", content);
+      result.put("isError", false);
+      return result(id, result);
+
+    } catch (final SecurityException e) {
+      LogManager.instance()
+          .log(this, Level.INFO, "MCP[%s] tools/call '%s' -> permission denied: %s", transport, toolName, e.getMessage());
+      return toolError(id, e.getMessage());
+    } catch (final Exception e) {
+      LogManager.instance()
+          .log(this, Level.WARNING, "MCP[%s] tools/call '%s' -> error: %s", transport, toolName, e.getMessage());
+      return toolError(id, e.getMessage());
+    }
+  }
+
+  private static String formatArgs(final JSONObject args) {
+    if (args.length() == 0)
+      return "{}";
+    final StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (final String key : args.keySet()) {
+      if (!first)
+        sb.append(", ");
+      first = false;
+      final Object value = args.get(key);
+      if (value instanceof String s) {
+        final String sanitized = sanitizeForLog(s);
+        if (sanitized.length() > 100)
+          sb.append(key).append("=\"").append(sanitized, 0, 100).append("...\"");
+        else
+          sb.append(key).append("=\"").append(sanitized).append("\"");
+      } else
+        sb.append(key).append("=").append(value);
+    }
+    return sb.append("}").toString();
+  }
+
+  private static String sanitizeForLog(final String value) {
+    return value.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t");
+  }
+
+  private static String formatResult(final String toolName, final JSONObject result) {
+    return switch (toolName) {
+      case "list_databases" -> result.getJSONArray("databases", new JSONArray()).length() + " database(s)";
+      case "get_schema" -> result.getJSONArray("types", new JSONArray()).length() + " type(s)";
+      case "query", "execute_command" -> result.getInt("count", 0) + " record(s)";
+      case "full_text_search" -> result.getInt("count", 0) + " hit(s)";
+      case "server_status" -> "ok";
+      case "profiler_start" -> result.getString("status", "ok");
+      case "profiler_stop" -> result.getInt("totalQueries", 0) + " queries captured";
+      case "profiler_status" -> result.getBoolean("recording", false) ? "recording" : "idle";
+      case "get_server_settings" -> result.getJSONArray("settings", new JSONArray()).length() + " setting(s)";
+      case "set_server_setting" -> result.getString("key", "") + " updated";
+      default -> "ok";
+    };
+  }
+
+  private static MCPResponse toolError(final Object id, final String message) {
+    final JSONObject result = new JSONObject();
+    final JSONArray content = new JSONArray();
+    content.put(new JSONObject()
+        .put("type", "text")
+        .put("text", message));
+    result.put("content", content);
+    result.put("isError", true);
+    return result(id, result);
+  }
+
+  private static MCPResponse result(final Object id, final JSONObject result) {
+    final JSONObject response = new JSONObject();
+    response.put("jsonrpc", "2.0");
+    response.put("id", id);
+    response.put("result", result);
+    return new MCPResponse(200, response);
+  }
+
+  private static MCPResponse error(final Object id, final int code, final String message, final int httpStatus) {
+    final JSONObject response = new JSONObject();
+    response.put("jsonrpc", "2.0");
+    response.put("id", id);
+    response.put("error", new JSONObject().put("code", code).put("message", message));
+    return new MCPResponse(httpStatus, response);
+  }
+}
+```
+
+- [ ] **Step 2: Rewrite `MCPHttpHandler` as a transport adapter**
+
+Replace the entire body of `server/src/main/java/com/arcadedb/server/mcp/MCPHttpHandler.java` below the license header with this. Everything else in the old file is now dead and is deleted with it.
+
+```java
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.handler.AbstractServerHttpHandler;
+import com.arcadedb.server.http.handler.ExecutionResponse;
+import com.arcadedb.server.mcp.MCPDispatcher.MCPResponse;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * HTTP transport for MCP. Owns the HTTP envelope only; all protocol routing lives in {@link MCPDispatcher}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class MCPHttpHandler extends AbstractServerHttpHandler {
+  private final MCPDispatcher dispatcher;
+
+  public MCPHttpHandler(final HttpServer httpServer, final ArcadeDBServer server, final MCPConfiguration config) {
+    super(httpServer);
+    this.dispatcher = new MCPDispatcher(server, config, "http");
+  }
+
+  @Override
+  protected boolean mustExecuteOnWorkerThread() {
+    return true;
+  }
+
+  @Override
+  public boolean isRequireAuthentication() {
+    return true;
+  }
+
+  @Override
+  protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
+    final MCPResponse response = dispatcher.dispatch(payload, user);
+
+    // A null body is a JSON-RPC notification, which takes no response at all.
+    if (response.json() == null)
+      return new ExecutionResponse(204, "");
+
+    return new ExecutionResponse(response.httpStatus(), response.json().toString());
+  }
+}
+```
+
+- [ ] **Step 3: Run the full HTTP suite to verify nothing regressed**
+
+Run: `mvn -pl server test -Dtest=MCPServerPluginTest`
+Expected: PASS, all tests, **with no edit to the test file**. This is the whole point of the task: `initialize`, `toolsList` (still 11), `disabledMCP` (503), `unauthorizedUserDenied` (403), `notificationReturns204`, `methodNotFound` (-32601), and every `tools/call` test must behave exactly as before.
+
+If any of these fail, the extraction changed behavior. Do not adjust the test. Diff the dispatcher against the original `MCPHttpHandler` and find what moved.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java \
+        server/src/main/java/com/arcadedb/server/mcp/MCPHttpHandler.java
+git commit -m "refactor(mcp): extract MCPDispatcher and add resources/list and resources/read"
+```
+
+---
+
+### Task 4: Rewire `MCPStdioServer` onto the dispatcher
+
+Stdio loses its duplicate `TOOLS_LIST`, `initialize`, `tools/call` switch, and envelope helpers. It keeps `main()`, the read loop, and its own `-32700` parse error, because parsing a line off stdin is its own concern.
+
+This is where the intentional stdio behavior change lands: stdio now honors `isEnabled()` and `isUserAllowed()`, and its `initialize` now returns `instructions`.
+
+**Files:**
+- Modify: `server/src/main/java/com/arcadedb/server/mcp/MCPStdioServer.java:52-248`
+- Test: `server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java`
+
+**Interfaces:**
+- Consumes: `MCPDispatcher`, `MCPDispatcher.MCPResponse` from Task 3.
+- Produces: nothing new. The public constructor signature `MCPStdioServer(ArcadeDBServer, MCPConfiguration, ServerSecurityUser, InputStream, PrintStream)` is unchanged, because `MCPStdioServerTest` constructs it directly.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these three tests to `server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java`, above the `// ---- Helpers ----` comment. They use the existing `sendSingleRequest` helper.
+
+```java
+  @Test
+  void initializeAdvertisesResourcesAndInstructions() throws Exception {
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 400)
+        .put("method", "initialize")
+        .put("params", new JSONObject());
+
+    final JSONObject response = sendSingleRequest(request);
+
+    final JSONObject result = response.getJSONObject("result");
+    final JSONObject resources = result.getJSONObject("capabilities").getJSONObject("resources");
+    assertThat(resources.getBoolean("listChanged")).isFalse();
+    assertThat(resources.getBoolean("subscribe")).isFalse();
+    assertThat(result.getString("instructions")).contains("arcadedb://{database}/schema");
+  }
+
+  @Test
+  void resourcesList() throws Exception {
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 401)
+        .put("method", "resources/list")
+        .put("params", new JSONObject());
+
+    final JSONObject response = sendSingleRequest(request);
+
+    final JSONArray resources = response.getJSONObject("result").getJSONArray("resources");
+    boolean foundGraph = false;
+    for (int i = 0; i < resources.length(); i++)
+      if ("arcadedb://graph/schema".equals(resources.getJSONObject(i).getString("uri")))
+        foundGraph = true;
+    assertThat(foundGraph).isTrue();
+  }
+
+  @Test
+  void resourcesRead() throws Exception {
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 402)
+        .put("method", "resources/read")
+        .put("params", new JSONObject().put("uri", "arcadedb://graph/schema"));
+
+    final JSONObject response = sendSingleRequest(request);
+
+    final JSONArray contents = response.getJSONObject("result").getJSONArray("contents");
+    assertThat(contents.length()).isEqualTo(1);
+    assertThat(contents.getJSONObject(0).getString("mimeType")).isEqualTo("application/json");
+
+    final JSONObject schema = new JSONObject(contents.getJSONObject(0).getString("text"));
+    assertThat(schema.getString("database")).isEqualTo("graph");
+    assertThat(schema.getJSONArray("types").length()).isGreaterThan(0);
+  }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvn -pl server test -Dtest=MCPStdioServerTest`
+Expected: the three new tests FAIL. `initializeAdvertisesResourcesAndInstructions` fails with a JSON key-not-found on `resources`; the other two fail because `resources/list` and `resources/read` currently hit the `default ->` arm and return a `-32601` error, so `getJSONObject("result")` finds no `result` key.
+
+- [ ] **Step 3: Rewrite `MCPStdioServer` onto the dispatcher**
+
+Replace everything in `MCPStdioServer.java` below the license header with this. `main()` and `run()` are unchanged from the original; `dispatch` now delegates, and `TOOLS_LIST`, `handleInitialize`, `handleToolsList`, `handleToolsCall`, `toolError`, and `jsonRpcResult` are deleted.
+
+```java
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.mcp.MCPDispatcher.MCPResponse;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+
+/**
+ * MCP server using stdio transport (JSON-RPC 2.0 over stdin/stdout, newline-delimited).
+ * This allows ArcadeDB to work natively with mcp-proxy, Claude Desktop, Cursor, etc.
+ * Owns the stdio envelope only; all protocol routing lives in {@link MCPDispatcher}.
+ */
+public class MCPStdioServer {
+  private final MCPDispatcher    dispatcher;
+  private final ServerSecurityUser user;
+  private final InputStream      input;
+  private final PrintStream      output;
+
+  public MCPStdioServer(final ArcadeDBServer server, final MCPConfiguration config, final ServerSecurityUser user,
+      final InputStream input, final PrintStream output) {
+    this.dispatcher = new MCPDispatcher(server, config, "stdio");
+    this.user = user;
+    this.input = input;
+    this.output = output;
+  }
+
+  public static void main(final String[] args) {
+    // Save the real stdout for MCP JSON-RPC before any server code can write to it
+    final PrintStream mcpOut = System.out;
+    System.setOut(System.err);
+
+    final String rootPassword = GlobalConfiguration.SERVER_ROOT_PASSWORD.getValueAsString();
+    if (rootPassword == null || rootPassword.isEmpty()) {
+      System.err.println("ERROR: arcadedb.server.rootPassword must be set for MCP stdio mode");
+      System.exit(1);
+    }
+
+    final ArcadeDBServer server = new ArcadeDBServer(new ContextConfiguration());
+    try {
+      server.start();
+
+      final MCPConfiguration config = server.getMCPConfiguration();
+      config.setEnabled(true);
+
+      final ServerSecurityUser user = server.getSecurity().authenticate("root", rootPassword, null);
+
+      final MCPStdioServer stdioServer = new MCPStdioServer(server, config, user, System.in, mcpOut);
+      stdioServer.run();
+    } catch (final Exception e) {
+      System.err.println("ERROR: " + e.getMessage());
+      e.printStackTrace(System.err);
+    } finally {
+      server.stop();
+    }
+  }
+
+  public void run() {
+    final BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+    try {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.isBlank())
+          continue;
+
+        try {
+          final JSONObject request = new JSONObject(line);
+          final String response = dispatch(request);
+          if (response != null) {
+            output.println(response);
+            output.flush();
+          }
+        } catch (final Exception e) {
+          // JSON parse error
+          final String errorResponse = jsonRpcError(null, -32700, "Parse error: " + e.getMessage());
+          output.println(errorResponse);
+          output.flush();
+        }
+      }
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "MCP stdio error: %s", e.getMessage());
+    }
+  }
+
+  private String dispatch(final JSONObject request) {
+    final MCPResponse response = dispatcher.dispatch(request, user);
+
+    // A null body is a JSON-RPC notification, which is written back as nothing at all.
+    return response.json() == null ? null : response.json().toString();
+  }
+
+  private static String jsonRpcError(final Object id, final int code, final String message) {
+    final JSONObject response = new JSONObject();
+    response.put("jsonrpc", "2.0");
+    response.put("id", id);
+    response.put("error", new JSONObject().put("code", code).put("message", message));
+    return response.toString();
+  }
+}
+```
+
+Note the deleted `Constants` and `JSONArray` imports, and the deleted per-tool imports: none of them are used any more.
+
+- [ ] **Step 4: Run the stdio suite to verify it passes**
+
+Run: `mvn -pl server test -Dtest=MCPStdioServerTest`
+Expected: PASS, including the three new tests and every pre-existing test unedited. `toolsList` still asserts 11 tools. `multipleRequestsInSequence` still emits exactly 3 lines.
+
+The pre-existing tests keep passing through the new gating because `MCPStdioServerTest.setupMCP` calls `config.setEnabled(true)` and authenticates as `root`, and `root` is the default sole entry in `allowedUsers`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/mcp/MCPStdioServer.java \
+        server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
+git commit -m "refactor(mcp): route stdio transport through MCPDispatcher"
+```
+
+---
+
+### Task 5: HTTP resources tests
+
+The dispatcher already serves resources over HTTP (Task 3). This task proves it, and lands the two acceptance criteria the issue calls out by name: the `resources` capability, and schema content identical between tool and resource.
+
+`mcpRequest` reads `connection.getInputStream()`, which throws on a non-2xx status. That is fine here: every JSON-RPC error in this task is returned at HTTP 200 with an `error` member in the body. Only the transport-level denials (401/503/403) use non-200 statuses, and those are already covered by existing tests.
+
+**Files:**
+- Modify: `server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java`
+
+**Interfaces:**
+- Consumes: the HTTP `resources/list` and `resources/read` methods from Task 3.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these to `MCPServerPluginTest`, before the `// ---- Helpers ----` section. They reuse the existing `mcpRequest`, `callTool`, `saveMCPConfig`, and `getBasicAuth` helpers, and the `restricteduser` pattern from the existing `databaseAuthorizationDenied` test.
+
+```java
+  @Test
+  void initializeAdvertisesResourcesCapability() throws Exception {
+    final JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 400)
+        .put("method", "initialize")
+        .put("params", new JSONObject()));
+
+    final JSONObject capabilities = response.getJSONObject("result").getJSONObject("capabilities");
+    assertThat(capabilities.has("resources")).isTrue();
+    final JSONObject resources = capabilities.getJSONObject("resources");
+    assertThat(resources.getBoolean("listChanged")).isFalse();
+    assertThat(resources.getBoolean("subscribe")).isFalse();
+  }
+
+  @Test
+  void resourcesList() throws Exception {
+    final JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 401)
+        .put("method", "resources/list")
+        .put("params", new JSONObject()));
+
+    final JSONArray resources = response.getJSONObject("result").getJSONArray("resources");
+
+    JSONObject graphResource = null;
+    for (int i = 0; i < resources.length(); i++)
+      if ("arcadedb://graph/schema".equals(resources.getJSONObject(i).getString("uri")))
+        graphResource = resources.getJSONObject(i);
+
+    assertThat(graphResource).isNotNull();
+    assertThat(graphResource.getString("name")).isEqualTo("graph schema");
+    assertThat(graphResource.getString("mimeType")).isEqualTo("application/json");
+  }
+
+  @Test
+  void resourcesListMatchesListDatabases() throws Exception {
+    final JSONObject listResponse = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 402)
+        .put("method", "resources/list")
+        .put("params", new JSONObject()));
+
+    final Set<String> fromResources = new HashSet<>();
+    final JSONArray resources = listResponse.getJSONObject("result").getJSONArray("resources");
+    for (int i = 0; i < resources.length(); i++) {
+      final String uri = resources.getJSONObject(i).getString("uri");
+      fromResources.add(uri.substring("arcadedb://".length(), uri.length() - "/schema".length()));
+    }
+
+    final JSONObject toolResponse = callTool("list_databases", new JSONObject());
+    final JSONArray databases = new JSONObject(
+        toolResponse.getJSONArray("content").getJSONObject(0).getString("text")).getJSONArray("databases");
+
+    final Set<String> fromTool = new HashSet<>();
+    for (int i = 0; i < databases.length(); i++)
+      fromTool.add(databases.getString(i));
+
+    assertThat(fromResources).isEqualTo(fromTool);
+  }
+
+  @Test
+  void resourcesReadMatchesGetSchemaTool() throws Exception {
+    final JSONObject readResponse = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 403)
+        .put("method", "resources/read")
+        .put("params", new JSONObject().put("uri", "arcadedb://graph/schema")));
+
+    final JSONArray contents = readResponse.getJSONObject("result").getJSONArray("contents");
+    assertThat(contents.length()).isEqualTo(1);
+    assertThat(contents.getJSONObject(0).getString("uri")).isEqualTo("arcadedb://graph/schema");
+    assertThat(contents.getJSONObject(0).getString("mimeType")).isEqualTo("application/json");
+
+    final JSONObject toolResponse = callTool("get_schema", new JSONObject().put("database", "graph"));
+    final String toolText = toolResponse.getJSONArray("content").getJSONObject(0).getString("text");
+
+    assertThat(contents.getJSONObject(0).getString("text")).isEqualTo(toolText);
+  }
+
+  @Test
+  void resourcesReadUnknownDatabaseReturnsNotFound() throws Exception {
+    final JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 404)
+        .put("method", "resources/read")
+        .put("params", new JSONObject().put("uri", "arcadedb://nosuchdb/schema")));
+
+    assertThat(response.has("error")).isTrue();
+    assertThat(response.getJSONObject("error").getInt("code")).isEqualTo(-32002);
+  }
+
+  @Test
+  void resourcesReadMalformedUriReturnsNotFound() throws Exception {
+    final JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 405)
+        .put("method", "resources/read")
+        .put("params", new JSONObject().put("uri", "arcadedb://graph/tables")));
+
+    assertThat(response.has("error")).isTrue();
+    assertThat(response.getJSONObject("error").getInt("code")).isEqualTo(-32002);
+  }
+
+  @Test
+  void resourcesDeniedWhenReadsDisabled() throws Exception {
+    saveMCPConfig(new JSONObject()
+        .put("enabled", true)
+        .put("allowReads", false)
+        .put("allowedUsers", new JSONArray().put("root")));
+
+    try {
+      final JSONObject listResponse = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 406)
+          .put("method", "resources/list")
+          .put("params", new JSONObject()));
+
+      // A discovery call stays quiet: nothing is readable, so nothing is listed.
+      assertThat(listResponse.getJSONObject("result").getJSONArray("resources").length()).isZero();
+
+      final JSONObject readResponse = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 407)
+          .put("method", "resources/read")
+          .put("params", new JSONObject().put("uri", "arcadedb://graph/schema")));
+
+      assertThat(readResponse.has("error")).isTrue();
+      assertThat(readResponse.getJSONObject("error").getInt("code")).isEqualTo(-32600);
+      assertThat(readResponse.getJSONObject("error").getString("message")).contains("not allowed");
+    } finally {
+      // Restore for the other tests in this class.
+      saveMCPConfig(new JSONObject()
+          .put("enabled", true)
+          .put("allowReads", true)
+          .put("allowedUsers", new JSONArray().put("root")));
+    }
+  }
+
+  @Test
+  void resourcesListOmitsUnauthorizedDatabases() throws Exception {
+    saveMCPConfig(new JSONObject()
+        .put("enabled", true)
+        .put("allowReads", true)
+        .put("allowedUsers", new JSONArray().put("root").put("restricteduser")));
+
+    // A user authorized only for a database that does not exist here, so "graph" must not appear in its resource list.
+    if (!getServer(0).getSecurity().existsUser("restricteduser"))
+      getServer(0).getSecurity().createUser(new JSONObject()
+          .put("name", "restricteduser")
+          .put("password", getServer(0).getSecurity().encodePassword("restrictedpass"))
+          .put("databases", new JSONObject()
+              .put("otherdb", new JSONArray().put("admin"))));
+
+    final String restrictedAuth = "Basic " + Base64.getEncoder()
+        .encodeToString("restricteduser:restrictedpass".getBytes(StandardCharsets.UTF_8));
+
+    final HttpURLConnection connection = (HttpURLConnection) new URI(getMcpUrl()).toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", restrictedAuth);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 408)
+        .put("method", "resources/list")
+        .put("params", new JSONObject());
+    try (final DataOutputStream out = new DataOutputStream(connection.getOutputStream())) {
+      out.write(request.toString().getBytes(StandardCharsets.UTF_8));
+    }
+    connection.connect();
+
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      final String body = FileUtils.readStreamAsString(connection.getInputStream(), "utf8");
+      final JSONArray resources = new JSONObject(body).getJSONObject("result").getJSONArray("resources");
+
+      for (int i = 0; i < resources.length(); i++)
+        assertThat(resources.getJSONObject(i).getString("uri")).isNotEqualTo("arcadedb://graph/schema");
+    } finally {
+      connection.disconnect();
+      saveMCPConfig(new JSONObject()
+          .put("enabled", true)
+          .put("allowReads", true)
+          .put("allowedUsers", new JSONArray().put("root")));
+    }
+  }
+```
+
+Add these two imports to the top of `MCPServerPluginTest.java` (the rest are already there):
+
+```java
+import java.util.HashSet;
+import java.util.Set;
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `mvn -pl server test -Dtest=MCPServerPluginTest`
+Expected: PASS, all tests including the eight new ones.
+
+These are written after the implementation because Task 3 already shipped the HTTP resources arms. If any of them fail, the defect is in `MCPDispatcher` or `MCPResources`, not in the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+git commit -m "test(mcp): cover resources/list and resources/read over HTTP"
+```
+
+---
+
+### Task 6: Full verification sweep
+
+**Files:**
+- No source changes expected. This task is a gate.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces: a verified branch, ready for the maintainer to review and push.
+
+- [ ] **Step 1: Compile the server module cleanly**
+
+Run: `mvn -pl server -am -DskipTests install`
+Expected: BUILD SUCCESS. No warnings about unused imports in the MCP package (Task 4 deleted several).
+
+- [ ] **Step 2: Run every MCP test class**
+
+Run: `mvn -pl server test -Dtest='MCP*Test'`
+Expected: PASS across `MCPConfigurationTest`, `MCPPermissionsTest`, `MCPServerPluginTest`, `MCPStdioServerTest`, `MCPResourcesTest`.
+
+- [ ] **Step 3: Confirm no existing test was edited except the one intentional change**
+
+Run:
+
+```bash
+git diff --stat main -- server/src/test/java/com/arcadedb/server/mcp/
+```
+
+Expected: `MCPServerPluginTest.java` and `MCPStdioServerTest.java` show **additions only** (new test methods and imports), and `MCPResourcesTest.java` is new. `MCPConfigurationTest.java` and `MCPPermissionsTest.java` are untouched.
+
+If any *pre-existing* test method body changed, that is the signal from the Global Constraints: the dispatcher extraction altered behavior. Investigate rather than accept.
+
+- [ ] **Step 4: Confirm no `System.out` or debug output was left behind**
+
+Run:
+
+```bash
+git diff main -- server/src/main/java/com/arcadedb/server/mcp/ | grep -n "System.out" || echo "clean"
+```
+
+Expected: `clean`. (`MCPStdioServer.main` assigns `System.out` to a local `PrintStream` before redirecting it; that is pre-existing and is on an unchanged line, so it will not appear in the diff as an addition.)
+
+- [ ] **Step 5: Run the wider server suite for collateral damage**
+
+Run: `mvn -pl server test`
+Expected: PASS, or the same set of failures that `main` already has. Compare against a baseline run on `main` if anything is red, because the server module has pre-existing flaky tests unrelated to MCP.
+
+- [ ] **Step 6: Final commit if anything was touched**
+
+```bash
+git status --short
+```
+
+If clean, nothing to do. The branch is ready.
+
+**Do not push and do not open a PR.** The maintainer reviews first.
+
+**For the PR body, when the maintainer opens it**, include this note, because it is a behavior change that is not visible in the test diff:
+
+> **Behavior change (stdio transport).** `MCPStdioServer` now honors `MCPConfiguration.isEnabled()` and `isUserAllowed()`, which it previously ignored, and its `initialize` response now includes the `instructions` block that the HTTP transport already returned. The default path is unaffected: `main()` sets `enabled=true` and authenticates as `root`, and `root` is the default sole entry in `allowedUsers`. A stdio deployment that had rewritten `allowedUsers` to omit `root` will now be refused.
+
+---
+
+## Sequencing note for the maintainer
+
+This plan rewrites `MCPHttpHandler.java` and `MCPStdioServer.java`, the two files that #4860 (`vector_search`), #4863 (`sample_records`), and #4864 (`upsert_entity`/`upsert_relationship`) also edit. Per the spec, **#4865 should land before those three.**
+
+The ordering is cheaper in both directions. Each of those issues adds a tool, which today means touching two `TOOLS_LIST` static blocks and two dispatch switches. After this refactor there is exactly one of each, in `MCPDispatcher`, so a sibling PR's diff halves. Landing #4865 last would instead force it to absorb every sibling's duplicated edits before deleting them.

--- a/docs/superpowers/specs/2026-07-14-mcp-schema-resource-4865-design.md
+++ b/docs/superpowers/specs/2026-07-14-mcp-schema-resource-4865-design.md
@@ -1,0 +1,218 @@
+# MCP: expose schema as a Resource (#4865)
+
+**Issue:** [#4865](https://github.com/ArcadeData/arcadedb/issues/4865)
+**Epic:** [#4859 - MCP GraphRAG & Agent-Memory Surface](https://github.com/ArcadeData/arcadedb/issues/4859) (Wave 1)
+**Date:** 2026-07-14
+**Status:** approved
+
+## Problem
+
+ArcadeDB's MCP server implements exactly one MCP protocol primitive: **Tools**. `handleInitialize` advertises `capabilities.tools` and nothing else; there are zero matches for `resources/list` or `resources/read` in the `com.arcadedb.server.mcp` package.
+
+The cost is a wasted turn. Every agent session that touches an unfamiliar database must spend a tool call on `get_schema` before it can write a single query, and the server's own `instructions` block tells it to (rule 4). Schema is static reference material, which is precisely what the Resources primitive exists to carry: a client that supports Resources can auto-load it at session start, with no model turn spent at all.
+
+This is epic justification **#4 (structured shaping)**, delivered through the correct protocol primitive instead of yet another tool. It is the one child issue that *reduces* pressure on the tool-count discipline rather than adding to it.
+
+## Governing constraint
+
+The MCP layer stays **schema-agnostic**, per the maintainer's ruling on the epic thread: MCP is "just another protocol/api, like the http api or grpc or bolt." The resource returns the database's real structure and imposes no governance or memory vocabulary on top of it.
+
+## Design
+
+Three layers. Two are new; one is the refactor the issue asks for.
+
+### 1. `MCPDispatcher` (new, `com.arcadedb.server.mcp`)
+
+`MCPHttpHandler` and `MCPStdioServer` are today near-duplicates. Each carries its own static `TOOLS_LIST`, its own `MCP_PROTOCOL_VERSION`, its own method `switch`, and its own copies of `jsonRpcResult`, `jsonRpcError`, and `toolError`. Adding a second protocol primitive would pay that duplication twice more, and the divergence between them is already leaking real bugs (see *Behavior reconciliation* below).
+
+`MCPDispatcher` becomes the single source of truth for the JSON-RPC method surface: protocol version, `TOOLS_LIST`, the `instructions` text, the gating checks, the method `switch`, and one copy each of the envelope helpers. It is instantiated per transport with `(server, config, transportName)` so log lines stay attributable.
+
+**Boundary: transports own I/O and parsing; the dispatcher owns protocol.** HTTP already receives a parsed `JSONObject` from `AbstractServerHttpHandler`. Stdio parses its own line and raises its own `-32700` on malformed JSON. Neither concern belongs in the dispatcher, so `dispatch()` accepts an already-parsed request and never sees a byte of transport.
+
+Return type is transport-neutral:
+
+```java
+public record MCPResponse(int httpStatus, JSONObject json) {}   // json == null => notification, no reply
+```
+
+- `MCPHttpHandler` maps it to `ExecutionResponse`: `json == null` becomes `204 ""`, otherwise `(httpStatus, json.toString())`.
+- `MCPStdioServer` ignores `httpStatus` entirely, prints `json.toString()`, or prints nothing when `json` is null.
+
+Both transports collapse to thin adapters.
+
+### 2. `MCPResources` (new, `com.arcadedb.server.mcp`)
+
+All Resources logic lives here, so neither transport learns anything about URIs.
+
+```java
+public static JSONObject list(ArcadeDBServer server, ServerSecurityUser user, MCPConfiguration config);
+public static JSONObject read(ArcadeDBServer server, ServerSecurityUser user, MCPConfiguration config, String uri);
+```
+
+### 3. `GetSchemaTool` refactor
+
+The schema walk (currently the body of `execute()`, lines 62-127) is extracted verbatim to:
+
+```java
+public static JSONObject buildSchema(final Database database, final String databaseName);
+```
+
+`execute()` shrinks to: `allowReads` check, `MCPToolUtils.resolveDatabase`, `buildSchema`. `MCPResources.read` calls the same `buildSchema`.
+
+This is what makes the issue's headline acceptance criterion, that tool output and resource content are identical, true **by construction** rather than by coincidence. It cannot drift, because there is only one implementation.
+
+## URI scheme
+
+`arcadedb://{database}/schema`, per the issue.
+
+**Parse it with plain string operations, deliberately not `java.net.URI`.** `URI.getHost()` applies hostname syntax rules: it lowercases the authority and returns `null` for an authority containing an underscore. ArcadeDB database names are case-sensitive and may legally contain `_`, so `arcadedb://My_DB/schema` would silently resolve to nothing, or to the wrong database, under `java.net.URI`.
+
+The parse is therefore: strip the `arcadedb://` prefix, require the `/schema` suffix, take the middle as the database name verbatim. Anything that does not match that shape is a resource-not-found. Database names cannot contain `/` (they are directory names on disk), so the form round-trips exactly against what `list` emits.
+
+## `resources/list`
+
+Filters `server.getDatabaseNames()` through `user.canAccessToDatabase(db)`, sorted by database name for deterministic output.
+
+`canAccessToDatabase` is `databasesNames.contains(SecurityManager.ANY) || databasesNames.contains(databaseName)`, which is exactly the predicate `ListDatabasesTool` open-codes as `getAuthorizedDatabases()` plus a `*` wildcard check, and exactly the one `MCPToolUtils.resolveDatabase` (and therefore `get_schema`) already applies. Using it satisfies the issue's "access control matches `get_schema`" criterion literally, and keeps the resource list consistent with `list_databases`. A test asserts the two sets are equal.
+
+One entry per accessible database:
+
+```json
+{
+  "uri": "arcadedb://graph/schema",
+  "name": "graph schema",
+  "description": "Schema of the ArcadeDB database 'graph': types (vertex, edge, document), properties, indexes, inheritance.",
+  "mimeType": "application/json"
+}
+```
+
+## `resources/read`
+
+```json
+{
+  "contents": [
+    {
+      "uri": "arcadedb://graph/schema",
+      "mimeType": "application/json",
+      "text": "{\"database\":\"graph\",\"types\":[...]}"
+    }
+  ]
+}
+```
+
+The `text` value is `buildSchema(...).toString()`, byte-identical to what the `get_schema` tool returns.
+
+## Capability advertisement
+
+In the dispatcher's single `handleInitialize`:
+
+```java
+capabilities.put("resources", new JSONObject().put("listChanged", false).put("subscribe", false));
+```
+
+Both flags are `false` and both are honest: the schema resource list changes only when a database is created or dropped, and no change-notification or subscription machinery is being built.
+
+## The `instructions` block
+
+The issue asks that "docs should note Resources as the preferred path for clients that support it." The out-of-tree `arcadedb-docs` repository is a follow-up (see *Out of scope*), but the `instructions` string returned by `initialize` is documentation that ships in this repo and is read by every connecting agent, so it is updated here.
+
+Rule 4 currently reads:
+
+> 4. Call get_schema before writing queries against an unfamiliar database to understand its types and properties.
+
+It gains one sentence:
+
+> 4. Call get_schema before writing queries against an unfamiliar database to understand its types and properties. If your client supports MCP Resources, prefer reading `arcadedb://{database}/schema` instead: it carries the same content without spending a tool call.
+
+The other four rules are unchanged. `get_schema` stays, and stays recommended, for clients that do not implement Resources.
+
+## Error handling
+
+`MCPResources` signals failure with exception types; the dispatcher maps them to JSON-RPC codes.
+
+| Condition | Signal | JSON-RPC code |
+|---|---|---|
+| `allowReads=false`, on `resources/list` | none, returns `{"resources": []}` | 200 (success) |
+| `allowReads=false`, on `resources/read` | `SecurityException` | `-32600` |
+| unknown database, on `read` | `MCPResourceNotFoundException` | `-32002` |
+| unauthorized database, on `read` | `MCPResourceNotFoundException` | `-32002` |
+| malformed URI, on `read` | `MCPResourceNotFoundException` | `-32002` |
+| anything else | `Exception` | `-32603` |
+
+`MCPResourceNotFoundException` is a new `RuntimeException` in `com.arcadedb.server.mcp`. `-32002` is the MCP-standard "resource not found" code.
+
+Two deliberate asymmetries:
+
+**`list` hides, `read` errors.** `resources/list` is a discovery call that most clients issue unprompted at session start. Returning an empty array when reads are disabled keeps a reads-disabled server quiet, where an error would show a banner to every connecting agent. `resources/read` is an explicit request, so it fails loudly rather than returning nothing and letting the caller infer emptiness means absence.
+
+**Unknown and unauthorized collapse to one indistinguishable `-32002`.** This departs from the house `MCPToolUtils.resolveDatabase` pattern, which enumerates the available databases in its error text so the model can self-correct without a round-trip. That pattern is right for tools, where the model supplies the database name from memory and can guess wrong. It is wrong here: `resources/read` URIs come from `resources/list`, so a legitimate caller never guesses one, and distinguishing the two errors would turn `resources/read` into a probe for which databases exist.
+
+## Behavior reconciliation
+
+Unifying the two transports forces the places where they currently disagree to resolve. Both resolve toward the HTTP behavior, which is the more correct one in each case.
+
+| Behavior | HTTP today | Stdio today | Unified |
+|---|---|---|---|
+| `isEnabled()` gate | 503 if disabled | absent | gated |
+| `isUserAllowed()` gate | 403 if not allowed | absent | gated |
+| `instructions` in `initialize` | present | absent | present |
+| unauthenticated (`user == null`) | 401 | n/a | 401 |
+
+Check order in `dispatch()` preserves HTTP's current ordering, auth before enablement, so server state is not leaked to unauthenticated callers.
+
+**This is a behavior change for stdio, and warrants a release note.** Stdio will now honor `allowedUsers`. The default path is unaffected: `MCPStdioServer.main()` already calls `config.setEnabled(true)` and authenticates as `root`, and `root` is the default sole entry in `allowedUsers`. A stdio deployment that had rewritten `allowedUsers` to omit `root` would newly be refused, which is the correct outcome and is arguably a latent bug being fixed.
+
+Stdio gaining `instructions` is a straightforward win: it is the transport Claude Desktop and Cursor actually use, and it is the one that was missing the guidance text.
+
+## Files touched
+
+**New**
+- `server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java`
+- `server/src/main/java/com/arcadedb/server/mcp/MCPResources.java`
+- `server/src/main/java/com/arcadedb/server/mcp/MCPResourceNotFoundException.java`
+
+**Modified**
+- `server/src/main/java/com/arcadedb/server/mcp/MCPHttpHandler.java` (shrinks to an HTTP adapter)
+- `server/src/main/java/com/arcadedb/server/mcp/MCPStdioServer.java` (shrinks to a stdio adapter)
+- `server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java` (extract `buildSchema`)
+- `server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java` (additions only)
+- `server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java` (additions only)
+
+**New test**
+- `server/src/test/java/com/arcadedb/server/mcp/MCPResourcesTest.java`
+
+`MCPPermissionsTest` is deliberately **not** touched. It is a pure unit test that constructs a bare `MCPConfiguration` with no server, and both `MCPResources.list` and `MCPResources.read` require an `ArcadeDBServer` and a `ServerSecurityUser`. The `allowReads=false` coverage therefore lands in `MCPResourcesTest` (direct calls) and `MCPServerPluginTest` (over the wire).
+
+## Testing
+
+The dispatcher extraction is the risky part of this change, and the existing MCP suites are its safety net. **Every current test must stay green, and no existing test method may be edited at all.** New coverage arrives as new test methods, never as amended assertions on old ones, so that the old suites remain an untainted control. If an existing test method needs editing to pass, that is a signal the refactor changed behavior, and must be investigated rather than accommodated.
+
+This is stricter than it first appears. Stdio gaining `instructions` could have been folded into the existing `MCPStdioServerTest.initialize` assertion; instead it gets its own test method, leaving `initialize` free to keep proving that nothing else about the initialize response moved.
+
+| Suite | Coverage |
+|---|---|
+| `MCPResourcesTest` (new) | Direct, transport-free calls into `MCPResources`: `list` shapes one resource per accessible database; `list` is empty when `allowReads=false`; `read` content equals `GetSchemaTool.execute` output; `read` raises `MCPResourceNotFoundException` for an unknown database and for each malformed URI shape; `read` raises `SecurityException` when `allowReads=false`; `parseSchemaURI` preserves case and underscores (the `java.net.URI` trap) and round-trips against `schemaURI` |
+| `MCPServerPluginTest` (HTTP) | `initialize` advertises the `resources` capability; `resources/list` contains `arcadedb://graph/schema` with `mimeType: application/json`; **`get_schema` tool output equals `resources/read` content text** (the issue's explicit criterion); the `resources/list` database set equals the `list_databases` set; unknown database and malformed URI both return `-32002`; a user unauthorized for a database does not see it listed; `allowReads=false` makes `resources/list` empty and `resources/read` return `-32600` |
+| `MCPStdioServerTest` | `resources/list` and `resources/read` work over stdio; `initialize` advertises `resources` and now carries `instructions` |
+| all existing MCP tests | Regression net for the dispatcher extraction: `tools/list` still returns 11 tools, every `tools/call` behaves as before, `ping` and `notifications/initialized` unchanged |
+
+The existing `capabilities` assertions use `capabilities.has("tools")` rather than asserting `tools` is the *only* key, so adding `resources` alongside it is a no-op for them. Verify this during implementation rather than assuming it.
+
+`git diff --stat main -- server/src/test/java/com/arcadedb/server/mcp/` at the end of the work must show additions only, plus the new `MCPResourcesTest.java`.
+
+## Risks
+
+**Sequencing against the rest of Wave 1.** This rewrites both files that #4860, #4863, and #4864 also edit, and the epic flags that collision explicitly. **#4865 should land first**, with the siblings rebased onto it. That ordering is cheaper in both directions: each sibling adds a tool, which after this refactor means one `TOOLS_LIST` line and one `switch` arm instead of two of each. Landing #4865 last would instead force it to absorb every sibling's duplicated edits before deleting them.
+
+**Stdio behavior change.** Covered above under *Behavior reconciliation*. Needs a release note, not a code change.
+
+**Log attribution.** `LogManager.instance().log(this, ...)` will now report `MCPDispatcher` as the source class rather than `MCPHttpHandler` or `MCPStdioServer`. The `transportName` field is carried into the message text so the two transports stay distinguishable in logs.
+
+## Out of scope
+
+- **`resources/templates/list`.** `resources/list` enumerates every accessible database concretely, so a URI template adds no reachability. Justified only if per-database scoping (#4868) later makes concrete enumeration impractical.
+- **Subscriptions.** `subscribe` and `listChanged` are advertised `false`; no `notifications/resources/updated` machinery is built.
+- **Any resource other than schema.** Sample records, server status, and index statistics are all plausible future resources; none is needed to satisfy #4865, and the epic enforces surface discipline.
+- **Collapsing the remaining transport duplication.** The dispatcher extraction takes the JSON-RPC surface. Whatever incidental duplication survives in the two adapters is left alone.
+- **Documentation.** The MCP docs live in the out-of-tree `arcadedb-docs` repository and are tracked as a separate follow-up, consistent with how #4862 handled it.
+- **Any relaxation of default permissions.** `enabled=false` and all write flags `false` are unchanged; this issue adds no new configuration flag.

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -92,16 +92,17 @@ public class MCPDispatcher {
    * anything else, so that server state is not disclosed to unauthenticated callers.
    */
   public MCPResponse dispatch(final JSONObject request, final ServerSecurityUser user) {
+    // Echo the JSON-RPC id on every error response when the request carries one, per JSON-RPC 2.0.
+    final Object id = request != null ? request.opt("id") : null;
+
     if (user == null)
-      return error(null, -32600, "Authentication required", 401);
+      return error(id, -32600, "Authentication required", 401);
 
     if (!config.isEnabled())
-      return error(null, -32600, "MCP server is disabled", 503);
+      return error(id, -32600, "MCP server is disabled", 503);
 
     if (request == null)
-      return error(null, -32700, "Parse error: empty request body", 200);
-
-    final Object id = request.opt("id");
+      return error(id, -32700, "Parse error: empty request body", 200);
 
     if (!config.isUserAllowed(user.getName()))
       return error(id, -32600, "User not authorized for MCP access", 403);

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.Constants;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.mcp.tools.ExecuteCommandTool;
+import com.arcadedb.server.mcp.tools.FullTextSearchTool;
+import com.arcadedb.server.mcp.tools.GetSchemaTool;
+import com.arcadedb.server.mcp.tools.GetServerSettingsTool;
+import com.arcadedb.server.mcp.tools.ListDatabasesTool;
+import com.arcadedb.server.mcp.tools.ProfilerStartTool;
+import com.arcadedb.server.mcp.tools.ProfilerStatusTool;
+import com.arcadedb.server.mcp.tools.ProfilerStopTool;
+import com.arcadedb.server.mcp.tools.QueryTool;
+import com.arcadedb.server.mcp.tools.ServerStatusTool;
+import com.arcadedb.server.mcp.tools.SetServerSettingTool;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import java.util.logging.Level;
+
+/**
+ * Transport-neutral MCP JSON-RPC dispatcher. Owns the protocol surface (version, tool list, instructions, gating,
+ * method routing, envelope shaping); the HTTP and stdio transports own only their I/O and their own parse errors.
+ */
+public class MCPDispatcher {
+  public static final  String    MCP_PROTOCOL_VERSION = "2025-03-26";
+  private static final JSONArray TOOLS_LIST;
+
+  private static final String INSTRUCTIONS =
+      """
+      You are connected to an ArcadeDB multi-model database server. Follow these rules:
+      1. ALWAYS call list_databases first when you do not know the target database name. Never guess it.
+      2. Prefer Cypher (language: 'cypher') for graph queries unless SQL is explicitly requested.
+      3. Use the 'query' tool for read-only operations (SELECT, MATCH, RETURN) and 'execute_command' for writes (CREATE, INSERT, UPDATE, DELETE, MERGE).
+      4. Call get_schema before writing queries against an unfamiliar database to understand its types and properties. If your client supports MCP Resources, prefer reading arcadedb://{database}/schema instead: it carries the same content without spending a tool call.
+      5. If a query returns no results, verify the type/property names with get_schema before concluding the data does not exist.""";
+
+  static {
+    TOOLS_LIST = new JSONArray();
+    TOOLS_LIST.put(ListDatabasesTool.getDefinition());
+    TOOLS_LIST.put(GetSchemaTool.getDefinition());
+    TOOLS_LIST.put(QueryTool.getDefinition());
+    TOOLS_LIST.put(ExecuteCommandTool.getDefinition());
+    TOOLS_LIST.put(FullTextSearchTool.getDefinition());
+    TOOLS_LIST.put(ServerStatusTool.getDefinition());
+    TOOLS_LIST.put(ProfilerStartTool.getDefinition());
+    TOOLS_LIST.put(ProfilerStopTool.getDefinition());
+    TOOLS_LIST.put(ProfilerStatusTool.getDefinition());
+    TOOLS_LIST.put(GetServerSettingsTool.getDefinition());
+    TOOLS_LIST.put(SetServerSettingTool.getDefinition());
+  }
+
+  /**
+   * A transport-neutral reply. A null json means a JSON-RPC notification, for which no reply is sent at all;
+   * the httpStatus is meaningful only to the HTTP transport and is ignored by stdio.
+   */
+  public record MCPResponse(int httpStatus, JSONObject json) {
+  }
+
+  private final ArcadeDBServer   server;
+  private final MCPConfiguration config;
+  private final String           transport;
+
+  public MCPDispatcher(final ArcadeDBServer server, final MCPConfiguration config, final String transport) {
+    this.server = server;
+    this.config = config;
+    this.transport = transport;
+  }
+
+  /**
+   * Routes one parsed JSON-RPC request. A null request means an empty body. Authentication is checked before
+   * anything else, so that server state is not disclosed to unauthenticated callers.
+   */
+  public MCPResponse dispatch(final JSONObject request, final ServerSecurityUser user) {
+    if (user == null)
+      return error(null, -32600, "Authentication required", 401);
+
+    if (!config.isEnabled())
+      return error(null, -32600, "MCP server is disabled", 503);
+
+    if (request == null)
+      return error(null, -32700, "Parse error: empty request body", 200);
+
+    final Object id = request.opt("id");
+
+    if (!config.isUserAllowed(user.getName()))
+      return error(id, -32600, "User not authorized for MCP access", 403);
+
+    final String method = request.getString("method", "");
+    final JSONObject params = request.getJSONObject("params", new JSONObject());
+
+    LogManager.instance().log(this, Level.INFO, "MCP[%s] %s (user=%s)", transport, method, user.getName());
+
+    return switch (method) {
+      case "initialize" -> result(id, initialize());
+      case "notifications/initialized" -> new MCPResponse(204, null);
+      case "tools/list" -> result(id, new JSONObject().put("tools", TOOLS_LIST));
+      case "tools/call" -> toolsCall(id, params, user);
+      case "resources/list" -> resourcesList(id, user);
+      case "resources/read" -> resourcesRead(id, params, user);
+      case "ping" -> result(id, new JSONObject());
+      default -> error(id, -32601, "Method not found: " + method, 200);
+    };
+  }
+
+  private JSONObject initialize() {
+    final JSONObject result = new JSONObject();
+    result.put("protocolVersion", MCP_PROTOCOL_VERSION);
+
+    final JSONObject serverInfo = new JSONObject();
+    serverInfo.put("name", "arcadedb");
+    serverInfo.put("version", Constants.getVersion());
+    result.put("serverInfo", serverInfo);
+
+    final JSONObject capabilities = new JSONObject();
+    capabilities.put("tools", new JSONObject().put("listChanged", false));
+    capabilities.put("resources", new JSONObject().put("listChanged", false).put("subscribe", false));
+    result.put("capabilities", capabilities);
+
+    result.put("instructions", INSTRUCTIONS);
+
+    return result;
+  }
+
+  private MCPResponse resourcesList(final Object id, final ServerSecurityUser user) {
+    try {
+      return result(id, MCPResources.list(server, user, config));
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "MCP[%s] resources/list -> error: %s", transport, e.getMessage());
+      return error(id, -32603, "Internal error: " + e.getMessage(), 200);
+    }
+  }
+
+  private MCPResponse resourcesRead(final Object id, final JSONObject params, final ServerSecurityUser user) {
+    final String uri = params.getString("uri", "");
+
+    LogManager.instance().log(this, Level.INFO, "MCP[%s] resources/read '%s' (user=%s)", transport, uri, user.getName());
+
+    try {
+      return result(id, MCPResources.read(server, user, config, uri));
+    } catch (final SecurityException e) {
+      LogManager.instance().log(this, Level.INFO, "MCP[%s] resources/read -> permission denied: %s", transport, e.getMessage());
+      return error(id, -32600, e.getMessage(), 200);
+    } catch (final MCPResourceNotFoundException e) {
+      return error(id, -32002, e.getMessage(), 200);
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "MCP[%s] resources/read -> error: %s", transport, e.getMessage());
+      return error(id, -32603, "Internal error: " + e.getMessage(), 200);
+    }
+  }
+
+  private MCPResponse toolsCall(final Object id, final JSONObject params, final ServerSecurityUser user) {
+    final String toolName = params.getString("name", "");
+    final JSONObject args = params.getJSONObject("arguments", new JSONObject());
+
+    LogManager.instance()
+        .log(this, Level.INFO, "MCP[%s] tools/call '%s' %s (user=%s)", transport, toolName, formatArgs(args), user.getName());
+
+    try {
+      final JSONObject toolResult = switch (toolName) {
+        case "list_databases" -> ListDatabasesTool.execute(server, user, args, config);
+        case "get_schema" -> GetSchemaTool.execute(server, user, args, config);
+        case "query" -> QueryTool.execute(server, user, args, config);
+        case "execute_command" -> ExecuteCommandTool.execute(server, user, args, config);
+        case "full_text_search" -> FullTextSearchTool.execute(server, user, args, config);
+        case "server_status" -> ServerStatusTool.execute(server, user, args, config);
+        case "profiler_start" -> ProfilerStartTool.execute(server, user, args, config);
+        case "profiler_stop" -> ProfilerStopTool.execute(server, user, args, config);
+        case "profiler_status" -> ProfilerStatusTool.execute(server, user, args, config);
+        case "get_server_settings" -> GetServerSettingsTool.execute(server, user, args, config);
+        case "set_server_setting" -> SetServerSettingTool.execute(server, user, args, config);
+        default -> throw new IllegalArgumentException("Unknown tool: " + toolName);
+      };
+
+      LogManager.instance()
+          .log(this, Level.INFO, "MCP[%s] tools/call '%s' -> %s", transport, toolName, formatResult(toolName, toolResult));
+
+      final JSONObject result = new JSONObject();
+      final JSONArray content = new JSONArray();
+      content.put(new JSONObject()
+          .put("type", "text")
+          .put("text", toolResult.toString()));
+      result.put("content", content);
+      result.put("isError", false);
+      return result(id, result);
+
+    } catch (final SecurityException e) {
+      LogManager.instance()
+          .log(this, Level.INFO, "MCP[%s] tools/call '%s' -> permission denied: %s", transport, toolName, e.getMessage());
+      return toolError(id, e.getMessage());
+    } catch (final Exception e) {
+      LogManager.instance()
+          .log(this, Level.WARNING, "MCP[%s] tools/call '%s' -> error: %s", transport, toolName, e.getMessage());
+      return toolError(id, e.getMessage());
+    }
+  }
+
+  private static String formatArgs(final JSONObject args) {
+    if (args.length() == 0)
+      return "{}";
+    final StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (final String key : args.keySet()) {
+      if (!first)
+        sb.append(", ");
+      first = false;
+      final Object value = args.get(key);
+      if (value instanceof String s) {
+        final String sanitized = sanitizeForLog(s);
+        if (sanitized.length() > 100)
+          sb.append(key).append("=\"").append(sanitized, 0, 100).append("...\"");
+        else
+          sb.append(key).append("=\"").append(sanitized).append("\"");
+      } else
+        sb.append(key).append("=").append(value);
+    }
+    return sb.append("}").toString();
+  }
+
+  private static String sanitizeForLog(final String value) {
+    return value.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t");
+  }
+
+  private static String formatResult(final String toolName, final JSONObject result) {
+    return switch (toolName) {
+      case "list_databases" -> result.getJSONArray("databases", new JSONArray()).length() + " database(s)";
+      case "get_schema" -> result.getJSONArray("types", new JSONArray()).length() + " type(s)";
+      case "query", "execute_command" -> result.getInt("count", 0) + " record(s)";
+      case "full_text_search" -> result.getInt("count", 0) + " hit(s)";
+      case "server_status" -> "ok";
+      case "profiler_start" -> result.getString("status", "ok");
+      case "profiler_stop" -> result.getInt("totalQueries", 0) + " queries captured";
+      case "profiler_status" -> result.getBoolean("recording", false) ? "recording" : "idle";
+      case "get_server_settings" -> result.getJSONArray("settings", new JSONArray()).length() + " setting(s)";
+      case "set_server_setting" -> result.getString("key", "") + " updated";
+      default -> "ok";
+    };
+  }
+
+  private static MCPResponse toolError(final Object id, final String message) {
+    final JSONObject result = new JSONObject();
+    final JSONArray content = new JSONArray();
+    content.put(new JSONObject()
+        .put("type", "text")
+        .put("text", message));
+    result.put("content", content);
+    result.put("isError", true);
+    return result(id, result);
+  }
+
+  private static MCPResponse result(final Object id, final JSONObject result) {
+    final JSONObject response = new JSONObject();
+    response.put("jsonrpc", "2.0");
+    response.put("id", id);
+    response.put("result", result);
+    return new MCPResponse(200, response);
+  }
+
+  private static MCPResponse error(final Object id, final int code, final String message, final int httpStatus) {
+    final JSONObject response = new JSONObject();
+    response.put("jsonrpc", "2.0");
+    response.put("id", id);
+    response.put("error", new JSONObject().put("code", code).put("message", message));
+    return new MCPResponse(httpStatus, response);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPHttpHandler.java
@@ -18,59 +18,26 @@
  */
 package com.arcadedb.server.mcp;
 
-import com.arcadedb.Constants;
-import com.arcadedb.log.LogManager;
-import com.arcadedb.server.mcp.tools.ExecuteCommandTool;
-import com.arcadedb.server.mcp.tools.FullTextSearchTool;
-import com.arcadedb.server.mcp.tools.GetSchemaTool;
-import com.arcadedb.server.mcp.tools.GetServerSettingsTool;
-import com.arcadedb.server.mcp.tools.ListDatabasesTool;
-import com.arcadedb.server.mcp.tools.ProfilerStartTool;
-import com.arcadedb.server.mcp.tools.ProfilerStatusTool;
-import com.arcadedb.server.mcp.tools.ProfilerStopTool;
-import com.arcadedb.server.mcp.tools.QueryTool;
-import com.arcadedb.server.mcp.tools.ServerStatusTool;
-import com.arcadedb.server.mcp.tools.SetServerSettingTool;
-import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.AbstractServerHttpHandler;
 import com.arcadedb.server.http.handler.ExecutionResponse;
+import com.arcadedb.server.mcp.MCPDispatcher.MCPResponse;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
-import java.util.logging.Level;
-
 /**
+ * HTTP transport for MCP. Owns the HTTP envelope only; all protocol routing lives in {@link MCPDispatcher}.
+ *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class MCPHttpHandler extends AbstractServerHttpHandler {
-  private static final String    MCP_PROTOCOL_VERSION = "2025-03-26";
-  private static final JSONArray TOOLS_LIST;
-
-  static {
-    TOOLS_LIST = new JSONArray();
-    TOOLS_LIST.put(ListDatabasesTool.getDefinition());
-    TOOLS_LIST.put(GetSchemaTool.getDefinition());
-    TOOLS_LIST.put(QueryTool.getDefinition());
-    TOOLS_LIST.put(ExecuteCommandTool.getDefinition());
-    TOOLS_LIST.put(FullTextSearchTool.getDefinition());
-    TOOLS_LIST.put(ServerStatusTool.getDefinition());
-    TOOLS_LIST.put(ProfilerStartTool.getDefinition());
-    TOOLS_LIST.put(ProfilerStopTool.getDefinition());
-    TOOLS_LIST.put(ProfilerStatusTool.getDefinition());
-    TOOLS_LIST.put(GetServerSettingsTool.getDefinition());
-    TOOLS_LIST.put(SetServerSettingTool.getDefinition());
-  }
-
-  private final ArcadeDBServer  server;
-  private final MCPConfiguration config;
+  private final MCPDispatcher dispatcher;
 
   public MCPHttpHandler(final HttpServer httpServer, final ArcadeDBServer server, final MCPConfiguration config) {
     super(httpServer);
-    this.server = server;
-    this.config = config;
+    this.dispatcher = new MCPDispatcher(server, config, "http");
   }
 
   @Override
@@ -85,183 +52,12 @@ public class MCPHttpHandler extends AbstractServerHttpHandler {
 
   @Override
   protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
-    // Auth check first to avoid leaking server state to unauthenticated requests
-    if (user == null)
-      return jsonRpcError(null, -32600, "Authentication required", 401);
+    final MCPResponse response = dispatcher.dispatch(payload, user);
 
-    if (!config.isEnabled())
-      return jsonRpcError(null, -32600, "MCP server is disabled", 503);
+    // A null body is a JSON-RPC notification, which takes no response at all.
+    if (response.json() == null)
+      return new ExecutionResponse(204, "");
 
-    if (payload == null)
-      return jsonRpcError(null, -32700, "Parse error: empty request body");
-
-    if (!config.isUserAllowed(user.getName()))
-      return jsonRpcError(payload.opt("id"), -32600, "User not authorized for MCP access", 403);
-
-    final String method = payload.getString("method", "");
-    final JSONObject params = payload.getJSONObject("params", new JSONObject());
-    final Object id = payload.opt("id");
-
-    LogManager.instance().log(this, Level.INFO, "MCP %s (user=%s)", method, user.getName());
-
-    return switch (method) {
-      case "initialize" -> handleInitialize(id);
-      case "notifications/initialized" -> handleNotification();
-      case "tools/list" -> handleToolsList(id);
-      case "tools/call" -> handleToolsCall(id, params, user);
-      case "ping" -> jsonRpcResult(id, new JSONObject());
-      default -> jsonRpcError(id, -32601, "Method not found: " + method);
-    };
-  }
-
-  private ExecutionResponse handleInitialize(final Object id) {
-    final JSONObject result = new JSONObject();
-    result.put("protocolVersion", MCP_PROTOCOL_VERSION);
-
-    final JSONObject serverInfo = new JSONObject();
-    serverInfo.put("name", "arcadedb");
-    serverInfo.put("version", Constants.getVersion());
-    result.put("serverInfo", serverInfo);
-
-    final JSONObject capabilities = new JSONObject();
-    capabilities.put("tools", new JSONObject().put("listChanged", false));
-    result.put("capabilities", capabilities);
-
-    result.put("instructions",
-        """
-        You are connected to an ArcadeDB multi-model database server. Follow these rules:
-        1. ALWAYS call list_databases first when you do not know the target database name. Never guess it.
-        2. Prefer Cypher (language: 'cypher') for graph queries unless SQL is explicitly requested.
-        3. Use the 'query' tool for read-only operations (SELECT, MATCH, RETURN) and 'execute_command' for writes (CREATE, INSERT, UPDATE, DELETE, MERGE).
-        4. Call get_schema before writing queries against an unfamiliar database to understand its types and properties.
-        5. If a query returns no results, verify the type/property names with get_schema before concluding the data does not exist.""");
-
-    return jsonRpcResult(id, result);
-  }
-
-  private ExecutionResponse handleNotification() {
-    // Notifications don't get a response in JSON-RPC; return 204 No Content
-    return new ExecutionResponse(204, "");
-  }
-
-  private ExecutionResponse handleToolsList(final Object id) {
-    final JSONObject result = new JSONObject();
-    result.put("tools", TOOLS_LIST);
-    return jsonRpcResult(id, result);
-  }
-
-  private ExecutionResponse handleToolsCall(final Object id, final JSONObject params, final ServerSecurityUser user) {
-    final String toolName = params.getString("name", "");
-    final JSONObject args = params.getJSONObject("arguments", new JSONObject());
-
-    LogManager.instance().log(this, Level.INFO, "MCP tools/call '%s' %s (user=%s)", toolName, formatArgs(args), user.getName());
-
-    try {
-      final JSONObject toolResult = switch (toolName) {
-        case "list_databases" -> ListDatabasesTool.execute(server, user, args, config);
-        case "get_schema" -> GetSchemaTool.execute(server, user, args, config);
-        case "query" -> QueryTool.execute(server, user, args, config);
-        case "execute_command" -> ExecuteCommandTool.execute(server, user, args, config);
-        case "full_text_search" -> FullTextSearchTool.execute(server, user, args, config);
-        case "server_status" -> ServerStatusTool.execute(server, user, args, config);
-        case "profiler_start" -> ProfilerStartTool.execute(server, user, args, config);
-        case "profiler_stop" -> ProfilerStopTool.execute(server, user, args, config);
-        case "profiler_status" -> ProfilerStatusTool.execute(server, user, args, config);
-        case "get_server_settings" -> GetServerSettingsTool.execute(server, user, args, config);
-        case "set_server_setting" -> SetServerSettingTool.execute(server, user, args, config);
-        default -> throw new IllegalArgumentException("Unknown tool: " + toolName);
-      };
-
-      LogManager.instance().log(this, Level.INFO, "MCP tools/call '%s' -> %s", toolName, formatResult(toolName, toolResult));
-
-      final JSONObject result = new JSONObject();
-      final JSONArray content = new JSONArray();
-      content.put(new JSONObject()
-          .put("type", "text")
-          .put("text", toolResult.toString()));
-      result.put("content", content);
-      result.put("isError", false);
-      return jsonRpcResult(id, result);
-
-    } catch (final SecurityException e) {
-      LogManager.instance().log(this, Level.INFO, "MCP tools/call '%s' -> permission denied: %s", toolName, e.getMessage());
-      return toolError(id, e.getMessage());
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING, "MCP tools/call '%s' -> error: %s", toolName, e.getMessage());
-      return toolError(id, e.getMessage());
-    }
-  }
-
-  private static String formatArgs(final JSONObject args) {
-    if (args.length() == 0)
-      return "{}";
-    final StringBuilder sb = new StringBuilder("{");
-    boolean first = true;
-    for (final String key : args.keySet()) {
-      if (!first)
-        sb.append(", ");
-      first = false;
-      final Object value = args.get(key);
-      if (value instanceof String s) {
-        final String sanitized = sanitizeForLog(s);
-        if (sanitized.length() > 100)
-          sb.append(key).append("=\"").append(sanitized, 0, 100).append("...\"");
-        else
-          sb.append(key).append("=\"").append(sanitized).append("\"");
-      } else
-        sb.append(key).append("=").append(value);
-    }
-    return sb.append("}").toString();
-  }
-
-  private static String sanitizeForLog(final String value) {
-    return value.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t");
-  }
-
-  private static String formatResult(final String toolName, final JSONObject result) {
-    return switch (toolName) {
-      case "list_databases" -> result.getJSONArray("databases", new JSONArray()).length() + " database(s)";
-      case "get_schema" -> result.getJSONArray("types", new JSONArray()).length() + " type(s)";
-      case "query", "execute_command" -> result.getInt("count", 0) + " record(s)";
-      case "full_text_search" -> result.getInt("count", 0) + " hit(s)";
-      case "server_status" -> "ok";
-      case "profiler_start" -> result.getString("status", "ok");
-      case "profiler_stop" -> result.getInt("totalQueries", 0) + " queries captured";
-      case "profiler_status" -> result.getBoolean("recording", false) ? "recording" : "idle";
-      case "get_server_settings" -> result.getJSONArray("settings", new JSONArray()).length() + " setting(s)";
-      case "set_server_setting" -> result.getString("key", "") + " updated";
-      default -> "ok";
-    };
-  }
-
-  private ExecutionResponse toolError(final Object id, final String message) {
-    final JSONObject result = new JSONObject();
-    final JSONArray content = new JSONArray();
-    content.put(new JSONObject()
-        .put("type", "text")
-        .put("text", message));
-    result.put("content", content);
-    result.put("isError", true);
-    return jsonRpcResult(id, result);
-  }
-
-  private ExecutionResponse jsonRpcResult(final Object id, final JSONObject result) {
-    final JSONObject response = new JSONObject();
-    response.put("jsonrpc", "2.0");
-    response.put("id", id);
-    response.put("result", result);
-    return new ExecutionResponse(200, response.toString());
-  }
-
-  private ExecutionResponse jsonRpcError(final Object id, final int code, final String message) {
-    return jsonRpcError(id, code, message, 200);
-  }
-
-  private ExecutionResponse jsonRpcError(final Object id, final int code, final String message, final int httpStatus) {
-    final JSONObject response = new JSONObject();
-    response.put("jsonrpc", "2.0");
-    response.put("id", id);
-    response.put("error", new JSONObject().put("code", code).put("message", message));
-    return new ExecutionResponse(httpStatus, response.toString());
+    return new ExecutionResponse(response.httpStatus(), response.json().toString());
   }
 }

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPResourceNotFoundException.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPResourceNotFoundException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp;
+
+/**
+ * Raised when an MCP resource URI does not resolve. Unknown databases, databases the user cannot access, and
+ * malformed URIs all raise this same exception, so that resources/read cannot be used to probe which databases exist.
+ */
+public class MCPResourceNotFoundException extends RuntimeException {
+
+  public MCPResourceNotFoundException(final String message) {
+    super(message);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPResources.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPResources.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.mcp.tools.GetSchemaTool;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import java.util.TreeSet;
+
+/**
+ * MCP Resources surface. Exposes each database's schema at arcadedb://{database}/schema.
+ */
+public class MCPResources {
+  public static final String URI_SCHEME    = "arcadedb://";
+  public static final String SCHEMA_SUFFIX = "/schema";
+  public static final String MIME_TYPE     = "application/json";
+
+  private MCPResources() {
+  }
+
+  /**
+   * Enumerates the schema resources the user may read. A discovery call issued unprompted by most clients at session
+   * start, so a denial is expressed as an empty list rather than an error, and databases the user cannot access are
+   * omitted rather than reported.
+   */
+  public static JSONObject list(final ArcadeDBServer server, final ServerSecurityUser user, final MCPConfiguration config) {
+    final JSONArray resources = new JSONArray();
+
+    if (config.isAllowReads())
+      for (final String databaseName : new TreeSet<>(server.getDatabaseNames())) {
+        if (!user.canAccessToDatabase(databaseName))
+          continue;
+
+        resources.put(new JSONObject()
+            .put("uri", schemaURI(databaseName))
+            .put("name", databaseName + " schema")
+            .put("description", "Schema of the ArcadeDB database '" + databaseName
+                + "': types (vertex, edge, document), properties, indexes, inheritance.")
+            .put("mimeType", MIME_TYPE));
+      }
+
+    return new JSONObject().put("resources", resources);
+  }
+
+  /**
+   * Reads a schema resource. An unknown database, an unauthorized database, and a malformed URI are indistinguishable
+   * to the caller, so that this method cannot be used to probe which databases exist.
+   */
+  public static JSONObject read(final ArcadeDBServer server, final ServerSecurityUser user, final MCPConfiguration config,
+      final String uri) {
+    if (!config.isAllowReads())
+      throw new SecurityException("Read operations are not allowed by MCP configuration");
+
+    final String databaseName = parseSchemaURI(uri);
+    if (databaseName == null || !server.existsDatabase(databaseName) || !user.canAccessToDatabase(databaseName))
+      throw new MCPResourceNotFoundException("Resource not found: " + uri);
+
+    final Database database = server.getDatabase(databaseName);
+    final JSONObject schema = GetSchemaTool.buildSchema(database, databaseName);
+
+    final JSONArray contents = new JSONArray();
+    contents.put(new JSONObject()
+        .put("uri", uri)
+        .put("mimeType", MIME_TYPE)
+        .put("text", schema.toString()));
+
+    return new JSONObject().put("contents", contents);
+  }
+
+  public static String schemaURI(final String databaseName) {
+    return URI_SCHEME + databaseName + SCHEMA_SUFFIX;
+  }
+
+  /**
+   * Returns the database name in arcadedb://{database}/schema, or null when the URI does not match that shape.
+   * Parsed with string operations rather than java.net.URI on purpose: URI applies hostname rules to the authority,
+   * lowercasing it and rejecting the underscores that an ArcadeDB database name may legally contain, so
+   * arcadedb://My_DB/schema would otherwise resolve to nothing. A database name cannot contain '/', because it is a
+   * directory name on disk, so this parse round-trips exactly against what list() emits.
+   */
+  public static String parseSchemaURI(final String uri) {
+    if (uri == null || !uri.startsWith(URI_SCHEME) || !uri.endsWith(SCHEMA_SUFFIX))
+      return null;
+    if (uri.length() <= URI_SCHEME.length() + SCHEMA_SUFFIX.length())
+      return null;
+
+    final String databaseName = uri.substring(URI_SCHEME.length(), uri.length() - SCHEMA_SUFFIX.length());
+    if (databaseName.indexOf('/') >= 0)
+      return null;
+
+    return databaseName;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPStdioServer.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPStdioServer.java
@@ -18,24 +18,12 @@
  */
 package com.arcadedb.server.mcp;
 
-import com.arcadedb.Constants;
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
-import com.arcadedb.server.ArcadeDBServer;
-import com.arcadedb.server.mcp.tools.ExecuteCommandTool;
-import com.arcadedb.server.mcp.tools.FullTextSearchTool;
-import com.arcadedb.server.mcp.tools.GetSchemaTool;
-import com.arcadedb.server.mcp.tools.GetServerSettingsTool;
-import com.arcadedb.server.mcp.tools.ListDatabasesTool;
-import com.arcadedb.server.mcp.tools.ProfilerStartTool;
-import com.arcadedb.server.mcp.tools.ProfilerStatusTool;
-import com.arcadedb.server.mcp.tools.ProfilerStopTool;
-import com.arcadedb.server.mcp.tools.QueryTool;
-import com.arcadedb.server.mcp.tools.ServerStatusTool;
-import com.arcadedb.server.mcp.tools.SetServerSettingTool;
-import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.mcp.MCPDispatcher.MCPResponse;
 import com.arcadedb.server.security.ServerSecurityUser;
 
 import java.io.BufferedReader;
@@ -48,36 +36,17 @@ import java.util.logging.Level;
 /**
  * MCP server using stdio transport (JSON-RPC 2.0 over stdin/stdout, newline-delimited).
  * This allows ArcadeDB to work natively with mcp-proxy, Claude Desktop, Cursor, etc.
+ * Owns the stdio envelope only; all protocol routing lives in {@link MCPDispatcher}.
  */
 public class MCPStdioServer {
-  private static final String    MCP_PROTOCOL_VERSION = "2025-03-26";
-  private static final JSONArray TOOLS_LIST;
-
-  static {
-    TOOLS_LIST = new JSONArray();
-    TOOLS_LIST.put(ListDatabasesTool.getDefinition());
-    TOOLS_LIST.put(GetSchemaTool.getDefinition());
-    TOOLS_LIST.put(QueryTool.getDefinition());
-    TOOLS_LIST.put(ExecuteCommandTool.getDefinition());
-    TOOLS_LIST.put(FullTextSearchTool.getDefinition());
-    TOOLS_LIST.put(ServerStatusTool.getDefinition());
-    TOOLS_LIST.put(ProfilerStartTool.getDefinition());
-    TOOLS_LIST.put(ProfilerStopTool.getDefinition());
-    TOOLS_LIST.put(ProfilerStatusTool.getDefinition());
-    TOOLS_LIST.put(GetServerSettingsTool.getDefinition());
-    TOOLS_LIST.put(SetServerSettingTool.getDefinition());
-  }
-
-  private final ArcadeDBServer   server;
-  private final MCPConfiguration config;
+  private final MCPDispatcher      dispatcher;
   private final ServerSecurityUser user;
-  private final InputStream      input;
-  private final PrintStream      output;
+  private final InputStream        input;
+  private final PrintStream        output;
 
   public MCPStdioServer(final ArcadeDBServer server, final MCPConfiguration config, final ServerSecurityUser user,
       final InputStream input, final PrintStream output) {
-    this.server = server;
-    this.config = config;
+    this.dispatcher = new MCPDispatcher(server, config, "stdio");
     this.user = user;
     this.input = input;
     this.output = output;
@@ -141,101 +110,10 @@ public class MCPStdioServer {
   }
 
   private String dispatch(final JSONObject request) {
-    final String method = request.getString("method", "");
-    final JSONObject params = request.getJSONObject("params", new JSONObject());
-    final Object id = request.opt("id");
+    final MCPResponse response = dispatcher.dispatch(request, user);
 
-    LogManager.instance().log(this, Level.INFO, "MCP stdio %s (user=%s)", method, user.getName());
-
-    return switch (method) {
-      case "initialize" -> handleInitialize(id);
-      case "notifications/initialized" -> null; // notifications get no response
-      case "tools/list" -> handleToolsList(id);
-      case "tools/call" -> handleToolsCall(id, params);
-      case "ping" -> jsonRpcResult(id, new JSONObject());
-      default -> jsonRpcError(id, -32601, "Method not found: " + method);
-    };
-  }
-
-  private String handleInitialize(final Object id) {
-    final JSONObject result = new JSONObject();
-    result.put("protocolVersion", MCP_PROTOCOL_VERSION);
-
-    final JSONObject serverInfo = new JSONObject();
-    serverInfo.put("name", "arcadedb");
-    serverInfo.put("version", Constants.getVersion());
-    result.put("serverInfo", serverInfo);
-
-    final JSONObject capabilities = new JSONObject();
-    capabilities.put("tools", new JSONObject().put("listChanged", false));
-    result.put("capabilities", capabilities);
-
-    return jsonRpcResult(id, result);
-  }
-
-  private String handleToolsList(final Object id) {
-    final JSONObject result = new JSONObject();
-    result.put("tools", TOOLS_LIST);
-    return jsonRpcResult(id, result);
-  }
-
-  private String handleToolsCall(final Object id, final JSONObject params) {
-    final String toolName = params.getString("name", "");
-    final JSONObject args = params.getJSONObject("arguments", new JSONObject());
-
-    LogManager.instance().log(this, Level.INFO, "MCP stdio tools/call '%s' (user=%s)", toolName, user.getName());
-
-    try {
-      final JSONObject toolResult = switch (toolName) {
-        case "list_databases" -> ListDatabasesTool.execute(server, user, args, config);
-        case "get_schema" -> GetSchemaTool.execute(server, user, args, config);
-        case "query" -> QueryTool.execute(server, user, args, config);
-        case "execute_command" -> ExecuteCommandTool.execute(server, user, args, config);
-        case "full_text_search" -> FullTextSearchTool.execute(server, user, args, config);
-        case "server_status" -> ServerStatusTool.execute(server, user, args, config);
-        case "profiler_start" -> ProfilerStartTool.execute(server, user, args, config);
-        case "profiler_stop" -> ProfilerStopTool.execute(server, user, args, config);
-        case "profiler_status" -> ProfilerStatusTool.execute(server, user, args, config);
-        case "get_server_settings" -> GetServerSettingsTool.execute(server, user, args, config);
-        case "set_server_setting" -> SetServerSettingTool.execute(server, user, args, config);
-        default -> throw new IllegalArgumentException("Unknown tool: " + toolName);
-      };
-
-      final JSONObject result = new JSONObject();
-      final JSONArray content = new JSONArray();
-      content.put(new JSONObject()
-          .put("type", "text")
-          .put("text", toolResult.toString()));
-      result.put("content", content);
-      result.put("isError", false);
-      return jsonRpcResult(id, result);
-
-    } catch (final SecurityException e) {
-      LogManager.instance().log(this, Level.INFO, "MCP stdio tools/call '%s' -> permission denied: %s", toolName, e.getMessage());
-      return toolError(id, e.getMessage());
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING, "MCP stdio tools/call '%s' -> error: %s", toolName, e.getMessage());
-      return toolError(id, e.getMessage());
-    }
-  }
-
-  private static String toolError(final Object id, final String message) {
-    final JSONObject result = new JSONObject();
-    final JSONArray content = new JSONArray();
-    content.put(new JSONObject()
-        .put("type", "text")
-        .put("text", message));
-    result.put("content", content);
-    result.put("isError", true);
-    return jsonRpcResult(id, result);
-  }
-
-  private static String jsonRpcResult(final Object id, final JSONObject result) {
-    final JSONObject response = new JSONObject();
-    response.put("jsonrpc", "2.0");
-    response.put("id", id);
-    response.put("result", result);
-    return response.toString();
+    // A null body is a JSON-RPC notification, which is written back as nothing at all.
+    return response.json() == null ? null : response.json().toString();
   }
 
   private static String jsonRpcError(final Object id, final int code, final String message) {

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java
@@ -59,6 +59,15 @@ public class GetSchemaTool {
 
     final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
 
+    return buildSchema(database, databaseName);
+  }
+
+  /**
+   * Builds the JSON schema document for a database. The single source of truth for schema shaping: the get_schema
+   * tool and the arcadedb://{database}/schema resource both render from here, so their content cannot drift apart.
+   * Performs no permission or authorization check; the caller is responsible for both.
+   */
+  public static JSONObject buildSchema(final Database database, final String databaseName) {
     final Schema schema = database.getSchema();
     final JSONArray types = new JSONArray();
 

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPResourcesTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPResourcesTest.java
@@ -106,6 +106,28 @@ class MCPResourcesTest extends BaseGraphServerTest {
   }
 
   @Test
+  void readUnauthorizedDatabaseIsIndistinguishableFromUnknown() {
+    // An existing database the user cannot access must raise the same MCPResourceNotFoundException as an unknown
+    // database, and must be omitted from the list, so resources/read cannot be used to probe which databases exist.
+    if (!getServer(0).getSecurity().existsUser("restricteduser"))
+      getServer(0).getSecurity().createUser(new JSONObject()
+          .put("name", "restricteduser")
+          .put("password", getServer(0).getSecurity().encodePassword("restrictedpass"))
+          .put("databases", new JSONObject()
+              .put("otherdb", new JSONArray().put("admin"))));
+
+    final ServerSecurityUser restricted = getServer(0).getSecurity().authenticate("restricteduser", "restrictedpass", null);
+
+    assertThatThrownBy(() -> MCPResources.read(getServer(0), restricted, config, "arcadedb://graph/schema"))
+        .isInstanceOf(MCPResourceNotFoundException.class)
+        .hasMessageContaining("Resource not found");
+
+    final JSONArray resources = MCPResources.list(getServer(0), restricted, config).getJSONArray("resources");
+    for (int i = 0; i < resources.length(); i++)
+      assertThat(resources.getJSONObject(i).getString("uri")).isNotEqualTo("arcadedb://graph/schema");
+  }
+
+  @Test
   void parseSchemaURIPreservesCaseAndUnderscores() {
     // java.net.URI would lowercase the authority and reject the underscore, silently resolving this to nothing.
     assertThat(MCPResources.parseSchemaURI("arcadedb://My_DB/schema")).isEqualTo("My_DB");

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPResourcesTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPResourcesTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.mcp.tools.GetSchemaTool;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MCPResourcesTest extends BaseGraphServerTest {
+
+  private MCPConfiguration   config;
+  private ServerSecurityUser user;
+
+  @BeforeEach
+  void setupMCP() {
+    config = getServer(0).getMCPConfiguration();
+    config.setEnabled(true);
+    config.setAllowReads(true);
+    user = getServer(0).getSecurity().authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
+  }
+
+  @Test
+  void listExposesOneSchemaResourcePerDatabase() {
+    final JSONArray resources = MCPResources.list(getServer(0), user, config).getJSONArray("resources");
+
+    JSONObject graphResource = null;
+    for (int i = 0; i < resources.length(); i++)
+      if ("arcadedb://graph/schema".equals(resources.getJSONObject(i).getString("uri")))
+        graphResource = resources.getJSONObject(i);
+
+    assertThat(graphResource).isNotNull();
+    assertThat(graphResource.getString("name")).isEqualTo("graph schema");
+    assertThat(graphResource.getString("mimeType")).isEqualTo("application/json");
+    assertThat(graphResource.getString("description")).contains("graph");
+  }
+
+  @Test
+  void listIsEmptyWhenReadsDisabled() {
+    config.setAllowReads(false);
+
+    final JSONArray resources = MCPResources.list(getServer(0), user, config).getJSONArray("resources");
+
+    assertThat(resources.length()).isZero();
+  }
+
+  @Test
+  void readReturnsSchemaIdenticalToGetSchemaTool() {
+    final JSONObject resource = MCPResources.read(getServer(0), user, config, "arcadedb://graph/schema");
+
+    final JSONArray contents = resource.getJSONArray("contents");
+    assertThat(contents.length()).isEqualTo(1);
+    assertThat(contents.getJSONObject(0).getString("uri")).isEqualTo("arcadedb://graph/schema");
+    assertThat(contents.getJSONObject(0).getString("mimeType")).isEqualTo("application/json");
+
+    final JSONObject toolResult = GetSchemaTool.execute(getServer(0), user, new JSONObject().put("database", "graph"), config);
+
+    assertThat(contents.getJSONObject(0).getString("text")).isEqualTo(toolResult.toString());
+  }
+
+  @Test
+  void readRejectsUnknownDatabase() {
+    assertThatThrownBy(() -> MCPResources.read(getServer(0), user, config, "arcadedb://nosuchdb/schema"))
+        .isInstanceOf(MCPResourceNotFoundException.class)
+        .hasMessageContaining("Resource not found");
+  }
+
+  @Test
+  void readRejectsMalformedURI() {
+    // Wrong scheme, wrong suffix, empty database, embedded slash, and a URI too short to hold a database name.
+    for (final String uri : new String[] { "http://graph/schema", "arcadedb://graph/tables", "arcadedb:///schema",
+        "arcadedb://a/b/schema", "arcadedb://schema", "graph", "" })
+      assertThatThrownBy(() -> MCPResources.read(getServer(0), user, config, uri))
+          .isInstanceOf(MCPResourceNotFoundException.class);
+  }
+
+  @Test
+  void readDeniedWhenReadsDisabled() {
+    config.setAllowReads(false);
+
+    assertThatThrownBy(() -> MCPResources.read(getServer(0), user, config, "arcadedb://graph/schema"))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not allowed");
+  }
+
+  @Test
+  void parseSchemaURIPreservesCaseAndUnderscores() {
+    // java.net.URI would lowercase the authority and reject the underscore, silently resolving this to nothing.
+    assertThat(MCPResources.parseSchemaURI("arcadedb://My_DB/schema")).isEqualTo("My_DB");
+    assertThat(MCPResources.parseSchemaURI("arcadedb://graph/schema")).isEqualTo("graph");
+    assertThat(MCPResources.parseSchemaURI("arcadedb://schema")).isNull();
+    assertThat(MCPResources.parseSchemaURI(null)).isNull();
+  }
+
+  @Test
+  void schemaURIRoundTripsThroughParse() {
+    assertThat(MCPResources.parseSchemaURI(MCPResources.schemaURI("My_DB"))).isEqualTo("My_DB");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -1320,6 +1320,44 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     }
   }
 
+  @Test
+  void disabledServerErrorEchoesRequestId() throws Exception {
+    saveMCPConfig(new JSONObject()
+        .put("enabled", false)
+        .put("allowedUsers", new JSONArray().put("root")));
+
+    final HttpURLConnection connection = (HttpURLConnection) new URI(getMcpUrl()).toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", getBasicAuth());
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 409)
+        .put("method", "initialize")
+        .put("params", new JSONObject());
+    try (final DataOutputStream out = new DataOutputStream(connection.getOutputStream())) {
+      out.write(request.toString().getBytes(StandardCharsets.UTF_8));
+    }
+    connection.connect();
+
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(503);
+      // A 503 body arrives on the error stream; it must echo the request id per JSON-RPC 2.0.
+      final String body = FileUtils.readStreamAsString(connection.getErrorStream(), "utf8");
+      final JSONObject response = new JSONObject(body);
+      assertThat(response.getInt("id")).isEqualTo(409);
+      assertThat(response.getJSONObject("error").getInt("code")).isEqualTo(-32600);
+    } finally {
+      connection.disconnect();
+      saveMCPConfig(new JSONObject()
+          .put("enabled", true)
+          .put("allowReads", true)
+          .put("allowedUsers", new JSONArray().put("root")));
+    }
+  }
+
   // ---- Helper methods ----
 
   private JSONObject mcpRequest(final JSONObject request) throws Exception {

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -31,6 +31,8 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -1127,6 +1129,195 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     final String errorText = response.getJSONArray("content").getJSONObject(0).getString("text");
     assertThat(errorText).contains("indexName");
     assertThat(errorText).contains("typeName");
+  }
+
+  @Test
+  void initializeAdvertisesResourcesCapability() throws Exception {
+    final JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 400)
+        .put("method", "initialize")
+        .put("params", new JSONObject()));
+
+    final JSONObject capabilities = response.getJSONObject("result").getJSONObject("capabilities");
+    assertThat(capabilities.has("resources")).isTrue();
+    final JSONObject resources = capabilities.getJSONObject("resources");
+    assertThat(resources.getBoolean("listChanged")).isFalse();
+    assertThat(resources.getBoolean("subscribe")).isFalse();
+  }
+
+  @Test
+  void resourcesList() throws Exception {
+    final JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 401)
+        .put("method", "resources/list")
+        .put("params", new JSONObject()));
+
+    final JSONArray resources = response.getJSONObject("result").getJSONArray("resources");
+
+    JSONObject graphResource = null;
+    for (int i = 0; i < resources.length(); i++)
+      if ("arcadedb://graph/schema".equals(resources.getJSONObject(i).getString("uri")))
+        graphResource = resources.getJSONObject(i);
+
+    assertThat(graphResource).isNotNull();
+    assertThat(graphResource.getString("name")).isEqualTo("graph schema");
+    assertThat(graphResource.getString("mimeType")).isEqualTo("application/json");
+  }
+
+  @Test
+  void resourcesListMatchesListDatabases() throws Exception {
+    final JSONObject listResponse = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 402)
+        .put("method", "resources/list")
+        .put("params", new JSONObject()));
+
+    final Set<String> fromResources = new HashSet<>();
+    final JSONArray resources = listResponse.getJSONObject("result").getJSONArray("resources");
+    for (int i = 0; i < resources.length(); i++) {
+      final String uri = resources.getJSONObject(i).getString("uri");
+      fromResources.add(uri.substring("arcadedb://".length(), uri.length() - "/schema".length()));
+    }
+
+    final JSONObject toolResponse = callTool("list_databases", new JSONObject());
+    final JSONArray databases = new JSONObject(
+        toolResponse.getJSONArray("content").getJSONObject(0).getString("text")).getJSONArray("databases");
+
+    final Set<String> fromTool = new HashSet<>();
+    for (int i = 0; i < databases.length(); i++)
+      fromTool.add(databases.getString(i));
+
+    assertThat(fromResources).isEqualTo(fromTool);
+  }
+
+  @Test
+  void resourcesReadMatchesGetSchemaTool() throws Exception {
+    final JSONObject readResponse = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 403)
+        .put("method", "resources/read")
+        .put("params", new JSONObject().put("uri", "arcadedb://graph/schema")));
+
+    final JSONArray contents = readResponse.getJSONObject("result").getJSONArray("contents");
+    assertThat(contents.length()).isEqualTo(1);
+    assertThat(contents.getJSONObject(0).getString("uri")).isEqualTo("arcadedb://graph/schema");
+    assertThat(contents.getJSONObject(0).getString("mimeType")).isEqualTo("application/json");
+
+    final JSONObject toolResponse = callTool("get_schema", new JSONObject().put("database", "graph"));
+    final String toolText = toolResponse.getJSONArray("content").getJSONObject(0).getString("text");
+
+    assertThat(contents.getJSONObject(0).getString("text")).isEqualTo(toolText);
+  }
+
+  @Test
+  void resourcesReadUnknownDatabaseReturnsNotFound() throws Exception {
+    final JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 404)
+        .put("method", "resources/read")
+        .put("params", new JSONObject().put("uri", "arcadedb://nosuchdb/schema")));
+
+    assertThat(response.has("error")).isTrue();
+    assertThat(response.getJSONObject("error").getInt("code")).isEqualTo(-32002);
+  }
+
+  @Test
+  void resourcesReadMalformedUriReturnsNotFound() throws Exception {
+    final JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 405)
+        .put("method", "resources/read")
+        .put("params", new JSONObject().put("uri", "arcadedb://graph/tables")));
+
+    assertThat(response.has("error")).isTrue();
+    assertThat(response.getJSONObject("error").getInt("code")).isEqualTo(-32002);
+  }
+
+  @Test
+  void resourcesDeniedWhenReadsDisabled() throws Exception {
+    saveMCPConfig(new JSONObject()
+        .put("enabled", true)
+        .put("allowReads", false)
+        .put("allowedUsers", new JSONArray().put("root")));
+
+    try {
+      final JSONObject listResponse = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 406)
+          .put("method", "resources/list")
+          .put("params", new JSONObject()));
+
+      // A discovery call stays quiet: nothing is readable, so nothing is listed.
+      assertThat(listResponse.getJSONObject("result").getJSONArray("resources").length()).isZero();
+
+      final JSONObject readResponse = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 407)
+          .put("method", "resources/read")
+          .put("params", new JSONObject().put("uri", "arcadedb://graph/schema")));
+
+      assertThat(readResponse.has("error")).isTrue();
+      assertThat(readResponse.getJSONObject("error").getInt("code")).isEqualTo(-32600);
+      assertThat(readResponse.getJSONObject("error").getString("message")).contains("not allowed");
+    } finally {
+      // Restore for the other tests in this class.
+      saveMCPConfig(new JSONObject()
+          .put("enabled", true)
+          .put("allowReads", true)
+          .put("allowedUsers", new JSONArray().put("root")));
+    }
+  }
+
+  @Test
+  void resourcesListOmitsUnauthorizedDatabases() throws Exception {
+    saveMCPConfig(new JSONObject()
+        .put("enabled", true)
+        .put("allowReads", true)
+        .put("allowedUsers", new JSONArray().put("root").put("restricteduser")));
+
+    // A user authorized only for a database that does not exist here, so "graph" must not appear in its resource list.
+    if (!getServer(0).getSecurity().existsUser("restricteduser"))
+      getServer(0).getSecurity().createUser(new JSONObject()
+          .put("name", "restricteduser")
+          .put("password", getServer(0).getSecurity().encodePassword("restrictedpass"))
+          .put("databases", new JSONObject()
+              .put("otherdb", new JSONArray().put("admin"))));
+
+    final String restrictedAuth = "Basic " + Base64.getEncoder()
+        .encodeToString("restricteduser:restrictedpass".getBytes(StandardCharsets.UTF_8));
+
+    final HttpURLConnection connection = (HttpURLConnection) new URI(getMcpUrl()).toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", restrictedAuth);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 408)
+        .put("method", "resources/list")
+        .put("params", new JSONObject());
+    try (final DataOutputStream out = new DataOutputStream(connection.getOutputStream())) {
+      out.write(request.toString().getBytes(StandardCharsets.UTF_8));
+    }
+    connection.connect();
+
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      final String body = FileUtils.readStreamAsString(connection.getInputStream(), "utf8");
+      final JSONArray resources = new JSONObject(body).getJSONObject("result").getJSONArray("resources");
+
+      for (int i = 0; i < resources.length(); i++)
+        assertThat(resources.getJSONObject(i).getString("uri")).isNotEqualTo("arcadedb://graph/schema");
+    } finally {
+      connection.disconnect();
+      saveMCPConfig(new JSONObject()
+          .put("enabled", true)
+          .put("allowReads", true)
+          .put("allowedUsers", new JSONArray().put("root")));
+    }
   }
 
   // ---- Helper methods ----

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
@@ -224,6 +224,60 @@ class MCPStdioServerTest extends BaseGraphServerTest {
     assertThat(resp3.has("result")).isTrue();
   }
 
+  @Test
+  void initializeAdvertisesResourcesAndInstructions() throws Exception {
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 400)
+        .put("method", "initialize")
+        .put("params", new JSONObject());
+
+    final JSONObject response = sendSingleRequest(request);
+
+    final JSONObject result = response.getJSONObject("result");
+    final JSONObject resources = result.getJSONObject("capabilities").getJSONObject("resources");
+    assertThat(resources.getBoolean("listChanged")).isFalse();
+    assertThat(resources.getBoolean("subscribe")).isFalse();
+    assertThat(result.getString("instructions")).contains("arcadedb://{database}/schema");
+  }
+
+  @Test
+  void resourcesList() throws Exception {
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 401)
+        .put("method", "resources/list")
+        .put("params", new JSONObject());
+
+    final JSONObject response = sendSingleRequest(request);
+
+    final JSONArray resources = response.getJSONObject("result").getJSONArray("resources");
+    boolean foundGraph = false;
+    for (int i = 0; i < resources.length(); i++)
+      if ("arcadedb://graph/schema".equals(resources.getJSONObject(i).getString("uri")))
+        foundGraph = true;
+    assertThat(foundGraph).isTrue();
+  }
+
+  @Test
+  void resourcesRead() throws Exception {
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 402)
+        .put("method", "resources/read")
+        .put("params", new JSONObject().put("uri", "arcadedb://graph/schema"));
+
+    final JSONObject response = sendSingleRequest(request);
+
+    final JSONArray contents = response.getJSONObject("result").getJSONArray("contents");
+    assertThat(contents.length()).isEqualTo(1);
+    assertThat(contents.getJSONObject(0).getString("mimeType")).isEqualTo("application/json");
+
+    final JSONObject schema = new JSONObject(contents.getJSONObject(0).getString("text"));
+    assertThat(schema.getString("database")).isEqualTo("graph");
+    assertThat(schema.getJSONArray("types").length()).isGreaterThan(0);
+  }
+
   // ---- Helpers ----
 
   private JSONObject sendSingleRequest(final JSONObject request) {


### PR DESCRIPTION
Closes #4865. Part of epic #4859 (Wave 1).

## What

Exposes each accessible database's schema as an MCP **Resource** at `arcadedb://{database}/schema`, over both the HTTP and stdio transports. A client that supports Resources can now auto-load schema at session start instead of spending a model turn on the `get_schema` tool. `get_schema` stays, and stays recommended, for clients that do not implement Resources.

`initialize` now advertises `capabilities.resources` with `listChanged: false` and `subscribe: false`. Both flags are honest: no change-notification or subscription machinery is built.

## The refactor

`MCPHttpHandler` and `MCPStdioServer` were near-duplicates: each carried its own `TOOLS_LIST`, its own `MCP_PROTOCOL_VERSION`, its own method `switch`, and its own copies of the JSON-RPC envelope helpers. Adding a second protocol primitive would have paid that duplication twice more.

A new `MCPDispatcher` now owns the whole JSON-RPC surface (protocol version, tool list, `instructions`, gating, method routing, envelope shaping) and both transports collapse to thin adapters. Transports own I/O and their own parse errors; the dispatcher owns protocol.

Net effect: a whole new protocol primitive lands for **net +112 lines** of main source, because ~346 lines of transport duplication were deleted.

The schema walk was extracted to a single `GetSchemaTool.buildSchema(Database, String)`. The tool and the resource both render from it, so the issue's headline criterion (tool output and resource content are identical) is true **by construction** rather than by coincidence. It cannot drift, because there is only one implementation.

## Behavior change (stdio transport)

`MCPStdioServer` now honors `MCPConfiguration.isEnabled()` and `isUserAllowed()`, which it previously ignored, and its `initialize` response now includes the `instructions` block that the HTTP transport already returned. The default path is unaffected: `main()` sets `enabled=true` and authenticates as `root`, and `root` is the default sole entry in `allowedUsers`. A stdio deployment that had rewritten `allowedUsers` to omit `root` will now be refused, which is arguably a latent bug being fixed.

**This warrants a release note.**

## Design notes

- **The resource URI is parsed with plain string operations, deliberately not `java.net.URI`.** `URI.getHost()` applies hostname syntax rules: it lowercases the authority and returns `null` for an authority containing an underscore. ArcadeDB database names are case-sensitive and may legally contain `_`, so `arcadedb://My_DB/schema` would silently resolve to nothing under `java.net.URI`.
- **`resources/read` deliberately departs from the house error convention.** `MCPToolUtils.resolveDatabase` enumerates the available databases in its error text so the model can self-correct. That is right for tools, where the model supplies the name from memory and can guess wrong. Here, unknown database, unauthorized database, and malformed URI all collapse to one indistinguishable `-32002`, so `resources/read` cannot be used to probe which databases exist. Safe because read URIs come from `resources/list`, so a legitimate caller never guesses one.
- **`list` hides, `read` errors.** With `allowReads=false`, `resources/list` returns an empty array (a discovery call most clients issue unprompted, so a reads-disabled server stays quiet) while `resources/read` fails loudly with `-32600`.

## Testing

Tool count stays at 11: this adds a protocol primitive, not a tool.

- **New `MCPResourcesTest`** (8 tests): transport-free calls into `MCPResources`; `read` content equals `GetSchemaTool.execute` output; malformed-URI shapes; the `java.net.URI` case/underscore trap; URI round-trip.
- **`MCPServerPluginTest`** (+8): `resources` capability advertised; `resources/list` set equals the `list_databases` set; **`get_schema` output equals `resources/read` content text**; `-32002` for unknown database and malformed URI; unauthorized databases omitted from the list; `allowReads=false` behavior.
- **`MCPStdioServerTest`** (+3): `resources/list` and `resources/read` over stdio; `initialize` advertises `resources` and now carries `instructions`.

**The existing MCP suites are the regression net for the dispatcher extraction, and they pass completely unedited.** The test diff against `main` is **additions only** - zero deletions in any test file - so the old suites remain an untainted control.

- 100 MCP tests green across all 5 MCP test classes
- Full `server` module green: 601 tests, 0 failures

## Sequencing

This rewrites `MCPHttpHandler.java` and `MCPStdioServer.java`, the two files that #4860 (`vector_search`), #4863 (`sample_records`), and #4864 (`upsert_entity`/`upsert_relationship`) also edit. **#4865 should land before those three**, with the siblings rebased onto it: each of them adds a tool, which after this refactor means one `TOOLS_LIST` line and one `switch` arm instead of two of each.

## Out of scope

`resources/templates/list`, subscriptions, any resource other than schema, and the out-of-tree `arcadedb-docs` update (tracked separately, consistent with how #4862 handled it). No new configuration flag; default permissions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
