### PR TITLE
fix(#5345): bound Raft log growth with a periodic snapshot trigger

### DIFF
--- a/docs/5345-raft-log-unbounded-growth.md
+++ b/docs/5345-raft-log-unbounded-growth.md
@@ -63,5 +63,39 @@ trigger for both.
   gap to 1, the shutdown flag suppresses the tick, a failing snapshot request never escapes the
   scheduler thread, the disk warning is throttled, and unknown volume size is not misread as
   pressure.
+- `RaftPeriodicSnapshotCompactionIT` (new, `ha-raft`): against a real 3-peer Ratis mini-cluster with
+  `ArcadeStateMachine`, asserts a node-local snapshot request succeeds and produces a positive snapshot
+  index on every peer including followers, and pins the reply contract `tick()` depends on (a
+  short-circuited request reports the existing snapshot index, not the log index).
+- `RaftLogCompactionWiringIT` (new, `ha-raft`): against a real `RaftHAServer` HA cluster, covers the
+  seam between the two suites above - `takeLocalSnapshot()` assembling the request from the real client
+  id, peer id and group id, and the compaction target resolving the Raft storage volume for the
+  free-space probe.
 - `HAConfigDefaultsTest` (existing, extended): pins the three new configuration defaults.
 - `mvn -pl ha-raft test` for the ha-raft module.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5350
+
+## Review cycles
+
+| cycle | head SHA | changes | outcome |
+|---|---|---|---|
+| 1 | `29be8ca2b` | initial implementation | gemini: volatile `raftServer`, overflow in percentage math, cache storage dir. claude: no-op ticks logged as compactions, half-covered overflow guard, plus non-blocking notes. |
+| 2 | `1d2129b93` | `raftServer` volatile; double arithmetic for disk pressure; cached storage dir; only report an advanced snapshot index; tests for the sentinel distinction and petabyte-scale volumes | gemini: reposted the (already fixed) volatile comment. claude: phantom first-tick compaction log after a RECOVER restart, no-op reply contract unpinned, PoolMetrics note. |
+| 3 | `4578e3e80` | first tick seeds the baseline without claiming a compaction; IT pins `reply.getLogIndex()`; PoolMetrics note in the class doc | gemini: reposted the same volatile comment a third time. claude: wiring test gap (the main pre-merge ask), `stop()` does not await termination, warning message omits the knob that fired it. |
+| 4 | (this commit) | `RaftLogCompactionWiringIT` closes the wiring gap; `stop()` awaits in-flight ticks; warning names `raftStorageMinFreeSpacePerc` | - |
+
+### Feedback deliberately not actioned
+
+- **gemini, "declare `raftServer` volatile" (repeated on all three head SHAs).** Actioned in cycle 2;
+  the field reads `private volatile RaftServer raftServer;` in the very commits the later copies were
+  posted against. The reposts are stale, not new findings.
+- **claude, "the first genuine compaction on a fresh node is never logged".** This is the deliberate
+  trade-off of suppressing the baseline tick, which claude also called acceptable. Distinguishing "the
+  first snapshot this scheduler created" from "a snapshot Ratis loaded at startup" is not possible from
+  the reply alone, and purging is unaffected - only the log line is.
+- **claude, "`getUsableSpace()` returns 0, not negative, for an unstattable path".** Correct, and the
+  conservative reading (0 free on a sized volume = pressure) is the intended behaviour. Raised as an
+  observation, not a change request.

--- a/docs/5345-raft-log-unbounded-growth.md
+++ b/docs/5345-raft-log-unbounded-growth.md
@@ -1,0 +1,67 @@
+# Issue #5345 - Raft log grows unbounded until disk-full
+
+## Problem
+
+On a low/moderate-write HA cluster the segmented Raft log under `raftStorageDirectory` grows
+without bound until it fills the volume. Log purge is gated on the snapshot index
+(`arcadedb.ha.logPurgeUptoSnapshot=true`), and the snapshot index only advances when Ratis's
+auto-snapshot fires, which happens every `arcadedb.ha.snapshotThreshold` (default 100000)
+applied entries. A cluster committing ~8500 entries/day needs ~12 days of uninterrupted uptime
+to reach that count, so in practice the only thing advancing the purge point is the snapshot
+taken at process start. A node that stays up long enough fills its PVC; once the log writer hits
+`java.io.IOException: No space left on device`, Ratis marks the log permanently failed at that
+index and rejects every subsequent `APPEND_ENTRIES`, wedging the follower until an operator
+restarts the pod.
+
+## Root cause
+
+`RaftPropertiesBuilder` configures only a **count-based** auto-snapshot trigger
+(`RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold`). There is no time-based or
+disk-pressure-based trigger, so on a low-write cluster the state machine never checkpoints and
+Ratis never purges. The log size is driven by **bytes** (~45 KB/entry in the reported cluster,
+1.9 GB for 44k entries) while the trigger is expressed in **entries**, so the count threshold
+gives no bound on disk usage at all.
+
+## Fix
+
+ArcadeDB's Raft snapshot is a zero-byte marker file (`ArcadeStateMachine.takeSnapshot()` - the
+database files on disk are already the durable state), so taking one is essentially free. That
+makes a periodic trigger the right shape for this bug.
+
+New `RaftLogCompactionScheduler` (module `ha-raft`) runs on **every** node - leader and followers
+alike, since each Ratis server purges its own log against its own snapshot index - and on each
+tick asks the local Ratis server to create a snapshot via
+`RaftServer.snapshotManagement(SnapshotManagementRequest.newCreate(...))`. Ratis short-circuits
+the request when fewer than `creationGap` entries have been applied since the last snapshot, so an
+idle cluster does no work.
+
+- `arcadedb.ha.snapshotInterval` (default `300000` ms = 5 min, `0` disables) - how often the tick runs.
+- `arcadedb.ha.snapshotMinEntries` (default `64`) - creation gap for a normal tick; below this many
+  new entries the tick is a no-op.
+- `arcadedb.ha.raftStorageMinFreeSpacePerc` (default `20`) - when the volume hosting
+  `raftStorageDirectory` drops below this percentage of free space, the tick escalates: the creation
+  gap drops to 1 so the snapshot/purge fires as aggressively as Ratis allows, and a throttled
+  (60 s) WARNING names the directory and the free/total bytes so the condition is visible before
+  the disk fills.
+
+The count-based `arcadedb.ha.snapshotThreshold` is left untouched, so existing deployments keep
+their current behaviour on top of the new periodic floor.
+
+## Scope note
+
+The issue lists five suggested fixes. This change implements (1) making auto-snapshot fire on a
+low-write cluster, (2) snapshot + purge under disk pressure, and (5) sizing documentation. Items
+(3) "make a `No space left` wedge recoverable without a restart" and (4) "account for disk space in
+stale-follower recovery" are Ratis-internal recovery work with a materially different blast radius
+and are tracked separately - preventing the disk from filling is the change that removes the
+trigger for both.
+
+## Verification
+
+- `RaftLogCompactionSchedulerTest` (new, `ha-raft`): unit-tests the tick logic - disabled when the
+  interval is not positive, normal ticks use the configured creation gap, disk pressure drops the
+  gap to 1, the shutdown flag suppresses the tick, a failing snapshot request never escapes the
+  scheduler thread, the disk warning is throttled, and unknown volume size is not misread as
+  pressure.
+- `HAConfigDefaultsTest` (existing, extended): pins the three new configuration defaults.
+- `mvn -pl ha-raft test` for the ha-raft module.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -948,7 +948,10 @@ public enum GlobalConfiguration {
       until the volume is full. This time-based trigger bounds the retained log by wall-clock age instead. \
       An ArcadeDB snapshot is a zero-byte marker (the database files on disk are the durable state), so a \
       tick is cheap; it is additionally a no-op when fewer than HA_SNAPSHOT_MIN_ENTRIES entries were \
-      applied since the last snapshot. Set to 0 to disable and rely on HA_SNAPSHOT_THRESHOLD only.""",
+      applied since the last snapshot. Set to 0 to disable and rely on HA_SNAPSHOT_THRESHOLD only. \
+      Note this interval also bounds the reaction time to disk pressure, not just steady-state log \
+      retention: the free-space escalation described in HA_RAFT_STORAGE_MIN_FREE_SPACE_PERC fires on the \
+      next tick, so a volume that fills faster than one interval needs a shorter interval.""",
       Long.class, 300_000L),
 
   HA_SNAPSHOT_MIN_ENTRIES("arcadedb.ha.snapshotMinEntries", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -940,6 +940,32 @@ public enum GlobalConfiguration {
       Lower values cause more frequent snapshots and earlier log compaction.""",
       Long.class, 100_000L),
 
+  HA_SNAPSHOT_INTERVAL("arcadedb.ha.snapshotInterval", SCOPE.SERVER,
+      """
+      Interval in milliseconds between periodic Raft snapshot checkpoints on every node. \
+      HA_SNAPSHOT_THRESHOLD alone counts entries, so a low-write cluster can run for weeks without ever \
+      reaching it: the snapshot index stays frozen, no log segment is ever purged, and the Raft log grows \
+      until the volume is full. This time-based trigger bounds the retained log by wall-clock age instead. \
+      An ArcadeDB snapshot is a zero-byte marker (the database files on disk are the durable state), so a \
+      tick is cheap; it is additionally a no-op when fewer than HA_SNAPSHOT_MIN_ENTRIES entries were \
+      applied since the last snapshot. Set to 0 to disable and rely on HA_SNAPSHOT_THRESHOLD only.""",
+      Long.class, 300_000L),
+
+  HA_SNAPSHOT_MIN_ENTRIES("arcadedb.ha.snapshotMinEntries", SCOPE.SERVER,
+      """
+      Minimum number of Raft log entries applied since the last snapshot before a periodic \
+      HA_SNAPSHOT_INTERVAL tick actually takes one. Keeps an idle cluster from rewriting a snapshot marker \
+      that would not advance the purge point. Values below 1 are clamped to 1.""",
+      Long.class, 64L),
+
+  HA_RAFT_STORAGE_MIN_FREE_SPACE_PERC("arcadedb.ha.raftStorageMinFreeSpacePerc", SCOPE.SERVER,
+      """
+      Percentage of free space on the volume hosting HA_RAFT_STORAGE_DIRECTORY below which the periodic \
+      snapshot tick escalates: it forces a snapshot and log purge regardless of HA_SNAPSHOT_MIN_ENTRIES and \
+      logs a throttled WARNING. Guards against the Raft log filling the volume, after which Ratis marks the \
+      log permanently failed and the node rejects every append until restarted. Set to 0 to disable the check.""",
+      Integer.class, 20),
+
   HA_LOG_VERBOSE("arcadedb.ha.logVerbose", SCOPE.SERVER,
       "HA verbose logging level: 0=off, 1=basic (elections, leader changes), 2=detailed (replication, forwarding), 3=trace (every state machine apply)",
       Integer.class, 0),

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2481,6 +2481,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
+   * Package-private test hook: a compaction target bound to this server, so an integration test can
+   * assert the free-space probe resolves a real volume without reaching into the scheduler's thread.
+   */
+  RaftLogCompactionScheduler.CompactionTarget newCompactionTargetForTesting() {
+    return new RaftLogCompactionTarget();
+  }
+
+  /**
    * Asks the local Ratis server to create a snapshot, which is what authorises it to purge log
    * segments up to the new snapshot index ({@code arcadedb.ha.logPurgeUptoSnapshot}). This is a
    * node-local admin operation - it is valid on the leader and on followers alike, and does not

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -144,7 +144,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private final    Map<RaftPeerId, String> peerDisplayNames   = new ConcurrentHashMap<>();
   private final    String                  clusterName;
 
-  private          RaftServer                raftServer;
+  // volatile: reassigned by the recovery path (restartRatis) and cleared by stop(), while background
+  // threads - the health monitor and, since #5345, the log compaction scheduler - read it. Every reader
+  // still copies it to a local before use so a concurrent reassignment cannot null it mid-method.
+  private volatile RaftServer                raftServer;
   private          RaftClient                raftClient;
   private          RaftProperties            raftProperties;
   private volatile RaftTransactionBroker     transactionBroker;
@@ -173,6 +176,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // scheduler issues. A stable ClientId keeps the requests distinguishable in Ratis's logs.
   private final    ClientId                  snapshotClientId      = ClientId.randomId();
   private final    AtomicLong                snapshotCallId        = new AtomicLong();
+  // Resolved Raft storage directory, cached for the free-space probes the compaction scheduler runs on
+  // every tick. Config-derived and constant for this server's lifetime.
+  private volatile File                      cachedRaftStorageDir  = null;
   // Follower-side Raft log catch-up narrative. Driven by the health-monitor tick; only active on a
   // follower with a non-trivial apply backlog (committed-but-not-yet-applied entries) and not installing
   // a snapshot.
@@ -2456,9 +2462,18 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
      * The Raft storage directory, or its nearest existing ancestor. {@code File.getUsableSpace()}
      * returns 0 for a path that does not exist, which would otherwise read as "disk full" during the
      * window between server start and Ratis creating the directory.
+     * <p>
+     * The configured directory itself is resolved once and cached: {@code resolveRaftStorageDir} is
+     * config-derived and constant for the server's lifetime, and re-running its {@code exists()} probes
+     * on every tick is pointless I/O. The ancestor walk stays per-call because its result legitimately
+     * changes once Ratis creates the directory.
      */
     private File raftStorageVolume() {
-      File dir = getRaftStorageDir();
+      File dir = cachedRaftStorageDir;
+      if (dir == null) {
+        dir = getRaftStorageDir();
+        cachedRaftStorageDir = dir;
+      }
       while (dir != null && !dir.exists())
         dir = dir.getParentFile();
       return dir;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -35,12 +35,14 @@ import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
 import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.SnapshotManagementRequest;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.server.DivisionInfo;
@@ -79,6 +81,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -111,6 +114,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // Package-private so other cluster-internal RPC callers (e.g. LeaderDatabaseQuery) reuse the same constant
   // instead of re-inlining the "root" literal.
   static final String FORWARDED_ROOT_USER = "root";
+
+  // Timeout carried by the node-local snapshot-management requests the log compaction scheduler issues.
+  // Generous: the request is served on the state-machine updater thread, which may be busy applying a
+  // backlog, and a timeout here only skips one compaction tick.
+  private static final long SNAPSHOT_REQUEST_TIMEOUT_MS = 30_000L;
 
   private final    ArcadeDBServer          arcadeServer;
   private final    ContextConfiguration    configuration;
@@ -158,6 +166,13 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private volatile Thread                    autoJoinThread        = null;
   private volatile LifeCycle.State           forcedStateForTesting = null;
   private          HealthMonitor             healthMonitor;
+  // Periodic Raft snapshot/log-purge trigger (issue #5345). Runs on every node, leader and follower
+  // alike, because each Ratis server purges its own log against its own snapshot index.
+  private          RaftLogCompactionScheduler logCompactionScheduler;
+  // Client identity and call-id sequence for the local snapshot-management requests the compaction
+  // scheduler issues. A stable ClientId keeps the requests distinguishable in Ratis's logs.
+  private final    ClientId                  snapshotClientId      = ClientId.randomId();
+  private final    AtomicLong                snapshotCallId        = new AtomicLong();
   // Follower-side Raft log catch-up narrative. Driven by the health-monitor tick; only active on a
   // follower with a non-trivial apply backlog (committed-but-not-yet-applied entries) and not installing
   // a snapshot.
@@ -633,6 +648,18 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     this.healthMonitor = new HealthMonitor(this, healthInterval, staleFollowerLagThreshold, staleFollowerRecoveryDurationMs,
         divergedFollowerRecovery, divergedFollowerMaxReformats, crashLoopRestartThreshold);
     this.healthMonitor.start();
+
+    // Periodic snapshot/log-purge trigger (issue #5345). Started on every node, not only the leader:
+    // Ratis purges each server's own log against that server's own snapshot index, so a follower whose
+    // snapshot index never advances fills its volume even while the leader stays healthy.
+    final long snapshotInterval = configuration.getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_INTERVAL);
+    final long snapshotMinEntries = configuration.getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_MIN_ENTRIES);
+    final int raftStorageMinFreeSpacePerc = configuration.getValueAsInteger(
+        GlobalConfiguration.HA_RAFT_STORAGE_MIN_FREE_SPACE_PERC);
+    this.logCompactionScheduler = new RaftLogCompactionScheduler(new RaftLogCompactionTarget(), snapshotInterval,
+        snapshotMinEntries, raftStorageMinFreeSpacePerc);
+    this.logCompactionScheduler.start();
+
     if (configuration.getValueAsBoolean(GlobalConfiguration.HA_RESYNC_PROGRESS_LOGGING))
       this.resyncProgressTracker = new FollowerResyncProgressTracker(
           configuration.getValueAsLong(GlobalConfiguration.HA_RESYNC_PROGRESS_INTERVAL),
@@ -1042,6 +1069,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (healthMonitor != null) {
       healthMonitor.stop();
       healthMonitor = null;
+    }
+    if (logCompactionScheduler != null) {
+      logCompactionScheduler.stop();
+      logCompactionScheduler = null;
     }
     stopLagMonitor();
     stalledResyncExecutor.shutdownNow();
@@ -2384,6 +2415,88 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    */
   static boolean isExplicitlyConfigured(final ContextConfiguration configuration, final GlobalConfiguration key) {
     return configuration.hasValue(key.getKey()) || System.getProperty(key.getKey()) != null;
+  }
+
+  /**
+   * Binds {@link RaftLogCompactionScheduler} to this server's Ratis instance and Raft storage volume
+   * (issue #5345). Kept as an inner class so the scheduler itself stays free of Ratis and filesystem
+   * details and can be unit-tested against a fake.
+   */
+  private final class RaftLogCompactionTarget implements RaftLogCompactionScheduler.CompactionTarget {
+
+    @Override
+    public boolean isShutdownRequested() {
+      return shutdownRequested;
+    }
+
+    @Override
+    public long triggerSnapshot(final long creationGap) {
+      return takeLocalSnapshot(creationGap);
+    }
+
+    @Override
+    public long getRaftStorageUsableSpaceBytes() {
+      final File dir = raftStorageVolume();
+      return dir != null ? dir.getUsableSpace() : -1L;
+    }
+
+    @Override
+    public long getRaftStorageTotalSpaceBytes() {
+      final File dir = raftStorageVolume();
+      return dir != null ? dir.getTotalSpace() : -1L;
+    }
+
+    @Override
+    public String getRaftStorageDescription() {
+      final File dir = raftStorageVolume();
+      return dir != null ? dir.getAbsolutePath() : "<unknown>";
+    }
+
+    /**
+     * The Raft storage directory, or its nearest existing ancestor. {@code File.getUsableSpace()}
+     * returns 0 for a path that does not exist, which would otherwise read as "disk full" during the
+     * window between server start and Ratis creating the directory.
+     */
+    private File raftStorageVolume() {
+      File dir = getRaftStorageDir();
+      while (dir != null && !dir.exists())
+        dir = dir.getParentFile();
+      return dir;
+    }
+  }
+
+  /**
+   * Asks the local Ratis server to create a snapshot, which is what authorises it to purge log
+   * segments up to the new snapshot index ({@code arcadedb.ha.logPurgeUptoSnapshot}). This is a
+   * node-local admin operation - it is valid on the leader and on followers alike, and does not
+   * replicate.
+   * <p>
+   * Ratis completes the request as a no-op when fewer than {@code creationGap} entries have been
+   * applied since the last snapshot, and rejects it while a snapshot install is in progress.
+   *
+   * @return the resulting snapshot index, or -1 when no snapshot was taken
+   */
+  long takeLocalSnapshot(final long creationGap) {
+    final RaftServer server = raftServer;
+    if (server == null || shutdownRequested)
+      return -1L;
+    if (server.getLifeCycleState() != LifeCycle.State.RUNNING)
+      return -1L;
+
+    try {
+      final RaftClientReply reply = server.snapshotManagement(
+          SnapshotManagementRequest.newCreate(snapshotClientId, localPeerId, raftGroup.getGroupId(),
+              snapshotCallId.incrementAndGet(), SNAPSHOT_REQUEST_TIMEOUT_MS, creationGap));
+      if (reply == null || !reply.isSuccess()) {
+        LogManager.instance().log(this, Level.FINE, "Local Raft snapshot request was not successful: %s", reply);
+        return -1L;
+      }
+      return reply.getLogIndex();
+    } catch (final IOException e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Could not take a local Raft snapshot to compact the log: %s", e.getMessage());
+      return -1L;
+    }
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
@@ -49,6 +49,12 @@ import java.util.logging.Level;
  * When free space on the Raft storage volume drops below the configured percentage the gap is
  * lowered to 1, purging as aggressively as Ratis allows, and a throttled WARNING surfaces the
  * condition before the disk fills.
+ * <p>
+ * <b>Note on pool metrics:</b> this class owns a single-thread scheduled executor, but it is
+ * deliberately not registered with the engine's {@code PoolMetrics} binder. That binder covers pools
+ * that do query or storage work whose saturation an operator must see; this one runs one bounded task
+ * every few minutes with no queue to back up, alongside the other HA housekeeping timers
+ * ({@link HealthMonitor}, the lag monitor), none of which are surfaced there either.
  */
 public final class RaftLogCompactionScheduler {
 
@@ -101,6 +107,12 @@ public final class RaftLogCompactionScheduler {
   // Highest snapshot index observed so far, so an idle tick (which Ratis answers with the unchanged
   // index) is not reported as a compaction. Read/written only on the single scheduler thread.
   private          long                     lastSnapshotIndex = -1L;
+  // Whether any tick has completed yet. The first tick only records the index it observes: after a
+  // RECOVER restart Ratis already holds a snapshot at some index N, and reporting that pre-existing N
+  // as "compacted at index N" would be a phantom compaction line for work this scheduler never did.
+  private          boolean                  firstTickObserved = false;
+  // Whether a real compaction (an index advance after the baseline tick) has ever been reported.
+  private          boolean                  reportedCompaction = false;
   // Injectable for deterministic tests; defaults to the system clock.
   private          LongSupplier             clock             = System::currentTimeMillis;
 
@@ -153,9 +165,14 @@ public final class RaftLogCompactionScheduler {
     return underDiskPressure;
   }
 
-  /** Visible for tests: highest snapshot index observed, or -1 before any snapshot was taken. */
+  /** Visible for tests: highest snapshot index observed, or -1 before the first tick. */
   long getLastSnapshotIndex() {
     return lastSnapshotIndex;
+  }
+
+  /** Visible for tests: whether a real compaction (an advance past the baseline) was ever reported. */
+  boolean hasReportedCompaction() {
+    return reportedCompaction;
   }
 
   /**
@@ -189,9 +206,13 @@ public final class RaftLogCompactionScheduler {
     // purgeable.
     if (snapshotIndex > lastSnapshotIndex) {
       lastSnapshotIndex = snapshotIndex;
-      HALog.log(this, HALog.BASIC, "Raft log compaction: snapshot at index %d (creationGap=%d)", snapshotIndex,
-          creationGap);
+      if (firstTickObserved) {
+        reportedCompaction = true;
+        HALog.log(this, HALog.BASIC, "Raft log compaction: snapshot at index %d (creationGap=%d)", snapshotIndex,
+            creationGap);
+      }
     }
+    firstTickObserved = true;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.log.LogManager;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import java.util.logging.Level;
+
+/**
+ * Periodic Raft snapshot trigger that keeps the segmented Raft log bounded in time rather than in
+ * entry count.
+ * <p>
+ * Ratis purges log segments only up to the latest snapshot index, and its built-in auto-snapshot is
+ * driven purely by a count of applied entries ({@code arcadedb.ha.snapshotThreshold}). On a low or
+ * moderate write cluster that count is effectively never reached between process restarts, so the
+ * snapshot index stays frozen at the value captured at startup, nothing is purged, and the log grows
+ * monotonically until the volume is full. Once the log writer hits {@code No space left on device},
+ * Ratis marks the log permanently failed at that index and the node rejects every subsequent
+ * {@code APPEND_ENTRIES} until it is restarted.
+ * <p>
+ * ArcadeDB's snapshot is a zero-byte marker file - the database files on disk are already the
+ * durable state, see {@link ArcadeStateMachine#takeSnapshot()} - so triggering one is cheap enough
+ * to do on a wall-clock schedule. Each tick asks the <b>local</b> Ratis server to create a snapshot;
+ * this runs on leader and followers alike because every Ratis server purges its own log against its
+ * own snapshot index.
+ * <p>
+ * A tick carries a creation gap: Ratis completes the request without doing any work when fewer than
+ * that many entries have been applied since the last snapshot, so an idle cluster costs nothing.
+ * When free space on the Raft storage volume drops below the configured percentage the gap is
+ * lowered to 1, purging as aggressively as Ratis allows, and a throttled WARNING surfaces the
+ * condition before the disk fills.
+ */
+public final class RaftLogCompactionScheduler {
+
+  /**
+   * Minimal surface of {@link RaftHAServer} the scheduler depends on. Kept small for testing.
+   */
+  public interface CompactionTarget {
+    boolean isShutdownRequested();
+
+    /**
+     * Requests a snapshot of the local Ratis server, skipped by Ratis when fewer than
+     * {@code creationGap} entries have been applied since the last snapshot.
+     *
+     * @return the resulting snapshot index, or a negative value when no snapshot was taken
+     */
+    long triggerSnapshot(long creationGap);
+
+    /**
+     * Free bytes on the volume hosting the Raft storage directory, or a non-positive value when it
+     * cannot be determined.
+     */
+    long getRaftStorageUsableSpaceBytes();
+
+    /**
+     * Total bytes of the volume hosting the Raft storage directory, or a non-positive value when it
+     * cannot be determined.
+     */
+    long getRaftStorageTotalSpaceBytes();
+
+    /** Human-readable Raft storage location, used only in log messages. */
+    String getRaftStorageDescription();
+  }
+
+  /** Creation gap used once the Raft storage volume is under disk pressure: purge as far as possible. */
+  static final long DISK_PRESSURE_CREATION_GAP = 1L;
+
+  /** At most one disk-pressure WARNING per this window, matching the engine-wide saturation convention. */
+  static final long DISK_WARNING_THROTTLE_MS = 60_000L;
+
+  private final    CompactionTarget         target;
+  private final    long                     intervalMs;
+  // Creation gap for a normal tick. Clamped to >= 1 because Ratis reads a gap of 0 as "use the
+  // configured default", which would silently reinstate the count-based-only behaviour this fixes.
+  private final    long                     minEntries;
+  private final    int                      minFreeSpacePerc;
+  private volatile ScheduledExecutorService executor;
+  private volatile boolean                  underDiskPressure = false;
+  // Wall-clock time (ms) of the last emitted disk-pressure WARNING; -1 = never warned.
+  private          long                     lastDiskWarningMs = -1L;
+  // Injectable for deterministic tests; defaults to the system clock.
+  private          LongSupplier             clock             = System::currentTimeMillis;
+
+  public RaftLogCompactionScheduler(final CompactionTarget target, final long intervalMs, final long minEntries,
+      final int minFreeSpacePerc) {
+    this.target = target;
+    this.intervalMs = intervalMs;
+    this.minEntries = Math.max(1L, minEntries);
+    this.minFreeSpacePerc = minFreeSpacePerc;
+  }
+
+  /** Package-private test hook to drive the warning throttle deterministically. */
+  void setClock(final LongSupplier clock) {
+    this.clock = clock;
+  }
+
+  public void start() {
+    if (intervalMs <= 0) {
+      LogManager.instance().log(this, Level.FINE,
+          "Raft log compaction scheduler disabled (arcadedb.ha.snapshotInterval=%d)", intervalMs);
+      return;
+    }
+    executor = Executors.newSingleThreadScheduledExecutor(r -> {
+      final Thread t = new Thread(r, "arcadedb-raft-log-compaction");
+      t.setDaemon(true);
+      return t;
+    });
+    // Start one full interval in so the first tick does not race Ratis's initial election and log replay.
+    executor.scheduleWithFixedDelay(this::tickSafely, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+    LogManager.instance().log(this, Level.FINE,
+        "Raft log compaction scheduler started (interval=%dms, minEntries=%d, minFreeSpacePerc=%d%%)",
+        intervalMs, minEntries, minFreeSpacePerc);
+  }
+
+  public void stop() {
+    final ScheduledExecutorService current = executor;
+    if (current != null) {
+      current.shutdownNow();
+      executor = null;
+    }
+  }
+
+  /** Visible for tests: whether the periodic task is scheduled. */
+  boolean isRunning() {
+    return executor != null;
+  }
+
+  /** Visible for tests: whether the last tick observed the Raft storage volume under disk pressure. */
+  boolean isUnderDiskPressure() {
+    return underDiskPressure;
+  }
+
+  /**
+   * Wrapper that swallows every throwable. A {@code scheduleWithFixedDelay} task that throws is
+   * silently cancelled, which would turn a single transient snapshot refusal into the permanent loss
+   * of log compaction - exactly the failure mode this class exists to prevent.
+   */
+  void tickSafely() {
+    try {
+      tick();
+    } catch (final Throwable t) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Raft log compaction tick failed: %s", t.getMessage());
+    }
+  }
+
+  /**
+   * Package-private for tests. Runs one compaction check synchronously.
+   */
+  void tick() {
+    if (target.isShutdownRequested())
+      return;
+
+    final boolean pressure = evaluateDiskPressure();
+    final long creationGap = pressure ? DISK_PRESSURE_CREATION_GAP : minEntries;
+
+    final long snapshotIndex = target.triggerSnapshot(creationGap);
+    if (snapshotIndex >= 0)
+      HALog.log(this, HALog.BASIC, "Raft log compaction: snapshot at index %d (creationGap=%d)", snapshotIndex,
+          creationGap);
+  }
+
+  /**
+   * Recomputes the disk-pressure state from the current free/total bytes of the Raft storage volume
+   * and emits a throttled WARNING while the condition holds.
+   *
+   * @return {@code true} when free space is strictly below the configured percentage
+   */
+  private boolean evaluateDiskPressure() {
+    if (minFreeSpacePerc <= 0) {
+      underDiskPressure = false;
+      return false;
+    }
+
+    final long total = target.getRaftStorageTotalSpaceBytes();
+    final long usable = target.getRaftStorageUsableSpaceBytes();
+    if (total <= 0 || usable < 0) {
+      // Volume size unknown (e.g. the directory does not exist yet): never guess pressure from it.
+      underDiskPressure = false;
+      return false;
+    }
+
+    // Percentage arithmetic on longs: usable * 100 can overflow on volumes above ~92 PB, so divide first
+    // when the numbers are large enough for that to matter.
+    final boolean pressure = usable < Long.MAX_VALUE / 100L
+        ? usable * 100L < total * (long) minFreeSpacePerc
+        : usable / (total / 100L) < minFreeSpacePerc;
+    underDiskPressure = pressure;
+
+    if (pressure && shouldWarnAboutDiskPressure())
+      LogManager.instance().log(this, Level.WARNING,
+          "Raft storage '%s' is low on space: %d of %d bytes free (below %d%%). Forcing snapshot and log purge. "
+              + "Raft storage must be sized for the log, not just the databases - see arcadedb.ha.snapshotInterval "
+              + "and arcadedb.ha.snapshotThreshold",
+          target.getRaftStorageDescription(), usable, total, minFreeSpacePerc);
+
+    return pressure;
+  }
+
+  /**
+   * Package-private for tests. Returns {@code true} at most once per {@link #DISK_WARNING_THROTTLE_MS}
+   * window, recording the emission time when it does.
+   */
+  boolean shouldWarnAboutDiskPressure() {
+    final long now = clock.getAsLong();
+    if (lastDiskWarningMs >= 0 && now - lastDiskWarningMs < DISK_WARNING_THROTTLE_MS)
+      return false;
+    lastDiskWarningMs = now;
+    return true;
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
@@ -98,6 +98,9 @@ public final class RaftLogCompactionScheduler {
   private volatile boolean                  underDiskPressure = false;
   // Wall-clock time (ms) of the last emitted disk-pressure WARNING; -1 = never warned.
   private          long                     lastDiskWarningMs = -1L;
+  // Highest snapshot index observed so far, so an idle tick (which Ratis answers with the unchanged
+  // index) is not reported as a compaction. Read/written only on the single scheduler thread.
+  private          long                     lastSnapshotIndex = -1L;
   // Injectable for deterministic tests; defaults to the system clock.
   private          LongSupplier             clock             = System::currentTimeMillis;
 
@@ -150,6 +153,11 @@ public final class RaftLogCompactionScheduler {
     return underDiskPressure;
   }
 
+  /** Visible for tests: highest snapshot index observed, or -1 before any snapshot was taken. */
+  long getLastSnapshotIndex() {
+    return lastSnapshotIndex;
+  }
+
   /**
    * Wrapper that swallows every throwable. A {@code scheduleWithFixedDelay} task that throws is
    * silently cancelled, which would turn a single transient snapshot refusal into the permanent loss
@@ -175,9 +183,15 @@ public final class RaftLogCompactionScheduler {
     final long creationGap = pressure ? DISK_PRESSURE_CREATION_GAP : minEntries;
 
     final long snapshotIndex = target.triggerSnapshot(creationGap);
-    if (snapshotIndex >= 0)
+    // Ratis answers a short-circuited (below the creation gap) request with a SUCCESS reply carrying the
+    // existing snapshot index, so a bare "index >= 0" check would announce a compaction on every idle
+    // tick. Only report when the index actually moved, which is the only case where segments became
+    // purgeable.
+    if (snapshotIndex > lastSnapshotIndex) {
+      lastSnapshotIndex = snapshotIndex;
       HALog.log(this, HALog.BASIC, "Raft log compaction: snapshot at index %d (creationGap=%d)", snapshotIndex,
           creationGap);
+    }
   }
 
   /**
@@ -200,11 +214,11 @@ public final class RaftLogCompactionScheduler {
       return false;
     }
 
-    // Percentage arithmetic on longs: usable * 100 can overflow on volumes above ~92 PB, so divide first
-    // when the numbers are large enough for that to matter.
-    final boolean pressure = usable < Long.MAX_VALUE / 100L
-        ? usable * 100L < total * (long) minFreeSpacePerc
-        : usable / (total / 100L) < minFreeSpacePerc;
+    // Double arithmetic rather than long products: both usable*100 and total*minFreeSpacePerc can
+    // overflow independently on very large volumes, and a wrapped negative product would silently
+    // under-report pressure. A double's 53-bit mantissa is far more precision than a free-space
+    // percentage comparison needs.
+    final boolean pressure = (double) usable / (double) total * 100.0 < minFreeSpacePerc;
     underDiskPressure = pressure;
 
     if (pressure && shouldWarnAboutDiskPressure())

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
@@ -94,6 +94,9 @@ public final class RaftLogCompactionScheduler {
   /** At most one disk-pressure WARNING per this window, matching the engine-wide saturation convention. */
   static final long DISK_WARNING_THROTTLE_MS = 60_000L;
 
+  /** How long {@link #stop()} waits for an in-flight tick before returning. */
+  static final long SHUTDOWN_AWAIT_MS = 2_000L;
+
   private final    CompactionTarget         target;
   private final    long                     intervalMs;
   // Creation gap for a normal tick. Clamped to >= 1 because Ratis reads a gap of 0 as "use the
@@ -151,6 +154,14 @@ public final class RaftLogCompactionScheduler {
     final ScheduledExecutorService current = executor;
     if (current != null) {
       current.shutdownNow();
+      // Briefly await termination so a tick already inside a snapshot request (which carries a 30s Ratis
+      // timeout) finishes before RaftHAServer.stop() tears Ratis down. Re-entry is already blocked by the
+      // shutdownRequested check, so this only avoids a spurious WARNING from a request racing the teardown.
+      try {
+        current.awaitTermination(SHUTDOWN_AWAIT_MS, TimeUnit.MILLISECONDS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
       executor = null;
     }
   }
@@ -244,9 +255,9 @@ public final class RaftLogCompactionScheduler {
 
     if (pressure && shouldWarnAboutDiskPressure())
       LogManager.instance().log(this, Level.WARNING,
-          "Raft storage '%s' is low on space: %d of %d bytes free (below %d%%). Forcing snapshot and log purge. "
-              + "Raft storage must be sized for the log, not just the databases - see arcadedb.ha.snapshotInterval "
-              + "and arcadedb.ha.snapshotThreshold",
+          "Raft storage '%s' is low on space: %d of %d bytes free (below arcadedb.ha.raftStorageMinFreeSpacePerc=%d%%). "
+              + "Forcing snapshot and log purge. Raft storage must be sized for the log, not just the databases - "
+              + "see arcadedb.ha.snapshotInterval and arcadedb.ha.snapshotThreshold",
           target.getRaftStorageDescription(), usable, total, minFreeSpacePerc);
 
     return pressure;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogCompactionScheduler.java
@@ -223,7 +223,11 @@ public final class RaftLogCompactionScheduler {
             creationGap);
       }
     }
-    firstTickObserved = true;
+    // Seed the baseline from the first SUCCESSFUL observation only. A failed first tick returns -1;
+    // marking the baseline observed there would let the next successful tick report a pre-existing
+    // startup snapshot as a compaction, defeating the suppression above.
+    if (snapshotIndex >= 0)
+      firstTickObserved = true;
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HAConfigDefaultsTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HAConfigDefaultsTest.java
@@ -65,4 +65,26 @@ class HAConfigDefaultsTest {
   void replicationLagWarningDefault() {
     assertThat(GlobalConfiguration.HA_REPLICATION_LAG_WARNING.getDefValue()).isEqualTo(1000L);
   }
+
+  /**
+   * The periodic snapshot trigger (issue #5345) must be enabled by default: with only the count-based
+   * HA_SNAPSHOT_THRESHOLD, a low-write cluster never purges its Raft log and eventually fills the volume.
+   */
+  @Test
+  void snapshotIntervalDefaultIsEnabled() {
+    assertThat(GlobalConfiguration.HA_SNAPSHOT_INTERVAL.getDefValue()).isEqualTo(300_000L);
+    assertThat(GlobalConfiguration.HA_SNAPSHOT_INTERVAL.getType()).isEqualTo(Long.class);
+  }
+
+  @Test
+  void snapshotMinEntriesDefault() {
+    assertThat(GlobalConfiguration.HA_SNAPSHOT_MIN_ENTRIES.getDefValue()).isEqualTo(64L);
+    assertThat(GlobalConfiguration.HA_SNAPSHOT_MIN_ENTRIES.getType()).isEqualTo(Long.class);
+  }
+
+  @Test
+  void raftStorageMinFreeSpacePercDefault() {
+    assertThat(GlobalConfiguration.HA_RAFT_STORAGE_MIN_FREE_SPACE_PERC.getDefValue()).isEqualTo(20);
+    assertThat(GlobalConfiguration.HA_RAFT_STORAGE_MIN_FREE_SPACE_PERC.getType()).isEqualTo(Integer.class);
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionSchedulerTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionSchedulerTest.java
@@ -39,6 +39,7 @@ class RaftLogCompactionSchedulerTest {
     volatile boolean    failSnapshot      = false;
     volatile long       usableSpace       = 900L;
     volatile long       totalSpace        = 1000L;
+    volatile long       snapshotIndex     = 42L;
 
     @Override
     public boolean isShutdownRequested() {
@@ -50,7 +51,7 @@ class RaftLogCompactionSchedulerTest {
       requestedGaps.add(creationGap);
       if (failSnapshot)
         throw new IllegalStateException("snapshot request refused");
-      return 42L;
+      return snapshotIndex;
     }
 
     @Override
@@ -208,6 +209,65 @@ class RaftLogCompactionSchedulerTest {
 
     now.addAndGet(1);
     assertThat(scheduler.shouldWarnAboutDiskPressure()).isTrue();
+  }
+
+  /**
+   * Ratis answers a request below the creation gap with a SUCCESS reply carrying the <i>existing</i>
+   * snapshot index, so the scheduler must only treat a strictly higher index as a real compaction.
+   */
+  @Test
+  void repeatedTicksAtTheSameIndexAreNotCountedAsNewCompactions() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+    assertThat(scheduler.getLastSnapshotIndex()).isEqualTo(42L);
+
+    scheduler.tick();
+    assertThat(scheduler.getLastSnapshotIndex()).isEqualTo(42L);
+
+    target.snapshotIndex = 100L;
+    scheduler.tick();
+    assertThat(scheduler.getLastSnapshotIndex()).isEqualTo(100L);
+  }
+
+  /**
+   * The sentinel distinction is load-bearing: a negative reading means "volume size unknown" and must
+   * never be read as pressure, while a genuine zero free bytes on a sized volume is the disk-full case
+   * this scheduler exists to catch.
+   */
+  @Test
+  void negativeUsableSpaceIsUnknownButZeroUsableSpaceIsPressure() {
+    final FakeCompactionTarget unknown = new FakeCompactionTarget();
+    unknown.usableSpace = -1L;
+    final RaftLogCompactionScheduler unknownScheduler = newScheduler(unknown);
+    unknownScheduler.tick();
+    assertThat(unknownScheduler.isUnderDiskPressure()).isFalse();
+    assertThat(unknown.requestedGaps).containsExactly(64L);
+
+    final FakeCompactionTarget full = new FakeCompactionTarget();
+    full.usableSpace = 0L;
+    final RaftLogCompactionScheduler fullScheduler = newScheduler(full);
+    fullScheduler.tick();
+    assertThat(fullScheduler.isUnderDiskPressure()).isTrue();
+    assertThat(full.requestedGaps).containsExactly(1L);
+  }
+
+  /**
+   * Percentage arithmetic must not overflow: long products of petabyte-scale byte counts wrap negative
+   * and would silently under-report a nearly full volume.
+   */
+  @Test
+  void diskPressureIsDetectedOnPetabyteScaleVolumes() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.totalSpace = Long.MAX_VALUE / 2L;
+    target.usableSpace = target.totalSpace / 100L; // 1% free, well below the 20% threshold
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+
+    assertThat(scheduler.isUnderDiskPressure()).isTrue();
+    assertThat(target.requestedGaps).containsExactly(1L);
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionSchedulerTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionSchedulerTest.java
@@ -255,6 +255,31 @@ class RaftLogCompactionSchedulerTest {
   }
 
   /**
+   * A failed first tick must not consume the baseline: otherwise the next successful tick would report
+   * a pre-existing startup snapshot as a compaction, which is exactly what the baseline suppresses.
+   */
+  @Test
+  void aFailedFirstTickDoesNotConsumeTheBaseline() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.snapshotIndex = -1L; // Ratis refused the request
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+    assertThat(scheduler.getLastSnapshotIndex()).isEqualTo(-1L);
+    assertThat(scheduler.hasReportedCompaction()).isFalse();
+
+    // A pre-existing startup snapshot observed by the first SUCCESSFUL tick is still only a baseline.
+    target.snapshotIndex = 24_269L;
+    scheduler.tick();
+    assertThat(scheduler.getLastSnapshotIndex()).isEqualTo(24_269L);
+    assertThat(scheduler.hasReportedCompaction()).isFalse();
+
+    target.snapshotIndex = 24_400L;
+    scheduler.tick();
+    assertThat(scheduler.hasReportedCompaction()).isTrue();
+  }
+
+  /**
    * The sentinel distinction is load-bearing: a negative reading means "volume size unknown" and must
    * never be read as pressure, while a genuine zero free bytes on a sized volume is the disk-full case
    * this scheduler exists to catch.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionSchedulerTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionSchedulerTest.java
@@ -232,6 +232,29 @@ class RaftLogCompactionSchedulerTest {
   }
 
   /**
+   * After a RECOVER restart Ratis already holds a snapshot at some index, which the first (no-op) tick
+   * observes. That index must be recorded as the baseline rather than reported as work this scheduler
+   * did, while a genuine later advance still registers.
+   */
+  @Test
+  void firstTickSeedsTheBaselineIndexWithoutClaimingACompaction() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.snapshotIndex = 24_269L; // a snapshot Ratis loaded at startup
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    assertThat(scheduler.getLastSnapshotIndex()).isEqualTo(-1L);
+
+    scheduler.tick();
+    assertThat(scheduler.getLastSnapshotIndex()).isEqualTo(24_269L);
+    assertThat(scheduler.hasReportedCompaction()).isFalse();
+
+    target.snapshotIndex = 24_400L;
+    scheduler.tick();
+    assertThat(scheduler.getLastSnapshotIndex()).isEqualTo(24_400L);
+    assertThat(scheduler.hasReportedCompaction()).isTrue();
+  }
+
+  /**
    * The sentinel distinction is load-bearing: a negative reading means "volume size unknown" and must
    * never be read as pressure, while a genuine zero free bytes on a sized volume is the disk-full case
    * this scheduler exists to catch.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionSchedulerTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionSchedulerTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RaftLogCompactionScheduler}, the periodic snapshot trigger that keeps the
+ * Raft log bounded on a low-write cluster where the count-based auto-snapshot threshold is never
+ * reached (issue #5345).
+ */
+class RaftLogCompactionSchedulerTest {
+
+  static final class FakeCompactionTarget implements RaftLogCompactionScheduler.CompactionTarget {
+    final    List<Long> requestedGaps     = new ArrayList<>();
+    volatile boolean    shutdownRequested = false;
+    volatile boolean    failSnapshot      = false;
+    volatile long       usableSpace       = 900L;
+    volatile long       totalSpace        = 1000L;
+
+    @Override
+    public boolean isShutdownRequested() {
+      return shutdownRequested;
+    }
+
+    @Override
+    public long triggerSnapshot(final long creationGap) {
+      requestedGaps.add(creationGap);
+      if (failSnapshot)
+        throw new IllegalStateException("snapshot request refused");
+      return 42L;
+    }
+
+    @Override
+    public long getRaftStorageUsableSpaceBytes() {
+      return usableSpace;
+    }
+
+    @Override
+    public long getRaftStorageTotalSpaceBytes() {
+      return totalSpace;
+    }
+
+    @Override
+    public String getRaftStorageDescription() {
+      return "/tmp/raft-storage-test";
+    }
+  }
+
+  private static RaftLogCompactionScheduler newScheduler(final FakeCompactionTarget target) {
+    return new RaftLogCompactionScheduler(target, 300_000L, 64L, 20);
+  }
+
+  @Test
+  void schedulerIsDisabledWhenIntervalIsNotPositive() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    final RaftLogCompactionScheduler scheduler = new RaftLogCompactionScheduler(target, 0L, 64L, 20);
+    scheduler.start();
+    try {
+      assertThat(scheduler.isRunning()).isFalse();
+    } finally {
+      scheduler.stop();
+    }
+  }
+
+  @Test
+  void schedulerStartsAndStopsWhenIntervalIsPositive() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+    scheduler.start();
+    try {
+      assertThat(scheduler.isRunning()).isTrue();
+    } finally {
+      scheduler.stop();
+    }
+    assertThat(scheduler.isRunning()).isFalse();
+  }
+
+  @Test
+  void normalTickRequestsSnapshotWithConfiguredCreationGap() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+
+    assertThat(target.requestedGaps).containsExactly(64L);
+  }
+
+  @Test
+  void creationGapIsClampedToAtLeastOne() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    final RaftLogCompactionScheduler scheduler = new RaftLogCompactionScheduler(target, 300_000L, 0L, 20);
+
+    scheduler.tick();
+
+    assertThat(target.requestedGaps).containsExactly(1L);
+  }
+
+  @Test
+  void diskPressureDropsCreationGapToOne() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    // 100 free of 1000 total = 10% free, below the 20% threshold
+    target.usableSpace = 100L;
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+
+    assertThat(scheduler.isUnderDiskPressure()).isTrue();
+    assertThat(target.requestedGaps).containsExactly(1L);
+  }
+
+  @Test
+  void freeSpaceExactlyAtThresholdIsNotDiskPressure() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.usableSpace = 200L;
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+
+    assertThat(scheduler.isUnderDiskPressure()).isFalse();
+    assertThat(target.requestedGaps).containsExactly(64L);
+  }
+
+  @Test
+  void unknownVolumeSizeIsNotReportedAsDiskPressure() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.totalSpace = 0L;
+    target.usableSpace = 0L;
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+
+    assertThat(scheduler.isUnderDiskPressure()).isFalse();
+    assertThat(target.requestedGaps).containsExactly(64L);
+  }
+
+  @Test
+  void diskPressureCheckIsSkippedWhenThresholdIsNotPositive() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.usableSpace = 1L;
+    final RaftLogCompactionScheduler scheduler = new RaftLogCompactionScheduler(target, 300_000L, 64L, 0);
+
+    scheduler.tick();
+
+    assertThat(scheduler.isUnderDiskPressure()).isFalse();
+    assertThat(target.requestedGaps).containsExactly(64L);
+  }
+
+  @Test
+  void tickIsSuppressedWhileShutdownIsRequested() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.shutdownRequested = true;
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+
+    assertThat(target.requestedGaps).isEmpty();
+  }
+
+  @Test
+  void snapshotFailureDoesNotEscapeTheSchedulerThread() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.failSnapshot = true;
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tickSafely();
+    scheduler.tickSafely();
+
+    // Both ticks ran: the first failure did not kill the periodic task.
+    assertThat(target.requestedGaps).containsExactly(64L, 64L);
+  }
+
+  @Test
+  void diskPressureWarningIsThrottledToOnePerWindow() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.usableSpace = 10L;
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+    final AtomicLong now = new AtomicLong(1_000L);
+    scheduler.setClock(now::get);
+
+    assertThat(scheduler.shouldWarnAboutDiskPressure()).isTrue();
+    assertThat(scheduler.shouldWarnAboutDiskPressure()).isFalse();
+
+    now.addAndGet(RaftLogCompactionScheduler.DISK_WARNING_THROTTLE_MS - 1);
+    assertThat(scheduler.shouldWarnAboutDiskPressure()).isFalse();
+
+    now.addAndGet(1);
+    assertThat(scheduler.shouldWarnAboutDiskPressure()).isTrue();
+  }
+
+  @Test
+  void diskPressureStateClearsWhenSpaceIsReclaimed() {
+    final FakeCompactionTarget target = new FakeCompactionTarget();
+    target.usableSpace = 50L;
+    final RaftLogCompactionScheduler scheduler = newScheduler(target);
+
+    scheduler.tick();
+    assertThat(scheduler.isUnderDiskPressure()).isTrue();
+
+    target.usableSpace = 800L;
+    scheduler.tick();
+    assertThat(scheduler.isUnderDiskPressure()).isFalse();
+    assertThat(target.requestedGaps).containsExactly(1L, 64L);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionWiringIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogCompactionWiringIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end coverage of the production wiring behind the periodic Raft log compaction (issue #5345),
+ * against a real {@link RaftHAServer} cluster.
+ * <p>
+ * {@link RaftPeriodicSnapshotCompactionIT} proves the Ratis mechanism itself but builds the request
+ * itself against a mini-cluster; the unit tests drive {@link RaftLogCompactionScheduler} against a
+ * fake. This test covers the seam between them - {@code RaftHAServer.takeLocalSnapshot()} assembling
+ * the request from the real client id, local peer id and group id, and the compaction target resolving
+ * the Raft storage volume for the free-space probe. A wrong group id or an unresolvable storage volume
+ * would be invisible to both of the other suites.
+ */
+@Tag("slow")
+class RaftLogCompactionWiringIT extends BaseRaftHATest {
+
+  @Test
+  void takeLocalSnapshotSucceedsOnEveryNodeThroughTheProductionRequestPath() throws Exception {
+    // Give the state machine something to snapshot, and let every peer apply it.
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final RaftHAPlugin plugin = getRaftPlugin(i);
+      assertThat(plugin).as("server %d must expose a Raft plugin", i).isNotNull();
+
+      final RaftHAServer haServer = plugin.getRaftHAServer();
+      assertThat(haServer).as("server %d must expose a Raft HA server", i).isNotNull();
+
+      // A creation gap of 1 is what the scheduler uses under disk pressure. Leader and followers alike
+      // must accept the request: each node purges its own log against its own snapshot index.
+      final long snapshotIndex = haServer.takeLocalSnapshot(1L);
+      assertThat(snapshotIndex)
+          .as("server %d (leader=%s) must take a local snapshot through the production request path",
+              i, haServer.isLeader())
+          .isNotNegative();
+    }
+  }
+
+  @Test
+  void compactionTargetResolvesTheRaftStorageVolumeForTheFreeSpaceProbe() {
+    for (int i = 0; i < getServerCount(); i++) {
+      final RaftHAServer haServer = getRaftPlugin(i).getRaftHAServer();
+      final RaftLogCompactionScheduler.CompactionTarget target = haServer.newCompactionTargetForTesting();
+
+      // A zero or negative total would make the scheduler read the volume as "size unknown" and disable
+      // the disk-pressure escalation entirely, silently losing the guard against the log filling the disk.
+      assertThat(target.getRaftStorageTotalSpaceBytes())
+          .as("server %d must resolve a real Raft storage volume size", i)
+          .isPositive();
+      assertThat(target.getRaftStorageUsableSpaceBytes())
+          .as("server %d must report free space on the Raft storage volume", i)
+          .isNotNegative();
+      assertThat(target.getRaftStorageDescription())
+          .as("server %d must name the Raft storage location for the disk-pressure warning", i)
+          .isNotBlank()
+          .isNotEqualTo("<unknown>");
+      assertThat(target.isShutdownRequested())
+          .as("server %d is running, so the tick must not be suppressed", i)
+          .isFalse();
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPeriodicSnapshotCompactionIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPeriodicSnapshotCompactionIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.SnapshotManagementRequest;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5345: on a low-write cluster the count-based auto-snapshot threshold is
+ * never reached, so the snapshot index never advances, no Raft log segment is ever purged, and the log
+ * grows until the volume is full.
+ * <p>
+ * Exercises the exact mechanism {@link RaftLogCompactionScheduler} relies on against real Ratis peers:
+ * a node-local {@link SnapshotManagementRequest} creates a snapshot and so advances the index Ratis
+ * purges log segments against. Crucially it asserts this on <b>every</b> peer, leader and follower
+ * alike - the node that wedged in the report was a follower, and each Ratis server purges its own log
+ * against its own snapshot index.
+ */
+class RaftPeriodicSnapshotCompactionIT extends BaseMiniRaftTest {
+
+  private static final String DB_NAME     = "mini-raft-test";
+  private static final int    ENTRY_COUNT = 20;
+
+  private final ClientId  clientId = ClientId.randomId();
+  private final AtomicLong callId  = new AtomicLong();
+
+  @Override
+  protected int getPeerCount() {
+    return 3;
+  }
+
+  @Test
+  void nodeLocalSnapshotRequestAdvancesSnapshotIndexOnEveryPeer() throws Exception {
+    for (int i = 0; i < ENTRY_COUNT; i++)
+      submitSchemaEntry(DB_NAME, null);
+
+    assertAllPeersConverged(ENTRY_COUNT);
+
+    // Precondition: the count-based trigger has NOT fired - this is the low-write cluster of the issue.
+    // Without the periodic trigger the snapshot index would stay here forever and nothing would purge.
+    for (final RaftPeerId peerId : peerIds()) {
+      final RaftServer.Division division = getCluster().getDivision(peerId);
+      assertThat(division.getStateMachine().getLatestSnapshot())
+          .as("peer %s must have no snapshot before the periodic trigger fires", peerId)
+          .isNull();
+    }
+
+    // A periodic tick: ask every node to snapshot locally with a creation gap of 1.
+    for (final RaftPeerId peerId : peerIds()) {
+      final RaftServer.Division division = getCluster().getDivision(peerId);
+      final TermIndex applied = division.getStateMachine().getLastAppliedTermIndex();
+      assertThat(applied).as("peer %s must have applied entries", peerId).isNotNull();
+
+      final RaftClientReply reply = division.getRaftServer().snapshotManagement(
+          SnapshotManagementRequest.newCreate(clientId, peerId, division.getMemberId().getGroupId(),
+              callId.incrementAndGet(), 30_000L, 1L));
+
+      assertThat(reply.isSuccess())
+          .as("node-local snapshot request must succeed on peer %s (leader and followers alike)", peerId)
+          .isTrue();
+
+      assertThat(division.getStateMachine().getLatestSnapshot())
+          .as("peer %s must have a snapshot after the periodic trigger", peerId)
+          .isNotNull();
+      // The snapshot index is the value Ratis purges log segments against when
+      // arcadedb.ha.logPurgeUptoSnapshot is enabled, so it must be a real, positive index.
+      assertThat(division.getStateMachine().getLatestSnapshot().getIndex())
+          .as("peer %s snapshot index must be a real log index so segments below it become purgeable", peerId)
+          .isPositive();
+    }
+  }
+
+  @Test
+  void snapshotRequestIsANoOpWhenFewerEntriesThanTheCreationGapWereApplied() throws Exception {
+    submitSchemaEntry(DB_NAME, null);
+    assertAllPeersConverged(1);
+
+    // An idle cluster must not pay for a tick: a gap far above the applied count short-circuits in Ratis,
+    // which is what makes arcadedb.ha.snapshotMinEntries a cheap floor rather than busywork.
+    for (final RaftPeerId peerId : peerIds()) {
+      final RaftServer.Division division = getCluster().getDivision(peerId);
+      final RaftClientReply reply = division.getRaftServer().snapshotManagement(
+          SnapshotManagementRequest.newCreate(clientId, peerId, division.getMemberId().getGroupId(),
+              callId.incrementAndGet(), 30_000L, 1_000_000L));
+
+      assertThat(reply.isSuccess()).as("an under-gap snapshot request must still report success").isTrue();
+      assertThat(division.getStateMachine().getLatestSnapshot())
+          .as("peer %s must not have taken a snapshot below the creation gap", peerId)
+          .isNull();
+    }
+  }
+
+  private java.util.List<RaftPeerId> peerIds() {
+    return getPeers().stream().map(p -> p.getId()).toList();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPeriodicSnapshotCompactionIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPeriodicSnapshotCompactionIT.java
@@ -112,6 +112,13 @@ class RaftPeriodicSnapshotCompactionIT extends BaseMiniRaftTest {
       assertThat(division.getStateMachine().getLatestSnapshot())
           .as("peer %s must not have taken a snapshot below the creation gap", peerId)
           .isNull();
+      // Pins the reply contract RaftLogCompactionScheduler.tick() depends on: a short-circuited request
+      // reports the EXISTING snapshot index (0 when there is none), not the current log/commit index.
+      // Were a future Ratis to return the commit index here, the scheduler would log a phantom
+      // compaction every tick and advance its baseline past the real snapshot index.
+      assertThat(reply.getLogIndex())
+          .as("peer %s under-gap reply must carry the existing snapshot index, not the log index", peerId)
+          .isZero();
     }
   }
 


### PR DESCRIPTION
Closes #5345

## Summary

Raft log purge is gated on the snapshot index (`arcadedb.ha.logPurgeUptoSnapshot=true`), and the only auto-snapshot trigger was a count of applied entries (`arcadedb.ha.snapshotThreshold`, default 100000). On a low or moderate write cluster that count is effectively never reached between process restarts, so the snapshot index stays frozen at the value captured at startup, no log segment is ever purged, and the segmented log grows monotonically until the volume is full. Once the log writer hits `No space left on device`, Ratis marks the log permanently failed at that index and the node rejects every subsequent `APPEND_ENTRIES` until an operator restarts it. The reported cluster produced 1.5-1.9 GB of Raft log for ~72 MB of databases.

The fix adds `RaftLogCompactionScheduler`, a periodic node-local snapshot trigger that bounds the retained log by wall-clock age rather than entry count. It runs on **every** node, leader and followers alike, because each Ratis server purges its own log against its own snapshot index - the node that wedged in the report was a follower. Each tick issues a `SnapshotManagementRequest` to the local Ratis server; Ratis completes it as a no-op when fewer than the creation gap entries have been applied since the last snapshot, so an idle cluster costs nothing. An ArcadeDB snapshot is a zero-byte marker (the database files on disk are already the durable state), which is what makes a wall-clock schedule affordable here.

New configuration:

| key | default | meaning |
|---|---|---|
| `arcadedb.ha.snapshotInterval` | `300000` ms | tick interval; `0` disables and restores the previous count-only behaviour |
| `arcadedb.ha.snapshotMinEntries` | `64` | creation gap for a normal tick; below this many new entries the tick is a no-op |
| `arcadedb.ha.raftStorageMinFreeSpacePerc` | `20` | below this much free space on the Raft storage volume the gap drops to 1 and a throttled (60 s) WARNING names the directory and free/total bytes |

`arcadedb.ha.snapshotThreshold` is untouched, so existing deployments keep their current behaviour on top of the new periodic floor.

### Scope

The issue lists five suggested fixes. This PR implements (1) making auto-snapshot fire on a low-write cluster, (2) snapshot + purge under disk pressure, and (5) sizing documentation. Items (3) "make a `No space left` wedge recoverable without a pod restart" and (4) "account for disk space in stale-follower recovery" are Ratis-internal recovery work with a materially different blast radius and are left for a follow-up - preventing the volume from filling removes the trigger for both.

## Test plan

- [x] `RaftLogCompactionSchedulerTest` (new, 12 cases): scheduler disabled when the interval is not positive; start/stop lifecycle; normal tick uses the configured creation gap; the gap is clamped to >= 1 (Ratis reads 0 as "use the default", which would silently reinstate count-only behaviour); disk pressure drops the gap to 1; free space exactly at the threshold is not pressure; unknown volume size is not misread as pressure; the check is skippable via a non-positive threshold; the shutdown flag suppresses the tick; a failing snapshot request never escapes the scheduler thread (a throwing `scheduleWithFixedDelay` task would be silently cancelled, permanently losing compaction); the disk warning is throttled to one per 60 s window; pressure state clears when space is reclaimed.
- [x] `RaftPeriodicSnapshotCompactionIT` (new): against a real 3-peer Ratis mini-cluster with `ArcadeStateMachine`, submits 20 entries, asserts no snapshot exists (the low-write precondition of the issue), then asserts a node-local snapshot request succeeds and produces a positive snapshot index on **every** peer including followers; a second case asserts a request below the creation gap is a successful no-op.
- [x] `HAConfigDefaultsTest` extended to pin the three new defaults, including that the periodic trigger is enabled out of the box.
- [x] Full `ha-raft` unit suite: 687 tests, 0 failures.
- [x] `engine` configuration tests: 46 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)