### PR TITLE
fix(#5289): Postgres plugin advertises LIST OF EMBEDDED properties as json[] instead of text[]

### DIFF
--- a/docs/5289-postgres-list-of-embedded-array-json.md
+++ b/docs/5289-postgres-list-of-embedded-array-json.md
@@ -1,5 +1,7 @@
 # #5289 - Postgres plugin treats LIST OF EMBEDDED properties as ARRAY[TEXT]
 
+PR: https://github.com/ArcadeData/arcadedb/pull/5310
+
 ## Symptom
 
 A `LIST OF <DocumentType>` property is advertised over the Postgres wire protocol as `text[]` (OID 1009)
@@ -60,3 +62,55 @@ value path. Untyped `LIST` behaviour is unchanged.
 
 Note: for a `json[]` column pgJDBC returns `String` elements, matching stock PostgreSQL behaviour. The fix
 corrects the advertised OID, which is what clients use to decide whether to parse elements as JSON.
+
+## Review cycles
+
+### Cycle 1 - c73cd0e46
+
+- `claude[bot]`: recommended merge. Highlighted the schema/value path mapping parity as correct. Three
+  non-blocking notes.
+- `gemini-code-assist[bot]`: COMMENTED, one medium inline suggestion with two parts.
+
+Applied:
+- Blank `ofType` now returns `ARRAY_TEXT` (gemini). Real defect: `Type.getTypeByName("")` returns null, which
+  the code read as "not a scalar, therefore an embedded document type", yielding `json[]` for a blank string.
+- Dropped "/MAP" from the `ofType` javadoc (claude): only `LIST` resolves `ofType`.
+
+Declined, with reasoning posted to the review thread:
+- `DECIMAL -> ARRAY_DOUBLE` (gemini). Superficially consistent with the scalar `DECIMAL -> DOUBLE` mapping,
+  but the parity target here is the *value* path, and `getArrayTypeForElementType` has no
+  `BigDecimal`/`Number` branch, so a populated `LIST OF DECIMAL` is `ARRAY_TEXT`. Adopting the suggestion
+  would make the column report `_float8` when empty and `_text` once populated - reintroducing the OID
+  flapping this fix removes - and would advertise `BigDecimal` as lossy float8. Locked by
+  `getTypeFromArcadeListOfDecimalMatchesValuePath`. The correct version of that change would add a
+  `BigDecimal` branch to `getArrayTypeForElementType` and update both paths together, separately from this
+  regression fix.
+
+Skipped:
+- Empty non-`Collection` arrays bypass the empty-list guard (claude). Not reachable today: ArcadeDB LIST
+  properties surface as `java.util.List`, as the reviewer noted.
+- `getColumnsFromQuerySchema` uses non-polymorphic `getProperty` (claude). Verified a non-issue:
+  `getPropertyNames()` is own-only, with `getPolymorphicPropertyNames()` as the separate polymorphic variant,
+  so no inherited name can reach `getProperty`.
+
+### Cycle 2 - 665365ab7
+
+Timeout: neither bot posted a new review within the 15-minute window (the `claude-review` workflow job ran
+and passed, posting no new findings; gemini's inline comment is the cycle-1 one re-anchored by GitHub to the
+new SHA). No unaddressed feedback outstanding.
+
+## Final state
+
+`timeout` (cycle 2). No deferred items - every cycle-1 comment was applied, declined with reasoning, or
+verified as a non-issue.
+
+CI: three red checks, all verified pre-existing and repo-wide rather than caused by this change.
+
+- `unit-tests` / `integration-tests`: the test steps themselves pass (`Run Unit Tests with Coverage` and
+  `Run Integration Tests with Coverage` both succeed); the jobs go red on the `Unit Tests Reporter` /
+  `IT Tests Reporter` step. The same step fails on #5308 and #5305, where the test step likewise succeeds.
+- `Meterian client scan`: fails on `security: 0`, a dependency-score gate. Reproduces identically on #5308,
+  #5305, #5300 and #5200; this change touches no dependency files.
+- `ha-integration-tests` was still running at handoff.
+
+Everything else green, including `build-and-package`, `claude-review`, CodeQL and all e2e suites.

--- a/docs/5289-postgres-list-of-embedded-array-json.md
+++ b/docs/5289-postgres-list-of-embedded-array-json.md
@@ -27,8 +27,14 @@ the same column could flap between `text[]` and `json[]` across result sets.
 
 - `PostgresType.getTypeFromArcade(Type, String ofType)` - new overload resolving a LIST's element type from
   the declared `OF` clause. An `ofType` that names no scalar `Type` refers to an embedded document type and
-  maps to `ARRAY_JSON`; scalars map to their matching array type; an undeclared `ofType` stays `ARRAY_TEXT`.
-  This reuses the discriminator convention already established by `Type.coerceCollectionOfType` (#5261).
+  maps to `ARRAY_JSON`; scalars map to their matching array type; an undeclared or blank `ofType` stays
+  `ARRAY_TEXT`. This reuses the discriminator convention already established by `Type.coerceCollectionOfType`
+  (#5261).
+
+  Every scalar branch must agree with `getArrayTypeForElementType` (the value path), otherwise the OID would
+  again depend on whether the list is empty. `DECIMAL` therefore maps to `ARRAY_TEXT`, not `ARRAY_DOUBLE`:
+  `getArrayTypeForElementType` has no `BigDecimal`/`Number` branch, so a populated list of `BigDecimal` is
+  `ARRAY_TEXT`. Locked by `getTypeFromArcadeListOfDecimalMatchesValuePath`.
 - `PostgresNetworkExecutor.getColumnsFromQuerySchema` - passes `prop.getOfType()` (schema path).
 - `PostgresNetworkExecutor.getColumns` - for an empty list, prefers the declared `LIST OF <type>` via the new
   `getDeclaredListType` helper (value path), keeping the OID stable across rows.

--- a/docs/5289-postgres-list-of-embedded-array-json.md
+++ b/docs/5289-postgres-list-of-embedded-array-json.md
@@ -1,0 +1,56 @@
+# #5289 - Postgres plugin treats LIST OF EMBEDDED properties as ARRAY[TEXT]
+
+## Symptom
+
+A `LIST OF <DocumentType>` property is advertised over the Postgres wire protocol as `text[]` (OID 1009)
+instead of `json[]` (OID 199), so clients treat each element as an opaque string and re-escape the nested
+JSON. Follow-up to #5253, which fixed the same asymmetry for scalar `EMBEDDED` / `MAP` properties.
+
+## Root cause
+
+`PostgresType.getTypeFromArcade` mapped `Type.LIST` to `ARRAY_TEXT` unconditionally, ignoring the property's
+declared `OF <type>` element type. `EMBEDDED` and `MAP` were already mapped to `JSON`, so only lists were
+affected.
+
+The value-based path (`getTypeForValue`) infers the array type from the first non-null element, so a
+*non-empty* list of embedded documents already resolved to `ARRAY_JSON`. The defect surfaces whenever no
+sample element is available and the declared schema is the only source of truth:
+
+1. **Empty result set** - `getColumnsFromQuerySchema` falls back to the declared schema. Reached by client
+   schema introspection (DbVisualizer, PhpStorm) and Spark/PySpark `WHERE 1=0` probes.
+2. **Empty list value** - `getTypeForValue` has no element to inspect and falls back to `ARRAY_TEXT`.
+
+Case 2 also made a column's advertised OID depend on whether the first row's list happened to be empty, so
+the same column could flap between `text[]` and `json[]` across result sets.
+
+## Fix
+
+- `PostgresType.getTypeFromArcade(Type, String ofType)` - new overload resolving a LIST's element type from
+  the declared `OF` clause. An `ofType` that names no scalar `Type` refers to an embedded document type and
+  maps to `ARRAY_JSON`; scalars map to their matching array type; an undeclared `ofType` stays `ARRAY_TEXT`.
+  This reuses the discriminator convention already established by `Type.coerceCollectionOfType` (#5261).
+- `PostgresNetworkExecutor.getColumnsFromQuerySchema` - passes `prop.getOfType()` (schema path).
+- `PostgresNetworkExecutor.getColumns` - for an empty list, prefers the declared `LIST OF <type>` via the new
+  `getDeclaredListType` helper (value path), keeping the OID stable across rows.
+
+The single-argument `getTypeFromArcade` overload is retained and unchanged.
+
+## Tests
+
+- `PostgresWJdbcIT.embeddedListPropertyReportedAsJsonArray` - reporter's fixture: `LIST OF Product` with one
+  element reports `_json`, elements parse as un-escaped JSON, plain `LIST` stays `_text`.
+- `PostgresWJdbcIT.embeddedListReportedAsJsonArrayWithoutSampleElement` - the two failing paths: empty result
+  set (schema fallback) and empty list value. Also guards `LIST` and `LIST OF STRING` staying `_text`.
+- `PostgresTypeTest` - unit coverage for the new overload: embedded document ofType, scalar ofTypes, null
+  ofType, and non-LIST types ignoring ofType.
+
+Full `postgresw` suite green: 210 unit + 108 IT.
+
+## Impact
+
+Confined to the Postgres wire protocol's RowDescription column typing. `LIST OF <DocumentType>` is now
+advertised as `json[]`, and `LIST OF <scalar>` as its matching array type, aligning the schema path with the
+value path. Untyped `LIST` behaviour is unchanged.
+
+Note: for a `json[]` column pgJDBC returns `String` elements, matching stock PostgreSQL behaviour. The fix
+corrects the advertised OID, which is what clients use to decide whether to parse elements as JSON.

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -43,6 +43,7 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
+import com.arcadedb.schema.Type;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.monitor.QueryProfile;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
@@ -59,6 +60,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -781,7 +783,17 @@ public class PostgresNetworkExecutor extends Thread {
           // EMBEDDED documents and MAP values (issue #5253) are advertised as JSON so clients parse
           // the nested object instead of re-escaping it as an opaque VARCHAR string.
           final Object value = row.getProperty(p);
-          final PostgresType pgType = PostgresType.getTypeForValue(value);
+          PostgresType pgType = PostgresType.getTypeForValue(value);
+
+          // An empty list carries no element to infer the type from, so getTypeForValue falls back to text[].
+          // Prefer the declared "LIST OF <type>" (issue #5289) so a column's OID does not depend on whether
+          // the first row's list happens to be empty.
+          if (value instanceof Collection<?> collection && collection.isEmpty()) {
+            final PostgresType declaredType = getDeclaredListType(row, p);
+            if (declaredType != null)
+              pgType = declaredType;
+          }
+
           if (pgType.isArrayType() || pgType.isNativeScalarType() || pgType == PostgresType.JSON)
             columns.put(p, pgType);
           else
@@ -797,6 +809,26 @@ public class PostgresNetworkExecutor extends Thread {
     }
 
     return columns;
+  }
+
+  /**
+   * Returns the array type declared by the schema for a LIST property, or null when the row is not a schema
+   * element or the property is not a declared LIST.
+   */
+  private PostgresType getDeclaredListType(final Result row, final String propertyName) {
+    final Document element = row.getElement().orElse(null);
+    if (element == null)
+      return null;
+
+    final DocumentType documentType = element.getType();
+    if (documentType == null)
+      return null;
+
+    final Property property = documentType.getPolymorphicPropertyIfExists(propertyName);
+    if (property == null || property.getType() != Type.LIST)
+      return null;
+
+    return PostgresType.getTypeFromArcade(property.getType(), property.getOfType());
   }
 
   /**
@@ -871,7 +903,7 @@ public class PostgresNetworkExecutor extends Thread {
       for (final String propName : docType.getPropertyNames()) {
         final Property prop = docType.getProperty(propName);
         if (prop != null && prop.getType() != null) {
-          columns.put(propName, PostgresType.getTypeFromArcade(prop.getType()));
+          columns.put(propName, PostgresType.getTypeFromArcade(prop.getType(), prop.getOfType()));
         } else {
           columns.put(propName, PostgresType.VARCHAR);
         }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -292,6 +292,46 @@ public enum PostgresType {
   }
 
   /**
+   * Maps an ArcadeDB schema Type to a PostgreSQL type, resolving the element type of a LIST from the
+   * property's declared "OF" clause.
+   *
+   * @param arcadeType The ArcadeDB schema type
+   * @param ofType     The declared element type name of a LIST/MAP property, or null when undeclared
+   *
+   * @return The corresponding PostgreSQL type
+   */
+  public static PostgresType getTypeFromArcade(final Type arcadeType, final String ofType) {
+    if (arcadeType == Type.LIST)
+      return getArrayTypeForOfType(ofType);
+    return getTypeFromArcade(arcadeType);
+  }
+
+  /**
+   * Resolves the array type of a "LIST OF &lt;ofType&gt;" property. An ofType that does not name a scalar
+   * {@link Type} refers to an embedded document type, so the list is advertised as json[]; this mirrors the
+   * convention used by Type.coerceCollectionOfType. An undeclared ofType stays text[].
+   */
+  private static PostgresType getArrayTypeForOfType(final String ofType) {
+    if (ofType == null)
+      return ARRAY_TEXT;
+
+    final Type elementType = Type.getTypeByName(ofType);
+    if (elementType == null)
+      // Not a scalar: the list holds embedded documents of a schema type.
+      return ARRAY_JSON;
+
+    return switch (elementType) {
+      case BOOLEAN -> ARRAY_BOOLEAN;
+      case INTEGER, SHORT, BYTE -> ARRAY_INT;
+      case LONG -> ARRAY_LONG;
+      case FLOAT -> ARRAY_REAL;
+      case DOUBLE -> ARRAY_DOUBLE;
+      case MAP, EMBEDDED -> ARRAY_JSON;
+      default -> ARRAY_TEXT;
+    };
+  }
+
+  /**
    * Maps an ArcadeDB schema Type to a PostgreSQL type.
    *
    * @param arcadeType The ArcadeDB schema type

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -296,7 +296,8 @@ public enum PostgresType {
    * property's declared "OF" clause.
    *
    * @param arcadeType The ArcadeDB schema type
-   * @param ofType     The declared element type name of a LIST/MAP property, or null when undeclared
+   * @param ofType     The declared element type name of a LIST property, or null when undeclared. Ignored for
+   *                   any other type.
    *
    * @return The corresponding PostgreSQL type
    */
@@ -312,7 +313,7 @@ public enum PostgresType {
    * convention used by Type.coerceCollectionOfType. An undeclared ofType stays text[].
    */
   private static PostgresType getArrayTypeForOfType(final String ofType) {
-    if (ofType == null)
+    if (ofType == null || ofType.isBlank())
       return ARRAY_TEXT;
 
     final Type elementType = Type.getTypeByName(ofType);
@@ -320,6 +321,9 @@ public enum PostgresType {
       // Not a scalar: the list holds embedded documents of a schema type.
       return ARRAY_JSON;
 
+    // Every branch must agree with getArrayTypeForElementType, which types a populated list from its first
+    // element: a mismatch would make a column's OID depend on whether the list is empty. DECIMAL therefore
+    // falls through to ARRAY_TEXT, because a list of BigDecimal has no match there either.
     return switch (elementType) {
       case BOOLEAN -> ARRAY_BOOLEAN;
       case INTEGER, SHORT, BYTE -> ARRAY_INT;

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -376,6 +376,32 @@ class PostgresTypeTest {
   }
 
   @Test
+  void getTypeFromArcadeListOfEmbeddedDocumentType() {
+    // An ofType that names no scalar Type refers to an embedded document type: issue #5289.
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "Product")).isEqualTo(PostgresType.ARRAY_JSON);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "EMBEDDED")).isEqualTo(PostgresType.ARRAY_JSON);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "MAP")).isEqualTo(PostgresType.ARRAY_JSON);
+  }
+
+  @Test
+  void getTypeFromArcadeListOfScalar() {
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, null)).isEqualTo(PostgresType.ARRAY_TEXT);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "STRING")).isEqualTo(PostgresType.ARRAY_TEXT);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "LONG")).isEqualTo(PostgresType.ARRAY_LONG);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "INTEGER")).isEqualTo(PostgresType.ARRAY_INT);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "BOOLEAN")).isEqualTo(PostgresType.ARRAY_BOOLEAN);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "DOUBLE")).isEqualTo(PostgresType.ARRAY_DOUBLE);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "FLOAT")).isEqualTo(PostgresType.ARRAY_REAL);
+  }
+
+  @Test
+  void getTypeFromArcadeNonListIgnoresOfType() {
+    assertThat(PostgresType.getTypeFromArcade(Type.EMBEDDED, "Product")).isEqualTo(PostgresType.JSON);
+    assertThat(PostgresType.getTypeFromArcade(Type.MAP, "Product")).isEqualTo(PostgresType.JSON);
+    assertThat(PostgresType.getTypeFromArcade(Type.STRING, "Product")).isEqualTo(PostgresType.VARCHAR);
+  }
+
+  @Test
   void getTypeFromArcadeMap() {
     assertThat(PostgresType.getTypeFromArcade(Type.MAP)).isEqualTo(PostgresType.JSON);
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -386,12 +387,26 @@ class PostgresTypeTest {
   @Test
   void getTypeFromArcadeListOfScalar() {
     assertThat(PostgresType.getTypeFromArcade(Type.LIST, null)).isEqualTo(PostgresType.ARRAY_TEXT);
+    // A blank ofType names no type at all, so it must not be mistaken for an embedded document type.
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "")).isEqualTo(PostgresType.ARRAY_TEXT);
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "   ")).isEqualTo(PostgresType.ARRAY_TEXT);
     assertThat(PostgresType.getTypeFromArcade(Type.LIST, "STRING")).isEqualTo(PostgresType.ARRAY_TEXT);
     assertThat(PostgresType.getTypeFromArcade(Type.LIST, "LONG")).isEqualTo(PostgresType.ARRAY_LONG);
     assertThat(PostgresType.getTypeFromArcade(Type.LIST, "INTEGER")).isEqualTo(PostgresType.ARRAY_INT);
     assertThat(PostgresType.getTypeFromArcade(Type.LIST, "BOOLEAN")).isEqualTo(PostgresType.ARRAY_BOOLEAN);
     assertThat(PostgresType.getTypeFromArcade(Type.LIST, "DOUBLE")).isEqualTo(PostgresType.ARRAY_DOUBLE);
     assertThat(PostgresType.getTypeFromArcade(Type.LIST, "FLOAT")).isEqualTo(PostgresType.ARRAY_REAL);
