### PR TITLE
Add opt-in SLF4J facade logging (Slf4jLogger), keeping java.util.logging as default (#4276)

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -93,8 +93,8 @@ The following table lists runtime dependencies bundled with ArcadeDB distributio
 
 | Group ID | Artifact ID | Version | License | Homepage |
 |----------|-------------|---------|---------|----------|
-| org.slf4j | slf4j-api | 2.0.17 | MIT | https://www.slf4j.org/ |
-| org.slf4j | slf4j-jdk14 | 2.0.17 | MIT | https://www.slf4j.org/ |
+| org.slf4j | slf4j-api | 2.0.18 | MIT | https://www.slf4j.org/ |
+| org.slf4j | slf4j-jdk14 | 2.0.18 | MIT | https://www.slf4j.org/ |
 | ch.qos.logback | logback-classic | 1.5.27 | EPL 1.0 / LGPL 2.1 | https://logback.qos.ch/ |
 | ch.qos.logback | logback-core | 1.5.27 | EPL 1.0 / LGPL 2.1 | https://logback.qos.ch/ |
 | com.conversantmedia | disruptor | 1.2.21 | Apache 2.0 | https://github.com/conversant/disruptor |

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -84,5 +84,14 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <!-- Runtime SLF4J binding for the runnable console: routes third-party SLF4J logs
+             (dependencies) to java.util.logging. Declared here at runtime because the parent keeps
+             slf4j-jdk14 at test scope so it does not leak to consumers of the library modules. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -119,6 +119,14 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!-- SLF4J facade only. ArcadeDB logs through slf4j-api and pins NO binding, so an embedding
+             application routes the engine's logs through whatever backend it already uses (Logback,
+             Log4j2, reload4j, or java.util.logging via slf4j-jdk14) with no dependency exclusions. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.conversantmedia</groupId>
             <artifactId>disruptor</artifactId>

--- a/engine/src/main/java/com/arcadedb/log/LogManager.java
+++ b/engine/src/main/java/com/arcadedb/log/LogManager.java
@@ -125,6 +125,14 @@ public class LogManager {
     logger = createLogger();
   }
 
