### PR TITLE
Use indexed anchors for bounded variable-length Cypher paths

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1791,6 +1791,7 @@ public class CypherExecutionPlan {
     if (physicalPlan == null || physicalPlan.getAnchor() == null || !physicalPlan.getAnchor().useIndex()
         || physicalPlan.getAnchor().isRangeScan() || physicalPlan.getAnchor().getIndex() == null
         || physicalPlan.getAnchor().getPropertyValue() instanceof InListValues
+        || physicalPlan.getAnchor().getIndex().getPropertyNames() == null
         || physicalPlan.getAnchor().getIndex().getPropertyNames().size() != 1)
       return false;
     if (!statement.isReadOnly() || statement.hasUnwindBeforeMatch() || statement.hasWithBeforeMatch()

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -73,6 +73,7 @@ import com.arcadedb.query.opencypher.ast.VariableExpression;
 import com.arcadedb.query.opencypher.ast.WhereClause;
 import com.arcadedb.query.opencypher.ast.WithClause;
 import com.arcadedb.query.opencypher.executor.operators.GAVFusedChainOperator;
+import com.arcadedb.query.opencypher.executor.operators.InListValues;
 import com.arcadedb.query.opencypher.executor.steps.AggregationStep;
 import com.arcadedb.query.opencypher.executor.steps.CallStep;
 import com.arcadedb.query.opencypher.executor.steps.AntiJoinChainOp;
@@ -253,10 +254,7 @@ public class CypherExecutionPlan {
     if (rootStep == null) {
       // Phase 4: Use optimized physical plan if available
       // Use pre-computed flags from the cached CypherStatement to avoid scanning clause lists per execution
-      if (physicalPlan != null && physicalPlan.getRootOperator() != null
-          && !statement.hasUnwindBeforeMatch() && !statement.hasSubquery()
-          && !statement.hasWithBeforeMatch() && !statement.hasVariableLengthPath()
-          && !statement.hasWriteBeforeMatch()) {
+      if (canUseOptimizedPhysicalPlan()) {
         // Use optimizer - execute physical operators directly
         // Note: For Phase 4, we only optimize MATCH patterns
         // RETURN, ORDER BY, LIMIT are still handled by execution steps
@@ -314,6 +312,13 @@ public class CypherExecutionPlan {
     }
 
     return resultSet;
+  }
+
+  private boolean canUseOptimizedPhysicalPlan() {
+    return physicalPlan != null && physicalPlan.getRootOperator() != null
+        && !statement.hasUnwindBeforeMatch() && !statement.hasSubquery()
+        && !statement.hasWithBeforeMatch() && !statement.hasVariableLengthPath()
+        && !statement.hasWriteBeforeMatch();
   }
 
   /**
@@ -488,7 +493,7 @@ public class CypherExecutionPlan {
     explainOutput.append("OpenCypher Native Execution Plan\n");
     explainOutput.append("=================================\n\n");
 
-    if (physicalPlan != null && physicalPlan.getRootOperator() != null) {
+    if (canUseOptimizedPhysicalPlan()) {
       explainOutput.append("Using Cost-Based Query Optimizer\n\n");
       explainOutput.append("Physical Plan:\n");
       explainOutput.append(physicalPlan.getRootOperator().explain(0));
@@ -538,16 +543,9 @@ public class CypherExecutionPlan {
         rootStep = tryOptimizeCountStar(context);
 
         if (rootStep == null) {
-          final boolean hasUnwindBeforeMatch = hasUnwindPrecedingMatch();
-          final boolean hasWithBeforeMatch2 = hasWithPrecedingMatch();
-
-          final boolean hasVLP2 = hasVariableLengthPath();
-          final boolean hasWriteBeforeMatch2 = statement.hasWriteBeforeMatch();
-          final boolean hasSubquery2 = statement.hasSubquery();
-          if (physicalPlan != null && physicalPlan.getRootOperator() != null && !hasUnwindBeforeMatch && !hasWithBeforeMatch2
-              && !hasVLP2 && !hasWriteBeforeMatch2 && !hasSubquery2)
+          if (canUseOptimizedPhysicalPlan()) {
             rootStep = buildExecutionStepsWithOptimizer(context);
-          else
+          } else
             rootStep = buildExecutionSteps(context);
         }
 
@@ -576,7 +574,7 @@ public class CypherExecutionPlan {
     if (errorMessage != null)
       profileOutput.append(String.format("\nError: %s\n", errorMessage));
 
-    if (physicalPlan != null && physicalPlan.getRootOperator() != null) {
+    if (canUseOptimizedPhysicalPlan()) {
       profileOutput.append("\nExecution Plan (Cost-Based Optimizer):\n");
       profileOutput.append(physicalPlan.getRootOperator().explain(0));
       profileOutput.append(String.format("\nEstimated Cost: %.2f\n", physicalPlan.getTotalEstimatedCost()));
@@ -850,58 +848,6 @@ public class CypherExecutionPlan {
   }
 
   /**
-   * Checks if the query has UNWIND before MATCH in clause order.
-   * This is used to disable the optimizer for such queries because the optimizer
-   * doesn't handle clause ordering correctly.
-   */
-  private boolean hasUnwindPrecedingMatch() {
-    final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
-    if (clausesInOrder == null || clausesInOrder.isEmpty()) {
-      // Fall back to checking if both UNWIND and MATCH exist
-      return !statement.getUnwindClauses().isEmpty() && !statement.getMatchClauses().isEmpty();
-    }
-
-    // Find the first UNWIND and first MATCH in clause order
-    int firstUnwindOrder = Integer.MAX_VALUE;
-    int firstMatchOrder = Integer.MAX_VALUE;
-
-    for (final ClauseEntry entry : clausesInOrder) {
-      if (entry.getType() == ClauseEntry.ClauseType.UNWIND) {
-        firstUnwindOrder = Math.min(firstUnwindOrder, entry.getOrder());
-      } else if (entry.getType() == ClauseEntry.ClauseType.MATCH) {
-        firstMatchOrder = Math.min(firstMatchOrder, entry.getOrder());
-      }
-    }
-
-    // Return true if UNWIND appears before MATCH
-    return firstUnwindOrder < firstMatchOrder;
-  }
-
-  /**
-   * Checks if the query has WITH before MATCH in clause order.
-   * The optimizer path processes all MATCH clauses first via the physical plan,
-   * which breaks queries like: WITH date(...) AS x MATCH (d:Duration) RETURN x + d.dur
-   * because WITH needs to execute before MATCH to provide variables.
-   */
-  private boolean hasWithPrecedingMatch() {
-    final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
-    if (clausesInOrder == null || clausesInOrder.isEmpty())
-      return !statement.getWithClauses().isEmpty() && !statement.getMatchClauses().isEmpty();
-
-    int firstWithOrder = Integer.MAX_VALUE;
-    int firstMatchOrder = Integer.MAX_VALUE;
-
-    for (final ClauseEntry entry : clausesInOrder) {
-      if (entry.getType() == ClauseEntry.ClauseType.WITH)
-        firstWithOrder = Math.min(firstWithOrder, entry.getOrder());
-      else if (entry.getType() == ClauseEntry.ClauseType.MATCH)
-        firstMatchOrder = Math.min(firstMatchOrder, entry.getOrder());
-    }
-
-    return firstWithOrder < firstMatchOrder;
-  }
-
-  /**
    * Checks if the query contains a CALL subquery clause.
    * The optimizer path doesn't handle SUBQUERY steps, so we fall back to the
    * non-optimized execution path when subqueries are present.
@@ -914,23 +860,6 @@ public class CypherExecutionPlan {
     for (final ClauseEntry entry : clausesInOrder) {
       if (entry.getType() == ClauseEntry.ClauseType.SUBQUERY)
         return true;
-    }
-    return false;
-  }
-
-  /**
-   * Checks if any MATCH clause contains a variable-length path pattern.
-   * The optimizer doesn't support VLP (it only uses ExpandAll for fixed-length),
-   * so we fall back to the step-based execution path.
-   */
-  private boolean hasVariableLengthPath() {
-    for (final MatchClause matchClause : statement.getMatchClauses()) {
-      for (final PathPattern path : matchClause.getPathPatterns()) {
-        for (int i = 0; i < path.getRelationshipCount(); i++) {
-          if (path.getRelationship(i).isVariableLength())
-            return true;
-        }
-      }
     }
     return false;
   }
@@ -1624,6 +1553,12 @@ public class CypherExecutionPlan {
         String sourceVar = sourceNode.getVariable() != null ? sourceNode.getVariable() :
             ("  src" + anonymousVarCounter++);
 
+        boolean reversed = shouldReverseVariableLengthPathFromIndexedAnchor(matchClause, pathPattern);
+        if (reversed) {
+          sourceNode = pathPattern.getLastNode();
+          sourceVar = sourceNode.getVariable();
+        }
+
         // Check if source node variable is already bound (either from previous MATCH or
         // from earlier patterns in this same MATCH clause)
         boolean sourceAlreadyBound = stepBeforeMatch != null &&
@@ -1636,8 +1571,7 @@ public class CypherExecutionPlan {
         // Example: OPTIONAL MATCH (c:Comment)-[:COMMENTED_ON]->(q) where q is bound
         // Without reversal: scan all Comments → check if each connects to q (slow!)
         // With reversal: start from q → follow INCOMING COMMENTED_ON edges (fast!)
-        boolean reversed = false;
-        if (!sourceAlreadyBound && pathPattern.getRelationshipCount() == 1
+        if (!reversed && !sourceAlreadyBound && pathPattern.getRelationshipCount() == 1
             && !pathPattern.getRelationship(0).isVariableLength()) {
           final NodePattern targetNode = pathPattern.getLastNode();
           final String targetVar = targetNode.getVariable();
@@ -1762,7 +1696,8 @@ public class CypherExecutionPlan {
           AbstractExecutionStep nextStep;
           if (relPattern.isVariableLength()) {
             nextStep = new ExpandPathStep(effectiveSourceVar, pathVariable, relVar, effectiveTargetVar, relPattern,
-                true, effectiveTargetNode, pathPattern.getEffectivePathMode(), computePrevVarsForVlp(pathPattern, i, boundVariables), context);
+                true, effectiveTargetNode, pathPattern.getEffectivePathMode(), computePrevVarsForVlp(pathPattern, i, boundVariables),
+                directionOverride, reversed, context);
           } else {
             // Check if this hop requires IN traversal on a unidirectional edge.
             // Unidirectional edges don't store incoming links, so we must restructure:
@@ -1844,6 +1779,35 @@ public class CypherExecutionPlan {
     boundVariables.addAll(matchVariables);
 
     return currentStep;
+  }
+
+  /**
+   * The physical operators do not yet implement variable-length expansion, but their cost-based
+   * anchor selection is still useful to the traditional executor. Limit this bridge to a single,
+   * bounded relationship whose indexed target can be reached through stored incoming adjacency.
+   */
+  private boolean shouldReverseVariableLengthPathFromIndexedAnchor(final MatchClause matchClause,
+      final PathPattern pathPattern) {
+    if (physicalPlan == null || physicalPlan.getAnchor() == null || !physicalPlan.getAnchor().useIndex()
+        || physicalPlan.getAnchor().isRangeScan() || physicalPlan.getAnchor().getIndex() == null
+        || physicalPlan.getAnchor().getPropertyValue() instanceof InListValues
+        || physicalPlan.getAnchor().getIndex().getPropertyNames().size() != 1)
+      return false;
+    if (!statement.isReadOnly() || statement.hasUnwindBeforeMatch() || statement.hasWithBeforeMatch()
+        || statement.hasSubquery() || statement.hasWriteBeforeMatch()
+        || statement.getMatchClauses().size() != 1 || matchClause.isOptional()
+        || matchClause.getPathPatterns().size() != 1 || pathPattern.getRelationshipCount() != 1)
+      return false;
+
+    final RelationshipPattern relationship = pathPattern.getRelationship(0);
+    if (!relationship.isVariableLength() || relationship.getMaxHops() == null || !relationship.hasTypes()
+        || isAnyEdgeTypeUnidirectional(relationship.getTypes()))
+      return false;
+
+    final String sourceVariable = pathPattern.getFirstNode().getVariable();
+    final String targetVariable = pathPattern.getLastNode().getVariable();
+    return sourceVariable != null && targetVariable != null && !sourceVariable.equals(targetVariable)
+        && targetVariable.equals(physicalPlan.getAnchor().getVariable());
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.NodePattern;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
@@ -59,6 +60,8 @@ public class ExpandPathStep extends AbstractExecutionStep {
   private final boolean useBFS;
   private final PathMode pathMode;
   private final Set<String> previousStepVariables;
+  private final Direction directionOverride;
+  private final boolean reverseResultPath;
 
   /**
    * Creates an expand path step.
@@ -104,6 +107,14 @@ public class ExpandPathStep extends AbstractExecutionStep {
       final String targetVariable, final RelationshipPattern pattern, final boolean useBFS,
       final NodePattern targetNodePattern, final PathMode pathMode, final Set<String> previousStepVariables,
       final CommandContext context) {
+    this(sourceVariable, pathVariable, relationshipVariable, targetVariable, pattern, useBFS,
+        targetNodePattern, pathMode, previousStepVariables, null, false, context);
+  }
+
+  public ExpandPathStep(final String sourceVariable, final String pathVariable, final String relationshipVariable,
+      final String targetVariable, final RelationshipPattern pattern, final boolean useBFS,
+      final NodePattern targetNodePattern, final PathMode pathMode, final Set<String> previousStepVariables,
+      final Direction directionOverride, final boolean reverseResultPath, final CommandContext context) {
     super(context);
 
     if (!pattern.isVariableLength())
@@ -118,6 +129,8 @@ public class ExpandPathStep extends AbstractExecutionStep {
     this.useBFS = useBFS;
     this.pathMode = pathMode;
     this.previousStepVariables = previousStepVariables;
+    this.directionOverride = directionOverride;
+    this.reverseResultPath = reverseResultPath;
   }
 
   /**
@@ -186,8 +199,9 @@ public class ExpandPathStep extends AbstractExecutionStep {
               if (context.isProfiling())
                 rowCount++;
 
-              final TraversalPath path = currentPaths.next();
-              final Vertex targetVertex = path.getEndVertex();
+              final TraversalPath traversedPath = currentPaths.next();
+              final Vertex targetVertex = traversedPath.getEndVertex();
+              final TraversalPath path = reverseResultPath ? traversedPath.reversed() : traversedPath;
 
               // Filter by target node label if specified
               if (targetNodePattern != null && targetNodePattern.hasLabels()) {
@@ -286,14 +300,16 @@ public class ExpandPathStep extends AbstractExecutionStep {
 
     final Map<String, Object> props = pattern.hasProperties() ? pattern.getProperties() : null;
 
+    final Direction direction = directionOverride != null ? directionOverride : pattern.getDirection();
+
     if (pathMode != null)
       return new VariableLengthPathTraverser(
-          pattern.getDirection(), types, props,
+          direction, types, props,
           pattern.getEffectiveMinHops(), pattern.getEffectiveMaxHops(),
           true, useBFS, pathMode);
 
     return new VariableLengthPathTraverser(
-        pattern.getDirection(), types, props,
+        direction, types, props,
         pattern.getEffectiveMinHops(), pattern.getEffectiveMaxHops(),
         true, useBFS);
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/TraversalPath.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/TraversalPath.java
@@ -142,6 +142,19 @@ public class TraversalPath {
   }
 
   /**
+   * Returns this path in the opposite traversal order.
+   */
+  public TraversalPath reversed() {
+    if (vertices.isEmpty())
+      return new TraversalPath();
+
+    final TraversalPath reversed = new TraversalPath(vertices.get(vertices.size() - 1));
+    for (int i = edges.size() - 1; i >= 0; i--)
+      reversed.addStep(edges.get(i), vertices.get(i));
+    return reversed;
+  }
+
+  /**
    * Returns the path as a flat list of alternating vertices and edges: [v0, e0, v1, e1, v2, ...].
    */
   public List<Object> toAlternatingList() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CypherVariableLengthAnchorSelectionTest {
+  private static final String DATABASE_PATH = "./target/databases/cypher-vlp-anchor-selection";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DATABASE_PATH).create();
+    database.getSchema().createVertexType("Area").createProperty("id", Type.STRING);
+    database.getSchema().createEdgeType("PART_OF");
+    database.getSchema().buildEdgeType().withName("PART_OF_ONE_WAY").withBidirectional(false).create();
+
+    database.transaction(() -> {
+      final MutableVertex country = area("country");
+      final MutableVertex region = area("region");
+      final MutableVertex city = area("city");
+
+      city.newEdge("PART_OF", region, true, (Object[]) null).set("step", "city-region").save();
+      region.newEdge("PART_OF", country, true, (Object[]) null).set("step", "region-country").save();
+      city.newEdge("PART_OF_ONE_WAY", region).save();
+      region.newEdge("PART_OF_ONE_WAY", country).save();
+
+      for (int i = 0; i < 256; i++)
+        area("decoy-" + i);
+    });
+
+    database.transaction(() -> database.getSchema().createTypeIndex(
+        Schema.INDEX_TYPE.LSM_TREE, true, "Area", "id"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void startsBoundedVariableLengthTraversalFromIndexedTarget() {
+    final String sourceFirst = """
+        MATCH (place:Area)-[:PART_OF*0..3]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN DISTINCT place.id AS id
+        ORDER BY id""";
+    final String targetFirst = """
+        MATCH (country:Area)<-[:PART_OF*0..3]-(place:Area)
+        WHERE country.id = $countryId
+        RETURN DISTINCT place.id AS id
+        ORDER BY id""";
+    final Map<String, Object> parameters = Map.of("countryId", "country");
+
+    assertThat(queryIds(sourceFirst, parameters)).containsExactly("city", "country", "region");
+    assertThat(queryIds(targetFirst, parameters)).containsExactly("city", "country", "region");
+
+    final ExecutionPlan plan;
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + sourceFirst, parameters)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      plan = resultSet.getExecutionPlan().orElseThrow();
+    }
+
+    assertThat(plan.getSteps()).isNotEmpty();
+    assertThat(plan.getSteps().get(0).getDescription())
+        .contains("MATCH NODE (country:Area)")
+        .contains("[index: Area[id]]")
+        .contains("1 rows");
+    assertThat(plan.prettyPrint(0, 2))
+        .contains("Execution Plan (Traditional)")
+        .contains("MATCH NODE (country:Area)")
+        .doesNotContain("Execution Plan (Cost-Based Optimizer)");
+
+    try (ResultSet resultSet = database.query("opencypher", "EXPLAIN " + sourceFirst, parameters)) {
+      assertThat(resultSet.getExecutionPlan().orElseThrow().prettyPrint(0, 2))
+          .contains("Using Traditional Execution (Non-Optimized)")
+          .doesNotContain("Using Cost-Based Query Optimizer");
+    }
+  }
+
+  @Test
+  void preservesRelationshipListInWrittenPathOrder() {
+    final String query = """
+        MATCH (place:Area)-[relationships:PART_OF*1..3]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN place.id AS id, relationships AS relationships
+        ORDER BY id""";
+
+    final List<Result> rows;
+    final ExecutionPlan plan;
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, Map.of("countryId", "country"))) {
+      rows = resultSet.stream().toList();
+      plan = resultSet.getExecutionPlan().orElseThrow();
+    }
+
+    assertThat(plan.getSteps().get(0).getDescription())
+        .contains("MATCH NODE (country:Area)")
+        .contains("[index: Area[id]]");
+
+    final Result city = rows.stream()
+        .filter(row -> "city".equals(row.<String>getProperty("id")))
+        .findFirst()
+        .orElseThrow();
+    final List<Edge> relationships = city.getProperty("relationships");
+    assertThat(relationships)
+        .extracting(edge -> edge.<String>get("step"))
+        .containsExactly("city-region", "region-country");
+  }
+
+  @Test
+  void keepsSourceScanWhenIncomingAdjacencyIsUnavailable() {
+    final String query = """
+        MATCH (place:Area)-[:PART_OF_ONE_WAY*0..3]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN DISTINCT place.id AS id
+        ORDER BY id""";
+    final Map<String, Object> parameters = Map.of("countryId", "country");
+
+    assertThat(queryIds(query, parameters)).containsExactly("city", "country", "region");
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
+          .contains("MATCH NODE (place:Area)")
+          .doesNotContain("[index:");
+    }
+  }
+
+  @Test
+  void keepsSourceScanForUntypedRelationships() {
+    final String query = """
+        MATCH (place:Area)-[*0..3]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN DISTINCT place.id AS id
+        ORDER BY id""";
+    final Map<String, Object> parameters = Map.of("countryId", "country");
+
+    assertThat(queryIds(query, parameters)).containsExactly("city", "country", "region");
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
+          .contains("MATCH NODE (place:Area)")
+          .doesNotContain("[index:");
+    }
+  }
+
+  private MutableVertex area(final String id) {
+    return database.newVertex("Area").set("id", id).save();
+  }
+
+  private List<String> queryIds(final String query, final Map<String, Object> parameters) {
+    try (ResultSet resultSet = database.query("opencypher", query, parameters)) {
+      return resultSet.stream()
+          .map((Result result) -> result.<String>getProperty("id"))
+          .toList();
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Uses the cost-based optimizer's indexed equality anchor to seed the traditional
Cypher executor for a conservative bounded variable-length path shape.

- Starts a source-first path from its indexed target when reverse adjacency is
  available.
- Reverses traversal direction internally while preserving returned path and
  named relationship-list order as written by the query.
- Keeps variable-length expansion in the existing traditional executor; the
  physical operators still do not claim to execute unsupported variable-length
  paths.
- Makes `EXPLAIN` and `PROFILE` report the executor that is actually used.
- Falls back to existing behavior for optional or multi-pattern matches,
  unbounded paths, untyped or unidirectional relationships, range and `IN`
  anchors, composite indexes, subqueries, and write-sensitive clause shapes.

## Motivation

The native Cypher engine currently excludes statements containing a
variable-length path from physical-plan execution. Its fallback executor begins
at the first node written in the path and only reverses a bound-target traversal
for a fixed-length single hop.

This makes the following query scan every candidate `place` even though the
`country.id` predicate identifies one indexed vertex:

```cypher
MATCH (place:Area)-[:PART_OF*0..3]->(country:Area)
WHERE country.id = $countryId
RETURN DISTINCT place.id
```

Writing the equivalent path from `country` first avoids that scan, but query
performance should not depend on which equivalent orientation the caller
writes. The optimizer already selects the indexed target; this change lets the
traditional executor use that decision for the guarded shape it can execute
safely.

## Related issues

None found for this exact variable-length anchor-selection gap.

## Additional Notes

The deterministic regression uses an indexed `Area(id)` target, a
bidirectional `PART_OF` hierarchy, and 256 unrelated `Area` vertices.

Red on the base commit
`2f985b85a9ac9ba3fc50e11d8f325c68661044f6` with the regression alone:

```text
First step: MATCH NODE (place:Area)
Source rows: 259
Index: none
```

Green with this change:

```text
First step: MATCH NODE (country:Area)
Source rows: 1
Index: Area[id]
```

The local implementation commit is
`fcf228f258dbb8fb686951971d4de8a3cc356c16`.

Both written orientations return the same country, region, and city rows. A
named relationship list for the city-to-country path remains in written order:
`city-region`, then `region-country`.

Validation:

```text
CypherVariableLengthAnchorSelectionTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0

CypherVariableLengthAnchorSelectionTest,GAVEligibilityTest,
CypherExecutionPlanTest,MatchRelationshipStepProfilingTest
Tests run: 99, Failures: 0, Errors: 0, Skipped: 0

OpenCypherLoadCSVTest, outside the network-restricted sandbox
Tests run: 26, Failures: 0, Errors: 0, Skipped: 0

ScriptExecutionTest#commitRetryMultiThreadsSQLIncrementRepeatableRead,
with -XX:ActiveProcessorCount=32
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

./mvnw package -DskipTests
Reactor modules: 26, BUILD SUCCESS
```

A broader engine run completed 6,335 tests across 617 classes with no
assertion failures before an unrelated inherited slow transaction stress class
stopped making progress. The seven errors recorded before that stop were the
two environment-sensitive cases rerun successfully above: six loopback-server
errors and one host-processor-count error.

## Checklist

- [x] The 26-module package build succeeds with tests skipped
- [x] Unit tests cover optimized and fallback behavior
- [x] Returned relationship order is covered explicitly
- [x] No database format changes or changes to existing API behavior
