### PR TITLE
fix(tests): stop QueryEngineManagerPoolTest deadlocking the shared query pool

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -87,6 +87,9 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     needs: build-and-package
+    # A hung test used to burn the workflow's whole budget in silence (run 29645471373 sat for
+    # 2h15m on a deadlocked shared thread pool). Cap the job so a hang costs minutes, not hours.
+    timeout-minutes: 60
     permissions:
       contents: read
       checks: write
@@ -108,7 +111,23 @@ jobs:
 
       - name: Run Unit Tests with Coverage
         # package phase runs surefire (test) and JaCoCo report (prepare-package) without reaching integration-test phase
-        run: ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e,!load-tests -DexcludedGroups=slow,benchmark -Dsurefire.includes=**/*Test.java,**/*Suite.java
+        # A watchdog dumps every JVM's stacks before the job timeout fires. Without it a deadlocked
+        # surefire fork produces no output at all, so there is nothing to diagnose after the fact.
+        run: |
+          (
+            sleep 2700
+            echo "::warning::Unit tests still running after 45m - dumping JVM thread stacks"
+            for pid in $(jps -q 2>/dev/null); do
+              echo "===== jstack $pid ====="
+              jstack "$pid" 2>&1 || true
+            done
+          ) &
+          watchdog=$!
+          set +e
+          ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e,!load-tests -DexcludedGroups=slow,benchmark -Dsurefire.includes=**/*Test.java,**/*Suite.java
+          status=$?
+          kill "$watchdog" 2>/dev/null || true
+          exit $status
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -116,10 +116,15 @@ jobs:
         run: |
           (
             sleep 2700
-            echo "::warning::Unit tests still running after 45m - dumping JVM thread stacks"
-            for pid in $(jps -q 2>/dev/null); do
-              echo "===== jstack $pid ====="
-              jstack "$pid" 2>&1 || true
+            # Repeats until killed: a single dump at 45m would show a healthy build and tell us
+            # nothing about a hang that only begins afterwards.
+            while true; do
+              echo "::warning::Unit tests still running - dumping JVM thread stacks"
+              for pid in $(jps -q 2>/dev/null); do
+                echo "===== jstack $pid ====="
+                jstack "$pid" 2>&1 || true
+              done
+              sleep 300
             done
           ) &
           watchdog=$!

