### PR TITLE
test(#5366): e2e JdbcQueriesIT reads list-of-documents as a json array

### DIFF
--- a/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesIT.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.e2e;
 
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -214,10 +215,11 @@ class JdbcQueriesIT extends ArcadeContainerTemplate {
       try (final ResultSet rs = st.executeQuery("SELECT * FROM article ORDER BY id")) {
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("title")).isEqualTo("My first article");
-        //comments is an array of embedded docs on first row
-        ResultSet comments = rs.getArray("comment").getResultSet();
-        assertThat(comments.next()).isTrue();
-        assertThat(new JSONObject(comments.getString("value")).getString("content")).isEqualTo("This is a comment");
+        //comments is an array of embedded docs on first row, carried as a json array (issue #5366)
+        final JSONArray comments = new JSONArray(rs.getString("comment"));
+        assertThat(comments.length()).isEqualTo(2);
+        assertThat(comments.getJSONObject(0).getString("content")).isEqualTo("This is a comment");
+        assertThat(comments.getJSONObject(1).getString("content")).isEqualTo("This is a comment 2");
         //location is an embedded doc
         assertThat(rs.getString("location")).isNotNull();
         assertThat(new JSONObject(rs.getString("location")).getString("name")).contains("My location");
@@ -240,10 +242,12 @@ class JdbcQueriesIT extends ArcadeContainerTemplate {
 
       final ResultSet rs = st.executeQuery("{sql}select from schema:types");
       while (rs.next()) {
-        if (rs.getArray("properties").getResultSet().next()) {
-          ResultSet props = rs.getArray("properties").getResultSet();
-          assertThat(props.next()).isTrue();
-          assertThat(new JSONObject(props.getString("value")).getString("type")).isIn("INTEGER", "STRING");
+        // A list of documents travels as a json array (issue #5366).
+        final String properties = rs.getString("properties");
+        if (properties != null && properties.startsWith("[")) {
+          final JSONArray props = new JSONArray(properties);
+          if (!props.isEmpty())
+            assertThat(props.getJSONObject(0).getString("type")).isIn("INTEGER", "STRING");
         }
       }
 


### PR DESCRIPTION
## Problem

`e2e/JdbcQueriesIT` fails on `main` with `ArrayIndexOutOfBoundsException`:

```
JdbcQueriesIT.createSchemaWithSqlScript:218 » ArrayIndexOutOfBounds Index 167 out of bounds for length 167
JdbcQueriesIT.selectSchemaTypes:243       » ArrayIndexOutOfBounds Index 812 out of bounds for length 812
```

## Root cause

Not a product regression - the wire behavior changed **intentionally** in #5366 (`9d3e2a3bd`, "a Postgres list of documents is announced as json, not json[]"):

> A list of documents, maps or nested collections is now advertised as `json` (OID 114) carrying a plain JSON array [...]. Scalar lists keep their native array types.

Because a `LIST OF <document>` column is now a scalar `json` value rather than `json[]`, the pgjdbc driver no longer exposes it through `java.sql.Array`. The old test code still called `rs.getArray("comment")` / `rs.getArray("properties")`, and the driver threw `ArrayIndexOutOfBoundsException` while trying to parse the scalar `json` payload as a Postgres array literal.

`PostgresWJdbcIT` (postgresw module) was updated in #5366 to read these columns with `rs.getString(...)` + `JSONArray`, but the sibling e2e test `JdbcQueriesIT` was missed. This PR applies the same client-side pattern to the e2e test.

## Change

Test-only. Read the list-of-documents columns with `rs.getString(...)` and parse them as `JSONArray`, mirroring `PostgresWJdbcIT`. Scalar lists (still `text[]`) are untouched.

## Verification

- `postgresw` wire ITs (the Postgres tests): `PostgresWJdbcIT` -> **42 run, 0 failures** (confirms the `json`/OID 114 contract is the intended behavior).
- Reproduced the failure with the **unpatched** e2e test against a locally-built `arcadedata/arcadedb:latest` image -> 2 errors at lines 218/243.
- With the fix, `JdbcQueriesIT` -> **10 run, 0 failures, 1 skipped** (the `@Disabled` test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)