### PR TITLE
feat(#5372): step-by-step progress reporting for CHECK DATABASE (engine, HTTP, console, Studio)

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -29,6 +29,9 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.TransactionContext;
 import com.arcadedb.database.async.AsyncResultsetCallback;
 import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
+import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.integration.misc.IntegrationUtils;
@@ -629,6 +632,9 @@ public class Console {
         }
       });
     } else {
+      // LONG-RUNNING MAINTENANCE COMMANDS (issue #5372): render a live progress line while the synchronous
+      // command runs, polling the local registry (embedded) or the server's progress endpoint (remote).
+      final Thread progressMonitor = startProgressMonitor(line);
       try {
         resultSet = databaseProxy.command(language, line);
       } catch (Exception e) {
@@ -638,6 +644,8 @@ public class Console {
         else
           outputError(e);
         return;
+      } finally {
+        stopProgressMonitor(progressMonitor);
       }
     }
 
@@ -795,6 +803,87 @@ public class Console {
 
   private void outputLine(final int level, final String text, final Object... args) {
     output(level, "\n" + text, args);
+  }
+
+  /**
+   * Starts the live progress line for long-running maintenance commands (issue #5372), or returns null when
+   * not applicable (not a monitored command, or the output is redirected to an embedding application).
+   * Polling is best-effort: any failure silently stops the rendering, never the command.
+   */
+  private Thread startProgressMonitor(final String line) {
+    if (output != null || verboseLevel < 2)
+      return null;
+    if (!line.trim().toLowerCase(Locale.ENGLISH).startsWith("check database"))
+      return null;
+
+    final Thread monitor = new Thread(() -> {
+      int lastRenderedLength = 0;
+      try {
+        while (!Thread.currentThread().isInterrupted()) {
+          Thread.sleep(500);
+          final String rendered = renderProgressLine();
+          if (rendered != null) {
+            // PAD WITH SPACES so a shorter update fully overwrites the previous, longer one.
+            terminal.writer().print("\r" + rendered + " ".repeat(Math.max(0, lastRenderedLength - rendered.length())));
+            terminal.writer().flush();
+            lastRenderedLength = rendered.length();
+          }
+        }
+      } catch (final InterruptedException e) {
+        // COMMAND FINISHED
+      } catch (final Exception e) {
+        // BEST-EFFORT: a progress-polling failure must never disturb the running command
+      } finally {
+        if (lastRenderedLength > 0) {
+          terminal.writer().print("\r" + " ".repeat(lastRenderedLength) + "\r");
+          terminal.writer().flush();
+        }
+      }
+    }, "ArcadeDB-Console-Progress");
+    monitor.setDaemon(true);
+    monitor.start();
+    return monitor;
+  }
+
+  private void stopProgressMonitor(final Thread monitor) {
+    if (monitor == null)
+      return;
+    monitor.interrupt();
+    try {
+      monitor.join(2_000);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /** One line describing the first running operation of the current database, or null when none is running. */
+  private String renderProgressLine() {
+    if (isRemoteDatabase()) {
+      final List<JSONObject> operations = ((RemoteDatabase) databaseProxy).getProgress();
+      if (operations.isEmpty())
+        return null;
+      final JSONObject op = operations.getFirst();
+      return formatProgressLine(op.getString("operation", ""), op.getString("stepName", ""),
+          op.getInt("stepIndex", 0), op.getInt("totalSteps", 0), op.getInt("percentage", -1));
+    }
+
+    final List<OperationProgress> operations = OperationProgressRegistry.instance().getOperations(databaseProxy.getName());
+    if (operations.isEmpty())
+      return null;
+    final OperationProgress op = operations.getFirst();
+    return formatProgressLine(op.getOperation(), op.getStepName(), op.getStepIndex(), op.getTotalSteps(), op.getPercentage());
+  }
+
+  private static String formatProgressLine(final String operation, final String stepName, final int stepIndex,
+      final int totalSteps, final int percentage) {
+    final StringBuilder line = new StringBuilder(128);
+    line.append(operation).append(" [step ").append(stepIndex).append('/').append(totalSteps).append("] ").append(stepName);
+    if (percentage >= 0) {
+      final int filled = percentage / 5;
+      line.append(" |").append("=".repeat(filled)).append(" ".repeat(20 - filled)).append("| ").append(percentage).append('%');
+    } else
+      line.append(" ...");
+    return line.toString();
   }
 
   private void output(final int level, final String text, final Object... args) {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -816,13 +816,16 @@ public class Console {
     if (!line.trim().toLowerCase(Locale.ENGLISH).startsWith("check database"))
       return null;
 
+    progressMonitorStopped = false;
     final Thread monitor = new Thread(() -> {
       int lastRenderedLength = 0;
       try {
-        while (!Thread.currentThread().isInterrupted()) {
+        while (!Thread.currentThread().isInterrupted() && !progressMonitorStopped) {
           Thread.sleep(500);
           final String rendered = renderProgressLine();
-          if (rendered != null) {
+          // RE-CHECK THE STOP FLAG RIGHT BEFORE PRINTING: if the command completed while we were polling, a
+          // late line must not interleave with the result rendering on the main thread.
+          if (rendered != null && !progressMonitorStopped) {
             // PAD WITH SPACES so a shorter update fully overwrites the previous, longer one.
             terminal.writer().print("\r" + rendered + " ".repeat(Math.max(0, lastRenderedLength - rendered.length())));
             terminal.writer().flush();
@@ -845,9 +848,14 @@ public class Console {
     return monitor;
   }
 
+  private volatile boolean progressMonitorStopped;
+
   private void stopProgressMonitor(final Thread monitor) {
     if (monitor == null)
       return;
+    // SET THE FLAG FIRST: the interrupt alone leaves a window where a poll in flight could still print after
+    // this method returns and the main thread starts rendering the command result.
+    progressMonitorStopped = true;
     monitor.interrupt();
     try {
       monitor.join(2_000);
@@ -856,7 +864,11 @@ public class Console {
     }
   }
 
-  /** One line describing the first running operation of the current database, or null when none is running. */
+  /**
+   * One line describing the OLDEST running operation of the current database, or null when none is running.
+   * Deliberate limitation: with several concurrent operations on the same database only the oldest is
+   * rendered - a single console line cannot show more, and the HTTP endpoint still exposes all of them.
+   */
   private String renderProgressLine() {
     if (isRemoteDatabase()) {
       final List<JSONObject> operations = ((RemoteDatabase) databaseProxy).getProgress();

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -37,6 +37,7 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.serializer.BinarySerializer;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.LongHashSet;
+import com.arcadedb.utility.ProgressCallback;
 
 import java.io.IOException;
 import java.util.*;
@@ -61,6 +62,16 @@ public class DatabaseChecker {
   private final Map<RID, Long>      missingReferences      = new HashMap<>();
   private final Map<RID, String>    missingReferenceErrors = new HashMap<>();
 
+  // Progress reporting (issue #5372): the step plan is computed upfront in check() so every emission carries a
+  // stable stepIndex/totalSteps pair; per-record emissions are throttled to integer-percentage changes.
+  private ProgressCallback progressCallback;
+  private int              currentStep;
+  private int              totalSteps;
+  private String           currentStepName = "";
+  private long             stepDone;
+  private long             stepTotal;
+  private int              lastReportedPct;
+
   public DatabaseChecker(final Database database) {
     this.database = (DatabaseInternal) database;
   }
@@ -84,11 +95,32 @@ public class DatabaseChecker {
     result.put("distinctMissingReferences", 0L);
     result.put("topMissingReferences", new ArrayList<String>());
 
-    checkEdges();
+    // COMPUTE THE STEP PLAN UPFRONT so every progress emission carries a stable stepIndex/totalSteps pair.
+    final List<DocumentType> edgeTypes = new ArrayList<>();
+    final List<DocumentType> vertexTypes = new ArrayList<>();
+    final List<DocumentType> documentTypes = new ArrayList<>();
+    for (final DocumentType type : database.getSchema().getTypes()) {
+      if (types != null && !types.isEmpty() && (type == null || !types.contains(type.getName())))
+        continue;
+      if (type instanceof LocalEdgeType)
+        edgeTypes.add(type);
+      else if (type instanceof LocalVertexType)
+        vertexTypes.add(type);
+      else
+        documentTypes.add(type);
+    }
 
-    checkVertices();
+    currentStep = 0;
+    totalSteps = edgeTypes.size() + vertexTypes.size() + documentTypes.size() // per-type checks
+        + 3 // buckets + external properties + indexes
+        + (fix ? 1 : 0) // rebuild affected indexes
+        + (compress ? 1 : 0);
 
-    checkDocuments();
+    checkEdges(edgeTypes);
+
+    checkVertices(vertexTypes);
+
+    checkDocuments(documentTypes);
 
     checkBuckets(result);
 
@@ -117,6 +149,9 @@ public class DatabaseChecker {
       LogManager.instance().log(this, Level.INFO, "Rebuilding indexes %s...", null, rebuildIndexes);
 
     if (fix)
+      stepBegin("Rebuilding indexes", affectedIndexes.size());
+
+    if (fix)
       for (final Index idx : affectedIndexes) {
         final String bucketName = database.getSchema().getBucketById(idx.getAssociatedBucketId()).getName();
         final Schema.INDEX_TYPE indexType = idx.getType();
@@ -130,7 +165,12 @@ public class DatabaseChecker {
 
         database.getSchema().buildBucketIndex(typeName, bucketName, propNames.toArray(new String[propNames.size()]))
             .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy).create();
+
+        stepTick();
       }
+
+    if (fix)
+      stepComplete();
 
     if (compress)
       compress();
@@ -166,49 +206,53 @@ public class DatabaseChecker {
         .collect(Collectors.toList());
   }
 
-  private void checkDocuments() {
+  private void checkDocuments(final List<DocumentType> documentTypes) {
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Checking documents...");
 
     final List<String> warnings = new ArrayList<>();
     final Set<RID> corruptedRecords = new LinkedHashSet<>();
 
-    for (final DocumentType type : database.getSchema().getTypes()) {
-      if (types != null && !types.isEmpty())
-        if (type == null || !types.contains(type.getName()))
-          continue;
+    for (final DocumentType type : documentTypes) {
+      stepBegin("Checking documents '" + type.getName() + "'", database.countType(type.getName(), false));
 
-      if (!(type instanceof LocalVertexType) && !(type instanceof LocalEdgeType)) {
-        database.begin();
-        try {
+      database.begin();
+      try {
 
-          // CHECK RECORD IS OF THE RIGHT TYPE
-          for (final Bucket b : type.getBuckets(false)) {
-            b.scan((rid, view) -> {
-              try {
-                final Record record = database.getRecordFactory().newImmutableRecord(database, type, rid, view, null);
-                record.asDocument(true);
-              } catch (Exception e) {
-                warnings.add("vertex " + rid + " cannot be loaded, removing it");
-                corruptedRecords.add(rid);
-              }
-              return true;
-            }, null);
-          }
-
-        } finally {
-          database.commit();
+        // CHECK RECORD IS OF THE RIGHT TYPE
+        for (final Bucket b : type.getBuckets(false)) {
+          b.scan((rid, view) -> {
+            try {
+              final Record record = database.getRecordFactory().newImmutableRecord(database, type, rid, view, null);
+              record.asDocument(true);
+            } catch (Exception e) {
+              warnings.add("vertex " + rid + " cannot be loaded, removing it");
+              corruptedRecords.add(rid);
+            }
+            stepTick();
+            return true;
+          }, null);
         }
 
-        ((LinkedHashSet<String>) result.get("warnings")).addAll(warnings);
-        ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll(corruptedRecords);
+      } finally {
+        database.commit();
       }
+
+      stepComplete();
+
+      ((LinkedHashSet<String>) result.get("warnings")).addAll(warnings);
+      ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll(corruptedRecords);
     }
   }
 
   public void compress() {
     if (database.isTransactionActive())
       database.rollback();
+
+    long totalPagesToCompress = 0;
+    for (final Bucket b : database.getSchema().getBuckets())
+      totalPagesToCompress += ((LocalBucket) b).getTotalPages();
+    stepBegin("Compressing buckets", totalPagesToCompress);
 
     int pageTxBatch = 10;
     int pageBatch = 0;
@@ -237,59 +281,58 @@ public class DatabaseChecker {
         } catch (IOException e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on loading page %d of bucket %s", e, i, bucket.getName());
         }
+        stepTick();
       }
 
       database.commit();
     }
+
+    stepComplete();
   }
 
-  private void checkEdges() {
+  private void checkEdges(final List<DocumentType> edgeTypes) {
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Checking edges...");
 
-    for (final DocumentType type : database.getSchema().getTypes()) {
-      if (types != null && !types.isEmpty())
-        if (type == null || !types.contains(type.getName()))
-          continue;
+    for (final DocumentType type : edgeTypes) {
+      ++currentStep;
 
-      if (type instanceof LocalEdgeType) {
-        final int currentWarnings = ((LinkedHashSet<String>) result.get("warnings")).size();
-        final int currentCorrupted = ((LinkedHashSet<RID>) result.get("corruptedRecords")).size();
-        final Map<String, Object> stats = new GraphDatabaseChecker(database).checkEdges(type.getName(), fix, verboseLevel,
-            Math.max(0, maxWarnings - currentWarnings), Math.max(0, maxWarnings - currentCorrupted));
+      final int currentWarnings = ((LinkedHashSet<String>) result.get("warnings")).size();
+      final int currentCorrupted = ((LinkedHashSet<RID>) result.get("corruptedRecords")).size();
+      final Map<String, Object> stats = new GraphDatabaseChecker(database)
+          .setProgress(progressCallback, "Checking edges '" + type.getName() + "'", currentStep, totalSteps)
+          .checkEdges(type.getName(), fix, verboseLevel,
+              Math.max(0, maxWarnings - currentWarnings), Math.max(0, maxWarnings - currentCorrupted));
 
-        updateStats(stats);
+      updateStats(stats);
 
-        ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
-        ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
-        mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
-            (Map<RID, String>) stats.get("missingReferenceErrors"));
-      }
+      ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
+      ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+      mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
+          (Map<RID, String>) stats.get("missingReferenceErrors"));
     }
   }
 
-  private void checkVertices() {
+  private void checkVertices(final List<DocumentType> vertexTypes) {
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Checking vertices...");
 
-    for (final DocumentType type : database.getSchema().getTypes()) {
-      if (types != null && !types.isEmpty())
-        if (type == null || !types.contains(type.getName()))
-          continue;
+    for (final DocumentType type : vertexTypes) {
+      ++currentStep;
 
-      if (type instanceof LocalVertexType) {
-        final int currentWarnings = ((LinkedHashSet<String>) result.get("warnings")).size();
-        final int currentCorrupted = ((LinkedHashSet<RID>) result.get("corruptedRecords")).size();
-        final Map<String, Object> stats = new GraphDatabaseChecker(database).checkVertices(type.getName(), fix, verboseLevel,
-            Math.max(0, maxWarnings - currentWarnings), Math.max(0, maxWarnings - currentCorrupted));
+      final int currentWarnings = ((LinkedHashSet<String>) result.get("warnings")).size();
+      final int currentCorrupted = ((LinkedHashSet<RID>) result.get("corruptedRecords")).size();
+      final Map<String, Object> stats = new GraphDatabaseChecker(database)
+          .setProgress(progressCallback, "Checking vertices '" + type.getName() + "'", currentStep, totalSteps)
+          .checkVertices(type.getName(), fix, verboseLevel,
+              Math.max(0, maxWarnings - currentWarnings), Math.max(0, maxWarnings - currentCorrupted));
 
-        updateStats(stats);
+      updateStats(stats);
 
-        ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
-        ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
-        mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
-            (Map<RID, String>) stats.get("missingReferenceErrors"));
-      }
+      ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
+      ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+      mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
+          (Map<RID, String>) stats.get("missingReferenceErrors"));
     }
   }
 
@@ -323,10 +366,56 @@ public class DatabaseChecker {
     return this;
   }
 
+  /**
+   * Installs a receiver for step-by-step progress of the whole check (issue #5372). The step plan is computed
+   * upfront in {@link #check()}; emissions are throttled to integer-percentage changes so the callback is
+   * never on the hot path.
+   */
+  public DatabaseChecker setProgressCallback(final ProgressCallback progressCallback) {
+    this.progressCallback = progressCallback;
+    return this;
+  }
+
+  /** Starts a new step of the plan and emits it immediately so pollers see the transition right away. */
+  private void stepBegin(final String name, final long total) {
+    ++currentStep;
+    currentStepName = name;
+    stepDone = 0;
+    stepTotal = total;
+    lastReportedPct = -1;
+    if (progressCallback != null)
+      progressCallback.onProgress(currentStepName, currentStep, totalSteps, 0, total);
+  }
+
+  /** One unit of work done in the current step; emits only when the integer percentage changes. */
+  private void stepTick() {
+    if (progressCallback == null)
+      return;
+    ++stepDone;
+    if (stepTotal > 0 && stepDone > stepTotal)
+      stepDone = stepTotal; // COUNT DRIFT (concurrent writes, placeholders): clamp, never report over 100%
+    final int pct = stepTotal > 0 ? (int) (stepDone * 100 / stepTotal) : (int) (stepDone >>> 13);
+    if (pct != lastReportedPct) {
+      lastReportedPct = pct;
+      progressCallback.onProgress(currentStepName, currentStep, totalSteps, stepDone, stepTotal);
+    }
+  }
+
+  /** Emits the current step as finished (done == total). */
+  private void stepComplete() {
+    if (progressCallback == null)
+      return;
+    if (stepTotal > 0)
+      stepDone = stepTotal;
+    progressCallback.onProgress(currentStepName, currentStep, totalSteps, stepDone, stepTotal > 0 ? stepTotal : stepDone);
+  }
+
   /** Detects (and on FIX deletes) external-property records that are no longer referenced by any primary record. */
   private void checkExternalProperties() {
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Checking external-property buckets...");
+
+    stepBegin("Checking external properties", -1);
 
     final List<String> warnings = new ArrayList<>();
     final Set<RID> orphanedExternalRecords = new LinkedHashSet<>();
@@ -431,6 +520,8 @@ public class DatabaseChecker {
     ((LinkedHashSet<String>) result.get("warnings")).addAll(warnings);
     if (fix)
       ((LinkedHashSet<RID>) result.get("deletedRecordsAfterFix")).addAll(orphanedExternalRecords);
+
+    stepComplete();
   }
 
   /**
@@ -443,11 +534,14 @@ public class DatabaseChecker {
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Checking index metadata...");
 
+    stepBegin("Checking indexes", database.getSchema().getIndexes().length);
+
     final List<String> warnings = new ArrayList<>();
     final Set<String>  corruptedIndexNames = new LinkedHashSet<>();
     final Set<Index>   corruptedIndexes    = new HashSet<>();
 
     for (final Index index : database.getSchema().getIndexes()) {
+      stepTick();
       if (types != null && !types.isEmpty()) {
         final String typeName = index.getTypeName();
         if (typeName == null || !types.contains(typeName))
@@ -475,12 +569,16 @@ public class DatabaseChecker {
     ((LinkedHashSet<String>) result.get("corruptedIndexes")).addAll(corruptedIndexNames);
     ((LinkedHashSet<String>) result.get("warnings")).addAll(warnings);
 
+    stepComplete();
+
     return corruptedIndexes;
   }
 
   private void checkBuckets(final Map<String, Object> result) {
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Checking buckets...");
+
+    stepBegin("Checking buckets", database.getSchema().getBuckets().size());
 
     result.put("pageSize", 0L);
     result.put("totalPages", 0L);
@@ -498,6 +596,8 @@ public class DatabaseChecker {
     result.put("totalActiveEdges", 0L);
 
     for (final Bucket b : database.getSchema().getBuckets()) {
+      stepTick();
+
       final LocalBucket bucket = (LocalBucket) b;
       if (buckets != null && !buckets.isEmpty())
         if (!buckets.contains(bucket.componentName))
@@ -527,6 +627,8 @@ public class DatabaseChecker {
     result.put("avgPageUsed", (Long) result.get("totalPages") > 0 ?
         ((float) (Long) result.get("totalMaxOffset")) / (Long) result.get("totalPages") * 100F / (Long) result.get("pageSize") :
         0F);
+
+    stepComplete();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/OperationProgress.java
+++ b/engine/src/main/java/com/arcadedb/engine/OperationProgress.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.ProgressCallback;
+
+/**
+ * Live progress of one long-running operation, published in {@link OperationProgressRegistry} while the
+ * operation runs. The producer thread updates the volatile fields through {@link #onProgress}; reader threads
+ * (HTTP progress endpoint, console poller) take a weakly-consistent snapshot via the getters or
+ * {@link #toJSON()}. Lock-free by design: updates are plain volatile writes of primitives, so the producer's
+ * hot loop never blocks on a reader.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class OperationProgress implements ProgressCallback {
+  private final    long   id;
+  private final    String databaseName;
+  private final    String operation;
+  private final    long   startedOn;
+  private volatile String stepName   = "";
+  private volatile int    stepIndex  = 0;
+  private volatile int    totalSteps = 0;
+  private volatile long   done       = 0L;
+  private volatile long   total      = -1L;
+
+  OperationProgress(final long id, final String databaseName, final String operation) {
+    this.id = id;
+    this.databaseName = databaseName;
+    this.operation = operation;
+    this.startedOn = System.currentTimeMillis();
+  }
+
+  @Override
+  public void onProgress(final String stepName, final int stepIndex, final int totalSteps, final long done, final long total) {
+    this.stepName = stepName;
+    this.stepIndex = stepIndex;
+    this.totalSteps = totalSteps;
+    this.done = done;
+    this.total = total;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public String getDatabaseName() {
+    return databaseName;
+  }
+
+  public String getOperation() {
+    return operation;
+  }
+
+  public String getStepName() {
+    return stepName;
+  }
+
+  public int getStepIndex() {
+    return stepIndex;
+  }
+
+  public int getTotalSteps() {
+    return totalSteps;
+  }
+
+  public long getDone() {
+    return done;
+  }
+
+  public long getTotal() {
+    return total;
+  }
+
+  /** Percentage of the current step, or -1 when the step total is unknown. */
+  public int getPercentage() {
+    final long currentTotal = total;
+    if (currentTotal <= 0)
+      return -1;
+    final long currentDone = done;
+    return (int) Math.min(100L, currentDone * 100L / currentTotal);
+  }
+
+  public long getStartedOn() {
+    return startedOn;
+  }
+
+  public JSONObject toJSON() {
+    final JSONObject json = new JSONObject();
+    json.put("id", id);
+    json.put("database", databaseName);
+    json.put("operation", operation);
+    json.put("stepName", stepName);
+    json.put("stepIndex", stepIndex);
+    json.put("totalSteps", totalSteps);
+    json.put("done", done);
+    json.put("total", total);
+    json.put("percentage", getPercentage());
+    json.put("startedOn", startedOn);
+    json.put("elapsedMs", System.currentTimeMillis() - startedOn);
+    return json;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/engine/OperationProgress.java
+++ b/engine/src/main/java/com/arcadedb/engine/OperationProgress.java
@@ -103,16 +103,25 @@ public class OperationProgress implements ProgressCallback {
   }
 
   public JSONObject toJSON() {
+    // READ EACH VOLATILE ONCE so done/total/percentage in the emitted JSON are mutually consistent. The
+    // snapshot as a whole is still weakly consistent across fields (no lock is taken on the producer), which
+    // is the documented contract and harmless for a progress display.
+    final String currentStepName = stepName;
+    final int currentStepIndex = stepIndex;
+    final int currentTotalSteps = totalSteps;
+    final long currentDone = done;
+    final long currentTotal = total;
+
     final JSONObject json = new JSONObject();
     json.put("id", id);
     json.put("database", databaseName);
     json.put("operation", operation);
-    json.put("stepName", stepName);
-    json.put("stepIndex", stepIndex);
-    json.put("totalSteps", totalSteps);
-    json.put("done", done);
-    json.put("total", total);
-    json.put("percentage", getPercentage());
+    json.put("stepName", currentStepName);
+    json.put("stepIndex", currentStepIndex);
+    json.put("totalSteps", currentTotalSteps);
+    json.put("done", currentDone);
+    json.put("total", currentTotal);
+    json.put("percentage", currentTotal <= 0 ? -1 : (int) Math.min(100L, currentDone * 100L / currentTotal));
     json.put("startedOn", startedOn);
     json.put("elapsedMs", System.currentTimeMillis() - startedOn);
     return json;

--- a/engine/src/main/java/com/arcadedb/engine/OperationProgressRegistry.java
+++ b/engine/src/main/java/com/arcadedb/engine/OperationProgressRegistry.java
@@ -31,6 +31,11 @@ import java.util.concurrent.atomic.AtomicLong;
  * it in a finally block. Readers (HTTP progress endpoint, console/Studio pollers) get a weakly-consistent
  * snapshot. The registry is deliberately process-local: in an HA cluster each server reports what it is doing,
  * which is what an operator polling that node wants to see.
+ * <p>
+ * Operations are keyed by DATABASE NAME, JVM-globally: in an embedded process hosting two databases that share
+ * a name (different directories), {@link #getOperations} merges their operations in one snapshot. Accepted for
+ * now - the server never hosts two same-named databases - revisit with identity-based keying if that topology
+ * ever becomes supported.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/engine/OperationProgressRegistry.java
+++ b/engine/src/main/java/com/arcadedb/engine/OperationProgressRegistry.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * JVM-wide registry of the long-running maintenance operations currently in progress (CHECK DATABASE first;
+ * COMPACT INDEX, index rebuilds, backups and imports can publish here too). Producers register an
+ * {@link OperationProgress} when the operation starts, feed it as their progress callback, and MUST unregister
+ * it in a finally block. Readers (HTTP progress endpoint, console/Studio pollers) get a weakly-consistent
+ * snapshot. The registry is deliberately process-local: in an HA cluster each server reports what it is doing,
+ * which is what an operator polling that node wants to see.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class OperationProgressRegistry {
+  private static final OperationProgressRegistry INSTANCE = new OperationProgressRegistry();
+
+  private final AtomicLong                                idCounter  = new AtomicLong();
+  private final ConcurrentHashMap<Long, OperationProgress> operations = new ConcurrentHashMap<>();
+
+  private OperationProgressRegistry() {
+  }
+
+  public static OperationProgressRegistry instance() {
+    return INSTANCE;
+  }
+
+  public OperationProgress register(final String databaseName, final String operation) {
+    final OperationProgress progress = new OperationProgress(idCounter.incrementAndGet(), databaseName, operation);
+    operations.put(progress.getId(), progress);
+    return progress;
+  }
+
+  public void unregister(final OperationProgress progress) {
+    if (progress != null)
+      operations.remove(progress.getId());
+  }
+
+  /** Snapshot of the running operations for a database, oldest first. */
+  public List<OperationProgress> getOperations(final String databaseName) {
+    final List<OperationProgress> result = new ArrayList<>();
+    for (final OperationProgress op : operations.values())
+      if (op.getDatabaseName().equals(databaseName))
+        result.add(op);
+    result.sort(Comparator.comparingLong(OperationProgress::getId));
+    return result;
+  }
+
+  public int size() {
+    return operations.size();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -27,6 +27,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.ProgressCallback;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -42,9 +43,65 @@ public class GraphDatabaseChecker {
   private final DatabaseInternal database;
   private final GraphEngine      graphEngine;
 
+  // Progress reporting (issue #5372): the step identity (name/index/totalSteps) is assigned by the caller
+  // (DatabaseChecker owns the step plan); this class emits within-step done/total, throttled to integer
+  // percentage changes so the scan hot loops never pay for the callback.
+  private ProgressCallback progress;
+  private String           progressStepName;
+  private int              progressStepIndex;
+  private int              progressTotalSteps;
+  private long             progressDone;
+  private long             progressTotal;
+  private int              lastReportedPct;
+
   public GraphDatabaseChecker(DatabaseInternal database) {
     this.database = database;
     this.graphEngine = database.getGraphEngine();
+  }
+
+  /** Installs the progress receiver and this checker's step identity in the caller's step plan. */
+  public GraphDatabaseChecker setProgress(final ProgressCallback progress, final String stepName, final int stepIndex,
+      final int totalSteps) {
+    this.progress = progress;
+    this.progressStepName = stepName;
+    this.progressStepIndex = stepIndex;
+    this.progressTotalSteps = totalSteps;
+    return this;
+  }
+
+  /** Starts a (sub-)phase of the current step, emitting it immediately so pollers see the transition. */
+  private void progressBegin(final String name, final long total) {
+    if (progress == null)
+      return;
+    progressStepName = name;
+    progressDone = 0;
+    progressTotal = total;
+    lastReportedPct = -1;
+    progress.onProgress(progressStepName, progressStepIndex, progressTotalSteps, 0, total);
+  }
+
+  /** One unit of work done; emits only when the integer percentage changes. */
+  private void progressTick() {
+    if (progress == null)
+      return;
+    ++progressDone;
+    if (progressTotal > 0 && progressDone > progressTotal)
+      progressDone = progressTotal; // COUNT DRIFT (concurrent writes, placeholders): clamp, never report over 100%
+    final int pct = progressTotal > 0 ? (int) (progressDone * 100 / progressTotal) : (int) (progressDone >>> 13);
+    if (pct != lastReportedPct) {
+      lastReportedPct = pct;
+      progress.onProgress(progressStepName, progressStepIndex, progressTotalSteps, progressDone, progressTotal);
+    }
+  }
+
+  /** Emits the current phase as finished (done == total). */
+  private void progressComplete() {
+    if (progress == null)
+      return;
+    if (progressTotal > 0)
+      progressDone = progressTotal;
+    progress.onProgress(progressStepName, progressStepIndex, progressTotalSteps, progressDone,
+        progressTotal > 0 ? progressTotal : progressDone);
   }
 
   public Map<String, Object> checkVertices(final String typeName, final boolean fix, final int verboseLevel) {
@@ -68,6 +125,9 @@ public class GraphDatabaseChecker {
 
     database.begin();
     try {
+      // TWO FULL PASSES OVER THE TYPE (record-type scan + connectivity walk): progress total is 2x the count.
+      progressBegin(progressStepName, 2 * database.countType(typeName, false));
+
       // CHECK RECORD IS OF THE RIGHT TYPE
       final DocumentType type = database.getSchema().getType(typeName);
       for (final Bucket b : type.getBuckets(false)) {
@@ -79,11 +139,13 @@ public class GraphDatabaseChecker {
             addWarning(warnings, totalWarnings, maxWarnings, "vertex " + rid + " cannot be loaded, removing it");
             addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
           }
+          progressTick();
           return true;
         }, null);
       }
 
       database.scanType(typeName, false, record -> {
+        progressTick();
         try {
           Vertex vertex = record.asVertex(true);
 
@@ -105,11 +167,14 @@ public class GraphDatabaseChecker {
 
         return true;
       }, (rid, exception) -> {
+        progressTick();
         addWarning(warnings, totalWarnings, maxWarnings,
             "vertex " + rid + " cannot be loaded (error: " + describe(exception) + ")");
         addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
         return true;
       });
+
+      progressComplete();
 
       if (fix) {
         if (!reconnectOutEdges.isEmpty() || !reconnectInEdges.isEmpty())
@@ -170,11 +235,14 @@ public class GraphDatabaseChecker {
     final List<Edge> outEdgesToReconnect = new ArrayList<>();
     final List<Edge> inEdgesToReconnect = new ArrayList<>();
 
+    progressBegin(progressStepName == null ? "Rebuilding edge lists" : progressStepName + " - rebuilding edge lists", -1);
+
     for (EdgeType edgeType : edgeTypes) {
       final boolean bidirectional = edgeType.isBidirectional();
       // Scan with an error callback: on a damaged database an unreadable edge record must not abort the whole
       // rebuild - it is skipped (checkEdges reports/deletes it), the surviving records still reconnect.
       database.scanType(edgeType.getName(), false, record -> {
+        progressTick();
         try {
           final Edge e = record.asEdge(true);
           if (corruptedRecords.contains(e.getIdentity()))
@@ -711,6 +779,9 @@ public class GraphDatabaseChecker {
     database.begin();
 
     try {
+      // TWO FULL PASSES OVER THE TYPE (record-type scan + endpoint checks): progress total is 2x the count.
+      progressBegin(progressStepName, 2 * database.countType(typeName, false));
+
       // CHECK RECORD IS OF THE RIGHT TYPE
       final DocumentType type = database.getSchema().getType(typeName);
       for (final Bucket b : type.getBuckets(false)) {
@@ -722,11 +793,13 @@ public class GraphDatabaseChecker {
             addWarning(warnings, totalWarnings, maxWarnings, "edge " + rid + " cannot be loaded, removing it");
             addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
           }
+          progressTick();
           return true;
         }, null);
       }
 
       database.scanType(typeName, false, record -> {
+        progressTick();
         final RID edgeRID = record.getIdentity();
 
         try {
@@ -805,11 +878,14 @@ public class GraphDatabaseChecker {
 
         return true;
       }, (rid, exception) -> {
+        progressTick();
         addWarning(warnings, totalWarnings, maxWarnings,
             "edge " + rid + " cannot be loaded (error: " + describe(exception) + ")");
         addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
         return true;
       });
+
+      progressComplete();
 
       if (fix) {
         for (final RID rid : corruptedRecords) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -126,6 +126,7 @@ public class GraphDatabaseChecker {
     database.begin();
     try {
       // TWO FULL PASSES OVER THE TYPE (record-type scan + connectivity walk): progress total is 2x the count.
+      // countType reads the maintained bucket counters (no scan), so sizing the total is negligible.
       progressBegin(progressStepName, 2 * database.countType(typeName, false));
 
       // CHECK RECORD IS OF THE RIGHT TYPE

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CheckDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CheckDatabaseStatement.java
@@ -52,7 +52,7 @@ public class CheckDatabaseStatement extends SimpleExecStatement {
     if (context.getDatabase().isTransactionActive())
       context.getDatabase().rollback();
 
-    final DatabaseChecker checker = new DatabaseChecker(context.getDatabase().getWrappedDatabaseInstance());
+    final DatabaseChecker checker = createChecker(context);
     checker.setVerboseLevel(0);
     checker.setBuckets(buckets.stream().map(x -> x.getValue()).collect(Collectors.toSet()));
     checker.setTypes(types.stream().map(x -> x.getStringValue().startsWith("\"") || x.getStringValue().startsWith("'") ?
@@ -79,6 +79,11 @@ public class CheckDatabaseStatement extends SimpleExecStatement {
     final InternalResultSet rs = new InternalResultSet();
     rs.add(result);
     return rs;
+  }
+
+  /** Package-private seam for tests: lets a test inject a checker whose {@code check()} fails mid-run. */
+  DatabaseChecker createChecker(final CommandContext context) {
+    return new DatabaseChecker(context.getDatabase().getWrappedDatabaseInstance());
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CheckDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CheckDatabaseStatement.java
@@ -21,6 +21,8 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.engine.DatabaseChecker;
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.ResultInternal;
@@ -59,7 +61,18 @@ public class CheckDatabaseStatement extends SimpleExecStatement {
     checker.setFix(fix);
     checker.setCompress(compress);
 
-    final Map<String, Object> checkResult = checker.check();
+    // PUBLISH LIVE PROGRESS (issue #5372): pollable while the check runs via the progress HTTP endpoint,
+    // the console and Studio. Always retired in the finally, even when the check fails.
+    final OperationProgress progress = OperationProgressRegistry.instance()
+        .register(context.getDatabase().getName(), fix ? "check database fix" : "check database");
+    checker.setProgressCallback(progress);
+
+    final Map<String, Object> checkResult;
+    try {
+      checkResult = checker.check();
+    } finally {
+      OperationProgressRegistry.instance().unregister(progress);
+    }
 
     result.setPropertiesFromMap(checkResult);
 

--- a/engine/src/main/java/com/arcadedb/utility/ProgressCallback.java
+++ b/engine/src/main/java/com/arcadedb/utility/ProgressCallback.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+/**
+ * Receives progress notifications from long-running maintenance operations (CHECK DATABASE, index rebuilds,
+ * etc.). Implementations must be cheap and non-blocking: producers invoke the callback from their hot loop
+ * (already throttled to integer-percentage changes) and pass only primitives plus interned/step-constant
+ * strings, so a well-behaved implementation causes no garbage-collector pressure.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@FunctionalInterface
+public interface ProgressCallback {
+  /**
+   * @param stepName   human-readable name of the current step (e.g. "Checking vertices 'Account'")
+   * @param stepIndex  1-based index of the current step
+   * @param totalSteps total number of steps of the whole operation
+   * @param done       units of work completed in the current step
+   * @param total      total units of work of the current step, or -1 when unknown
+   */
+  void onProgress(String stepName, int stepIndex, int totalSteps, long done, long total);
+}

--- a/engine/src/test/java/com/arcadedb/engine/CheckDatabaseProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/CheckDatabaseProgressTest.java
@@ -131,21 +131,7 @@ class CheckDatabaseProgressTest extends TestHelper {
     }
 
     // THE OPERATION MUST BE RETIRED FROM THE REGISTRY WHEN THE STATEMENT COMPLETES.
+    // The failure path (retire despite a mid-check exception) is covered by CheckDatabaseStatementProgressTest.
     assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).hasSize(before);
-  }
-
-  @Test
-  void sqlStatementRetiresTheOperationOnFailureToo() {
-    createSampleGraph();
-
-    // TYPE FILTER ON A NON-EXISTENT TYPE STILL RUNS AND COMPLETES; the retire-on-completion contract is the
-    // finally block, exercised on the happy path above. Here the statement is run twice back to back to prove
-    // no registrations leak across runs.
-    for (int i = 0; i < 2; i++)
-      try (final ResultSet result = database.command("sql", "CHECK DATABASE")) {
-        result.hasNext();
-      }
-
-    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/CheckDatabaseProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/CheckDatabaseProgressTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CHECK DATABASE progress reporting: the checker emits step-by-step progress with percentages through
+ * {@link com.arcadedb.utility.ProgressCallback}, and the SQL statement publishes/retires the operation in
+ * {@link OperationProgressRegistry}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseProgressTest extends TestHelper {
+
+  private record Emission(String stepName, int stepIndex, int totalSteps, long done, long total) {
+  }
+
+  private void createSampleGraph() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Person", 1);
+      database.getSchema().createVertexType("Company", 1);
+      database.getSchema().createEdgeType("WorksAt", 1);
+      database.getSchema().createDocumentType("Note", 1);
+    });
+
+    database.transaction(() -> {
+      final MutableVertex company = database.newVertex("Company").set("name", "Arcade").save();
+      for (int i = 0; i < 500; i++) {
+        final MutableVertex person = database.newVertex("Person").set("i", i).save();
+        person.newEdge("WorksAt", company);
+      }
+      for (int i = 0; i < 100; i++) {
+        final MutableDocument note = database.newDocument("Note");
+        note.set("i", i).save();
+      }
+    });
+  }
+
+  @Test
+  void checkerEmitsOrderedStepsWithPercentages() {
+    createSampleGraph();
+
+    final List<Emission> emissions = new ArrayList<>();
+    final DatabaseChecker checker = new DatabaseChecker(database).setVerboseLevel(0)
+        .setProgressCallback((stepName, stepIndex, totalSteps, done, total) ->
+            emissions.add(new Emission(stepName, stepIndex, totalSteps, done, total)));
+
+    checker.check();
+
+    assertThat(emissions).isNotEmpty();
+
+    final int totalSteps = emissions.getFirst().totalSteps;
+    // 1 edge type + 2 vertex types + 1 document type + buckets + external + indexes = 7 (no fix, no compress).
+    assertThat(totalSteps).isEqualTo(7);
+
+    int lastStep = 0;
+    for (final Emission e : emissions) {
+      // STEP INDEX IS MONOTONIC, 1-BASED, BOUNDED; TOTAL STEPS IS STABLE ACROSS THE WHOLE RUN.
+      assertThat(e.stepIndex).isBetween(1, totalSteps);
+      assertThat(e.stepIndex).isGreaterThanOrEqualTo(lastStep);
+      assertThat(e.totalSteps).isEqualTo(totalSteps);
+      assertThat(e.stepName).isNotBlank();
+      if (e.total > 0)
+        assertThat(e.done).isLessThanOrEqualTo(e.total);
+      lastStep = e.stepIndex;
+    }
+    // THE RUN WALKS EVERY STEP AND FINISHES THE LAST ONE.
+    assertThat(lastStep).isEqualTo(totalSteps);
+
+    // THE PER-TYPE STEPS ARE NAMED AFTER THE TYPES AND REACH 100%.
+    for (final String expectedStep : new String[] { "Checking edges 'WorksAt'", "Checking vertices 'Person'",
+        "Checking vertices 'Company'", "Checking documents 'Note'" }) {
+      final List<Emission> step = emissions.stream().filter(e -> e.stepName.equals(expectedStep)).toList();
+      assertThat(step).as("emissions for step '" + expectedStep + "'").isNotEmpty();
+      final Emission last = step.getLast();
+      assertThat(last.total).isGreaterThan(0);
+      assertThat(last.done).isEqualTo(last.total);
+    }
+  }
+
+  @Test
+  void fixModeAddsRebuildIndexesStep() {
+    createSampleGraph();
+
+    final List<Emission> emissions = new ArrayList<>();
+    new DatabaseChecker(database).setVerboseLevel(0).setFix(true)
+        .setProgressCallback((stepName, stepIndex, totalSteps, done, total) ->
+            emissions.add(new Emission(stepName, stepIndex, totalSteps, done, total)))
+        .check();
+
+    // FIX ADDS THE "Rebuilding indexes" STEP: 7 + 1.
+    assertThat(emissions.getFirst().totalSteps).isEqualTo(8);
+    assertThat(emissions.stream().anyMatch(e -> e.stepName.startsWith("Rebuilding indexes"))).isTrue();
+  }
+
+  @Test
+  void sqlStatementRegistersAndRetiresTheOperation() {
+    createSampleGraph();
+
+    final int before = OperationProgressRegistry.instance().getOperations(database.getName()).size();
+
+    try (final ResultSet result = database.command("sql", "CHECK DATABASE")) {
+      assertThat(result.hasNext()).isTrue();
+    }
+
+    // THE OPERATION MUST BE RETIRED FROM THE REGISTRY WHEN THE STATEMENT COMPLETES.
+    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).hasSize(before);
+  }
+
+  @Test
+  void sqlStatementRetiresTheOperationOnFailureToo() {
+    createSampleGraph();
+
+    // TYPE FILTER ON A NON-EXISTENT TYPE STILL RUNS AND COMPLETES; the retire-on-completion contract is the
+    // finally block, exercised on the happy path above. Here the statement is run twice back to back to prove
+    // no registrations leak across runs.
+    for (int i = 0; i < 2; i++)
+      try (final ResultSet result = database.command("sql", "CHECK DATABASE")) {
+        result.hasNext();
+      }
+
+    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/OperationProgressRegistryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/OperationProgressRegistryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.serializer.json.JSONObject;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the running-operations registry backing the progress reporting of long maintenance
+ * operations.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class OperationProgressRegistryTest {
+
+  @Test
+  void registerUpdateSnapshotUnregister() {
+    final OperationProgressRegistry registry = OperationProgressRegistry.instance();
+    final int initialSize = registry.size();
+
+    final OperationProgress op = registry.register("testdb-progress", "check database");
+    try {
+      assertThat(registry.size()).isEqualTo(initialSize + 1);
+      assertThat(op.getDatabaseName()).isEqualTo("testdb-progress");
+      assertThat(op.getOperation()).isEqualTo("check database");
+      assertThat(op.getStartedOn()).isGreaterThan(0L);
+
+      // BEFORE ANY UPDATE: empty step, unknown total.
+      assertThat(op.getStepIndex()).isEqualTo(0);
+      assertThat(op.getPercentage()).isEqualTo(-1);
+
+      op.onProgress("Checking vertices 'Account'", 2, 7, 421, 1000);
+      assertThat(op.getStepName()).isEqualTo("Checking vertices 'Account'");
+      assertThat(op.getStepIndex()).isEqualTo(2);
+      assertThat(op.getTotalSteps()).isEqualTo(7);
+      assertThat(op.getDone()).isEqualTo(421);
+      assertThat(op.getTotal()).isEqualTo(1000);
+      assertThat(op.getPercentage()).isEqualTo(42);
+
+      // SNAPSHOT BY DATABASE, oldest first.
+      final List<OperationProgress> ops = registry.getOperations("testdb-progress");
+      assertThat(ops).hasSize(1);
+      assertThat(ops.getFirst().getId()).isEqualTo(op.getId());
+      assertThat(registry.getOperations("some-other-db")).isEmpty();
+
+      // JSON SHAPE consumed by the HTTP endpoint and the pollers.
+      final JSONObject json = op.toJSON();
+      assertThat(json.getLong("id", -1)).isEqualTo(op.getId());
+      assertThat(json.getString("database", "")).isEqualTo("testdb-progress");
+      assertThat(json.getString("operation", "")).isEqualTo("check database");
+      assertThat(json.getString("stepName", "")).isEqualTo("Checking vertices 'Account'");
+      assertThat(json.getInt("stepIndex", -1)).isEqualTo(2);
+      assertThat(json.getInt("totalSteps", -1)).isEqualTo(7);
+      assertThat(json.getLong("done", -1)).isEqualTo(421);
+      assertThat(json.getLong("total", -1)).isEqualTo(1000);
+      assertThat(json.getInt("percentage", -1)).isEqualTo(42);
+      assertThat(json.getLong("elapsedMs", -1)).isGreaterThanOrEqualTo(0L);
+    } finally {
+      registry.unregister(op);
+    }
+    assertThat(registry.size()).isEqualTo(initialSize);
+    assertThat(registry.getOperations("testdb-progress")).isEmpty();
+  }
+
+  @Test
+  void percentageClampsAndHandlesUnknownTotal() {
+    final OperationProgressRegistry registry = OperationProgressRegistry.instance();
+    final OperationProgress op = registry.register("testdb-progress2", "check database fix");
+    try {
+      op.onProgress("rebuild", 1, 1, 50, -1);
+      assertThat(op.getPercentage()).isEqualTo(-1); // UNKNOWN TOTAL
+
+      op.onProgress("rebuild", 1, 1, 2000, 1000);
+      assertThat(op.getPercentage()).isEqualTo(100); // CLAMPED, NEVER OVER 100
+    } finally {
+      registry.unregister(op);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/CheckDatabaseStatementProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/CheckDatabaseStatementProgressTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.DatabaseChecker;
+import com.arcadedb.engine.OperationProgressRegistry;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The CHECK DATABASE statement must retire its {@link OperationProgressRegistry} entry even when the check
+ * itself fails mid-run (issue #5372): a leaked entry would make pollers show a phantom operation forever.
+ * Uses the statement's package-private checker seam to inject a checker that throws.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseStatementProgressTest extends TestHelper {
+
+  @Test
+  void operationIsRetiredWhenTheCheckFails() {
+    final CommandContext context = new BasicCommandContext();
+    ((BasicCommandContext) context).setDatabase(database);
+
+    final CheckDatabaseStatement statement = new CheckDatabaseStatement(-1) {
+      @Override
+      DatabaseChecker createChecker(final CommandContext ctx) {
+        return new DatabaseChecker(ctx.getDatabase().getWrappedDatabaseInstance()) {
+          @Override
+          public Map<String, Object> check() {
+            throw new RuntimeException("simulated mid-check failure");
+          }
+        };
+      }
+    };
+
+    assertThatThrownBy(() -> statement.executeSimple(context))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("simulated mid-check failure");
+
+    // THE FINALLY BLOCK MUST HAVE RETIRED THE OPERATION DESPITE THE FAILURE.
+    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
+  }
+}

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -662,6 +662,34 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
         callback);
   }
 
+  /**
+   * Returns the long-running maintenance operations (CHECK DATABASE, ...) currently in progress on the
+   * connected server for this database (issue #5372), one JSON object per operation carrying
+   * {@code operation}, {@code stepName}, {@code stepIndex}, {@code totalSteps}, {@code done}, {@code total}
+   * and {@code percentage} (-1 when the step total is unknown). Safe to poll at any frequency: the server side
+   * answers from a lock-free in-memory snapshot without touching the database.
+   */
+  public List<JSONObject> getProgress() {
+    checkDatabaseIsOpen();
+    try {
+      final HttpRequest request = createRequestBuilder("GET", getUrl("progress", databaseName)).GET().build();
+      final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() != 200)
+        throw new RemoteException("Error on requesting operation progress", manageException(response, "progress"));
+
+      final JSONArray result = new JSONObject(response.body()).getJSONArray("result");
+      final List<JSONObject> operations = new ArrayList<>(result.length());
+      for (int i = 0; i < result.length(); i++)
+        operations.add(result.getJSONObject(i));
+      return operations;
+    } catch (final RemoteException | SecurityException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new RemoteException("Error on requesting operation progress", e);
+    }
+  }
+
   String getSessionId() {
     return sessionId;
   }

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -37,6 +37,7 @@ import com.arcadedb.server.http.handler.GetDynamicContentHandler;
 import com.arcadedb.server.http.handler.GetExistsDatabaseHandler;
 import com.arcadedb.server.http.handler.GetHealthHandler;
 import com.arcadedb.server.http.handler.GetOpenApiHandler;
+import com.arcadedb.server.http.handler.GetProgressHandler;
 import com.arcadedb.server.http.handler.GetQueryHandler;
 import com.arcadedb.server.http.handler.GetReadyHandler;
 import com.arcadedb.server.http.handler.GetServerHandler;
@@ -224,6 +225,7 @@ public class HttpServer implements ServerPlugin {
         .post("/commit/{database}", new PostCommitHandler(this))
         .get("/databases", new GetDatabasesHandler(this))
         .get("/exists/{database}", new GetExistsDatabaseHandler(this))
+        .get("/progress/{database}", new GetProgressHandler(this))
         .post("/login", new PostLoginHandler(this))
         .post("/logout", new PostLogoutHandler(this))
         .get("/query/{database}/{language}/{command}", new GetQueryHandler(this))

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetProgressHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetProgressHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.server.HttpServerExchange;
+
+import java.util.Deque;
+import java.util.Set;
+
+/**
+ * Returns the long-running maintenance operations (CHECK DATABASE, ...) currently in progress on this server
+ * for one database, with their step-by-step progress (issue #5372). Polled by the console and Studio to render
+ * a progress bar while a synchronous command runs. Deliberately reads only the lock-free
+ * {@link OperationProgressRegistry} snapshot: no database access, no transaction, so polling is safe at any
+ * frequency and cannot interfere with the operation being watched.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class GetProgressHandler extends AbstractServerHttpHandler {
+  public GetProgressHandler(final HttpServer httpServer) {
+    super(httpServer);
+  }
+
+  @Override
+  public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
+    final Deque<String> databaseNameParam = exchange.getQueryParameters().get("database");
+    if (databaseNameParam == null || databaseNameParam.isEmpty())
+      return new ExecutionResponse(400, "{ \"error\" : \"Database parameter is null\"}");
+
+    final String databaseName = databaseNameParam.getFirst();
+
+    // SAME AUTHORIZATION MODEL AS THE OTHER DATABASE ENDPOINTS: the user must be authorized on the database.
+    final Set<String> allowedDatabases = user.getAuthorizedDatabases();
+    if (!allowedDatabases.contains("*") && !allowedDatabases.contains(databaseName))
+      return new ExecutionResponse(403, "{ \"error\" : \"Not authorized on database '" + databaseName + "'\"}");
+
+    final JSONArray operations = new JSONArray();
+    for (final OperationProgress op : OperationProgressRegistry.instance().getOperations(databaseName))
+      operations.put(op.toJSON());
+
+    final JSONObject response = new JSONObject();
+    response.put("result", operations);
+    return new ExecutionResponse(200, response.toString());
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetProgressHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetProgressHandler.java
@@ -27,7 +27,6 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
 import java.util.Deque;
-import java.util.Set;
 
 /**
  * Returns the long-running maintenance operations (CHECK DATABASE, ...) currently in progress on this server
@@ -46,15 +45,12 @@ public class GetProgressHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
     final Deque<String> databaseNameParam = exchange.getQueryParameters().get("database");
-    if (databaseNameParam == null || databaseNameParam.isEmpty())
-      return new ExecutionResponse(400, "{ \"error\" : \"Database parameter is null\"}");
+    final String databaseName = databaseNameParam == null || databaseNameParam.isEmpty() ? null : databaseNameParam.getFirst();
 
-    final String databaseName = databaseNameParam.getFirst();
-
-    // SAME AUTHORIZATION MODEL AS THE OTHER DATABASE ENDPOINTS: the user must be authorized on the database.
-    final Set<String> allowedDatabases = user.getAuthorizedDatabases();
-    if (!allowedDatabases.contains("*") && !allowedDatabases.contains(databaseName))
-      return new ExecutionResponse(403, "{ \"error\" : \"Not authorized on database '" + databaseName + "'\"}");
+    // CONSOLIDATED PER-DATABASE AUTHORIZATION GATE (GHSA-x8mg-6r4p-87pf): throws IllegalArgumentException
+    // (mapped to HTTP 400) on a missing database name and SecurityException (mapped to HTTP 403) when the
+    // authenticated user cannot access the database.
+    checkAuthorizationOnDatabase(user, databaseName);
 
     final JSONArray operations = new JSONArray();
     for (final OperationProgress op : OperationProgressRegistry.instance().getOperations(databaseName))

--- a/server/src/test/java/com/arcadedb/server/http/handler/GetProgressHandlerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/GetProgressHandlerTest.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +62,9 @@ class GetProgressHandlerTest {
 
   private ServerSecurityUser userAuthorizedOn(final String... databases) {
     final ServerSecurityUser user = mock(ServerSecurityUser.class);
-    when(user.getAuthorizedDatabases()).thenReturn(Set.of(databases));
+    final Set<String> authorized = Set.of(databases);
+    when(user.canAccessToDatabase(anyString()))
+        .thenAnswer(invocation -> authorized.contains("*") || authorized.contains((String) invocation.getArgument(0)));
     return user;
   }
 
@@ -102,17 +106,18 @@ class GetProgressHandlerTest {
   void unauthorizedDatabaseIsRejected() {
     final GetProgressHandler handler = new GetProgressHandler(mock(HttpServer.class));
 
-    final ExecutionResponse response = handler.execute(exchangeFor("someoneelsesdb"), userAuthorizedOn("progressdb"), null);
-
-    assertThat(response.getCode()).isEqualTo(403);
+    // The consolidated checkAuthorizationOnDatabase gate throws SecurityException, mapped to HTTP 403 by the
+    // base handler's catch chain.
+    assertThatThrownBy(() -> handler.execute(exchangeFor("someoneelsesdb"), userAuthorizedOn("progressdb"), null))
+        .isInstanceOf(SecurityException.class);
   }
 
   @Test
   void missingDatabaseParameterIsRejected() {
     final GetProgressHandler handler = new GetProgressHandler(mock(HttpServer.class));
 
-    final ExecutionResponse response = handler.execute(exchangeFor(null), userAuthorizedOn("*"), null);
-
-    assertThat(response.getCode()).isEqualTo(400);
+    // A missing database name throws IllegalArgumentException, mapped to HTTP 400 by the base handler.
+    assertThatThrownBy(() -> handler.execute(exchangeFor(null), userAuthorizedOn("*"), null))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/GetProgressHandlerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/GetProgressHandlerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import io.undertow.server.HttpServerExchange;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The progress endpoint (issue #5372) returns the running maintenance operations of a database and enforces
+ * the per-database authorization model.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GetProgressHandlerTest {
+
+  private HttpServerExchange exchangeFor(final String databaseName) {
+    final HttpServerExchange exchange = mock(HttpServerExchange.class);
+    final Map<String, Deque<String>> params = new HashMap<>();
+    if (databaseName != null) {
+      final Deque<String> db = new ArrayDeque<>();
+      db.add(databaseName);
+      params.put("database", db);
+    }
+    when(exchange.getQueryParameters()).thenReturn(params);
+    return exchange;
+  }
+
+  private ServerSecurityUser userAuthorizedOn(final String... databases) {
+    final ServerSecurityUser user = mock(ServerSecurityUser.class);
+    when(user.getAuthorizedDatabases()).thenReturn(Set.of(databases));
+    return user;
+  }
+
+  @Test
+  void returnsRunningOperationsForAuthorizedUser() {
+    final GetProgressHandler handler = new GetProgressHandler(mock(HttpServer.class));
+
+    final OperationProgress op = OperationProgressRegistry.instance().register("progressdb", "check database fix");
+    try {
+      op.onProgress("Checking vertices 'Account'", 3, 9, 42, 100);
+
+      final ExecutionResponse response = handler.execute(exchangeFor("progressdb"), userAuthorizedOn("progressdb"), null);
+
+      assertThat(response.getCode()).isEqualTo(200);
+      final JSONArray result = new JSONObject(response.getResponse()).getJSONArray("result");
+      assertThat(result.length()).isEqualTo(1);
+      final JSONObject json = result.getJSONObject(0);
+      assertThat(json.getString("operation", "")).isEqualTo("check database fix");
+      assertThat(json.getString("stepName", "")).isEqualTo("Checking vertices 'Account'");
+      assertThat(json.getInt("stepIndex", -1)).isEqualTo(3);
+      assertThat(json.getInt("totalSteps", -1)).isEqualTo(9);
+      assertThat(json.getInt("percentage", -1)).isEqualTo(42);
+    } finally {
+      OperationProgressRegistry.instance().unregister(op);
+    }
+  }
+
+  @Test
+  void emptyResultWhenNothingIsRunning() {
+    final GetProgressHandler handler = new GetProgressHandler(mock(HttpServer.class));
+
+    final ExecutionResponse response = handler.execute(exchangeFor("idledb"), userAuthorizedOn("*"), null);
+
+    assertThat(response.getCode()).isEqualTo(200);
+    assertThat(new JSONObject(response.getResponse()).getJSONArray("result").length()).isEqualTo(0);
+  }
+
+  @Test
+  void unauthorizedDatabaseIsRejected() {
+    final GetProgressHandler handler = new GetProgressHandler(mock(HttpServer.class));
+
+    final ExecutionResponse response = handler.execute(exchangeFor("someoneelsesdb"), userAuthorizedOn("progressdb"), null);
+
+    assertThat(response.getCode()).isEqualTo(403);
+  }
+
+  @Test
+  void missingDatabaseParameterIsRejected() {
+    final GetProgressHandler handler = new GetProgressHandler(mock(HttpServer.class));
+
+    final ExecutionResponse response = handler.execute(exchangeFor(null), userAuthorizedOn("*"), null);
+
+    assertThat(response.getCode()).isEqualTo(400);
+  }
+}

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3048,6 +3048,11 @@ function startCommandProgressMonitor(database, command) {
         }
         $("#commandProgressLabel").html(label);
         $("#commandProgressBar").css("width", (pct != null ? pct : 100) + "%");
+      })
+      .fail(function () {
+        // The endpoint is unavailable (older server, auth change, network): stop polling instead of firing
+        // a failing request every second until the command completes.
+        stopCommandProgressMonitor();
       });
   }, 1000);
 }

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3009,6 +3009,56 @@ function executeCommand(language, query) {
   if (activeSidebarPanel == "history") populateHistoryPanel();
 }
 
+// Live progress for long-running maintenance commands (issue #5372): while a matching command is in flight,
+// poll the server's progress endpoint and render a small progress bar next to the execute spinner.
+let globalCommandProgressTimer = null;
+
+function startCommandProgressMonitor(database, command) {
+  if (!/^\s*check\s+database/i.test(command)) return;
+
+  stopCommandProgressMonitor();
+
+  globalCommandProgressTimer = setInterval(function () {
+    jQuery
+      .ajax({
+        type: "GET",
+        url: "api/v1/progress/" + database,
+        beforeSend: function (xhr) {
+          xhr.setRequestHeader("Authorization", globalCredentials);
+        },
+      })
+      .done(function (data) {
+        if (data.result == null || data.result.length == 0) return;
+
+        let op = data.result[0];
+        let pct = op.percentage >= 0 ? op.percentage : null;
+        let label = escapeHtml(op.operation) + " [step " + op.stepIndex + "/" + op.totalSteps + "] " + escapeHtml(op.stepName) + (pct != null ? " - " + pct + "%" : "");
+
+        let container = $("#commandProgress");
+        if (container.length == 0) {
+          $("#executeSpinner").after(
+            "<div id='commandProgress' class='ms-2' style='display: inline-block; min-width: 320px; vertical-align: middle;'>" +
+              "<div id='commandProgressLabel' style='font-size: 12px;'></div>" +
+              "<div class='progress' style='height: 6px;'>" +
+                "<div id='commandProgressBar' class='progress-bar progress-bar-striped progress-bar-animated' role='progressbar' style='width: 0%'></div>" +
+              "</div>" +
+            "</div>",
+          );
+        }
+        $("#commandProgressLabel").html(label);
+        $("#commandProgressBar").css("width", (pct != null ? pct : 100) + "%");
+      });
+  }, 1000);
+}
+
+function stopCommandProgressMonitor() {
+  if (globalCommandProgressTimer != null) {
+    clearInterval(globalCommandProgressTimer);
+    globalCommandProgressTimer = null;
+  }
+  $("#commandProgress").remove();
+}
+
 function executeCommandTable() {
   let database = getCurrentDatabase();
   let language = escapeHtml($("#inputLanguage").val());
@@ -3020,6 +3070,7 @@ function executeCommandTable() {
   let profileExecution = $("#profileCommand").prop("checked") ? "detailed" : "basic";
 
   $("#executeSpinner").show();
+  startCommandProgressMonitor(database, command);
 
   let beginTime = new Date();
 
@@ -3058,6 +3109,7 @@ function executeCommandTable() {
     })
     .always(function (data) {
       $("#executeSpinner").hide();
+      stopCommandProgressMonitor();
     });
 }
 
@@ -3073,6 +3125,7 @@ function executeCommandGraph() {
   let profileExecution = $("#profileCommand").prop("checked") ? "detailed" : "basic";
 
   $("#executeSpinner").show();
+  startCommandProgressMonitor(database, command);
 
   let beginTime = new Date();
 
@@ -3123,6 +3176,7 @@ function executeCommandGraph() {
     })
     .always(function (data) {
       $("#executeSpinner").hide();
+      stopCommandProgressMonitor();
     });
 }
 

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3030,6 +3030,7 @@ function startCommandProgressMonitor(database, command) {
       .done(function (data) {
         if (data.result == null || data.result.length == 0) return;
 
+        // Deliberate limitation: only the oldest running operation is rendered (the endpoint returns all).
         let op = data.result[0];
         let pct = op.percentage >= 0 ? op.percentage : null;
         let label = escapeHtml(op.operation) + " [step " + op.stepIndex + "/" + op.totalSteps + "] " + escapeHtml(op.stepName) + (pct != null ? " - " + pct + "%" : "");


### PR DESCRIPTION
Closes #5372.

> **Stacked on #5370** (base is `check-rebuild-edge-chains`, not `main`) because the progress wiring touches the rebuilt `GraphDatabaseChecker`. Merge #5370 first; GitHub will retarget this PR to `main` automatically and the diff here stays limited to the progress feature.

Long-running maintenance operations gave no feedback until they returned. This adds live "step 3/7 - 42%" progress for `CHECK DATABASE`, built on a generic primitive that `COMPACT INDEX`, index rebuilds, backups and imports can adopt later.

## Engine
- `ProgressCallback` (`onProgress(stepName, stepIndex, totalSteps, done, total)`), designed to be allocation-free on the hot path.
- `OperationProgress` / `OperationProgressRegistry`: a JVM-wide, lock-free registry of running operations. Producers update volatile primitives; readers (HTTP endpoint, pollers) take weakly-consistent snapshots. Deliberately process-local: in HA each node reports what it is doing.
- `DatabaseChecker.check()` computes the full step plan upfront (per-type edge/vertex/document checks + buckets + external properties + indexes + fix-rebuild + compress), so every emission carries a stable `stepIndex/totalSteps`. Per-record ticks are throttled to integer-percentage changes and clamped against count drift.
- `GraphDatabaseChecker` reports within-step progress: the two scan passes count against `2 x countType`, and the fix-mode edge-list rebuild is an explicit unknown-total sub-phase.
- `CHECK DATABASE` registers the operation and retires it in a `finally`, so a failed check never leaks a registry entry.

## Server
- `GET /api/v1/progress/{database}` returns the running operations as JSON. It reads only the in-memory snapshot - no database access, no transaction - so it is safe to poll at any frequency and cannot interfere with the operation being watched. Enforces the per-database authorization model (403 otherwise, 400 on missing parameter).

## Network
- `RemoteDatabase.getProgress()` exposes the endpoint to any remote client.

## Console
- A `CHECK DATABASE` command renders a live single-line bar refreshed every 500ms, e.g. `check database fix [step 3/9] Checking vertices 'Account' |========            | 42%` - local registry when embedded, progress endpoint when remote. Strictly best-effort: a polling failure stops the rendering, never the command; silent in batch/embedded-output modes.

## Studio
- While a `CHECK DATABASE` command is in flight, the query panel polls the endpoint every second and shows a Bootstrap progress bar with the current step and percentage next to the execute spinner, removed when the command returns.

## Verification
- Engine: `OperationProgressRegistryTest` (2), `CheckDatabaseProgressTest` (4: step ordering/bounds/percentages, per-type steps reach 100%, fix-mode adds the rebuild step, registry retirement) + regression: `CheckDatabaseTest` (9), `CheckDatabaseExtendedTest` (12), `GraphDatabaseCheckerChainRebuildTest` (4), `GraphDatabaseCheckerDiagnosticsTest` (3) - all green.
- Server: `GetProgressHandlerTest` (4: result shape, empty case, 403, 400) - green.
- Console: `ConsoleTest` (30), `ConsoleBatchTest` (7) - green. Network compiles; Studio JS passes syntax check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5y8EbmkvSpFBbeDtTu33m