--- a/engine/src/test/java/com/arcadedb/query/QueryEngineManagerPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/query/QueryEngineManagerPoolTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
@@ -78,19 +79,46 @@ class QueryEngineManagerPoolTest {
    * <p>
    * A leaked pin is otherwise undetectable here and lethal later - the pool is JVM-wide, so the
    * next caller that waits on an untimed future blocks for the lifetime of the fork, with no error
-   * and no output to attribute it to. Both leak shapes are caught: if the workers are pinned and
-   * the queue is full the canary is redirected to the caller thread by the rejection policy (so the
-   * thread id comes back equal to ours), and if the queue still has room the canary sits in it
-   * forever (so the timed get expires). Either way this fails fast, right next to the culprit.
+   * and no output to attribute it to. Both leak shapes are caught: if the queue still has room the
+   * canary sits in it behind the pinned workers until the timed get expires, and if the queue is
+   * full the rejection policy keeps redirecting the canary to this thread until the deadline. Both
+   * paths raise an {@link AssertionError} naming the pinning discipline, so the CI log explains
+   * itself rather than showing a bare timeout.
    */
   @AfterEach
   void poolMustNotBeLeftSaturated() throws Exception {
+    final ExecutorService executor = QueryEngineManager.getInstance().getExecutorService();
     final long callerThreadId = Thread.currentThread().threadId();
-    final Future<Long> canary = QueryEngineManager.getInstance().getExecutorService()
-        .submit(() -> Thread.currentThread().threadId());
-    assertThat(canary.get(WORKER_PIN_TIMEOUT_SECONDS, TimeUnit.SECONDS))
-        .as("pool must be left usable: a test leaked a pinned worker and poisoned the shared pool")
-        .isNotEqualTo(callerThreadId);
+    final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(WORKER_PIN_TIMEOUT_SECONDS);
+
+    // Retried rather than judged on a single sample. A saturation test's finally releases the pinned
+    // workers but does not wait for them to drain the queue, so for a short window afterwards the
+    // queue is still full and the rejection policy legitimately runs the canary on this thread.
+    // Reading that first inline run as a leak would make this guard flaky under exactly the load
+    // conditions the rest of the class was fixed to survive.
+    while (true) {
+      final long remainingMs = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+      if (remainingMs <= 0)
+        throw new AssertionError("pool left saturated: the canary was still being redirected to the caller thread after "
+            + WORKER_PIN_TIMEOUT_SECONDS + "s, so a test leaked a pinned worker and poisoned the shared pool");
+
+      final Future<Long> canary = executor.submit(() -> Thread.currentThread().threadId());
+      final long ranOnThreadId;
+      try {
+        ranOnThreadId = canary.get(remainingMs, TimeUnit.MILLISECONDS);
+      } catch (final TimeoutException e) {
+        // Built here, not via assertThat: the timeout fires before any assertion can run, and this
+        // is the likelier of the two leak shapes (a pin that leaks before the queue is filled leaves
+        // the canary queued behind it forever). Without this the CI log shows a bare
+        // TimeoutException with nothing to connect it to the pinning discipline.
+        throw new AssertionError("pool left saturated: the canary never reached a worker thread within "
+            + WORKER_PIN_TIMEOUT_SECONDS + "s, so a test leaked a pinned worker and poisoned the shared pool", e);
+      }
+      if (ranOnThreadId != callerThreadId)
+        // Ran on a pool thread: the pool is healthy again.
+        return;
+      Thread.sleep(25);
+    }
   }
 
   /** {@link QueryEngineManager.PoolStats} fields are non-negative and self-consistent at rest. */

--- a/engine/src/test/java/com/arcadedb/query/QueryEngineManagerPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/query/QueryEngineManagerPoolTest.java
@@ -18,7 +18,9 @@
  */
 package com.arcadedb.query;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -40,8 +43,55 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The pool's behaviour matters operationally (it backs every parallel query), so these tests
  * pin the contract independently of the rest of the engine. The pool itself is a JVM-wide
  * singleton, so the tests target observable behaviour rather than reconfiguring the singleton.
+ * <p>
+ * <b>Pinning discipline.</b> Saturating the pool means blocking every one of its worker threads.
+ * Because the pool is shared by the whole JVM, a leaked latch leaves those workers blocked for
+ * the rest of the surefire fork; every later caller that waits on an untimed {@code Future.get()}
+ * (e.g. {@code GraphAlgorithms.awaitFutures}) then hangs forever. So every test that pins workers
+ * MUST take the latch inside a try/finally that releases it, with no assertion or pool interaction
+ * placed before the {@code try}. The class-level timeout is the backstop if that discipline slips.
  */
+@Timeout(120)
 class QueryEngineManagerPoolTest {
+
+  /**
+   * How long a pinning task is given to reach a worker thread. Generous on purpose: the pool is
+   * shared, so on a loaded CI runner the workers may be finishing other engine work when the
+   * pinning tasks are submitted. A tight bound here is the difference between a stable test and a
+   * spurious failure.
+   */
+  private static final int WORKER_PIN_TIMEOUT_SECONDS = 30;
+
+  /**
+   * Worker count read from the pool itself rather than recomputed from {@code availableProcessors()}.
+   * The pool honours {@code arcadedb.queryParallelismPoolThreads}, so a guess based on CPU count can
+   * be too low (queue never fills, no fallback happens) or too high (the pin latch never reaches
+   * zero) depending on how the JVM was configured.
+   */
+  private static int maxPoolThreads() {
+    return ((ThreadPoolExecutor) QueryEngineManager.getInstance().getExecutorService()).getMaximumPoolSize();
+  }
+
+  /**
+   * Guards the pinning discipline described in the class javadoc: after every test the shared pool
+   * must still be able to run work on its own threads.
+   * <p>
+   * A leaked pin is otherwise undetectable here and lethal later - the pool is JVM-wide, so the
+   * next caller that waits on an untimed future blocks for the lifetime of the fork, with no error
+   * and no output to attribute it to. Both leak shapes are caught: if the workers are pinned and
+   * the queue is full the canary is redirected to the caller thread by the rejection policy (so the
+   * thread id comes back equal to ours), and if the queue still has room the canary sits in it
+   * forever (so the timed get expires). Either way this fails fast, right next to the culprit.
+   */
+  @AfterEach
+  void poolMustNotBeLeftSaturated() throws Exception {
+    final long callerThreadId = Thread.currentThread().threadId();
+    final Future<Long> canary = QueryEngineManager.getInstance().getExecutorService()
+        .submit(() -> Thread.currentThread().threadId());
+    assertThat(canary.get(WORKER_PIN_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        .as("pool must be left usable: a test leaked a pinned worker and poisoned the shared pool")
+        .isNotEqualTo(callerThreadId);
+  }
 
   /** {@link QueryEngineManager.PoolStats} fields are non-negative and self-consistent at rest. */
   @Test
@@ -82,30 +132,33 @@ class QueryEngineManagerPoolTest {
   void callerRunsFallbackTicksWhenQueueSaturates() throws Exception {
     final ExecutorService executor = QueryEngineManager.getInstance().getExecutorService();
     final QueryEngineManager.PoolStats before = QueryEngineManager.getInstance().getExecutorStats();
-    final int poolSize = Math.max(2, Runtime.getRuntime().availableProcessors());
+    final int poolSize = maxPoolThreads();
     final int queueCapacity = before.queueCapacityRemaining() + before.queueDepth();
     final CountDownLatch release = new CountDownLatch(1);
     final CountDownLatch allWorkersBusy = new CountDownLatch(poolSize);
 
-    // Pin every worker thread on a latch so the queue actually fills.
-    for (int i = 0; i < poolSize; i++) {
-      executor.submit(() -> {
-        try {
-          allWorkersBusy.countDown();
-          release.await();
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      });
-    }
-    assertThat(allWorkersBusy.await(5, TimeUnit.SECONDS))
-        .as("all workers should pick up the blocking task within 5s").isTrue();
-
-    // Fill the queue. Each task is a no-op runnable; they remain queued until release fires.
-    for (int i = 0; i < queueCapacity; i++)
-      executor.submit(() -> { /* no-op */ });
-
+    // Everything that touches the pool lives inside this try: the finally is the only thing that
+    // un-pins the shared worker threads, so nothing may throw before we get here.
     try {
+      // Pin every worker thread on a latch so the queue actually fills.
+      for (int i = 0; i < poolSize; i++) {
+        executor.submit(() -> {
+          try {
+            allWorkersBusy.countDown();
+            release.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        });
+      }
+      assertThat(allWorkersBusy.await(WORKER_PIN_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          .as("all %d workers should pick up the blocking task within %ds", poolSize, WORKER_PIN_TIMEOUT_SECONDS)
+          .isTrue();
+
+      // Fill the queue. Each task is a no-op runnable; they remain queued until release fires.
+      for (int i = 0; i < queueCapacity; i++)
+        executor.submit(() -> { /* no-op */ });
+
       // The next submit must trigger caller-runs. Use a sentinel that records its execution
       // thread so we can assert it ran on this thread.
       final long callerThreadId = Thread.currentThread().threadId();
@@ -153,6 +206,15 @@ class QueryEngineManagerPoolTest {
         (AtomicLong) throttleField.get(QueryEngineManager.getInstance());
     throttle.set(0L);
 
+    // Read the pool geometry before swapping the logger, so that the swap is the last thing that
+    // happens before the try: nothing between it and the finally can throw and strand the
+    // substitute logger in place for the rest of the fork.
+    final int poolSize = maxPoolThreads();
+    final QueryEngineManager.PoolStats before = QueryEngineManager.getInstance().getExecutorStats();
+    final int queueCapacity = before.queueCapacityRemaining() + before.queueDepth();
+    final CountDownLatch release = new CountDownLatch(1);
+    final CountDownLatch allWorkersBusy = new CountDownLatch(poolSize);
+
     // Capture WARNING logs via the LogManager logger swap. The production logger writes to the
     // server console (and routes through the slf4j chain in production); the test substitutes a
     // simple list-collector for the duration of the test, then restores.
@@ -175,11 +237,6 @@ class QueryEngineManagerPoolTest {
       @Override public void flush() {}
     });
 
-    final int poolSize = Math.max(2, Runtime.getRuntime().availableProcessors());
-    final QueryEngineManager.PoolStats before = QueryEngineManager.getInstance().getExecutorStats();
-    final int queueCapacity = before.queueCapacityRemaining() + before.queueDepth();
-    final CountDownLatch release = new CountDownLatch(1);
-    final CountDownLatch allWorkersBusy = new CountDownLatch(poolSize);
     try {
       for (int i = 0; i < poolSize; i++) {
         executor.submit(() -> {
@@ -191,7 +248,11 @@ class QueryEngineManagerPoolTest {
           }
         });
       }
-      allWorkersBusy.await(5, TimeUnit.SECONDS);
+      // Asserted, not ignored: if the workers never pinned, the queue below never fills and the
+      // saturation this test exists to observe would silently not happen.
+      assertThat(allWorkersBusy.await(WORKER_PIN_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          .as("all %d workers should pick up the blocking task within %ds", poolSize, WORKER_PIN_TIMEOUT_SECONDS)
+          .isTrue();
       for (int i = 0; i < queueCapacity; i++)
         executor.submit(() -> { /* no-op */ });
 


### PR DESCRIPTION
## What does this PR do?

Fixes a deadlock in `QueryEngineManagerPoolTest` that could hang the `unit-tests` CI job indefinitely, and adds two CI safety nets so a future hang is bounded and diagnosable.

## Motivation

The `unit-tests` job on run [29645471373](https://github.com/ArcadeData/arcadedb/actions/runs/29645471373) ran **2h28m** before being cancelled.

The OpenCypher TCK was the initial suspect, but the log clears it:

```
Tests run: 3897, Skipped: 85, Time elapsed: 220.6 s -- in OpenCypherTCKSuite
```

3897 scenarios in 3.7 minutes, finished at 13:14:56 — seven minutes before anything went wrong. The job instead went silent right after:

```
13:22:05.729  [INFO] Running com.arcadedb.query.QueryEngineManagerPoolTest
15:37:29.411  ##[error]The operation was canceled.
```

Corroborating: 504 classes printed `Running`, 503 printed a result line, and the job never left the Engine module.

### Root cause

`QueryEngineManagerPoolTest` saturates the **JVM-wide singleton** query-parallelism pool by pinning every worker thread on a latch. The release lived in a `finally`, but the pinning submits and this assertion sat *before* the `try`:

```java
assertThat(allWorkersBusy.await(5, TimeUnit.SECONDS)).isTrue();   // outside try
...
try { ... } finally { release.countDown(); }
```

"All N workers pick up my task within 5s" holds on an idle dev machine and not on a loaded 2-4 core runner under JaCoCo. When it fails, `release` is never counted down and every pool worker blocks permanently. `GraphAlgorithms.awaitFutures` then waits on an **untimed** `futures[i].get()` — precisely the hang-forever path the pool's own rejection handler documents.

## Additional Notes

**Test changes**
- All pool interaction moved inside the `try`, so the `finally` always releases
- Worker count read from `getMaximumPoolSize()` rather than guessed via `availableProcessors()`; the guess breaks whenever `arcadedb.queryParallelismPoolThreads` is set (too low → queue never fills; too high → pin latch never reaches zero)
- Pin timeout 5s → 30s, and the second test's previously-ignored `await` is now asserted
- Logger swap kept adjacent to its `try` so it cannot be stranded for the rest of the fork
- New `@AfterEach` canary that fails fast if a test leaves the pool pinned, plus class-level `@Timeout` as a backstop

**CI changes**
- `timeout-minutes: 60` on `unit-tests`, which previously had none
- Watchdog that jstacks every JVM at 45m, so a future hang leaves evidence instead of silence

**Verification.** I reintroduced the original defect to prove the guard works. It reproduced the CI mechanism exactly — the canary caught it, and every subsequent test in the class then failed with `TimeoutException`, confirming that one leaked pin poisons the shared pool for everything downstream:

```
[ERROR] QueryEngineManagerPoolTest.callerRunsFallbackTicksWhenQueueSaturates:150 [INJECTED FAILURE]
[ERROR] QueryEngineManagerPoolTest.poolMustNotBeLeftSaturated:91 » Timeout
[ERROR] QueryEngineManagerPoolTest.submittedTasksRunOnPoolThread:117 » Timeout
[INFO] BUILD FAILURE
```

157s and a clear failure, instead of an unbounded hang. After reverting, the class is green (4/4) and 307 related pool-consuming tests pass.

**Caveat for reviewers:** I could not reproduce the original hang from a clean run — the class passes in ~0.1s locally. The structural defect is certain from the code and the CI evidence firmly locates the stall in this class, but the precise trigger is inferred rather than observed. The new watchdog will confirm it definitively if it ever recurs.

## Checklist

- [x] I have run the build using `mvn clean package` command — engine module built and the affected tests run
- [x] My unit tests cover both failure and success scenarios — the guard was validated by deliberate defect injection, not just by passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
