### PR TITLE
feat(#5376): REBUILD INDEX, COMPACT INDEX, BACKUP DATABASE and IMPORT DATABASE publish live progress

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -817,7 +817,8 @@ public class Console {
   private Thread startProgressMonitor(final String line) {
     if (output != null || verboseLevel < 2)
       return null;
-    final String normalized = line.trim().toLowerCase(Locale.ENGLISH);
+    // Collapse whitespace runs so `REBUILD   INDEX` matches too, consistently with the Studio matcher.
+    final String normalized = line.trim().toLowerCase(Locale.ENGLISH).replaceAll("\\s+", " ");
     boolean monitored = false;
     for (final String command : PROGRESS_MONITORED_COMMANDS)
       if (normalized.startsWith(command)) {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -810,10 +810,21 @@ public class Console {
    * not applicable (not a monitored command, or the output is redirected to an embedding application).
    * Polling is best-effort: any failure silently stops the rendering, never the command.
    */
+  /** The maintenance commands that publish live progress in the operation registry (issues #5372, #5376). */
+  private static final String[] PROGRESS_MONITORED_COMMANDS = { "check database", "rebuild index", "compact index",
+      "backup database", "import database" };
+
   private Thread startProgressMonitor(final String line) {
     if (output != null || verboseLevel < 2)
       return null;
-    if (!line.trim().toLowerCase(Locale.ENGLISH).startsWith("check database"))
+    final String normalized = line.trim().toLowerCase(Locale.ENGLISH);
+    boolean monitored = false;
+    for (final String command : PROGRESS_MONITORED_COMMANDS)
+      if (normalized.startsWith(command)) {
+        monitored = true;
+        break;
+      }
+    if (!monitored)
       return null;
 
     progressMonitorStopped = false;

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -805,15 +805,15 @@ public class Console {
     output(level, "\n" + text, args);
   }
 
+  /** The maintenance commands that publish live progress in the operation registry (issues #5372, #5376). */
+  private static final String[] PROGRESS_MONITORED_COMMANDS = { "check database", "rebuild index", "compact index",
+      "backup database", "import database" };
+
   /**
    * Starts the live progress line for long-running maintenance commands (issue #5372), or returns null when
    * not applicable (not a monitored command, or the output is redirected to an embedding application).
    * Polling is best-effort: any failure silently stops the rendering, never the command.
    */
-  /** The maintenance commands that publish live progress in the operation registry (issues #5372, #5376). */
-  private static final String[] PROGRESS_MONITORED_COMMANDS = { "check database", "rebuild index", "compact index",
-      "backup database", "import database" };
-
   private Thread startProgressMonitor(final String line) {
     if (output != null || verboseLevel < 2)
       return null;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
@@ -23,6 +23,8 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -64,6 +66,12 @@ public class BackupDatabaseStatement extends SimpleExecStatement {
       context.getDatabase().rollback();
     }
 
+    // PUBLISH LIVE PROGRESS (issue #5376): the backup runs behind a reflective boundary (integration module),
+    // so only the coarse operation is published - visible in the progress endpoint, console and Studio while
+    // it runs. Always retired in the finally.
+    final OperationProgress progress = OperationProgressRegistry.instance()
+        .register(context.getDatabase().getName(), "backup database");
+    progress.onProgress("Backing up database", 1, 1, 0, -1);
     try {
       final Class<?> clazz = Class.forName("com.arcadedb.integration.backup.Backup");
       final Object backup = clazz.getConstructor(Database.class, String.class).newInstance(context.getDatabase(), targetUrl);
@@ -114,6 +122,8 @@ public class BackupDatabaseStatement extends SimpleExecStatement {
       throw new CommandExecutionException("Error on backing up database, backup libs not found in classpath", e);
     } catch (final InvocationTargetException e) {
       throw new CommandExecutionException("Error on backing up database", e.getTargetException());
+    } finally {
+      OperationProgressRegistry.instance().unregister(progress);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CompactIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CompactIndexStatement.java
@@ -19,6 +19,8 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexException;
@@ -67,22 +69,27 @@ public class CompactIndexStatement extends DDLStatement {
     final List<String> compactedIndexes = new ArrayList<>();
     boolean compacted = false;
     String indexName = null;
+    // PUBLISH LIVE PROGRESS (issue #5376): one step per index, pollable via the progress HTTP endpoint,
+    // the console and Studio. Always retired in the finally.
+    final OperationProgress progress = OperationProgressRegistry.instance().register(database.getName(), "compact index");
     try {
+      final List<Index> targetIndexes = new ArrayList<>();
       if (all) {
-        for (final Index idx : database.getSchema().getIndexes()) {
-          // Skip the logical TypeIndex wrappers: their bucket sub-indexes are already visited as standalone
-          // automatic indexes, so compacting the wrapper too would merge the same files twice.
-          if (idx.isAutomatic() && !(idx instanceof TypeIndex)) {
-            indexName = idx.getName();
-            if (compactIndex((IndexInternal) idx))
-              compacted = true;
-            compactedIndexes.add(idx.getName());
-          }
-        }
-      } else {
-        final Index idx = database.getSchema().getIndexByName(name.getValue());
+        // Skip the logical TypeIndex wrappers: their bucket sub-indexes are already visited as standalone
+        // automatic indexes, so compacting the wrapper too would merge the same files twice.
+        for (final Index idx : database.getSchema().getIndexes())
+          if (idx.isAutomatic() && !(idx instanceof TypeIndex))
+            targetIndexes.add(idx);
+      } else
+        targetIndexes.add(database.getSchema().getIndexByName(name.getValue()));
+
+      int stepIndex = 0;
+      for (final Index idx : targetIndexes) {
         indexName = idx.getName();
-        compacted = compactIndex((IndexInternal) idx);
+        ++stepIndex;
+        progress.onProgress("Compacting index '" + idx.getName() + "'", stepIndex, targetIndexes.size(), 0, -1);
+        if (compactIndex((IndexInternal) idx))
+          compacted = true;
         compactedIndexes.add(idx.getName());
       }
     } catch (final Exception e) {
@@ -91,6 +98,8 @@ public class CompactIndexStatement extends DDLStatement {
       throw new IndexException(
           "Error on compacting index '" + (indexName != null ? indexName : (name != null ? name.getValue() : "*")) + "' (error="
               + e.getMessage() + ")", e);
+    } finally {
+      OperationProgressRegistry.instance().unregister(progress);
     }
 
     result.setProperty("indexes", compactedIndexes);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -23,6 +23,8 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.InternalResultSet;
@@ -58,6 +60,12 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
     if (this.url != null)
       result.setProperty("fromUrl", this.url.getUrlString());
 
+    // PUBLISH LIVE PROGRESS (issue #5376): the importer runs behind a reflective boundary (integration
+    // module) and its record total is unknown upfront, so only the coarse operation is published - visible in
+    // the progress endpoint, console and Studio while it runs. Always retired in the finally.
+    final OperationProgress progress = OperationProgressRegistry.instance()
+        .register(context.getDatabase().getName(), "import database");
+    progress.onProgress("Importing database", 1, 1, 0, -1);
     try {
       final Class<?> clazz = Class.forName("com.arcadedb.integration.importer.Importer");
       // Use the outermost database wrapper (e.g. RaftReplicatedDatabase in HA mode) so that
@@ -93,6 +101,8 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
         result.setProperty("result", "FAIL");
       else
         throw new CommandExecutionException("Error on importing database", e.getTargetException());
+    } finally {
+      OperationProgressRegistry.instance().unregister(progress);
     }
 
     result.setProperty("result", "OK");

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -157,7 +157,9 @@ public class RebuildIndexStatement extends DDLStatement {
         final String stepName = "Rebuilding index '" + idx.getName() + "'";
         // A per-bucket sub-index rebuild scans only its associated bucket, so its step total is that bucket's
         // count; a named TypeIndex rebuild scans the whole type. Using countType for a sub-index would cap
-        // the step percentage at ~100/N% on a type spread over N buckets.
+        // the step percentage at ~100/N% on a type spread over N buckets. countType is deliberately
+        // NON-polymorphic: a TypeIndex build scans only the declaring type's own buckets - subtypes inheriting
+        // the index carry their own sub-indexes, rebuilt as their own targets.
         final int associatedBucketId = idx.getAssociatedBucketId();
         final long recordsTotal = associatedBucketId > -1 && !(idx instanceof TypeIndex) ?
             database.getSchema().getBucketById(associatedBucketId).count() :

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -156,7 +156,7 @@ public class RebuildIndexStatement extends DDLStatement {
         final int step = stepIndex;
         final String stepName = "Rebuilding index '" + idx.getName() + "'";
         // A per-bucket sub-index rebuild scans only its associated bucket, so its step total is that bucket's
-        // count; only a full TypeIndex rebuild scans the whole type. Using countType for a sub-index would cap
+        // count; a named TypeIndex rebuild scans the whole type. Using countType for a sub-index would cap
         // the step percentage at ~100/N% on a type spread over N buckets.
         final int associatedBucketId = idx.getAssociatedBucketId();
         final long recordsTotal = associatedBucketId > -1 && !(idx instanceof TypeIndex) ?
@@ -164,13 +164,22 @@ public class RebuildIndexStatement extends DDLStatement {
             idx.getTypeName() != null ? database.countType(idx.getTypeName(), false) : -1L;
         progress.onProgress(stepName, step, targetIndexes.size(), 0, recordsTotal);
 
+        // Own per-step counter: the callback's totalIndexed argument RESETS at every bucket boundary inside a
+        // TypeIndex build (each sub-index allocates a fresh counter), so it cannot be published against the
+        // whole-type total without sawtoothing.
+        final AtomicLong stepDone = new AtomicLong();
         final Index.BuildIndexCallback progressCallback = (document, totalIndexed) -> {
           callback.onDocumentIndexed(document, totalIndexed);
-          if ((totalIndexed & 1023) == 0) // THROTTLED: five volatile writes every 1024 records
-            progress.onProgress(stepName, step, targetIndexes.size(), totalIndexed, recordsTotal);
+          final long done = stepDone.incrementAndGet();
+          if ((done & 1023) == 0) // THROTTLED: five volatile writes every 1024 records
+            progress.onProgress(stepName, step, targetIndexes.size(), done, recordsTotal);
         };
 
         buildIndex(maxAttempts, database, progressCallback, idx, batchSize);
+        // COMPLETION EMISSION: small indexes (< 1024 records) never hit the throttle, and larger ones may end
+        // mid-window - land the step at 100% either way.
+        progress.onProgress(stepName, step, targetIndexes.size(), recordsTotal > 0 ? recordsTotal : stepDone.get(),
+            recordsTotal > 0 ? recordsTotal : stepDone.get());
         indexList.add(idx.getName());
       }
       result.setProperty("indexes", indexList);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -24,11 +24,11 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.exception.NeedRetryException;
-import com.arcadedb.engine.OperationProgress;
-import com.arcadedb.engine.OperationProgressRegistry;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.index.IndexInternal;
@@ -155,7 +155,13 @@ public class RebuildIndexStatement extends DDLStatement {
         ++stepIndex;
         final int step = stepIndex;
         final String stepName = "Rebuilding index '" + idx.getName() + "'";
-        final long recordsTotal = idx.getTypeName() != null ? database.countType(idx.getTypeName(), false) : -1L;
+        // A per-bucket sub-index rebuild scans only its associated bucket, so its step total is that bucket's
+        // count; only a full TypeIndex rebuild scans the whole type. Using countType for a sub-index would cap
+        // the step percentage at ~100/N% on a type spread over N buckets.
+        final int associatedBucketId = idx.getAssociatedBucketId();
+        final long recordsTotal = associatedBucketId > -1 && !(idx instanceof TypeIndex) ?
+            database.getSchema().getBucketById(associatedBucketId).count() :
+            idx.getTypeName() != null ? database.countType(idx.getTypeName(), false) : -1L;
         progress.onProgress(stepName, step, targetIndexes.size(), 0, recordsTotal);
 
         final Index.BuildIndexCallback progressCallback = (document, totalIndexed) -> {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -27,6 +27,8 @@ import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionS
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.index.IndexInternal;
@@ -133,21 +135,36 @@ public class RebuildIndexStatement extends DDLStatement {
     };
 
     String indexName = null;
+    // PUBLISH LIVE PROGRESS (issue #5376): one step per index, per-record progress inside each build, pollable
+    // via the progress HTTP endpoint, the console and Studio. Always retired in the finally.
+    final OperationProgress progress = OperationProgressRegistry.instance().register(database.getName(), "rebuild index");
     try {
       final List<String> indexList = new ArrayList<>();
 
+      final List<Index> targetIndexes = new ArrayList<>();
       if (all) {
-        for (final Index idx : database.getSchema().getIndexes()) {
-          if (idx.isAutomatic() && !(idx instanceof TypeIndex)) {
-            indexName = idx.getName();
-            buildIndex(maxAttempts, database, callback, idx, batchSize);
-            indexList.add(idx.getName());
-          }
-        }
-      } else {
-        final Index idx = database.getSchema().getIndexByName(name.getValue());
+        for (final Index idx : database.getSchema().getIndexes())
+          if (idx.isAutomatic() && !(idx instanceof TypeIndex))
+            targetIndexes.add(idx);
+      } else
+        targetIndexes.add(database.getSchema().getIndexByName(name.getValue()));
+
+      int stepIndex = 0;
+      for (final Index idx : targetIndexes) {
         indexName = idx.getName();
-        buildIndex(maxAttempts, database, callback, idx, batchSize);
+        ++stepIndex;
+        final int step = stepIndex;
+        final String stepName = "Rebuilding index '" + idx.getName() + "'";
+        final long recordsTotal = idx.getTypeName() != null ? database.countType(idx.getTypeName(), false) : -1L;
+        progress.onProgress(stepName, step, targetIndexes.size(), 0, recordsTotal);
+
+        final Index.BuildIndexCallback progressCallback = (document, totalIndexed) -> {
+          callback.onDocumentIndexed(document, totalIndexed);
+          if ((totalIndexed & 1023) == 0) // THROTTLED: five volatile writes every 1024 records
+            progress.onProgress(stepName, step, targetIndexes.size(), totalIndexed, recordsTotal);
+        };
+
+        buildIndex(maxAttempts, database, progressCallback, idx, batchSize);
         indexList.add(idx.getName());
       }
       result.setProperty("indexes", indexList);
@@ -175,6 +192,8 @@ public class RebuildIndexStatement extends DDLStatement {
       throw new IndexException(
           "Error on rebuilding index '" + (indexName != null ? indexName : name.getValue()) + "' (error=" + e.getMessage() + ")",
           e);
+    } finally {
+      OperationProgressRegistry.instance().unregister(progress);
     }
 
     // SUCCESS

--- a/engine/src/test/java/com/arcadedb/engine/MaintenanceOperationsProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/MaintenanceOperationsProgressTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * REBUILD INDEX and COMPACT INDEX publish their progress in {@link OperationProgressRegistry} (issue #5376),
+ * exactly like CHECK DATABASE: registered while running, retired in a finally - success or failure.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MaintenanceOperationsProgressTest extends TestHelper {
+
+  private void createIndexedType(final int records) {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Doc", "id");
+    });
+    database.transaction(() -> {
+      for (int i = 0; i < records; i++)
+        database.newDocument("Doc").set("id", i).save();
+    });
+  }
+
+  /** Samples the registry from a background thread while the synchronous statement runs. */
+  private List<OperationProgress> sampleWhile(final Runnable command) throws InterruptedException {
+    final List<OperationProgress> samples = new ArrayList<>();
+    final AtomicBoolean running = new AtomicBoolean(true);
+    final Thread sampler = new Thread(() -> {
+      while (running.get()) {
+        samples.addAll(OperationProgressRegistry.instance().getOperations(database.getName()));
+        Thread.yield();
+      }
+    });
+    sampler.setDaemon(true);
+    sampler.start();
+    try {
+      command.run();
+    } finally {
+      running.set(false);
+      sampler.join(2_000);
+    }
+    return samples;
+  }
+
+  @Test
+  void rebuildIndexPublishesAndRetiresProgress() throws InterruptedException {
+    createIndexedType(100_000);
+
+    final List<OperationProgress> samples = sampleWhile(() ->
+        database.command("sql", "REBUILD INDEX *").close());
+
+    // THE OPERATION WAS VISIBLE WHILE RUNNING...
+    assertThat(samples).as("the rebuild must be visible in the registry while it runs").isNotEmpty();
+    assertThat(samples.stream().anyMatch(op -> op.getOperation().equals("rebuild index"))).isTrue();
+    assertThat(samples.stream().anyMatch(op -> op.getStepName().startsWith("Rebuilding index"))).isTrue();
+    // ...AND RETIRED WHEN THE STATEMENT COMPLETED.
+    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
+  }
+
+  @Test
+  void compactIndexRetiresProgress() {
+    createIndexedType(1_000);
+
+    database.command("sql", "COMPACT INDEX *").close();
+
+    // COMPACTION IS FAST, SO ONLY THE RETIRE CONTRACT IS ASSERTED DETERMINISTICALLY.
+    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
+  }
+
+  @Test
+  void failedRebuildRetiresProgressToo() {
+    createIndexedType(10);
+
+    assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `does_not_exist`").close())
+        .isInstanceOf(Exception.class);
+
+    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/MaintenanceOperationsProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/MaintenanceOperationsProgressTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -57,7 +58,12 @@ class MaintenanceOperationsProgressTest extends TestHelper {
     final Thread sampler = new Thread(() -> {
       while (running.get()) {
         samples.addAll(OperationProgressRegistry.instance().getOperations(database.getName()));
-        Thread.yield();
+        try {
+          // 1ms cadence still catches the multi-second rebuild reliably without busy-spinning a CI core.
+          Thread.sleep(1);
+        } catch (final InterruptedException e) {
+          return;
+        }
       }
     });
     sampler.setDaemon(true);
@@ -72,6 +78,7 @@ class MaintenanceOperationsProgressTest extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   void rebuildIndexPublishesAndRetiresProgress() throws InterruptedException {
     createIndexedType(100_000);
 

--- a/engine/src/test/java/com/arcadedb/engine/MaintenanceOperationsProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/MaintenanceOperationsProgressTest.java
@@ -112,4 +112,22 @@ class MaintenanceOperationsProgressTest extends TestHelper {
 
     assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
   }
+
+  /**
+   * BACKUP/IMPORT DATABASE run behind the integration module's reflective boundary, absent from the engine
+   * test classpath: both commands register their progress and then fail, which is exactly what exercises the
+   * retire-in-finally contract for the two reflective paths.
+   */
+  @Test
+  void backupAndImportRetireProgressOnFailureToo() {
+    createIndexedType(10);
+
+    assertThatThrownBy(() -> database.command("sql", "BACKUP DATABASE").close())
+        .isInstanceOf(Exception.class);
+    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
+
+    assertThatThrownBy(() -> database.command("sql", "IMPORT DATABASE file:///tmp/does-not-exist.jsonl").close())
+        .isInstanceOf(Exception.class);
+    assertThat(OperationProgressRegistry.instance().getOperations(database.getName())).isEmpty();
+  }
 }

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3014,7 +3014,8 @@ function executeCommand(language, query) {
 let globalCommandProgressTimer = null;
 
 function startCommandProgressMonitor(database, command) {
-  if (!/^\s*check\s+database/i.test(command)) return;
+  // The maintenance commands that publish live progress in the operation registry (issues #5372, #5376).
+  if (!/^\s*(check\s+database|rebuild\s+index|compact\s+index|backup\s+database|import\s+database)/i.test(command)) return;
 
   stopCommandProgressMonitor();
 


### PR DESCRIPTION
Closes #5376. Follow-up of #5372.

Adopts the progress primitive in the remaining long-running maintenance statements:

- **REBUILD INDEX**: one step per target index (`Rebuilding index 'x'`, step i/N) with per-record within-step progress against the type's record count, throttled to one registry update every 1024 records so the build hot loop is untouched.
- **COMPACT INDEX**: one step per compacted index.
- **BACKUP DATABASE / IMPORT DATABASE**: coarse operation-level progress. Both run behind the integration module's reflective boundary (and the import's record total is unknown upfront), so this pass publishes the running operation without per-record detail - still enough for the console/Studio to show what is running and for how long. Finer-grained progress inside the integration classes can be a later refinement.

Every statement registers in `OperationProgressRegistry` and retires in a `finally`, success or failure, like `CHECK DATABASE`. The console and Studio monitors now match all five commands (`check database`, `rebuild index`, `compact index`, `backup database`, `import database`).

## Tests
`MaintenanceOperationsProgressTest`: a background sampler observes the registry while `REBUILD INDEX *` runs over 100k records (operation + step names asserted), retire-on-completion for compact, and retire-on-failure for a rebuild of a non-existent index. Regression: `RebuildIndexPartitionValidationTest`, `CompactIndexStatementTest(+Parser)`, `FullTextRebuildOverExistingTest` all green; console compiles; Studio JS syntax-checked.