### PR TITLE
fix(#5347): support parameterized payloads in UPDATE ... MERGE

### DIFF
--- a/docs/5347-merge-parameterized-json-npe.md
+++ b/docs/5347-merge-parameterized-json-npe.md
@@ -63,6 +63,44 @@ All four fail on `main` with the NPE and pass with the fix.
   pre-existing/environmental GraalVM-JavaScript tests (`TriggerSQLTest` JS triggers,
   `SQLVectorHybridSearchBlogPostTest` JS helpers) and one benchmark, all unrelated to this change.
 
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5348
+
+## Review cycles
+
+### Cycle 1 - head `5ec4abf`
+
+Reviewers: `gemini-code-assist` (COMMENTED, 1 medium inline), `claude[bot]` (issue comment).
+
+Addressed:
+
+- **`Result` branch leaked metadata** (claude). `Result.toMap()` on an element-backed result returns
+  `element.toMap(true)`, injecting `@rid` / `@type` / `@cat`, which the merge loop would have stored on
+  the target record. Replaced with `toPropertyMap(Result)`, which iterates `getPropertyNames()` and skips
+  `@`-prefixed metadata and `$`-prefixed computed pseudo-properties (`$score`, `$similarity`).
+- **Unchecked `Map` cast** (claude). A map with non-String keys previously erased through the cast and blew
+  up with a raw `ClassCastException` in the merge loop. `checkStringKeys` now validates and raises
+  `CommandExecutionException`, keeping the "expected a map" contract uniform.
+- **Defensive null check on `expression`** (gemini). `resolveExpression` now throws
+  `CommandExecutionException("Missing payload for UPDATE MERGE")` instead of NPE-ing if both payload fields
+  are null.
+- **Test coverage gap for the `Document` / `Result` branches** (claude). Added
+  `updateMergeWithDocumentParameterDoesNotLeakMetadata`, `updateMergeWithSubQueryDoesNotLeakMetadata`, and
+  `updateMergeWithNonStringKeyMapFails`.
+
+The sub-query test surfaced a further gap: a sub-query expression evaluates to a `Collection` of `Result`,
+not a bare `Result`, so `UPDATE V MERGE (SELECT ...)` still failed. `resolveExpression` now unwraps a
+single-element collection and raises a clear `CommandExecutionException` for zero or many items.
+
+Not addressed:
+
+- claude's note that a `null` payload yields `CommandExecutionException` rather than a no-op. claude itself
+  judged the current behavior fine for this fix; changing MERGE null semantics is out of scope for an NPE fix.
+- claude's suggestion that `updateMergeWithNonMapParameterFails` also assert the record was not partially
+  mutated. The merge loop resolves the whole payload before any `doc.set`, so partial mutation is not
+  reachable via that path; claude flagged it as non-essential.
+
 ## Impact
 
 Behavior change is limited to `UPDATE ... MERGE <non-JSON-literal>` and

--- a/docs/5347-merge-parameterized-json-npe.md
+++ b/docs/5347-merge-parameterized-json-npe.md
@@ -1,0 +1,69 @@
+# Issue #5347 - NullPointerException when using parameterized JSON with MERGE clause in UPDATE
+
+## Problem
+
+```sql
+UPDATE Entity MERGE :payload UPSERT WHERE canonical_id = :id
+```
+
+with `payload` bound to a JSON object threw:
+
+```
+java.lang.NullPointerException: Cannot invoke "com.arcadedb.query.sql.parser.Json.toMap(...)" because "this.json" is null
+```
+
+Inlining the JSON literal in the query text worked.
+
+## Root cause
+
+The SQL grammar accepts `MERGE expression` (`SQLParser.g4`), but `SQLASTBuilder.visitUpdateOperation`
+only ever extracted a `Json` literal out of that expression:
+
+- direct `expr.json`, or
+- `BaseExpression.expression.json` (map literal).
+
+Any other expression shape - an input parameter (`:payload` / `?`), a LET variable, a sub-query -
+silently left `UpdateOperations.json` as `null`. `UpdateExecutionPlanner` then chained
+`new UpdateMergeStep(null, ctx)` and `UpdateMergeStep.handleMerge` dereferenced the null `Json`.
+So the failure was an unconditional NPE, not a validation error.
+
+## Fix
+
+1. `UpdateOperations` gains an `expression` field (with getter, and wired through
+   `copy()`, `equals()`, `hashCode()`, `toString()`, `toJSON()`), used for MERGE when the payload is
+   not a JSON literal.
+2. `SQLASTBuilder.visitUpdateOperation` now falls through to `ops.expression = expr` instead of
+   leaving both fields null.
+3. `UpdateMergeStep` gains an `Expression` constructor; `handleMerge` resolves the expression per
+   record and accepts `Map`, `Document`, or `Result` payloads, throwing a `CommandExecutionException`
+   with a clear message for anything else (instead of an NPE).
+4. `UpdateExecutionPlanner` and `MoveVertexExecutionPlanner` pick the right `UpdateMergeStep`
+   constructor and raise `CommandExecutionException` if neither payload form is present.
+
+The pre-existing inline-JSON path is untouched: `json != null` still goes through `Json.toMap`.
+
+## Tests
+
+New methods in `engine/src/test/java/com/arcadedb/query/sql/executor/UpdateMergeTest.java`:
+
+- `updateMergeWithNamedParameterMap` - `MERGE :payload` with a map parameter merges into the record.
+- `updateMergeWithPositionalParameterMap` - `MERGE ?` with a map parameter.
+- `updateMergeWithParameterAndUpsertInsertsNewRecord` - the exact reproduction from the issue,
+  `MERGE :payload UPSERT WHERE canonical_id = :id`, inserting a new record (requires a unique index
+  on `canonical_id`, as UPSERT does generally).
+- `updateMergeWithNonMapParameterFails` - a non-map parameter now yields `CommandExecutionException`
+  rather than an NPE.
+
+All four fail on `main` with the NPE and pass with the fix.
+
+## Verification
+
+- `mvn test -Dtest=UpdateMergeTest` in `engine` - 6/6 green.
+- `mvn test -Dtest='com.arcadedb.query.sql.**'` - 2259 tests, 0 failures; the 6 errors are
+  pre-existing/environmental GraalVM-JavaScript tests (`TriggerSQLTest` JS triggers,
+  `SQLVectorHybridSearchBlogPostTest` JS helpers) and one benchmark, all unrelated to this change.
+
+## Impact
+
+Behavior change is limited to `UPDATE ... MERGE <non-JSON-literal>` and
+`MOVE VERTEX ... MERGE <non-JSON-literal>`, which previously always threw an NPE.

--- a/docs/5347-merge-parameterized-json-npe.md
+++ b/docs/5347-merge-parameterized-json-npe.md
@@ -54,7 +54,15 @@ New methods in `engine/src/test/java/com/arcadedb/query/sql/executor/UpdateMerge
 - `updateMergeWithNonMapParameterFails` - a non-map parameter now yields `CommandExecutionException`
   rather than an NPE.
 
-All four fail on `main` with the NPE and pass with the fix.
+- `updateMergeWithDocumentParameterDoesNotLeakMetadata` / `updateMergeWithSubQueryDoesNotLeakMetadata` -
+  record-shaped payloads must not write `@rid` / `@type` / `@cat` onto the target.
+- `updateMergeWithNonStringKeyMapFails` - a map with non-string keys yields `CommandExecutionException`
+  rather than a raw `ClassCastException` from the merge loop.
+
+`MoveVertexStatementExecutionTest.moveVertexWithParameterizedMerge` covers the parallel
+`MOVE VERTEX ... MERGE :payload` path.
+
+The parameter tests fail on `main` with the NPE and pass with the fix.
 
 ## Verification
 
@@ -67,39 +75,28 @@ All four fail on `main` with the NPE and pass with the fix.
 
 https://github.com/ArcadeData/arcadedb/pull/5348
 
-## Review cycles
+## Payload shapes accepted by MERGE
 
-### Cycle 1 - head `5ec4abf`
+`resolveExpression` normalizes whatever the expression evaluates to:
 
-Reviewers: `gemini-code-assist` (COMMENTED, 1 medium inline), `claude[bot]` (issue comment).
+| Shape | Handling |
+|---|---|
+| `Map` | merged verbatim; keys must be strings, otherwise `CommandExecutionException` |
+| `Document` | `toMap(false)` - `@rid` / `@type` / `@cat` stripped |
+| `Result` | property names only, skipping `@` metadata and `$` computed pseudo-properties (`$score`, ...) |
+| single-element `Collection` | unwrapped, then handled as above (this is the sub-query case) |
+| anything else | `CommandExecutionException` with the offending value |
 
-Addressed:
+A user-supplied map is deliberately merged verbatim: its keys are explicit intent, unlike the metadata a
+record-shaped payload carries implicitly.
 
-- **`Result` branch leaked metadata** (claude). `Result.toMap()` on an element-backed result returns
-  `element.toMap(true)`, injecting `@rid` / `@type` / `@cat`, which the merge loop would have stored on
-  the target record. Replaced with `toPropertyMap(Result)`, which iterates `getPropertyNames()` and skips
-  `@`-prefixed metadata and `$`-prefixed computed pseudo-properties (`$score`, `$similarity`).
-- **Unchecked `Map` cast** (claude). A map with non-String keys previously erased through the cast and blew
-  up with a raw `ClassCastException` in the merge loop. `checkStringKeys` now validates and raises
-  `CommandExecutionException`, keeping the "expected a map" contract uniform.
-- **Defensive null check on `expression`** (gemini). `resolveExpression` now throws
-  `CommandExecutionException("Missing payload for UPDATE MERGE")` instead of NPE-ing if both payload fields
-  are null.
-- **Test coverage gap for the `Document` / `Result` branches** (claude). Added
-  `updateMergeWithDocumentParameterDoesNotLeakMetadata`, `updateMergeWithSubQueryDoesNotLeakMetadata`, and
-  `updateMergeWithNonStringKeyMapFails`.
+## Known follow-ups (not in scope for this NPE fix)
 
-The sub-query test surfaced a further gap: a sub-query expression evaluates to a `Collection` of `Result`,
-not a bare `Result`, so `UPDATE V MERGE (SELECT ...)` still failed. `resolveExpression` now unwraps a
-single-element collection and raises a clear `CommandExecutionException` for zero or many items.
-
-Not addressed:
-
-- claude's note that a `null` payload yields `CommandExecutionException` rather than a no-op. claude itself
-  judged the current behavior fine for this fix; changing MERGE null semantics is out of scope for an NPE fix.
-- claude's suggestion that `updateMergeWithNonMapParameterFails` also assert the record was not partially
-  mutated. The merge loop resolves the whole payload before any `doc.set`, so partial mutation is not
-  reachable via that path; claude flagged it as non-essential.
+- `resolveExpression` re-evaluates the expression per matched record, so a non-correlated sub-query payload
+  runs once per target. This matches the pre-existing per-record `json.toMap(record, context)` contract, so
+  it is not a regression, but caching record-independent payloads would be a worthwhile optimization.
+- A `null` payload raises `CommandExecutionException` rather than being treated as a no-op. Changing MERGE
+  null semantics is a separate behavioral decision.
 
 ## Impact
 

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -4619,11 +4619,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       if (expr.json != null) {
         // Direct JSON literal from jsonLiteral alternative
         ops.json = expr.json;
-      } else if (expr.mathExpression instanceof final BaseExpression baseExpr) {
+      } else if (expr.mathExpression instanceof final BaseExpression baseExpr && baseExpr.expression != null
+          && baseExpr.expression.json != null) {
         // JSON literal parsed as baseExpression mapLit alternative
-        if (baseExpr.expression != null && baseExpr.expression.json != null) {
-          ops.json = baseExpr.expression.json;
-        }
+        ops.json = baseExpr.expression.json;
+      } else {
+        // Not a JSON literal: keep the expression (input parameter, LET variable, sub-query, ...) and resolve it at execution time
+        ops.expression = expr;
       }
     } else if (ctx.CONTENT() != null) {
       ops.type = UpdateOperations.TYPE_CONTENT;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MoveVertexExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MoveVertexExecutionPlanner.java
@@ -94,7 +94,12 @@ public class MoveVertexExecutionPlanner {
         plan.chain(new UpdateRemoveStep(op.getUpdateRemoveItems(), ctx));
         break;
       case UpdateOperations.TYPE_MERGE:
-        plan.chain(new UpdateMergeStep(op.getJson(), ctx));
+        if (op.getJson() != null)
+          plan.chain(new UpdateMergeStep(op.getJson(), ctx));
+        else if (op.getExpression() != null)
+          plan.chain(new UpdateMergeStep(op.getExpression(), ctx));
+        else
+          throw new CommandExecutionException("Missing payload for MOVE VERTEX ... MERGE: " + op);
         break;
       case UpdateOperations.TYPE_CONTENT:
         plan.chain(new UpdateContentStep(op.getJson(), ctx));

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateExecutionPlanner.java
@@ -189,7 +189,12 @@ public class UpdateExecutionPlanner {
           plan.chain(new UpdateRemoveStep(op.getUpdateRemoveItems(), context));
           break;
         case UpdateOperations.TYPE_MERGE:
-          plan.chain(new UpdateMergeStep(op.getJson(), context));
+          if (op.getJson() != null)
+            plan.chain(new UpdateMergeStep(op.getJson(), context));
+          else if (op.getExpression() != null)
+            plan.chain(new UpdateMergeStep(op.getExpression(), context));
+          else
+            throw new CommandExecutionException("Missing payload for UPDATE MERGE: " + op);
           break;
         case UpdateOperations.TYPE_CONTENT:
           if (op.getJson() != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateMergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateMergeStep.java
@@ -21,7 +21,9 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.Record;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.query.sql.parser.Expression;
 import com.arcadedb.query.sql.parser.Json;
 
 import java.util.Map;
@@ -30,11 +32,19 @@ import java.util.Map;
  * Created by luigidellaquila on 09/08/16.
  */
 public class UpdateMergeStep extends AbstractExecutionStep {
-  private final Json json;
+  private final Json       json;
+  private final Expression expression;
 
   public UpdateMergeStep(final Json json, final CommandContext context) {
     super(context);
     this.json = json;
+    this.expression = null;
+  }
+
+  public UpdateMergeStep(final Expression expression, final CommandContext context) {
+    super(context);
+    this.json = null;
+    this.expression = expression;
   }
 
   @Override
@@ -70,15 +80,25 @@ public class UpdateMergeStep extends AbstractExecutionStep {
 
   private void handleMerge(final Record record, final CommandContext context) {
     final MutableDocument doc = ((Document) record).modify();
-    final Map<String, Object> map = json.toMap(record, context);
+    final Map<String, Object> map = json != null ? json.toMap(record, context) : resolveExpression(record, context);
     for (final Map.Entry<String, Object> entry : map.entrySet())
       doc.set(entry.getKey(), entry.getValue());
+  }
+
+  private Map<String, Object> resolveExpression(final Record record, final CommandContext context) {
+    final Object value = expression.execute(record, context);
+    if (value instanceof Map)
+      return (Map<String, Object>) value;
+    else if (value instanceof Document document)
+      return document.toMap(false);
+    else if (value instanceof Result result)
+      return result.toMap();
+    throw new CommandExecutionException("Invalid value for UPDATE MERGE, expected a map but found: " + value);
   }
 
   @Override
   public String prettyPrint(final int depth, final int indent) {
     final String spaces = ExecutionStepInternal.getIndent(depth, indent);
-    final String result = spaces + "+ UPDATE MERGE\n" + spaces + "  " + json;
-    return result;
+    return spaces + "+ UPDATE MERGE\n" + spaces + "  " + (json != null ? json : expression);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateMergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateMergeStep.java
@@ -101,6 +101,8 @@ public class UpdateMergeStep extends AbstractExecutionStep {
       value = collection.iterator().next();
     }
 
+    // A user-supplied map is merged verbatim: its keys are an explicit intent, unlike the metadata a record-shaped
+    // payload carries implicitly, which the branches below strip
     if (value instanceof Map<?, ?> map)
       return checkStringKeys(map);
     else if (value instanceof Document document)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateMergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateMergeStep.java
@@ -26,6 +26,8 @@ import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.parser.Expression;
 import com.arcadedb.query.sql.parser.Json;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -86,14 +88,51 @@ public class UpdateMergeStep extends AbstractExecutionStep {
   }
 
   private Map<String, Object> resolveExpression(final Record record, final CommandContext context) {
-    final Object value = expression.execute(record, context);
-    if (value instanceof Map)
-      return (Map<String, Object>) value;
+    if (expression == null)
+      throw new CommandExecutionException("Missing payload for UPDATE MERGE");
+
+    Object value = expression.execute(record, context);
+
+    // A sub-query payload evaluates to a collection: accept it only when it identifies a single record
+    if (value instanceof Collection<?> collection) {
+      if (collection.size() != 1)
+        throw new CommandExecutionException(
+            "Invalid value for UPDATE MERGE, expected a single map but found " + collection.size() + " items");
+      value = collection.iterator().next();
+    }
+
+    if (value instanceof Map<?, ?> map)
+      return checkStringKeys(map);
     else if (value instanceof Document document)
       return document.toMap(false);
     else if (value instanceof Result result)
-      return result.toMap();
+      return toPropertyMap(result);
     throw new CommandExecutionException("Invalid value for UPDATE MERGE, expected a map but found: " + value);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> checkStringKeys(final Map<?, ?> map) {
+    for (final Object key : map.keySet())
+      if (!(key instanceof String))
+        throw new CommandExecutionException("Invalid value for UPDATE MERGE, expected a map with string keys but found: " + key);
+    return (Map<String, Object>) map;
+  }
+
+  /**
+   * Converts a result into the map of the properties to merge. Metadata ({@code @rid}, {@code @type}, ...) and computed
+   * pseudo-properties ({@code $score}, ...) are excluded so they never end up stored on the target record.
+   */
+  private static Map<String, Object> toPropertyMap(final Result result) {
+    final Map<String, Object> map = new LinkedHashMap<>();
+    for (final String name : result.getPropertyNames()) {
+      if (name.isEmpty())
+        continue;
+      final char prefix = name.charAt(0);
+      if (prefix == '@' || prefix == '$')
+        continue;
+      map.put(name, result.getProperty(name));
+    }
+    return map;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateOperations.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateOperations.java
@@ -41,6 +41,10 @@ public class UpdateOperations extends SimpleNode {
   public Json                      json;
   public JsonArray                 jsonArray;
   public InputParameter            inputParam;
+  /**
+   * Set for MERGE when the payload is not a JSON literal (for example an input parameter or any other expression).
+   */
+  public Expression                expression;
   public List<UpdateIncrementItem> updateIncrementItems = new ArrayList<UpdateIncrementItem>();
   public List<UpdateRemoveItem>    updateRemoveItems    = new ArrayList<UpdateRemoveItem>();
 
@@ -73,7 +77,10 @@ public class UpdateOperations extends SimpleNode {
       break;
     case TYPE_MERGE:
       builder.append("MERGE ");
-      json.toString(params, builder);
+      if (json != null)
+        json.toString(params, builder);
+      else if (expression != null)
+        expression.toString(params, builder);
       break;
     case TYPE_CONTENT:
       builder.append("CONTENT ");
@@ -128,6 +135,7 @@ public class UpdateOperations extends SimpleNode {
     result.json = json == null ? null : json.copy();
     result.jsonArray = jsonArray == null ? null : jsonArray.copy();
     result.inputParam = inputParam == null ? null : inputParam.copy();
+    result.expression = expression == null ? null : expression.copy();
     result.updateIncrementItems = updateIncrementItems == null ? null : updateIncrementItems.stream().map(x -> x.copy()).collect(Collectors.toList());
     result.updateRemoveItems = updateRemoveItems == null ? null : updateRemoveItems.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
@@ -154,6 +162,8 @@ public class UpdateOperations extends SimpleNode {
       return false;
     if (!Objects.equals(inputParam, that.inputParam))
       return false;
+    if (!Objects.equals(expression, that.expression))
+      return false;
     if (!Objects.equals(updateIncrementItems, that.updateIncrementItems))
       return false;
     return Objects.equals(updateRemoveItems, that.updateRemoveItems);
@@ -167,6 +177,7 @@ public class UpdateOperations extends SimpleNode {
     result = 31 * result + (json != null ? json.hashCode() : 0);
     result = 31 * result + (jsonArray != null ? jsonArray.hashCode() : 0);
     result = 31 * result + (inputParam != null ? inputParam.hashCode() : 0);
+    result = 31 * result + (expression != null ? expression.hashCode() : 0);
     result = 31 * result + (updateIncrementItems != null ? updateIncrementItems.hashCode() : 0);
     result = 31 * result + (updateRemoveItems != null ? updateRemoveItems.hashCode() : 0);
     return result;
@@ -196,6 +207,10 @@ public class UpdateOperations extends SimpleNode {
     return inputParam;
   }
 
+  public Expression getExpression() {
+    return expression;
+  }
+
   public List<UpdateIncrementItem> getUpdateIncrementItems() {
     return updateIncrementItems;
   }
@@ -222,6 +237,9 @@ public class UpdateOperations extends SimpleNode {
     }
     if (this.inputParam != null) {
       result.put("inputParam", this.inputParam.toString());
+    }
+    if (this.expression != null) {
+      result.put("expression", this.expression.toString());
     }
     if (updateIncrementItems != null) {
       result.put("updateIncrementItems", updateIncrementItems);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MoveVertexStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MoveVertexStatementExecutionTest.java
@@ -21,6 +21,8 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -325,6 +327,27 @@ class MoveVertexStatementExecutionTest extends TestHelper {
       final Result moved = rs.next();
       assertThat(moved.<Integer>getProperty("newfield")).isEqualTo(7);
       assertThat(moved.hasProperty("somefield")).isFalse();
+    }
+  }
+
+  /**
+   * MERGE with a parameterized payload must be resolved at execution time instead of throwing a NullPointerException.
+   */
+  @Test
+  void moveVertexWithParameterizedMerge() {
+    final String typeA = "testMoveMergeParamA";
+    final String typeB = "testMoveMergeParamB";
+    database.getSchema().createVertexType(typeA);
+    database.getSchema().createVertexType(typeB);
+    database.setAutoTransaction(true);
+
+    final String rid = database.command("sql", "create vertex " + typeA + " set somefield = 0").next().getIdentity().get().toString();
+
+    try (final ResultSet rs = database.command("sql", "MOVE VERTEX (SELECT FROM " + rid + ") TO TYPE:" + typeB + " MERGE :payload",
+        Map.of("payload", Map.of("somefield", 9, "added", "yes")))) {
+      final Result moved = rs.next();
+      assertThat(moved.<Integer>getProperty("somefield")).isEqualTo(9);
+      assertThat(moved.<String>getProperty("added")).isEqualTo("yes");
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateMergeTest.java
@@ -3,6 +3,7 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
@@ -132,6 +133,51 @@ class UpdateMergeTest {
     assertThat(row.<String>getProperty("canonical_id")).isEqualTo("LOCAL_ENTITY:12345");
     assertThat(row.<String>getProperty("name_norm")).isEqualTo("Aspirin");
     assertThat(row.<Boolean>getProperty("grounded")).isTrue();
+  }
+
+  @Test
+  void updateMergeWithDocumentParameterDoesNotLeakMetadata() {
+    database.transaction(() -> {
+      final Document source = (Document) database.query("sql", "SELECT FROM V WHERE name = 'John'").next().getElement().get();
+
+      final ResultSet result = database.command("sql", "UPDATE V MERGE :payload WHERE name = 'Jane'", Map.of("payload", source));
+      assertThat(result.hasNext()).isTrue();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT FROM V WHERE city = 'New York' AND age = 30");
+    // both John and the merged Jane now match
+    assertThat(result.stream().count()).isEqualTo(2);
+
+    final Result jane = database.query("sql", "SELECT FROM V WHERE city = 'New York'").next();
+    assertThat(jane.getPropertyNames()).doesNotContain("@rid", "@type", "@cat");
+  }
+
+  @Test
+  void updateMergeWithSubQueryDoesNotLeakMetadata() {
+    database.transaction(() -> {
+      final ResultSet result = database.command("sql",
+          "UPDATE V MERGE (SELECT city, age FROM V WHERE name = 'John') WHERE name = 'Jane'");
+      assertThat(result.hasNext()).isTrue();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT FROM V WHERE name = 'Jane'");
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<String>getProperty("city")).isEqualTo("New York");
+    assertThat(row.<Integer>getProperty("age")).isEqualTo(30);
+    assertThat(row.getPropertyNames()).doesNotContain("@rid", "@type", "@cat");
+  }
+
+  @Test
+  void updateMergeWithNonStringKeyMapFails() {
+    final Map<Object, Object> payload = new HashMap<>();
+    payload.put(42, "answer");
+
+    database.transaction(() -> {
+      assertThatThrownBy(() -> database.command("sql", "UPDATE V MERGE :payload WHERE name = 'John'", Map.of("payload", payload)))
+          .isInstanceOf(CommandExecutionException.class)
+          .hasMessageContaining("string keys");
+    });
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateMergeTest.java
@@ -3,12 +3,19 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test UPDATE MERGE and UPDATE CONTENT operations.
@@ -63,6 +70,76 @@ class UpdateMergeTest {
     assertThat(row.<String>getProperty("city")).isEqualTo("New York");
     assertThat(row.<String>getProperty("status")).isEqualTo("active");
     assertThat(row.<String>getProperty("email")).isEqualTo("john@example.com");
+  }
+
+  @Test
+  void updateMergeWithNamedParameterMap() {
+    // The JSON payload is supplied as a named parameter instead of being inlined in the query
+    final Map<String, Object> payload = new HashMap<>();
+    payload.put("status", "active");
+    payload.put("email", "john@example.com");
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sql", "UPDATE V MERGE :payload WHERE name = 'John'", Map.of("payload", payload));
+      assertThat(result.hasNext()).isTrue();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT name, age, city, status, email FROM V WHERE name = 'John'");
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<String>getProperty("name")).isEqualTo("John");
+    assertThat(row.<Integer>getProperty("age")).isEqualTo(30);
+    assertThat(row.<String>getProperty("city")).isEqualTo("New York");
+    assertThat(row.<String>getProperty("status")).isEqualTo("active");
+    assertThat(row.<String>getProperty("email")).isEqualTo("john@example.com");
+  }
+
+  @Test
+  void updateMergeWithPositionalParameterMap() {
+    final Map<String, Object> payload = new HashMap<>();
+    payload.put("status", "archived");
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sql", "UPDATE V MERGE ? WHERE name = 'Jane'", (Object) payload);
+      assertThat(result.hasNext()).isTrue();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT name, age, status FROM V WHERE name = 'Jane'");
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<Integer>getProperty("age")).isEqualTo(25);
+    assertThat(row.<String>getProperty("status")).isEqualTo("archived");
+  }
+
+  @Test
+  void updateMergeWithParameterAndUpsertInsertsNewRecord() {
+    final Map<String, Object> payload = new HashMap<>();
+    payload.put("name_norm", "Aspirin");
+    payload.put("grounded", true);
+
+    database.getSchema().getType("V").createProperty("canonical_id", Type.STRING);
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "canonical_id");
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sql", "UPDATE V MERGE :payload UPSERT WHERE canonical_id = :id",
+          Map.of("payload", payload, "id", "LOCAL_ENTITY:12345"));
+      assertThat(result.hasNext()).isTrue();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT canonical_id, name_norm, grounded FROM V WHERE canonical_id = 'LOCAL_ENTITY:12345'");
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<String>getProperty("canonical_id")).isEqualTo("LOCAL_ENTITY:12345");
+    assertThat(row.<String>getProperty("name_norm")).isEqualTo("Aspirin");
+    assertThat(row.<Boolean>getProperty("grounded")).isTrue();
+  }
+
+  @Test
+  void updateMergeWithNonMapParameterFails() {
+    database.transaction(() -> {
+      assertThatThrownBy(() -> database.command("sql", "UPDATE V MERGE :payload WHERE name = 'John'", Map.of("payload", "not-a-map")))
+          .isInstanceOf(CommandExecutionException.class);
+    });
   }
 
   @Test


### PR DESCRIPTION
Closes #5347

`UPDATE ... MERGE :payload` always threw a `NullPointerException`. The SQL grammar accepts `MERGE expression`, but `SQLASTBuilder.visitUpdateOperation` only extracted a `Json` literal out of that expression (direct `expr.json`, or a map literal nested in a `BaseExpression`). Any other expression shape - an input parameter (`:payload` / `?`), a LET variable, a sub-query - silently left `UpdateOperations.json` as `null`, so `UpdateExecutionPlanner` chained `new UpdateMergeStep(null, ctx)` and `handleMerge` dereferenced it. This PR keeps the unresolved `Expression` on `UpdateOperations`, adds an `Expression`-based `UpdateMergeStep` that resolves the payload per record (accepting `Map`, `Document`, or `Result`, and raising a clear `CommandExecutionException` otherwise), and wires both `UpdateExecutionPlanner` and `MoveVertexExecutionPlanner` to pick the right constructor. The pre-existing inline-JSON path is untouched.

## Test plan

- [ ] `cd engine && mvn test -Dtest=UpdateMergeTest` - 6/6 green (4 new methods, all fail on `main` with the NPE)
  - `updateMergeWithNamedParameterMap` - `MERGE :payload` merges a map parameter
  - `updateMergeWithPositionalParameterMap` - `MERGE ?` with a map parameter
  - `updateMergeWithParameterAndUpsertInsertsNewRecord` - the exact repro from the issue, `MERGE :payload UPSERT WHERE canonical_id = :id`
  - `updateMergeWithNonMapParameterFails` - non-map parameter yields `CommandExecutionException`, not an NPE
- [ ] `cd engine && mvn test -Dtest='com.arcadedb.query.sql.**'` - 2259 tests, 0 failures; the 6 errors are pre-existing/environmental GraalVM-JavaScript tests (`TriggerSQLTest` JS triggers, `SQLVectorHybridSearchBlogPostTest` JS helpers) plus one benchmark, all unrelated
