### PR TITLE
fix(#5311): Postgres schema path collapses ARRAY_OF_*/DATETIME_* to VARCHAR, and ARRAY_OF_SHORTS makes queries fail

### DIFF
--- a/docs/5311-postgres-schema-path-type-mapping.md
+++ b/docs/5311-postgres-schema-path-type-mapping.md
@@ -27,9 +27,10 @@ Two defects in how the Postgres wire types a RowDescription column:
 
 Scoped to items 1 and 2 of the issue's suggested scope.
 
-- `getTypeForValue`: added `short[]`/`Short[]` -> `ARRAY_INT`. Shorts widen to `int4[]` because
-  `getArrayTypeForElementType` already answers `ARRAY_INT` for a `Short` element and `PostgresType` has no
-  `int2[]` entry to pair with a narrower answer.
+- `getTypeForValue`: added `short[]`/`Short[]`/`Byte[]` -> `ARRAY_INT`. These widen to `int4[]` because
+  `getArrayTypeForElementType` already answers `ARRAY_INT` for a `Short` or `Byte` element and `PostgresType`
+  has no `int2[]` entry to pair with a narrower answer. `Byte[]` was found during review (see below) and is
+  the same crash reached via a query parameter rather than a property declaration.
 - `getTypeFromArcade`: added the 8 missing cases - `ARRAY_OF_SHORTS`/`ARRAY_OF_INTEGERS` -> `ARRAY_INT`,
   `ARRAY_OF_LONGS` -> `ARRAY_LONG`, `ARRAY_OF_FLOATS` -> `ARRAY_REAL`, `ARRAY_OF_DOUBLES` -> `ARRAY_DOUBLE`,
   and `DATETIME_MICROS`/`DATETIME_NANOS`/`DATETIME_SECOND` -> `TIMESTAMP` (folded into the existing
@@ -57,7 +58,33 @@ table against silently skipping a `Type` added to the enum later.
 Verified the tests genuinely catch the bug by reverting the production change and confirming they fail
 (4 failures + 1 `IllegalStateException`), then restoring it.
 
-Results: `postgresw` 218 unit + 110 integration tests pass.
+Results: `postgresw` 220 unit + 110 integration tests pass.
+
+## Review cycles
+
+### Cycle 1 - `67a53e9`
+
+`gemini-code-assist` (COMMENTED) raised one medium finding: the value path's array switch has no `Byte[]`
+case, so a `Byte[]` reaches the throwing `default`. Verified and accepted:
+
+- **Reachable.** `byte[]` is matched earlier and returns `ARRAY_CHAR`, but `Byte[]` is not a `byte[]`, so it
+  falls into the switch. `InputParameter.isPrimitiveOrWrapperArray` deliberately passes `Byte[]` through
+  un-converted rather than boxing it into a collection, so a query parameter or projection can carry one to
+  the wire. Same crash class as Finding 1, reached via a parameter rather than a property declaration.
+- **Mapped to `ARRAY_INT`, not `ARRAY_CHAR`.** The competing anchor is the primitive/boxed symmetry with
+  `byte[]` -> `ARRAY_CHAR`. `ARRAY_INT` wins: `getTypeForValue(Byte)` -> `INTEGER`,
+  `getArrayTypeForElementType(Byte)` -> `ARRAY_INT` and `getArrayTypeForOfType`'s `INTEGER, SHORT, BYTE ->
+  ARRAY_INT` all agree a `Byte` element is int-ish, and only `Type.BINARY` maps `byte[].class`, so a `Byte[]`
+  does not carry the blob meaning. `byte[] -> ARRAY_CHAR` is also the mapping the issue's Finding 4 already
+  calls incorrect, so anchoring to it would inherit a decision due to change.
+
+Rather than adding the single reported case, the fix closes the family: every type in
+`InputParameter.isPrimitiveOrWrapperArray` is now covered, and
+`valuePathTypesEveryPrimitiveAndWrapperArrayWithoutThrowing` asserts none of them throws. Verified the new
+tests catch the defect by removing the `Byte[]` case and observing 2 `IllegalStateException`s.
+
+`gemini-code-assist` also noted that its consumer GitHub integration is being sunset (no action).
+No findings from `claude`.
 
 ## Impact
 

--- a/docs/5311-postgres-schema-path-type-mapping.md
+++ b/docs/5311-postgres-schema-path-type-mapping.md
@@ -60,31 +60,21 @@ Verified the tests genuinely catch the bug by reverting the production change an
 
 Results: `postgresw` 220 unit + 110 integration tests pass.
 
-## Review cycles
+## Review
 
-### Cycle 1 - `67a53e9`
+PR: https://github.com/ArcadeData/arcadedb/pull/5313 - final state: clean approval (2 cycles).
 
-`gemini-code-assist` (COMMENTED) raised one medium finding: the value path's array switch has no `Byte[]`
-case, so a `Byte[]` reaches the throwing `default`. Verified and accepted:
-
-- **Reachable.** `byte[]` is matched earlier and returns `ARRAY_CHAR`, but `Byte[]` is not a `byte[]`, so it
-  falls into the switch. `InputParameter.isPrimitiveOrWrapperArray` deliberately passes `Byte[]` through
-  un-converted rather than boxing it into a collection, so a query parameter or projection can carry one to
-  the wire. Same crash class as Finding 1, reached via a parameter rather than a property declaration.
-- **Mapped to `ARRAY_INT`, not `ARRAY_CHAR`.** The competing anchor is the primitive/boxed symmetry with
-  `byte[]` -> `ARRAY_CHAR`. `ARRAY_INT` wins: `getTypeForValue(Byte)` -> `INTEGER`,
-  `getArrayTypeForElementType(Byte)` -> `ARRAY_INT` and `getArrayTypeForOfType`'s `INTEGER, SHORT, BYTE ->
-  ARRAY_INT` all agree a `Byte` element is int-ish, and only `Type.BINARY` maps `byte[].class`, so a `Byte[]`
-  does not carry the blob meaning. `byte[] -> ARRAY_CHAR` is also the mapping the issue's Finding 4 already
-  calls incorrect, so anchoring to it would inherit a decision due to change.
-
-Rather than adding the single reported case, the fix closes the family: every type in
-`InputParameter.isPrimitiveOrWrapperArray` is now covered, and
-`valuePathTypesEveryPrimitiveAndWrapperArrayWithoutThrowing` asserts none of them throws. Verified the new
-tests catch the defect by removing the `Byte[]` case and observing 2 `IllegalStateException`s.
-
-`gemini-code-assist` also noted that its consumer GitHub integration is being sunset (no action).
-No findings from `claude`.
+- **Cycle 1 (`67a53e9`)** - `gemini` flagged that the value path's array switch has no `Byte[]` case.
+  Verified reachable and fixed: `Byte[]` is not `byte[]`, and `InputParameter.isPrimitiveOrWrapperArray`
+  passes it through un-converted, so a query parameter can carry one to the wire - the same crash as
+  Finding 1 via a different route. Mapped to `ARRAY_INT` rather than following `byte[] -> ARRAY_CHAR`,
+  because only `byte[].class` carries `Type.BINARY`'s blob meaning while `getTypeForValue(Byte)`,
+  `getArrayTypeForElementType(Byte)` and `getArrayTypeForOfType` all treat a `Byte` element as int4.
+  Closed the whole family rather than the single reported case.
+- **Cycle 2 (`a10df87`)** - `claude` approved (LGTM, no bugs found). `gemini`'s only comment was its cycle-1
+  one re-anchored, already applied. Two non-blocking notes not actioned: unused switch pattern bindings
+  (claude itself endorsed matching the surrounding style), and a request to call the wire-visible behaviour
+  change out in **release notes** - see Impact below, left for the maintainer.
 
 ## Impact
 

--- a/docs/5311-postgres-schema-path-type-mapping.md
+++ b/docs/5311-postgres-schema-path-type-mapping.md
@@ -1,0 +1,90 @@
+# #5311 - Postgres schema-path type mapping collapses ARRAY_OF_*/DATETIME_* to VARCHAR
+
+## Symptom
+
+Two defects in how the Postgres wire types a RowDescription column:
+
+1. `SELECT` on a type with an `ARRAY_OF_SHORTS` property failed outright:
+   `PSQLException: ERROR: Error on executing query: Unexpected value: [S@38013adc`.
+2. The five `ARRAY_OF_*` and the three sub-second `DATETIME_*` types were advertised as scalar `varchar`
+   when a query returned no rows, but as their real array/timestamp OID once a row existed. The column's
+   advertised type therefore depended on whether the table happened to be empty.
+
+## Root cause
+
+`PostgresType` resolves a column via two independent paths that had drifted apart:
+
+- **Value path** (`getTypeForValue`) - used when a sample row exists. Its array `switch` had cases for
+  `int[]`, `long[]`, `double[]`, `float[]`, `boolean[]`, `char[]`, `String[]` and their boxed forms, but
+  none for `short[]`/`Short[]`, so an `ARRAY_OF_SHORTS` value reached `default -> throw new
+  IllegalStateException`. `Type.ARRAY_OF_SHORTS` declares `short[]` as its default Java type, so a plain
+  property declaration was enough to reach it.
+- **Schema path** (`getTypeFromArcade`) - used when a query returns 0 rows (client schema introspection,
+  Spark `WHERE 1=0` probes). Its `switch` had no case for 8 of the 24 `Type` values, so they fell through
+  to `default -> VARCHAR`.
+
+## Fix
+
+Scoped to items 1 and 2 of the issue's suggested scope.
+
+- `getTypeForValue`: added `short[]`/`Short[]` -> `ARRAY_INT`. Shorts widen to `int4[]` because
+  `getArrayTypeForElementType` already answers `ARRAY_INT` for a `Short` element and `PostgresType` has no
+  `int2[]` entry to pair with a narrower answer.
+- `getTypeFromArcade`: added the 8 missing cases - `ARRAY_OF_SHORTS`/`ARRAY_OF_INTEGERS` -> `ARRAY_INT`,
+  `ARRAY_OF_LONGS` -> `ARRAY_LONG`, `ARRAY_OF_FLOATS` -> `ARRAY_REAL`, `ARRAY_OF_DOUBLES` -> `ARRAY_DOUBLE`,
+  and `DATETIME_MICROS`/`DATETIME_NANOS`/`DATETIME_SECOND` -> `TIMESTAMP` (folded into the existing
+  `DATETIME` branch).
+
+`convertPrimitiveArrayToCollection` needed no change: it already handles `short[]`, and `Short[]` is matched
+by its `Object[]` branch.
+
+`DECIMAL` (item 3) and `BINARY` (item 4) are deliberately out of scope - both need a new `PostgresType`
+entry (`NUMERIC` OID 1700 / `BYTEA` OID 17) with a binary encoder, not a missing switch case.
+
+## Tests
+
+`PostgresTypeResolutionPathTest` (new) is the table-driven regression test the issue asked for: it asserts
+that for every one of the 24 `Type` values the schema path and the value path resolve to the same
+`PostgresType`, with a `KNOWN_DISAGREEMENTS` table pinning the documented exceptions so that fixing one
+forces its entry to be removed rather than leaving a stale exemption. `everyTypeHasASampleValue` guards the
+table against silently skipping a `Type` added to the enum later.
+
+`PostgresWJdbcIT` (2 new methods) reproduce both findings end-to-end over pgJDBC:
+- `shortArrayPropertyIsQueryable` - the issue's exact repro; previously threw.
+- `arrayAndDatetimeColumnsKeepTheirTypeWhenTheResultSetIsEmpty` - asserts the same OIDs are advertised for
+  an empty and a populated result set across all 8 affected columns.
+
+Verified the tests genuinely catch the bug by reverting the production change and confirming they fail
+(4 failures + 1 `IllegalStateException`), then restoring it.
+
+Results: `postgresw` 218 unit + 110 integration tests pass.
+
+## Impact
+
+`getTypeFromArcade` / `getTypeForValue` are consumed only by `PostgresNetworkExecutor` within `postgresw`,
+so the blast radius is limited to the Postgres wire.
+
+Behaviour change for clients: columns of the 8 affected types now advertise their real OID on empty result
+sets instead of `varchar`. A client that had adapted to reading these as text from an empty-result-set probe
+will now receive the array/timestamp OID. This is the intended correction and matches what those clients
+already received for non-empty result sets.
+
+## Follow-up: three disagreements not in the issue's audit table
+
+Running the new table-driven test against unpatched `main` surfaced three pairs that also disagree, none of
+which the issue's audit lists as broken (it states the other 14 types "agree and are fine"):
+
+| `Type` | Schema path | Value path |
+|---|---|---|
+| `SHORT` | `SMALLINT` | `INTEGER` |
+| `BYTE` | `SMALLINT` | `INTEGER` |
+| `DATETIME` | `TIMESTAMP` | `DATE` |
+
+- `SHORT`/`BYTE`: the value path widens `Short`/`Byte` to `INTEGER`. Reconciling on `SMALLINT` would change
+  the OID clients already receive for populated rows, so the direction is a judgment call rather than a
+  mechanical fix.
+- `DATETIME`: `java.util.Date` is the default Java type of both `DATE` and `DATETIME`, so the value path
+  cannot distinguish them and answers `DATE` for either. Not fixable by a switch case.
+
+These are recorded in `KNOWN_DISAGREEMENTS` alongside `DECIMAL` and `BINARY` and are left for a separate
+issue, since each changes behaviour beyond the scope this issue audited.

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -266,10 +266,12 @@ public enum PostgresType {
     } else if (val.getClass().isArray()) {
       // Handle Java arrays
       return switch (val) {
-        // Shorts widen to int4[]: getArrayTypeForElementType answers ARRAY_INT for a Short element, and there is
-        // no int2[] entry to pair with a narrower answer.
+        // Shorts and boxed bytes widen to int4[]: getArrayTypeForElementType answers ARRAY_INT for a Short or a
+        // Byte element, and there is no int2[] entry to pair with a narrower answer. Only the primitive byte[]
+        // means BINARY (handled above); a Byte[] is an array of small integers.
         case short[] shorts -> PostgresType.ARRAY_INT;
         case Short[] shorts -> PostgresType.ARRAY_INT;
+        case Byte[] bytes -> PostgresType.ARRAY_INT;
         case int[] ints -> PostgresType.ARRAY_INT;
         case Integer[] ints -> PostgresType.ARRAY_INT;
         case long[] longs -> PostgresType.ARRAY_LONG;

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -266,6 +266,10 @@ public enum PostgresType {
     } else if (val.getClass().isArray()) {
       // Handle Java arrays
       return switch (val) {
+        // Shorts widen to int4[]: getArrayTypeForElementType answers ARRAY_INT for a Short element, and there is
+        // no int2[] entry to pair with a narrower answer.
+        case short[] shorts -> PostgresType.ARRAY_INT;
+        case Short[] shorts -> PostgresType.ARRAY_INT;
         case int[] ints -> PostgresType.ARRAY_INT;
         case Integer[] ints -> PostgresType.ARRAY_INT;
         case long[] longs -> PostgresType.ARRAY_LONG;
@@ -347,6 +351,8 @@ public enum PostgresType {
       return PostgresType.VARCHAR;
     }
 
+    // Every branch must agree with getTypeForValue, which types a column from a sample row: a mismatch would make
+    // the column's OID depend on whether the result set happens to be empty.
     return switch (arcadeType) {
       case BOOLEAN -> PostgresType.BOOLEAN;
       case INTEGER -> PostgresType.INTEGER;
@@ -356,10 +362,14 @@ public enum PostgresType {
       case DOUBLE -> PostgresType.DOUBLE;
       case BYTE -> PostgresType.SMALLINT;
       case STRING -> PostgresType.VARCHAR;
-      case DATETIME -> PostgresType.TIMESTAMP;
+      case DATETIME, DATETIME_MICROS, DATETIME_NANOS, DATETIME_SECOND -> PostgresType.TIMESTAMP;
       case DATE -> PostgresType.DATE;
       case BINARY -> PostgresType.VARCHAR; // No direct binary type, use VARCHAR
       case LIST -> PostgresType.ARRAY_TEXT;
+      case ARRAY_OF_SHORTS, ARRAY_OF_INTEGERS -> PostgresType.ARRAY_INT;
+      case ARRAY_OF_LONGS -> PostgresType.ARRAY_LONG;
+      case ARRAY_OF_FLOATS -> PostgresType.ARRAY_REAL;
+      case ARRAY_OF_DOUBLES -> PostgresType.ARRAY_DOUBLE;
       case MAP, EMBEDDED -> PostgresType.JSON;
       case LINK -> PostgresType.VARCHAR;
       case DECIMAL -> PostgresType.DOUBLE;

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
@@ -143,6 +143,35 @@ class PostgresTypeResolutionPathTest {
   }
 
   @Test
+  void valuePathTypesBoxedByteArraysAsIntArrays() {
+    // Only the primitive byte[] carries Type.BINARY's blob meaning; a Byte[] is an array of small integers, and
+    // Byte elements already resolve to int4 everywhere else (getTypeForValue, getArrayTypeForElementType).
+    assertThat(PostgresType.getTypeForValue(new Byte[] { 1, 2 })).isEqualTo(PostgresType.ARRAY_INT);
+    assertThat(PostgresType.getTypeForValue(new byte[] { 1, 2 })).isEqualTo(PostgresType.ARRAY_CHAR);
+  }
+
+  @Test
+  void valuePathTypesEveryPrimitiveAndWrapperArrayWithoutThrowing() {
+    // SQL passes these through to the wire un-converted rather than boxing them into a collection (see
+    // InputParameter.isPrimitiveOrWrapperArray), so each one reaches the value path's array switch. Any type
+    // missing a case there hits its throwing default and fails the whole query, which is what #5311 reported
+    // for short[]. Assert the family is covered rather than only the reported member.
+    final List<Object> arrays = List.of(
+        new byte[] { 1 }, new Byte[] { 1 },
+        new short[] { 1 }, new Short[] { 1 },
+        new int[] { 1 }, new Integer[] { 1 },
+        new long[] { 1L }, new Long[] { 1L },
+        new float[] { 1f }, new Float[] { 1f },
+        new double[] { 1d }, new Double[] { 1d },
+        new boolean[] { true }, new Boolean[] { true },
+        new char[] { 'a' }, new Character[] { 'a' },
+        new String[] { "a" });
+
+    for (final Object array : arrays)
+      assertThat(PostgresType.getTypeForValue(array)).as("value path of %s", array.getClass().getSimpleName()).isNotNull();
+  }
+
+  @Test
   void schemaPathTypesArrayTypesAsArrays() {
     assertThat(PostgresType.getTypeFromArcade(Type.ARRAY_OF_SHORTS)).isEqualTo(PostgresType.ARRAY_INT);
     assertThat(PostgresType.getTypeFromArcade(Type.ARRAY_OF_INTEGERS)).isEqualTo(PostgresType.ARRAY_INT);

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A RowDescription column is typed either from a sample value ({@link PostgresType#getTypeForValue}, the value
+ * path) or from the declared schema ({@link PostgresType#getTypeFromArcade}, the schema path, taken when a query
+ * returns no rows). The two must resolve every {@link Type} to the same PostgreSQL type: when they disagree, a
+ * column's advertised OID depends on whether the table happens to be empty and clients see it change between
+ * result sets.
+ */
+class PostgresTypeResolutionPathTest {
+
+  /**
+   * A representative value of each Type's default Java type, as the value path would receive it from a stored
+   * record.
+   */
+  private static final Map<Type, Object> SAMPLE_VALUES = new EnumMap<>(Type.class);
+
+  static {
+    SAMPLE_VALUES.put(Type.BOOLEAN, Boolean.TRUE);
+    SAMPLE_VALUES.put(Type.INTEGER, 42);
+    SAMPLE_VALUES.put(Type.SHORT, (short) 10);
+    SAMPLE_VALUES.put(Type.LONG, 100L);
+    SAMPLE_VALUES.put(Type.FLOAT, 1.5f);
+    SAMPLE_VALUES.put(Type.DOUBLE, 2.5d);
+    SAMPLE_VALUES.put(Type.DATETIME, new Date());
+    SAMPLE_VALUES.put(Type.STRING, "text");
+    SAMPLE_VALUES.put(Type.BINARY, new byte[] { 1, 2 });
+    SAMPLE_VALUES.put(Type.LIST, List.of("a", "b"));
+    SAMPLE_VALUES.put(Type.MAP, Map.of("k", "v"));
+    SAMPLE_VALUES.put(Type.LINK, new RID(1, 1));
+    SAMPLE_VALUES.put(Type.BYTE, (byte) 5);
+    SAMPLE_VALUES.put(Type.DATE, new Date());
+    SAMPLE_VALUES.put(Type.DECIMAL, new BigDecimal("10.55"));
+    SAMPLE_VALUES.put(Type.EMBEDDED, new JSONObject());
+    SAMPLE_VALUES.put(Type.DATETIME_MICROS, LocalDateTime.now());
+    SAMPLE_VALUES.put(Type.DATETIME_NANOS, LocalDateTime.now());
+    SAMPLE_VALUES.put(Type.DATETIME_SECOND, LocalDateTime.now());
+    SAMPLE_VALUES.put(Type.ARRAY_OF_SHORTS, new short[] { 1, 2 });
+    SAMPLE_VALUES.put(Type.ARRAY_OF_INTEGERS, new int[] { 1, 2 });
+    SAMPLE_VALUES.put(Type.ARRAY_OF_LONGS, new long[] { 1L, 2L });
+    SAMPLE_VALUES.put(Type.ARRAY_OF_FLOATS, new float[] { 1.5f, 2.5f });
+    SAMPLE_VALUES.put(Type.ARRAY_OF_DOUBLES, new double[] { 1.5d, 2.5d });
+  }
+
+  /**
+   * Types whose two paths are known to disagree, each pending a fix that is not a missing switch case:
+   * <ul>
+   *   <li>SHORT/BYTE: the value path widens Short/Byte to INTEGER, because PostgresType has no int2[] to pair
+   *       with it; reconciling on SMALLINT changes the OID existing clients already receive for populated rows.
+   *   <li>DATETIME: java.util.Date is the default Java type of both DATE and DATETIME, so the value path cannot
+   *       tell them apart and answers DATE for either.
+   *   <li>DECIMAL: neither DOUBLE (lossy) nor VARCHAR is right; the fix is a NUMERIC (OID 1700) entry with a
+   *       binary encoder.
+   *   <li>BINARY: neither VARCHAR nor _char is right; the fix is a BYTEA (OID 17) entry.
+   * </ul>
+   * Removing an entry here is the intended way to land one of those fixes.
+   */
+  private static final Map<Type, PathDisagreement> KNOWN_DISAGREEMENTS = new EnumMap<>(Type.class);
+
+  static {
+    KNOWN_DISAGREEMENTS.put(Type.SHORT, new PathDisagreement(PostgresType.SMALLINT, PostgresType.INTEGER));
+    KNOWN_DISAGREEMENTS.put(Type.BYTE, new PathDisagreement(PostgresType.SMALLINT, PostgresType.INTEGER));
+    KNOWN_DISAGREEMENTS.put(Type.DATETIME, new PathDisagreement(PostgresType.TIMESTAMP, PostgresType.DATE));
+    KNOWN_DISAGREEMENTS.put(Type.DECIMAL, new PathDisagreement(PostgresType.DOUBLE, PostgresType.VARCHAR));
+    KNOWN_DISAGREEMENTS.put(Type.BINARY, new PathDisagreement(PostgresType.VARCHAR, PostgresType.ARRAY_CHAR));
+  }
+
+  private record PathDisagreement(PostgresType schemaPath, PostgresType valuePath) {
+  }
+
+  @Test
+  void everyTypeHasASampleValue() {
+    // Guards the table below against silently skipping a Type added to the enum later.
+    assertThat(SAMPLE_VALUES.keySet()).containsExactlyInAnyOrder(Type.values());
+  }
+
+  @Test
+  void schemaPathAgreesWithValuePathForEveryType() {
+    for (final Type arcadeType : Type.values()) {
+      if (KNOWN_DISAGREEMENTS.containsKey(arcadeType))
+        continue;
+
+      final PostgresType fromSchema = PostgresType.getTypeFromArcade(arcadeType);
+      final PostgresType fromValue = PostgresType.getTypeForValue(SAMPLE_VALUES.get(arcadeType));
+
+      assertThat(fromSchema)
+          .as("%s resolves to %s from a sample value but to %s from the schema, so its column OID would depend "
+              + "on whether the result set is empty", arcadeType, fromValue, fromSchema)
+          .isEqualTo(fromValue);
+    }
+  }
+
+  @Test
+  void knownDisagreementsStillDisagree() {
+    // Pins the documented exceptions so that fixing one forces its entry to be removed above rather than leaving
+    // a stale exemption that would mask a regression.
+    KNOWN_DISAGREEMENTS.forEach((arcadeType, expected) -> {
+      assertThat(PostgresType.getTypeFromArcade(arcadeType)).as("schema path of %s", arcadeType).isEqualTo(expected.schemaPath());
+      assertThat(PostgresType.getTypeForValue(SAMPLE_VALUES.get(arcadeType))).as("value path of %s", arcadeType)
+          .isEqualTo(expected.valuePath());
+    });
+  }
+
+  @Test
+  void valuePathTypesShortArrays() {
+    // Type.ARRAY_OF_SHORTS declares short[] as its default Java type, so a plain property declaration reaches
+    // the value path with one: it used to hit the switch's default and abort the whole query.
+    assertThat(PostgresType.getTypeForValue(new short[] { 1, 2 })).isEqualTo(PostgresType.ARRAY_INT);
+    assertThat(PostgresType.getTypeForValue(new Short[] { 1, 2 })).isEqualTo(PostgresType.ARRAY_INT);
+  }
+
+  @Test
+  void schemaPathTypesArrayTypesAsArrays() {
+    assertThat(PostgresType.getTypeFromArcade(Type.ARRAY_OF_SHORTS)).isEqualTo(PostgresType.ARRAY_INT);
+    assertThat(PostgresType.getTypeFromArcade(Type.ARRAY_OF_INTEGERS)).isEqualTo(PostgresType.ARRAY_INT);
+    assertThat(PostgresType.getTypeFromArcade(Type.ARRAY_OF_LONGS)).isEqualTo(PostgresType.ARRAY_LONG);
+    assertThat(PostgresType.getTypeFromArcade(Type.ARRAY_OF_FLOATS)).isEqualTo(PostgresType.ARRAY_REAL);
+    assertThat(PostgresType.getTypeFromArcade(Type.ARRAY_OF_DOUBLES)).isEqualTo(PostgresType.ARRAY_DOUBLE);
+  }
+
+  @Test
+  void schemaPathTypesSubSecondDatetimesAsTimestamps() {
+    assertThat(PostgresType.getTypeFromArcade(Type.DATETIME_MICROS)).isEqualTo(PostgresType.TIMESTAMP);
+    assertThat(PostgresType.getTypeFromArcade(Type.DATETIME_NANOS)).isEqualTo(PostgresType.TIMESTAMP);
+    assertThat(PostgresType.getTypeFromArcade(Type.DATETIME_SECOND)).isEqualTo(PostgresType.TIMESTAMP);
+  }
+
+  @Test
+  void arrayTypesAreAdvertisedAsArrays() {
+    // The five ARRAY_OF_* types used to collapse to a scalar varchar on the schema path.
+    for (final Type arrayType : EnumSet.of(Type.ARRAY_OF_SHORTS, Type.ARRAY_OF_INTEGERS, Type.ARRAY_OF_LONGS,
+        Type.ARRAY_OF_FLOATS, Type.ARRAY_OF_DOUBLES))
+      assertThat(PostgresType.getTypeFromArcade(arrayType).isArrayType()).as("%s is an array type", arrayType).isTrue();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -39,7 +39,9 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -732,6 +734,95 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
           assertThat(meta.getColumnTypeName(rs.findColumn("embedded_list"))).isEqualToIgnoringCase("_json");
           assertThat(meta.getColumnTypeName(rs.findColumn("certifications"))).isEqualToIgnoringCase("_text");
           assertThat((Object[]) rs.getArray("embedded_list").getArray()).isEmpty();
+        }
+      }
+    }
+  }
+
+  /**
+   * Issue #5311: an ARRAY_OF_SHORTS property made the whole query fail. The value path's array switch had no
+   * short[]/Short[] case, so it reached its throwing default and the client got an error instead of rows.
+   */
+  @Test
+  void shortArrayPropertyIsQueryable() throws Exception {
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("""
+            {sqlscript}
+            CREATE DOCUMENT TYPE Reading IF NOT EXISTS;
+            CREATE PROPERTY Reading.shorts IF NOT EXISTS ARRAY_OF_SHORTS;
+
+            INSERT INTO Reading SET shorts = [1,2];
+            """);
+      }
+
+      try (var st = conn.createStatement()) {
+        try (var rs = st.executeQuery("SELECT FROM Reading")) {
+          assertThat(rs.next()).isTrue();
+          // Shorts are advertised as int4[]: there is no int2[] type to announce them with.
+          assertThat(rs.getMetaData().getColumnTypeName(rs.findColumn("shorts"))).isEqualToIgnoringCase("_int4");
+          assertThat((Object[]) rs.getArray("shorts").getArray()).containsExactly(1, 2);
+          assertThat(rs.next()).isFalse();
+        }
+      }
+    }
+  }
+
+  /**
+   * Issue #5311: the schema path had no case for the ARRAY_OF_* and sub-second DATETIME_* types, so it collapsed
+   * them to a scalar varchar. Querying the same type empty and then populated must advertise the same OID.
+   */
+  @Test
+  void arrayAndDatetimeColumnsKeepTheirTypeWhenTheResultSetIsEmpty() throws Exception {
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("""
+            {sqlscript}
+            CREATE DOCUMENT TYPE Sample IF NOT EXISTS;
+            CREATE PROPERTY Sample.shorts  IF NOT EXISTS ARRAY_OF_SHORTS;
+            CREATE PROPERTY Sample.ints    IF NOT EXISTS ARRAY_OF_INTEGERS;
+            CREATE PROPERTY Sample.longs   IF NOT EXISTS ARRAY_OF_LONGS;
+            CREATE PROPERTY Sample.floats  IF NOT EXISTS ARRAY_OF_FLOATS;
+            CREATE PROPERTY Sample.doubles IF NOT EXISTS ARRAY_OF_DOUBLES;
+            CREATE PROPERTY Sample.micros  IF NOT EXISTS DATETIME_MICROS;
+            CREATE PROPERTY Sample.nanos   IF NOT EXISTS DATETIME_NANOS;
+            CREATE PROPERTY Sample.seconds IF NOT EXISTS DATETIME_SECOND;
+            """);
+      }
+
+      final Map<String, String> expectedTypeNames = new LinkedHashMap<>();
+      expectedTypeNames.put("shorts", "_int4");
+      expectedTypeNames.put("ints", "_int4");
+      expectedTypeNames.put("longs", "_int8");
+      expectedTypeNames.put("floats", "_float4");
+      expectedTypeNames.put("doubles", "_float8");
+      expectedTypeNames.put("micros", "timestamp");
+      expectedTypeNames.put("nanos", "timestamp");
+      expectedTypeNames.put("seconds", "timestamp");
+
+      // No rows: RowDescription comes from the schema path. Before the fix every column below reported varchar.
+      try (var st = conn.createStatement()) {
+        try (var rs = st.executeQuery("SELECT FROM Sample WHERE 1=0")) {
+          final var meta = rs.getMetaData();
+          for (final var expected : expectedTypeNames.entrySet())
+            assertThat(meta.getColumnTypeName(rs.findColumn(expected.getKey()))).as("empty result set, column %s", expected.getKey())
+                .isEqualToIgnoringCase(expected.getValue());
+        }
+      }
+
+      try (var st = conn.createStatement()) {
+        st.execute("INSERT INTO Sample SET shorts = [1,2], ints = [3,4], longs = [5,6], floats = [1.5], "
+            + "doubles = [2.5], micros = sysdate(), nanos = sysdate(), seconds = sysdate()");
+      }
+
+      // Rows present: RowDescription comes from the value path and must announce the very same OIDs.
+      try (var st = conn.createStatement()) {
+        try (var rs = st.executeQuery("SELECT FROM Sample")) {
+          assertThat(rs.next()).isTrue();
+          final var meta = rs.getMetaData();
+          for (final var expected : expectedTypeNames.entrySet())
+            assertThat(meta.getColumnTypeName(rs.findColumn(expected.getKey()))).as("populated result set, column %s",
+                expected.getKey()).isEqualToIgnoringCase(expected.getValue());
         }
       }
     }


### PR DESCRIPTION
Closes #5311

Scoped to items 1 and 2 of the issue's suggested scope. `PostgresType` types a RowDescription column via two independent paths that had drifted apart: the value path (`getTypeForValue`, used when a sample row exists) and the schema path (`getTypeFromArcade`, used when a query returns 0 rows). The value path's array switch had no `short[]`/`Short[]` case, so an `ARRAY_OF_SHORTS` property, whose declared default Java type is `short[]`, reached `default -> throw new IllegalStateException` and failed the whole query; the schema path had no case for 8 of the 24 `Type` values, so the five `ARRAY_OF_*` types were announced as a scalar `varchar` and the sub-second `DATETIME_*` types lost their `timestamp` OID whenever the result set happened to be empty. This adds the missing cases on both sides, so a column's advertised OID no longer depends on whether the table is empty. `DECIMAL` (item 3) and `BINARY` (item 4) are deliberately left out: both need a new `PostgresType` entry (`NUMERIC` OID 1700 / `BYTEA` OID 17) with a binary encoder rather than a switch case.

Shorts widen to `int4[]` because `getArrayTypeForElementType` already answers `ARRAY_INT` for a `Short` element and there is no `int2[]` entry to pair with a narrower answer. `convertPrimitiveArrayToCollection` needed no change: it already handles `short[]`, and `Short[]` is matched by its `Object[]` branch.

### Newly found, not fixed here

The table-driven test surfaced three disagreements the issue's audit does not list (it states the other 14 types "agree and are fine"): `SHORT` and `BYTE` (schema `SMALLINT` vs value `INTEGER`), and `DATETIME` (schema `TIMESTAMP` vs value `DATE`, because `java.util.Date` is the default Java type of both `DATE` and `DATETIME` so the value path cannot tell them apart). Each changes behaviour beyond what this issue audited, so they are pinned in `KNOWN_DISAGREEMENTS` alongside `DECIMAL`/`BINARY` and left for a separate issue.

### Behaviour change

Columns of the 8 affected types now advertise their real OID on empty result sets instead of `varchar`. A client that adapted to reading these as text from an empty-result-set probe will now get the array/timestamp OID - the intended correction, and what those clients already received for non-empty result sets.

## Test plan

- [x] `PostgresTypeResolutionPathTest` (new): asserts the schema path and value path agree for every one of the 24 `Type` values, with a `KNOWN_DISAGREEMENTS` table pinning the documented exceptions so fixing one forces its exemption to be removed. `everyTypeHasASampleValue` guards the table against a `Type` added to the enum later being silently skipped.
- [x] `PostgresWJdbcIT#shortArrayPropertyIsQueryable`: the issue's exact repro over pgJDBC; previously threw `PSQLException: Unexpected value: [S@...`.
- [x] `PostgresWJdbcIT#arrayAndDatetimeColumnsKeepTheirTypeWhenTheResultSetIsEmpty`: asserts identical OIDs for empty vs populated result sets across all 8 affected columns.
- [x] Tests confirmed to genuinely catch the bug: reverted the production change and observed 4 failures + 1 `IllegalStateException`, then restored it.
- [x] `mvn -pl postgresw verify -DskipITs=false`: 218 unit + 110 integration tests pass.
- [x] `getTypeFromArcade`/`getTypeForValue` are consumed only by `PostgresNetworkExecutor` within `postgresw`, so the blast radius is limited to the Postgres wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)