### PR TITLE
fix: edge-append merge reverted concurrent writes on multi-page edge chunks

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -696,6 +696,17 @@ public class TransactionContext implements Transaction {
 
       final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(segmentRID.getBucketId());
 
+      // MULTI-PAGE / INDIRECTED CHUNK: the rebase re-derives ONE page, but a record whose content continues on
+      // other pages was drain-written there through page copies created only at drain time - copies that PASS
+      // the version check while carrying this transaction's STALE view of the record's continuation bytes.
+      // Rebasing would commit that stale slice, silently reverting concurrent appends on the continuation page
+      // (issue #565: zeroed/shifted chunk tails on chunks straddling a page boundary). Only a record living
+      // entirely in place on the conflicted page can be safely re-derived; anything else falls back to a full
+      // retry.
+      if (!bucket.isRecordStoredInSinglePage(segmentRID))
+        throw new ConcurrentModificationException(
+            "Edge-append rebase not possible: chunk " + segmentRID + " spans multiple pages. Please retry the operation");
+
       // Load the chunk fresh from the (now current) page, bypassing the tx record cache which still holds the
       // stale, already-appended instance. A concurrently-vanished chunk (RecordNotFoundException) cannot happen
       // under the held commit lock; if it ever did, fall back to a full retry rather than aborting the tx.

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -289,6 +289,42 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     }
   }
 
