### PR TITLE
fix(#5325): take the database lock before loading the schema of a crashed database

### DIFF
--- a/docs/5325-schema-load-before-recovery.md
+++ b/docs/5325-schema-load-before-recovery.md
@@ -1,0 +1,60 @@
+# 5325 - schema.load() runs before checkForRecovery()
+
+## Problem
+
+`LocalDatabase.openInternal` loaded the schema and only then called `checkForRecovery()`, which is the
+method that acquires the exclusive OS lock on `database.lck`. Loading the schema of a database that
+needs recovery is not a read-only operation:
+
+- `LocalSchema.load` runs `SortedIndexBuildRecoveryMarker.recoverInterruptedBuilds`, which **drops
+  component files** left by an interrupted sorted index build.
+- When the dictionary page never reached disk the file is zero length, and
+  `Dictionary.createHeaderPageIfMissing` **writes and commits** a fresh header page.
+
+Both happened while the database was still unlocked, so an open could mutate a database that another
+process owns. Reproduced by `RecoveryLockOrderingTest.openOfALockedCrashedDatabaseWritesNothingBeforeItIsRejected`:
+with the lock held by a second channel, the rejected open still wrote a 327680-byte dictionary page.
+
+The "unopenable database" symptom quoted in the issue (`SchemaException: File with id '0' was not
+found`) was already fixed in #5322, which deferred the header-page creation to
+`createHeaderPageIfMissing()` after the component is registered. What remained was the ordering itself.
+
+## Fix
+
+`checkForRecovery()` split into two phases in `LocalDatabase`:
+
+- `prepareRecovery()` - sets `lockFile`, performs the READ_ONLY-needs-recovery rejection, acquires the
+  exclusive lock, and returns whether the WAL still has to be replayed. Called **before**
+  `schema.create()` / `schema.load()`.
+- `performRecovery()` - resets the cached bucket record counts, fires `DB_NOT_CLOSED`, and runs
+  `transactionManager.checkIntegrity()`. Called **after** the schema is loaded, because the WAL replay
+  resolves file ids and the dictionary through the registered components.
+
+The replay therefore keeps its existing position (it needs the schema), while everything that takes
+ownership of the database now precedes any write to it.
+
+## Tests
+
+- `engine/src/test/java/com/arcadedb/database/RecoveryLockOrderingTest.java` (new)
+  - `openOfALockedCrashedDatabaseWritesNothingBeforeItIsRejected` - fails before the fix
+    (dictionary file grew to 327680 bytes), passes after.
+  - `readOnlyOpenOfACrashedDatabaseIsRejectedBeforeTheSchemaIsLoaded` - guards the READ_ONLY path.
+- `engine/src/test/java/com/arcadedb/database/UnflushedDictionaryRecoveryTest.java` (new) - a crash
+  that leaves the dictionary page unflushed must still replay the WAL: the type and the record
+  committed before the kill survive, and no WAL file is quarantined as `.corrupt`.
+
+Existing recovery/lock tests re-run green: `EmptyDictionaryFileReopenTest`,
+`FailedOpenPreservesWalTest`, `Issue4511OpenFailureLockLeakTest`,
+`Issue4547ReadOnlyRecoveryLockLeakTest`, `Issue5067KillLockSymmetryTest`,
+`DatabaseFactoryFailedOpenTest`, plus the full `arcadedb-engine` suite.
+
+## Notes
+
+- `database.lck` is now created (non-recovery READ_WRITE path) before the schema is loaded rather than
+  after. A failure during the load consequently leaves the marker behind, which makes the next open
+  recover - the behaviour `releaseResourcesOnOpenFailure` already documents as intentional.
+- Not changed: `createHeaderPageIfMissing()` still runs during the load, so an empty dictionary page is
+  committed at version 0 before the WAL replay. `UnflushedDictionaryRecoveryTest` shows the replay
+  handles it (a zero-length dictionary file implies its page was never flushed, so the WAL still holds
+  the whole version chain starting at 0). Moving the call after the replay would need the schema load
+  to be split as well and is out of scope here.

--- a/docs/5325-schema-load-before-recovery.md
+++ b/docs/5325-schema-load-before-recovery.md
@@ -43,10 +43,43 @@ ownership of the database now precedes any write to it.
   that leaves the dictionary page unflushed must still replay the WAL: the type and the record
   committed before the kill survive, and no WAL file is quarantined as `.corrupt`.
 
-Existing recovery/lock tests re-run green: `EmptyDictionaryFileReopenTest`,
+Existing recovery/lock tests re-run green (33 tests, 0 failures, 0 errors): `WalRecoveryCorrectnessTest`,
+`FlushRobustnessTest`, `TransactionManager*Test`, `WALFile*Test`, `EmptyDictionaryFileReopenTest`,
 `FailedOpenPreservesWalTest`, `Issue4511OpenFailureLockLeakTest`,
 `Issue4547ReadOnlyRecoveryLockLeakTest`, `Issue5067KillLockSymmetryTest`,
-`DatabaseFactoryFailedOpenTest`, plus the full `arcadedb-engine` suite.
+`DatabaseFactoryFailedOpenTest`, `DatabaseFactoryTest`.
+
+A wider `com.arcadedb.database.** + engine.** + schema.**` run was also made; it is reported here only
+for completeness, because it was invalidated part-way by the machine running out of disk (the resulting
+`NoClassDefFoundError`s name classes that exist in the tree). The `com.arcadedb.database.**` portion
+completed before that and was compared against the unmodified baseline: the only two failures,
+`DatabaseGetSizeTest.getSizeMultipleCalls` (async page-flush timing) and
+`ScriptTriggerSandboxTest.benignTriggerStillWorks` (GraalVM polyglot class init), reproduce identically
+without this change and are unrelated to it.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5351
+
+## Review cycles
+
+### Cycle 1 - `7ca03dd`
+
+Both gating bots responded. No code changes were required, so the branch ends the cycle unchanged.
+
+- **gemini-code-assist** (COMMENTED, 1 inline) - asked for braces around the single-statement `else`
+  in `prepareRecovery()`. Declined: CLAUDE.md sets the opposite convention ("if statements with only
+  one child sub-statement don't require a curly brace open/close"), and that `else` is verbatim
+  pre-existing code the diff only relocated out of `checkForRecovery()`.
+- **claude** - no blocking findings; confirmed the split is behavior-preserving against the base
+  revision (exception propagation, `.lck` not being in `SUPPORTED_FILE_EXT`, ordering inside
+  `performRecovery()`). Two optional notes, both declined with rationale:
+  - a shared test helper for the `.dict`/`.wal` listing code - `EmptyDictionaryFileReopenTest` already
+    carries its own copy, so self-contained-per-class is the existing convention;
+  - the clean-path `database.lck` creation moving ahead of `schema.load()` - already covered under
+    Notes below.
+
+Final state: `clean-approval`.
 
 ## Notes
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2278,7 +2278,17 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     return pageManagerReferenceReleased.get();
   }
 
-  private void checkForRecovery() throws IOException {
+  /**
+   * Takes ownership of the database before any of its content is touched: acquires the exclusive lock on
+   * {@code database.lck} and settles the read-only rejection. Runs BEFORE the schema is loaded, because loading a
+   * database that needs recovery writes to it - the sorted-index-build marker cleanup drops component files, and a
+   * dictionary whose page never reached disk has its header page written and committed. Doing that ahead of the lock
+   * let an open mutate a database another process owns.
+   *
+   * @return {@code true} when the marker file was present, so the WAL still has to be replayed by
+   * {@link #performRecovery()} once the schema is loaded.
+   */
+  private boolean prepareRecovery() throws IOException {
     lockFile = new File(databasePath + "/database.lck");
 
     if (lockFile.exists()) {
@@ -2291,24 +2301,32 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       }
 
       lockDatabase();
-
-      // RECOVERY
-      LogManager.instance().log(this, Level.WARNING, "Database '%s' was not closed properly last time", null, name);
-
-      // RESET THE COUNT OF RECORD IN CASE THE DATABASE WAS NOT CLOSED PROPERLY
-      for (Bucket b : schema.getBuckets())
-        ((LocalBucket) b).setCachedRecordCount(-1);
-
-      executeCallbacks(CALLBACK_EVENT.DB_NOT_CLOSED);
-
-      transactionManager.checkIntegrity();
-    } else {
-      if (mode == ComponentFile.MODE.READ_WRITE) {
-        lockFile.createNewFile();
-        lockDatabase();
-      } else
-        lockFile = null;
+      return true;
     }
+
+    if (mode == ComponentFile.MODE.READ_WRITE) {
+      lockFile.createNewFile();
+      lockDatabase();
+    } else
+      lockFile = null;
+
+    return false;
+  }
+
+  /**
+   * Replays the WAL of a database that was not closed properly. Runs after the schema is loaded, because the replay
+   * resolves file ids and the dictionary through the registered components.
+   */
+  private void performRecovery() throws IOException {
+    LogManager.instance().log(this, Level.WARNING, "Database '%s' was not closed properly last time", null, name);
+
+    // RESET THE COUNT OF RECORD IN CASE THE DATABASE WAS NOT CLOSED PROPERLY
+    for (Bucket b : schema.getBuckets())
+      ((LocalBucket) b).setCachedRecordCount(-1);
+
+    executeCallbacks(CALLBACK_EVENT.DB_NOT_CLOSED);
+
+    transactionManager.checkIntegrity();
   }
 
   private void openInternal() {
@@ -2324,6 +2342,9 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       try {
         schema = new LocalSchema(wrappedDatabaseInstance, databasePath, security);
 
+        // OWN THE DATABASE BEFORE READING IT: LOADING THE SCHEMA OF A CRASHED DATABASE WRITES TO IT.
+        final boolean recoveryPending = prepareRecovery();
+
         if (fileManager.getFiles().isEmpty())
           schema.create(mode);
         else
@@ -2332,7 +2353,8 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         serializer.setDateImplementation(configuration.getValue(GlobalConfiguration.DATE_IMPLEMENTATION));
         serializer.setDateTimeImplementation(configuration.getValue(GlobalConfiguration.DATE_TIME_IMPLEMENTATION));
 
-        checkForRecovery();
+        if (recoveryPending)
+          performRecovery();
 
         if (security != null)
           security.updateSchema(this);

--- a/engine/src/test/java/com/arcadedb/database/RecoveryLockOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/database/RecoveryLockOrderingTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.exception.DatabaseMetadataException;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Opening a database that needs recovery must take the exclusive lock, and settle the read-only
+ * rejection, before the schema is loaded.
+ * <p>
+ * {@code openInternal} used to run {@code schema.load()} first and only then {@code checkForRecovery()},
+ * which is where {@code database.lck} is locked. Everything the load does to a crashed database - the
+ * sorted-index-build marker cleanup that drops component files, and the dictionary header page that is
+ * written and committed when the page never reached disk - therefore happened while the database was
+ * still unlocked, so a second process holding the lock could not keep it out.
+ */
+class RecoveryLockOrderingTest {
+  private static final String DATABASE_NAME = "RecoveryLockOrderingTest";
+  private static final String DATABASE_PATH = "./target/databases/" + DATABASE_NAME;
+
+  @BeforeEach
+  @AfterEach
+  void cleanDatabaseDirectory() {
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
+    DatabaseContext.INSTANCE.removeCurrentThreadContexts();
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+  }
+
+  @Test
+  void openOfALockedCrashedDatabaseWritesNothingBeforeItIsRejected() throws IOException {
+    try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
+      crashDatabaseWithUnflushedDictionary(factory);
+
+      final long walBytesBefore = totalWalBytes();
+
+      // Stand in for the process that owns the database: hold the exclusive lock on the marker file.
+      try (final RandomAccessFile lockOwner = new RandomAccessFile(new File(DATABASE_PATH, "database.lck"), "rw");
+          final FileChannel channel = lockOwner.getChannel();
+          final FileLock lock = channel.lock()) {
+        assertThat(lock.isValid()).isTrue();
+
+        assertThatThrownBy(factory::open).isInstanceOf(RuntimeException.class);
+      }
+
+      assertThat(dictionaryLength())
+          .as("a rejected open must not write the dictionary header page of a database it does not own").isZero();
+      assertThat(totalWalBytes())
+          .as("a rejected open must not append transactions to the WAL of a database it does not own")
+          .isEqualTo(walBytesBefore);
+    }
+  }
+
+  @Test
+  void readOnlyOpenOfACrashedDatabaseIsRejectedBeforeTheSchemaIsLoaded() throws IOException {
+    try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
+      crashDatabaseWithUnflushedDictionary(factory);
+
+      final long walBytesBefore = totalWalBytes();
+
+      assertThatThrownBy(() -> factory.open(ComponentFile.MODE.READ_ONLY))
+          .isInstanceOf(DatabaseMetadataException.class)
+          .hasMessageContaining("read only");
+
+      assertThat(dictionaryLength()).as("a rejected read-only open must leave the dictionary file untouched").isZero();
+      assertThat(totalWalBytes()).as("a rejected read-only open must leave the WAL untouched").isEqualTo(walBytesBefore);
+    }
+  }
+
+  /**
+   * Leaves a database that needs recovery and whose dictionary page never reached disk.
+   */
+  private void crashDatabaseWithUnflushedDictionary(final DatabaseFactory factory) throws IOException {
+    final Database database = factory.create();
+    database.getSchema().createDocumentType("LockOrderingType");
+    database.transaction(() -> database.newDocument("LockOrderingType").set("k", 1).save());
+
+    ((DatabaseInternal) database).kill();
+    database.close();
+
+    assertThat(new File(DATABASE_PATH, "database.lck")).as("a killed database must leave the recovery marker").exists();
+
+    final File[] dictionaries = new File(DATABASE_PATH).listFiles((dir, name) -> name.endsWith(".dict"));
+    assertThat(dictionaries).as("the database must have a dictionary file").isNotNull().isNotEmpty();
+    for (final File dictionary : dictionaries)
+      try (final RandomAccessFile raf = new RandomAccessFile(dictionary, "rw")) {
+        raf.setLength(0);
+      }
+  }
+
+  private long dictionaryLength() {
+    final File[] dictionaries = new File(DATABASE_PATH).listFiles((dir, name) -> name.endsWith(".dict"));
+    long total = 0;
+    if (dictionaries != null)
+      for (final File dictionary : dictionaries)
+        total += dictionary.length();
+    return total;
+  }
+
+  private long totalWalBytes() {
+    final File[] files = new File(DATABASE_PATH).listFiles((dir, name) -> name.endsWith(".wal"));
+    long total = 0;
+    if (files != null)
+      for (final File file : files)
+        total += file.length();
+    return total;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/UnflushedDictionaryRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/database/UnflushedDictionaryRecoveryTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A crash that leaves the dictionary page unflushed must not cost the WAL.
+ * <p>
+ * {@code openInternal} loads the schema before the WAL is replayed, so the dictionary is built from
+ * whatever raw bytes are on disk. When the page never reached disk the file is zero length, and the
+ * load used to answer by committing a freshly created header page at version 0. Recovery then replayed
+ * a WAL whose dictionary entries sit at a much higher version, the version-gap guard fired, and the
+ * whole replay was aborted: every transaction still in the WAL was lost and the files were moved aside
+ * as {@code .corrupt}.
+ * <p>
+ * The zero-length file is produced directly rather than by hoping a kill lands in that window, which is
+ * a timing accident - the reason the symptom shows up on CI and not locally.
+ */
+class UnflushedDictionaryRecoveryTest {
+  private static final String DATABASE_NAME = "UnflushedDictionaryRecoveryTest";
+  private static final String DATABASE_PATH = "./target/databases/" + DATABASE_NAME;
+
+  @BeforeEach
+  @AfterEach
+  void cleanDatabaseDirectory() {
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
+    DatabaseContext.INSTANCE.removeCurrentThreadContexts();
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+  }
+
+  @Test
+  void recoveryReplaysTheWalWhenTheDictionaryPageWasNeverFlushed() throws IOException {
+    try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
+      // A clean create+close flushes the dictionary page and retires the WAL, so the entries written
+      // below are the only dictionary versions the recovery WAL will carry.
+      factory.create().close();
+
+      final Database database = factory.open();
+      database.getSchema().createDocumentType("UnflushedDictType");
+      database.transaction(() -> database.newDocument("UnflushedDictType").set("survivor", 42).save());
+
+      // Crash: the lock marker stays on disk so the next open recovers, and the WAL keeps the changes.
+      ((DatabaseInternal) database).kill();
+      database.close();
+
+      assertThat(walFiles()).as("the killed database must leave WAL files to replay").isNotEmpty();
+
+      truncateDictionaryFile();
+
+      final Database reopened = factory.open();
+      try {
+        assertThat(reopened.isOpen()).isTrue();
+
+        // The WAL held both the type and the record. Aborting the replay silently drops them.
+        assertThat(reopened.getSchema().existsType("UnflushedDictType"))
+            .as("the type committed before the crash must survive recovery").isTrue();
+
+        reopened.transaction(() -> {
+          final long count = reopened.countType("UnflushedDictType", false);
+          assertThat(count).as("the record committed before the crash must survive recovery").isEqualTo(1);
+
+          final Document doc = (Document) reopened.iterateType("UnflushedDictType", false).next();
+          // Property names live in the dictionary: a stale in-RAM dictionary reads them back as null or garbage.
+          assertThat(doc.getInteger("survivor")).isEqualTo(42);
+        });
+      } finally {
+        reopened.close();
+      }
+
+      assertThat(corruptWalFiles()).as("a recoverable WAL must not be quarantined as corrupt").isEmpty();
+    }
+  }
+
+  /**
+   * Empties the dictionary file, reproducing a page that was written but never flushed.
+   */
+  private void truncateDictionaryFile() throws IOException {
+    final File[] dictionaries = new File(DATABASE_PATH).listFiles((dir, name) -> name.endsWith(".dict"));
+    assertThat(dictionaries).as("the database must have a dictionary file").isNotNull().isNotEmpty();
+
+    for (final File dictionary : dictionaries)
+      try (final RandomAccessFile raf = new RandomAccessFile(dictionary, "rw")) {
+        raf.setLength(0);
+      }
+  }
+
+  private File[] walFiles() {
+    final File[] files = new File(DATABASE_PATH).listFiles((dir, name) -> name.endsWith(".wal"));
+    return files == null ? new File[0] : files;
+  }
+
+  private File[] corruptWalFiles() {
+    final File[] files = new File(DATABASE_PATH).listFiles((dir, name) -> name.endsWith(".wal.corrupt"));
+    return files == null ? new File[0] : files;
+  }
+}


### PR DESCRIPTION
Closes #5325

`LocalDatabase.openInternal` loaded the schema and only then called `checkForRecovery()`, which is the method that acquires the exclusive OS lock on `database.lck`. Loading the schema of a database that needs recovery is not a read-only operation: `LocalSchema.load` runs `SortedIndexBuildRecoveryMarker.recoverInterruptedBuilds`, which drops component files left by an interrupted sorted index build, and a dictionary whose page never reached disk has its header page written and committed by `Dictionary.createHeaderPageIfMissing`. Both happened while the database was still unlocked, so an open could mutate a database another process owns. `checkForRecovery()` is now split into `prepareRecovery()` - lock acquisition plus the READ_ONLY-needs-recovery rejection, run before the schema load - and `performRecovery()` - the WAL replay, which keeps its position after the load because it resolves file ids and the dictionary through the registered components. The `SchemaException: File with id '0' was not found` symptom quoted in the issue was already fixed in #5322; what remained was this ordering.

## Test plan

- [ ] `RecoveryLockOrderingTest.openOfALockedCrashedDatabaseWritesNothingBeforeItIsRejected` - with the lock held by a second channel, a rejected open must leave the dictionary file at zero bytes and the WAL unchanged. Fails before the fix (the dictionary file grew to 327680 bytes), passes after.
- [ ] `RecoveryLockOrderingTest.readOnlyOpenOfACrashedDatabaseIsRejectedBeforeTheSchemaIsLoaded` - guards the READ_ONLY path.
- [ ] `UnflushedDictionaryRecoveryTest.recoveryReplaysTheWalWhenTheDictionaryPageWasNeverFlushed` - a crash leaving the dictionary page unflushed must still replay the WAL: the type and record committed before the kill survive and no WAL file is quarantined as `.corrupt`.
- [ ] Existing recovery/lock coverage stays green: `EmptyDictionaryFileReopenTest`, `FailedOpenPreservesWalTest`, `Issue4511OpenFailureLockLeakTest`, `Issue4547ReadOnlyRecoveryLockLeakTest`, `Issue5067KillLockSymmetryTest`, `DatabaseFactoryFailedOpenTest`.
- [ ] `mvn -pl engine test -Dtest='com.arcadedb.database.**,com.arcadedb.engine.**,com.arcadedb.schema.**'` - the only two failures (`DatabaseGetSizeTest.getSizeMultipleCalls`, `ScriptTriggerSandboxTest.benignTriggerStillWorks`) reproduce identically on the unmodified baseline and are unrelated (async page-flush timing and a GraalVM polyglot class-init problem).