### PR TITLE
Complete MCP response and DNS-rebinding handling

### DIFF
--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -48,9 +48,9 @@ public class MCPConfiguration {
   private volatile boolean      allowSchemaChange = false;
   private volatile boolean      allowAdmin        = false;
   private volatile List<String> allowedUsers     = new CopyOnWriteArrayList<>(List.of("root"));
-  // Extra browser origins accepted by the HTTP transport, on top of the always-allowed loopback and
-  // same-host ones. Empty by default: a cross-origin browser page must be opted in explicitly, because
-  // accepting any origin would defeat the DNS-rebinding mitigation MCP requires.
+  // Extra browser origins accepted by the HTTP transport, on top of always-allowed loopback origins.
+  // Empty by default: a non-loopback browser page must be opted in explicitly, because deriving trust
+  // from its Host header would not prevent DNS rebinding.
   private volatile List<String> allowedOrigins   = new CopyOnWriteArrayList<>();
 
   public MCPConfiguration(final String rootPath) {

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -76,17 +76,17 @@ public class MCPDispatcher {
   }
 
   /**
-   * A transport-neutral reply. A null json means a JSON-RPC notification, for which no reply is sent at all;
-   * the httpStatus is meaningful only to the HTTP transport and is ignored by stdio.
+   * A transport-neutral reply. A null json means a one-way JSON-RPC notification or response, for which no
+   * reply is sent at all; the httpStatus is meaningful only to the HTTP transport and is ignored by stdio.
    */
   public record MCPResponse(int httpStatus, JSONObject json) {
   }
 
   /**
-   * The single reply for any JSON-RPC notification: no body at all, and - for the HTTP transport - the
-   * {@code 202 Accepted} that MCP 2025-03-26 mandates for a POST that carried only notifications.
+   * The transport result for any one-way JSON-RPC message: no body at all, and - for the HTTP transport -
+   * the {@code 202 Accepted} mandated for a POST that carried only notifications or responses.
    */
-  private static final MCPResponse NOTIFICATION_ACCEPTED = new MCPResponse(202, null);
+  private static final MCPResponse NO_RESPONSE = new MCPResponse(202, null);
 
   private final ArcadeDBServer   server;
   private final MCPConfiguration config;
@@ -99,10 +99,16 @@ public class MCPDispatcher {
   }
 
   /**
-   * Routes one parsed JSON-RPC request. A null request means an empty body. Authentication is checked before
-   * anything else, so that server state is not disclosed to unauthenticated callers.
+   * Routes one parsed JSON-RPC message. A null message means an empty body. One-way notifications and responses
+   * are discarded without consulting server state; messages that require a reply are authenticated before any
+   * server state is disclosed.
    */
   public MCPResponse dispatch(final JSONObject request, final ServerSecurityUser user) {
+    // A response acknowledges a server-to-client request and must never receive another response. ArcadeDB
+    // does not currently issue such requests, so valid responses are accepted and discarded.
+    if (isResponse(request))
+      return NO_RESPONSE;
+
     // A JSON-RPC notification is a request object carrying a method and NO id member, and the receiver must
     // not answer it at all (MCP 2025-03-26 base protocol). Detect it by the absent id rather than by method
     // name: keying on the name only suppressed 'notifications/initialized' and let every other notification
@@ -110,7 +116,7 @@ public class MCPDispatcher {
     // - ahead of the authentication and authorization gates, which have no way to report a failure back -
     // discloses nothing.
     if (request != null && request.has("method") && !request.has("id"))
-      return NOTIFICATION_ACCEPTED;
+      return NO_RESPONSE;
 
     // Echo the JSON-RPC id on every error response when the request carries one, per JSON-RPC 2.0.
     final Object id = request != null ? request.opt("id") : null;
@@ -152,7 +158,7 @@ public class MCPDispatcher {
       // A tool or resource read binds the authenticated principal onto this thread's DatabaseContext (so the engine
       // permission gates enforce, see MCPToolUtils.bindCurrentUser / GHSA-6x73-v3rc-f57c). This transport runs on a
       // pooled worker thread, so the binding MUST be dropped here or it would leak onto the next request served by
-      // the same thread. A no-op when nothing was bound (initialize/ping/tools-list). A notification returns
+      // the same thread. A no-op when nothing was bound (initialize/ping/tools-list). A one-way message returns
       // before this block but binds nothing, so it has nothing to drop.
       DatabaseContext.INSTANCE.removeCurrentThreadContexts();
     }
@@ -316,6 +322,14 @@ public class MCPDispatcher {
         || id instanceof Byte || id instanceof java.math.BigInteger;
   }
 
+  private static boolean isResponse(final JSONObject message) {
+    if (message == null || message.has("method") || !message.has("id") || !isValidRequestId(message.opt("id")))
+      return false;
+
+    return "2.0".equals(message.getString("jsonrpc", null))
+        && message.has("result") != message.has("error");
+  }
+
   private static MCPResponse result(final Object id, final JSONObject result) {
     final JSONObject response = new JSONObject();
     response.put("jsonrpc", "2.0");
@@ -343,7 +357,7 @@ public class MCPDispatcher {
   /**
    * Routes a JSON-RPC batch, which MCP 2025-03-26 requires every receiver to support. Each element is
    * dispatched independently and only the elements that are requests contribute a response, so a batch made
-   * only of notifications yields an empty array and the transport answers with no body at all.
+   * only of notifications and/or responses yields an empty array and the transport answers with no body.
    */
   public JSONArray dispatchBatch(final JSONArray batch, final ServerSecurityUser user) {
     final JSONArray responses = new JSONArray();

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPHttpHandler.java
@@ -40,7 +40,7 @@ import java.util.logging.Level;
  * Implements the envelope rules of the MCP 2025-03-26 Streamable HTTP transport: POST-only (no Server-Sent
  * Events stream is offered, so any other method is answered with {@code 405}), {@code Origin} validation
  * against DNS rebinding, JSON-RPC batches, and {@code 202 Accepted} with no body for a POST that carried
- * only notifications.
+ * only notifications and/or responses.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -85,7 +85,7 @@ public class MCPHttpHandler extends AbstractServerHttpHandler {
 
     final MCPResponse response = dispatcher.dispatch(payload, user);
 
-    // A null body is a JSON-RPC notification, which takes no response at all: 202 Accepted, no content.
+    // A null body is a one-way notification or response: 202 Accepted, no content.
     if (response.json() == null)
       return new ExecutionResponse(response.httpStatus(), "");
 
@@ -105,7 +105,7 @@ public class MCPHttpHandler extends AbstractServerHttpHandler {
 
     final JSONArray responses = dispatcher.dispatchBatch(batch, user);
 
-    // Nothing to correlate means the batch held only notifications: accepted, with no body.
+    // Nothing to correlate means the batch held only notifications and/or responses: accepted, with no body.
     if (responses.isEmpty())
       return new ExecutionResponse(202, "");
 
@@ -132,8 +132,8 @@ public class MCPHttpHandler extends AbstractServerHttpHandler {
    * <p>
    * A request with no {@code Origin} is accepted, because a non-browser MCP client sends none and it is the
    * browser that attaches the header a rebinding attack cannot forge. When present, the origin is accepted
-   * only if it is explicitly configured, is a loopback address, or matches the host the request was addressed
-   * to (a same-origin call).
+   * only if it is explicitly configured or is a loopback address. The request {@code Host} header is not a
+   * trust source: in a DNS-rebinding attack, the attacker-controlled Origin and Host names deliberately match.
    */
   private boolean isOriginAllowed(final HttpServerExchange exchange) {
     final String origin = exchange.getRequestHeaders().getFirst(Headers.ORIGIN);
@@ -152,11 +152,6 @@ public class MCPHttpHandler extends AbstractServerHttpHandler {
     if (isLoopback(originHost))
       return true;
 
-    // Same-origin: the browser page was served by this very endpoint's host.
-    final String requestHost = exchange.getRequestHeaders().getFirst(Headers.HOST);
-    if (requestHost != null && originHost.equals(stripPort(requestHost).toLowerCase(Locale.ROOT)))
-      return true;
-
     LogManager.instance().log(this, Level.FINE, "MCP[http] rejected cross-origin request from '%s'", origin);
     return false;
   }
@@ -172,14 +167,5 @@ public class MCPHttpHandler extends AbstractServerHttpHandler {
 
   private static boolean isLoopback(final String host) {
     return "localhost".equals(host) || "127.0.0.1".equals(host) || "::1".equals(host) || "[::1]".equals(host);
-  }
-
-  private static String stripPort(final String hostHeader) {
-    // IPv6 literals are bracketed, so only a colon after the closing bracket separates the port.
-    final int bracket = hostHeader.lastIndexOf(']');
-    final int colon = hostHeader.lastIndexOf(':');
-    if (colon > bracket)
-      return hostHeader.substring(0, colon);
-    return hostHeader;
   }
 }

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPStdioServer.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPStdioServer.java
@@ -115,14 +115,18 @@ public class MCPStdioServer {
    */
   private String dispatch(final String line) {
     if (line.charAt(0) == '[') {
-      final JSONArray responses = dispatcher.dispatchBatch(new JSONArray(line), user);
-      // A batch of notifications only produces no output at all.
+      final JSONArray batch = new JSONArray(line);
+      if (batch.isEmpty())
+        return jsonRpcError(null, -32600, "Invalid Request: empty batch");
+
+      final JSONArray responses = dispatcher.dispatchBatch(batch, user);
+      // A batch containing only notifications and/or responses produces no output.
       return responses.isEmpty() ? null : responses.toString();
     }
 
     final MCPResponse response = dispatcher.dispatch(new JSONObject(line), user);
 
-    // A null body is a JSON-RPC notification, which is written back as nothing at all.
+    // A null body is a one-way notification or response, which is written back as nothing at all.
     return response.json() == null ? null : response.json().toString();
   }
 

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
@@ -25,10 +25,13 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.HttpURLConnection;
+import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -41,9 +44,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Transport-envelope conformance for the Model Context Protocol version advertised by
- * {@link MCPDispatcher#MCP_PROTOCOL_VERSION} (issue #5394): JSON-RPC batches, notification
- * suppression, request-id validation, the HTTP status for an accepted notification, GET handling
- * and Origin validation.
+ * {@link MCPDispatcher#MCP_PROTOCOL_VERSION} (issue #5394): JSON-RPC batches, one-way notification
+ * and response handling, request-id validation, accepted-message HTTP status, GET handling and
+ * Origin validation.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -59,6 +62,7 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
     config.setEnabled(true);
     config.setAllowReads(true);
     config.setAllowedUsers(List.of("root"));
+    config.setAllowedOrigins(List.of());
   }
 
   // ---------------------------------------------------------------- notifications
@@ -189,6 +193,30 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
     assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32600);
   }
 
+  @Test
+  void batchOfOnlyResponsesReturns202WithoutBody() throws Exception {
+    final JSONArray batch = new JSONArray()
+        .put(new JSONObject().put("jsonrpc", "2.0").put("id", 1).put("result", new JSONObject()))
+        .put(new JSONObject().put("jsonrpc", "2.0").put("id", 2)
+            .put("error", new JSONObject().put("code", -32601).put("message", "Method not found")));
+
+    final Response response = post(batch.toString(), null);
+
+    assertThat(response.status).isEqualTo(202);
+    assertThat(response.body).isEmpty();
+  }
+
+  @Test
+  void singleResponseMessageReturns202WithoutBody() throws Exception {
+    final Response response = post(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 8)
+        .put("result", new JSONObject()).toString(), null);
+
+    assertThat(response.status).isEqualTo(202);
+    assertThat(response.body).isEmpty();
+  }
+
   // ---------------------------------------------------------------- HTTP method handling
 
   @Test
@@ -256,6 +284,19 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
     assertThat(response.status).isEqualTo(200);
   }
 
+  @Test
+  void matchingAttackerOriginAndHostAreRejected() throws Exception {
+    final String payload = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 1)
+        .put("method", "ping").toString();
+    final int port = getServer(0).getHttpServer().getPort();
+
+    final int status = postWithAuthority(payload, "http://rebind.example", "rebind.example:" + port);
+
+    assertThat(status).isEqualTo(403);
+  }
+
   // ---------------------------------------------------------------- stdio transport
 
   @Test
@@ -279,6 +320,25 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
   void stdioWritesNothingForSingleNotification() throws Exception {
     final String input = "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\"}\n";
     assertThat(runStdio(input).trim()).isEmpty();
+  }
+
+  @Test
+  void stdioWritesNothingForResponseOnlyBatch() throws Exception {
+    final String input = "[{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}},"
+        + "{\"jsonrpc\":\"2.0\",\"id\":2,\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}]\n";
+    assertThat(runStdio(input).trim()).isEmpty();
+  }
+
+  @Test
+  void stdioWritesNothingForSingleResponse() throws Exception {
+    final String input = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n";
+    assertThat(runStdio(input).trim()).isEmpty();
+  }
+
+  @Test
+  void stdioRejectsEmptyBatch() throws Exception {
+    final JSONObject response = new JSONObject(runStdio("[]\n").trim());
+    assertThat(response.getJSONObject("error").getInt("code")).isEqualTo(-32600);
   }
 
   private String runStdio(final String input) throws Exception {
@@ -312,6 +372,29 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
         .send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
 
     return new Response(response.statusCode(), response.body());
+  }
+
+  private int postWithAuthority(final String payload, final String origin, final String authority) throws Exception {
+    final byte[] body = payload.getBytes(StandardCharsets.UTF_8);
+    final String headers = "POST /api/v1/mcp HTTP/1.1\r\n"
+        + "Host: " + authority + "\r\n"
+        + "Origin: " + origin + "\r\n"
+        + "Authorization: " + getBasicAuth() + "\r\n"
+        + "Content-Type: application/json\r\n"
+        + "Content-Length: " + body.length + "\r\n"
+        + "Connection: close\r\n\r\n";
+
+    try (final Socket socket = new Socket("127.0.0.1", getServer(0).getHttpServer().getPort())) {
+      socket.getOutputStream().write(headers.getBytes(StandardCharsets.UTF_8));
+      socket.getOutputStream().write(body);
+      socket.getOutputStream().flush();
+
+      final BufferedReader reader = new BufferedReader(
+          new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+      final String statusLine = reader.readLine();
+      assertThat(statusLine).isNotNull();
+      return Integer.parseInt(statusLine.split(" ")[1]);
+    }
   }
 
   private static String getBasicAuth() {


### PR DESCRIPTION
## Summary

- accept valid JSON-RPC response messages as one-way input over HTTP and standard input/output, including response-only batches
- return HTTP `202 Accepted` with no body for response-only input, and emit no standard-output response
- reject an empty standard-input batch with JSON-RPC `-32600`, matching the HTTP transport
- require non-loopback browser origins to be explicitly configured instead of trusting equality between the attacker-controlled `Origin` and `Host` names
- add six focused transport regression tests

## Context

This is a focused follow-up to #5394 and commit `303e83c9`. That merged change handles the six reported findings; validation found these remaining envelope cases.

The [MCP 2025-03-26 Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports) accepts single response messages and response batches, and requires `202 Accepted` with no body for response-only or notification-only input. A receiver must not generate a response to a response.

For DNS rebinding, comparing the Origin hostname with the request Host hostname is not a trust check: the attack deliberately makes the attacker hostname resolve to the local endpoint, so both values match. The [official TypeScript SDK server guidance](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/server.md#dns-rebinding-protection) describes this same-origin property and recommends explicit host validation. This patch keeps ArcadeDB existing `allowedOrigins` design and makes non-loopback browser origins opt in through that list.

The separate documentation repository currently says same-host origins are always accepted. That sentence will need the corresponding small update if this behavior is accepted.

## Testing

- `./mvnw -pl server -am -Dtest=MCPTransportConformanceTest -Dsurefire.failIfNoSpecifiedTests=false test` (24 passed)
- `./mvnw -pl server -am -Dtest=MCPConfigurationTest,MCPStdioServerTest -Dsurefire.failIfNoSpecifiedTests=false test` (23 passed)
- full engine suite not run locally