### PR TITLE
fix: RaftGroupCommitter strands entries submitted after stop/transfer

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
@@ -208,6 +208,20 @@ class RaftGroupCommitter {
       throw new ReplicationQueueFullException("Interrupted while waiting for replication queue space");
     }
 
+    // Close the strand-after-stop window: a concurrent stop()/transferPendingTo() may have halted the
+    // flusher and drained the queue AFTER we reserved bytes but BEFORE our offer landed (a caller can
+    // still hold the old volatile broker reference across a leader refresh). Such an entry would sit in
+    // a queue nothing polls, blocking this caller for the whole 2*quorumTimeout grace window. Re-check
+    // running now that the entry is enqueued: if the committer has stopped and the entry is still ours
+    // to reclaim, fail fast with a retryable error so the caller re-submits against the fresh broker.
+    // The queue lock orders offer/drain, so if the drain already finished this read observes running=
+    // false and remove() succeeds; if remove() fails a concurrent flusher/transfer already took the
+    // entry and will complete its future, so we fall through to the normal wait.
+    if (!running && queue.remove(pending)) {
+      queuedBytes.addAndGet(-entrySize); // release the reservation: we reclaimed the un-dispatched entry
+      throw new QuorumNotReachedException("Group committer stopped before dispatch; retry");
+    }
+
     // Test-only: simulate "entry dispatched, then quorum wait timed out" deterministically. The
     // entry stays on the queue (PENDING), so the flusher still dispatches and commits it for real;
     // we just abandon the wait here with the same exception the production grace-expiry path uses.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
@@ -199,13 +199,43 @@ class RaftGroupCommitterTest {
     // Critical: must NOT be the "Group committer shutting down" message that would surface if we
     // failed pending entries on the source. The new committer (target) handles it instead.
     assertThat(message).doesNotContain("Group committer shutting down");
-    // Either the transfer raced ahead and the entry was completed by the target's null-client
-    // path, or the source flusher caught it first - either is acceptable as long as we don't
-    // surface the hard-stop error.
-    assertThat(message).containsAnyOf("not available", "ok");
+    // Three legitimate outcomes, none of which is the hard-stop error: the transfer raced ahead and
+    // the target's null-client path completed it ("not available"/"ok"), the source flusher caught it
+    // first ("not available"), or the transfer fully won and the caller reclaimed its own un-dispatched
+    // entry ("stopped before dispatch").
+    assertThat(message).containsAnyOf("not available", "ok", "stopped before dispatch");
 
     source.stop();
     target.stop();
+  }
+
+  /**
+   * A {@code submitAndWait} that races in AFTER {@link RaftGroupCommitter#stop()} (or
+   * {@link RaftGroupCommitter#transferPendingTo}) has halted the flusher and drained the queue must
+   * NOT be stranded: the entry would otherwise sit in a queue nothing polls, blocking the caller for
+   * the whole {@code 2 * quorumTimeout} grace window. This reproduces the leader-refresh race where a
+   * caller holds the old (volatile) broker reference and submits just after the refresh stopped it.
+   */
+  @Test
+  void submitAfterStopFailsFastInsteadOfStranding() throws Exception {
+    // quorumTimeout 30s -> a stranded caller would block 2*30s = 60s; we require completion far sooner.
+    final RaftGroupCommitter committer = new RaftGroupCommitter(null, Quorum.MAJORITY, 30_000);
+    committer.stop(); // flusher halted and queue drained BEFORE we submit
+
+    final CompletableFuture<String> result = CompletableFuture.supplyAsync(() -> {
+      try {
+        committer.submitAndWait(new byte[] { 1, 2, 3 });
+        return "ok";
+      } catch (final QuorumNotReachedException e) {
+        return "failed: " + e.getMessage();
+      }
+    });
+
+    // Without the fix the future never completes and this get() times out; with the fix the caller
+    // fails fast with a retryable error well within the 2*quorumTimeout window.
+    final String message = result.get(3, TimeUnit.SECONDS);
+    assertThat(message).startsWith("failed:");
+    assertThat(message).doesNotContain("Group committer shutting down");
   }
 
   /**


### PR DESCRIPTION
## Problem

`RaftGroupCommitterTest#transferPendingToHandsOffUndispatchedEntries` fails on ~2-3% of runs with a `TimeoutException` at `result.get(5, SECONDS)`. Root cause is a real **strand-after-stop race** in `RaftGroupCommitter`, not a test-timing quirk.

`stop()` and `transferPendingTo()` both set `running=false`, interrupt the flusher, and drain the queue **exactly once**. `submitAndWait` had no guard against enqueuing *after* that drain:

1. A caller runs `submitAndWait(...)`.
2. Concurrently, `stop()`/`transferPendingTo()` halts the flusher and drains the queue.
3. If the caller's `queue.offer(...)` lands **after** the drain finished, the entry sits in a queue whose flusher has already exited. Nothing polls it, its future never completes, and the caller blocks for the full `2 * quorumTimeout` (60s in the test) before failing.

This is reachable in production: `RaftHAServer.transactionBroker` is `volatile`, so during `refreshRaftClient` a write caller can hold the *old* broker reference and submit right after the refresh stopped it - hanging that transaction thread for up to `2 * quorumTimeout`.

## Fix

In `submitAndWait`, after the entry is enqueued, re-check `running`. If the committer has stopped and the entry is still ours to reclaim (`queue.remove(pending)` succeeds), release its byte reservation and throw a retryable `QuorumNotReachedException` so the caller re-submits against the fresh broker.

Race-free thanks to the queue's internal lock ordering `offer` vs. the drain's `poll`s:
- Drain already finished before our offer → the lock's happens-before makes our post-offer read observe `running=false`, and `remove()` succeeds → fail fast.
- A concurrent flusher/transfer took the entry → `remove()` fails and we fall through to the normal wait; they complete the future.

## Verification

- New deterministic regression test `submitAfterStopFailsFastInsteadOfStranding` (`stop()` then submit): **hangs → `TimeoutException` without the fix**, passes with it.
- Updated the existing race test's final assertion to accept the third now-reachable legitimate outcome (`"stopped before dispatch"`), keeping the critical negative check on `"Group committer shutting down"`.
- `RaftGroupCommitterTest` (17) and `RaftTransactionBrokerTest` (6) pass.
- Stress: 30/30 runs of the two race-sensitive methods green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)