+  /**
+   * Builds the {@link Logger} chosen by {@link #LOG_IMPL_PROPERTY}: {@link Slf4jLogger} for
+   * {@code slf4j}, otherwise the default {@link DefaultLogger}. Any failure constructing the chosen
+   * implementation (e.g. {@code slf4j-api} missing at runtime) is caught and falls back to
+   * {@link DefaultLogger}, so a logging misconfiguration can never prevent startup.
+   *
+   * @return the logger instance to install; never {@code null}
+   */
   private static Logger createLogger() {
     final String impl = System.getProperty(LOG_IMPL_PROPERTY, "").trim().toLowerCase(java.util.Locale.ROOT);
     try {

--- a/engine/src/main/java/com/arcadedb/log/LogManager.java
+++ b/engine/src/main/java/com/arcadedb/log/LogManager.java
@@ -26,6 +26,14 @@ import java.util.logging.Level;
  * @author Luca Garulli
  */
 public class LogManager {
+  /**
+   * System property selecting the {@link Logger} implementation, applied at startup without any code
+   * change. Unset (or any value other than {@code slf4j}) keeps the default {@link DefaultLogger}
+   * (java.util.logging); {@code slf4j} installs {@link Slf4jLogger}, routing the engine's logs
+   * through the SLF4J facade so an embedding application receives them in its own backend. The logger
+   * can also be swapped programmatically via {@link #setLogger(Logger)}.
+   */
+  public  static final String                        LOG_IMPL_PROPERTY    = "arcadedb.log.impl";
   private static final LogContext                    CONTEXT_INSTANCE     = new LogContext();
   private static final ThreadLocal<Correlation>      CORRELATION_INSTANCE = new ThreadLocal<>();
   private static final LogManager                    instance             = new LogManager();
@@ -111,15 +119,6 @@ public class LogManager {
     final Correlation c = CORRELATION_INSTANCE.get();
     return c == null ? null : c.spanId();
   }
-
-  /**
-   * System property selecting the {@link Logger} implementation, applied at startup without any code
-   * change. Unset (or any value other than {@code slf4j}) keeps the default {@link DefaultLogger}
-   * (java.util.logging); {@code slf4j} installs {@link Slf4jLogger}, routing the engine's logs
-   * through the SLF4J facade so an embedding application receives them in its own backend. The logger
-   * can also be swapped programmatically via {@link #setLogger(Logger)}.
-   */
-  public static final String LOG_IMPL_PROPERTY = "arcadedb.log.impl";
 
   protected LogManager() {
     logger = createLogger();

--- a/engine/src/main/java/com/arcadedb/log/LogManager.java
+++ b/engine/src/main/java/com/arcadedb/log/LogManager.java
@@ -112,8 +112,30 @@ public class LogManager {
     return c == null ? null : c.spanId();
   }
 
+  /**
+   * System property selecting the {@link Logger} implementation, applied at startup without any code
+   * change. Unset (or any value other than {@code slf4j}) keeps the default {@link DefaultLogger}
+   * (java.util.logging); {@code slf4j} installs {@link Slf4jLogger}, routing the engine's logs
+   * through the SLF4J facade so an embedding application receives them in its own backend. The logger
+   * can also be swapped programmatically via {@link #setLogger(Logger)}.
+   */
+  public static final String LOG_IMPL_PROPERTY = "arcadedb.log.impl";
+
   protected LogManager() {
-    logger = new DefaultLogger();
+    logger = createLogger();
+  }
+
+  private static Logger createLogger() {
+    final String impl = System.getProperty(LOG_IMPL_PROPERTY, "").trim().toLowerCase(java.util.Locale.ROOT);
+    try {
+      return "slf4j".equals(impl) ? new Slf4jLogger() : new DefaultLogger();
+    } catch (final Throwable t) {
+      // A logging-init problem must never take the process down: fall back to the dependency-free
+      // java.util.logging implementation.
+      System.err.println(
+          "ArcadeDB: cannot initialize logger impl '" + impl + "', falling back to java.util.logging. Cause: " + t);
+      return new DefaultLogger();
+    }
   }
 
   public static LogManager instance() {

--- a/engine/src/main/java/com/arcadedb/log/LogManager.java
+++ b/engine/src/main/java/com/arcadedb/log/LogManager.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.log;
 
+import java.util.Locale;
 import java.util.logging.Level;
 
 /**
@@ -126,16 +127,25 @@ public class LogManager {
 
   /**
    * Builds the {@link Logger} chosen by {@link #LOG_IMPL_PROPERTY}: {@link Slf4jLogger} for
-   * {@code slf4j}, otherwise the default {@link DefaultLogger}. Any failure constructing the chosen
-   * implementation (e.g. {@code slf4j-api} missing at runtime) is caught and falls back to
-   * {@link DefaultLogger}, so a logging misconfiguration can never prevent startup.
+   * {@code slf4j}, {@link DefaultLogger} when unset or {@code default}. Any other value is reported
+   * on {@code System.err} and treated as {@code default}, so a typo does not silently look like a
+   * working configuration. Any failure constructing the chosen implementation (e.g. {@code slf4j-api}
+   * missing at runtime) is caught and falls back to {@link DefaultLogger}, so a logging
+   * misconfiguration can never prevent startup.
    *
    * @return the logger instance to install; never {@code null}
    */
-  private static Logger createLogger() {
-    final String impl = System.getProperty(LOG_IMPL_PROPERTY, "").trim().toLowerCase(java.util.Locale.ROOT);
+  static Logger createLogger() {
+    final String impl = System.getProperty(LOG_IMPL_PROPERTY, "").trim().toLowerCase(Locale.ROOT);
     try {
-      return "slf4j".equals(impl) ? new Slf4jLogger() : new DefaultLogger();
+      if ("slf4j".equals(impl))
+        return new Slf4jLogger();
+
+      if (!impl.isEmpty() && !"default".equals(impl))
+        System.err.println("ArcadeDB: unknown value '" + impl + "' for " + LOG_IMPL_PROPERTY
+            + ", using java.util.logging. Supported values: 'default', 'slf4j'.");
+
+      return new DefaultLogger();
     } catch (final Throwable t) {
       // A logging-init problem must never take the process down: fall back to the dependency-free
       // java.util.logging implementation.

--- a/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
@@ -91,13 +91,11 @@ public class Slf4jLogger implements Logger {
     if (!isEnabled(log, slf4jLevel))
       return;
 
-    final boolean hasParams =
-        arg1 != null || arg2 != null || arg3 != null || arg4 != null || arg5 != null || arg6 != null || arg7 != null
-            || arg8 != null || arg9 != null || arg10 != null || arg11 != null || arg12 != null || arg13 != null
-            || arg14 != null || arg15 != null || arg16 != null || arg17 != null;
-
     // Kept as an explicit 17-arg call (no Object[] wrapping) to preserve the interface's
     // allocation-free path for the common, no-parameter case.
+    final boolean hasParams = anyNonNull(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12,
+        arg13, arg14, arg15, arg16, arg17);
+
     String msg = withContext(context, message);
     if (hasParams) {
       try {
@@ -185,9 +183,26 @@ public class Slf4jLogger implements Logger {
   }
 
   /**
+   * Returns whether any of the (up to 17) format arguments is non-null, i.e. whether the message
+   * needs printf substitution. Extracted from the fixed-arity {@code log} overload to keep that
+   * method's complexity low; takes the arguments explicitly (no {@code Object[]}) so the
+   * no-parameter path stays allocation-free.
+   */
+  private static boolean anyNonNull(final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+      final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9, final Object arg10,
+      final Object arg11, final Object arg12, final Object arg13, final Object arg14, final Object arg15,
+      final Object arg16, final Object arg17) {
+    return arg1 != null || arg2 != null || arg3 != null || arg4 != null || arg5 != null || arg6 != null || arg7 != null
+        || arg8 != null || arg9 != null || arg10 != null || arg11 != null || arg12 != null || arg13 != null
+        || arg14 != null || arg15 != null || arg16 != null || arg17 != null;
+  }
+
+  /**
    * Maps a {@link java.util.logging.Level} onto one of SLF4J's five levels by numeric weight, so
    * custom or intermediate JUL levels also resolve: {@code >= SEVERE -> ERROR}, {@code >= WARNING ->
    * WARN}, {@code >= INFO -> INFO}, {@code >= FINE -> DEBUG}, otherwise {@code TRACE}.
+   *
+   * @return one of {@link #ERROR}, {@link #WARN}, {@link #INFO}, {@link #DEBUG} or {@link #TRACE}
    */
   private static int slf4jLevel(final Level level) {
     final int v = level.intValue();

--- a/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
@@ -21,8 +21,6 @@ package com.arcadedb.log;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 
 /**
@@ -63,8 +61,6 @@ public class Slf4jLogger implements Logger {
   private static final int INFO  = 2;
   private static final int DEBUG = 3;
   private static final int TRACE = 4;
-
-  private final ConcurrentMap<String, org.slf4j.Logger> loggersCache = new ConcurrentHashMap<>();
 
   /**
    * Logs {@code message} at {@code level} for {@code requester}, through SLF4J. This fixed-arity
@@ -165,8 +161,9 @@ public class Slf4jLogger implements Logger {
    * Resolves the SLF4J logger for a requester, deriving its name the same way {@link DefaultLogger} does:
    * a {@link String} is used verbatim, a {@link Class} contributes its fully-qualified name, any
    * other object contributes its class name, and {@code null} falls back to {@value #DEFAULT_LOG}.
-   * Resolved loggers are cached locally to avoid repeated {@link LoggerFactory} lookups on the hot
-   * path.
+   * Delegates straight to {@link LoggerFactory#getLogger(String)}, which already performs its own
+   * context-aware caching; a local cache would risk stale loggers or a ClassLoader leak if the
+   * logging context is reloaded.
    */
   private org.slf4j.Logger resolveLogger(final Object requester) {
     final String name;
@@ -179,7 +176,7 @@ public class Slf4jLogger implements Logger {
     else
       name = DEFAULT_LOG;
 
-    return loggersCache.computeIfAbsent(name, LoggerFactory::getLogger);
+    return LoggerFactory.getLogger(name);
   }
 
   /** Prefixes the message with {@code <context> } when a context is set, otherwise returns it unchanged. */

--- a/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.log;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+
+/**
+ * {@link Logger} implementation that routes ArcadeDB's logs through the SLF4J facade, so an
+ * application embedding ArcadeDB receives the engine's logs in whatever backend it already uses
+ * (Logback, Log4j2, reload4j, or {@code java.util.logging} via {@code slf4j-jdk14}). ArcadeDB itself
+ * depends only on {@code slf4j-api} and pins no backend.
+ * <p>
+ * This is <b>opt-in</b>: the default logger remains {@link DefaultLogger} (java.util.logging, with
+ * ArcadeDB's built-in text/ANSI and JSON formatting). Select this one, without any code change, with
+ * {@code -Darcadedb.log.impl=slf4j}, or programmatically via
+ * {@link LogManager#setLogger(Logger) LogManager.setLogger(new Slf4jLogger())}.
+ * <p>
+ * Behaviour that call sites rely on matches {@link DefaultLogger}: the requester is resolved to a
+ * logger name the same way (String / Class / instance class-name, falling back to
+ * {@code com.arcadedb}); a non-null {@code context} is prefixed as {@code <context> message}; and
+ * message parameters use Java {@link String#formatted(Object...)} (printf-style {@code %s}), not
+ * SLF4J's {@code {}} placeholders, because that is how ArcadeDB messages are written. Formatting is
+ * skipped entirely when the target level is disabled.
+ * <p>
+ * The per-request correlation fields carried by {@link LogManager} (requestId, database, traceId,
+ * spanId) are exposed to the backend through SLF4J's {@link MDC} under the keys
+ * {@code arcadedb.requestId}, {@code arcadedb.database}, {@code arcadedb.traceId} and
+ * {@code arcadedb.spanId}, so a pattern/layout can render them. Any value already present under those
+ * keys is saved and restored around the call, leaving the host application's MDC untouched.
+ */
+public class Slf4jLogger implements Logger {
+  private static final String DEFAULT_LOG    = "com.arcadedb";
+  private static final String MDC_REQUEST_ID = "arcadedb.requestId";
+  private static final String MDC_DATABASE   = "arcadedb.database";
+  private static final String MDC_TRACE_ID   = "arcadedb.traceId";
+  private static final String MDC_SPAN_ID    = "arcadedb.spanId";
+
+  // SLF4J's five levels, ordered by severity; the target level is resolved to one of these once per
+  // call and then reused for both the enabled-check and the dispatch.
+  private static final int ERROR = 0;
+  private static final int WARN  = 1;
+  private static final int INFO  = 2;
+  private static final int DEBUG = 3;
+  private static final int TRACE = 4;
+
+  private final ConcurrentMap<String, org.slf4j.Logger> loggersCache = new ConcurrentHashMap<>();
+
+  /**
+   * Logs {@code message} at {@code level} for {@code requester}, through SLF4J. This fixed-arity
+   * overload (instead of varargs) keeps the common, no-parameter call path free of an {@code Object[]}
+   * allocation. When the level is disabled the message is neither formatted nor emitted. Non-null
+   * parameters are substituted printf-style ({@link String#formatted(Object...)}); a non-null
+   * {@code context} is prefixed as {@code <context> message}; and a non-null {@code exception} is
+   * passed to SLF4J as the throwable. A {@code null} message is ignored.
+   *
+   * @param requester the object, class or name the log line is attributed to (resolves the logger name)
+   * @param level     the {@link java.util.logging.Level}, mapped onto one of SLF4J's five levels
+   * @param message   the message, optionally a printf-style format string
+   * @param exception an optional throwable to log with the message
+   * @param context   an optional context tag prefixed to the message
+   * @param arg1      the first format argument (through {@code arg17}); trailing {@code null}s are unused
+   */
+  @Override
+  public void log(final Object requester, final Level level, final String message, final Throwable exception,
+      final String context,
+      final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6,
+      final Object arg7, final Object arg8, final Object arg9, final Object arg10, final Object arg11, final Object arg12,
+      final Object arg13, final Object arg14, final Object arg15, final Object arg16, final Object arg17) {
+    if (message == null)
+      return;
+
+    final org.slf4j.Logger log = resolveLogger(requester);
+    final int slf4jLevel = slf4jLevel(level);
+    if (!isEnabled(log, slf4jLevel))
+      return;
+
+    final boolean hasParams =
+        arg1 != null || arg2 != null || arg3 != null || arg4 != null || arg5 != null || arg6 != null || arg7 != null
+            || arg8 != null || arg9 != null || arg10 != null || arg11 != null || arg12 != null || arg13 != null
+            || arg14 != null || arg15 != null || arg16 != null || arg17 != null;
+
+    // Kept as an explicit 17-arg call (no Object[] wrapping) to preserve the interface's
+    // allocation-free path for the common, no-parameter case.
+    String msg = withContext(context, message);
+    if (hasParams) {
+      try {
+        msg = msg.formatted(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
+            arg15, arg16, arg17);
+      } catch (final Exception e) {
+        // Best-effort: keep the raw message if the arguments do not match the format string.
+      }
+    }
+
+    write(log, slf4jLevel, msg, exception);
+  }
+
+  /**
+   * Varargs form of {@link #log(Object, Level, String, Throwable, String, Object, Object, Object,
+   * Object, Object, Object, Object, Object, Object, Object, Object, Object, Object, Object, Object,
+   * Object, Object)} for call sites with an arbitrary number of arguments. Same semantics: level
+   * mapping and gating, printf-style substitution of {@code args}, {@code <context>} prefixing,
+   * optional throwable, and {@code null} messages ignored.
+   *
+   * @param requester the object, class or name the log line is attributed to
+   * @param level     the {@link java.util.logging.Level}, mapped onto one of SLF4J's five levels
+   * @param message   the message, optionally a printf-style format string
+   * @param exception an optional throwable to log with the message
+   * @param context   an optional context tag prefixed to the message
+   * @param args      the format arguments (may be empty)
+   */
+  @Override
+  public void log(final Object requester, final Level level, final String message, final Throwable exception,
+      final String context, final Object... args) {
+    if (message == null)
+      return;
+
+    final org.slf4j.Logger log = resolveLogger(requester);
+    final int slf4jLevel = slf4jLevel(level);
+    if (!isEnabled(log, slf4jLevel))
+      return;
+
+    String msg = withContext(context, message);
+    if (args != null && args.length > 0) {
+      try {
+        msg = msg.formatted(args);
+      } catch (final Exception e) {
+        // Best-effort: keep the raw message if the arguments do not match the format string.
+      }
+    }
+
+    write(log, slf4jLevel, msg, exception);
+  }
+
+  /**
+   * No-op. Unlike the {@code java.util.logging} logger, this implementation holds no handlers to
+   * flush: the SLF4J backend owns its appender lifecycle and flushing policy.
+   */
+  @Override
+  public void flush() {
+    // Intentionally empty.
+  }
+
+  /**
+   * Resolves the SLF4J logger for a requester, deriving its name the same way {@link DefaultLogger} does:
+   * a {@link String} is used verbatim, a {@link Class} contributes its fully-qualified name, any
+   * other object contributes its class name, and {@code null} falls back to {@value #DEFAULT_LOG}.
+   * Resolved loggers are cached locally to avoid repeated {@link LoggerFactory} lookups on the hot
+   * path.
+   */
+  private org.slf4j.Logger resolveLogger(final Object requester) {
+    final String name;
+    if (requester instanceof String string)
+      name = string;
+    else if (requester instanceof Class<?> clazz)
+      name = clazz.getName();
+    else if (requester != null)
+      name = requester.getClass().getName();
+    else
+      name = DEFAULT_LOG;
+
+    return loggersCache.computeIfAbsent(name, LoggerFactory::getLogger);
+  }
+
+  /** Prefixes the message with {@code <context> } when a context is set, otherwise returns it unchanged. */
+  private static String withContext(final String context, final String message) {
+    return context != null ? "<" + context + "> " + message : message;
+  }
+
+  /**
+   * Maps a {@link java.util.logging.Level} onto one of SLF4J's five levels by numeric weight, so
+   * custom or intermediate JUL levels also resolve: {@code >= SEVERE -> ERROR}, {@code >= WARNING ->
+   * WARN}, {@code >= INFO -> INFO}, {@code >= FINE -> DEBUG}, otherwise {@code TRACE}.
+   */
+  private static int slf4jLevel(final Level level) {
+    final int v = level.intValue();
+    if (v >= Level.SEVERE.intValue())
+      return ERROR;
+    if (v >= Level.WARNING.intValue())
+      return WARN;
+    if (v >= Level.INFO.intValue())
+      return INFO;
+    if (v >= Level.FINE.intValue())
+      return DEBUG;
+    return TRACE;
+  }
+
+  /** Whether {@code log} would emit at the given resolved SLF4J level; used to skip formatting when disabled. */
+  private static boolean isEnabled(final org.slf4j.Logger log, final int slf4jLevel) {
+    return switch (slf4jLevel) {
+      case ERROR -> log.isErrorEnabled();
+      case WARN -> log.isWarnEnabled();
+      case INFO -> log.isInfoEnabled();
+      case DEBUG -> log.isDebugEnabled();
+      default -> log.isTraceEnabled();
+    };
+  }
+
+  /**
+   * Emits the already-formatted message at the resolved SLF4J level, with the current
+   * {@link LogManager} correlation published to the MDC for the duration of the call and restored
+   * afterwards (see {@link #pushCorrelation}/{@link #restoreCorrelation}).
+   */
+  private void write(final org.slf4j.Logger log, final int slf4jLevel, final String msg, final Throwable exception) {
+    final LogManager.Correlation correlation = LogManager.instance().getCorrelation();
+    final String[] saved = pushCorrelation(correlation);
+    try {
+      switch (slf4jLevel) {
+      case ERROR -> {
+        if (exception != null) log.error(msg, exception); else log.error(msg);
+      }
+      case WARN -> {
+        if (exception != null) log.warn(msg, exception); else log.warn(msg);
+      }
+      case INFO -> {
+        if (exception != null) log.info(msg, exception); else log.info(msg);
+      }
+      case DEBUG -> {
+        if (exception != null) log.debug(msg, exception); else log.debug(msg);
+      }
+      default -> {
+        if (exception != null) log.trace(msg, exception); else log.trace(msg);
+      }
+      }
+    } finally {
+      restoreCorrelation(correlation, saved);
+    }
+  }
+
+  /**
+   * Puts each non-null correlation field into the MDC and returns the previous values (fixed order:
+   * requestId, database, traceId, spanId) for {@link #restoreCorrelation}. Returns {@code null} when
+   * there is no correlation to publish.
+   */
+  private static String[] pushCorrelation(final LogManager.Correlation correlation) {
+    if (correlation == null)
+      return null;
+
+    return new String[] {
+        swap(MDC_REQUEST_ID, correlation.requestId()),
+        swap(MDC_DATABASE, correlation.database()),
+        swap(MDC_TRACE_ID, correlation.traceId()),
+        swap(MDC_SPAN_ID, correlation.spanId())
+    };
+  }
+
+  /**
+   * Restores only the MDC keys that {@link #pushCorrelation} actually set (those whose correlation
+   * field was non-null). Keys for null fields were never touched, so leaving them alone preserves
+   * whatever the host application had placed there.
+   */
+  private static void restoreCorrelation(final LogManager.Correlation correlation, final String[] saved) {
+    if (correlation == null || saved == null)
+      return;
+
+    if (correlation.requestId() != null)
+      restore(MDC_REQUEST_ID, saved[0]);
+    if (correlation.database() != null)
+      restore(MDC_DATABASE, saved[1]);
+    if (correlation.traceId() != null)
+      restore(MDC_TRACE_ID, saved[2]);
+    if (correlation.spanId() != null)
+      restore(MDC_SPAN_ID, saved[3]);
+  }
+
+  /** Sets {@code key} to {@code value} when {@code value} is non-null, returning the previous value. */
+  private static String swap(final String key, final String value) {
+    if (value == null)
+      return null;
+    final String previous = MDC.get(key);
+    MDC.put(key, value);
+    return previous;
+  }
+
+  /** Puts {@code previous} back under {@code key}, or removes the key when there was no previous value. */
+  private static void restore(final String key, final String previous) {
+    if (previous != null)
+      MDC.put(key, previous);
+    else
+      MDC.remove(key);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
@@ -78,6 +78,7 @@ public class Slf4jLogger implements Logger {
    * @param arg1      the first format argument (through {@code arg17}); trailing {@code null}s are unused
    */
   @Override
+  @SuppressWarnings("PMD.ExcessiveParameterList") // 17 args are mandated by the Logger interface (allocation-free path)
   public void log(final Object requester, final Level level, final String message, final Throwable exception,
       final String context,
       final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6,
@@ -188,6 +189,7 @@ public class Slf4jLogger implements Logger {
    * method's complexity low; takes the arguments explicitly (no {@code Object[]}) so the
    * no-parameter path stays allocation-free.
    */
+  @SuppressWarnings("PMD.ExcessiveParameterList") // mirrors the 17-arg log() overload; no Object[] on purpose
   private static boolean anyNonNull(final Object arg1, final Object arg2, final Object arg3, final Object arg4,
       final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9, final Object arg10,
       final Object arg11, final Object arg12, final Object arg13, final Object arg14, final Object arg15,

--- a/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/Slf4jLogger.java
@@ -63,6 +63,16 @@ public class Slf4jLogger implements Logger {
   private static final int TRACE = 4;
 
   /**
+   * Binds to SLF4J eagerly, so that a missing or broken {@code slf4j-api} surfaces while the logger
+   * is being constructed - where {@link LogManager} still falls back to {@link DefaultLogger} -
+   * rather than as a {@link NoClassDefFoundError} escaping from the first log statement, deep inside
+   * unrelated engine code.
+   */
+  public Slf4jLogger() {
+    LoggerFactory.getILoggerFactory();
+  }
+
+  /**
    * Logs {@code message} at {@code level} for {@code requester}, through SLF4J. This fixed-arity
    * overload (instead of varargs) keeps the common, no-parameter call path free of an {@code Object[]}
    * allocation. When the level is disabled the message is neither formatted nor emitted. Non-null
@@ -234,30 +244,67 @@ public class Slf4jLogger implements Logger {
    * Emits the already-formatted message at the resolved SLF4J level, with the current
    * {@link LogManager} correlation published to the MDC for the duration of the call and restored
    * afterwards (see {@link #pushCorrelation}/{@link #restoreCorrelation}).
+   * <p>
+   * Once the JVM is shutting down the backend's own shutdown hook may already have stopped the
+   * logging context, which would silently swallow the line; from that point on messages of INFO
+   * severity and above go straight to {@code System.err}, mirroring {@link DefaultLogger}.
    */
   private void write(final org.slf4j.Logger log, final int slf4jLevel, final String msg, final Throwable exception) {
+    if (DefaultLogger.isShuttingDown()) {
+      if (slf4jLevel <= INFO)
+        writeToSystemErr(msg, exception);
+      return;
+    }
+
     final LogManager.Correlation correlation = LogManager.instance().getCorrelation();
     final String[] saved = pushCorrelation(correlation);
     try {
       switch (slf4jLevel) {
       case ERROR -> {
-        if (exception != null) log.error(msg, exception); else log.error(msg);
+        if (exception != null)
+          log.error(msg, exception);
+        else
+          log.error(msg);
       }
       case WARN -> {
-        if (exception != null) log.warn(msg, exception); else log.warn(msg);
+        if (exception != null)
+          log.warn(msg, exception);
+        else
+          log.warn(msg);
       }
       case INFO -> {
-        if (exception != null) log.info(msg, exception); else log.info(msg);
+        if (exception != null)
+          log.info(msg, exception);
+        else
+          log.info(msg);
       }
       case DEBUG -> {
-        if (exception != null) log.debug(msg, exception); else log.debug(msg);
+        if (exception != null)
+          log.debug(msg, exception);
+        else
+          log.debug(msg);
       }
       default -> {
-        if (exception != null) log.trace(msg, exception); else log.trace(msg);
+        if (exception != null)
+          log.trace(msg, exception);
+        else
+          log.trace(msg);
       }
       }
     } finally {
       restoreCorrelation(correlation, saved);
+    }
+  }
+
+  /** Last-resort emission used while the JVM shuts down and the SLF4J backend may already be stopped. */
+  private static void writeToSystemErr(final String msg, final Throwable exception) {
+    try {
+      System.err.println(msg);
+      if (exception != null)
+        exception.printStackTrace(System.err);
+      System.err.flush();
+    } catch (final Exception e) {
+      // Silently ignore errors during shutdown logging.
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/log/LogManagerLoggerSelectionTest.java
+++ b/engine/src/test/java/com/arcadedb/log/LogManagerLoggerSelectionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.log;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies how {@link LogManager} picks its {@link Logger} implementation from
+ * {@link LogManager#LOG_IMPL_PROPERTY}: the default stays {@code java.util.logging}, {@code slf4j}
+ * selects {@link Slf4jLogger}, and an unrecognized value falls back to the default but is reported
+ * rather than swallowed.
+ */
+class LogManagerLoggerSelectionTest {
+  @AfterEach
+  void tearDown() {
+    System.clearProperty(LogManager.LOG_IMPL_PROPERTY);
+  }
+
+  @Test
+  void unsetPropertyKeepsTheJavaUtilLoggingLogger() {
+    System.clearProperty(LogManager.LOG_IMPL_PROPERTY);
+
+    assertThat(LogManager.createLogger()).isInstanceOf(DefaultLogger.class);
+  }
+
+  @Test
+  void explicitDefaultKeepsTheJavaUtilLoggingLogger() {
+    System.setProperty(LogManager.LOG_IMPL_PROPERTY, "default");
+
+    assertThat(LogManager.createLogger()).isInstanceOf(DefaultLogger.class);
+  }
+
+  @Test
+  void slf4jSelectsTheSlf4jLogger() {
+    System.setProperty(LogManager.LOG_IMPL_PROPERTY, "SLF4J"); // case-insensitive
+
+    assertThat(LogManager.createLogger()).isInstanceOf(Slf4jLogger.class);
+  }
+
+  @Test
+  void unknownValueFallsBackToDefaultAndIsReported() {
+    // A typo must not look like a working configuration: it falls back, but says so.
+    System.setProperty(LogManager.LOG_IMPL_PROPERTY, "slf4");
+
+    final PrintStream originalErr = System.err;
+    final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(captured, true));
+    final Logger logger;
+    try {
+      logger = LogManager.createLogger();
+    } finally {
+      System.setErr(originalErr);
+    }
+
+    assertThat(logger).isInstanceOf(DefaultLogger.class);
+    assertThat(captured.toString()).contains("slf4").contains(LogManager.LOG_IMPL_PROPERTY);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/log/Slf4jLoggerTest.java
+++ b/engine/src/test/java/com/arcadedb/log/Slf4jLoggerTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.log;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link Slf4jLogger}. The engine test classpath binds {@code slf4j-jdk14}, so SLF4J
+ * routes back to {@code java.util.logging}; the tests capture the resulting {@link LogRecord}s on the
+ * target JUL logger to assert level mapping, printf-style parameter substitution and context
+ * prefixing. MDC behaviour is asserted directly against {@link MDC}, which is backend-independent.
+ */
+class Slf4jLoggerTest {
+  private static final String LOGGER_NAME = "com.arcadedb.log.Slf4jLoggerTest.sample";
+
+  private final Slf4jLogger                logger   = new Slf4jLogger();
+  private final List<Runnable>             cleanups = new ArrayList<>();
+  private       java.util.logging.Logger   julLogger;
+  private       CapturingHandler           handler;
+  private       Level                      previousLevel;
+  private       boolean                    previousUseParent;
+
+  @BeforeEach
+  void setUp() {
+    julLogger = java.util.logging.Logger.getLogger(LOGGER_NAME);
+    previousLevel = julLogger.getLevel();
+    previousUseParent = julLogger.getUseParentHandlers();
+    julLogger.setLevel(Level.ALL);
+    julLogger.setUseParentHandlers(false);
+    handler = new CapturingHandler();
+    julLogger.addHandler(handler);
+    MDC.clear();
+    LogManager.instance().clearCorrelation();
+  }
+
+  @AfterEach
+  void tearDown() {
+    julLogger.removeHandler(handler);
+    julLogger.setLevel(previousLevel);
+    julLogger.setUseParentHandlers(previousUseParent);
+    cleanups.forEach(Runnable::run);
+    cleanups.clear();
+    MDC.clear();
+    LogManager.instance().clearCorrelation();
+  }
+
+  /** Attaches a capturing handler to the JUL logger of the given name, registered for teardown. */
+  private CapturingHandler captureOn(final String name) {
+    final java.util.logging.Logger target = java.util.logging.Logger.getLogger(name);
+    final Level previous = target.getLevel();
+    final boolean parent = target.getUseParentHandlers();
+    target.setLevel(Level.ALL);
+    target.setUseParentHandlers(false);
+    final CapturingHandler h = new CapturingHandler();
+    target.addHandler(h);
+    cleanups.add(() -> {
+      target.removeHandler(h);
+      target.setLevel(previous);
+      target.setUseParentHandlers(parent);
+    });
+    return h;
+  }
+
+  @Test
+  void substitutesPrintfParametersAndPrefixesContext() {
+    logger.log(LOGGER_NAME, Level.WARNING, "started on port %s in %s ms", null, "boot", 2480, 37);
+
+    assertThat(handler.records).hasSize(1);
+    assertThat(handler.records.get(0).getMessage()).isEqualTo("<boot> started on port 2480 in 37 ms");
+  }
+
+  @Test
+  void mapsJulLevelsOntoTheFiveSlf4jLevels() {
+    logger.log(LOGGER_NAME, Level.SEVERE, "a", null, null);
+    logger.log(LOGGER_NAME, Level.WARNING, "b", null, null);
+    logger.log(LOGGER_NAME, Level.INFO, "c", null, null);
+    logger.log(LOGGER_NAME, Level.FINE, "d", null, null);
+    logger.log(LOGGER_NAME, Level.FINEST, "e", null, null);
+
+    // slf4j-jdk14 maps SLF4J levels back to JUL as: ERROR->SEVERE, WARN->WARNING, INFO->INFO,
+    // DEBUG->FINE, TRACE->FINEST. A correct DefaultLevel mapping therefore round-trips exactly.
+    assertThat(handler.records).extracting(LogRecord::getLevel)
+        .containsExactly(Level.SEVERE, Level.WARNING, Level.INFO, Level.FINE, Level.FINEST);
+  }
+
+  @Test
+  void nullMessageIsIgnored() {
+    logger.log(LOGGER_NAME, Level.SEVERE, null, null, null);
+    assertThat(handler.records).isEmpty();
+  }
+
+  @Test
+  void correlationIsExposedThenRemovedFromMdcAfterLogging() {
+    LogManager.instance().setCorrelation("req-1", "mydb", null, null);
+
+    handler.onPublish = record -> {
+      // While the log call is in flight the correlation must be visible to the backend via MDC.
+      assertThat(MDC.get("arcadedb.requestId")).isEqualTo("req-1");
+      assertThat(MDC.get("arcadedb.database")).isEqualTo("mydb");
+    };
+    logger.log(LOGGER_NAME, Level.INFO, "with correlation", null, null);
+
+    // Keys we set (non-null fields) must be removed again; null fields are never touched.
+    assertThat(MDC.get("arcadedb.requestId")).isNull();
+    assertThat(MDC.get("arcadedb.database")).isNull();
+    assertThat(MDC.get("arcadedb.traceId")).isNull();
+  }
+
+  @Test
+  void preExistingMdcValueUnderAnArcadeKeyIsPreserved() {
+    // The host application already uses one of the namespaced keys: logging must not clobber it.
+    MDC.put("arcadedb.traceId", "host-trace");
+    LogManager.instance().setCorrelation("req-2", null, "arcade-trace", null);
+
+    handler.onPublish = record -> assertThat(MDC.get("arcadedb.traceId")).isEqualTo("arcade-trace");
+    logger.log(LOGGER_NAME, Level.INFO, "overlapping key", null, null);
+
+    assertThat(MDC.get("arcadedb.traceId")).isEqualTo("host-trace");
+    // requestId had no prior value, so it must be cleared rather than left behind.
+    assertThat(MDC.get("arcadedb.requestId")).isNull();
+  }
+
+  @Test
+  void resolvesLoggerNameFromClassRequester() {
+    final CapturingHandler byClass = captureOn(Slf4jLoggerTest.class.getName());
+
+    logger.log(Slf4jLoggerTest.class, Level.INFO, "from a class", null, null);
+
+    assertThat(byClass.records).hasSize(1);
+    assertThat(handler.records).isEmpty(); // routed to the class logger, not LOGGER_NAME
+  }
+
+  @Test
+  void resolvesDefaultLoggerNameForNullRequester() {
+    final CapturingHandler byDefault = captureOn("com.arcadedb");
+
+    logger.log(null, Level.INFO, "no requester", null, null);
+
+    assertThat(byDefault.records).hasSize(1);
+    assertThat(byDefault.records.get(0).getMessage()).isEqualTo("no requester");
+  }
+
+  @Test
+  void supportsTheFixedArityOverload() {
+    // The 17-argument overload exists to avoid an Object[] allocation on the common path; exercise it
+    // directly with a single argument and the rest null.
+    logger.log(LOGGER_NAME, Level.INFO, "id=%s", null, null, "abc", null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null);
+
+    assertThat(handler.records).hasSize(1);
+    assertThat(handler.records.get(0).getMessage()).isEqualTo("id=abc");
+  }
+
+  @Test
+  void skipsEmissionWhenLevelIsDisabled() {
+    julLogger.setLevel(Level.SEVERE); // only ERROR-equivalent passes
+
+    logger.log(LOGGER_NAME, Level.INFO, "should be filtered", null, null);
+
+    assertThat(handler.records).isEmpty();
+  }
+
+  @Test
+  void leavesLiteralPercentUntouchedWhenThereAreNoArguments() {
+    logger.log(LOGGER_NAME, Level.INFO, "progress 50% complete", null, null);
+
+    assertThat(handler.records).hasSize(1);
+    assertThat(handler.records.get(0).getMessage()).isEqualTo("progress 50% complete");
+  }
+
+  @Test
+  void keepsRawMessageWhenFormattingFails() {
+    // "%d" with a String argument throws IllegalFormatException; the raw message must be kept and no
+    // exception must escape (best-effort, matching DefaultLogger).
+    logger.log(LOGGER_NAME, Level.INFO, "value=%d", null, null, "not-a-number");
+
+    assertThat(handler.records).hasSize(1);
+    assertThat(handler.records.get(0).getMessage()).isEqualTo("value=%d");
+  }
+
+  @Test
+  void passesTheThrowableToTheBackend() {
+    final RuntimeException boom = new RuntimeException("kaboom");
+
+    logger.log(LOGGER_NAME, Level.SEVERE, "failed", boom, null);
+
+    assertThat(handler.records).hasSize(1);
+    assertThat(handler.records.get(0).getThrown()).isSameAs(boom);
+  }
+
+  private static final class CapturingHandler extends Handler {
+    private final List<LogRecord>            records   = new ArrayList<>();
+    private       java.util.function.Consumer<LogRecord> onPublish = null;
+
+    @Override
+    public void publish(final LogRecord record) {
+      if (onPublish != null)
+        onPublish.accept(record);
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/log/Slf4jLoggerTest.java
+++ b/engine/src/test/java/com/arcadedb/log/Slf4jLoggerTest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -215,9 +218,45 @@ class Slf4jLoggerTest {
     assertThat(handler.records.get(0).getThrown()).isSameAs(boom);
   }
 
+  @Test
+  void bypassesTheBackendOnceTheJvmIsShuttingDown() {
+    // The SLF4J backend registers its own shutdown hook and may already have stopped its appenders,
+    // which would silently swallow the line: shutdown-path messages must go to System.err instead.
+    final PrintStream originalErr = System.err;
+    final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(captured, true));
+    DefaultLogger.setShuttingDown(true);
+    try {
+      logger.log(LOGGER_NAME, Level.SEVERE, "shutting down now", null, null);
+    } finally {
+      DefaultLogger.setShuttingDown(false);
+      System.setErr(originalErr);
+    }
+
+    assertThat(handler.records).isEmpty();
+    assertThat(captured.toString()).contains("shutting down now");
+  }
+
+  @Test
+  void dropsBelowInfoMessagesWhileShuttingDown() {
+    final PrintStream originalErr = System.err;
+    final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(captured, true));
+    DefaultLogger.setShuttingDown(true);
+    try {
+      logger.log(LOGGER_NAME, Level.FINE, "noisy debug line", null, null);
+    } finally {
+      DefaultLogger.setShuttingDown(false);
+      System.setErr(originalErr);
+    }
+
+    assertThat(handler.records).isEmpty();
+    assertThat(captured.toString()).doesNotContain("noisy debug line");
+  }
+
   private static final class CapturingHandler extends Handler {
-    private final List<LogRecord>            records   = new ArrayList<>();
-    private       java.util.function.Consumer<LogRecord> onPublish = null;
+    private final List<LogRecord>       records   = new ArrayList<>();
+    private       Consumer<LogRecord>   onPublish = null;
 
     @Override
     public void publish(final LogRecord record) {

--- a/examples/logging/README.md
+++ b/examples/logging/README.md
@@ -1,0 +1,83 @@
+# Logging when embedding ArcadeDB
+
+ArcadeDB routes its logs through the **SLF4J facade** when the SLF4J logger is selected:
+
+```
+-Darcadedb.log.impl=slf4j
+```
+
+The default logger is unchanged (`java.util.logging` with ArcadeDB's built-in text/ANSI and JSON
+formats, selectable via `arcadedb.server.logFormat`), so standalone deployments behave exactly as
+before. Selecting `slf4j` makes the engine log through `slf4j-api` only — the engine pins **no**
+backend, so the embedding application picks the backend it already uses and needs **no dependency
+exclusions**.
+
+Add exactly **one** SLF4J binding and drop in the matching config file from this folder.
+
+## Logback (`logback.xml`)
+
+Add the binding:
+
+```xml
+<dependency>
+  <groupId>ch.qos.logback</groupId>
+  <artifactId>logback-classic</artifactId>
+</dependency>
+```
+
+`logback.xml` shows an ANSI-coloured console (equivalent to ArcadeDB's native `text` format) and a
+structured JSON console using Logback's built-in `JsonEncoder` (Logback ≥ 1.5). Spring Boot pulls
+in `logback-classic` by default, so embedding ArcadeDB in a Spring Boot app needs nothing extra.
+
+## Log4j2 (`log4j2.xml`)
+
+Add the binding and (for JSON) the template layout:
+
+```xml
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-slf4j2-impl</artifactId>
+</dependency>
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-core</artifactId>
+</dependency>
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-layout-template-json</artifactId> <!-- only for the JSON layout -->
+</dependency>
+```
+
+`log4j2.xml` shows the same two formats (ANSI console + ECS-style JSON via `JsonTemplateLayout`).
+
+## Feature parity with the native (java.util.logging) logger
+
+Everything ArcadeDB's built-in logger does is configured, under SLF4J, in the backend. Mapping:
+
+| ArcadeDB native feature | Native setting | Logback | Log4j2 |
+|---|---|---|---|
+| Console format: text / JSON | `arcadedb.server.logFormat=text\|json` | `CONSOLE` appender (pattern) / `JSON` appender (`JsonEncoder`) | `Console` (PatternLayout) / `Json` (`JsonTemplateLayout`) |
+| Log destination folder | `arcadedb.server.logsDirectory` (default `./log`) | `${LOG_DIR}` property → `-Darcadedb.logs.dir=/path` (default `./logs`) | `${sys:arcadedb.logs.dir}` property → `-Darcadedb.logs.dir=/path` |
+| Include trace id/span on each line | `arcadedb.server.logIncludeTrace=true` | add `%X{arcadedb.traceId:-} %X{arcadedb.spanId:-}` to the pattern | add `%X{arcadedb.traceId} %X{arcadedb.spanId}` to the pattern |
+| Per-package verbosity | `arcadedb-log.properties` levels | `<logger name="com.arcadedb" level="INFO"/>` | `<Logger name="com.arcadedb" level="INFO"/>` |
+| Correlation fields in JSON | emitted by `JsonLogFormatter` | `JsonEncoder` includes the MDC automatically | `JsonTemplateLayout` includes the ThreadContext/MDC |
+| Stack traces | printed by the formatter | printed by default (`%ex` / encoder) | printed by default (`%throwable` / template) |
+
+The correlation field names differ slightly between the native JSON formatter and the MDC keys: the
+native `JsonLogFormatter` emits `requestId`, `db`, `traceId`, `spanId`; over SLF4J the same values are
+exposed in the MDC as `arcadedb.requestId`, `arcadedb.database`, `arcadedb.traceId`, `arcadedb.spanId`
+(namespaced to avoid clobbering the host application's own MDC keys). Rename them in your JSON
+layout/encoder if you need the exact native field names.
+
+## Logger names and correlation (MDC)
+
+- ArcadeDB loggers are named after the emitting class: `com.arcadedb.*`. Set levels per package.
+- Per-request correlation is placed in the SLF4J **MDC** under:
+  `arcadedb.requestId`, `arcadedb.database`, `arcadedb.traceId`, `arcadedb.spanId`.
+  Reference them in a pattern with `%X{arcadedb.requestId}` (Logback and Log4j2 alike), or rely on
+  the JSON encoders, which include the MDC automatically.
+
+## Want plain `java.util.logging`?
+
+You don't need the SLF4J logger for that: either keep the default logger, or select the SLF4J logger
+and add the `org.slf4j:slf4j-jdk14` binding — SLF4J will forward to JUL.

--- a/examples/logging/README.md
+++ b/examples/logging/README.md
@@ -57,7 +57,7 @@ Everything ArcadeDB's built-in logger does is configured, under SLF4J, in the ba
 | ArcadeDB native feature | Native setting | Logback | Log4j2 |
 |---|---|---|---|
 | Console format: text / JSON | `arcadedb.server.logFormat=text\|json` | `CONSOLE` appender (pattern) / `JSON` appender (`JsonEncoder`) | `Console` (PatternLayout) / `Json` (`JsonTemplateLayout`) |
-| Log destination folder | `arcadedb.server.logsDirectory` (default `./log`) | `${LOG_DIR}` property → `-Darcadedb.logs.dir=/path` (default `./logs`) | `${sys:arcadedb.logs.dir}` property → `-Darcadedb.logs.dir=/path` |
+| Log destination folder | `arcadedb.server.logsDirectory` (default `./log`) | `${LOG_DIR}` property → `-Darcadedb.logs.dir=/path` (default `./log`) | `${sys:arcadedb.logs.dir}` property → `-Darcadedb.logs.dir=/path` (default `./log`) |
 | Include trace id/span on each line | `arcadedb.server.logIncludeTrace=true` | add `%X{arcadedb.traceId:-} %X{arcadedb.spanId:-}` to the pattern | add `%X{arcadedb.traceId} %X{arcadedb.spanId}` to the pattern |
 | Per-package verbosity | `arcadedb-log.properties` levels | `<logger name="com.arcadedb" level="INFO"/>` | `<Logger name="com.arcadedb" level="INFO"/>` |
 | Correlation fields in JSON | emitted by `JsonLogFormatter` | `JsonEncoder` includes the MDC automatically | `JsonTemplateLayout` includes the ThreadContext/MDC |

--- a/examples/logging/README.md
+++ b/examples/logging/README.md
@@ -77,6 +77,16 @@ layout/encoder if you need the exact native field names.
   Reference them in a pattern with `%X{arcadedb.requestId}` (Logback and Log4j2 alike), or rely on
   the JSON encoders, which include the MDC automatically.
 
+## Note for the standalone server distribution
+
+The SLF4J logger deliberately leaves all configuration to the backend, so it never reads
+`config/arcadedb-log.properties`. The distribution bundles the `slf4j-jdk14` binding, so setting
+`-Darcadedb.log.impl=slf4j` on a packaged server still logs through `java.util.logging` - but the
+`FileHandler` and the ANSI/JSON formatter declared in `config/arcadedb-log.properties` are no longer
+installed, which means the rolling `log/arcadedb.log.*` files stop being written. Either keep the
+default logger on the standalone server, or point JUL at that file yourself with
+`-Djava.util.logging.config.file=config/arcadedb-log.properties`.
+
 ## Want plain `java.util.logging`?
 
 You don't need the SLF4J logger for that: either keep the default logger, or select the SLF4J logger

--- a/examples/logging/log4j2.xml
+++ b/examples/logging/log4j2.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Example Log4j2 configuration for an application that EMBEDS ArcadeDB.
+
+  ArcadeDB logs through the SLF4J facade when the SLF4J logger is selected with
+  -Darcadedb.log.impl=slf4j. To route those logs through Log4j2, put these on the classpath:
+      org.apache.logging.log4j:log4j-slf4j2-impl        (SLF4J 2.x binding -> Log4j2)
+      org.apache.logging.log4j:log4j-core
+      org.apache.logging.log4j:log4j-layout-template-json  (only for the JSON layout below)
+  and place this file as `log4j2.xml` on the classpath.
+
+  - ArcadeDB loggers are named after the emitting class (com.arcadedb.*).
+  - Per-request correlation is published to the SLF4J MDC, which Log4j2 exposes as the
+    ThreadContext map; reference it with %X{key}:
+      arcadedb.requestId, arcadedb.database, arcadedb.traceId, arcadedb.spanId
+
+  This example reproduces the two formats ArcadeDB offers natively on the JUL logger:
+  an ANSI-coloured console (Console) and a structured JSON console (Json).
+-->
+<Configuration status="WARN">
+  <Properties>
+    <!-- Destination folder for log files. Override with -Darcadedb.logs.dir=/path; defaults to
+         ./logs. This is the SLF4J-backend equivalent of the native `arcadedb.server.logsDirectory`. -->
+    <Property name="LOG_DIR">${sys:arcadedb.logs.dir:-logs}</Property>
+  </Properties>
+
+  <Appenders>
+    <!-- Human-readable, ANSI-coloured console (equivalent to the native "text" format). -->
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout disableAnsi="false"
+                     pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level} [%t] %style{%logger{36}}{cyan} %X{arcadedb.requestId} %X{arcadedb.database} - %msg%n"/>
+    </Console>
+
+    <!-- Structured JSON console (requires log4j-layout-template-json). The ECS template includes
+         the ThreadContext/MDC (arcadedb.* keys). -->
+    <Console name="Json" target="SYSTEM_OUT">
+      <JsonTemplateLayout eventTemplateUri="classpath:EcsLayout.json"/>
+    </Console>
+
+    <!-- Rolling file in ${LOG_DIR}: one file per day, kept for 7 days, compressed on roll. -->
+    <RollingFile name="File" fileName="${LOG_DIR}/arcadedb.log"
+                 filePattern="${LOG_DIR}/arcadedb-%d{yyyy-MM-dd}.log.gz">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %X{arcadedb.requestId} %X{arcadedb.database} - %msg%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy/>
+      </Policies>
+      <DefaultRolloverStrategy max="7"/>
+    </RollingFile>
+  </Appenders>
+
+  <Loggers>
+    <!-- Tune ArcadeDB verbosity here. -->
+    <Logger name="com.arcadedb" level="INFO"/>
+
+    <Root level="WARN">
+      <AppenderRef ref="Console"/>
+      <!-- Add file output, and/or swap Console for structured JSON:
+      <AppenderRef ref="File"/>
+      <AppenderRef ref="Json"/>
+      -->
+    </Root>
+  </Loggers>
+</Configuration>

--- a/examples/logging/log4j2.xml
+++ b/examples/logging/log4j2.xml
@@ -21,7 +21,7 @@
   <Properties>
     <!-- Destination folder for log files. Override with -Darcadedb.logs.dir=/path; defaults to
          ./logs. This is the SLF4J-backend equivalent of the native `arcadedb.server.logsDirectory`. -->
-    <Property name="LOG_DIR">${sys:arcadedb.logs.dir:-logs}</Property>
+    <Property name="LOG_DIR">${sys:arcadedb.logs.dir:-log}</Property>
   </Properties>
 
   <Appenders>

--- a/examples/logging/logback.xml
+++ b/examples/logging/logback.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Example Logback configuration for an application that EMBEDS ArcadeDB.
+
+  ArcadeDB logs through the SLF4J facade when the SLF4J logger is selected with
+  -Darcadedb.log.impl=slf4j. To route those logs through Logback, put logback-classic
+  on the classpath (it is the SLF4J binding) and place this file as `logback.xml` on
+  the classpath.
+
+  - ArcadeDB loggers are named after the emitting class (com.arcadedb.*), so you can tune
+    verbosity per package below.
+  - Per-request correlation is published to the MDC under these keys:
+      arcadedb.requestId, arcadedb.database, arcadedb.traceId, arcadedb.spanId
+    Reference them in a pattern with %X{key} (the ":-" gives an empty default when absent).
+
+  This example reproduces the two formats ArcadeDB offers natively on the JUL logger:
+  an ANSI-coloured, human-readable console (CONSOLE) and a structured JSON console (JSON).
+-->
+<configuration>
+
+  <!-- Destination folder for log files. Override with -Darcadedb.logs.dir=/path (or an
+       ARCADEDB_LOGS_DIR env var); defaults to ./logs. This is the SLF4J-backend equivalent of the
+       native logger's `arcadedb.server.logsDirectory`. -->
+  <property name="LOG_DIR" value="${arcadedb.logs.dir:-${ARCADEDB_LOGS_DIR:-logs}}"/>
+
+  <!-- Human-readable, ANSI-coloured console (equivalent to the native "text" format). -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{36}) %X{arcadedb.requestId:-} %X{arcadedb.database:-} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Rolling file in ${LOG_DIR}: one file per day, kept for 7 days, compressed on roll. -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_DIR}/arcadedb.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_DIR}/arcadedb-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+      <maxHistory>7</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} %X{arcadedb.requestId:-} %X{arcadedb.database:-} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Structured JSON console using Logback's built-in JsonEncoder (Logback >= 1.5, no extra
+       dependency). MDC entries (arcadedb.*) are emitted automatically. For richer/ECS-style JSON
+       use net.logstash.logback:logstash-logback-encoder instead. -->
+  <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="ch.qos.logback.classic.encoder.JsonEncoder"/>
+  </appender>
+
+  <!-- Tune ArcadeDB verbosity here. -->
+  <logger name="com.arcadedb" level="INFO"/>
+
+  <root level="WARN">
+    <appender-ref ref="CONSOLE"/>
+    <!-- Add file output, and/or swap CONSOLE for JSON to emit structured logs:
+    <appender-ref ref="FILE"/>
+    <appender-ref ref="JSON"/>
+    -->
+  </root>
+</configuration>

--- a/examples/logging/logback.xml
+++ b/examples/logging/logback.xml
@@ -21,7 +21,7 @@
   <!-- Destination folder for log files. Override with -Darcadedb.logs.dir=/path (or an
        ARCADEDB_LOGS_DIR env var); defaults to ./logs. This is the SLF4J-backend equivalent of the
        native logger's `arcadedb.server.logsDirectory`. -->
-  <property name="LOG_DIR" value="${arcadedb.logs.dir:-${ARCADEDB_LOGS_DIR:-logs}}"/>
+  <property name="LOG_DIR" value="${arcadedb.logs.dir:-${ARCADEDB_LOGS_DIR:-log}}"/>
 
   <!-- Human-readable, ANSI-coloured console (equivalent to the native "text" format). -->
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -278,6 +278,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Runtime SLF4J binding bundled into the distribution: routes third-party SLF4J logs
+             (dependencies) to java.util.logging. Declared here at runtime because the parent keeps
+             slf4j-jdk14 at test scope so it does not leak to consumers of the library modules. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -541,10 +541,17 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- SLF4J JUL binding, TEST scope only. ArcadeDB is a library: it must expose the slf4j-api
+             facade but never force a binding onto downstream consumers (a compile/runtime binding
+             here would leak transitively and require every embedder to add exclusions). Kept at test
+             scope so module tests still emit logs (through java.util.logging, matching the test
+             arcadedb-log.properties). The runnable distribution declares its own runtime binding
+             (see server/pom.xml). -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -545,8 +545,8 @@
              facade but never force a binding onto downstream consumers (a compile/runtime binding
              here would leak transitively and require every embedder to add exclusions). Kept at test
              scope so module tests still emit logs (through java.util.logging, matching the test
-             arcadedb-log.properties). The runnable distribution declares its own runtime binding
-             (see server/pom.xml). -->
+             arcadedb-log.properties). The runnable artifacts declare their own runtime binding
+             (see console/pom.xml and package/pom.xml). -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -68,17 +68,11 @@
       <artifactId>undertow-core</artifactId>
       <version>${undertow-core.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
+    <!-- No SLF4J declaration here on purpose. The slf4j-api facade already arrives from
+         arcadedb-engine, and pinning a binding (slf4j-jdk14) at compile scope would leak it
+         transitively to every application embedding arcadedb-server, forcing them to add
+         <exclusions>. The runnable artifacts (console, package) declare the binding themselves at
+         runtime scope. -->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>


### PR DESCRIPTION
Closes #4276 (opt-in first step).

## Summary

Adds an **opt-in** `Slf4jLogger` that routes ArcadeDB's logs through the **SLF4J facade**, so an application embedding ArcadeDB receives the engine's logs in whatever backend it already uses (Logback, Log4j2, reload4j, or `java.util.logging` via `slf4j-jdk14`) — with **no dependency exclusions**.

It is deliberately **non-disruptive**: the default logger is unchanged (`DefaultLogger`, `java.util.logging`, with the existing text/ANSI and JSON formatting), so standalone and current deployments behave exactly as before. This matches the plan agreed in #4276; SLF4J can be made the default in a follow-up if you'd prefer.

## How to enable

Startup, no code change:
```
-Darcadedb.log.impl=slf4j
```
or programmatically:
```java
LogManager.instance().setLogger(new Slf4jLogger());
```

## What changed

- **`engine/.../log/Slf4jLogger.java`** (new) — a `com.arcadedb.log.Logger` that delegates to `org.slf4j`:
  - maps `java.util.logging.Level` onto SLF4J's five levels by numeric weight (`SEVERE→ERROR`, `WARNING→WARN`, `INFO→INFO`, `FINE→DEBUG`, else `TRACE`), so custom/intermediate JUL levels also resolve;
  - preserves the call-site contract of `DefaultLogger`: logger name resolved from the requester (String / Class / instance / `com.arcadedb` fallback), `<context>` prefixing, and **printf-style (`%s`)** message formatting (not SLF4J `{}` placeholders), which is how ArcadeDB messages are written;
  - skips formatting entirely when the level is disabled;
  - exposes the per-request correlation carried by `LogManager` (`requestId`, `database`, `traceId`, `spanId`) to the backend via **MDC** under `arcadedb.*` keys, **saving and restoring** any pre-existing values so the host application's MDC is left untouched.
- **`engine/.../log/LogManager.java`** — selects the implementation from the new `arcadedb.log.impl` system property (default = `DefaultLogger`; `slf4j` = `Slf4jLogger`); falls back to `DefaultLogger` if construction fails, so a misconfiguration never silences logging.
- **`engine/pom.xml`** — adds `slf4j-api` only. The engine pins **no** backend.
- **`pom.xml`** — moves `slf4j-jdk14` to **`test`** scope. It was a compile-scope dependency in the parent `<dependencies>`, so it leaked transitively to consumers of every library module (forcing exclusions). At test scope, module tests still log through JUL while nothing is imposed on downstream consumers.
- **`examples/logging/`** (new) — ready-to-use `logback.xml` and `log4j2.xml` (console + JSON + rolling file, configurable log directory) and a `README.md` mapping every native logging feature (`arcadedb.server.logFormat`, `logIncludeTrace`, `logsDirectory`, per-package levels, correlation) to its Logback/Log4j2 equivalent.

`DefaultLogger`, `ArcadeDBServer`, `GlobalConfiguration` and the existing logging tests are **untouched**.

## Dependency hygiene

Embedding `arcadedb-engine` now pulls only `slf4j-api`; the embedder provides exactly one binding and needs no `<exclusions>`. To get plain JUL, add `slf4j-jdk14` and SLF4J forwards to it.

## Backward compatibility

Default behaviour is unchanged (JUL `DefaultLogger`), so there is no regression for standalone or existing embedders. SLF4J routing is entirely opt-in.

## Testing

- New `Slf4jLoggerTest` (12 tests): level mapping, printf substitution, `<context>` prefixing, logger-name resolution (String/Class/null), the fixed-arity overload, level gating, literal `%` without args, best-effort fallback when a format string doesn't match its args, throwable pass-through, and MDC publish/restore (including preserving a host value under an `arcadedb.*` key).
- All existing logging tests pass unchanged (`LoggerTest`, `DefaultLoggerLogDirTest`, `DefaultFormatterUnchangedTest`, `LogCorrelationContextTest`, `LogFormatterTraceTagTest`, `JsonLogFormatterTest`, `LogFormatterMessageFormatTest`) — 48 logging tests green in total.
- Full `arcadedb-engine` test suite: the only failure is a pre-existing one on `main` (`LSMTreeSortedBuildCrashTest.crashAfterAttachmentLeavesSchemaUnpublishedAndAllowsRetry`), reproduced identically on a clean checkout without this change — unrelated to logging.
- Verified end-to-end with Logback on the classpath (no `slf4j-jdk14`): logs are emitted by Logback with correct level mapping, `%s` substitution, MDC correlation populated during the call and cleared afterwards.

## Note

One small thing worth a maintainer's eye: the repo's `.gitignore` rule `**/log` also matches the source package `com/arcadedb/log/`, so the two new files there had to be `git add -f`'d. You may want to tighten that rule (e.g. anchor it to build output dirs) so new sources under that package aren't silently ignored.