+  }
+
+  /**
+   * The declared-schema path and the value path must agree, otherwise a column's OID would depend on whether
+   * its list happens to be empty. A list of BigDecimal is typed ARRAY_TEXT by getArrayTypeForElementType, so
+   * LIST OF DECIMAL must resolve to ARRAY_TEXT too, despite the scalar DECIMAL mapping to DOUBLE.
+   */
+  @Test
+  void getTypeFromArcadeListOfDecimalMatchesValuePath() {
+    assertThat(PostgresType.getTypeFromArcade(Type.LIST, "DECIMAL")).isEqualTo(PostgresType.ARRAY_TEXT);
+    assertThat(PostgresType.getTypeForValue(List.of(new BigDecimal("1.23")))).isEqualTo(PostgresType.ARRAY_TEXT);
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -637,6 +637,106 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
     }
   }
 
+  /**
+   * Issue #5289: a LIST of EMBEDDED documents must be advertised over the Postgres wire protocol as
+   * json[] (OID 199) rather than text[] (OID 1009). When advertised as text[] the client treats each
+   * element as an opaque string and re-escapes the nested JSON.
+   */
+  @Test
+  void embeddedListPropertyReportedAsJsonArray() throws Exception {
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("""
+            {sqlscript}
+            CREATE DOCUMENT TYPE Product IF NOT EXISTS;
+            CREATE PROPERTY Product.sku IF NOT EXISTS STRING;
+            CREATE PROPERTY Product.name IF NOT EXISTS STRING;
+
+            CREATE VERTEX TYPE Supplier IF NOT EXISTS;
+            CREATE PROPERTY Supplier.name IF NOT EXISTS STRING;
+            CREATE PROPERTY Supplier.certifications IF NOT EXISTS LIST;
+            CREATE PROPERTY Supplier.embedded_list IF NOT EXISTS LIST OF Product;
+
+            INSERT INTO Supplier (name, certifications, embedded_list) VALUES ('Berlin Sensors GmbH', 'ISO-9001,RoHS', [{ "@type": "Product", "sku": "1234", "name": "CPU"}]);
+            """);
+      }
+
+      try (var st = conn.createStatement()) {
+        try (var rs = st.executeQuery("SELECT FROM Supplier")) {
+          assertThat(rs.next()).isTrue();
+
+          final int listCol = rs.findColumn("embedded_list");
+          // Before the fix this reported "_text"; a list of embedded documents must be json[].
+          assertThat(rs.getMetaData().getColumnTypeName(listCol)).isEqualToIgnoringCase("_json");
+
+          // A plain LIST of strings must keep reporting text[].
+          assertThat(rs.getMetaData().getColumnTypeName(rs.findColumn("certifications"))).isEqualToIgnoringCase("_text");
+
+          // Each element must be valid, un-escaped JSON.
+          final Object[] elements = (Object[]) rs.getArray("embedded_list").getArray();
+          assertThat(elements).hasSize(1);
+
+          final JSONObject embedded = new JSONObject(elements[0].toString());
+          assertThat(embedded.getString("sku")).isEqualTo("1234");
+          assertThat(embedded.getString("name")).isEqualTo("CPU");
+
+          assertThat(rs.next()).isFalse();
+        }
+      }
+    }
+  }
+
+
+  /**
+   * Issue #5289: the RowDescription for a "LIST OF &lt;DocumentType&gt;" property must be json[] even when the
+   * declared element type cannot be inferred from the data: an empty result set (schema fallback) or a row
+   * whose list is empty. Otherwise the advertised OID flaps between text[] and json[] across result sets.
+   */
+  @Test
+  void embeddedListReportedAsJsonArrayWithoutSampleElement() throws Exception {
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("""
+            {sqlscript}
+            CREATE DOCUMENT TYPE Product IF NOT EXISTS;
+            CREATE PROPERTY Product.sku IF NOT EXISTS STRING;
+
+            CREATE VERTEX TYPE Supplier IF NOT EXISTS;
+            CREATE PROPERTY Supplier.certifications IF NOT EXISTS LIST;
+            CREATE PROPERTY Supplier.tags IF NOT EXISTS LIST OF STRING;
+            CREATE PROPERTY Supplier.embedded_list IF NOT EXISTS LIST OF Product;
+            """);
+      }
+
+      // No rows at all: RowDescription comes from the schema-discovery fallback.
+      try (var st = conn.createStatement()) {
+        try (var rs = st.executeQuery("SELECT FROM Supplier WHERE 1=0")) {
+          final var meta = rs.getMetaData();
+          // Before the fix the schema path collapsed every LIST to text[], ignoring the "OF Product".
+          assertThat(meta.getColumnTypeName(rs.findColumn("embedded_list"))).isEqualToIgnoringCase("_json");
+          // A LIST without an "OF" clause, and a LIST OF a scalar, must stay text[].
+          assertThat(meta.getColumnTypeName(rs.findColumn("certifications"))).isEqualToIgnoringCase("_text");
+          assertThat(meta.getColumnTypeName(rs.findColumn("tags"))).isEqualToIgnoringCase("_text");
+        }
+      }
+
+      // Row present but the list is empty: the value carries no element to infer the type from.
+      try (var st = conn.createStatement()) {
+        st.execute("INSERT INTO Supplier (certifications, embedded_list) VALUES ('ISO-9001', [])");
+      }
+      try (var st = conn.createStatement()) {
+        try (var rs = st.executeQuery("SELECT FROM Supplier")) {
+          assertThat(rs.next()).isTrue();
+          final var meta = rs.getMetaData();
+          // Before the fix an empty list fell back to text[], so the same column changed OID per result set.
+          assertThat(meta.getColumnTypeName(rs.findColumn("embedded_list"))).isEqualToIgnoringCase("_json");
+          assertThat(meta.getColumnTypeName(rs.findColumn("certifications"))).isEqualToIgnoringCase("_text");
+          assertThat((Object[]) rs.getArray("embedded_list").getArray()).isEmpty();
+        }
+      }
+    }
+  }
+
   private static final int    DEFAULT_SIZE = 64;
   private static final Random RANDOM       = ThreadLocalRandom.current();
 


