### PR TITLE
fix(#5374): unexpected internal server errors stay visible in production-mode logs

### DIFF
--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -459,7 +459,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         // diagnosable. Passing the throwable is what makes the logger emit the trace; without it no stack trace
         // is ever printed, at any log level. Use realException (the actual cause) for a useful trace.
         LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s)", realException,
+                .log(this, getInternalErrorLogLevel(), "Error on command execution (%s)", realException,
                         getClass().getSimpleName());
         sendErrorResponse(exchange, 500, "Cannot execute command", realException, null);
       }
@@ -541,7 +541,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         // throwable the logger never prints a trace, at any level, which is why a BufferUnderflowException on a
         // read-only command surfaced with no diagnosable trace even at DEBUG.
         LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on transaction execution (%s)", realException,
+                .log(this, getInternalErrorLogLevel(), "Error on transaction execution (%s)", realException,
                         getClass().getSimpleName());
         sendErrorResponse(exchange, 500, "Error on transaction commit", realException, null);
       }
@@ -557,8 +557,10 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         }
         cause = cause.getCause();
       }
+      // UNEXPECTED RAW THROWABLE (typical for non-database handlers): same treatment as the other
+      // unexpected-internal-error arms - full stack trace, visible in production mode (issue #5374).
       LogManager.instance()
-              .log(this, getErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(), e.getMessage());
+              .log(this, getInternalErrorLogLevel(), "Error on command execution (%s)", e, getClass().getSimpleName());
       sendErrorResponse(exchange, 500, "Internal error", e, null);
     } finally {
       // If execution threw after this request reserved the idempotency key, clear the PENDING marker so a
@@ -879,10 +881,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     return par == null || par.isEmpty() ? defaultValue : par.getFirst();
   }
 