+  /**
+   * Tells whether the record is stored entirely in place on its own page (positive size marker), as opposed to
+   * a placeholder indirection or a multi-page record whose continuation chunks live on other pages. The
+   * commit-time edge-append rebase ({@code TransactionContext.rebaseEdgeAppends}) relies on this: rebasing
+   * re-reads and re-writes a record assuming its bytes live on the ONE conflicted page, so any record with
+   * content on other pages must fall back to a full-transaction retry - re-writing it would publish the
+   * transaction's stale copy of the continuation pages, silently reverting concurrently committed bytes there
+   * (those pages pass the MVCC version check because their transaction copy is created only at drain time).
+   * Reads the CURRENT state through the transaction (the caller holds the file's commit lock).
+   */
+  public boolean isRecordStoredInSinglePage(final RID rid) {
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    if (pageId >= pageCount.get() && pageId >= getTotalPages())
+      return false;
+
+    try {
+      final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
+
+      final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
+      if (positionInPage >= recordCountInPage)
+        return false;
+
+      final int recordPositionInPage = getRecordPositionInPage(page, positionInPage);
+      if (recordPositionInPage == 0)
+        return false;
+
+      final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
+      return recordSize[0] > 0;
+
+    } catch (final IOException e) {
+      throw new DatabaseOperationException("Error on checking record layout for " + rid);
+    }
+  }
+
   @Override
   public void deleteRecord(final RID rid) {
     database.checkPermissionsOnFile(fileId, SecurityDatabaseUser.ACCESS.DELETE_RECORD);

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -259,30 +259,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   public boolean existsRecord(final RID rid) {
     database.checkPermissionsOnFile(fileId, SecurityDatabaseUser.ACCESS.READ_RECORD);
 
-    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
-    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
-
-    if (pageId >= pageCount.get()) {
-      final int txPageCount = getTotalPages();
-      if (pageId >= txPageCount)
-        return false;
-    }
-
     try {
-      final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
-
-      final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
-      if (positionInPage >= recordCountInPage)
-        return false;
-
-      final int recordPositionInPage = getRecordPositionInPage(page, positionInPage);
-      if (recordPositionInPage == 0)
-        // DELETED RECORD (>= 24.1.1, IT WAS CLEANED CORRUPTED RECORD BEFORE)
-        return false;
-
-      final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
-
-      return recordSize[0] > 0 || recordSize[0] == RECORD_PLACEHOLDER_POINTER || recordSize[0] == FIRST_CHUNK;
+      final long[] recordSize = readRecordSizeMarker(rid);
+      return recordSize != null && (recordSize[0] > 0 || recordSize[0] == RECORD_PLACEHOLDER_POINTER
+          || recordSize[0] == FIRST_CHUNK);
 
     } catch (final IOException e) {
       throw new DatabaseOperationException("Error on checking record existence for " + rid);
@@ -300,29 +280,45 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * Reads the CURRENT state through the transaction (the caller holds the file's commit lock).
    */
   public boolean isRecordStoredInSinglePage(final RID rid) {
-    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
-    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
-
-    if (pageId >= pageCount.get() && pageId >= getTotalPages())
+    if (rid == null || rid.getPosition() < 0)
       return false;
 
     try {
-      final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
-
-      final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
-      if (positionInPage >= recordCountInPage)
-        return false;
-
-      final int recordPositionInPage = getRecordPositionInPage(page, positionInPage);
-      if (recordPositionInPage == 0)
-        return false;
-
-      final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
-      return recordSize[0] > 0;
+      final long[] recordSize = readRecordSizeMarker(rid);
+      return recordSize != null && recordSize[0] > 0;
 
     } catch (final IOException e) {
-      throw new DatabaseOperationException("Error on checking record layout for " + rid);
+      throw new DatabaseOperationException("Error on checking record layout for " + rid, e);
     }
+  }
+
+  /**
+   * Reads the raw size marker of the record's slot on its page through the transaction (positive = in-place
+   * record, {@link #RECORD_PLACEHOLDER_POINTER}, {@link #FIRST_CHUNK}, {@link #NEXT_CHUNK}, negative =
+   * placeholder content), or {@code null} when the page or slot does not exist or the record was deleted.
+   */
+  private long[] readRecordSizeMarker(final RID rid) throws IOException {
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    if (pageId >= pageCount.get()) {
+      final int txPageCount = getTotalPages();
+      if (pageId >= txPageCount)
+        return null;
+    }
+
+    final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
+
+    final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
+    if (positionInPage >= recordCountInPage)
+      return null;
+
+    final int recordPositionInPage = getRecordPositionInPage(page, positionInPage);
+    if (recordPositionInPage == 0)
+      // DELETED RECORD (>= 24.1.1, IT WAS CLEANED CORRUPTED RECORD BEFORE)
+      return null;
+
+    return page.readNumberAndSize(recordPositionInPage);
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeConcurrentStressTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeConcurrentStressTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Commutative edge-append merge (GRAPH_EDGE_APPEND_MERGE, new in 26.7.2) under concurrent ADD + REMOVE on the
+ * same hot vertex, on the CLASSIC (non-striped) layout - i.e. the exact configuration of a 26.7.2 deployment.
+ * <p>
+ * The merge rebases a conflicting edge-list page by re-applying this transaction's tracked appends on top of
+ * the current committed page. Correctness depends on every NON-append write to that page poisoning it first
+ * (removal relink, chunk allocation, chunk delete). A gap there would let a rebase re-derive a page from
+ * committed-state + appends and drop a concurrent removal's relink - producing a chain whose bytes no longer
+ * parse, which surfaces later as a truncated read (BufferUnderflowException) on any traversal of the vertex.
+ */
+class EdgeAppendMergeConcurrentStressTest extends TestHelper {
+  private static final int THREADS         = 8;
+  private static final int EDGES_PER_THREAD = 400;
+
+  private int     savedThreshold;
+  private boolean savedMerge;
+
+  @BeforeEach
+  void saveConfig() {
+    savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+    savedMerge = GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean();
+  }
+
+  @AfterEach
+  void restoreConfig() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(savedMerge);
+  }
+
+  @Test
+  void concurrentAddAndRemoveOnHotVertexKeepsChainReadable() throws Exception {
+    // 26.7.2 SHAPE: the striped super-node layout did not exist, so the hot vertex keeps ONE classic chain and
+    // every writer contends on its head chunk page - which is precisely what the merge was built to rebase.
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(0);
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(true);
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account", 4).createProperty("number", Type.INTEGER);
+      database.getSchema().createEdgeType("TRANSFERS", 8);
+    });
+
+    final RID[] hubHolder = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account");
+      hub.set("number", 0);
+      hub.save();
+      hubHolder[0] = hub.getIdentity();
+    });
+    final RID hubRID = hubHolder[0];
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    final List<RID> added = Collections.synchronizedList(new ArrayList<>());
+    final AtomicInteger removed = new AtomicInteger();
+    final CountDownLatch start = new CountDownLatch(1);
+    final List<Thread> threads = new ArrayList<>();
+
+    for (int t = 0; t < THREADS; t++) {
+      final int threadId = t;
+      final Thread thread = new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < EDGES_PER_THREAD; i++) {
+            final int n = threadId * EDGES_PER_THREAD + i;
+
+            // ADD: a tracked, rebasable in-chunk append onto the hot vertex's head chunk.
+            final RID[] srcHolder = new RID[1];
+            database.transaction(() -> {
+              final MutableVertex src = database.newVertex("Account");
+              src.set("number", n + 1);
+              src.save();
+              src.newEdge("TRANSFERS", hubRID);
+              srcHolder[0] = src.getIdentity();
+            }, true, 50);
+            added.add(srcHolder[0]);
+
+            // REMOVE: a NON-commutative write (relink / possible chunk delete) that must poison the page,
+            // racing the other threads' appends onto the same chunks.
+            if (i % 7 == 3) {
+              RID victim = null;
+              synchronized (added) {
+                if (added.size() > 20)
+                  victim = added.remove(added.size() / 2);
+              }
+              if (victim != null) {
+                final RID v = victim;
+                database.transaction(() -> v.asVertex(true).delete(), true, 50);
+                removed.incrementAndGet();
+              }
+            }
+
+            // READ: traverse the hot vertex while it is being mutated - this is where a page whose bytes no
+            // longer parse shows up as a BufferUnderflowException.
+            if (i % 11 == 5)
+              database.transaction(() -> hubRID.asVertex(true).countEdges(Vertex.DIRECTION.IN, "TRANSFERS"), true, 50);
+          }
+        } catch (final Throwable e) {
+          errors.add(e);
+        }
+      }, "writer-" + t);
+      threads.add(thread);
+      thread.start();
+    }
+
+    start.countDown();
+    for (final Thread thread : threads)
+      thread.join();
+
+    if (!errors.isEmpty()) {
+      for (final Throwable e : errors)
+        e.printStackTrace();
+      throw new AssertionError(errors.size() + " thread(s) failed, first: " + errors.getFirst(), errors.getFirst());
+    }
+
+    final int expected = THREADS * EDGES_PER_THREAD - removed.get();
+    final long merges = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges;
+    System.out.println(">>> expected=" + expected + " removed=" + removed.get() + " edgeAppendMerges=" + merges);
+
+    // The whole point of this test is the REBASE path: if no merge ever fired, a green result proves nothing.
+    assertThat(merges).as("edge-append rebase must actually have fired").isGreaterThan(0);
+
+    // THE CHAIN MUST STILL PARSE AND COUNT EXACTLY.
+    database.transaction(() -> {
+      assertThat(hubRID.asVertex(true).countEdges(Vertex.DIRECTION.IN, "TRANSFERS")).isEqualTo(expected);
+      try (final ResultSet rs = database.query("SQL",
+          "SELECT number, both().size() FROM Account ORDER BY both().size() DESC LIMIT 5")) {
+        final Result top = rs.next();
+        System.out.println(">>> TOP ROW: " + top.toJSON());
+        assertThat(top.<Number>getProperty("both().size()").intValue()).isEqualTo(expected);
+      }
+      // EVERY SURVIVING EDGE MUST STILL BE REACHABLE (no append lost to a rebase).
+      int seen = 0;
+      for (final Vertex ignored : hubRID.asVertex(true).getVertices(Vertex.DIRECTION.IN, "TRANSFERS"))
+        seen++;
+      assertThat(seen).isEqualTo(expected);
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeConcurrentStressTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeConcurrentStressTest.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -48,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * committed-state + appends and drop a concurrent removal's relink - producing a chain whose bytes no longer
  * parse, which surfaces later as a truncated read (BufferUnderflowException) on any traversal of the vertex.
  */
+@Tag("slow")
 class EdgeAppendMergeConcurrentStressTest extends TestHelper {
   private static final int THREADS         = 8;
   private static final int EDGES_PER_THREAD = 400;
@@ -153,7 +155,6 @@ class EdgeAppendMergeConcurrentStressTest extends TestHelper {
 
     final int expected = THREADS * EDGES_PER_THREAD - removed.get();
     final long merges = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges;
-    System.out.println(">>> expected=" + expected + " removed=" + removed.get() + " edgeAppendMerges=" + merges);
 
     // The whole point of this test is the REBASE path: if no merge ever fired, a green result proves nothing.
     assertThat(merges).as("edge-append rebase must actually have fired").isGreaterThan(0);
@@ -164,7 +165,6 @@ class EdgeAppendMergeConcurrentStressTest extends TestHelper {
       try (final ResultSet rs = database.query("SQL",
           "SELECT number, both().size() FROM Account ORDER BY both().size() DESC LIMIT 5")) {
         final Result top = rs.next();
-        System.out.println(">>> TOP ROW: " + top.toJSON());
         assertThat(top.<Number>getProperty("both().size()").intValue()).isEqualTo(expected);
       }
       // EVERY SURVIVING EDGE MUST STILL BE REACHABLE (no append lost to a rebase).

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeMultiPageChunkTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeMultiPageChunkTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -51,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * short concurrent run reliably exercises the multi-page + rebase combination the 64 KB default only hits at
  * scale. The fix makes multi-page/indirected chunk records non-rebasable (full retry instead).
  */
+@Tag("slow")
 class EdgeAppendMergeMultiPageChunkTest extends TestHelper {
   private static final int ADDERS     = 8;
   private static final int PER_ADDER  = 1_500;

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeMultiPageChunkTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeMultiPageChunkTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #565: the commutative edge-append merge (GRAPH_EDGE_APPEND_MERGE) corrupted edge
+ * chunks STORED AS MULTI-PAGE RECORDS (a chunk allocated near the end of a page continues on the next page).
+ * <p>
+ * The rebase re-derived only the conflicted FIRST page of the chunk; the record's continuation slice was
+ * committed from the transaction's stale drain-time copy, whose page passed the MVCC version check because it
+ * was created only at drain time. Concurrently committed bytes on the continuation page were silently
+ * reverted: zeroed tails on young chunks, shifted pairs (aliased edges/vertices) on filled ones, and lost
+ * edges - exactly the client-reported corruption shape behind #565.
+ * <p>
+ * A 16 KB bucket page makes a cap-size (8 KB) chunk straddle a page boundary roughly every other chunk, so a
+ * short concurrent run reliably exercises the multi-page + rebase combination the 64 KB default only hits at
+ * scale. The fix makes multi-page/indirected chunk records non-rebasable (full retry instead).
+ */
+class EdgeAppendMergeMultiPageChunkTest extends TestHelper {
+  private static final int ADDERS     = 8;
+  private static final int PER_ADDER  = 1_500;
+
+  private int     savedThreshold;
+  private boolean savedMerge;
+  private int     savedPageSize;
+
+  @BeforeEach
+  void saveConfig() {
+    savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+    savedMerge = GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean();
+    savedPageSize = GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getValueAsInteger();
+  }
+
+  @AfterEach
+  void restoreConfig() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(savedMerge);
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(savedPageSize);
+  }
+
+  @Test
+  void concurrentAppendsOnPageStraddlingChunksLoseNothing() throws Exception {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(0);
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(true);
+    // The buckets (including the lazily-created *_in_edges chunk bucket) are created below, so the small page
+    // applies to them: a cap-size 8 KB chunk then straddles a 16 KB page boundary roughly every other chunk.
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(16_384);
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account", 8).createProperty("number", Type.INTEGER);
+      database.getSchema().createEdgeType("TRANSFERS", 8);
+    });
+
+    final RID[] hubHolder = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account");
+      hub.set("number", 0);
+      hub.save();
+      hubHolder[0] = hub.getIdentity();
+    });
+    final RID hubRID = hubHolder[0];
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    final Set<String> expectedPairs = java.util.Collections.synchronizedSet(new HashSet<>(ADDERS * PER_ADDER));
+    final CountDownLatch start = new CountDownLatch(1);
+    final List<Thread> threads = new ArrayList<>();
+
+    for (int t = 0; t < ADDERS; t++) {
+      final int id = t;
+      threads.add(new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < PER_ADDER; i++) {
+            final int n = id * PER_ADDER + i;
+            final String[] pairHolder = new String[1];
+            database.transaction(() -> {
+              final MutableVertex src = database.newVertex("Account");
+              src.set("number", n + 1);
+              src.save();
+              final MutableEdge e = src.newEdge("TRANSFERS", hubRID);
+              pairHolder[0] = e.getIdentity() + "|" + src.getIdentity();
+            }, true, 100);
+            expectedPairs.add(pairHolder[0]);
+          }
+        } catch (final Throwable e) {
+          errors.add(e);
+        }
+      }, "adder-" + t));
+    }
+    threads.forEach(Thread::start);
+    start.countDown();
+    for (final Thread thread : threads)
+      thread.join();
+
+    if (!errors.isEmpty()) {
+      errors.getFirst().printStackTrace();
+      throw new AssertionError(errors.size() + " thread(s) failed, first: " + errors.getFirst(), errors.getFirst());
+    }
+
+    final long merges = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges;
+    assertThat(merges).as("edge-append rebase must actually have fired").isGreaterThan(0);
+
+    // WALK THE HUB'S RAW PAIR STREAM: every appended pair present exactly once, nothing alien, no zeroed bytes.
+    final List<String> diskPairs = new ArrayList<>(expectedPairs.size());
+    database.transaction(() -> {
+      EdgeSegment seg = (EdgeSegment) database.lookupByRID(((VertexInternal) hubRID.asVertex(true)).getInEdgesHeadChunk(), true);
+      while (seg != null) {
+        final MutableEdgeSegment m = (MutableEdgeSegment) seg;
+        final AtomicInteger pos = new AtomicInteger(MutableEdgeSegment.CONTENT_START_POSITION);
+        final int used = m.getUsed();
+        while (pos.get() < used) {
+          final RID e = m.getRID(pos);
+          final RID v = m.getRID(pos);
+          assertThat(e.getBucketId() == 0 && e.getPosition() == 0 && v.getBucketId() == 0 && v.getPosition() == 0)
+              .as("zeroed (unwritten) bytes inside the used range of chunk " + m.getIdentity()).isFalse();
+          diskPairs.add(e + "|" + v);
+        }
+        seg = seg.getPrevious();
+      }
+    });
+
+    final Set<String> disk = new HashSet<>(diskPairs);
+    assertThat(disk).as("no pair duplicated by a rebase").hasSize(diskPairs.size());
+    assertThat(disk).as("every committed pair present, none alien").isEqualTo(expectedPairs);
+
+    database.transaction(() ->
+        assertThat(hubRID.asVertex(true).countEdges(Vertex.DIRECTION.IN, "TRANSFERS")).isEqualTo(ADDERS * PER_ADDER));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * committed-state + appends and drop the relink, leaving a chain whose bytes no longer parse - the truncated
  * read surfaces as java.nio.BufferUnderflowException on the next traversal (the shape reported in #565).
  */
+@Tag("slow")
 class EdgeAppendMergeRaceTest extends TestHelper {
   private int     savedThreshold;
   private boolean savedMerge;
@@ -169,8 +171,6 @@ class EdgeAppendMergeRaceTest extends TestHelper {
       thread.join();
 
     final long merges = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges;
-    System.out.println(">>> added=" + addedCount.get() + " removed=" + removedCount.get()
-        + " edgeAppendMerges=" + merges + " errors=" + errors.size());
 
     if (!errors.isEmpty()) {
       errors.getFirst().printStackTrace();

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Adversarial race between the commutative edge-append merge (GRAPH_EDGE_APPEND_MERGE, new in 26.7.2) and the
+ * structural writes it must never rebase over: edge REMOVAL (chunk relink + empty-chunk delete) on the classic
+ * layout, with dedicated adder / remover / reader threads all hitting one hot vertex at once.
+ * <p>
+ * If a structural write ever failed to poison its page, a concurrent rebase would re-derive that page from
+ * committed-state + appends and drop the relink, leaving a chain whose bytes no longer parse - the truncated
+ * read surfaces as java.nio.BufferUnderflowException on the next traversal (the shape reported in #565).
+ */
+class EdgeAppendMergeRaceTest extends TestHelper {
+  private int     savedThreshold;
+  private boolean savedMerge;
+
+  @BeforeEach
+  void saveConfig() {
+    savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+    savedMerge = GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean();
+  }
+
+  @AfterEach
+  void restoreConfig() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(savedMerge);
+  }
+
+  @Test
+  void addersRemoversAndReadersOnOneHotVertex() throws Exception {
+    // 26.7.2 SHAPE: no striped layout, so every writer contends on the hot vertex's single head chunk.
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(0);
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(true);
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account", 4).createProperty("number", Type.INTEGER);
+      database.getSchema().createEdgeType("TRANSFERS", 8);
+    });
+
+    final RID[] hubHolder = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account");
+      hub.set("number", 0);
+      hub.save();
+      hubHolder[0] = hub.getIdentity();
+    });
+    final RID hubRID = hubHolder[0];
+
+    final int ADDERS = 8, REMOVERS = 4, READERS = 4, PER_ADDER = 1500;
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    final ConcurrentLinkedQueue<RID> live = new ConcurrentLinkedQueue<>();
+    final AtomicInteger addedCount = new AtomicInteger();
+    final AtomicInteger removedCount = new AtomicInteger();
+    final AtomicBoolean addersDone = new AtomicBoolean();
+    final CountDownLatch start = new CountDownLatch(1);
+    final List<Thread> threads = new ArrayList<>();
+
+    for (int t = 0; t < ADDERS; t++) {
+      final int id = t;
+      threads.add(new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < PER_ADDER; i++) {
+            final int n = id * PER_ADDER + i;
+            final RID[] holder = new RID[1];
+            database.transaction(() -> {
+              final MutableVertex src = database.newVertex("Account");
+              src.set("number", n + 1);
+              src.save();
+              src.newEdge("TRANSFERS", hubRID);
+              holder[0] = src.getIdentity();
+            }, true, 100);
+            // Only half are ever eligible for removal: the chain must stay long (many chunks) while the
+            // removers churn it, instead of draining to empty.
+            if ((n & 1) == 0)
+              live.add(holder[0]);
+            addedCount.incrementAndGet();
+          }
+        } catch (final Throwable e) {
+          errors.add(e);
+        }
+      }, "adder-" + t));
+    }
+
+    // REMOVERS: delete source vertices, which relinks (and may delete) chunks in the hub's chain while the
+    // adders are appending to it - the structural-vs-append race the merge must never smooth over.
+    for (int t = 0; t < REMOVERS; t++) {
+      threads.add(new Thread(() -> {
+        try {
+          start.await();
+          while (!addersDone.get() || !live.isEmpty()) {
+            final RID victim = live.poll();
+            if (victim == null) {
+              Thread.yield();
+              continue;
+            }
+            database.transaction(() -> victim.asVertex(true).delete(), true, 100);
+            removedCount.incrementAndGet();
+          }
+        } catch (final Throwable e) {
+          errors.add(e);
+        }
+      }, "remover-" + t));
+    }
+
+    // READERS: traverse the hot vertex continuously; a chain whose bytes stopped parsing shows up here.
+    for (int t = 0; t < READERS; t++) {
+      threads.add(new Thread(() -> {
+        try {
+          start.await();
+          while (!addersDone.get()) {
+            database.transaction(() -> {
+              final Vertex hub = hubRID.asVertex(true);
+              hub.countEdges(Vertex.DIRECTION.IN, "TRANSFERS");
+              for (final Vertex ignored : hub.getVertices(Vertex.DIRECTION.IN, "TRANSFERS")) {
+                // full traversal: forces every chunk in the chain to be parsed
+              }
+            }, true, 100);
+          }
+        } catch (final Throwable e) {
+          errors.add(e);
+        }
+      }, "reader-" + t));
+    }
+
+    threads.forEach(Thread::start);
+    start.countDown();
+    for (int i = 0; i < ADDERS; i++)
+      threads.get(i).join();
+    addersDone.set(true);
+    for (final Thread thread : threads)
+      thread.join();
+
+    final long merges = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges;
+    System.out.println(">>> added=" + addedCount.get() + " removed=" + removedCount.get()
+        + " edgeAppendMerges=" + merges + " errors=" + errors.size());
+
+    if (!errors.isEmpty()) {
+      errors.getFirst().printStackTrace();
+      throw new AssertionError(errors.size() + " thread(s) failed, first: " + errors.getFirst(), errors.getFirst());
+    }
+    assertThat(merges).as("edge-append rebase must actually have fired").isGreaterThan(0);
+
+    final int expected = addedCount.get() - removedCount.get();
+    database.transaction(() -> {
+      assertThat(hubRID.asVertex(true).countEdges(Vertex.DIRECTION.IN, "TRANSFERS")).isEqualTo(expected);
+      int seen = 0;
+      for (final Vertex ignored : hubRID.asVertex(true).getVertices(Vertex.DIRECTION.IN, "TRANSFERS"))
+        seen++;
+      assertThat(seen).as("every surviving edge still reachable").isEqualTo(expected);
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/SuperNodeDefaultThresholdTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/SuperNodeDefaultThresholdTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Super-node promotion at the SHIPPED DEFAULT threshold (GRAPH_SUPERNODE_THRESHOLD=4096).
+ * <p>
+ * The other super-node tests all lower the threshold to 64/128, which promotes through the geometric
+ * chunk-size estimate in {@link EdgeLinkedList#tryPromoteToSuperNode}. At the default the estimate saturates
+ * at ~2048 edges (the 8192-byte chunk cap over ~8 bytes per entry), so promotion can only ever happen through
+ * the BOUNDED CHAIN-WALK branch - the branch every production deployment uses and no test covered.
+ * <p>
+ * Both tests below assert edge-list reads over a vertex promoted that way, using the aggregation reported in
+ * issue #565 ({@code both().size()}).
+ */
+class SuperNodeDefaultThresholdTest extends TestHelper {
+  private int savedThreshold;
+  private int savedStripes;
+
+  @BeforeEach
+  void saveConfig() {
+    savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+    savedStripes = GlobalConfiguration.GRAPH_SUPERNODE_STRIPES.getValueAsInteger();
+  }
+
+  @AfterEach
+  void restoreConfig() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+    GlobalConfiguration.GRAPH_SUPERNODE_STRIPES.setValue(savedStripes);
+  }
+
+  @Test
+  void bothSizeOnPromotedHubAtDefaultThreshold() {
+    // Promotion via the bounded-walk path: the geometric estimate saturates below 4096.
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(4096);
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account", 4).createProperty("number", Type.INTEGER);
+      database.getSchema().createEdgeType("TRANSFERS", 8);
+    });
+
+    final RID[] hubHolder = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account");
+      hub.set("number", 0);
+      hub.save();
+      hubHolder[0] = hub.getIdentity();
+    });
+    final RID hubRID = hubHolder[0];
+
+    // Enough edges to cross the 4096 threshold through the chunk-size cap + walk path.
+    final int total = 12_000;
+    for (int batch = 0; batch < total / 200; batch++) {
+      final int base = batch * 200;
+      database.transaction(() -> {
+        for (int i = 0; i < 200; i++) {
+          final MutableVertex src = database.newVertex("Account");
+          src.set("number", base + i + 1);
+          src.save();
+          src.newEdge("TRANSFERS", hubRID);
+        }
+      });
+    }
+
+    // PRECONDITION: the hub must actually be promoted, otherwise this test proves nothing.
+    database.transaction(() -> {
+      final RID inHead = ((VertexInternal) hubRID.asVertex(true)).getInEdgesHeadChunk();
+      assertThat(database.lookupByRID(inHead, true))
+          .as("hub must be promoted to the striped layout at the default threshold")
+          .isInstanceOf(StripeDirectory.class);
+    });
+
+    // THE CLIENT'S QUERY, verbatim.
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("SQL",
+          "SELECT number, both().size() FROM Account ORDER BY both().size() DESC LIMIT 5")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Result top = rs.next();
+        assertThat(top.<Integer>getProperty("number")).isEqualTo(0);
+        assertThat(top.<Number>getProperty("both().size()").intValue()).isEqualTo(total);
+      }
+    });
+  }
+
+  /**
+   * A database promoted before a restart rewrites its directory (stripe chunk-full -> updateSlot) from a
+   * buffer LOADED from disk rather than built in-process. The existing reopen test adds only 10 edges, too few
+   * to fill any stripe chunk, so it never re-serialises a disk-loaded directory. This does.
+   */
+  @Test
+  void promotedHubRewrittenAfterReopenStaysReadable() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(4096);
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account", 4).createProperty("number", Type.INTEGER);
+      database.getSchema().createEdgeType("TRANSFERS", 8);
+    });
+
+    final RID[] hubHolder = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account");
+      hub.set("number", 0);
+      hub.save();
+      hubHolder[0] = hub.getIdentity();
+    });
+
+    addEdges(hubHolder[0], 0, 12_000);
+    reopenDatabase();
+
+    final RID hub = new RID(hubHolder[0].getBucketId(), hubHolder[0].getPosition());
+    database.transaction(() -> assertThat(database.lookupByRID(((VertexInternal) hub.asVertex(true)).getInEdgesHeadChunk(), true))
+        .isInstanceOf(StripeDirectory.class));
+
+    // Heavy appends AFTER the reopen: every stripe fills repeatedly, so the directory is re-serialised from a
+    // disk-loaded buffer many times.
+    addEdges(hub, 12_000, 8_000);
+    reopenDatabase();
+
+    final RID hub2 = new RID(hub.getBucketId(), hub.getPosition());
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("SQL",
+          "SELECT number, both().size() FROM Account ORDER BY both().size() DESC LIMIT 5")) {
+        final Result top = rs.next();
+        assertThat(top.<Integer>getProperty("number")).isEqualTo(0);
+        assertThat(top.<Number>getProperty("both().size()").intValue()).isEqualTo(20_000);
+      }
+      assertThat(hub2.asVertex().countEdges(Vertex.DIRECTION.IN, "TRANSFERS")).isEqualTo(20_000);
+    });
+  }
+
+  private void addEdges(final RID hubRID, final int startNumber, final int count) {
+    for (int batch = 0; batch < count / 200; batch++) {
+      final int base = startNumber + batch * 200;
+      database.transaction(() -> {
+        for (int i = 0; i < 200; i++) {
+          final MutableVertex src = database.newVertex("Account");
+          src.set("number", base + i + 1);
+          src.save();
+          src.newEdge("TRANSFERS", hubRID);
+        }
+      });
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/SuperNodeDefaultThresholdTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/SuperNodeDefaultThresholdTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Both tests below assert edge-list reads over a vertex promoted that way, using the aggregation reported in
  * issue #565 ({@code both().size()}).
  */
+@Tag("slow")
 class SuperNodeDefaultThresholdTest extends TestHelper {
   private int savedThreshold;
   private int savedStripes;


### PR DESCRIPTION
Fixes a silent data-corruption bug in the commutative edge-append merge (`GRAPH_EDGE_APPEND_MERGE`, on by default since 26.7.2), found while investigating a customer-reported `BufferUnderflowException` on a high-degree vertex. Internal tracking: https://github.com/ArcadeData/arcadedb-operations/issues/565

## The bug

When concurrent transactions append edges to the same vertex, a commit-time page conflict on the edge chunk is resolved by re-deriving the page from the current committed version and replaying the transaction's appends, instead of retrying the whole transaction.

That re-derivation is unsound when the chunk is stored as a **multi-page record** (a chunk allocated near the end of a page continues on the next page, `FIRST_CHUNK`/`NEXT_CHUNK`):

1. The drain writes the record's continuation slice through a page copy created only at drain time, so that page **passes the MVCC version check** while carrying the transaction's stale view of the continuation bytes.
2. The rebase evicts only the conflicted first page before re-reading the chunk, so the re-read walks the chunk chain **through the stale in-transaction copy** of the continuation page.
3. The result is committed: concurrently committed appends on the continuation page are silently reverted - zeroed chunk tails on young chunks, shifted/aliased edge-vertex pairs on filled ones, lost edges, `invalidLinks`/`corruptedRecords` in `CHECK DATABASE`, and `BufferUnderflowException` on later traversals (a shifted region can end mid-varint at the `used` boundary).

Only chunks that straddle a page boundary are exposed (~1/8 of cap-size chunks at the default 64 KB page), which is why this only shows up at scale, on hot vertices, under concurrent insertion.

## The fix

A chunk stored as a multi-page or indirected (placeholder) record is **not rebasable**: `rebaseEdgeAppends` now checks the record's layout marker on the current committed page (`LocalBucket.isRecordStoredInSinglePage`) and falls back to the standard retryable `ConcurrentModificationException`. Single-page chunks - the vast majority, including all super-node stripe chunks - keep the merge.

## Tests

- `EdgeAppendMergeMultiPageChunkTest` (regression): a 16 KB bucket page makes cap-size chunks straddle a boundary every other chunk; 8 threads x 1500 concurrent inserts on one hub, then the hub's raw pair stream is verified byte-exact (no zeroed bytes, no duplicates, no alien pairs, exact count) with the rebase asserted to have actually fired. Fails on every run without the fix; passes with it.
- `EdgeAppendMergeConcurrentStressTest`, `EdgeAppendMergeRaceTest`: concurrent add/remove/read races on the classic layout with the merge active.
- `SuperNodeDefaultThresholdTest`: super-node promotion at the shipped default threshold (4096), which promotes through the bounded chain-walk branch no test covered before.

Also verified at customer scale during the investigation: a 300k-edge hub with 8 concurrent writers and ~12k rebases fired ends with a byte-exact pair stream, and the full graph/database/engine test packages pass.

Please review before merging.
