### PR TITLE
Relax indexed anchors for open-ended and anonymous variable-length paths

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1553,6 +1553,7 @@ public class CypherExecutionPlan {
         NodePattern sourceNode = pathPattern.getFirstNode();
         String sourceVar = sourceNode.getVariable() != null ? sourceNode.getVariable() :
             ("  src" + anonymousVarCounter++);
+        final String writtenSourceVar = sourceVar;
 
         final boolean reversedFromIndexedAnchor =
             shouldReverseVariableLengthPathFromIndexedAnchor(matchClause, pathPattern);
@@ -1681,8 +1682,7 @@ public class CypherExecutionPlan {
           final Direction directionOverride;
           if (reversed) {
             effectiveSourceVar = currentSourceVar; // already swapped to bound target
-            effectiveTargetVar = pathPattern.getFirstNode().getVariable() != null ?
-                pathPattern.getFirstNode().getVariable() : targetVar;
+            effectiveTargetVar = writtenSourceVar;
             targetVar = effectiveTargetVar;
             effectiveTargetNode = pathPattern.getFirstNode(); // original source becomes target for label filtering
             directionOverride = relPattern.getDirection().reverse();
@@ -1792,8 +1792,8 @@ public class CypherExecutionPlan {
 
   /**
    * The physical operators do not yet implement variable-length expansion, but their cost-based
-   * anchor selection is still useful to the traditional executor. Limit this bridge to a single,
-   * bounded relationship whose indexed target can be reached through stored incoming adjacency.
+   * anchor selection is still useful to the traditional executor. Limit this bridge to a single
+   * relationship whose indexed target can be reached through stored incoming adjacency.
    */
   private boolean shouldReverseVariableLengthPathFromIndexedAnchor(final MatchClause matchClause,
       final PathPattern pathPattern) {
@@ -1818,13 +1818,13 @@ public class CypherExecutionPlan {
     }
 
     final RelationshipPattern relationship = pathPattern.getRelationship(0);
-    if (!relationship.isVariableLength() || relationship.getMaxHops() == null || !relationship.hasTypes()
+    if (!relationship.isVariableLength() || !relationship.hasTypes()
         || isAnyEdgeTypeUnidirectional(relationship.getTypes()))
       return false;
 
     final String sourceVariable = pathPattern.getFirstNode().getVariable();
     final String targetVariable = pathPattern.getLastNode().getVariable();
-    return sourceVariable != null && targetVariable != null && !sourceVariable.equals(targetVariable)
+    return targetVariable != null && !targetVariable.equals(sourceVariable)
         && targetVariable.equals(physicalPlan.getAnchor().getVariable());
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1675,7 +1675,11 @@ public class CypherExecutionPlan {
           String targetVar = targetNode.getVariable() != null ? targetNode.getVariable() :
               ("  tgt" + anonymousVarCounter++);
 
-          // When reversed, swap source/target variables and use the original source as target
+          // When reversed, swap source/target variables and use the original source as target.
+          // This mapping only holds for a single-relationship pattern: the written source is the
+          // end of the one reversed hop. Both entry points into `reversed` enforce that (the
+          // bound-target reversal below and shouldReverseVariableLengthPathFromIndexedAnchor);
+          // reversing a longer pattern requires rebuilding the whole pattern back to front.
           final String effectiveSourceVar;
           final String effectiveTargetVar;
           final NodePattern effectiveTargetNode;
@@ -1794,6 +1798,17 @@ public class CypherExecutionPlan {
    * The physical operators do not yet implement variable-length expansion, but their cost-based
    * anchor selection is still useful to the traditional executor. Limit this bridge to a single
    * relationship whose indexed target can be reached through stored incoming adjacency.
+   * <p>
+   * Two of the conditions below are load-bearing rather than merely conservative:
+   * <ul>
+   *   <li>a single relationship, because the reversal in {@code buildMatchStep} maps the one hop
+   *   back onto the written source node and cannot express a longer reversed pattern;</li>
+   *   <li>a single-property index, because {@code NodeIndexSeek} and {@link IndexSeekStep} seek
+   *   with a one-element key, which a composite index rejects.</li>
+   * </ul>
+   * The remaining conditions bound the shapes this bridge has been proven against; see issue #5358
+   * for the tracked relaxations and for the native variable-length expansion operator that makes
+   * this bridge unnecessary.
    */
   private boolean shouldReverseVariableLengthPathFromIndexedAnchor(final MatchClause matchClause,
       final PathPattern pathPattern) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
@@ -19,11 +19,15 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.NodePattern;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
+import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
+import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
 import com.arcadedb.query.opencypher.parser.CypherASTBuilder;
 import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.opencypher.ast.PathMode;
@@ -62,6 +66,11 @@ public class ExpandPathStep extends AbstractExecutionStep {
   private final Set<String> previousStepVariables;
   private final Direction directionOverride;
   private final boolean reverseResultPath;
+  /**
+   * Created only when the target node pattern carries Cypher 25 dynamic {@code $(expression)}
+   * labels: every other pattern shape resolves its labels statically and must not pay for it.
+   */
+  private final ExpressionEvaluator dynamicLabelEvaluator;
 
   /**
    * Creates an expand path step.
@@ -131,6 +140,8 @@ public class ExpandPathStep extends AbstractExecutionStep {
     this.previousStepVariables = previousStepVariables;
     this.directionOverride = directionOverride;
     this.reverseResultPath = reverseResultPath;
+    this.dynamicLabelEvaluator = targetNodePattern != null && targetNodePattern.hasDynamicLabels() ?
+        new ExpressionEvaluator(new CypherFunctionFactory(DefaultSQLFunctionFactory.getInstance())) : null;
   }
 
   /**
@@ -204,8 +215,8 @@ public class ExpandPathStep extends AbstractExecutionStep {
               final TraversalPath path = reverseResultPath ? traversedPath.reversed() : traversedPath;
 
               // Filter by target node label if specified
-              if (targetNodePattern != null && targetNodePattern.hasLabels()) {
-                if (!matchesTargetLabel(targetVertex))
+              if (targetNodePattern != null && (targetNodePattern.hasLabels() || targetNodePattern.hasDynamicLabels())) {
+                if (!matchesTargetLabel(targetVertex, lastResult))
                   continue;
               }
 
@@ -352,11 +363,57 @@ public class ExpandPathStep extends AbstractExecutionStep {
     return false;
   }
 
-  private boolean matchesTargetLabel(final Vertex vertex) {
-    for (final String label : targetNodePattern.getLabels())
-      if (!vertex.getType().instanceOf(label))
+  /**
+   * Applies the target node pattern labels to a traversed end vertex, with the same semantics
+   * {@link com.arcadedb.query.opencypher.executor.steps.MatchNodeStep} uses when the node is
+   * reached by a scan: a disjunction {@code (n:A|B)} accepts any of the labels, a conjunction
+   * {@code (n:A:B)} requires all of them, and Cypher 25 dynamic {@code $(expression)} labels are
+   * resolved against the current binding.
+   */
+  private boolean matchesTargetLabel(final Vertex vertex, final Result currentResult) {
+    final List<String> labels = resolveEffectiveLabels(currentResult);
+    if (labels.isEmpty())
+      return true;
+
+    if (targetNodePattern.isLabelDisjunction()) {
+      for (final String label : labels)
+        if (Labels.hasLabel(vertex, label))
+          return true;
+      return false;
+    }
+
+    for (final String label : labels)
+      if (!Labels.hasLabel(vertex, label))
         return false;
     return true;
+  }
+
+  /**
+   * Returns the labels the target vertex must satisfy, combining the statically written labels with
+   * the result of evaluating any dynamic label expression against the current binding. A dynamic
+   * expression may yield a single label or a collection of labels, all of which are required.
+   */
+  private List<String> resolveEffectiveLabels(final Result currentResult) {
+    final List<String> staticLabels = targetNodePattern.getLabels();
+    if (dynamicLabelEvaluator == null)
+      return staticLabels;
+
+    final List<String> labels = new ArrayList<>(staticLabels.size() + targetNodePattern.getDynamicLabels().size());
+    labels.addAll(staticLabels);
+    for (final Expression dynamicLabel : targetNodePattern.getDynamicLabels())
+      appendResolvedLabels(labels, dynamicLabelEvaluator.evaluate(dynamicLabel, currentResult, context));
+    return labels;
+  }
+
+  private static void appendResolvedLabels(final List<String> labels, final Object resolved) {
+    if (resolved == null)
+      return;
+    if (resolved instanceof Iterable) {
+      for (final Object item : (Iterable<?>) resolved)
+        if (item != null)
+          labels.add(item.toString());
+    } else
+      labels.add(resolved.toString());
   }
 
   private boolean matchesTargetProperties(final Vertex vertex, final Result currentResult) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
@@ -117,6 +117,111 @@ class CypherVariableLengthAnchorSelectionTest {
   }
 
   @Test
+  void startsUnboundedVariableLengthTraversalFromIndexedTarget() {
+    final String query = """
+        MATCH (place:Area)-[:PART_OF*]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN DISTINCT place.id AS id
+        ORDER BY id""";
+    final Map<String, Object> parameters = Map.of("countryId", "country");
+
+    assertThat(queryIds(query, parameters)).containsExactly("city", "region");
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
+          .contains("MATCH NODE (country:Area)")
+          .contains("[index: Area[id]]")
+          .contains("1 rows");
+    }
+  }
+
+  @Test
+  void startsOpenEndedTraversalWithMinimumHopsFromIndexedTarget() {
+    final String query = """
+        MATCH (place:Area)-[:PART_OF*2..]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN DISTINCT place.id AS id
+        ORDER BY id""";
+    final Map<String, Object> parameters = Map.of("countryId", "country");
+
+    assertThat(queryIds(query, parameters)).containsExactly("city");
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
+          .contains("MATCH NODE (country:Area)")
+          .contains("[index: Area[id]]")
+          .contains("1 rows");
+    }
+  }
+
+  @Test
+  void startsAnonymousSourceTraversalFromIndexedTarget() {
+    final String query = """
+        MATCH (:Area)-[:PART_OF*0..3]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN country.id AS id, count(*) AS places""";
+    final Map<String, Object> parameters = Map.of("countryId", "country");
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      assertThat(resultSet.hasNext()).isTrue();
+      final Result result = resultSet.next();
+      assertThat(result.<String>getProperty("id")).isEqualTo("country");
+      assertThat(result.<Long>getProperty("places")).isEqualTo(3L);
+      assertThat(resultSet.hasNext()).isFalse();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
+          .contains("MATCH NODE (country:Area)")
+          .contains("[index: Area[id]]")
+          .contains("1 rows");
+    }
+  }
+
+  @Test
+  void startsAnonymousUnboundedTraversalFromIndexedTarget() {
+    final String query = """
+        MATCH (:Area)-[:PART_OF*2..]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN country.id AS id, count(*) AS places""";
+    final Map<String, Object> parameters = Map.of("countryId", "country");
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      assertThat(resultSet.hasNext()).isTrue();
+      final Result result = resultSet.next();
+      assertThat(result.<String>getProperty("id")).isEqualTo("country");
+      assertThat(result.<Long>getProperty("places")).isEqualTo(1L);
+      assertThat(resultSet.hasNext()).isFalse();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
+          .contains("MATCH NODE (country:Area)")
+          .contains("[index: Area[id]]")
+          .contains("1 rows");
+    }
+  }
+
+  @Test
+  void startsAnonymousUnboundedTraversalFromIndexedInListTargets() {
+    final String query = """
+        MATCH (:Area)-[:PART_OF*]->(country:Area)
+        WHERE country.id IN $countryIds
+        RETURN country.id AS country, count(*) AS places
+        ORDER BY country""";
+    final Map<String, Object> parameters = Map.of("countryIds", List.of("country", "region", "absent"));
+
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, parameters)) {
+      assertThat(resultSet.stream()
+          .map(row -> row.<String>getProperty("country") + ":" + row.<Long>getProperty("places"))
+          .toList())
+          .containsExactly("country:2", "region:1");
+      assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
+          .contains("INDEX SEEK (country:Area)")
+          .contains("[index: Area[id]]")
+          .contains("2 rows");
+    }
+  }
+
+  @Test
   void startsBoundedVariableLengthTraversalFromIndexedInListTarget() {
     final String query = """
         MATCH (place:Area)-[:PART_OF*0..3]->(country:Area)
@@ -211,6 +316,35 @@ class CypherVariableLengthAnchorSelectionTest {
   void preservesRelationshipListInWrittenPathOrder() {
     final String query = """
         MATCH (place:Area)-[relationships:PART_OF*1..3]->(country:Area)
+        WHERE country.id = $countryId
+        RETURN place.id AS id, relationships AS relationships
+        ORDER BY id""";
+
+    final List<Result> rows;
+    final ExecutionPlan plan;
+    try (ResultSet resultSet = database.query("opencypher", "PROFILE " + query, Map.of("countryId", "country"))) {
+      rows = resultSet.stream().toList();
+      plan = resultSet.getExecutionPlan().orElseThrow();
+    }
+
+    assertThat(plan.getSteps().get(0).getDescription())
+        .contains("MATCH NODE (country:Area)")
+        .contains("[index: Area[id]]");
+
+    final Result city = rows.stream()
+        .filter(row -> "city".equals(row.<String>getProperty("id")))
+        .findFirst()
+        .orElseThrow();
+    final List<Edge> relationships = city.getProperty("relationships");
+    assertThat(relationships)
+        .extracting(edge -> edge.<String>get("step"))
+        .containsExactly("city-region", "region-country");
+  }
+
+  @Test
+  void preservesUnboundedRelationshipListInWrittenPathOrder() {
+    final String query = """
+        MATCH (place:Area)-[relationships:PART_OF*1..]->(country:Area)
         WHERE country.id = $countryId
         RETURN place.id AS id, relationships AS relationships
         ORDER BY id""";

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthReversedAnchorSemanticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthReversedAnchorSemanticsTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Semantic parity coverage for the indexed-anchor reversal bridge used by the traditional Cypher
+ * executor (PRs #5357, #5387, #5393).
+ * <p>
+ * Every test runs the same query twice against the same graph: once anchored on the indexed
+ * {@code id} property, which lets the bridge reverse the traversal, and once anchored on the
+ * non-indexed {@code name} property, which keeps the original source-first traversal. Both runs must
+ * be indistinguishable: same rows, same multiplicity, same written path order.
+ * <p>
+ * The graph is deliberately hostile to a naive reversal: a diamond gives two distinct paths between
+ * the same pair of vertices, and a back edge closes a cycle so unbounded expansion has to rely on
+ * relationship uniqueness to terminate.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherVariableLengthReversedAnchorSemanticsTest {
+  private static final String DATABASE_PATH = "./target/databases/cypher-vlp-reversed-anchor-semantics";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DATABASE_PATH).create();
+    database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final Map<String, MutableVertex> vertices = new HashMap<>();
+      for (final String id : List.of("a", "b", "c", "d", "hub"))
+        vertices.put(id, node(id));
+
+      // diamond: two distinct 2-hop trails from "a" to "d"
+      link(vertices, "a", "b");
+      link(vertices, "a", "c");
+      link(vertices, "b", "d");
+      link(vertices, "c", "d");
+      link(vertices, "d", "hub");
+      // back edge closing a cycle so unbounded expansion must rely on relationship uniqueness
+      link(vertices, "hub", "a");
+
+      for (int i = 0; i < 128; i++)
+        node("decoy-" + i);
+    });
+
+    database.transaction(() -> database.getSchema().createTypeIndex(
+        Schema.INDEX_TYPE.LSM_TREE, true, "Node", "id"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void unboundedReversalKeepsRowMultiplicity() {
+    assertParity("""
+        MATCH (n:Node)-[:LINK*]->(hub:Node)
+        WHERE hub.%s = 'hub'
+        RETURN n.id AS id
+        ORDER BY id""");
+  }
+
+  @Test
+  void openEndedMinimumHopsReversalKeepsRowMultiplicity() {
+    assertParity("""
+        MATCH (n:Node)-[:LINK*2..]->(hub:Node)
+        WHERE hub.%s = 'hub'
+        RETURN n.id AS id
+        ORDER BY id""");
+  }
+
+  @Test
+  void zeroLengthOpenEndedReversalKeepsRowMultiplicity() {
+    assertParity("""
+        MATCH (n:Node)-[:LINK*0..]->(hub:Node)
+        WHERE hub.%s = 'hub'
+        RETURN n.id AS id
+        ORDER BY id""");
+  }
+
+  @Test
+  void boundedReversalKeepsRowMultiplicity() {
+    assertParity("""
+        MATCH (n:Node)-[:LINK*1..3]->(hub:Node)
+        WHERE hub.%s = 'hub'
+        RETURN n.id AS id
+        ORDER BY id""");
+  }
+
+  @Test
+  void undirectedUnboundedReversalKeepsRowMultiplicity() {
+    assertParity("""
+        MATCH (n:Node)-[:LINK*1..2]-(hub:Node)
+        WHERE hub.%s = 'hub'
+        RETURN n.id AS id
+        ORDER BY id""");
+  }
+
+  @Test
+  void anonymousSourceUnboundedReversalKeepsPathCount() {
+    assertParity("""
+        MATCH (:Node)-[:LINK*]->(hub:Node)
+        WHERE hub.%s = 'hub'
+        RETURN count(*) AS paths""");
+  }
+
+  @Test
+  void anonymousSourceReversalDoesNotRebindTheAnchor() {
+    assertParity("""
+        MATCH (:Node)-[:LINK*1..2]->(hub:Node)
+        WHERE hub.%s = 'hub'
+        RETURN hub.id AS anchor, count(*) AS paths
+        ORDER BY anchor""");
+  }
+
+  @Test
+  void unboundedReversalKeepsWrittenRelationshipOrder() {
+    assertParity("""
+        MATCH (n:Node)-[relationships:LINK*]->(hub:Node)
+        WHERE hub.%s = 'hub'
+        RETURN n.id AS id, [r IN relationships | r.step] AS steps
+        ORDER BY id, steps""");
+  }
+
+  /**
+   * The optimizer never plans a statement with an inline node property constraint or a named path
+   * variable, so no physical anchor exists and the bridge cannot engage. The queries must still
+   * return the correct rows through the plain source-first plan; this test locks in that both
+   * shapes stay ineligible and correct, so a future eligibility change cannot silently reroute them.
+   */
+  @Test
+  void shapesIneligibleForTheBridgeStayCorrect() {
+    final String inlineProperty = """
+        MATCH (n:Node {name: 'a'})-[:LINK*]->(hub:Node)
+        WHERE hub.id = 'hub'
+        RETURN n.id AS id
+        ORDER BY id""";
+    final String namedPath = """
+        MATCH p = (n:Node)-[:LINK*]->(hub:Node)
+        WHERE hub.id = 'hub'
+        RETURN [x IN nodes(p) | x.id] AS ids
+        ORDER BY ids""";
+
+    assertThat(planStartsFromAnchor(inlineProperty)).isFalse();
+    assertThat(planStartsFromAnchor(namedPath)).isFalse();
+
+    assertThat(rows(inlineProperty)).containsExactly("id=a;", "id=a;");
+    assertThat(rows(namedPath)).containsExactly(
+        "ids=[a, b, d, hub];", "ids=[a, c, d, hub];", "ids=[b, d, hub];", "ids=[c, d, hub];",
+        "ids=[d, hub];", "ids=[hub, a, b, d, hub];", "ids=[hub, a, c, d, hub];");
+  }
+
+  @Test
+  void unboundedReversalKeepsSourcePredicateInWhere() {
+    assertParity("""
+        MATCH (n:Node)-[:LINK*]->(hub:Node)
+        WHERE hub.%s = 'hub' AND n.id <> 'a'
+        RETURN n.id AS id
+        ORDER BY id""");
+  }
+
+  @Test
+  void inListUnboundedReversalKeepsRowMultiplicity() {
+    assertParity("""
+        MATCH (n:Node)-[:LINK*]->(hub:Node)
+        WHERE hub.%s IN ['hub', 'd']
+        RETURN hub.id AS target, n.id AS id
+        ORDER BY target, id""");
+  }
+
+  /**
+   * Runs the query anchored on the indexed property (bridge reverses the traversal) and on the
+   * non-indexed twin property (bridge stays out of the way), then compares rows one by one.
+   */
+  private void assertParity(final String queryTemplate) {
+    final String indexed = queryTemplate.formatted("id");
+    final String notIndexed = queryTemplate.formatted("name");
+
+    assertThat(planStartsFromAnchor(indexed))
+        .as("the indexed variant must start from the anchor: %s", indexed)
+        .isTrue();
+    assertThat(planStartsFromAnchor(notIndexed))
+        .as("the non-indexed variant must keep the source-first plan: %s", notIndexed)
+        .isFalse();
+
+    assertThat(rows(indexed))
+        .as("reversed and source-first execution must agree: %s", indexed)
+        .isEqualTo(rows(notIndexed));
+  }
+
+  private boolean planStartsFromAnchor(final String query) {
+    try (final ResultSet resultSet = database.query("opencypher", "PROFILE " + query)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+      final String firstStep = resultSet.getExecutionPlan().orElseThrow().getSteps().getFirst().getDescription();
+      return firstStep.contains("(hub:Node)") && firstStep.contains("[index: Node[id]]");
+    }
+  }
+
+  private List<String> rows(final String query) {
+    final List<String> rows = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext()) {
+        final Result row = resultSet.next();
+        final StringBuilder buffer = new StringBuilder();
+        for (final String property : row.getPropertyNames().stream().sorted().toList())
+          buffer.append(property).append('=').append(String.valueOf(row.<Object>getProperty(property))).append(';');
+        rows.add(buffer.toString());
+      }
+    }
+    return rows;
+  }
+
+  private MutableVertex node(final String id) {
+    return database.newVertex("Node").set("id", id).set("name", id).save();
+  }
+
+  private void link(final Map<String, MutableVertex> vertices, final String from, final String to) {
+    vertices.get(from).newEdge("LINK", vertices.get(to), true, (Object[]) null).set("step", from + "-" + to).save();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherOptionalMatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherOptionalMatchTest.java
@@ -89,6 +89,47 @@ class OpenCypherOptionalMatchTest {
     result.close();
   }
 
+  /**
+   * An unbound source with a bound target is executed by following the target's incoming edges
+   * instead of scanning the source type. When the source is written anonymously, the reversed hop
+   * must bind its result to the internal variable generated for it: binding it to the target
+   * variable instead collapsed every incoming edge of a vertex into a single row.
+   */
+  @Test
+  void optionalMatchWithAnonymousReversedSourceKeepsEveryIncomingEdge() {
+    database.transaction(() -> database.command("opencypher", """
+        MATCH (c:Person {name: 'Charlie'}), (b:Person {name: 'Bob'}) \
+        CREATE (c)-[:KNOWS]->(b)"""));
+
+    // Bob is now known by both Alice and Charlie
+    try (final ResultSet result = database.query("opencypher", """
+        MATCH (p:Person) \
+        OPTIONAL MATCH (:Person)-[:KNOWS]->(p) \
+        RETURN p.name AS person, count(*) AS rows \
+        ORDER BY person""")) {
+      final List<String> rows = new ArrayList<>();
+      while (result.hasNext()) {
+        final Result row = result.next();
+        rows.add(row.<String>getProperty("person") + "=" + row.<Long>getProperty("rows"));
+      }
+      assertThat(rows).containsExactly("Alice=1", "Bob=2", "Charlie=1");
+    }
+
+    // the named equivalent must agree, counting only the vertices that actually matched
+    try (final ResultSet result = database.query("opencypher", """
+        MATCH (p:Person) \
+        OPTIONAL MATCH (k:Person)-[:KNOWS]->(p) \
+        RETURN p.name AS person, count(k) AS known \
+        ORDER BY person""")) {
+      final List<String> rows = new ArrayList<>();
+      while (result.hasNext()) {
+        final Result row = result.next();
+        rows.add(row.<String>getProperty("person") + "=" + row.<Long>getProperty("known"));
+      }
+      assertThat(rows).containsExactly("Alice=0", "Bob=2", "Charlie=0");
+    }
+  }
+
   @Test
   void matchCharlieAlone() {
     // First test that basic MATCH with property filter works

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthTargetLabelTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthTargetLabelTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The node pattern at the far end of a variable-length relationship is filtered by the expansion
+ * step itself, not by a scan step, so it needs the same label semantics a scanned node gets:
+ * disjunction {@code (n:A|B)} matches any label, conjunction {@code (n:A:B)} matches all of them,
+ * and a Cypher 25 dynamic {@code $(expression)} label is resolved per row.
+ * <p>
+ * Both written orientations are covered, because the indexed-anchor bridge reverses the traversal
+ * and then evaluates the written source node as the expansion target.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class OpenCypherVariableLengthTargetLabelTest {
+  private static final String DATABASE_PATH = "./target/databases/cypher-vlp-target-label";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DATABASE_PATH).create();
+    database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+    database.getSchema().createVertexType("Special").addSuperType("Node");
+    database.getSchema().createVertexType("Other").addSuperType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Node").set("id", "hub").save();
+      for (final String type : List.of("Node", "Special", "Other")) {
+        final MutableVertex leaf = database.newVertex(type).set("id", type.toLowerCase()).save();
+        leaf.newEdge("LINK", hub, true, (Object[]) null).save();
+      }
+      for (int i = 0; i < 128; i++)
+        database.newVertex("Node").set("id", "decoy-" + i).save();
+    });
+
+    database.transaction(() -> database.getSchema().createTypeIndex(
+        Schema.INDEX_TYPE.LSM_TREE, true, "Node", "id"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void labelDisjunctionOnExpansionTargetMatchesAnyLabel() {
+    assertThat(ids("MATCH (hub:Node)<-[:LINK*1..2]-(n:Special|Other) WHERE hub.id = 'hub' RETURN n.id AS id ORDER BY id"))
+        .containsExactly("other", "special");
+  }
+
+  @Test
+  void labelDisjunctionOnReversedExpansionTargetMatchesAnyLabel() {
+    assertThat(ids("MATCH (n:Special|Other)-[:LINK*1..2]->(hub:Node) WHERE hub.id = 'hub' RETURN n.id AS id ORDER BY id"))
+        .containsExactly("other", "special");
+  }
+
+  @Test
+  void labelConjunctionOnExpansionTargetRequiresEveryLabel() {
+    assertThat(ids("MATCH (hub:Node)<-[:LINK*1..2]-(n:Node) WHERE hub.id = 'hub' RETURN n.id AS id ORDER BY id"))
+        .containsExactly("node", "other", "special");
+    assertThat(ids("MATCH (hub:Node)<-[:LINK*1..2]-(n:Special) WHERE hub.id = 'hub' RETURN n.id AS id ORDER BY id"))
+        .containsExactly("special");
+  }
+
+  @Test
+  void dynamicLabelOnExpansionTargetIsResolved() {
+    assertThat(ids("MATCH (hub:Node)<-[:LINK*1..2]-(n:Node:$('Special')) WHERE hub.id = 'hub' RETURN n.id AS id ORDER BY id"))
+        .containsExactly("special");
+  }
+
+  @Test
+  void dynamicLabelOnReversedExpansionTargetIsResolved() {
+    assertThat(ids("MATCH (n:Node:$('Special'))-[:LINK*1..2]->(hub:Node) WHERE hub.id = 'hub' RETURN n.id AS id ORDER BY id"))
+        .containsExactly("special");
+  }
+
+  private List<String> ids(final String query) {
+    final List<String> ids = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        ids.add(resultSet.next().getProperty("id"));
+    }
+    return ids;
+  }
+}


### PR DESCRIPTION
## Summary

- allow the traditional-executor bridge to start open-ended variable-length paths (`*` and `*2..`) from the indexed target selected by the optimizer
- retain the generated internal source variable when the written source node is anonymous
- preserve the `IN`-list constraint safety guard from #5387 and cover the combined anonymous/open-ended/multi-value case

This is a focused follow-up to #5357 and #5387 and addresses the first two remaining guard relaxations in #5358.

## Safety

The existing conservative requirements remain unchanged: read-only single-path queries, one typed variable-length relationship, stored incoming adjacency, a single-property indexed target, and the existing exclusions for optional/multi-MATCH, range, composite-index, unidirectional, untyped, and constrained `IN`-list anchor shapes.

The underlying `ExpandPathStep` already implements open-ended traversal; the previous upper-bound requirement was only an admission guard. Anonymous sources use the internal variable already allocated by the traditional executor so the reversed expansion can bind the original written source correctly.

## Verification

- `./mvnw -pl engine -Dtest=CypherVariableLengthAnchorSelectionTest test`: 14 passed
- adjacent variable-length, optimizer, anchor-selector, and multi-value gate: 85 passed
- `git diff --check origin/main...HEAD`: passed

The new coverage includes `*`, `*2..`, bounded and open-ended anonymous sources, the combined indexed `IN`-list case, and written relationship-list order for open-ended reversed traversal.

This PR intentionally does not address composite indexes, multi-pattern planning, range anchors, or the future native variable-length expansion physical operator.