### PR TITLE
CHECK DATABASE fix mode rebuilds unreadable edge lists; ORDER BY on graph-function expressions actually sorts

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -24,7 +24,6 @@ import com.arcadedb.database.Record;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.log.LogManager;
-import com.arcadedb.query.select.SelectIterator;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.utility.Pair;
@@ -91,10 +90,12 @@ public class GraphDatabaseChecker {
           final RID vertexIdentity = vertex.getIdentity();
 
           vertex = checkOutgoingEdges(fix, vertex, warnings, totalWarnings, maxWarnings, vertexIdentity, invalidLinks,
-              corruptedRecords, totalCorrupted, maxCorrupted, reconnectOutEdges, missingReferences, missingReferenceErrors);
+              corruptedRecords, totalCorrupted, maxCorrupted, reconnectOutEdges, reconnectInEdges, missingReferences,
+              missingReferenceErrors);
 
           checkIncomingEdges(fix, vertex, warnings, totalWarnings, maxWarnings, vertexIdentity, invalidLinks,
-              corruptedRecords, totalCorrupted, maxCorrupted, reconnectInEdges, missingReferences, missingReferenceErrors);
+              corruptedRecords, totalCorrupted, maxCorrupted, reconnectInEdges, reconnectOutEdges, missingReferences,
+              missingReferenceErrors);
 
         } catch (final Throwable e) {
           addWarning(warnings, totalWarnings, maxWarnings,
@@ -112,7 +113,7 @@ public class GraphDatabaseChecker {
 
       if (fix) {
         if (!reconnectOutEdges.isEmpty() || !reconnectInEdges.isEmpty())
-          reconnectEdges(reconnectOutEdges, reconnectInEdges, warnings, totalWarnings, maxWarnings, stats);
+          reconnectEdges(reconnectOutEdges, reconnectInEdges, corruptedRecords, warnings, totalWarnings, maxWarnings, stats);
 
         for (final RID rid : corruptedRecords) {
           if (rid == null)
@@ -150,8 +151,8 @@ public class GraphDatabaseChecker {
     return stats;
   }
 
-  private void reconnectEdges(Set<RID> reconnectOutEdges, Set<RID> reconnectInEdges, List<String> warnings,
-      AtomicLong totalWarnings, int maxWarnings, Map<String, Object> stats) {
+  private void reconnectEdges(Set<RID> reconnectOutEdges, Set<RID> reconnectInEdges, Set<RID> corruptedRecords,
+      List<String> warnings, AtomicLong totalWarnings, int maxWarnings, Map<String, Object> stats) {
     // BROWSE ALL THE EDGES AND COLLECT THE ONES PART OF THE RECONNECTION
     final List<EdgeType> edgeTypes = new ArrayList<>();
     for (DocumentType schemaType : database.getSchema().getTypes()) {
@@ -163,14 +164,31 @@ public class GraphDatabaseChecker {
     final List<Edge> inEdgesToReconnect = new ArrayList<>();
 
     for (EdgeType edgeType : edgeTypes) {
-      final SelectIterator<Edge> edges = database.select().fromType(edgeType.getName()).edges();
-      while (edges.hasNext()) {
-        final Edge e = edges.next();
-        if (reconnectOutEdges.contains(e.getOut()))
-          outEdgesToReconnect.add(e);
-        if (reconnectInEdges.contains(e.getIn()))
-          inEdgesToReconnect.add(e);
-      }
+      final boolean bidirectional = edgeType.isBidirectional();
+      // Scan with an error callback: on a damaged database an unreadable edge record must not abort the whole
+      // rebuild - it is skipped (checkEdges reports/deletes it), the surviving records still reconnect.
+      database.scanType(edgeType.getName(), false, record -> {
+        try {
+          final Edge e = record.asEdge(true);
+          if (corruptedRecords.contains(e.getIdentity()))
+            // ABOUT TO BE DELETED BY THE FIX: re-adding it would rebuild a dangling entry
+            return true;
+          if (reconnectOutEdges.contains(e.getOut()))
+            outEdgesToReconnect.add(e);
+          // A unidirectional edge is never stored in the target's IN list: rebuilding it there would invent
+          // adjacency that never existed.
+          if (bidirectional && reconnectInEdges.contains(e.getIn()))
+            inEdgesToReconnect.add(e);
+        } catch (final Exception e) {
+          addWarning(warnings, totalWarnings, maxWarnings, "edge " + record.getIdentity()
+              + " could not be read during the edge-list rebuild, skipping it (error: " + describe(e) + ")");
+        }
+        return true;
+      }, (rid, exception) -> {
+        addWarning(warnings, totalWarnings, maxWarnings,
+            "edge " + rid + " could not be read during the edge-list rebuild, skipping it (error: " + describe(exception) + ")");
+        return true;
+      });
     }
 
     if (!outEdgesToReconnect.isEmpty()) {
@@ -195,26 +213,47 @@ public class GraphDatabaseChecker {
 
   private void checkIncomingEdges(boolean fix, Vertex vertex, List<String> warnings, AtomicLong totalWarnings, int maxWarnings,
       RID vertexIdentity, AtomicLong invalidLinks, LinkedHashSet<RID> corruptedRecords, AtomicLong totalCorrupted,
-      int maxCorrupted, Set<RID> reconnectInEdges, Map<RID, Long> missingReferences, Map<RID, String> missingReferenceErrors) {
+      int maxCorrupted, Set<RID> reconnectInEdges, Set<RID> reconnectOutEdges, Map<RID, Long> missingReferences,
+      Map<RID, String> missingReferenceErrors) {
     if (((VertexInternal) vertex).getInEdgesHeadChunk() != null) {
       EdgeLinkedList inEdges = null;
       try {
         inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.DIRECTION.IN);
       } catch (Exception e) {
-        // IGNORE IT
+        // IGNORE IT: HANDLED AS AN UNREADABLE LIST BELOW
       }
 
       if (inEdges == null) {
+        final RID headChunkRID = ((VertexInternal) vertex).getInEdgesHeadChunk();
+        addWarning(warnings, totalWarnings, maxWarnings, "vertex " + vertexIdentity + " in edges record " + headChunkRID
+            + " is not valid" + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
         if (fix) {
-          vertex = vertex.modify();
-          ((VertexInternal) vertex).setInEdgesHeadChunk(null);
-          ((MutableVertex) vertex).save();
-          addWarning(warnings, totalWarnings, maxWarnings, "vertex " + vertexIdentity + " in edges record "
-              + ((VertexInternal) vertex).getInEdgesHeadChunk() + " is not valid, removing it");
+          vertex = resetChain(vertex, Vertex.DIRECTION.IN);
+          reconnectInEdges.add(vertexIdentity);
         }
       } else {
-        final Iterator<Pair<RID, RID>> in = inEdges.entryIterator();
-        while (in.hasNext()) {
+        Iterator<Pair<RID, RID>> in = null;
+        boolean chainBroken = false;
+        String chainError = null;
+        try {
+          in = inEdges.entryIterator();
+        } catch (final Exception e) {
+          chainBroken = true;
+          chainError = describe(e);
+        }
+
+        while (in != null) {
+          try {
+            // hasNext() HOPS ONTO THE NEXT CHUNK OF THE LINKED LIST, so an unreadable chunk fails HERE, not in
+            // next(). Before this guard the failure escaped the walk, the scan callback flagged the whole VERTEX
+            // as corrupted and fix mode deleted it: the vertex was lost over a repairable adjacency list.
+            if (!in.hasNext())
+              break;
+          } catch (final Exception e) {
+            chainBroken = true;
+            chainError = describe(e);
+            break;
+          }
           try {
             final Pair<RID, RID> current = in.next();
             final RID edgeRID = current.getFirst();
@@ -302,13 +341,12 @@ public class GraphDatabaseChecker {
                     // ORIGINAL OUT VERTEX POINTER MUST BE WRONG, CHECKING
                     final VertexInternal wrongInVertex = (VertexInternal) edge.getIn().asVertex(false);
                     if (((VertexInternal) vertex).getInEdgesHeadChunk().equals(wrongInVertex.getInEdgesHeadChunk())) {
-                      // CURRENT VERTEX POINTS TO ANOTHER LINKED LIST. SEARCHING FOR ITS CORRECT LINKED LIST LATER
-                      reconnectInEdges.add(vertexIdentity);
-
-                      // RESET POINTER TO OUT EDGES
-                      vertex = vertex.modify();
-                      ((VertexInternal) vertex).setInEdgesHeadChunk(null);
-                      ((MutableVertex) vertex).save();
+                      // CURRENT VERTEX POINTS TO ANOTHER LINKED LIST. SEARCHING FOR ITS CORRECT LINKED LIST LATER.
+                      // Mutate ONLY in fix mode: a plain check must stay read-only.
+                      if (fix) {
+                        reconnectInEdges.add(vertexIdentity);
+                        vertex = resetChain(vertex, Vertex.DIRECTION.IN);
+                      }
 
                       // SKIP THE REST OF THE EDGES
                       break;
@@ -331,8 +369,23 @@ public class GraphDatabaseChecker {
                   invalidLinks.incrementAndGet();
                 }
 
-                if (((EdgeType) edge.getType()).isBidirectional()) {
-                  if (inVertex != null && !inVertex.isConnectedTo(vertexIdentity, Vertex.DIRECTION.OUT, edge.getTypeName())) {
+                if (((EdgeType) edge.getType()).isBidirectional() && inVertex != null) {
+                  Boolean connected = null;
+                  try {
+                    connected = inVertex.isConnectedTo(vertexIdentity, Vertex.DIRECTION.OUT, edge.getTypeName());
+                  } catch (final Exception probeError) {
+                    // The FAR vertex's OUT list is unreadable: never blame this edge record for it (before this
+                    // guard the probe failure flagged the edge as corrupted and fix mode deleted a VALID edge).
+                    // Register the far vertex so its list is rebuilt from the surviving edge records instead.
+                    if (reconnectOutEdges.add(inVertex.getIdentity())) {
+                      addWarning(warnings, totalWarnings, maxWarnings,
+                          "vertex " + inVertex.getIdentity() + " outgoing edge list is unreadable (error: "
+                              + describe(probeError) + ")" + (fix ? ", rebuilding it from the surviving edge records" : ""));
+                      if (fix)
+                        resetChain(inVertex, Vertex.DIRECTION.OUT);
+                    }
+                  }
+                  if (connected != null && !connected && !reconnectOutEdges.contains(inVertex.getIdentity())) {
                     addWarning(warnings, totalWarnings, maxWarnings,
                         "edge " + edgeRID + " was not connected from the incoming vertex " + edge.getOut() + " to the vertex "
                             + vertexIdentity);
@@ -361,18 +414,20 @@ public class GraphDatabaseChecker {
             if (fix && removeEntry)
               in.remove();
           } catch (Exception e) {
-            // UNKNOWN ERROR ON LOADING EDGES
-            addWarning(warnings, totalWarnings, maxWarnings,
-                "error on loading incoming edges from vertex " + vertexIdentity + " (error: " + describe(e) + ")");
-
-            if (fix) {
-              vertex = vertex.modify();
-              ((VertexInternal) vertex).setInEdgesHeadChunk(null);
-              ((MutableVertex) vertex).save();
-              addWarning(warnings, totalWarnings, maxWarnings, "vertex " + vertexIdentity + " in edges record "
-                  + ((VertexInternal) vertex).getInEdgesHeadChunk() + " is not valid, removing it");
-            }
+            // UNKNOWN ERROR WHILE WALKING THE LIST: the chain is unreliable, rebuild it below
+            chainBroken = true;
+            chainError = describe(e);
             break;
+          }
+        }
+
+        if (chainBroken) {
+          addWarning(warnings, totalWarnings, maxWarnings,
+              "error on loading incoming edges from vertex " + vertexIdentity + " (error: " + chainError + ")"
+                  + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
+          if (fix) {
+            vertex = resetChain(vertex, Vertex.DIRECTION.IN);
+            reconnectInEdges.add(vertexIdentity);
           }
         }
       }
@@ -382,28 +437,48 @@ public class GraphDatabaseChecker {
   private Vertex checkOutgoingEdges(final boolean fix, Vertex vertex, final List<String> warnings,
       final AtomicLong totalWarnings, final int maxWarnings, final RID vertexIdentity, final AtomicLong invalidLinks,
       final LinkedHashSet<RID> corruptedRecords, final AtomicLong totalCorrupted, final int maxCorrupted,
-      final Set<RID> reconnectOutEdges, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors) {
+      final Set<RID> reconnectOutEdges, final Set<RID> reconnectInEdges, final Map<RID, Long> missingReferences,
+      final Map<RID, String> missingReferenceErrors) {
     // CHECK THE EDGE IS CONNECTED FROM THE OTHER SIDE
     if (((VertexInternal) vertex).getOutEdgesHeadChunk() != null) {
       EdgeLinkedList outEdges = null;
       try {
         outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.DIRECTION.OUT);
       } catch (Exception e) {
-        // IGNORE IT
+        // IGNORE IT: HANDLED AS AN UNREADABLE LIST BELOW
       }
 
       if (outEdges == null) {
+        final RID headChunkRID = ((VertexInternal) vertex).getOutEdgesHeadChunk();
+        addWarning(warnings, totalWarnings, maxWarnings, "vertex " + vertexIdentity + " out edges record " + headChunkRID
+            + " is not valid" + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
         if (fix) {
-          vertex = vertex.modify();
-          ((VertexInternal) vertex).setOutEdgesHeadChunk(null);
-          ((MutableVertex) vertex).save();
-          addWarning(warnings, totalWarnings, maxWarnings, "vertex " + vertexIdentity + " out edges record "
-              + ((VertexInternal) vertex).getOutEdgesHeadChunk() + " is not valid, removing it");
+          vertex = resetChain(vertex, Vertex.DIRECTION.OUT);
+          reconnectOutEdges.add(vertexIdentity);
         }
       } else {
+        Iterator<Pair<RID, RID>> out = null;
+        boolean chainBroken = false;
+        String chainError = null;
+        try {
+          out = outEdges.entryIterator();
+        } catch (final Exception e) {
+          chainBroken = true;
+          chainError = describe(e);
+        }
 
-        final Iterator<Pair<RID, RID>> out = outEdges.entryIterator();
-        while (out.hasNext()) {
+        while (out != null) {
+          try {
+            // hasNext() HOPS ONTO THE NEXT CHUNK OF THE LINKED LIST, so an unreadable chunk fails HERE, not in
+            // next(). Before this guard the failure escaped the walk, the scan callback flagged the whole VERTEX
+            // as corrupted and fix mode deleted it: the vertex was lost over a repairable adjacency list.
+            if (!out.hasNext())
+              break;
+          } catch (final Exception e) {
+            chainBroken = true;
+            chainError = describe(e);
+            break;
+          }
           try {
             final Pair<RID, RID> current = out.next();
             final RID edgeRID = current.getFirst();
@@ -489,13 +564,12 @@ public class GraphDatabaseChecker {
                     // ORIGINAL OUT VERTEX POINTER MUST BE WRONG, CHECKING
                     final VertexInternal wrongOutVertex = (VertexInternal) edge.getOut().asVertex(false);
                     if (((VertexInternal) vertex).getOutEdgesHeadChunk().equals(wrongOutVertex.getOutEdgesHeadChunk())) {
-                      // CURRENT VERTEX POINTS TO ANOTHER LINKED LIST. SEARCHING FOR ITS CORRECT LINKED LIST LATER
-                      reconnectOutEdges.add(vertexIdentity);
-
-                      // RESET POINTER TO OUT EDGES
-                      vertex = vertex.modify();
-                      ((VertexInternal) vertex).setOutEdgesHeadChunk(null);
-                      ((MutableVertex) vertex).save();
+                      // CURRENT VERTEX POINTS TO ANOTHER LINKED LIST. SEARCHING FOR ITS CORRECT LINKED LIST LATER.
+                      // Mutate ONLY in fix mode: a plain check must stay read-only.
+                      if (fix) {
+                        reconnectOutEdges.add(vertexIdentity);
+                        vertex = resetChain(vertex, Vertex.DIRECTION.OUT);
+                      }
 
                       // SKIP THE REST OF THE EDGES
                       break;
@@ -519,9 +593,24 @@ public class GraphDatabaseChecker {
                   invalidLinks.incrementAndGet();
                 }
 
-                if (((EdgeType) edge.getType()).isBidirectional()) {
+                if (((EdgeType) edge.getType()).isBidirectional() && outVertex != null) {
                   // CHECK THE EDGE IS CONNECTED FROM THE OTHER SIDE
-                  if (outVertex != null && !outVertex.isConnectedTo(vertexIdentity, Vertex.DIRECTION.IN, edge.getTypeName())) {
+                  Boolean connected = null;
+                  try {
+                    connected = outVertex.isConnectedTo(vertexIdentity, Vertex.DIRECTION.IN, edge.getTypeName());
+                  } catch (final Exception probeError) {
+                    // The FAR vertex's IN list is unreadable: never blame this edge record for it (before this
+                    // guard the probe failure flagged the edge as corrupted and fix mode deleted a VALID edge).
+                    // Register the far vertex so its list is rebuilt from the surviving edge records instead.
+                    if (reconnectInEdges.add(outVertex.getIdentity())) {
+                      addWarning(warnings, totalWarnings, maxWarnings,
+                          "vertex " + outVertex.getIdentity() + " incoming edge list is unreadable (error: "
+                              + describe(probeError) + ")" + (fix ? ", rebuilding it from the surviving edge records" : ""));
+                      if (fix)
+                        resetChain(outVertex, Vertex.DIRECTION.IN);
+                    }
+                  }
+                  if (connected != null && !connected && !reconnectInEdges.contains(outVertex.getIdentity())) {
                     addWarning(warnings, totalWarnings, maxWarnings,
                         "edge " + edgeRID + " was not connected from the outgoing vertex " + edge.getIn() + " back to the vertex "
                             + vertexIdentity);
@@ -551,23 +640,41 @@ public class GraphDatabaseChecker {
               out.remove();
 
           } catch (Exception e) {
-            // UNKNOWN ERROR ON LOADING EDGES
-            addWarning(warnings, totalWarnings, maxWarnings,
-                "error on loading outgoing edges from vertex " + vertexIdentity + " (error: " + describe(e) + ")");
-
-            if (fix) {
-              vertex = vertex.modify();
-              ((VertexInternal) vertex).setOutEdgesHeadChunk(null);
-              ((MutableVertex) vertex).save();
-              addWarning(warnings, totalWarnings, maxWarnings, "vertex " + vertexIdentity + " out edges record "
-                  + ((VertexInternal) vertex).getOutEdgesHeadChunk() + " is not valid, removing it");
-            }
+            // UNKNOWN ERROR WHILE WALKING THE LIST: the chain is unreliable, rebuild it below
+            chainBroken = true;
+            chainError = describe(e);
             break;
+          }
+        }
+
+        if (chainBroken) {
+          addWarning(warnings, totalWarnings, maxWarnings,
+              "error on loading outgoing edges from vertex " + vertexIdentity + " (error: " + chainError + ")"
+                  + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
+          if (fix) {
+            vertex = resetChain(vertex, Vertex.DIRECTION.OUT);
+            reconnectOutEdges.add(vertexIdentity);
           }
         }
       }
     }
     return vertex;
+  }
+
+  /**
+   * Nulls the vertex's head-chunk pointer for the given direction, dropping the unreadable chain so the
+   * adjacency can be rebuilt from the surviving edge records by {@link #reconnectEdges}. Each edge record
+   * stores its own out/in vertex RIDs, so losing the linked list does not lose the graph. Returns the saved
+   * mutable copy so callers keep operating on the fresh vertex.
+   */
+  private Vertex resetChain(final Vertex vertex, final Vertex.DIRECTION direction) {
+    final MutableVertex mutable = vertex.modify();
+    if (direction == Vertex.DIRECTION.OUT)
+      mutable.setOutEdgesHeadChunk(null);
+    else
+      mutable.setInEdgesHeadChunk(null);
+    mutable.save();
+    return mutable;
   }
 
   public Map<String, Object> checkEdges(final String typeName, final boolean fix, final int verboseLevel) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -151,6 +151,13 @@ public class GraphDatabaseChecker {
     return stats;
   }
 
+  /**
+   * Rebuilds the edge lists of the registered vertices from the surviving edge records. NOTE: this is a FULL
+   * scan of every edge type, even when a single vertex needs reconnection - acceptable because it runs only in
+   * fix mode on an already-damaged database, and the pre-existing reconnect path had the same cost. A rebuilt
+   * entry may still point to a far endpoint vertex that no longer exists (the edge record survives, its target
+   * does not): that is the same behaviour as before and the {@code checkEdges} pass reports it.
+   */
   private void reconnectEdges(Set<RID> reconnectOutEdges, Set<RID> reconnectInEdges, Set<RID> corruptedRecords,
       List<String> warnings, AtomicLong totalWarnings, int maxWarnings, Map<String, Object> stats) {
     // BROWSE ALL THE EDGES AND COLLECT THE ONES PART OF THE RECONNECTION
@@ -180,13 +187,11 @@ public class GraphDatabaseChecker {
           if (bidirectional && reconnectInEdges.contains(e.getIn()))
             inEdgesToReconnect.add(e);
         } catch (final Exception e) {
-          addWarning(warnings, totalWarnings, maxWarnings, "edge " + record.getIdentity()
-              + " could not be read during the edge-list rebuild, skipping it (error: " + describe(e) + ")");
+          warnUnreadableEdgeDuringRebuild(warnings, totalWarnings, maxWarnings, record.getIdentity(), e);
         }
         return true;
       }, (rid, exception) -> {
-        addWarning(warnings, totalWarnings, maxWarnings,
-            "edge " + rid + " could not be read during the edge-list rebuild, skipping it (error: " + describe(exception) + ")");
+        warnUnreadableEdgeDuringRebuild(warnings, totalWarnings, maxWarnings, rid, exception);
         return true;
       });
     }
@@ -209,6 +214,12 @@ public class GraphDatabaseChecker {
       addWarning(warnings, totalWarnings, maxWarnings, "reconnected " + inEdgesToReconnect.size() + " incoming edges");
       stats.put("inEdgesToReconnect", inEdgesToReconnect);
     }
+  }
+
+  private static void warnUnreadableEdgeDuringRebuild(final List<String> warnings, final AtomicLong totalWarnings,
+      final int maxWarnings, final Object rid, final Throwable error) {
+    addWarning(warnings, totalWarnings, maxWarnings,
+        "edge " + rid + " could not be read during the edge-list rebuild, skipping it (error: " + describe(error) + ")");
   }
 
   private void checkIncomingEdges(boolean fix, Vertex vertex, List<String> warnings, AtomicLong totalWarnings, int maxWarnings,

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -4199,12 +4199,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
             item.setAlias(baseExpr.identifier.suffix.identifier.getValue());
             // Set the modifier chain
             item.modifier = baseExpr.modifier;
-          } else {
-            // Fallback: use string representation
-            final StringBuilder sb = new StringBuilder();
-            baseExpr.toString(Collections.emptyMap(), sb);
-            item.setAlias(sb.toString());
           }
+          // else: a non-identifier base with modifiers (e.g. ORDER BY both().size()) - the alias/recordAttr/
+          // modifier fields stay null and the tail below stores the FULL expression. Collapsing it to its
+          // string representation as an alias made every sort key resolve to a non-existent property (null),
+          // silently returning the rows unsorted.
         } else if (baseExpr.identifier != null) {
           // No modifiers - try simple identifier extraction
           final SuffixIdentifier suffix = baseExpr.identifier.suffix;

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerChainRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerChainRebuildTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CHECK DATABASE repair of unreadable edge chains: when a chunk of a vertex's edge linked list is lost or
+ * corrupted (e.g. after a replication incident), the edge RECORDS usually survive - each edge stores its own
+ * out/in vertex RIDs - so the adjacency list can be REBUILT from them instead of amputated.
+ * <p>
+ * Before this feature the checker did worse than amputate:
+ * <ul>
+ *   <li>a MID-CHAIN unreadable chunk escaped through {@code Iterator.hasNext()} in the walk loop, the vertex
+ *   itself was flagged corrupted, and fix mode DELETED THE VERTEX outright;</li>
+ *   <li>an unreadable HEAD chunk nulled the vertex's head pointer, silently losing the whole adjacency
+ *   (queries like {@code both().size()} then return 0 instead of failing).</li>
+ * </ul>
+ * With the rebuild, fix mode reconnects every surviving edge record through the existing
+ * {@code reconnectEdges} machinery and a follow-up check reports a clean database.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphDatabaseCheckerChainRebuildTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+
+  private int savedThreshold;
+
+  @BeforeEach
+  void saveConfig() {
+    savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+  }
+
+  @AfterEach
+  void restoreConfig() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+  }
+
+  /**
+   * MID-CHAIN corruption on the classic layout: walking the IN list of the hub throws when the iterator hops
+   * onto the deleted chunk. Fix mode must rebuild the full adjacency from the surviving edge records - and it
+   * must NOT delete the hub vertex (the pre-rebuild behavior).
+   */
+  @Test
+  void midChainCorruptionRebuildsAdjacencyAndKeepsVertex() {
+    final int degree = 500;
+    final RID hubRid = createHub(degree);
+
+    // BREAK THE CHAIN IN THE MIDDLE: the head chunk is the newest; its "previous" is an older, mid-chain chunk.
+    final RID[] midChunk = new RID[1];
+    database.transaction(() -> {
+      final RID head = ((VertexInternal) hubRid.asVertex(true)).getInEdgesHeadChunk();
+      final EdgeSegment headChunk = (EdgeSegment) ((DatabaseInternal) database).lookupByRID(head, true);
+      midChunk[0] = headChunk.getPreviousRID();
+      assertThat(midChunk[0]).as("the hub degree must span more than one chunk").isNotNull();
+    });
+    deleteRecordLowLevel(midChunk[0]);
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database).checkVertices(VERTEX_TYPE, true, 0);
+    assertThat((Long) stats.get("invalidLinks")).isGreaterThanOrEqualTo(0L); // stats map is populated
+
+    // THE HUB SURVIVED THE FIX...
+    database.transaction(() -> assertThat(hubRid.asVertex(true)).isNotNull());
+    // ...WITH ITS FULL ADJACENCY REBUILT FROM THE EDGE RECORDS.
+    assertRepaired(hubRid, degree);
+  }
+
+  /**
+   * HEAD-CHUNK corruption on the classic layout: {@code getEdgeHeadChunk} cannot load the list at all. Fix
+   * mode must rebuild instead of just nulling the head pointer (which silently reported 0 edges).
+   */
+  @Test
+  void headChunkCorruptionRebuildsAdjacency() {
+    final int degree = 500;
+    final RID hubRid = createHub(degree);
+
+    final RID[] headChunk = new RID[1];
+    database.transaction(() -> headChunk[0] = ((VertexInternal) hubRid.asVertex(true)).getInEdgesHeadChunk());
+    deleteRecordLowLevel(headChunk[0]);
+
+    new GraphDatabaseChecker((DatabaseInternal) database).checkVertices(VERTEX_TYPE, true, 0);
+
+    assertRepaired(hubRid, degree);
+  }
+
+  /**
+   * The super-node shape: the hub is promoted to the striped layout, then a mid-chain chunk of the
+   * generation-0 (pre-promotion) chain is lost. Fix mode must rebuild the full adjacency.
+   */
+  @Test
+  void promotedSuperNodeChainCorruptionRebuildsAdjacency() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(256);
+
+    final int degree = 2_000;
+    final RID hubRid = createHub(degree);
+
+    final RID[] gen0MidChunk = new RID[1];
+    database.transaction(() -> {
+      final RID head = ((VertexInternal) hubRid.asVertex(true)).getInEdgesHeadChunk();
+      final Record headRecord = ((DatabaseInternal) database).lookupByRID(head, true);
+      assertThat(headRecord).as("the hub must have been promoted to the striped layout").isInstanceOf(StripeDirectory.class);
+      final StripeDirectory directory = (StripeDirectory) headRecord;
+      // Generation 0 is the single pre-promotion classic chain: with a 256 threshold it spans several chunks.
+      final RID gen0Head = directory.getHead(0, 0);
+      final EdgeSegment gen0HeadChunk = (EdgeSegment) ((DatabaseInternal) database).lookupByRID(gen0Head, true);
+      gen0MidChunk[0] = gen0HeadChunk.getPreviousRID();
+      assertThat(gen0MidChunk[0]).as("the generation-0 chain must span more than one chunk").isNotNull();
+    });
+    deleteRecordLowLevel(gen0MidChunk[0]);
+
+    new GraphDatabaseChecker((DatabaseInternal) database).checkVertices(VERTEX_TYPE, true, 0);
+
+    database.transaction(() -> assertThat(hubRid.asVertex(true)).isNotNull());
+    assertRepaired(hubRid, degree);
+  }
+
+  /**
+   * Scan-order regression: when the hub sits AFTER its sources in the bucket, the sources are checked first
+   * and each one probes the hub's broken IN list ({@code isConnectedTo}). Before the rebuild the probe failure
+   * was blamed on the EDGE record, which fix mode then deleted - permanently losing valid edges. The probe
+   * failure must instead register the hub for a rebuild and leave every edge record alone.
+   */
+  @Test
+  void probeFailureOnBrokenNeighbourChainMustNotDeleteValidEdges() {
+    final int degree = 500;
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE, 1);
+      database.getSchema().createEdgeType(EDGE_TYPE, 1);
+    });
+
+    // SOURCES FIRST so they occupy the low positions of the bucket and are scanned BEFORE the hub.
+    final RID[] sources = new RID[degree];
+    database.transaction(() -> {
+      for (int i = 0; i < degree; i++)
+        sources[i] = database.newVertex(VERTEX_TYPE).set("i", i).save().getIdentity();
+    });
+
+    final RID[] hub = new RID[1];
+    database.transaction(() -> hub[0] = database.newVertex(VERTEX_TYPE).set("name", "hub").save().getIdentity());
+
+    final int batch = 500;
+    for (int from = 0; from < degree; from += batch) {
+      final int start = from;
+      final int end = Math.min(from + batch, degree);
+      database.transaction(() -> {
+        for (int i = start; i < end; i++)
+          sources[i].asVertex(true).newEdge(EDGE_TYPE, hub[0]);
+      });
+    }
+
+    final RID[] midChunk = new RID[1];
+    database.transaction(() -> {
+      final RID head = ((VertexInternal) hub[0].asVertex(true)).getInEdgesHeadChunk();
+      final EdgeSegment headChunk = (EdgeSegment) ((DatabaseInternal) database).lookupByRID(head, true);
+      midChunk[0] = headChunk.getPreviousRID();
+      assertThat(midChunk[0]).as("the hub degree must span more than one chunk").isNotNull();
+    });
+    deleteRecordLowLevel(midChunk[0]);
+
+    new GraphDatabaseChecker((DatabaseInternal) database).checkVertices(VERTEX_TYPE, true, 0);
+
+    database.transaction(() -> assertThat(hub[0].asVertex(true)).isNotNull());
+    assertRepaired(hub[0], degree);
+  }
+
+  /** Creates the hub plus {@code degree} sources, each with one edge source -> hub (hub's IN list). */
+  private RID createHub(final int degree) {
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE, 1);
+      database.getSchema().createEdgeType(EDGE_TYPE, 1);
+    });
+
+    final RID[] hub = new RID[1];
+    database.transaction(() -> hub[0] = database.newVertex(VERTEX_TYPE).set("name", "hub").save().getIdentity());
+
+    final int batch = 500;
+    for (int b = 0; b < (degree + batch - 1) / batch; b++) {
+      final int from = b * batch;
+      final int to = Math.min(from + batch, degree);
+      database.transaction(() -> {
+        for (int i = from; i < to; i++)
+          database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, hub[0]);
+      });
+    }
+    return hub[0];
+  }
+
+  private void deleteRecordLowLevel(final RID rid) {
+    database.transaction(() -> database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid));
+  }
+
+  /** The full adjacency is available again, the traversal query works, and a follow-up check is clean. */
+  private void assertRepaired(final RID hubRid, final int degree) {
+    database.transaction(() -> {
+      final Vertex hub = hubRid.asVertex(true);
+      assertThat(hub.countEdges(Vertex.DIRECTION.IN, EDGE_TYPE)).isEqualTo(degree);
+
+      try (final ResultSet rs = database.query("sql",
+          "SELECT name, both().size() AS degree FROM " + VERTEX_TYPE + " ORDER BY degree DESC LIMIT 1")) {
+        final Result top = rs.next();
+        assertThat((String) top.getProperty("name")).isEqualTo("hub");
+        assertThat(((Number) top.getProperty("degree")).intValue()).isEqualTo(degree);
+      }
+    });
+
+    final Map<String, Object> verify = new GraphDatabaseChecker((DatabaseInternal) database).checkVertices(VERTEX_TYPE, false, 0);
+    assertThat((Long) verify.get("totalWarnings")).as("the database must be clean after the repair").isEqualTo(0L);
+    assertThat((Long) verify.get("totalCorruptedRecords")).isEqualTo(0L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/OrderByGraphFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/OrderByGraphFunctionTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Vertex;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ORDER BY on a graph-function expression (e.g. {@code ORDER BY both().size() DESC}) must actually sort.
+ * The AST builder used to collapse such an expression into a property ALIAS holding its literal text
+ * ("both().size()"), so every sort key resolved to null and the rows silently came back in scan order -
+ * only queries whose hub happened to be the first record in the bucket looked correct.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class OrderByGraphFunctionTest extends TestHelper {
+  private static final int SOURCES = 50;
+
+  /**
+   * Creates {@code SOURCES} low-degree vertices and one high-degree hub. The hub's position in the bucket is
+   * chosen AGAINST the expected result order ({@code hubFirst} for ascending tests, hub last for descending
+   * ones) so a broken (no-op) sort returning scan order can never look correct by accident.
+   */
+  private RID setupGraph(final boolean hubFirst) {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node", 1);
+      database.getSchema().createEdgeType("Link", 1);
+    });
+
+    final RID[] hub = new RID[1];
+    if (hubFirst)
+      database.transaction(() -> hub[0] = database.newVertex("Node").set("name", "hub").save().getIdentity());
+
+    final RID[] sources = new RID[SOURCES];
+    database.transaction(() -> {
+      for (int i = 0; i < SOURCES; i++)
+        sources[i] = database.newVertex("Node").set("i", i).save().getIdentity();
+    });
+
+    database.transaction(() -> {
+      if (!hubFirst)
+        hub[0] = database.newVertex("Node").set("name", "hub").save().getIdentity();
+      for (int i = 0; i < SOURCES; i++)
+        sources[i].asVertex(true).newEdge("Link", hub[0]);
+    });
+    return hub[0];
+  }
+
+  private RID setupGraph() {
+    return setupGraph(false);
+  }
+
+  @Test
+  void orderByGraphFunctionExpressionWithMatchingProjection() {
+    setupGraph();
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT name, both().size() AS degree FROM Node ORDER BY both().size() DESC LIMIT 3")) {
+        final Result top = rs.next();
+        assertThat((String) top.getProperty("name")).isEqualTo("hub");
+        assertThat(((Number) top.getProperty("degree")).intValue()).isEqualTo(SOURCES);
+        // The remaining rows are the degree-1 sources.
+        assertThat(((Number) rs.next().getProperty("degree")).intValue()).isEqualTo(1);
+      }
+    });
+  }
+
+  @Test
+  void orderByGraphFunctionExpressionWithoutMatchingProjection() {
+    setupGraph();
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT name FROM Node ORDER BY in().size() DESC LIMIT 1")) {
+        assertThat((String) rs.next().getProperty("name")).isEqualTo("hub");
+      }
+    });
+  }
+
+  @Test
+  void orderByGraphFunctionExpressionWithoutProjection() {
+    final RID hub = setupGraph();
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Node ORDER BY both().size() DESC LIMIT 1")) {
+        assertThat(rs.next().getIdentity().orElse(null)).isEqualTo(hub);
+      }
+    });
+  }
+
+  @Test
+  void orderByProjectionAliasStillSorts() {
+    setupGraph();
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT name, both().size() AS degree FROM Node ORDER BY degree DESC LIMIT 1")) {
+        final Result top = rs.next();
+        assertThat((String) top.getProperty("name")).isEqualTo("hub");
+        assertThat(((Number) top.getProperty("degree")).intValue()).isEqualTo(SOURCES);
+      }
+    });
+  }
+
+  /** Ascending order must put the hub LAST, proving the direction handling on expression sort keys. */
+  @Test
+  void orderByGraphFunctionExpressionAscending() {
+    setupGraph(true);
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT name, both().size() AS degree FROM Node ORDER BY both().size() ASC")) {
+        Result last = null;
+        while (rs.hasNext())
+          last = rs.next();
+        assertThat(last).isNotNull();
+        assertThat((String) last.getProperty("name")).isEqualTo("hub");
+      }
+    });
+  }
+
+  /** The hub still traverses as a vertex after the projection machinery (sanity on the hidden projection). */
+  @Test
+  void hubDegreeIsCorrect() {
+    final RID hub = setupGraph();
+    database.transaction(() ->
+        assertThat(hub.asVertex(true).countEdges(Vertex.DIRECTION.BOTH, "Link")).isEqualTo(SOURCES));
+  }
+}


### PR DESCRIPTION
Fixes #5371.

Two related engine fixes that came out of the same customer-recovery investigation (broken edge chains after replication incidents on older builds).

## 1. CHECK DATABASE fix mode rebuilds unreadable edge lists from the surviving edge records

An unreadable chunk in a vertex's edge linked list previously caused, depending on where the walk failed:

- **the vertex itself to be deleted** by fix mode: the failure escaped through `Iterator.hasNext()` in the walk loop (outside the try/catch), so the scan callback flagged the whole vertex as corrupted;
- **valid edge records to be deleted** when a healthy vertex was scanned before its broken neighbour: the bidirectional back-reference probe (`isConnectedTo`) threw on the neighbour's broken chain and the edge record was blamed for it;
- **silent amputation** of the whole adjacency on head-chunk loss (head pointer nulled, `both().size()` then returned 0).

Each edge record stores its own out/in vertex RIDs, so the adjacency is now **rebuilt** through the existing `reconnectEdges` machinery instead: chain-walk failures and far-vertex probe failures register the vertex for a rebuild, the head pointer is reset, and every surviving edge reconnects. The rebuild scan tolerates unreadable edge records (skipped with a warning), skips edges already marked corrupted (they are deleted right after), and only rebuilds IN lists for bidirectional edge types. Plain CHECK (no fix) no longer mutates the database in the points-to-another-list arm. Works for both the classic and the striped super-node layouts.

Tests: `GraphDatabaseCheckerChainRebuildTest` - mid-chain corruption, head-chunk corruption, striped super-node generation-0 corruption, and the scan-order case where the neighbour probe fires first.

## 2. ORDER BY on a graph-function expression silently returned unsorted rows

`SELECT name, both().size() AS degree FROM Node ORDER BY both().size() DESC` returned rows in scan order on a **healthy** database: the AST builder collapsed the ORDER BY expression into a property alias holding its literal text (`"both().size()"`), so every sort key resolved to null. Queries only looked sorted when the highest-degree vertex happened to be the first record in the bucket.

The AST builder now keeps the full expression for non-identifier bases with modifier chains; both the ORDER BY comparator and the planner's hidden pre-projection already evaluate `item.expression` correctly.

Tests: `OrderByGraphFunctionTest` - with/without matching projection, no projection, ascending/descending, with hub bucket positions deliberately chosen against the expected order so a no-op sort can never pass by accident.

## Verification

All new tests green plus regression sweeps: CheckDatabaseTest (9), CheckDatabaseExtendedTest (12), GraphDatabaseCheckerDiagnosticsTest (3), BasicGraphTest (19), SuperNodeStripingTest (17), EdgeLinkedListRemoveAllSegmentsTest (2), SelectStatementExecutionTest (159), MatchStatementExecutionTest (93), OrderByStepTest (13), LimitSkipStepTest (10), SubQueryStepTest (10).

Known limitation (unchanged from the previous amputation behaviour): the old orphaned chunks / stripe directory remain on disk as unreachable garbage after a rebuild.