### PR TITLE
Optimize IN-list anchors for bounded variable-length Cypher paths

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1554,7 +1554,9 @@ public class CypherExecutionPlan {
         String sourceVar = sourceNode.getVariable() != null ? sourceNode.getVariable() :
             ("  src" + anonymousVarCounter++);
 
-        boolean reversed = shouldReverseVariableLengthPathFromIndexedAnchor(matchClause, pathPattern);
+        final boolean reversedFromIndexedAnchor =
+            shouldReverseVariableLengthPathFromIndexedAnchor(matchClause, pathPattern);
+        boolean reversed = reversedFromIndexedAnchor;
         if (reversed) {
           sourceNode = pathPattern.getLastNode();
           sourceVar = sourceNode.getVariable();
@@ -1602,7 +1604,7 @@ public class CypherExecutionPlan {
         final BooleanExpression sourcePushdown = sourceAlreadyBound ? null :
             extractPushdownFilter(whereClause, sourceVar, boundVariables, matchVariables);
         final AbstractExecutionStep sourceStep;
-        if (reversed && physicalPlan.getAnchor().getPropertyValue() instanceof InListValues) {
+        if (reversedFromIndexedAnchor && physicalPlan.getAnchor().getPropertyValue() instanceof InListValues) {
           final var anchor = physicalPlan.getAnchor();
           sourceStep = new IndexSeekStep(anchor.getVariable(), anchor.getIndex().getTypeName(),
               anchor.getPropertyName(), anchor.getPropertyValue(), anchor.getIndex().getIndexName(),

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -93,6 +93,7 @@ import com.arcadedb.query.opencypher.executor.steps.FilterPropertiesStep;
 import com.arcadedb.query.opencypher.executor.steps.FinalProjectionStep;
 import com.arcadedb.query.opencypher.executor.steps.ForeachStep;
 import com.arcadedb.query.opencypher.executor.steps.GroupByAggregationStep;
+import com.arcadedb.query.opencypher.executor.steps.IndexSeekStep;
 import com.arcadedb.query.opencypher.executor.steps.LimitStep;
 import com.arcadedb.query.opencypher.executor.steps.LoadCSVStep;
 import com.arcadedb.query.opencypher.executor.steps.MatchNodeStep;
@@ -1600,8 +1601,14 @@ public class CypherExecutionPlan {
         final String sourceIdFilter = sourceAlreadyBound ? null : extractIdFilter(whereClause, sourceVar);
         final BooleanExpression sourcePushdown = sourceAlreadyBound ? null :
             extractPushdownFilter(whereClause, sourceVar, boundVariables, matchVariables);
-        final MatchNodeStep sourceStep = new MatchNodeStep(sourceVar, sourceNode, context, sourceIdFilter,
-            sourcePushdown);
+        final AbstractExecutionStep sourceStep;
+        if (reversed && physicalPlan.getAnchor().getPropertyValue() instanceof InListValues) {
+          final var anchor = physicalPlan.getAnchor();
+          sourceStep = new IndexSeekStep(anchor.getVariable(), anchor.getIndex().getTypeName(),
+              anchor.getPropertyName(), anchor.getPropertyValue(), anchor.getIndex().getIndexName(),
+              anchor.getEstimatedCost(), anchor.getEstimatedCardinality(), context);
+        } else
+          sourceStep = new MatchNodeStep(sourceVar, sourceNode, context, sourceIdFilter, sourcePushdown);
 
         if (isOptional) {
           if (matchChainStart == null) {
@@ -1790,7 +1797,6 @@ public class CypherExecutionPlan {
       final PathPattern pathPattern) {
     if (physicalPlan == null || physicalPlan.getAnchor() == null || !physicalPlan.getAnchor().useIndex()
         || physicalPlan.getAnchor().isRangeScan() || physicalPlan.getAnchor().getIndex() == null
-        || physicalPlan.getAnchor().getPropertyValue() instanceof InListValues
         || physicalPlan.getAnchor().getIndex().getPropertyNames() == null
         || physicalPlan.getAnchor().getIndex().getPropertyNames().size() != 1)
       return false;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1808,6 +1808,15 @@ public class CypherExecutionPlan {
         || matchClause.getPathPatterns().size() != 1 || pathPattern.getRelationshipCount() != 1)
       return false;
 
+    if (physicalPlan.getAnchor().getPropertyValue() instanceof InListValues) {
+      final NodePattern indexedTarget = pathPattern.getLastNode();
+      final String indexedType = physicalPlan.getAnchor().getIndex().getTypeName();
+      if (indexedTarget.hasProperties() || indexedTarget.hasDynamicLabels()
+          || indexedTarget.getLabels().size() != 1 || indexedType == null
+          || !indexedType.equals(indexedTarget.getLabels().getFirst()))
+        return false;
+    }
+
     final RelationshipPattern relationship = pathPattern.getRelationship(0);
     if (!relationship.isVariableLength() || relationship.getMaxHops() == null || !relationship.hasTypes()
         || isAnyEdgeTypeUnidirectional(relationship.getTypes()))

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
@@ -53,6 +53,9 @@ class CypherVariableLengthAnchorSelectionTest {
       final MutableVertex region = area("region");
       final MutableVertex city = area("city");
 
+      country.set("region", "EU").save();
+      region.set("region", "NA").save();
+
       city.newEdge("PART_OF", region, true, (Object[]) null).set("step", "city-region").save();
       region.newEdge("PART_OF", country, true, (Object[]) null).set("step", "region-country").save();
       city.newEdge("PART_OF_ONE_WAY", region).save();
@@ -136,6 +139,53 @@ class CypherVariableLengthAnchorSelectionTest {
           .contains("INDEX SEEK (country:Area)")
           .contains("[index: Area[id]]")
           .contains("2 rows");
+    }
+  }
+
+  @Test
+  void preservesInlinePropertiesOnIndexedInListAnchor() {
+    final String query = """
+        MATCH (place:Area)-[:PART_OF*0..3]->(country:Area {region: 'EU'})
+        WHERE country.id IN $countryIds
+        RETURN country.id AS country, place.id AS place
+        ORDER BY country, place""";
+    final Map<String, Object> parameters = Map.of("countryIds", List.of("country", "region"));
+
+    try (ResultSet resultSet = database.query("opencypher", query, parameters)) {
+      assertThat(resultSet.stream()
+          .map(row -> row.<String>getProperty("country") + ":" + row.<String>getProperty("place"))
+          .toList())
+          .containsExactly("country:city", "country:country", "country:region");
+    }
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().prettyPrint(0, 2))
+          .contains("MATCH NODE (place:Area)")
+          .doesNotContain("INDEX SEEK (country:Area)");
+    }
+  }
+
+  @Test
+  void preservesAdditionalLabelsOnIndexedInListAnchor() {
+    final String query = """
+        MATCH (place:Area)-[:PART_OF*0..3]->(country:Area:Selected)
+        WHERE country.id IN $countryIds
+        RETURN country.id AS country, place.id AS place
+        ORDER BY country, place""";
+    final Map<String, Object> parameters = Map.of("countryIds", List.of("country", "region"));
+
+    try (ResultSet resultSet = database.query("opencypher", query, parameters)) {
+      assertThat(resultSet.stream()).isEmpty();
+    }
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().prettyPrint(0, 2))
+          .contains("MATCH NODE (place:Area)")
+          .doesNotContain("INDEX SEEK (country:Area)");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
@@ -114,6 +114,32 @@ class CypherVariableLengthAnchorSelectionTest {
   }
 
   @Test
+  void startsBoundedVariableLengthTraversalFromIndexedInListTarget() {
+    final String query = """
+        MATCH (place:Area)-[:PART_OF*0..3]->(country:Area)
+        WHERE country.id IN $countryIds
+        RETURN country.id AS country, place.id AS place
+        ORDER BY country, place""";
+    final Map<String, Object> parameters = Map.of("countryIds", List.of("country", "region", "absent"));
+
+    try (ResultSet resultSet = database.query("opencypher", query, parameters)) {
+      assertThat(resultSet.stream()
+          .map(row -> row.<String>getProperty("country") + ":" + row.<String>getProperty("place"))
+          .toList())
+          .containsExactly("country:city", "country:country", "country:region", "region:city", "region:region");
+    }
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
+          .contains("INDEX SEEK (country:Area)")
+          .contains("[index: Area[id]]")
+          .contains("2 rows");
+    }
+  }
+
+  @Test
   void preservesRelationshipListInWrittenPathOrder() {
     final String query = """
         MATCH (place:Area)-[relationships:PART_OF*1..3]->(country:Area)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
@@ -140,6 +140,24 @@ class CypherVariableLengthAnchorSelectionTest {
   }
 
   @Test
+  void keepsBoundTargetReversalIndependentOfIndexedAnchor() {
+    final String query = """
+        MATCH (country:Area {id: 'country'})
+        OPTIONAL MATCH (place:Area)-[:PART_OF]->(country)
+        WHERE place.id = 'region'
+        WITH country, count(place) AS places
+        RETURN country.id AS id, places""";
+
+    try (ResultSet resultSet = database.query("opencypher", query)) {
+      assertThat(resultSet.hasNext()).isTrue();
+      final Result result = resultSet.next();
+      assertThat(result.<String>getProperty("id")).isEqualTo("country");
+      assertThat(result.<Long>getProperty("places")).isEqualTo(1L);
+      assertThat(resultSet.hasNext()).isFalse();
+    }
+  }
+
+  @Test
   void preservesRelationshipListInWrittenPathOrder() {
     final String query = """
         MATCH (place:Area)-[relationships:PART_OF*1..3]->(country:Area)


### PR DESCRIPTION
## Summary

- allow the bounded variable-length path bridge introduced in #5357 to accept indexed `IN`-list target anchors
- start the reversed traversal with `IndexSeekStep`, reusing the existing multi-value seek and runtime parameter handling
- add regression coverage for both the index-backed plan and existing bound-target reversal without a physical optimizer plan

This preserves the existing bridge safety gates: read-only execution, one bounded and typed bidirectional relationship, a single-property index, and no shape-changing clauses before `MATCH`.

The indexed-anchor reversal is tracked separately from the existing reversal of ordinary single-hop paths whose target is already bound, so fallback execution does not require a physical optimizer plan.

## Motivation

The bridge currently rejects `InListValues`, so a query such as:

```cypher
MATCH (place:Area)-[:PART_OF*0..3]->(country:Area)
WHERE country.id IN $countryIds
RETURN country.id, place.id
```

cannot start from the selective indexed target even though `NodeIndexSeek` already supports literal and parameterized `IN` lists. This patch connects that existing operator to the traditional variable-length executor.

Part of #5358.

## Verification

```text
./mvnw -pl engine -Dtest=CypherVariableLengthAnchorSelectionTest,CypherMultiHopInListIssue5306Test,OpenCypherVariableLengthPathTest,Issue5362DuplicatePredicateIndexSeekTest,OpenCypherOptimizerVerificationTest,AnchorSelectorTest,CypherOptimizerIntegrationTest,CountEdgesOptimizationTest,StreamingAggregationTest,CypherLabelFilteringTest,OpenCypherOptionalMatchTest test
```

Result: 128 tests run, 0 failures, 0 errors, 0 skipped.

```text
./mvnw -pl engine -Dtest=com.arcadedb.query.opencypher.tck.OpenCypherTCKSuite test
```

Result: 3,897 scenarios run, 0 failures, 0 errors, 85 expected skips.
