### PR TITLE
ci(native): Native Image workflow_dispatch stub (enables testing PR #5323)

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -1,0 +1,16 @@
+name: Native Image
+
+# Stub. This enables the `workflow_dispatch` event so the full Native Image workflow, which lives
+# on the `feat/native-image` branch, can be run manually against that branch: workflow_dispatch
+# only registers a workflow as dispatchable once a workflow of this name exists on the default
+# branch, and dispatching executes the version of the file present on the selected ref. This stub
+# is replaced by the real 5-target build/smoke/Docker workflow when the native-image feature merges.
+on:
+  workflow_dispatch:
+
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - run: echo "Stub. The full native-image workflow lives on feat/native-image; dispatch that branch to run it."


### PR DESCRIPTION
## What does this PR do?

Adds a minimal `workflow_dispatch` stub of the `Native Image` workflow to `main`.

## Motivation

The full Native Image workflow (on `feat/native-image`, PR #5323) triggers only on `workflow_dispatch` and `release`, so it cannot be exercised from a PR. GitHub only registers a workflow as dispatchable once a workflow of that name exists on the **default branch**; dispatching then runs the version of the file present on the **selected ref**.

Merging this stub lets the full workflow be run against `feat/native-image` (select that branch in "Run workflow") to validate the real 5-target build, smoke, and Docker logic before merge. Dispatch is safe: in the full workflow, Docker pushes are gated to the `release` event, so a `workflow_dispatch` run builds and smoke-tests (`--load` + local container smoke) without publishing anything to `arcadedata/arcadedb`.

## Related issues

Bootstraps testing for PR #5323 (experimental GraalVM native-image build). This stub is replaced by the real workflow when that feature merges.

## Additional Notes

The stub does nothing but a checkout + an echo. After it merges, `feat/native-image` will be rebased onto `main` (a trivial one-file conflict on `native-image.yml`, resolved in favor of the feature branch's full version).

## Checklist

- [x] I have run the build using `mvn clean package` command (n/a - workflow-only change; `actionlint` + YAML validation pass)
- [x] My unit tests cover both failure and success scenarios (n/a - stub workflow, no logic)
