### PR TITLE
feat(#5375): CHECK DATABASE FIX reclaims orphaned edge-list segments

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -110,15 +110,33 @@ public class DatabaseChecker {
         documentTypes.add(type);
     }
 
+    // The orphaned-segment reclaim (issue #5375) requires walking EVERY vertex to build the reachable set, so
+    // it only runs on a full-scope fix: under a type/bucket filter the unwalked vertices' segments would be
+    // misclassified as orphans.
+    final boolean reclaimOrphanedSegments =
+        fix && (types == null || types.isEmpty()) && (buckets == null || buckets.isEmpty());
+
     currentStep = 0;
     totalSteps = edgeTypes.size() + vertexTypes.size() + documentTypes.size() // per-type checks
         + 3 // buckets + external properties + indexes
+        + (reclaimOrphanedSegments ? 1 : 0)
         + (fix ? 1 : 0) // rebuild affected indexes
         + (compress ? 1 : 0);
 
     checkEdges(edgeTypes);
 
     checkVertices(vertexTypes);
+
+    if (reclaimOrphanedSegments) {
+      // AFTER checkVertices: the chain rebuilds have already re-attached every recoverable segment, so what
+      // remains unreachable in the edge-list buckets is genuine garbage.
+      ++currentStep;
+      final Map<String, Object> stats = new GraphDatabaseChecker(database)
+          .setProgress(progressCallback, "Reclaiming orphaned edge segments", currentStep, totalSteps)
+          .reclaimOrphanedEdgeSegments(verboseLevel, maxWarnings);
+      updateStats(stats);
+      ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
+    }
 
     checkDocuments(documentTypes);
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -113,6 +113,10 @@ public class GraphDatabaseChecker {
    * broken chain is rebuilt from the surviving edge records, or by historical bugs. MUST only run on a FULL
    * check (no type/bucket filter): a partial walk would classify the unwalked vertices' segments as orphans.
    * Like the rest of fix mode, assumes no concurrent writers - run it in a maintenance window.
+   * <p>
+   * Known limitation (matching the corrupted-records pattern in the vertex/edge checks): the orphan RIDs are
+   * accumulated in memory and deleted inside one transaction, so a database with an extreme number of orphaned
+   * segments grows both unbounded. Batched commits are a possible follow-up if such corruption is ever seen.
    */
   public Map<String, Object> reclaimOrphanedEdgeSegments(final int verboseLevel, final int maxWarnings) {
     final List<String> warnings = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.graph;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
@@ -27,11 +28,13 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.LocalVertexType;
+import com.arcadedb.schema.Schema;
 import com.arcadedb.utility.LongHashSet;
 import com.arcadedb.utility.Pair;
 import com.arcadedb.utility.ProgressCallback;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
@@ -114,9 +117,23 @@ public class GraphDatabaseChecker {
    * check (no type/bucket filter): a partial walk would classify the unwalked vertices' segments as orphans.
    * Like the rest of fix mode, assumes no concurrent writers - run it in a maintenance window.
    * <p>
-   * Known limitation (matching the corrupted-records pattern in the vertex/edge checks): the orphan RIDs are
-   * accumulated in memory and deleted inside one transaction, so a database with an extreme number of orphaned
-   * segments grows both unbounded. Batched commits are a possible follow-up if such corruption is ever seen.
+   * DATA-SAFETY GUARANTEES (both failure modes here delete live data, so they are guarded rather than left to
+   * the caller):
+   * <ul>
+   *   <li>the segment buckets are identified from the SCHEMA - the engine-created {@code _out_edges}/
+   *   {@code _in_edges} bucket of every vertex bucket and every vertex type's super-node stripe pool - never by
+   *   matching bucket names alone (see {@link #collectEdgeSegmentBucketIds()}); a user data bucket whose name
+   *   merely collides with the naming scheme is therefore never scanned or deleted;</li>
+   *   <li>the reclaim FAILS CLOSED: if any vertex could not be walked in phase 1 its live segments are missing
+   *   from the reachable set, so the whole deletion phase is skipped (nothing is deleted) rather than risk
+   *   destroying them.</li>
+   * </ul>
+   * <p>
+   * Known limitation (matching the corrupted-records pattern in the vertex/edge checks): the whole reachable set
+   * (a position entry for EVERY reachable segment across the database, which dominates memory on a large healthy
+   * graph) and the orphan RID list are held in memory and the delete runs inside one transaction, so an extreme
+   * database grows them unbounded. Batched commits + a segment-count-bounded reachable set are a possible
+   * follow-up if such scale is ever seen.
    */
   public Map<String, Object> reclaimOrphanedEdgeSegments(final int verboseLevel, final int maxWarnings) {
     final List<String> warnings = new ArrayList<>();
@@ -139,6 +156,9 @@ public class GraphDatabaseChecker {
     try {
       // PHASE 1: walk every vertex's chains and mark every reachable segment. LongHashSet keyed by position
       // per bucket keeps the footprint primitive-sized (same approach as the external-property orphan scan).
+      // FAIL CLOSED: a vertex we cannot walk leaves its live segments unmarked, so ANY walk failure disables
+      // the deletion phase entirely - deleting then would treat live data as garbage.
+      final AtomicBoolean reachabilityComplete = new AtomicBoolean(true);
       progressBegin("Reclaiming orphaned edge segments - collecting reachable segments", totalVertices);
       for (final DocumentType type : vertexTypes)
         database.scanType(type.getName(), false, record -> {
@@ -148,42 +168,53 @@ public class GraphDatabaseChecker {
             markReachableSegments(vertex.getOutEdgesHeadChunk(), reachable);
             markReachableSegments(vertex.getInEdgesHeadChunk(), reachable);
           } catch (final Exception e) {
+            reachabilityComplete.set(false);
             addWarning(warnings, totalWarnings, maxWarnings,
                 "vertex " + record.getIdentity() + " could not be walked during the orphan reclaim (error: " + describe(e)
                     + ")");
           }
           return true;
-        }, (rid, exception) -> true);
-
-      // PHASE 2: scan the dedicated edge-list buckets; anything not marked reachable is an orphan.
-      progressBegin("Reclaiming orphaned edge segments - scanning segment buckets", -1);
-      final List<RID> orphansToDelete = new ArrayList<>();
-      for (final Bucket b : database.getSchema().getBuckets()) {
-        final String name = b.getName();
-        if (!name.endsWith(GraphEngine.OUT_EDGES_SUFFIX) && !name.endsWith(GraphEngine.IN_EDGES_SUFFIX)
-            && !name.contains(StripedEdgeList.STRIPE_BUCKET_INFIX))
-          continue;
-
-        final LongHashSet reachableInBucket = reachable.get(b.getFileId());
-        b.scan((rid, view) -> {
-          progressTick();
-          if (reachableInBucket == null || !reachableInBucket.contains(rid.getPosition()))
-            orphansToDelete.add(rid);
-          return true;
-        }, null);
-      }
-      orphans = orphansToDelete.size();
-
-      for (final RID orphan : orphansToDelete) {
-        try {
-          database.getSchema().getBucketById(orphan.getBucketId()).deleteRecord(orphan);
-          ++reclaimed;
-        } catch (final RecordNotFoundException e) {
-          // ALREADY GONE
-        } catch (final Exception e) {
+        }, (rid, exception) -> {
+          // A vertex record that cannot even be loaded during the scan is the same fail-closed case: its
+          // segments were never marked, so the deletion phase must not run.
+          reachabilityComplete.set(false);
           addWarning(warnings, totalWarnings, maxWarnings,
-              "orphaned edge segment " + orphan + " could not be reclaimed (error: " + describe(e) + ")");
+              "vertex " + rid + " could not be loaded during the orphan reclaim (error: " + describe(exception) + ")");
+          return true;
+        });
+
+      if (reachabilityComplete.get()) {
+        // PHASE 2: scan ONLY the internal edge-list buckets the graph engine created for the vertices (derived
+        // from the schema, never matched by name), and delete anything not marked reachable.
+        progressBegin("Reclaiming orphaned edge segments - scanning segment buckets", -1);
+        final List<RID> orphansToDelete = new ArrayList<>();
+        for (final Integer bucketId : collectEdgeSegmentBucketIds()) {
+          final Bucket b = database.getSchema().getBucketById(bucketId);
+          final LongHashSet reachableInBucket = reachable.get(bucketId);
+          b.scan((rid, view) -> {
+            progressTick();
+            if (reachableInBucket == null || !reachableInBucket.contains(rid.getPosition()))
+              orphansToDelete.add(rid);
+            return true;
+          }, null);
         }
+        orphans = orphansToDelete.size();
+
+        for (final RID orphan : orphansToDelete) {
+          try {
+            database.getSchema().getBucketById(orphan.getBucketId()).deleteRecord(orphan);
+            ++reclaimed;
+          } catch (final RecordNotFoundException e) {
+            // ALREADY GONE
+          } catch (final Exception e) {
+            addWarning(warnings, totalWarnings, maxWarnings,
+                "orphaned edge segment " + orphan + " could not be reclaimed (error: " + describe(e) + ")");
+          }
+        }
+      } else {
+        addWarning(warnings, totalWarnings, maxWarnings,
+            "orphaned edge segment reclaim skipped: the reachability walk did not complete (one or more vertices "
+                + "could not be walked); no segments were deleted to avoid destroying live data");
       }
 
       if (verboseLevel > 0)
@@ -200,6 +231,56 @@ public class GraphDatabaseChecker {
       stats.put("totalWarnings", totalWarnings.get());
     }
     return stats;
+  }
+
+  /**
+   * The file-ids of the internal edge-list buckets the graph engine created for the registered vertex types: the
+   * {@code _out_edges}/{@code _in_edges} bucket of every vertex bucket, and every vertex type's super-node stripe
+   * pool. DERIVED FROM THE SCHEMA, never by matching bucket names blindly, so a user data bucket whose name
+   * collides with the edge-list naming scheme is never treated as reclaimable. A bucket that IS owned by a type
+   * is user data by definition and is excluded - the same collision guard {@link StripedEdgeList#ensureStripePool}
+   * uses, since the engine's edge-list buckets are created standalone ({@code schema.createBucket}) and belong to
+   * no type.
+   */
+  private Set<Integer> collectEdgeSegmentBucketIds() {
+    final Schema schema = database.getSchema();
+    final Set<Integer> ids = new HashSet<>();
+    final int configuredStripes = database.getConfiguration().getValueAsInteger(GlobalConfiguration.GRAPH_SUPERNODE_STRIPES);
+    for (final DocumentType type : schema.getTypes()) {
+      if (!(type instanceof LocalVertexType))
+        continue;
+      for (final Bucket vb : type.getBuckets(false)) {
+        addSegmentBucketIfInternal(ids, vb.getName() + GraphEngine.OUT_EDGES_SUFFIX);
+        addSegmentBucketIfInternal(ids, vb.getName() + GraphEngine.IN_EDGES_SUFFIX);
+      }
+      // Super-node stripe pool (per type). Pools are created contiguously from slot 0 (see
+      // GraphEngine.dropVertexType): sweep until the first gap AT OR PAST the configured pool size, stepping over
+      // gaps below it (a partially-created pool). No slot 0 means the type never promoted - skip the whole sweep.
+      for (int i = 0; ; i++) {
+        final String stripeBucketName = StripedEdgeList.stripeBucketName(type.getName(), i);
+        if (!schema.existsBucket(stripeBucketName)) {
+          if (i == 0 || i >= configuredStripes)
+            break;
+          continue;
+        }
+        addSegmentBucketIfInternal(ids, stripeBucketName);
+      }
+    }
+    return ids;
+  }
+
+  /**
+   * Adds the named bucket's file-id to {@code ids} only when it exists AND is not owned by a type. A type-owned
+   * bucket is user data that merely collides with the edge-list naming scheme and must never be reclaimed.
+   */
+  private void addSegmentBucketIfInternal(final Set<Integer> ids, final String bucketName) {
+    final Schema schema = database.getSchema();
+    if (!schema.existsBucket(bucketName))
+      return;
+    final Bucket b = schema.getBucketByName(bucketName);
+    if (schema.getTypeByBucketId(b.getFileId()) != null)
+      return; // USER DATA BUCKET colliding with the naming scheme
+    ids.add(b.getFileId());
   }
 
   /** Marks every segment reachable from the given head: a classic chain, or a stripe directory + all its chains. */

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -133,7 +133,10 @@ public class GraphDatabaseChecker {
    * (a position entry for EVERY reachable segment across the database, which dominates memory on a large healthy
    * graph) and the orphan RID list are held in memory and the delete runs inside one transaction, so an extreme
    * database grows them unbounded. Batched commits + a segment-count-bounded reachable set are a possible
-   * follow-up if such scale is ever seen.
+   * follow-up if such scale is ever seen. Phase 1 is also a SECOND full vertex scan (the preceding
+   * {@code checkVertices} already scanned them all): the reachable set could instead be accumulated during that
+   * pass to halve the vertex-scan cost of a full fix - deferred, since keeping the reclaim self-contained is
+   * worth the extra pass on an already-damaged database run in a maintenance window.
    */
   public Map<String, Object> reclaimOrphanedEdgeSegments(final int verboseLevel, final int maxWarnings) {
     final List<String> warnings = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -127,17 +127,26 @@ public class GraphDatabaseChecker {
    *   <li>the reclaim FAILS CLOSED: if in phase 1 any vertex record could not be loaded OR its edge chain could
    *   not be fully walked (a segment read failed ANYWHERE along a live chain - unreadable head, or a mid-chain
    *   chunk lookup that threw), that chain's live tail is missing from the reachable set, so the whole deletion
-   *   phase is skipped (nothing is deleted) rather than risk destroying it.</li>
+   *   phase is skipped (nothing is deleted) rather than risk destroying it. The skip is DELIBERATELY
+   *   database-wide (one unwalkable vertex blocks reclaim everywhere), not scoped to the affected type: a
+   *   vertex's segments can land in any edge-list bucket, so a narrower scope cannot be proven safe. Scoping it
+   *   is a possible future refinement.</li>
    * </ul>
    * <p>
    * Known limitation (matching the corrupted-records pattern in the vertex/edge checks): the whole reachable set
    * (a position entry for EVERY reachable segment across the database, which dominates memory on a large healthy
    * graph) and the orphan RID list are held in memory and the delete runs inside one transaction, so an extreme
-   * database grows them unbounded. Batched commits + a segment-count-bounded reachable set are a possible
-   * follow-up if such scale is ever seen. Phase 1 is also a SECOND full vertex scan (the preceding
-   * {@code checkVertices} already scanned them all): the reachable set could instead be accumulated during that
-   * pass to halve the vertex-scan cost of a full fix - deferred, since keeping the reclaim self-contained is
-   * worth the extra pass on an already-damaged database run in a maintenance window.
+   * database grows them unbounded. Batched commits + a segment-count-bounded reachable set are the mitigation
+   * before this is safe on the very large deployments the feature targets. Phase 1 is also a SECOND full vertex
+   * scan (the preceding {@code checkVertices} already scanned them all): the reachable set could instead be
+   * accumulated during that pass to halve the vertex-scan cost of a full fix - deferred, since keeping the
+   * reclaim self-contained is worth the extra pass on an already-damaged database run in a maintenance window.
+   * <p>
+   * DELIBERATELY ALWAYS-ON: this runs on every full-scope fix, even a no-repair run that reclaims zero segments
+   * (a healthy large graph still pays the scans + reachable set). That is intentional - orphans also come from
+   * historical bugs, not only from a rebuild in THIS run, so gating on "did we rebuild a chain this run" would
+   * never sweep a database that is otherwise clean. An explicit opt-in (e.g. a {@code FIX RECLAIM} keyword) is
+   * the alternative if the always-on cost proves unwelcome; left always-on for now.
    */
   public Map<String, Object> reclaimOrphanedEdgeSegments(final int verboseLevel, final int maxWarnings) {
     final List<String> warnings = new ArrayList<>();
@@ -181,6 +190,9 @@ public class GraphDatabaseChecker {
                   + "the reclaim will be skipped to avoid deleting live data");
             }
           } catch (final Exception e) {
+            // DEFENSIVE TWIN of the scan error callback below: a vertex's edge-pointer prefix is validated at
+            // record construction, so a truncated/corrupt vertex normally fails to load inside the scan and
+            // surfaces through that callback; this catches any residual failure of asVertex here. Same effect.
             reachabilityComplete.set(false);
             addWarning(warnings, totalWarnings, maxWarnings,
                 "vertex " + record.getIdentity() + " could not be walked during the orphan reclaim (error: " + describe(e)

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -26,6 +26,8 @@ import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
+import com.arcadedb.schema.LocalVertexType;
+import com.arcadedb.utility.LongHashSet;
 import com.arcadedb.utility.Pair;
 import com.arcadedb.utility.ProgressCallback;
 
@@ -102,6 +104,137 @@ public class GraphDatabaseChecker {
       progressDone = progressTotal;
     progress.onProgress(progressStepName, progressStepIndex, progressTotalSteps, progressDone,
         progressTotal > 0 ? progressTotal : progressDone);
+  }
+
+  /**
+   * Collects every edge-list segment reachable from any vertex's OUT/IN chains (classic chunks, stripe
+   * directories, stripe chains and generation-0 chains of promoted super-nodes) and deletes the segments in
+   * the dedicated edge-list buckets that are NOT reachable (issue #5375). Orphans are left behind when a
+   * broken chain is rebuilt from the surviving edge records, or by historical bugs. MUST only run on a FULL
+   * check (no type/bucket filter): a partial walk would classify the unwalked vertices' segments as orphans.
+   * Like the rest of fix mode, assumes no concurrent writers - run it in a maintenance window.
+   */
+  public Map<String, Object> reclaimOrphanedEdgeSegments(final int verboseLevel, final int maxWarnings) {
+    final List<String> warnings = new ArrayList<>();
+    final AtomicLong totalWarnings = new AtomicLong();
+    final Map<String, Object> stats = new HashMap<>();
+
+    final Map<Integer, LongHashSet> reachable = new HashMap<>();
+    long totalVertices = 0;
+    final List<DocumentType> vertexTypes = new ArrayList<>();
+    for (final DocumentType type : database.getSchema().getTypes())
+      if (type instanceof LocalVertexType) {
+        vertexTypes.add(type);
+        totalVertices += database.countType(type.getName(), false);
+      }
+
+    long orphans = 0;
+    long reclaimed = 0;
+
+    database.begin();
+    try {
+      // PHASE 1: walk every vertex's chains and mark every reachable segment. LongHashSet keyed by position
+      // per bucket keeps the footprint primitive-sized (same approach as the external-property orphan scan).
+      progressBegin("Reclaiming orphaned edge segments - collecting reachable segments", totalVertices);
+      for (final DocumentType type : vertexTypes)
+        database.scanType(type.getName(), false, record -> {
+          progressTick();
+          try {
+            final VertexInternal vertex = (VertexInternal) record.asVertex(true);
+            markReachableSegments(vertex.getOutEdgesHeadChunk(), reachable);
+            markReachableSegments(vertex.getInEdgesHeadChunk(), reachable);
+          } catch (final Exception e) {
+            addWarning(warnings, totalWarnings, maxWarnings,
+                "vertex " + record.getIdentity() + " could not be walked during the orphan reclaim (error: " + describe(e)
+                    + ")");
+          }
+          return true;
+        }, (rid, exception) -> true);
+
+      // PHASE 2: scan the dedicated edge-list buckets; anything not marked reachable is an orphan.
+      progressBegin("Reclaiming orphaned edge segments - scanning segment buckets", -1);
+      final List<RID> orphansToDelete = new ArrayList<>();
+      for (final Bucket b : database.getSchema().getBuckets()) {
+        final String name = b.getName();
+        if (!name.endsWith(GraphEngine.OUT_EDGES_SUFFIX) && !name.endsWith(GraphEngine.IN_EDGES_SUFFIX)
+            && !name.contains(StripedEdgeList.STRIPE_BUCKET_INFIX))
+          continue;
+
+        final LongHashSet reachableInBucket = reachable.get(b.getFileId());
+        b.scan((rid, view) -> {
+          progressTick();
+          if (reachableInBucket == null || !reachableInBucket.contains(rid.getPosition()))
+            orphansToDelete.add(rid);
+          return true;
+        }, null);
+      }
+      orphans = orphansToDelete.size();
+
+      for (final RID orphan : orphansToDelete) {
+        try {
+          database.getSchema().getBucketById(orphan.getBucketId()).deleteRecord(orphan);
+          ++reclaimed;
+        } catch (final RecordNotFoundException e) {
+          // ALREADY GONE
+        } catch (final Exception e) {
+          addWarning(warnings, totalWarnings, maxWarnings,
+              "orphaned edge segment " + orphan + " could not be reclaimed (error: " + describe(e) + ")");
+        }
+      }
+
+      if (verboseLevel > 0)
+        for (final String warning : warnings)
+          LogManager.instance().log(this, Level.WARNING, "- " + warning);
+
+      database.commit();
+      progressComplete();
+
+    } finally {
+      stats.put("orphanedEdgeSegments", orphans);
+      stats.put("orphanedEdgeSegmentsReclaimed", reclaimed);
+      stats.put("warnings", warnings);
+      stats.put("totalWarnings", totalWarnings.get());
+    }
+    return stats;
+  }
+
+  /** Marks every segment reachable from the given head: a classic chain, or a stripe directory + all its chains. */
+  private void markReachableSegments(final RID head, final Map<Integer, LongHashSet> reachable) {
+    if (head == null)
+      return;
+    final Record headRecord;
+    try {
+      headRecord = database.lookupByRID(head, true);
+    } catch (final Exception e) {
+      // UNREADABLE HEAD: the rebuild in checkVertices handles the chain itself; nothing reachable to mark.
+      return;
+    }
+    if (headRecord instanceof StripeDirectory directory) {
+      mark(reachable, head);
+      for (int g = 0; g < directory.getGenerationCount(); g++)
+        for (int s = 0; s < directory.getStripes(g); s++)
+          markChain(directory.getHead(g, s), reachable);
+    } else
+      markChain(head, reachable);
+  }
+
+  /** Walks a classic chunk chain marking every chunk; stops on cycles and unreadable chunks. */
+  private void markChain(final RID head, final Map<Integer, LongHashSet> reachable) {
+    RID current = head;
+    while (current != null) {
+      if (!mark(reachable, current))
+        return; // ALREADY VISITED: guards against a corrupt cyclic chain looping forever
+      try {
+        current = ((EdgeSegment) database.lookupByRID(current, true)).getPreviousRID();
+      } catch (final Exception e) {
+        return; // BROKEN TAIL: the rebuild in checkVertices handles the chain itself
+      }
+    }
+  }
+
+  /** @return true when the RID was newly marked as reachable. */
+  private boolean mark(final Map<Integer, LongHashSet> reachable, final RID rid) {
+    return reachable.computeIfAbsent(rid.getBucketId(), k -> new LongHashSet()).add(rid.getPosition());
   }
 
   public Map<String, Object> checkVertices(final String typeName, final boolean fix, final int verboseLevel) {
@@ -774,6 +907,9 @@ public class GraphDatabaseChecker {
     final List<String> warnings = new ArrayList<>();
     final Map<RID, Long> missingReferences = new HashMap<>();
     final Map<RID, String> missingReferenceErrors = new HashMap<>();
+    // Vertices whose edge LIST failed to walk during the back-reference probe: warned once each (a broken
+    // super-node chain is referenced by millions of edges), never flagged corrupted - see the probe guards.
+    final Set<RID> unreadableListVertices = new HashSet<>();
 
     final Map<String, Object> stats = new HashMap<>();
 
@@ -821,14 +957,9 @@ public class GraphDatabaseChecker {
             invalidLinks.incrementAndGet();
 
           } else {
+            Vertex inVertex = null;
             try {
-              final Vertex vertex = edge.getInVertex().asVertex(true);
-
-              final EdgeLinkedList inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.DIRECTION.IN);
-              if (inEdges == null || !inEdges.containsEdge(edgeRID))
-                // UNI DIRECTIONAL EDGE
-                missingReferenceBack.incrementAndGet();
-
+              inVertex = edge.getInVertex().asVertex(true);
             } catch (final RecordNotFoundException e) {
               addWarning(warnings, totalWarnings, maxWarnings,
                   "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
@@ -846,14 +977,26 @@ public class GraphDatabaseChecker {
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
             }
 
+            if (inVertex != null)
+              try {
+                final EdgeLinkedList inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) inVertex, Vertex.DIRECTION.IN);
+                if (inEdges == null || !inEdges.containsEdge(edgeRID))
+                  // UNI DIRECTIONAL EDGE
+                  missingReferenceBack.incrementAndGet();
+              } catch (final Exception e) {
+                // The vertex record is FINE but its edge LIST is unreadable: neither the edge nor the vertex is
+                // at fault, so NOTHING is flagged corrupted here (before this guard the vertex was deleted by
+                // fix mode over its broken chain). checkVertices runs after this phase and rebuilds the list
+                // from the surviving edge records.
+                if (unreadableListVertices.add(inVertex.getIdentity()))
+                  addWarning(warnings, totalWarnings, maxWarnings,
+                      "vertex " + inVertex.getIdentity() + " incoming edge list is unreadable (error: " + describe(e)
+                          + "), left to the vertex check to rebuild");
+              }
+
+            Vertex outVertex = null;
             try {
-              final Vertex vertex = edge.getOutVertex().asVertex(true);
-
-              final EdgeLinkedList outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.DIRECTION.OUT);
-              if (outEdges == null || !outEdges.containsEdge(edgeRID))
-                // UNI DIRECTIONAL EDGE
-                missingReferenceBack.incrementAndGet();
-
+              outVertex = edge.getOutVertex().asVertex(true);
             } catch (final RecordNotFoundException e) {
               addWarning(warnings, totalWarnings, maxWarnings,
                   "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
@@ -869,6 +1012,20 @@ public class GraphDatabaseChecker {
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getOut());
             }
+
+            if (outVertex != null)
+              try {
+                final EdgeLinkedList outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) outVertex, Vertex.DIRECTION.OUT);
+                if (outEdges == null || !outEdges.containsEdge(edgeRID))
+                  // UNI DIRECTIONAL EDGE
+                  missingReferenceBack.incrementAndGet();
+              } catch (final Exception e) {
+                // Same as the incoming side: an unreadable LIST is not a corrupted edge or vertex.
+                if (unreadableListVertices.add(outVertex.getIdentity()))
+                  addWarning(warnings, totalWarnings, maxWarnings,
+                      "vertex " + outVertex.getIdentity() + " outgoing edge list is unreadable (error: " + describe(e)
+                          + "), left to the vertex check to rebuild");
+              }
           }
 
         } catch (final Throwable e) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -124,9 +124,10 @@ public class GraphDatabaseChecker {
    *   {@code _in_edges} bucket of every vertex bucket and every vertex type's super-node stripe pool - never by
    *   matching bucket names alone (see {@link #collectEdgeSegmentBucketIds()}); a user data bucket whose name
    *   merely collides with the naming scheme is therefore never scanned or deleted;</li>
-   *   <li>the reclaim FAILS CLOSED: if any vertex could not be walked in phase 1 its live segments are missing
-   *   from the reachable set, so the whole deletion phase is skipped (nothing is deleted) rather than risk
-   *   destroying them.</li>
+   *   <li>the reclaim FAILS CLOSED: if in phase 1 any vertex record could not be loaded OR its edge chain could
+   *   not be fully walked (a segment read failed ANYWHERE along a live chain - unreadable head, or a mid-chain
+   *   chunk lookup that threw), that chain's live tail is missing from the reachable set, so the whole deletion
+   *   phase is skipped (nothing is deleted) rather than risk destroying it.</li>
    * </ul>
    * <p>
    * Known limitation (matching the corrupted-records pattern in the vertex/edge checks): the whole reachable set
@@ -168,8 +169,17 @@ public class GraphDatabaseChecker {
           progressTick();
           try {
             final VertexInternal vertex = (VertexInternal) record.asVertex(true);
-            markReachableSegments(vertex.getOutEdgesHeadChunk(), reachable);
-            markReachableSegments(vertex.getInEdgesHeadChunk(), reachable);
+            // Walk BOTH directions (no short-circuit) so every readable segment is still marked, but a read
+            // failure on EITHER chain fails the whole reclaim closed - the chain is live, so an unmarked tail
+            // must not be deleted as an orphan.
+            final boolean outComplete = markReachableSegments(vertex.getOutEdgesHeadChunk(), reachable);
+            final boolean inComplete = markReachableSegments(vertex.getInEdgesHeadChunk(), reachable);
+            if (!outComplete || !inComplete) {
+              reachabilityComplete.set(false);
+              addWarning(warnings, totalWarnings, maxWarnings, "vertex " + record.getIdentity()
+                  + " edge chain could not be fully walked during the orphan reclaim (a segment read failed); "
+                  + "the reclaim will be skipped to avoid deleting live data");
+            }
           } catch (final Exception e) {
             reachabilityComplete.set(false);
             addWarning(warnings, totalWarnings, maxWarnings,
@@ -259,6 +269,10 @@ public class GraphDatabaseChecker {
       // Super-node stripe pool (per type). Pools are created contiguously from slot 0 (see
       // GraphEngine.dropVertexType): sweep until the first gap AT OR PAST the configured pool size, stepping over
       // gaps below it (a partially-created pool). No slot 0 means the type never promoted - skip the whole sweep.
+      // NOTE: the bound is the LIVE GRAPH_SUPERNODE_STRIPES, not the size persisted at promotion (same assumption
+      // as dropVertexType). If it was shrunk since promotion, buckets past the new size are simply not scanned -
+      // never deleted, and their live segments are still marked via the phase-1 directory walk - so orphans there
+      // just leak; not a data-loss path.
       for (int i = 0; ; i++) {
         final String stripeBucketName = StripedEdgeList.stripeBucketName(type.getName(), i);
         if (!schema.existsBucket(stripeBucketName)) {
@@ -286,38 +300,56 @@ public class GraphDatabaseChecker {
     ids.add(b.getFileId());
   }
 
-  /** Marks every segment reachable from the given head: a classic chain, or a stripe directory + all its chains. */
-  private void markReachableSegments(final RID head, final Map<Integer, LongHashSet> reachable) {
+  /**
+   * Marks every segment reachable from the given head: a classic chain, or a stripe directory + all its chains.
+   *
+   * @return false when a segment read FAILED mid-walk (unreadable head, or a chunk lookup threw) so the chain
+   * could not be fully accounted for. The caller must then FAIL CLOSED (skip the deletion phase): the chain is
+   * currently referenced by a live vertex, so a read error here - unlike genuine corruption the earlier
+   * checkVertices rebuild already re-attached - may leave live tail segments unmarked, and deleting them would
+   * destroy live data. A healthy chain always returns true.
+   */
+  private boolean markReachableSegments(final RID head, final Map<Integer, LongHashSet> reachable) {
     if (head == null)
-      return;
+      return true;
     final Record headRecord;
     try {
       headRecord = database.lookupByRID(head, true);
     } catch (final Exception e) {
-      // UNREADABLE HEAD: the rebuild in checkVertices handles the chain itself; nothing reachable to mark.
-      return;
+      // UNREADABLE HEAD: cannot account for this vertex's segments - fail closed rather than risk deleting them.
+      return false;
     }
     if (headRecord instanceof StripeDirectory directory) {
       mark(reachable, head);
+      boolean complete = true;
       for (int g = 0; g < directory.getGenerationCount(); g++)
         for (int s = 0; s < directory.getStripes(g); s++)
-          markChain(directory.getHead(g, s), reachable);
-    } else
-      markChain(head, reachable);
+          // Do NOT short-circuit: keep marking the readable stripe chains, just remember the walk was incomplete.
+          if (!markChain(directory.getHead(g, s), reachable))
+            complete = false;
+      return complete;
+    }
+    return markChain(head, reachable);
   }
 
-  /** Walks a classic chunk chain marking every chunk; stops on cycles and unreadable chunks. */
-  private void markChain(final RID head, final Map<Integer, LongHashSet> reachable) {
+  /**
+   * Walks a classic chunk chain marking every chunk; stops on cycles and unreadable chunks.
+   *
+   * @return false when a chunk lookup THREW (a broken/unreadable tail), leaving the rest of the chain unmarked;
+   * true when the whole chain was walked (including a cyclic chain fully covered before the cycle guard fired).
+   */
+  private boolean markChain(final RID head, final Map<Integer, LongHashSet> reachable) {
     RID current = head;
     while (current != null) {
       if (!mark(reachable, current))
-        return; // ALREADY VISITED: guards against a corrupt cyclic chain looping forever
+        return true; // ALREADY VISITED: cyclic chain fully covered (not a read failure) - guards infinite loop
       try {
         current = ((EdgeSegment) database.lookupByRID(current, true)).getPreviousRID();
       } catch (final Exception e) {
-        return; // BROKEN TAIL: the rebuild in checkVertices handles the chain itself
+        return false; // BROKEN/UNREADABLE TAIL: cannot confirm the rest of the chain - fail closed
       }
     }
+    return true;
   }
 
   /** @return true when the RID was newly marked as reachable. */

--- a/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
+++ b/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
@@ -58,7 +58,8 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class StripedEdgeList extends EdgeLinkedList {
-  private static final String STRIPE_BUCKET_INFIX = "_sn_stripe_";
+  // Package-visible for GraphDatabaseChecker's orphan reclaim, which identifies stripe buckets by name.
+  static final String STRIPE_BUCKET_INFIX = "_sn_stripe_";
 
   /** Guards against stampeding pool creations: one in-flight creation per database+type (value = start ms). */
   private static final ConcurrentHashMap<String, Long> POOLS_IN_CREATION = new ConcurrentHashMap<>();

--- a/engine/src/test/java/com/arcadedb/engine/CheckDatabaseProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/CheckDatabaseProgressTest.java
@@ -115,8 +115,9 @@ class CheckDatabaseProgressTest extends TestHelper {
             emissions.add(new Emission(stepName, stepIndex, totalSteps, done, total)))
         .check();
 
-    // FIX ADDS THE "Rebuilding indexes" STEP: 7 + 1.
-    assertThat(emissions.getFirst().totalSteps).isEqualTo(8);
+    // FULL-SCOPE FIX ADDS THE ORPHAN-RECLAIM (#5375) AND "Rebuilding indexes" STEPS: 7 + 2.
+    assertThat(emissions.getFirst().totalSteps).isEqualTo(9);
+    assertThat(emissions.stream().anyMatch(e -> e.stepName.startsWith("Reclaiming orphaned edge segments"))).isTrue();
     assertThat(emissions.stream().anyMatch(e -> e.stepName.startsWith("Rebuilding indexes"))).isTrue();
   }
 

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerOrphanReclaimTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerOrphanReclaimTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.engine.DatabaseChecker;
+import com.arcadedb.exception.RecordNotFoundException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * CHECK DATABASE FIX reclaims orphaned edge-list segments (issue #5375): when a broken chain is rebuilt from
+ * the surviving edge records, the old chunks (and, for promoted super-nodes, the old stripe directory and
+ * stripe chains) become unreachable garbage on disk. The fix pass now collects the set of reachable segments
+ * by walking every vertex's chains and deletes the rest.
+ * <p>
+ * The most important test here is the HEALTHY-database one: the reachability walk must cover every layout
+ * (classic chains, stripe directories, stripe chains, generation-0 chains), because a missed case would make
+ * the reclaim delete LIVE segments.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphDatabaseCheckerOrphanReclaimTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+
+  private int savedThreshold;
+
+  @BeforeEach
+  void saveConfig() {
+    savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+  }
+
+  @AfterEach
+  void restoreConfig() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+  }
+
+  /** Creates the hub plus {@code degree} sources, each with one edge source -> hub (hub's IN list). */
+  private RID createHub(final int degree) {
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE, 1);
+      database.getSchema().createEdgeType(EDGE_TYPE, 1);
+    });
+
+    final RID[] hub = new RID[1];
+    database.transaction(() -> hub[0] = database.newVertex(VERTEX_TYPE).set("name", "hub").save().getIdentity());
+
+    final int batch = 500;
+    for (int from = 0; from < degree; from += batch) {
+      final int start = from;
+      final int end = Math.min(from + batch, degree);
+      database.transaction(() -> {
+        for (int i = start; i < end; i++)
+          database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, hub[0]);
+      });
+    }
+    return hub[0];
+  }
+
+  /** All chunk RIDs of the hub's IN chain (classic layout), head first. */
+  private List<RID> collectClassicChainChunks(final RID hubRid) {
+    final List<RID> chunks = new ArrayList<>();
+    database.transaction(() -> {
+      RID current = ((VertexInternal) hubRid.asVertex(true)).getInEdgesHeadChunk();
+      while (current != null) {
+        chunks.add(current);
+        current = ((EdgeSegment) ((DatabaseInternal) database).lookupByRID(current, true)).getPreviousRID();
+      }
+    });
+    return chunks;
+  }
+
+  private void deleteRecordLowLevel(final RID rid) {
+    database.transaction(() -> database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid));
+  }
+
+  private Map<String, Object> runCheck(final boolean fix) {
+    return new DatabaseChecker(database).setVerboseLevel(0).setFix(fix).check();
+  }
+
+  /**
+   * Every old segment must be either deleted by the reclaim or - because {@code LocalBucket} recycles freed
+   * positions - reused as a segment of the hub's REBUILT (reachable) layout. A readable old RID that is not
+   * part of the rebuilt layout is a missed orphan.
+   */
+  private void assertOldSegmentsReclaimedOrReused(final RID hubRid, final List<RID> oldSegments) {
+    database.transaction(() -> {
+      final List<RID> reachableNow = collectHubReachableSegments(hubRid);
+      for (final RID oldSegment : oldSegments) {
+        Record survivor = null;
+        try {
+          survivor = ((DatabaseInternal) database).lookupByRID(oldSegment, true);
+        } catch (final RecordNotFoundException e) {
+          // RECLAIMED (or already gone): fine
+        }
+        if (survivor != null)
+          assertThat(reachableNow).as("old segment " + oldSegment + " is readable, so its slot must have been "
+              + "reused by the rebuilt layout - otherwise the reclaim missed an orphan").contains(oldSegment);
+      }
+    });
+  }
+
+  /** All segment RIDs of the hub's current IN layout: classic chain, or directory + every stripe chain. */
+  private List<RID> collectHubReachableSegments(final RID hubRid) {
+    final List<RID> segments = new ArrayList<>();
+    final RID head = ((VertexInternal) hubRid.asVertex(true)).getInEdgesHeadChunk();
+    if (head == null)
+      return segments;
+    final Record headRecord = ((DatabaseInternal) database).lookupByRID(head, true);
+    if (headRecord instanceof StripeDirectory directory) {
+      segments.add(head);
+      for (int g = 0; g < directory.getGenerationCount(); g++)
+        for (int s = 0; s < directory.getStripes(g); s++)
+          collectChain(directory.getHead(g, s), segments);
+    } else
+      collectChain(head, segments);
+    return segments;
+  }
+
+  private void collectChain(final RID head, final List<RID> segments) {
+    RID current = head;
+    while (current != null) {
+      segments.add(current);
+      current = ((EdgeSegment) ((DatabaseInternal) database).lookupByRID(current, true)).getPreviousRID();
+    }
+  }
+
+  @Test
+  void fixReclaimsOrphanedChunksAfterChainRebuild() {
+    final int degree = 500;
+    final RID hubRid = createHub(degree);
+
+    final List<RID> oldChunks = collectClassicChainChunks(hubRid);
+    assertThat(oldChunks.size()).as("the hub degree must span more than one chunk").isGreaterThan(1);
+
+    // BREAK THE CHAIN MID-WAY: fix rebuilds the adjacency, the surviving old chunks become orphans.
+    deleteRecordLowLevel(oldChunks.get(1));
+
+    final Map<String, Object> stats = runCheck(true);
+
+    // THE OLD CHUNKS HAVE BEEN RECLAIMED: each one is either deleted or its SLOT was legitimately reused by
+    // a segment of the rebuilt chain (LocalBucket recycles freed positions).
+    assertThat(((Number) stats.get("orphanedEdgeSegmentsReclaimed")).longValue())
+        .as("the old chain's surviving chunks must be reclaimed").isGreaterThanOrEqualTo(1L);
+    assertOldSegmentsReclaimedOrReused(hubRid, oldChunks);
+
+    // THE REBUILT ADJACENCY IS INTACT AND A FOLLOW-UP PLAIN CHECK IS CLEAN.
+    database.transaction(() ->
+        assertThat(hubRid.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE)).isEqualTo(degree));
+    assertThat(((Number) runCheck(false).get("totalWarnings")).longValue()).isEqualTo(0L);
+  }
+
+  @Test
+  void fixReclaimsOrphanedStripeDirectoryAfterSuperNodeRebuild() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(256);
+
+    final int degree = 2_000;
+    final RID hubRid = createHub(degree);
+
+    // COLLECT THE OLD STRIPED LAYOUT: directory + every chain head.
+    final List<RID> oldSegments = new ArrayList<>();
+    final RID[] gen0Mid = new RID[1];
+    database.transaction(() -> {
+      final RID head = ((VertexInternal) hubRid.asVertex(true)).getInEdgesHeadChunk();
+      final Record headRecord = ((DatabaseInternal) database).lookupByRID(head, true);
+      assertThat(headRecord).as("the hub must have been promoted").isInstanceOf(StripeDirectory.class);
+      final StripeDirectory directory = (StripeDirectory) headRecord;
+      oldSegments.add(head);
+      for (int g = 0; g < directory.getGenerationCount(); g++)
+        for (int s = 0; s < directory.getStripes(g); s++)
+          if (directory.getHead(g, s) != null)
+            oldSegments.add(directory.getHead(g, s));
+      final EdgeSegment gen0Head = (EdgeSegment) ((DatabaseInternal) database).lookupByRID(directory.getHead(0, 0), true);
+      gen0Mid[0] = gen0Head.getPreviousRID();
+      assertThat(gen0Mid[0]).as("the generation-0 chain must span more than one chunk").isNotNull();
+    });
+
+    deleteRecordLowLevel(gen0Mid[0]);
+
+    final Map<String, Object> stats = runCheck(true);
+
+    assertThat(((Number) stats.get("orphanedEdgeSegmentsReclaimed")).longValue()).isGreaterThanOrEqualTo(1L);
+    // THE OLD DIRECTORY AND CHAIN HEADS ARE GONE (or their slots were reused by the rebuilt layout).
+    assertOldSegmentsReclaimedOrReused(hubRid, oldSegments);
+
+    database.transaction(() ->
+        assertThat(hubRid.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE)).isEqualTo(degree));
+    assertThat(((Number) runCheck(false).get("totalWarnings")).longValue()).isEqualTo(0L);
+  }
+
+  /**
+   * THE SAFETY TEST: on a healthy database - classic chains AND a promoted super-node - the reclaim must
+   * delete NOTHING. A reachability walk missing any layout would classify live segments as orphans and
+   * destroy data.
+   */
+  @Test
+  void healthyDatabaseLosesNothing() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(256);
+
+    final int degree = 2_000;
+    final RID hubRid = createHub(degree); // promoted super-node + 2000 classic-layout sources
+
+    final Map<String, Object> stats = runCheck(true);
+
+    assertThat(((Number) stats.get("orphanedEdgeSegmentsReclaimed")).longValue())
+        .as("a healthy database has no orphans to reclaim").isEqualTo(0L);
+    database.transaction(() ->
+        assertThat(hubRid.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE)).isEqualTo(degree));
+    assertThat(((Number) runCheck(false).get("totalWarnings")).longValue()).isEqualTo(0L);
+  }
+
+  /** A type-filtered check walks only part of the graph, so it must NOT reclaim (false orphans otherwise). */
+  @Test
+  void filteredCheckDoesNotReclaim() {
+    final int degree = 500;
+    final RID hubRid = createHub(degree);
+
+    final List<RID> oldChunks = collectClassicChainChunks(hubRid);
+    deleteRecordLowLevel(oldChunks.get(1));
+
+    final Map<String, Object> stats = database.command("sql", "CHECK DATABASE TYPE " + VERTEX_TYPE + " FIX")
+        .next().toMap();
+
+    // THE CHAIN IS STILL REBUILT, BUT NO RECLAIM RUNS UNDER A FILTER.
+    assertThat(stats.get("orphanedEdgeSegmentsReclaimed")).isNull();
+    database.transaction(() -> {
+      assertThat(hubRid.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE)).isEqualTo(degree);
+      // The old head chunk survived: orphaned but not reclaimed.
+      assertThat(((DatabaseInternal) database).lookupByRID(oldChunks.getFirst(), true)).isNotNull();
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerOrphanReclaimTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerOrphanReclaimTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.DatabaseChecker;
 import com.arcadedb.exception.RecordNotFoundException;
 
@@ -267,6 +268,49 @@ class GraphDatabaseCheckerOrphanReclaimTest extends TestHelper {
 
     // REPAIR THE DELIBERATELY BROKEN CHAIN so the TestHelper post-test integrity check finds a clean database.
     runCheck(true);
+  }
+
+  /**
+   * Data-loss guard (PR #5379 review): the reclaim must identify the internal edge-list buckets from the SCHEMA,
+   * never by matching bucket names alone. A USER data bucket whose name collides with the edge-list naming scheme
+   * (ends with {@code _out_edges}/{@code _in_edges}, or contains the stripe infix {@code _sn_stripe_}) has no
+   * entry in the reachable set, so a name-only match would classify every record in it as an orphan and DELETE
+   * it. Here two such colliding user buckets are populated and a full CHECK DATABASE FIX must leave them intact.
+   */
+  @Test
+  void fullFixDoesNotDeleteUserBucketsCollidingWithSegmentNaming() {
+    createHub(500); // a healthy graph so the reclaim runs (full scope) but finds no real orphans
+
+    // A document type whose ONLY bucket is literally named "<x>_out_edges" (suffix collision), and a document
+    // type whose default bucket name CONTAINS the stripe infix "_sn_stripe_" (infix collision).
+    final String suffixBucketName = "Ledger" + GraphEngine.OUT_EDGES_SUFFIX;
+    final String infixTypeName    = "Audit" + StripedEdgeList.STRIPE_BUCKET_INFIX + "journal";
+    final int    suffixDocs       = 20;
+    final int    infixDocs        = 15;
+
+    database.transaction(() -> {
+      final Bucket ledgerBucket = database.getSchema().createBucket(suffixBucketName);
+      database.getSchema().createDocumentType("Ledger", List.of(ledgerBucket));
+      database.getSchema().createDocumentType(infixTypeName, 1);
+    });
+    database.transaction(() -> {
+      for (int i = 0; i < suffixDocs; i++)
+        database.newDocument("Ledger").set("i", i).save();
+      for (int i = 0; i < infixDocs; i++)
+        database.newDocument(infixTypeName).set("i", i).save();
+    });
+
+    final Map<String, Object> stats = runCheck(true);
+
+    // NO real orphans in a healthy graph, and NONE of the colliding user records were touched.
+    assertThat(((Number) stats.get("orphanedEdgeSegmentsReclaimed")).longValue())
+        .as("a healthy database has no orphans to reclaim").isEqualTo(0L);
+    database.transaction(() -> {
+      assertThat(database.countType("Ledger", false)).as("the _out_edges-named user bucket must be untouched")
+          .isEqualTo((long) suffixDocs);
+      assertThat(database.countType(infixTypeName, false)).as("the _sn_stripe_-named user bucket must be untouched")
+          .isEqualTo((long) infixDocs);
+    });
   }
 
   /** A type-filtered check walks only part of the graph, so it must NOT reclaim (false orphans otherwise). */

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerOrphanReclaimTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerOrphanReclaimTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -237,6 +238,35 @@ class GraphDatabaseCheckerOrphanReclaimTest extends TestHelper {
     database.transaction(() ->
         assertThat(hubRid.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE)).isEqualTo(degree));
     assertThat(((Number) runCheck(false).get("totalWarnings")).longValue()).isEqualTo(0L);
+  }
+
+  /**
+   * Focused regression for the checkEdges data-loss fix: the back-reference probe walking a vertex's BROKEN
+   * edge list must warn (once) and leave the repair to the vertex check - it must NOT flag the vertex or the
+   * edge as corrupted. Before the fix, running just checkEdges with fix deleted the perfectly healthy hub
+   * vertex over its broken chain.
+   */
+  @Test
+  void checkEdgesDoesNotBlameVertexForUnreadableEdgeList() {
+    final int degree = 500;
+    final RID hubRid = createHub(degree);
+
+    final List<RID> oldChunks = collectClassicChainChunks(hubRid);
+    deleteRecordLowLevel(oldChunks.get(1));
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkEdges(EDGE_TYPE, true, 0);
+
+    // NOTHING IS FLAGGED CORRUPTED: not the hub, not the edges probing its broken list.
+    assertThat((Collection<?>) stats.get("corruptedRecords")).isEmpty();
+    // THE UNREADABLE LIST IS WARNED EXACTLY ONCE despite hundreds of edges probing it.
+    assertThat(((Collection<String>) stats.get("warnings")).stream()
+        .filter(w -> w.contains("edge list is unreadable")).count()).isEqualTo(1);
+    // AND THE HUB SURVIVED.
+    database.transaction(() -> assertThat(hubRid.asVertex(true)).isNotNull());
+
+    // REPAIR THE DELIBERATELY BROKEN CHAIN so the TestHelper post-test integrity check finds a clean database.
+    runCheck(true);
   }
 
   /** A type-filtered check walks only part of the graph, so it must NOT reclaim (false orphans otherwise). */

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerReclaimFailClosedTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerReclaimFailClosedTest.java
@@ -71,6 +71,10 @@ class GraphDatabaseCheckerReclaimFailClosedTest extends TestHelper {
         .reclaimOrphanedEdgeSegments(0, Integer.MAX_VALUE);
 
     assertReclaimSkipped(stats);
+    // This drives the SCAN ERROR CALLBACK path: a vertex's edge-pointer prefix is validated at record
+    // construction inside bucket.scan, so the truncated buffer fails to load there (not later in asVertex),
+    // firing scanType's error callback - distinct from the mid-walk markChain path below.
+    assertWarned(stats, "could not be loaded during the orphan reclaim");
 
     // The hub's live IN chunks all survive.
     database.transaction(() -> {
@@ -109,6 +113,8 @@ class GraphDatabaseCheckerReclaimFailClosedTest extends TestHelper {
         .reclaimOrphanedEdgeSegments(0, Integer.MAX_VALUE);
 
     assertReclaimSkipped(stats);
+    // This drives the markChain mid-walk false-return path (a chunk lookup threw part-way).
+    assertWarned(stats, "edge chain could not be fully walked");
 
     // The downstream live chunk beyond the read failure survives (the data-loss the guard prevents).
     database.transaction(() -> {
@@ -164,6 +170,12 @@ class GraphDatabaseCheckerReclaimFailClosedTest extends TestHelper {
     // The skip is reported.
     assertThat(((Collection<String>) stats.get("warnings")).stream()
         .anyMatch(w -> w.contains("did not complete"))).as("the skipped reclaim must be reported").isTrue();
+  }
+
+  private void assertWarned(final Map<String, Object> stats, final String fragment) {
+    final Collection<String> warnings = (Collection<String>) stats.get("warnings");
+    assertThat(warnings.stream().anyMatch(w -> w.contains(fragment)))
+        .as("a warning containing '" + fragment + "' must be emitted; got: " + warnings).isTrue();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerReclaimFailClosedTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerReclaimFailClosedTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.exception.RecordNotFoundException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Data-loss guard (PR #5379 review): the orphaned-edge-segment reclaim must FAIL CLOSED. If a vertex cannot be
+ * walked during the reachability pass (phase 1), its live segments never make it into the reachable set, so
+ * deleting the "unreachable" segments in phase 2 would destroy them. The reclaim must skip the whole deletion
+ * phase whenever the walk is incomplete.
+ * <p>
+ * Here the hub vertex RECORD is corrupted so it cannot be loaded, then {@code reclaimOrphanedEdgeSegments} is
+ * invoked directly: with the guard the hub's live IN chain survives and nothing is reclaimed; without it the hub
+ * chain (unmarked because the hub could not be walked) would be deleted.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphDatabaseCheckerReclaimFailClosedTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // This test deliberately injects on-disk corruption, which the post-test integrity check would (correctly) flag.
+    return false;
+  }
+
+  @Test
+  void reclaimSkippedWhenAVertexCannotBeWalked() {
+    final int degree = 500;
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE, 1);
+      database.getSchema().createEdgeType(EDGE_TYPE, 1);
+    });
+
+    final RID[] hub = new RID[1];
+    database.transaction(() -> hub[0] = database.newVertex(VERTEX_TYPE).set("name", "hub").save().getIdentity());
+
+    final int batch = 250;
+    for (int from = 0; from < degree; from += batch) {
+      final int start = from;
+      final int end = Math.min(from + batch, degree);
+      database.transaction(() -> {
+        for (int i = start; i < end; i++)
+          database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, hub[0]);
+      });
+    }
+
+    // The hub's live IN chain: every one of these chunks must still exist after a fail-closed reclaim.
+    final List<RID> hubInChunks = new ArrayList<>();
+    database.transaction(() -> {
+      RID current = ((VertexInternal) hub[0].asVertex(true)).getInEdgesHeadChunk();
+      while (current != null) {
+        hubInChunks.add(current);
+        current = ((EdgeSegment) ((DatabaseInternal) database).lookupByRID(current, true)).getPreviousRID();
+      }
+    });
+    assertThat(hubInChunks.size()).as("the hub IN chain must span more than one chunk").isGreaterThan(1);
+
+    // Corrupt the hub vertex record so it can no longer be loaded during the reachability walk.
+    shrinkRecordContent(hub[0]);
+    reopenDatabase();
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .reclaimOrphanedEdgeSegments(0, Integer.MAX_VALUE);
+
+    // NOTHING was reclaimed: the incomplete walk disabled the deletion phase.
+    assertThat(((Number) stats.get("orphanedEdgeSegmentsReclaimed")).longValue())
+        .as("an incomplete reachability walk must skip the deletion phase").isEqualTo(0L);
+    assertThat(((Number) stats.get("orphanedEdgeSegments")).longValue()).isEqualTo(0L);
+    // The skip is reported.
+    assertThat(((Collection<String>) stats.get("warnings")).stream()
+        .anyMatch(w -> w.contains("did not complete"))).as("the skipped reclaim must be reported").isTrue();
+
+    // The hub's live IN chunks all survive.
+    database.transaction(() -> {
+      for (final RID chunk : hubInChunks) {
+        try {
+          assertThat(((DatabaseInternal) database).lookupByRID(chunk, true))
+              .as("live hub chunk " + chunk + " must survive the fail-closed reclaim").isNotNull();
+        } catch (final RecordNotFoundException e) {
+          throw new AssertionError("live hub chunk " + chunk + " was deleted by the reclaim", e);
+        }
+      }
+    });
+  }
+
+  /**
+   * Shrinks the record-size varint of the record at {@code rid} (page 0, slot 0) to a valid but tiny value (1
+   * content byte). Unlike a corrupt/oversized marker - which the bucket layer auto-deletes on the next scan - a
+   * small-but-valid size survives the reopen repair (it only checks size bounds), yet the truncated view is too
+   * short for {@code asVertex(true)} to read the fixed edge-head-chunk prefix, so the vertex fails to load during
+   * the reachability walk. The record is chosen tiny enough for its size to fit in a single-byte varint.
+   */
+  private void shrinkRecordContent(final RID rid) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = rid.getBucketId();
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, 0), pageSize, false);
+        final int recordTableOffset = Binary.SHORT_SERIALIZED_SIZE;
+        final int recordOffset = (int) page.readUnsignedInt(recordTableOffset);
+        final long[] recordSize = page.readNumberAndSize(recordOffset);
+        assertThat(recordSize[1]).as("the tiny hub record must use a single-byte size varint").isEqualTo(1L);
+        page.writeByte(recordOffset, (byte) 2); // zigzag(1) == 2  ->  content size 1 byte (too short for a vertex)
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerReclaimFailClosedTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerReclaimFailClosedTest.java
@@ -60,8 +60,68 @@ class GraphDatabaseCheckerReclaimFailClosedTest extends TestHelper {
 
   @Test
   void reclaimSkippedWhenAVertexCannotBeWalked() {
-    final int degree = 500;
+    final RID hub = buildHubWithMultiChunkInChain(500);
+    final List<RID> hubInChunks = collectInChunks(hub);
 
+    // Corrupt the hub vertex record so it can no longer be loaded during the reachability walk (scan-load path).
+    shrinkRecordContent(hub);
+    reopenDatabase();
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .reclaimOrphanedEdgeSegments(0, Integer.MAX_VALUE);
+
+    assertReclaimSkipped(stats);
+
+    // The hub's live IN chunks all survive.
+    database.transaction(() -> {
+      for (final RID chunk : hubInChunks) {
+        try {
+          assertThat(((DatabaseInternal) database).lookupByRID(chunk, true))
+              .as("live hub chunk " + chunk + " must survive the fail-closed reclaim").isNotNull();
+        } catch (final RecordNotFoundException e) {
+          throw new AssertionError("live hub chunk " + chunk + " was deleted by the reclaim", e);
+        }
+      }
+    });
+  }
+
+  /**
+   * PR #5379 review point 1: the fail-closed guarantee must also cover a read error that happens MID-WALK on a
+   * live chain (not just an unloadable vertex). Here a middle chunk of the hub's IN chain is corrupted so its
+   * lookup throws during {@code markChain}, leaving the downstream (older) chunks unmarked. Without the guard
+   * phase 2 would delete those live downstream chunks; with it the whole reclaim is skipped and they survive.
+   */
+  @Test
+  void reclaimSkippedWhenAChainReadFailsMidWalk() {
+    final RID hub = buildHubWithMultiChunkInChain(500);
+    final List<RID> hubInChunks = collectInChunks(hub);
+    assertThat(hubInChunks.size()).as("need at least 3 chunks: head, the corrupted middle, and a downstream tail")
+        .isGreaterThanOrEqualTo(3);
+
+    final RID middleChunk = hubInChunks.get(1);       // walk starts at the readable head then throws HERE...
+    final RID downstreamChunk = hubInChunks.get(2);   // ...leaving this LIVE chunk beyond it unmarked
+
+    // Remove a MIDDLE chunk (not the head, not the vertex) so markChain marks the head, then the next lookup
+    // throws RecordNotFoundException part-way through - a live chain whose walk fails mid-way.
+    database.transaction(() -> database.getSchema().getBucketById(middleChunk.getBucketId()).deleteRecord(middleChunk));
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .reclaimOrphanedEdgeSegments(0, Integer.MAX_VALUE);
+
+    assertReclaimSkipped(stats);
+
+    // The downstream live chunk beyond the read failure survives (the data-loss the guard prevents).
+    database.transaction(() -> {
+      try {
+        assertThat(((DatabaseInternal) database).lookupByRID(downstreamChunk, true))
+            .as("live downstream chunk " + downstreamChunk + " must survive the fail-closed reclaim").isNotNull();
+      } catch (final RecordNotFoundException e) {
+        throw new AssertionError("live downstream chunk " + downstreamChunk + " was deleted by the reclaim", e);
+      }
+    });
+  }
+
+  private RID buildHubWithMultiChunkInChain(final int degree) {
     database.transaction(() -> {
       database.getSchema().createVertexType(VERTEX_TYPE, 1);
       database.getSchema().createEdgeType(EDGE_TYPE, 1);
@@ -79,25 +139,24 @@ class GraphDatabaseCheckerReclaimFailClosedTest extends TestHelper {
           database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, hub[0]);
       });
     }
+    return hub[0];
+  }
 
-    // The hub's live IN chain: every one of these chunks must still exist after a fail-closed reclaim.
-    final List<RID> hubInChunks = new ArrayList<>();
+  /** The hub's IN chain chunk RIDs, head first. */
+  private List<RID> collectInChunks(final RID hub) {
+    final List<RID> chunks = new ArrayList<>();
     database.transaction(() -> {
-      RID current = ((VertexInternal) hub[0].asVertex(true)).getInEdgesHeadChunk();
+      RID current = ((VertexInternal) hub.asVertex(true)).getInEdgesHeadChunk();
       while (current != null) {
-        hubInChunks.add(current);
+        chunks.add(current);
         current = ((EdgeSegment) ((DatabaseInternal) database).lookupByRID(current, true)).getPreviousRID();
       }
     });
-    assertThat(hubInChunks.size()).as("the hub IN chain must span more than one chunk").isGreaterThan(1);
+    assertThat(chunks.size()).as("the hub IN chain must span more than one chunk").isGreaterThan(1);
+    return chunks;
+  }
 
-    // Corrupt the hub vertex record so it can no longer be loaded during the reachability walk.
-    shrinkRecordContent(hub[0]);
-    reopenDatabase();
-
-    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
-        .reclaimOrphanedEdgeSegments(0, Integer.MAX_VALUE);
-
+  private void assertReclaimSkipped(final Map<String, Object> stats) {
     // NOTHING was reclaimed: the incomplete walk disabled the deletion phase.
     assertThat(((Number) stats.get("orphanedEdgeSegmentsReclaimed")).longValue())
         .as("an incomplete reachability walk must skip the deletion phase").isEqualTo(0L);
@@ -105,18 +164,6 @@ class GraphDatabaseCheckerReclaimFailClosedTest extends TestHelper {
     // The skip is reported.
     assertThat(((Collection<String>) stats.get("warnings")).stream()
         .anyMatch(w -> w.contains("did not complete"))).as("the skipped reclaim must be reported").isTrue();
-
-    // The hub's live IN chunks all survive.
-    database.transaction(() -> {
-      for (final RID chunk : hubInChunks) {
-        try {
-          assertThat(((DatabaseInternal) database).lookupByRID(chunk, true))
-              .as("live hub chunk " + chunk + " must survive the fail-closed reclaim").isNotNull();
-        } catch (final RecordNotFoundException e) {
-          throw new AssertionError("live hub chunk " + chunk + " was deleted by the reclaim", e);
-        }
-      }
-    });
   }
 
   /**


### PR DESCRIPTION
Closes #5375. Follow-up of #5371/PR #5370.

## Orphan reclaim

A full-scope `CHECK DATABASE FIX` now adds a "Reclaiming orphaned edge segments" step (visible in the #5372 progress display) after the vertex checks:

1. walks every vertex's OUT/IN chains and marks every reachable segment - classic chunks, stripe directories, stripe chains and the generation-0 chains of promoted super-nodes, with a cycle guard for corrupt chains - into per-bucket primitive `LongHashSet`s (same footprint approach as the external-property orphan scan);
2. scans the dedicated edge-list buckets (`*_out_edges`, `*_in_edges`, `*_sn_stripe_*`) and deletes every segment not marked reachable.

The reclaim runs only when no type/bucket filter is set: a partial walk would misclassify the unwalked vertices' segments as orphans. New stats: `orphanedEdgeSegments` / `orphanedEdgeSegmentsReclaimed`. Like the rest of fix mode it assumes no concurrent writers.

## Data-loss bug found by the new tests

Exercising the FULL `check()` with fix over a broken chain (the earlier rebuild tests drove `checkVertices` directly) exposed a hole in the merged #5370 fix: `checkEdges` runs BEFORE the vertex checks, and its back-reference probe (`containsEdge` over the target vertex's edge list) blamed a broken CHAIN on the VERTEX record - fix mode then deleted the vertex before the rebuild could ever run. The probe now separates "the vertex record cannot be loaded" (vertex genuinely corrupted) from "the vertex's edge list cannot be walked" (warned once per vertex, left to the vertex check to rebuild, nothing flagged corrupted).

## Tests

`GraphDatabaseCheckerOrphanReclaimTest`:
- classic chain: orphans reclaimed after a rebuild, adjacency intact, follow-up check clean (slot reuse by `LocalBucket` accounted for: an old RID may legitimately live on as part of the rebuilt chain);
- striped super-node: old directory + stripe chains reclaimed;
- **healthy-database safety test**: the reclaim deletes nothing on a clean database with both layouts - the guard against an incomplete reachability walk destroying live data;
- filtered check: no reclaim under a TYPE filter.

Regression (68 tests green): chain-rebuild, checker diagnostics, CheckDatabaseTest/Extended, progress suites (fix-mode step plan updated to include the new step), SuperNodeStripingTest, BasicGraphTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5y8EbmkvSpFBbeDtTu33m