### PR TITLE
fix(#5326): applyChanges must drain the pending async flush of the page it replays

### DIFF
--- a/docs/5326-flaky-applychanges-page-replay.md
+++ b/docs/5326-flaky-applychanges-page-replay.md
@@ -72,6 +72,11 @@ state deterministically, applies a WAL entry at `baseVersion + 1` and asserts th
 
 Before the fix it fails on the first assertion (the pending copy survives) and on the version assertions.
 
+A second test, `applyChangesTakesTheDeferredBatchCopyOutOfThePipeline`, drives the same defect through the real flush
+pipeline: flushing is suspended so an ordinary commit parks page 0 in a genuine deferred batch, then `applyChanges`
+must detach it, and after resuming the batch must no longer be able to write the superseded version over the
+replicated one. It covers the identity-based batch removal and the #4728 deferred-RAM decrement.
+
 ## Verification
 
 - `mvn -pl engine test -Dtest=Issue5326ApplyChangesPendingFlushTest` - fails before the fix, passes after.
@@ -86,3 +91,19 @@ Before the fix it fails on the first assertion (the pending copy survives) and o
 Beyond de-flaking CI, this closes a real durability hole on the replication and crash-recovery path: a replicated page
 write could previously be silently reverted by a stale queued flush, which is the version-regression signature behind
 the `WALVersionGapException` cascades referenced in #4510 and #5322.
+
+## Review cycle 1 (PR #5349, head 3c9118b)
+
+- gemini-code-assist: `detachPendingPage` copied the flush queue via `queue.stream().toList()`. Applied - the
+  `ArrayBlockingQueue` iterator is weakly consistent, and this runs once per replayed page, so the snapshot was pure
+  overhead. The two neighbouring dropped-file methods keep the snapshot idiom; they run only on rare drop events.
+- claude: the batch-removal and deferred-RAM paths were never executed by a test. Applied - added
+  `applyChangesTakesTheDeferredBatchCopyOutOfThePipeline`, which goes through `setSuspended` + a real commit.
+- claude: the mid-enqueue window (`scheduleFlushOfPages` publishes to `pageIndex` before `queue.offer`) is not covered
+  by the detach. Applied as documentation - `detachPendingPage` now states the single-writer assumption that makes it
+  unreachable on the replay path.
+- claude: interrupt between the detach and `flushPage` leaves the page off the pipeline and off the disk. Applied as
+  documentation in `materializePendingFlushOfPage` - the page stays durable because its WAL ack is only released
+  inside `flushPage`, so the WAL entry survives and is replayed on the next open.
+- claude (optional): make `materializePendingFlushOfPage` package-private. Skipped - it matches the visibility of the
+  sibling `writePageWithLock`, which the reviewer noted; tightening one without the other would be inconsistent.

--- a/docs/5326-flaky-applychanges-page-replay.md
+++ b/docs/5326-flaky-applychanges-page-replay.md
@@ -1,0 +1,88 @@
+# Issue #5326 - Flaky on CI: applyChanges/page-replay tests
+
+## Symptom
+
+`Issue4712ReplicatedWriteLockTest`, `Issue4510ForceApplyPartialDeltaTest` and `ApplyChangesPartialReplayTest` fail
+intermittently on CI with `expected: 2L but was: 1L` on assertions of the form
+
+```java
+pageManager.removePageFromCache(pageId);
+final ImmutablePage reloaded = pageManager.getImmutablePage(pageId, pageSize, false, true);
+assertThat(reloaded.getVersion()).isEqualTo(baseVersion + 1);
+```
+
+An A/B re-run of the same commit produced 3 failures and then 0 failures, so the variable is timing, not code.
+
+## Root cause
+
+It is not a test-only defect: the tests were observing a genuine ordering hole in
+`TransactionManager.applyChanges`.
+
+A committed page is published to the read cache and to `PageManagerFlushThread.pageIndex` **before** it reaches the
+disk (`PageManager.writePages(..., asyncFlush=true)`). `applyChanges`, used for replicated and recovery replay, writes
+the page straight to its file via `PageManager.writePageWithLock` and evicts it from the read cache, but never looks at
+the flush pipeline. While the older copy is still pending, two things go wrong:
+
+1. `PageManager.loadPage` consults `flushThread.getCachedPageFromMutablePageInQueue(pageId)` **before** reading the
+   file. Once `applyChanges` evicts the read cache, every subsequent read resolves the page from the flush queue and
+   returns the superseded version - which is exactly the failing assertion.
+2. When the flush thread later writes that queued copy, it overwrites the replicated page on disk and rolls the page
+   version backwards, re-opening the version-gap cascade the replay exists to close.
+
+Whether either is observed depends on whether the flush thread drains the queue before the assertion runs. On an idle
+macOS box it always does; on a loaded Linux CI runner sharing one JVM (`forkCount=1, reuseForks=true`) with 13k
+preceding tests, sometimes it does not.
+
+## Fix
+
+`applyChanges` now drains the pipeline for the page it is about to write, before reading its version:
+
+- `PageManagerFlushThread.detachPendingPage(database, pageId)` removes the pending `MutablePage` from `pageIndex` and
+  from the queued, in-flight and deferred batches. Batch removal is by reference identity, matching
+  `removeFromFlushIndex`, so a newer copy queued for the same `PageId` is never dropped by mistake. Deferred removals
+  release their reserved RAM accounting (#4728).
+- `PageManager.materializePendingFlushOfPage(database, pageId)` detaches the page, waits for the in-flight batch to
+  finish (the detach can lose that race, and a write landing after ours would revert the page), writes the page to disk
+  via `flushPage` and evicts the read-cache copy.
+
+The pending page is **written**, not discarded: its content is the only baseline the WAL delta can be applied on top
+of, since the disk may be several versions behind it.
+
+`InterruptedException` from the drain is caught in `applyChanges` and rethrown as `WALException` with the interrupt
+flag restored, so an interrupted replay fails loud instead of leaving a silent version gap.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/engine/TransactionManager.java`
+- `engine/src/main/java/com/arcadedb/engine/PageManager.java`
+- `engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java`
+- `engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java` (new)
+
+No existing test was modified; the three flaky classes are left untouched and now pass deterministically because the
+condition they assert on no longer depends on flush timing.
+
+## Test
+
+`Issue5326ApplyChangesPendingFlushTest` is a white-box test in the `com.arcadedb.engine` package. It quiesces the flush
+pipeline, then publishes a pending copy of page 0 into `flushThread.pageIndex` to reproduce the between-commit-and-flush
+state deterministically, applies a WAL entry at `baseVersion + 1` and asserts that
+
+- no stale copy is left in the pipeline afterwards, and
+- both a cache-hit read and a read forced back to disk see `baseVersion + 1`.
+
+Before the fix it fails on the first assertion (the pending copy survives) and on the version assertions.
+
+## Verification
+
+- `mvn -pl engine test -Dtest=Issue5326ApplyChangesPendingFlushTest` - fails before the fix, passes after.
+- `mvn -pl engine test -Dtest='Issue4712*,Issue4510*,ApplyChanges*,Issue5326*,*PageManager*,*FlushThread*,*WAL*,Issue4928*,Issue4544*,Issue4728*,Issue5068*'`
+  - 54 tests, 0 failures.
+- `mvn -pl engine test -Dtest='com.arcadedb.engine.**,com.arcadedb.database.**'` - 642 tests, 0 failures; the single
+  error is `TimeSeriesEmbeddedBenchmark.run` failing with `No space left on device` on the build machine, unrelated to
+  this change.
+
+## Impact
+
+Beyond de-flaking CI, this closes a real durability hole on the replication and crash-recovery path: a replicated page
+write could previously be silently reverted by a stale queued flush, which is the version-regression signature behind
+the `WALVersionGapException` cascades referenced in #4510 and #5322.

--- a/docs/5326-flaky-applychanges-page-replay.md
+++ b/docs/5326-flaky-applychanges-page-replay.md
@@ -37,16 +37,20 @@ preceding tests, sometimes it does not.
 
 `applyChanges` now drains the pipeline for the page it is about to write, before reading its version:
 
-- `PageManagerFlushThread.detachPendingPage(database, pageId)` removes the pending `MutablePage` from `pageIndex` and
-  from the queued, in-flight and deferred batches. Batch removal is by reference identity, matching
-  `removeFromFlushIndex`, so a newer copy queued for the same `PageId` is never dropped by mistake. Deferred removals
+- `PageManagerFlushThread.detachPendingPages(database, pageId)` removes EVERY pending `MutablePage` for the page from
+  `pageIndex` and from the queued, in-flight and deferred batches. Copies are matched by `PageId`, not by reference
+  identity: successive commits can leave two instances pending at once (the newest in `pageIndex`, an older one still
+  in an earlier batch - the two-instance case `removeFromFlushIndex` exists for, #4544), and removing only the indexed
+  one would leave the older copy free to write the superseded version over the replicated one. Deferred removals
   release their reserved RAM accounting (#4728).
-- `PageManager.materializePendingFlushOfPage(database, pageId)` detaches the page, waits for the in-flight batch to
-  finish (the detach can lose that race, and a write landing after ours would revert the page), writes the page to disk
-  via `flushPage` and evicts the read-cache copy.
+- `PageManager.materializePendingFlushOfPage(database, pageId)` detaches the copies, waits for the in-flight batch to
+  finish (the detach can lose that race, and a write landing after ours would revert the page), writes the most recent
+  copy to disk via `flushPage`, releases the superseded copies' WAL acks (exactly-once via `takeWALFile`, as the
+  dropped-file purge does) and evicts the read-cache copy.
 
-The pending page is **written**, not discarded: its content is the only baseline the WAL delta can be applied on top
-of, since the disk may be several versions behind it.
+The pending content is **written**, not discarded: it is the only baseline the WAL delta can be applied on top of,
+since the disk may be several versions behind it. The most recent copy is a full page image covering every older one,
+so writing it alone puts all the pending content on disk.
 
 `InterruptedException` from the drain is caught in `applyChanges` and rethrown as `WALException` with the interrupt
 flag restored, so an interrupted replay fails loud instead of leaving a silent version gap.
@@ -72,10 +76,14 @@ state deterministically, applies a WAL entry at `baseVersion + 1` and asserts th
 
 Before the fix it fails on the first assertion (the pending copy survives) and on the version assertions.
 
-A second test, `applyChangesTakesTheDeferredBatchCopyOutOfThePipeline`, drives the same defect through the real flush
-pipeline: flushing is suspended so an ordinary commit parks page 0 in a genuine deferred batch, then `applyChanges`
-must detach it, and after resuming the batch must no longer be able to write the superseded version over the
-replicated one. It covers the identity-based batch removal and the #4728 deferred-RAM decrement.
+Two further tests drive the same defect through the real flush pipeline, with flushing suspended so ordinary commits
+park page 0 in genuine deferred batches:
+
+- `applyChangesTakesTheDeferredBatchCopyOutOfThePipeline` - one commit; covers the batch removal and the #4728
+  deferred-RAM decrement, and asserts that after resuming the batch can no longer write the superseded version.
+- `applyChangesTakesEveryPendingCopyOfThePageOutOfThePipeline` - two commits, so two copies of page 0 are pending at
+  once; asserts the deferred backlog drops by exactly both copies' size, which is what a `PageId`-matched detach does
+  and an identity-matched one does not.
 
 ## Verification
 
@@ -91,19 +99,3 @@ replicated one. It covers the identity-based batch removal and the #4728 deferre
 Beyond de-flaking CI, this closes a real durability hole on the replication and crash-recovery path: a replicated page
 write could previously be silently reverted by a stale queued flush, which is the version-regression signature behind
 the `WALVersionGapException` cascades referenced in #4510 and #5322.
-
-## Review cycle 1 (PR #5349, head 3c9118b)
-
-- gemini-code-assist: `detachPendingPage` copied the flush queue via `queue.stream().toList()`. Applied - the
-  `ArrayBlockingQueue` iterator is weakly consistent, and this runs once per replayed page, so the snapshot was pure
-  overhead. The two neighbouring dropped-file methods keep the snapshot idiom; they run only on rare drop events.
-- claude: the batch-removal and deferred-RAM paths were never executed by a test. Applied - added
-  `applyChangesTakesTheDeferredBatchCopyOutOfThePipeline`, which goes through `setSuspended` + a real commit.
-- claude: the mid-enqueue window (`scheduleFlushOfPages` publishes to `pageIndex` before `queue.offer`) is not covered
-  by the detach. Applied as documentation - `detachPendingPage` now states the single-writer assumption that makes it
-  unreachable on the replay path.
-- claude: interrupt between the detach and `flushPage` leaves the page off the pipeline and off the disk. Applied as
-  documentation in `materializePendingFlushOfPage` - the page stays durable because its WAL ack is only released
-  inside `flushPage`, so the WAL entry survives and is replayed on the next open.
-- claude (optional): make `materializePendingFlushOfPage` package-private. Skipped - it matches the visibility of the
-  sibling `writePageWithLock`, which the reviewer noted; tightening one without the other would be inconsistent.

--- a/docs/5326-flaky-applychanges-page-replay.md
+++ b/docs/5326-flaky-applychanges-page-replay.md
@@ -43,6 +43,12 @@ preceding tests, sometimes it does not.
   in an earlier batch - the two-instance case `removeFromFlushIndex` exists for, #4544), and removing only the indexed
   one would leave the older copy free to write the superseded version over the replicated one. Deferred removals
   release their reserved RAM accounting (#4728).
+- The detach is serialized against `resumeFlushing`'s Phase 1 by a per-database mutex. That phase detaches the
+  deferred batches and writes them from the resuming thread (a backup or HA-snapshot unsuspend), outside both the
+  queue and `nextPagesToFlush`, so without the mutex a replay could find the pipeline empty while a superseded copy
+  was still on its way to disk. An O(1) fast path skips the batch walk entirely when the whole pipeline is quiet,
+  which is the common case on a follower; it is deliberately conservative because a copy can outlive its `pageIndex`
+  entry when a newer instance flushes out of order.
 - `PageManager.materializePendingFlushOfPage(database, pageId)` detaches the copies, waits for the in-flight batch to
   finish (the detach can lose that race, and a write landing after ours would revert the page), writes the most recent
   copy to disk via `flushPage`, releases the superseded copies' WAL acks (exactly-once via `takeWALFile`, as the
@@ -90,9 +96,15 @@ park page 0 in genuine deferred batches:
 - `mvn -pl engine test -Dtest=Issue5326ApplyChangesPendingFlushTest` - fails before the fix, passes after.
 - `mvn -pl engine test -Dtest='Issue4712*,Issue4510*,ApplyChanges*,Issue5326*,*PageManager*,*FlushThread*,*WAL*,Issue4928*,Issue4544*,Issue4728*,Issue5068*'`
   - 54 tests, 0 failures.
-- `mvn -pl engine test -Dtest='com.arcadedb.engine.**,com.arcadedb.database.**'` - 642 tests, 0 failures; the single
-  error is `TimeSeriesEmbeddedBenchmark.run` failing with `No space left on device` on the build machine, unrelated to
-  this change.
+- `mvn -pl engine test -Dtest='com.arcadedb.engine.**'` - 506 tests, 0 failures; the single error is
+  `TimeSeriesEmbeddedBenchmark.run` failing with `No space left on device` on the build machine, unrelated to this
+  change (it fails the same way on an unmodified tree).
+
+## Known gaps
+
+- The `InterruptedException` path in `applyChanges` is covered by reasoning and comments, not by a test. Interrupting
+  mid-drain deterministically needs the white-box harness style of `PageManagerFlushThreadInterruptTest` (#5068); left
+  for a follow-up.
 
 ## Impact
 

--- a/docs/5326-flaky-applychanges-page-replay.md
+++ b/docs/5326-flaky-applychanges-page-replay.md
@@ -1,5 +1,7 @@
 # Issue #5326 - Flaky on CI: applyChanges/page-replay tests
 
+PR: https://github.com/ArcadeData/arcadedb/pull/5349
+
 ## Symptom
 
 `Issue4712ReplicatedWriteLockTest`, `Issue4510ForceApplyPartialDeltaTest` and `ApplyChangesPartialReplayTest` fail
@@ -111,3 +113,9 @@ park page 0 in genuine deferred batches:
 Beyond de-flaking CI, this closes a real durability hole on the replication and crash-recovery path: a replicated page
 write could previously be silently reverted by a stale queued flush, which is the version-regression signature behind
 the `WALVersionGapException` cascades referenced in #4510 and #5322.
+- The per-page batch walk is O(deferred backlog) while a backup or HA-snapshot suspend is open on the same database.
+  Bounded by `arcadedb.flushSuspendMaxDeferredRAM` and correct, but worth knowing as a load characteristic of replay
+  during a suspend window.
+- The `detachPendingPages` ASSUMPTION (replay is the sole writer of the pages it applies) is the linchpin of the
+  correctness argument. It holds on the follower and recovery paths today; a future caller of `applyChanges` from a
+  context that also commits locally would silently violate it.

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -510,7 +510,9 @@ public class PageManager extends LockContext {
       return;
 
     // The flush thread may have taken the page's batch before the detach reached it: let the in-flight write finish,
-    // or it could still land after the caller's write and revert the page on disk.
+    // or it could still land after the caller's write and revert the page on disk. An interrupt here leaves the page
+    // detached but not yet written: it stays durable because its WAL ack has NOT been released (notifyPageFlushed
+    // runs inside flushPage below), so its WAL entry is preserved and replayed on the next open.
     thread.waitForCurrentFlushToComplete(database);
 
     flushPage(pending);

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -499,23 +499,43 @@ public class PageManager extends LockContext {
    * replicated page, rolling its version backwards. Pushing the pending copy to disk here (rather than discarding it)
    * preserves its content, which is the only baseline the WAL delta can be applied on top of.
    */
-  public void materializePendingFlushOfPage(final Database database, final PageId pageId)
+  void materializePendingFlushOfPage(final Database database, final PageId pageId)
       throws IOException, InterruptedException {
     final PageManagerFlushThread thread = flushThread;
     if (thread == null)
       return;
 
-    final MutablePage pending = thread.detachPendingPage(database, pageId);
-    if (pending == null)
+    final List<MutablePage> pending = thread.detachPendingPages(database, pageId);
+    if (pending.isEmpty())
       return;
 
-    // The flush thread may have taken the page's batch before the detach reached it: let the in-flight write finish,
-    // or it could still land after the caller's write and revert the page on disk. An interrupt here leaves the page
-    // detached but not yet written: it stays durable because its WAL ack has NOT been released (notifyPageFlushed
-    // runs inside flushPage below), so its WAL entry is preserved and replayed on the next open.
+    // The flush thread may have taken a batch before the detach reached it: let the in-flight write finish, or it
+    // could still land after the caller's write and revert the page on disk. An interrupt here leaves the copies
+    // detached but not yet written: they stay durable because their WAL acks have NOT been released
+    // (notifyPageFlushed runs inside flushPage below), so their WAL entries are preserved and replayed on the next
+    // open.
     thread.waitForCurrentFlushToComplete(database);
 
-    flushPage(pending);
+    // Successive commits can leave more than one copy pending. The most recent one is a full page image covering
+    // every older one, so writing it alone puts the whole pending content on disk.
+    MutablePage mostRecent = pending.getFirst();
+    for (int i = 1; i < pending.size(); i++)
+      if (pending.get(i).getVersion() > mostRecent.getVersion())
+        mostRecent = pending.get(i);
+
+    flushPage(mostRecent);
+
+    // The superseded copies will never be written. Release their WAL acks - as the dropped-file purge does - or the
+    // stale pending count would keep their WAL files alive forever (the close-time ack gate, #4928). takeWALFile
+    // makes the release exactly-once.
+    for (int i = 0; i < pending.size(); i++) {
+      final MutablePage page = pending.get(i);
+      if (page != mostRecent) {
+        final WALFile walFile = page.takeWALFile();
+        if (walFile != null)
+          walFile.notifyPageFlushed();
+      }
+    }
 
     // The read cache holds the same pending copy: drop it so the caller reads the content just written.
     removePageFromCache(pageId);

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -488,6 +488,37 @@ public class PageManager extends LockContext {
     totalPagesWritten.incrementAndGet();
   }
 
+  /**
+   * Writes to disk, and takes out of the asynchronous flush pipeline, any page still pending for {@code pageId}.
+   * <p>
+   * Callers that write a page directly to its file instead of going through the flush queue
+   * ({@link TransactionManager#applyChanges} during replicated / recovery replay) must call this first. A committed
+   * page is published to the read cache and to the flush thread's index before it reaches the disk, and while that
+   * older copy is still pending {@link #loadPage} resolves the page from the queue instead of from the file - so the
+   * replicated write stays invisible to every later read - and the eventual flush of that copy overwrites the
+   * replicated page, rolling its version backwards. Pushing the pending copy to disk here (rather than discarding it)
+   * preserves its content, which is the only baseline the WAL delta can be applied on top of.
+   */
+  public void materializePendingFlushOfPage(final Database database, final PageId pageId)
+      throws IOException, InterruptedException {
+    final PageManagerFlushThread thread = flushThread;
+    if (thread == null)
+      return;
+
+    final MutablePage pending = thread.detachPendingPage(database, pageId);
+    if (pending == null)
+      return;
+
+    // The flush thread may have taken the page's batch before the detach reached it: let the in-flight write finish,
+    // or it could still land after the caller's write and revert the page on disk.
+    thread.waitForCurrentFlushToComplete(database);
+
+    flushPage(pending);
+
+    // The read cache holds the same pending copy: drop it so the caller reads the content just written.
+    removePageFromCache(pageId);
+  }
+
   public PPageManagerStats getStats() {
     final PPageManagerStats stats = new PPageManagerStats();
     stats.maxRAM = maxRAM;

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -637,6 +637,12 @@ public class PageManagerFlushThread extends Thread {
    * same {@link PageId} is never dropped by mistake, matching {@link #removeFromFlushIndex}. The batch currently
    * being written is also visited: the flush thread mutates the very same list, so the removal may lose that race,
    * which is why the caller waits for the in-flight batch to complete before writing.
+   * <p>
+   * ASSUMPTION: no other thread is scheduling a flush of this same page instance concurrently.
+   * {@link #scheduleFlushOfPages} publishes to {@link #pageIndex} BEFORE enqueueing, so a commit sitting between
+   * those two statements would have its batch enqueued after this detach walked the queue, and that batch would
+   * still carry the superseded page. This holds on the only caller's path: replicated and crash-recovery replay is
+   * the sole writer of the pages it applies, so no local commit can be mid-enqueue for them.
    *
    * @return the detached page, or {@code null} when nothing was pending for this page.
    */
@@ -645,7 +651,9 @@ public class PageManagerFlushThread extends Thread {
     if (pending == null)
       return null;
 
-    for (final PagesToFlush batch : queue.stream().toList())
+    // Iterated directly rather than through a snapshot: ArrayBlockingQueue's iterator is weakly consistent and never
+    // throws ConcurrentModificationException, and this runs per replayed page, so the copy would be pure overhead.
+    for (final PagesToFlush batch : queue)
       removePageFromBatch(batch, pending);
 
     removePageFromBatch(nextPagesToFlush.get(), pending);

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -28,6 +28,7 @@ import com.arcadedb.log.LogManager;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -68,6 +69,11 @@ public class PageManagerFlushThread extends Thread {
   // unsuspend already drained the deferred map, leaving it stuck in deferredByDatabase / pageIndex forever.
   // Also the monitor new suspenders wait on while a resume is in flight (see resumingDatabases).
   private final        ConcurrentHashMap<Database, Object>                      suspendLocks        = new ConcurrentHashMap<>();
+  // Per-database mutex serializing detachPendingPages against resumeFlushing's Phase 1. Phase 1 detaches the deferred
+  // batches and writes them from the resuming thread, outside both the queue and nextPagesToFlush, so without this
+  // lock a replay could take the pipeline for empty and have its page written over by a deferred copy landing later.
+  // Lock ordering is always this monitor BEFORE any batch.pages monitor; the flush thread takes batch.pages alone.
+  private final        ConcurrentHashMap<Database, Object>                      replayDrainLocks    = new ConcurrentHashMap<>();
 
   /**
    * O(1) index: pageId → most recent MutablePage in the flush queue or currently being flushed.
@@ -441,42 +447,47 @@ public class PageManagerFlushThread extends Thread {
     // end of the method, so the caller still observes its own cancellation and the re-enqueue phase below runs
     // interrupt-free.
     boolean restoreCallerInterrupt = false;
-    final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.remove(database);
-    if (deferred != null) {
-      for (final PagesToFlush batch : deferred) {
-        if (!batch.database.isOpen())
-          continue;
-        synchronized (batch.pages) {
-          for (final MutablePage page : batch.pages) {
-            if (!batch.database.isOpen())
-              break;
-            try {
-              pageManager.flushPage(page);
-            } catch (final DatabaseMetadataException e) {
-              // FILE DELETED, CONTINUE WITH THE NEXT PAGES
-              LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
-            } catch (final InterruptedIOException e) {
-              // Don't drop the deferred dirty page, its WAL entry was already acked: consume the flag and
-              // retry the write once.
-              restoreCallerInterrupt = true;
-              Thread.interrupted();
+    // Serialized against detachPendingPages: the detach must either see these batches (and take its page out of
+    // them) or run after they have all reached the disk. Otherwise a superseded copy written here could land after
+    // a replicated write and roll the page version backwards.
+    synchronized (replayDrainLock(database)) {
+      final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.remove(database);
+      if (deferred != null) {
+        for (final PagesToFlush batch : deferred) {
+          if (!batch.database.isOpen())
+            continue;
+          synchronized (batch.pages) {
+            for (final MutablePage page : batch.pages) {
+              if (!batch.database.isOpen())
+                break;
               try {
                 pageManager.flushPage(page);
-              } catch (final DatabaseMetadataException | IOException e2) {
-                // Contain every retry failure (file dropped, re-interrupt, real I/O error): letting it escape
-                // would skip the unsuspend phases below, leaving the database suspended with batches stranded
-                // in the deferred map. An unflushed page is recovered from the WAL (its entry was never acked).
-                // A fresh re-interrupt set the flag again: clear it so the remaining pages flush cleanly.
-                LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e2, page);
+              } catch (final DatabaseMetadataException e) {
+                // FILE DELETED, CONTINUE WITH THE NEXT PAGES
+                LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
+              } catch (final InterruptedIOException e) {
+                // Don't drop the deferred dirty page, its WAL entry was already acked: consume the flag and
+                // retry the write once.
+                restoreCallerInterrupt = true;
                 Thread.interrupted();
+                try {
+                  pageManager.flushPage(page);
+                } catch (final DatabaseMetadataException | IOException e2) {
+                  // Contain every retry failure (file dropped, re-interrupt, real I/O error): letting it escape
+                  // would skip the unsuspend phases below, leaving the database suspended with batches stranded
+                  // in the deferred map. An unflushed page is recovered from the WAL (its entry was never acked).
+                  // A fresh re-interrupt set the flag again: clear it so the remaining pages flush cleanly.
+                  LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e2, page);
+                  Thread.interrupted();
+                }
+              } catch (final IOException e) {
+                LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
+              } finally {
+                // The page leaves the deferred backlog (flushed to disk), so release its reserved RAM (issue #4728).
+                deferredRAMBytes.addAndGet(-page.getPhysicalSize());
+                removeFromFlushIndex(page);
+                bumpFlushProgress(page);
               }
-            } catch (final IOException e) {
-              LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
-            } finally {
-              // The page leaves the deferred backlog (flushed to disk), so release its reserved RAM (issue #4728).
-              deferredRAMBytes.addAndGet(-page.getPhysicalSize());
-              removeFromFlushIndex(page);
-              bumpFlushProgress(page);
             }
           }
         }
@@ -540,6 +551,10 @@ public class PageManagerFlushThread extends Thread {
     return suspendLocks.computeIfAbsent(database, k -> new Object());
   }
 
+  private Object replayDrainLock(final Database database) {
+    return replayDrainLocks.computeIfAbsent(database, k -> new Object());
+  }
+
   public void closeAndJoin() throws InterruptedException {
     running = false;
     queue.offer(SHUTDOWN_THREAD);
@@ -596,6 +611,7 @@ public class PageManagerFlushThread extends Thread {
     // Forget the per-database suspend bookkeeping so the dropped Database instance (and the resources it
     // pins) can be garbage collected instead of being retained for the flush thread's lifetime as a map key.
     suspendLocks.remove(database);
+    replayDrainLocks.remove(database);
     suspended.remove(database);
     resumingDatabases.remove(database);
     flushedPagesPerDatabase.remove(database);
@@ -643,6 +659,11 @@ public class PageManagerFlushThread extends Thread {
    * The batch currently being written is also visited: the flush thread mutates the very same list, so the removal
    * may lose that race, which is why the caller waits for the in-flight batch to complete before writing.
    * <p>
+   * Serialized against {@link #resumeFlushing}'s Phase 1 through {@link #replayDrainLock}: that phase detaches the
+   * deferred batches and writes them from the resuming thread, outside both {@link #queue} and
+   * {@link #nextPagesToFlush}, so without the mutex this walk could find the pipeline empty while a superseded copy
+   * was still on its way to the disk.
+   * <p>
    * ASSUMPTION: no other thread is scheduling a flush of this page concurrently. {@link #scheduleFlushOfPages}
    * publishes to {@link #pageIndex} BEFORE enqueueing, so a commit sitting between those two statements would have
    * its batch enqueued after this detach walked the queue, and that batch would still carry a superseded copy. This
@@ -653,28 +674,39 @@ public class PageManagerFlushThread extends Thread {
    * @return every detached copy, most recent one included; empty when nothing was pending for this page.
    */
   List<MutablePage> detachPendingPages(final Database database, final PageId pageId) {
-    final MutablePage indexed = pageIndex.remove(pageId);
-    final List<MutablePage> detached = new ArrayList<>(1);
+    // O(1) fast path for the common replay case of a page that is not in the pipeline at all. Deliberately
+    // conservative: it skips the walk only when the WHOLE pipeline is empty, because a copy can outlive its
+    // pageIndex entry (a newer instance flushed out of order removes the entry while an older one is still queued),
+    // so "no entry for this pageId" alone would not prove the batches are clean.
+    if (pageIndex.isEmpty() && queue.isEmpty() && deferredRAMBytes.get() == 0 && nextPagesToFlush.get() == null)
+      return Collections.emptyList();
 
-    // Iterated directly rather than through a snapshot: ArrayBlockingQueue's iterator is weakly consistent and never
-    // throws ConcurrentModificationException, and this runs per replayed page, so the copy would be pure overhead.
-    for (final PagesToFlush batch : queue)
-      removePagesOfPageIdFromBatch(batch, pageId, detached);
+    synchronized (replayDrainLock(database)) {
+      final MutablePage indexed = pageIndex.remove(pageId);
+      final List<MutablePage> detached = new ArrayList<>(1);
 
-    removePagesOfPageIdFromBatch(nextPagesToFlush.get(), pageId, detached);
+      // Iterated directly rather than through a snapshot: ArrayBlockingQueue's iterator is weakly consistent and
+      // never throws ConcurrentModificationException, and this runs per replayed page, so the copy would be pure
+      // overhead. The walk is bounded by the flush queue depth (arcadedb.pageFlushQueue) plus the deferred backlog,
+      // which is itself capped by arcadedb.flushSuspendMaxDeferredRAM.
+      for (final PagesToFlush batch : queue)
+        removePagesOfPageIdFromBatch(batch, pageId, detached);
 
-    final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.get(database);
-    if (deferred != null)
-      for (final PagesToFlush batch : deferred)
-        // The copies leave the deferred backlog, so release their reserved RAM accounting (issue #4728).
-        deferredRAMBytes.addAndGet(-removePagesOfPageIdFromBatch(batch, pageId, detached));
+      removePagesOfPageIdFromBatch(nextPagesToFlush.get(), pageId, detached);
 
-    // The indexed copy is missing from every batch only in the mid-enqueue window ruled out above, but adding it
-    // here keeps the caller's contract - "the pipeline no longer holds this page" - true without relying on it.
-    if (indexed != null && !containsInstance(detached, indexed))
-      detached.add(indexed);
+      final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.get(database);
+      if (deferred != null)
+        for (final PagesToFlush batch : deferred)
+          // The copies leave the deferred backlog, so release their reserved RAM accounting (issue #4728).
+          deferredRAMBytes.addAndGet(-removePagesOfPageIdFromBatch(batch, pageId, detached));
 
-    return detached;
+      // The indexed copy is missing from every batch only in the mid-enqueue window ruled out above, but adding it
+      // here keeps the caller's contract - "the pipeline no longer holds this page" - true without relying on it.
+      if (indexed != null && !containsInstance(detached, indexed))
+        detached.add(indexed);
+
+      return detached;
+    }
   }
 
   private static boolean containsInstance(final List<MutablePage> pages, final MutablePage page) {

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -627,59 +627,82 @@ public class PageManagerFlushThread extends Thread {
   }
 
   /**
-   * Takes the page pending for {@code pageId} out of the flush pipeline and hands it to the caller, which becomes
-   * responsible for writing it to disk. Used by {@link TransactionManager#applyChanges}, which writes replicated /
-   * recovery pages straight to the file: while an older copy of the same page stays in the pipeline, reads resolve
-   * it from {@link #pageIndex} instead of the file, and the eventual flush of that copy overwrites the replicated
-   * page and rolls its version backwards.
+   * Takes EVERY copy of {@code pageId} pending in the flush pipeline out of it and hands them to the caller, which
+   * becomes responsible for writing the most recent one to disk. Used by {@link TransactionManager#applyChanges},
+   * which writes replicated / recovery pages straight to the file: while an older copy of the same page stays in the
+   * pipeline, reads resolve it from {@link #pageIndex} instead of the file, and the eventual flush of that copy
+   * overwrites the replicated page and rolls its version backwards.
    * <p>
-   * The page is removed from the queued and deferred batches by reference identity so a NEWER copy queued for the
-   * same {@link PageId} is never dropped by mistake, matching {@link #removeFromFlushIndex}. The batch currently
-   * being written is also visited: the flush thread mutates the very same list, so the removal may lose that race,
-   * which is why the caller waits for the in-flight batch to complete before writing.
+   * Copies are matched by {@link PageId}, NOT by reference identity: successive commits can leave more than one
+   * {@link MutablePage} for the same page pending at once (the newest in {@link #pageIndex}, an older one still
+   * sitting in an earlier batch - the two-instance case {@link #removeFromFlushIndex} exists for, issue #4544).
+   * Removing only the indexed instance would leave the older copy free to write the superseded version over the
+   * replicated one. Every returned copy is superseded by the most recent one, whose content is a full page image
+   * covering all of them, so the caller writes that one and releases the others' WAL acks.
    * <p>
-   * ASSUMPTION: no other thread is scheduling a flush of this same page instance concurrently.
-   * {@link #scheduleFlushOfPages} publishes to {@link #pageIndex} BEFORE enqueueing, so a commit sitting between
-   * those two statements would have its batch enqueued after this detach walked the queue, and that batch would
-   * still carry the superseded page. This holds on the only caller's path: replicated and crash-recovery replay is
-   * the sole writer of the pages it applies, so no local commit can be mid-enqueue for them.
+   * The batch currently being written is also visited: the flush thread mutates the very same list, so the removal
+   * may lose that race, which is why the caller waits for the in-flight batch to complete before writing.
+   * <p>
+   * ASSUMPTION: no other thread is scheduling a flush of this page concurrently. {@link #scheduleFlushOfPages}
+   * publishes to {@link #pageIndex} BEFORE enqueueing, so a commit sitting between those two statements would have
+   * its batch enqueued after this detach walked the queue, and that batch would still carry a superseded copy. This
+   * holds on the only caller's path: replicated and crash-recovery replay is the sole writer of the pages it
+   * applies - it goes through {@code writePageWithLock}, which never touches this pipeline - and it runs on a
+   * follower or during recovery, where no local transaction is committing pages.
    *
-   * @return the detached page, or {@code null} when nothing was pending for this page.
+   * @return every detached copy, most recent one included; empty when nothing was pending for this page.
    */
-  MutablePage detachPendingPage(final Database database, final PageId pageId) {
-    final MutablePage pending = pageIndex.remove(pageId);
-    if (pending == null)
-      return null;
+  List<MutablePage> detachPendingPages(final Database database, final PageId pageId) {
+    final MutablePage indexed = pageIndex.remove(pageId);
+    final List<MutablePage> detached = new ArrayList<>(1);
 
     // Iterated directly rather than through a snapshot: ArrayBlockingQueue's iterator is weakly consistent and never
     // throws ConcurrentModificationException, and this runs per replayed page, so the copy would be pure overhead.
     for (final PagesToFlush batch : queue)
-      removePageFromBatch(batch, pending);
+      removePagesOfPageIdFromBatch(batch, pageId, detached);
 
-    removePageFromBatch(nextPagesToFlush.get(), pending);
+    removePagesOfPageIdFromBatch(nextPagesToFlush.get(), pageId, detached);
 
     final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.get(database);
     if (deferred != null)
       for (final PagesToFlush batch : deferred)
-        // The page leaves the deferred backlog, so release its reserved RAM accounting (issue #4728).
-        deferredRAMBytes.addAndGet(-removePageFromBatch(batch, pending));
+        // The copies leave the deferred backlog, so release their reserved RAM accounting (issue #4728).
+        deferredRAMBytes.addAndGet(-removePagesOfPageIdFromBatch(batch, pageId, detached));
 
-    return pending;
+    // The indexed copy is missing from every batch only in the mid-enqueue window ruled out above, but adding it
+    // here keeps the caller's contract - "the pipeline no longer holds this page" - true without relying on it.
+    if (indexed != null && !containsInstance(detached, indexed))
+      detached.add(indexed);
+
+    return detached;
   }
 
-  /** Removes a single page instance from a batch and returns its in-RAM size, or 0 when it was not there. */
-  private long removePageFromBatch(final PagesToFlush batch, final MutablePage target) {
+  private static boolean containsInstance(final List<MutablePage> pages, final MutablePage page) {
+    for (int i = 0; i < pages.size(); i++)
+      if (pages.get(i) == page)
+        return true;
+    return false;
+  }
+
+  /** Removes every copy of {@code pageId} from a batch into {@code detached} and returns the sum of their in-RAM size. */
+  private long removePagesOfPageIdFromBatch(final PagesToFlush batch, final PageId pageId,
+      final List<MutablePage> detached) {
+    // pages is null for the SHUTDOWN_THREAD marker.
     if (batch == null || batch.pages == null)
       return 0;
 
+    long removedBytes = 0;
     synchronized (batch.pages) {
-      for (final Iterator<MutablePage> it = batch.pages.iterator(); it.hasNext(); )
-        if (it.next() == target) {
+      for (final Iterator<MutablePage> it = batch.pages.iterator(); it.hasNext(); ) {
+        final MutablePage page = it.next();
+        if (pageId.equals(page.getPageId())) {
           it.remove();
-          return target.getPhysicalSize();
+          detached.add(page);
+          removedBytes += page.getPhysicalSize();
         }
+      }
     }
-    return 0;
+    return removedBytes;
   }
 
   /** Removes the dropped file's pages from a batch and returns the sum of their in-RAM size (issue #4728). */

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -626,6 +626,54 @@ public class PageManagerFlushThread extends Thread {
         .removeIf(e -> database.equals(e.getKey().getDatabase()) && e.getKey().getFileId() == fileId);
   }
 
+  /**
+   * Takes the page pending for {@code pageId} out of the flush pipeline and hands it to the caller, which becomes
+   * responsible for writing it to disk. Used by {@link TransactionManager#applyChanges}, which writes replicated /
+   * recovery pages straight to the file: while an older copy of the same page stays in the pipeline, reads resolve
+   * it from {@link #pageIndex} instead of the file, and the eventual flush of that copy overwrites the replicated
+   * page and rolls its version backwards.
+   * <p>
+   * The page is removed from the queued and deferred batches by reference identity so a NEWER copy queued for the
+   * same {@link PageId} is never dropped by mistake, matching {@link #removeFromFlushIndex}. The batch currently
+   * being written is also visited: the flush thread mutates the very same list, so the removal may lose that race,
+   * which is why the caller waits for the in-flight batch to complete before writing.
+   *
+   * @return the detached page, or {@code null} when nothing was pending for this page.
+   */
+  MutablePage detachPendingPage(final Database database, final PageId pageId) {
+    final MutablePage pending = pageIndex.remove(pageId);
+    if (pending == null)
+      return null;
+
+    for (final PagesToFlush batch : queue.stream().toList())
+      removePageFromBatch(batch, pending);
+
+    removePageFromBatch(nextPagesToFlush.get(), pending);
+
+    final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.get(database);
+    if (deferred != null)
+      for (final PagesToFlush batch : deferred)
+        // The page leaves the deferred backlog, so release its reserved RAM accounting (issue #4728).
+        deferredRAMBytes.addAndGet(-removePageFromBatch(batch, pending));
+
+    return pending;
+  }
+
+  /** Removes a single page instance from a batch and returns its in-RAM size, or 0 when it was not there. */
+  private long removePageFromBatch(final PagesToFlush batch, final MutablePage target) {
+    if (batch == null || batch.pages == null)
+      return 0;
+
+    synchronized (batch.pages) {
+      for (final Iterator<MutablePage> it = batch.pages.iterator(); it.hasNext(); )
+        if (it.next() == target) {
+          it.remove();
+          return target.getPhysicalSize();
+        }
+    }
+    return 0;
+  }
+
   /** Removes the dropped file's pages from a batch and returns the sum of their in-RAM size (issue #4728). */
   private long removePagesOfFileFromBatch(final PagesToFlush pagesToFlush, final Database database, final int fileId) {
     // pages is null for the SHUTDOWN_THREAD marker.

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -487,6 +487,12 @@ public class TransactionManager {
       }
 
       try {
+        // The asynchronous flush pipeline may still hold an older copy of this page. It must reach the disk BEFORE
+        // the replicated write below: while it is pending, every read resolves the page from the flush queue instead
+        // of from the file (so the replicated write stays invisible), and its eventual flush overwrites the
+        // replicated page and rolls the version backwards - the version-gap cascade this replay exists to close.
+        database.getPageManager().materializePendingFlushOfPage(database, pageId);
+
         final ImmutablePage page = database.getPageManager().getImmutablePage(pageId, file.getPageSize(), false, true);
 
         LogManager.instance()
@@ -613,6 +619,11 @@ public class TransactionManager {
 
       } catch (final ClosedByInterruptException e) {
         // NORMAL EXCEPTION IN CASE THE CONNECTION/THREAD IS CLOSED (=INTERRUPTED)
+        Thread.currentThread().interrupt();
+        throw new WALException("Cannot apply changes to page " + pageId, e);
+      } catch (final InterruptedException e) {
+        // Interrupted while draining the pending flush of this page: the page was NOT applied, so fail loud with the
+        // interrupt flag restored instead of leaving a silent version gap behind.
         Thread.currentThread().interrupt();
         throw new WALException("Cannot apply changes to page " + pageId, e);
       } catch (final IOException e) {

--- a/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
@@ -108,4 +108,85 @@ class Issue5326ApplyChangesPendingFlushTest extends TestHelper {
     final ImmutablePage reloaded = pageManager.getImmutablePage(pageId, pageSize, false, true);
     assertThat(reloaded.getVersion()).isEqualTo(baseVersion + 1);
   }
+
+  /**
+   * Same defect, but driven through the real flush pipeline instead of a fabricated index entry: the page is scheduled
+   * by an ordinary commit while flushing is suspended, so it sits in a genuine deferred batch. This covers the batch
+   * removal and the deferred-RAM accounting (#4728) that the white-box case above cannot reach, and it verifies the
+   * durability half of the fix: once flushing resumes, the deferred batch must no longer carry a copy able to write
+   * the superseded version over the replicated one.
+   */
+  @Test
+  void applyChangesTakesTheDeferredBatchCopyOutOfThePipeline() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    db.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        db.newDocument("TestType").set("name", "record-" + i).save();
+    });
+
+    final int fileId = db.getSchema().getType("TestType").getBuckets(false).getFirst().getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final int pageSize = file.getPageSize();
+    final PageId pageId = new PageId(db, fileId, 0);
+    final PageManager pageManager = db.getPageManager();
+    final PageManagerFlushThread flushThread = pageManager.getFlushThread();
+
+    assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+
+    final int replicatedVersion;
+
+    // Suspend flushing (what a backup or an HA snapshot ship does) so the next commit's pages are parked in a
+    // deferred batch instead of reaching the disk.
+    flushThread.setSuspended(db, true);
+    try {
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          db.newDocument("TestType").set("name", "deferred-" + i).save();
+      });
+
+      // Wait for the flush thread to move the committed batch into the deferred backlog.
+      final long deadline = System.currentTimeMillis() + 10_000;
+      while (flushThread.deferredRAMBytes.get() == 0 && System.currentTimeMillis() < deadline)
+        Thread.sleep(10);
+
+      final MutablePage pending = flushThread.pageIndex.get(pageId);
+      assertThat(pending).as("the committed page must still be pending in the flush pipeline").isNotNull();
+      assertThat(flushThread.deferredRAMBytes.get()).isPositive();
+
+      final long deferredBefore = flushThread.deferredRAMBytes.get();
+      final long pendingSize = pending.getPhysicalSize();
+      final int baseVersion = (int) pending.getVersion();
+      replicatedVersion = baseVersion + 1;
+
+      final WALFile.WALPage walPage = new WALFile.WALPage();
+      walPage.fileId = fileId;
+      walPage.pageNumber = 0;
+      walPage.currentPageVersion = baseVersion + 1;
+      walPage.changesFrom = BasePage.PAGE_HEADER_SIZE;
+      walPage.changesTo = BasePage.PAGE_HEADER_SIZE + 10;
+      walPage.currentPageSize = pending.getContentSize();
+      final byte[] content = new byte[11];
+      System.arraycopy(pending.getContent().array(), walPage.changesFrom, content, 0, content.length);
+      walPage.currentContent = new Binary(content);
+
+      final WALFile.WALTransaction walTx = new WALFile.WALTransaction();
+      walTx.txId = 53260;
+      walTx.timestamp = System.currentTimeMillis();
+      walTx.pages = new WALFile.WALPage[] { walPage };
+
+      assertThat(db.getTransactionManager().applyChanges(walTx, Collections.emptyMap(), false)).isTrue();
+
+      assertThat(flushThread.pageIndex.get(pageId)).isNull();
+      assertThat(flushThread.deferredRAMBytes.get()).isEqualTo(deferredBefore - pendingSize);
+    } finally {
+      // Resuming writes every batch still deferred: none of them may carry the superseded copy of this page.
+      flushThread.setSuspended(db, false);
+    }
+
+    assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+    pageManager.removePageFromCache(pageId);
+    final ImmutablePage reloaded = pageManager.getImmutablePage(pageId, pageSize, false, true);
+    assertThat(reloaded.getVersion()).isEqualTo(replicatedVersion);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * White-box regression test for the interaction between {@link TransactionManager#applyChanges} and the asynchronous
+ * flush pipeline.
+ * <p>
+ * A committed page is published to the read cache and to the flush thread's {@code pageIndex} before it reaches the
+ * disk. {@code applyChanges} (replicated/recovery replay) writes the page straight to the file, bypassing the queue.
+ * While the older copy stayed in the pipeline two things went wrong:
+ * <ul>
+ *   <li>{@code PageManager.loadPage} resolves a page from the flush queue BEFORE reading the file, so every read after
+ *   the replicated write kept returning the superseded version.</li>
+ *   <li>when the flush thread eventually wrote the queued copy, it overwrote the replicated page on disk, rolling the
+ *   page version backwards and re-opening the version-gap cascade the replay is meant to close.</li>
+ * </ul>
+ * Both outcomes depend on whether the flush thread happens to drain the queue before the read, which is what made the
+ * {@code applyChanges} regression tests fail intermittently on loaded CI machines (issue #5326).
+ * <p>
+ * {@code applyChanges} now pushes any pending copy of the page to disk and detaches it from the pipeline before
+ * applying the WAL delta, so the outcome no longer depends on flush timing.
+ */
+class Issue5326ApplyChangesPendingFlushTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("TestType");
+  }
+
+  @Test
+  void applyChangesOverridesAPageStillPendingInTheFlushPipeline() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    db.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        db.newDocument("TestType").set("name", "record-" + i).save();
+    });
+
+    final int fileId = db.getSchema().getType("TestType").getBuckets(false).getFirst().getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final int pageSize = file.getPageSize();
+    final PageId pageId = new PageId(db, fileId, 0);
+    final PageManager pageManager = db.getPageManager();
+
+    // Start from a quiet pipeline so the only pending entry is the one this test publishes below.
+    assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+
+    final ImmutablePage page = pageManager.getImmutablePage(pageId, pageSize, false, true);
+    final int baseVersion = (int) page.getVersion();
+
+    // Reproduce the state a page is in between commit and flush: published in the flush thread's index (so reads
+    // resolve it from there) while the disk still holds the same version.
+    final MutablePage pending = page.modify();
+    pageManager.getFlushThread().pageIndex.put(pageId, pending);
+
+    // Replicated/recovery WAL entry bumping the page by one version.
+    final WALFile.WALPage walPage = new WALFile.WALPage();
+    walPage.fileId = fileId;
+    walPage.pageNumber = 0;
+    walPage.currentPageVersion = baseVersion + 1;
+    walPage.changesFrom = BasePage.PAGE_HEADER_SIZE;
+    walPage.changesTo = BasePage.PAGE_HEADER_SIZE + 10;
+    walPage.currentPageSize = page.getContentSize();
+    final byte[] content = new byte[11];
+    System.arraycopy(page.getContent().array(), walPage.changesFrom, content, 0, content.length);
+    walPage.currentContent = new Binary(content);
+
+    final WALFile.WALTransaction walTx = new WALFile.WALTransaction();
+    walTx.txId = 5326;
+    walTx.timestamp = System.currentTimeMillis();
+    walTx.pages = new WALFile.WALPage[] { walPage };
+
+    assertThat(db.getTransactionManager().applyChanges(walTx, Collections.emptyMap(), false)).isTrue();
+
+    // No stale copy is left behind that a later flush would write over the replicated page.
+    assertThat(pageManager.getFlushThread().pageIndex.get(pageId)).isNull();
+
+    // The replicated version is what every subsequent read observes, cache-hit or reload from disk.
+    assertThat(pageManager.getImmutablePage(pageId, pageSize, false, true).getVersion()).isEqualTo(baseVersion + 1);
+
+    pageManager.removePageFromCache(pageId);
+    final ImmutablePage reloaded = pageManager.getImmutablePage(pageId, pageSize, false, true);
+    assertThat(reloaded.getVersion()).isEqualTo(baseVersion + 1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
@@ -145,8 +145,10 @@ class Issue5326ApplyChangesPendingFlushTest extends TestHelper {
           db.newDocument("TestType").set("name", "deferred-" + i).save();
       });
 
-      // Wait for the flush thread to move the committed batch into the deferred backlog.
-      final long deadline = System.currentTimeMillis() + 10_000;
+      // Wait for the flush thread to move the committed batch into the deferred backlog. The deadline only bounds a
+      // hang: the flush thread polls its queue on a 1s timeout, so 60s is orders of magnitude above the worst-case
+      // deferral latency even on the loaded runners that made #5326 visible in the first place.
+      final long deadline = System.currentTimeMillis() + 60_000;
       while (flushThread.deferredRAMBytes.get() == 0 && System.currentTimeMillis() < deadline)
         Thread.sleep(10);
 
@@ -184,6 +186,89 @@ class Issue5326ApplyChangesPendingFlushTest extends TestHelper {
       flushThread.setSuspended(db, false);
     }
 
+    assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+    pageManager.removePageFromCache(pageId);
+    final ImmutablePage reloaded = pageManager.getImmutablePage(pageId, pageSize, false, true);
+    assertThat(reloaded.getVersion()).isEqualTo(replicatedVersion);
+  }
+
+  /**
+   * Two commits of the same page while flushing is suspended leave TWO pending copies: the newest in
+   * {@code pageIndex} and the older one still in the first batch (the two-instance case
+   * {@link PageManagerFlushThread#removeFromFlushIndex} exists for, issue #4544). Detaching only the indexed copy
+   * would leave the older one free to write the superseded version over the replicated one once flushing resumes,
+   * so every copy has to leave the pipeline.
+   */
+  @Test
+  void applyChangesTakesEveryPendingCopyOfThePageOutOfThePipeline() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    db.transaction(() -> db.newDocument("TestType").set("name", "seed").save());
+
+    final int fileId = db.getSchema().getType("TestType").getBuckets(false).getFirst().getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final int pageSize = file.getPageSize();
+    final PageId pageId = new PageId(db, fileId, 0);
+    final PageManager pageManager = db.getPageManager();
+    final PageManagerFlushThread flushThread = pageManager.getFlushThread();
+
+    assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+
+    final int replicatedVersion;
+
+    flushThread.setSuspended(db, true);
+    try {
+      // Two separate commits: two batches, each carrying its own MutablePage for page 0.
+      for (int tx = 0; tx < 2; tx++) {
+        final int round = tx;
+        db.transaction(() -> {
+          for (int i = 0; i < 5; i++)
+            db.newDocument("TestType").set("name", "round-" + round + "-" + i).save();
+        });
+      }
+
+      final long deadline = System.currentTimeMillis() + 60_000;
+      while (flushThread.deferredRAMBytes.get() == 0 && System.currentTimeMillis() < deadline)
+        Thread.sleep(10);
+
+      final MutablePage newest = flushThread.pageIndex.get(pageId);
+      assertThat(newest).as("the twice-committed page must still be pending in the flush pipeline").isNotNull();
+
+      final int baseVersion = (int) newest.getVersion();
+      assertThat(baseVersion).as("both commits must have touched page 0, leaving two pending copies").isGreaterThan(1);
+      replicatedVersion = baseVersion + 1;
+
+      final WALFile.WALPage walPage = new WALFile.WALPage();
+      walPage.fileId = fileId;
+      walPage.pageNumber = 0;
+      walPage.currentPageVersion = replicatedVersion;
+      walPage.changesFrom = BasePage.PAGE_HEADER_SIZE;
+      walPage.changesTo = BasePage.PAGE_HEADER_SIZE + 10;
+      walPage.currentPageSize = newest.getContentSize();
+      final byte[] content = new byte[11];
+      System.arraycopy(newest.getContent().array(), walPage.changesFrom, content, 0, content.length);
+      walPage.currentContent = new Binary(content);
+
+      final WALFile.WALTransaction walTx = new WALFile.WALTransaction();
+      walTx.txId = 53261;
+      walTx.timestamp = System.currentTimeMillis();
+      walTx.pages = new WALFile.WALPage[] { walPage };
+
+      final long deferredBefore = flushThread.deferredRAMBytes.get();
+
+      assertThat(db.getTransactionManager().applyChanges(walTx, Collections.emptyMap(), false)).isTrue();
+      assertThat(flushThread.pageIndex.get(pageId)).isNull();
+
+      // Both copies left the deferred backlog, not just the indexed one.
+      assertThat(deferredBefore - flushThread.deferredRAMBytes.get())
+          .as("every pending copy of the page must be detached, not only the one in pageIndex")
+          .isEqualTo(2L * newest.getPhysicalSize());
+    } finally {
+      flushThread.setSuspended(db, false);
+    }
+
+    // Resuming writes every batch still deferred. If the older copy had survived the detach it would land here and
+    // roll the page back below the replicated version.
     assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
     pageManager.removePageFromCache(pageId);
     final ImmutablePage reloaded = pageManager.getImmutablePage(pageId, pageSize, false, true);


### PR DESCRIPTION
Closes #5326

## Summary

The three intermittently failing `applyChanges`/page-replay tests were observing a genuine ordering hole, not test noise. A committed page is published to the read cache and to `PageManagerFlushThread.pageIndex` before it reaches disk, but `TransactionManager.applyChanges` (replicated / crash-recovery replay) writes the page straight to its file and evicts the read cache without consulting the flush pipeline. While the older copy is still pending, `PageManager.loadPage` resolves the page from the flush queue *before* reading the file - so every read after the replicated write returns the superseded version - and when the flush thread eventually writes that queued copy it overwrites the replicated page and rolls its version backwards, which is the version-regression signature behind the `WALVersionGapException` cascades in #4510/#5322. `applyChanges` now detaches any pending copy of the page from the pipeline (identity-guarded, covering queued, in-flight and deferred batches, with the #4728 deferred-RAM accounting released), waits for the in-flight batch to finish, writes the pending page to disk and evicts the cached copy before applying the WAL delta. The pending page is written rather than discarded because its content is the only baseline the delta can be applied on top of. As a side effect the three flaky classes no longer depend on flush timing; none of them was modified.

## Test plan

- [x] `mvn -pl engine test -Dtest=Issue5326ApplyChangesPendingFlushTest` - new white-box regression test; fails before the fix (stale copy survives in `pageIndex`, reload returns the old version), passes after.
- [x] `mvn -pl engine test -Dtest='Issue4712*,Issue4510*,ApplyChanges*,Issue5326*,*PageManager*,*FlushThread*,*WAL*,Issue4928*,Issue4544*,Issue4728*,Issue5068*'` - 54 tests, 0 failures.
- [x] `mvn -pl engine test -Dtest='com.arcadedb.engine.**,com.arcadedb.database.**'` - 642 tests, 0 failures (one unrelated environmental error: `TimeSeriesEmbeddedBenchmark.run` hit `No space left on device` on the build machine).
- [ ] CI: watch the three previously flaky classes across a few runs to confirm the intermittency is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)