### PR DESCRIPTION
Closes #5289

## Summary

`PostgresType.getTypeFromArcade()` mapped `Type.LIST` to `ARRAY_TEXT` unconditionally, ignoring the property's declared `OF <type>` element type, so a `LIST OF <DocumentType>` was announced in RowDescription with the `text[]` OID (1009) instead of `json[]` (199). Clients then treated each element as an opaque string and re-escaped the nested JSON. `EMBEDDED`/`MAP` were already mapped to `JSON` by #5253, so only lists were affected.

The value-based path (`getTypeForValue`) infers the array type from the first non-null element, so a *non-empty* list of embedded documents already resolved to `ARRAY_JSON`. The defect surfaces whenever no sample element is available and the declared schema is the only source of truth:

1. **Empty result set** - `getColumnsFromQuerySchema` falls back to the declared schema. Reached by client schema introspection (DbVisualizer, PhpStorm - the tools in the report) and Spark/PySpark `WHERE 1=0` probes.
2. **Empty list value** - `getTypeForValue` has no element to inspect. This also made a column's advertised OID depend on whether the first row's list happened to be empty, so the same column could flap between `text[]` and `json[]` across result sets.

The fix resolves a LIST's element type from its `OF` clause: an `ofType` that names no scalar `Type` refers to an embedded document type and maps to `json[]` - reusing the discriminator convention already established by `Type.coerceCollectionOfType` (#5261). Scalars map to their matching array type, aligning the schema path with the value path; an undeclared `ofType` stays `text[]`.

Note: for a `json[]` column pgJDBC returns `String` elements, matching stock PostgreSQL behaviour (array literals always quote/escape their elements). This PR corrects the advertised OID, which is what clients use to decide whether to parse elements as JSON.

## Test plan

- [x] `PostgresWJdbcIT.embeddedListPropertyReportedAsJsonArray` - the reporter's fixture: `LIST OF Product` with one element reports `_json`, elements parse as un-escaped JSON, plain `LIST` stays `_text`
- [x] `PostgresWJdbcIT.embeddedListReportedAsJsonArrayWithoutSampleElement` - the two failing paths (empty result set / empty list value); also guards `LIST` and `LIST OF STRING` staying `_text`. Fails on `main`, passes with the fix
- [x] `PostgresTypeTest` - unit coverage for the new overload: embedded-document ofType, scalar ofTypes, null ofType, and non-LIST types ignoring ofType
- [x] Full `postgresw` suite green: 210 unit + 108 IT
- [ ] Reviewer: verify `LIST OF <scalar>` OID change on the empty-result schema path is acceptable (previously `text[]`, now matches the value path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)