-  private Level getErrorLogLevel() {
+  /**
+   * Log level for UNEXPECTED INTERNAL faults (potential data corruption, engine bugs): SEVERE in development
+   * mode, WARNING in production. Unlike user-triggered errors (see {@link #getUserSevereErrorLogLevel()}),
+   * these must stay visible with default logging in production - demoting them to FINE is how a
+   * BufferUnderflowException on a read-only command went undiagnosable (issue #5374).
+   */
+  private Level getInternalErrorLogLevel() {
     return "development".equals(httpServer.getServer().getConfiguration().getValueAsString(GlobalConfiguration.SERVER_MODE)) ?
             Level.SEVERE :
-            Level.FINE;
+            Level.WARNING;
   }
 
   private Level getUserSevereErrorLogLevel() {

--- a/server/src/test/java/com/arcadedb/server/http/handler/InternalErrorStackTraceLoggingTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/InternalErrorStackTraceLoggingTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.http.handler;
 
 import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.log.DefaultLogger;
 import com.arcadedb.log.LogManager;
@@ -72,13 +73,12 @@ class InternalErrorStackTraceLoggingTest {
     final BufferUnderflowException cause = new BufferUnderflowException();
     final TransactionException wrapped = new TransactionException("Error on executing command", cause);
 
-    final AtomicReference<Throwable> loggedThrowable = new AtomicReference<>();
-    final boolean[] sawExecutionLog = { false };
+    final CapturedLog captured = new CapturedLog();
 
-    final Logger original = installCapturingLogger(loggedThrowable, sawExecutionLog);
+    final Logger original = installCapturingLogger(captured, "Error on transaction execution");
     final HandledResponse response;
     try {
-      response = handle(wrapped);
+      response = handle(wrapped, "development");
     } finally {
       LogManager.instance().setLogger(original);
     }
@@ -90,25 +90,83 @@ class InternalErrorStackTraceLoggingTest {
     assertThat(json.getString("exception")).isEqualTo(BufferUnderflowException.class.getName());
 
     // 2) THE FIX: the internal error is logged WITH the throwable, so a real stack trace is emitted.
-    assertThat(sawExecutionLog[0]).as("the 'Error on transaction execution' line must be logged").isTrue();
-    assertThat(loggedThrowable.get())
+    assertThat(captured.seen).as("the 'Error on transaction execution' line must be logged").isTrue();
+    assertThat(captured.throwable.get())
         .as("the internal error must be logged WITH its throwable so the stack trace is printed")
         .isNotNull();
     // And it must be the REAL cause (BufferUnderflowException), not the opaque wrapper, so the trace is useful.
-    assertThat(loggedThrowable.get()).isInstanceOf(BufferUnderflowException.class);
+    assertThat(captured.throwable.get()).isInstanceOf(BufferUnderflowException.class);
+    // 3) In development mode an unexpected internal fault is loud (issue #5374).
+    assertThat(captured.level).isEqualTo(Level.SEVERE);
   }
 
   /**
-   * Installs a {@link Logger} that captures the {@link Throwable} passed alongside the
-   * "Error on transaction execution" line, returning the previous logger for restore.
+   * Issue #5374: in production mode the internal-error trace used to log at FINE, i.e. invisible with default
+   * logging. An unexpected internal fault (possible data corruption, engine bug) is not a user error, so the
+   * flood-protection demotion of user-triggered errors must not apply: it logs at WARNING or above.
    */
-  private Logger installCapturingLogger(final AtomicReference<Throwable> loggedThrowable, final boolean[] sawExecutionLog) {
+  @Test
+  void internalErrorInProductionModeIsStillVisible() {
+    final TransactionException wrapped = new TransactionException("Error on executing command", new BufferUnderflowException());
+
+    final CapturedLog captured = new CapturedLog();
+    final Logger original = installCapturingLogger(captured, "Error on transaction execution");
+    try {
+      handle(wrapped, "production");
+    } finally {
+      LogManager.instance().setLogger(original);
+    }
+
+    assertThat(captured.seen).isTrue();
+    assertThat(captured.throwable.get()).isInstanceOf(BufferUnderflowException.class);
+    assertThat(captured.level.intValue())
+        .as("an unexpected internal fault must be visible with default (INFO) logging in production mode")
+        .isGreaterThanOrEqualTo(Level.WARNING.intValue());
+  }
+
+  /**
+   * Issue #5374: a raw exception reaching the final catch-Throwable arm (typical for non-database handlers)
+   * lost its stack trace entirely - only the message was logged. It must carry the throwable and stay visible
+   * in production mode like the other internal-error arms.
+   */
+  @Test
+  void rawThrowableInFinalArmLogsFullStackTrace() {
+    final IllegalStateException raw = new IllegalStateException("unexpected internal state");
+
+    final CapturedLog captured = new CapturedLog();
+    final Logger original = installCapturingLogger(captured, "Error on command execution");
+    final HandledResponse response;
+    try {
+      response = handle(raw, "production");
+    } finally {
+      LogManager.instance().setLogger(original);
+    }
+
+    assertThat(response.statusCode).isEqualTo(500);
+    assertThat(captured.seen).isTrue();
+    assertThat(captured.throwable.get()).isInstanceOf(IllegalStateException.class);
+    assertThat(captured.level.intValue()).isGreaterThanOrEqualTo(Level.WARNING.intValue());
+  }
+
+  /** What the capturing logger observed for the matched line: whether it fired, the throwable and the level. */
+  private static final class CapturedLog {
+    private final AtomicReference<Throwable> throwable = new AtomicReference<>();
+    private volatile boolean seen;
+    private volatile Level   level;
+  }
+
+  /**
+   * Installs a {@link Logger} that captures the {@link Throwable} and {@link Level} passed alongside the line
+   * starting with {@code messagePrefix}, returning the previous logger for restore.
+   */
+  private Logger installCapturingLogger(final CapturedLog captured, final String messagePrefix) {
     final Logger capturing = new Logger() {
-      private void record(final String message, final Throwable throwable) {
-        if (message != null && message.startsWith("Error on transaction execution")) {
-          sawExecutionLog[0] = true;
+      private void record(final Level level, final String message, final Throwable throwable) {
+        if (message != null && message.startsWith(messagePrefix)) {
+          captured.seen = true;
+          captured.level = level;
           if (throwable != null)
-            loggedThrowable.set(throwable);
+            captured.throwable.set(throwable);
         }
       }
 
@@ -118,13 +176,13 @@ class InternalErrorStackTraceLoggingTest {
           final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
           final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
           final Object arg15, final Object arg16, final Object arg17) {
-        record(message, throwable);
+        record(level, message, throwable);
       }
 
       @Override
       public void log(final Object requester, final Level level, final String message, final Throwable throwable,
           final String context, final Object... args) {
-        record(message, throwable);
+        record(level, message, throwable);
       }
 
       @Override
@@ -141,10 +199,12 @@ class InternalErrorStackTraceLoggingTest {
   }
 
   /** Runs the real catch chain against a handler whose execute() throws, capturing status and body. */
-  private HandledResponse handle(final RuntimeException toThrow) {
+  private HandledResponse handle(final RuntimeException toThrow, final String serverMode) {
     final ArcadeDBServer server = mock(ArcadeDBServer.class);
     when(server.getObservationRegistry()).thenReturn(ObservationRegistry.create());
-    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_MODE, serverMode);
+    when(server.getConfiguration()).thenReturn(configuration);
     when(server.getServerName()).thenReturn("test");
 
     final HttpServer httpServer = mock(HttpServer.class);


### PR DESCRIPTION
Closes #5374. Follow-up of #5371/PR #5364.

The stack-trace logging added for the customer BufferUnderflowException case used `getUserSevereErrorLogLevel()`, which is FINE outside development mode - so a production operator with default logging would still see nothing. This PR:

- introduces `getInternalErrorLogLevel()` (SEVERE in development, WARNING in production) and uses it in both unexpected-internal-error arms: internal faults are potential data corruption or engine bugs, not user errors, so the log-flood demotion applied to user-triggered errors must not silence them;
- makes the final `catch (Throwable)` arm (typical for non-database handlers) pass the throwable too - it previously logged only `e.getMessage()`, losing the trace entirely at any level.

Tests: `InternalErrorStackTraceLoggingTest` extended to capture the log level and drive the real catch chain in both server modes, plus a new case for the raw-throwable arm; all three fail before the fix. Regression: `Issue5064CommittedRemotelyHttpStatusTest`, `GetProgressHandlerTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5y8EbmkvSpFBbeDtTu33m