### PR TITLE
feat(mcp): add dense and sparse vector_search tool

### DIFF
--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -37,6 +37,7 @@ import com.arcadedb.server.mcp.tools.ServerStatusTool;
 import com.arcadedb.server.mcp.tools.SetServerSettingTool;
 import com.arcadedb.server.mcp.tools.UpsertEntityTool;
 import com.arcadedb.server.mcp.tools.UpsertRelationshipTool;
+import com.arcadedb.server.mcp.tools.VectorSearchTool;
 import com.arcadedb.server.security.ServerSecurityUser;
 
 import java.util.logging.Level;
@@ -64,6 +65,7 @@ public class MCPDispatcher {
     TOOLS_LIST.put(GetSchemaTool.getDefinition());
     TOOLS_LIST.put(QueryTool.getDefinition());
     TOOLS_LIST.put(ExecuteCommandTool.getDefinition());
+    TOOLS_LIST.put(VectorSearchTool.getDefinition());
     TOOLS_LIST.put(FullTextSearchTool.getDefinition());
     TOOLS_LIST.put(UpsertEntityTool.getDefinition());
     TOOLS_LIST.put(UpsertRelationshipTool.getDefinition());
@@ -223,6 +225,7 @@ public class MCPDispatcher {
         case "get_schema" -> GetSchemaTool.execute(server, user, args, config);
         case "query" -> QueryTool.execute(server, user, args, config);
         case "execute_command" -> ExecuteCommandTool.execute(server, user, args, config);
+        case "vector_search" -> VectorSearchTool.execute(server, user, args, config);
         case "full_text_search" -> FullTextSearchTool.execute(server, user, args, config);
         case "upsert_entity" -> UpsertEntityTool.execute(server, user, args, config);
         case "upsert_relationship" -> UpsertRelationshipTool.execute(server, user, args, config);
@@ -274,7 +277,9 @@ public class MCPDispatcher {
           sb.append(key).append("=\"").append(sanitized, 0, 100).append("...\"");
         else
           sb.append(key).append("=\"").append(sanitized).append("\"");
-      } else
+      } else if (value instanceof JSONArray array)
+        sb.append(key).append("=[").append(array.length()).append(" item(s)]");
+      else
         sb.append(key).append("=").append(value);
     }
     return sb.append("}").toString();
@@ -289,6 +294,7 @@ public class MCPDispatcher {
       case "list_databases" -> result.getJSONArray("databases", new JSONArray()).length() + " database(s)";
       case "get_schema" -> result.getJSONArray("types", new JSONArray()).length() + " type(s)";
       case "query", "execute_command" -> result.getInt("count", 0) + " record(s)";
+      case "vector_search" -> result.getInt("count", 0) + " neighbor(s)";
       case "full_text_search" -> result.getInt("count", 0) + " hit(s)";
       case "upsert_entity", "upsert_relationship" -> result.getInt("count", 0) + " record(s)";
       case "server_status" -> "ok";

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp.tools;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.exception.SchemaException;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.sparsevector.LSMSparseVectorIndex;
+import com.arcadedb.index.vector.LSMVectorIndex;
+import com.arcadedb.query.QueryEngine;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LSMSparseVectorIndexMetadata;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.serializer.JsonSerializer;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.mcp.MCPConfiguration;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author Justin Blethrow
+ */
+public class VectorSearchTool {
+  private static final int DEFAULT_K             = 10;
+  private static final int MAX_K                 = 1_000;
+  private static final int FILTER_OVERFETCH      = 8;
+  private static final int MAX_FILTER_EXPRESSION = 4_096;
+
+  public static JSONObject getDefinition() {
+    return new JSONObject()
+        .put("name", "vector_search")
+        .put("description",
+            """
+            Search a dense LSM_VECTOR or sparse LSM_SPARSE_VECTOR index using a pre-computed query vector. \
+            Dense results expose a distance (lower is better); sparse results expose a score (higher is better). \
+            Set sparse=true for sparse indexes and pass queryIndices for a compact sparse representation. \
+            Embedding generation is not performed by ArcadeDB.""")
+        .put("inputSchema", new JSONObject()
+            .put("type", "object")
+            .put("properties", new JSONObject()
+                .put("database", new JSONObject()
+                    .put("type", "string")
+                    .put("description", "The name of the database to search"))
+                .put("indexName", new JSONObject()
+                    .put("type", "string")
+                    .put("description", "Name of an LSM_VECTOR or LSM_SPARSE_VECTOR index"))
+                .put("queryVector", new JSONObject()
+                    .put("type", "array")
+                    .put("items", new JSONObject().put("type", "number"))
+                    .put("description",
+                        "Dense query vector, or sparse weights corresponding to queryIndices when sparse=true"))
+                .put("queryIndices", new JSONObject()
+                    .put("type", "array")
+                    .put("items", new JSONObject().put("type", "integer").put("minimum", 0))
+                    .put("description",
+                        "Sparse dimension ids corresponding to queryVector weights; omit to use queryVector positions"))
+                .put("k", new JSONObject()
+                    .put("type", "integer")
+                    .put("minimum", 1)
+                    .put("maximum", MAX_K)
+                    .put("default", DEFAULT_K)
+                    .put("description", "Maximum number of results to return"))
+                .put("efSearch", new JSONObject()
+                    .put("type", "integer")
+                    .put("minimum", 1)
+                    .put("description", "Dense-index search beam width; higher values improve recall at higher cost"))
+                .put("filter", new JSONObject()
+                    .put("type", "string")
+                    .put("description",
+                        "Optional read-only SQL WHERE predicate applied to a bounded candidate set"))
+                .put("sparse", new JSONObject()
+                    .put("type", "boolean")
+                    .put("default", false)
+                    .put("description", "Use vector.sparseNeighbors against an LSM_SPARSE_VECTOR index")))
+            .put("required", new JSONArray().put("database").put("indexName").put("queryVector").put("k")));
+  }
+
+  public static JSONObject execute(final ArcadeDBServer server, final ServerSecurityUser user, final JSONObject args,
+      final MCPConfiguration config) {
+    if (!config.isAllowReads())
+      throw new SecurityException("Read operations are not allowed by MCP configuration");
+
+    final String databaseName = MCPToolUtils.requireString(args, "database");
+    final String indexName = MCPToolUtils.requireString(args, "indexName");
+    final int k = args.getInt("k", DEFAULT_K);
+    if (k < 1 || k > MAX_K)
+      throw new IllegalArgumentException("'k' must be between 1 and " + MAX_K);
+
+    final boolean sparse = args.getBoolean("sparse", false);
+    final Integer efSearch = args.has("efSearch") ? args.getInt("efSearch") : null;
+    if (efSearch != null && efSearch < 1)
+      throw new IllegalArgumentException("'efSearch' must be at least 1");
+    if (sparse && efSearch != null)
+      throw new IllegalArgumentException("'efSearch' applies only to dense LSM_VECTOR indexes");
+    if (!sparse && args.has("queryIndices"))
+      throw new IllegalArgumentException("'queryIndices' requires sparse=true");
+
+    final String filter = normalizeFilter(args.getString("filter", null));
+    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final ResolvedVectorIndex resolved = resolveIndex(database, indexName, sparse);
+    final float[] queryVector = readFloatArray(args.getJSONArray("queryVector", null), "queryVector");
+
+    final Map<String, Object> parameters = new LinkedHashMap<>();
+    parameters.put("indexName", resolved.typeIndex().getName());
+    parameters.put("k", k);
+
+    final Map<String, Object> options = new LinkedHashMap<>();
+    if (efSearch != null)
+      options.put("efSearch", efSearch);
+    parameters.put("options", options);
+
+    final String functionCall;
+    if (sparse) {
+      final SparseQuery sparseQuery = buildSparseQuery(args, queryVector, resolved.dimensions());
+      parameters.put("queryIndices", sparseQuery.indices());
+      parameters.put("queryVector", sparseQuery.values());
+      functionCall = "`vector.sparseNeighbors`(:indexName, :queryIndices, :queryVector, :candidateLimit, :options)";
+    } else {
+      if (queryVector.length != resolved.dimensions())
+        throw new IllegalArgumentException(
+            "'queryVector' has " + queryVector.length + " dimensions, but index '" + indexName + "' requires "
+                + resolved.dimensions());
+      parameters.put("queryVector", queryVector);
+      functionCall = "`vector.neighbors`(:indexName, :queryVector, :candidateLimit, :options)";
+    }
+
+    final int candidateLimit = filter == null ? k : (int) Math.min((long) k * FILTER_OVERFETCH, MAX_K);
+    parameters.put("candidateLimit", candidateLimit);
+
+    final StringBuilder sql = new StringBuilder("SELECT FROM (SELECT expand(").append(functionCall).append("))");
+    if (filter != null)
+      sql.append(" WHERE (").append(filter).append(')');
+    sql.append(" LIMIT :k");
+
+    final QueryEngine.AnalyzedQuery analyzed;
+    try {
+      analyzed = database.getQueryEngine("sql").analyze(sql.toString());
+    } catch (final RuntimeException e) {
+      throw invalidExpression(e);
+    }
+    if (!analyzed.isIdempotent())
+      throw new SecurityException("Generated vector search is not read-only");
+
+    final JsonSerializer serializer = JsonSerializer.createJsonSerializer()
+        .setIncludeVertexEdges(false)
+        .setUseCollectionSize(false)
+        .setUseCollectionSizeForEdges(false);
+
+    final JSONArray results = new JSONArray();
+    try {
+      final ResultSet analyzedResultSet = analyzed.execute(parameters);
+      try (final ResultSet resultSet =
+          analyzedResultSet != null ? analyzedResultSet : database.query("sql", sql.toString(), parameters)) {
+        while (resultSet.hasNext() && results.length() < k)
+          appendResult(database, resultSet.next(), sparse, serializer, results);
+      }
+    } catch (final SecurityException e) {
+      throw e;
+    } catch (final RuntimeException e) {
+      throw invalidExpression(e);
+    }
+
+    return new JSONObject()
+        .put("indexName", resolved.typeIndex().getName())
+        .put("sparse", sparse)
+        .put("scoring", resolved.scoring())
+        .put("count", results.length())
+        .put("results", results);
+  }
+
+  private static String normalizeFilter(final String raw) {
+    if (raw == null)
+      return null;
+    final String filter = raw.trim();
+    if (filter.isEmpty())
+      return null;
+    if (filter.length() > MAX_FILTER_EXPRESSION)
+      throw new IllegalArgumentException(
+          "'filter' must not exceed " + MAX_FILTER_EXPRESSION + " characters");
+    return filter;
+  }
+
+  private static ResolvedVectorIndex resolveIndex(final Database database, final String indexName,
+      final boolean sparse) {
+    final Index rawIndex;
+    try {
+      rawIndex = database.getSchema().getIndexByName(indexName);
+    } catch (final SchemaException e) {
+      throw new IllegalArgumentException(
+          "Vector index '" + indexName + "' does not exist. " + describeAvailableIndexes(database, sparse), e);
+    }
+
+    if (!(rawIndex instanceof final TypeIndex typeIndex))
+      throw new IllegalArgumentException(
+          "Index '" + indexName + "' is not a type index. " + describeAvailableIndexes(database, sparse));
+
+    final Schema.INDEX_TYPE expectedType =
+        sparse ? Schema.INDEX_TYPE.LSM_SPARSE_VECTOR : Schema.INDEX_TYPE.LSM_VECTOR;
+    final Schema.INDEX_TYPE actualType = typeIndex.getType();
+    if (actualType != expectedType) {
+      final String hint = actualType == Schema.INDEX_TYPE.LSM_SPARSE_VECTOR
+          ? " Set sparse=true for this index."
+          : actualType == Schema.INDEX_TYPE.LSM_VECTOR ? " Set sparse=false for this index." : "";
+      throw new IllegalArgumentException(
+          "Index '" + indexName + "' is " + actualType + ", not " + expectedType + "." + hint + " "
+              + describeAvailableIndexes(database, sparse));
+    }
+
+    for (final IndexInternal bucketIndex : typeIndex.getIndexesOnBuckets()) {
+      if (bucketIndex instanceof final LSMVectorIndex denseIndex)
+        return new ResolvedVectorIndex(typeIndex, denseIndex.getDimensions(),
+            "distance_lower_is_better:" + denseIndex.getSimilarityFunction().name());
+
+      if (bucketIndex instanceof final LSMSparseVectorIndex sparseIndex) {
+        final LSMSparseVectorIndexMetadata metadata = sparseIndex.getSparseMetadata();
+        final int dimensions = metadata != null ? metadata.dimensions : 0;
+        final String modifier = metadata != null ? metadata.modifier : LSMSparseVectorIndexMetadata.MODIFIER_NONE;
+        final String scoring = LSMSparseVectorIndexMetadata.MODIFIER_IDF.equals(modifier)
+            ? "score_higher_is_better:idf_weighted_dot_product"
+            : "score_higher_is_better:dot_product";
+        return new ResolvedVectorIndex(typeIndex, dimensions, scoring);
+      }
+    }
+
+    throw new IllegalArgumentException("Vector index '" + indexName + "' has no searchable bucket indexes");
+  }
+
+  private static String describeAvailableIndexes(final Database database, final boolean sparse) {
+    final Schema.INDEX_TYPE expectedType =
+        sparse ? Schema.INDEX_TYPE.LSM_SPARSE_VECTOR : Schema.INDEX_TYPE.LSM_VECTOR;
+    final Set<String> names = new TreeSet<>();
+    for (final Index index : database.getSchema().getIndexes())
+      if (index instanceof TypeIndex && index.getType() == expectedType)
+        names.add(index.getName());
+    return "Available " + expectedType + " indexes: " + names;
+  }
+
+  private static float[] readFloatArray(final JSONArray array, final String field) {
+    if (array == null || array.length() == 0)
+      throw new IllegalArgumentException("'" + field + "' is required and must not be empty");
+
+    final float[] result = new float[array.length()];
+    for (int i = 0; i < array.length(); i++) {
+      final Object value = array.get(i);
+      if (!(value instanceof final Number number))
+        throw new IllegalArgumentException("'" + field + "' must contain only numbers");
+      final double asDouble = number.doubleValue();
+      if (!Double.isFinite(asDouble) || Math.abs(asDouble) > Float.MAX_VALUE)
+        throw new IllegalArgumentException("'" + field + "' must contain only finite float values");
+      result[i] = (float) asDouble;
+    }
+    return result;
+  }
+
+  private static SparseQuery buildSparseQuery(final JSONObject args, final float[] queryVector,
+      final int dimensions) {
+    final JSONArray queryIndices = args.getJSONArray("queryIndices", null);
+    if (queryIndices == null) {
+      if (dimensions > 0 && queryVector.length != dimensions)
+        throw new IllegalArgumentException(
+            "Sparse 'queryVector' has " + queryVector.length + " dimensions, but the index requires " + dimensions
+                + ". Pass queryIndices with compact sparse weights instead.");
+
+      final List<Integer> indices = new ArrayList<>();
+      final List<Float> values = new ArrayList<>();
+      for (int i = 0; i < queryVector.length; i++)
+        if (queryVector[i] != 0.0f) {
+          indices.add(i);
+          values.add(queryVector[i]);
+        }
+      if (indices.isEmpty())
+        throw new IllegalArgumentException("Sparse 'queryVector' must contain at least one non-zero weight");
+
+      final int[] compactIndices = new int[indices.size()];
+      final float[] compactValues = new float[values.size()];
+      for (int i = 0; i < indices.size(); i++) {
+        compactIndices[i] = indices.get(i);
+        compactValues[i] = values.get(i);
+      }
+      return new SparseQuery(compactIndices, compactValues);
+    }
+
+    if (queryIndices.length() != queryVector.length)
+      throw new IllegalArgumentException(
+          "'queryIndices' and 'queryVector' must have the same length (got " + queryIndices.length() + " and "
+              + queryVector.length + ")");
+
+    final int[] indices = new int[queryIndices.length()];
+    final Set<Integer> seen = new HashSet<>();
+    boolean hasNonZeroWeight = false;
+    for (int i = 0; i < queryIndices.length(); i++) {
+      final Object raw = queryIndices.get(i);
+      if (!(raw instanceof final Number number) || !Double.isFinite(number.doubleValue())
+          || number.doubleValue() != Math.rint(number.doubleValue())
+          || number.doubleValue() < 0 || number.doubleValue() > Integer.MAX_VALUE)
+        throw new IllegalArgumentException("'queryIndices' must contain only non-negative integers");
+
+      final int index = number.intValue();
+      if (!seen.add(index))
+        throw new IllegalArgumentException("'queryIndices' contains duplicate dimension " + index);
+      if (dimensions > 0 && index >= dimensions)
+        throw new IllegalArgumentException(
+            "Sparse query dimension " + index + " is outside index dimensions 0-" + (dimensions - 1));
+      indices[i] = index;
+      hasNonZeroWeight |= queryVector[i] != 0.0f;
+    }
+    if (!hasNonZeroWeight)
+      throw new IllegalArgumentException("Sparse 'queryVector' must contain at least one non-zero weight");
+
+    return new SparseQuery(indices, queryVector);
+  }
+
+  private static void appendResult(final Database database, final Result row, final boolean sparse,
+      final JsonSerializer serializer, final JSONArray results) {
+    final RID rid = resolveRID(row);
+    if (rid == null)
+      return;
+
+    final Object rawScore = row.getProperty(sparse ? "score" : "distance");
+    if (!(rawScore instanceof final Number score))
+      return;
+
+    final Record record;
+    try {
+      record = database.lookupByRID(rid, true);
+    } catch (final RecordNotFoundException e) {
+      return;
+    }
+    if (!(record instanceof final Document document))
+      return;
+
+    final JSONObject result = new JSONObject()
+        .put("rid", rid.toString())
+        .put("score", score)
+        .put("properties", serializer.serializeDocument(document));
+    if (!sparse)
+      result.put("distance", score);
+    results.put(result);
+  }
+
+  private static RID resolveRID(final Result row) {
+    final Object raw = row.getProperty("@rid");
+    if (raw instanceof final RID rid)
+      return rid;
+    if (raw instanceof final String value && RID.is(value))
+      return new RID(value);
+    return row.getIdentity().orElse(null);
+  }
+
+  private static IllegalArgumentException invalidExpression(final RuntimeException cause) {
+    final String detail = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
+    return new IllegalArgumentException("Invalid vector search or filter expression: " + detail, cause);
+  }
+
+  private record ResolvedVectorIndex(TypeIndex typeIndex, int dimensions, String scoring) {
+  }
+
+  private record SparseQuery(int[] indices, float[] values) {
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
@@ -66,7 +66,10 @@ public class VectorSearchTool {
             Search a dense LSM_VECTOR or sparse LSM_SPARSE_VECTOR index using a pre-computed query vector. \
             Dense results expose a distance (lower is better); sparse results expose a score (higher is better). \
             Set sparse=true for sparse indexes and pass queryIndices for a compact sparse representation. \
-            Filtered searches inspect a bounded candidate window and report its size and possible truncation. \
+            Filtered searches inspect a bounded candidate window whose size is reported as candidateLimit. \
+            The truncated flag means the result window was filled, so more matches may exist: raise k to see them. \
+            When fewer than k results come back, truncated is false and the search already returned every match \
+            it could find within candidateLimit. \
             Embedding generation is not performed by ArcadeDB.""")
         .put("inputSchema", new JSONObject()
             .put("type", "object")
@@ -199,14 +202,17 @@ public class VectorSearchTool {
       throw invalidExpression(e);
     }
 
-    final long indexedEntries = resolved.typeIndex().countEntries();
+    // Truncation describes the result window, not the index. A filled window is the only state in which further
+    // matches may exist; a short result set means the search ran out of candidates that satisfy the request, so
+    // reporting truncation there would tell the caller to widen a search that cannot yield more. Index cardinality
+    // is deliberately not consulted: it is almost always larger than the window, which would pin the flag to true
+    // and strip it of meaning, and reading it costs a full scan of the index locations on the dense path.
     return new JSONObject()
         .put("indexName", resolved.typeIndex().getName())
         .put("sparse", sparse)
         .put("scoring", resolved.scoring())
-        .put("indexedEntries", indexedEntries)
         .put("candidateLimit", candidateLimit)
-        .put("truncated", indexedEntries > candidateLimit || filter != null && results.length() == k)
+        .put("truncated", results.length() >= k)
         .put("count", results.length())
         .put("results", results);
   }

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
@@ -21,7 +21,6 @@ package com.arcadedb.server.mcp.tools;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
-import com.arcadedb.database.Record;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.index.Index;
@@ -56,6 +55,7 @@ public class VectorSearchTool {
   private static final int DEFAULT_K             = 10;
   private static final int MAX_K                 = 1_000;
   private static final int FILTER_OVERFETCH      = 8;
+  private static final int MAX_FILTER_CANDIDATES = 8_000;
   private static final int MAX_FILTER_EXPRESSION = 4_096;
 
   public static JSONObject getDefinition() {
@@ -66,6 +66,7 @@ public class VectorSearchTool {
             Search a dense LSM_VECTOR or sparse LSM_SPARSE_VECTOR index using a pre-computed query vector. \
             Dense results expose a distance (lower is better); sparse results expose a score (higher is better). \
             Set sparse=true for sparse indexes and pass queryIndices for a compact sparse representation. \
+            Filtered searches inspect a bounded candidate window and report its size and possible truncation. \
             Embedding generation is not performed by ArcadeDB.""")
         .put("inputSchema", new JSONObject()
             .put("type", "object")
@@ -99,7 +100,9 @@ public class VectorSearchTool {
                 .put("filter", new JSONObject()
                     .put("type", "string")
                     .put("description",
-                        "Optional read-only SQL WHERE predicate applied to a bounded candidate set"))
+                        "Optional read-only SQL WHERE predicate applied to a bounded candidate set. It is evaluated "
+                            + "against each expanded neighbor row, where record properties are flattened and @rid, "
+                            + "@type, record, plus distance (dense) or score (sparse) are available."))
                 .put("sparse", new JSONObject()
                     .put("type", "boolean")
                     .put("default", false)
@@ -152,11 +155,13 @@ public class VectorSearchTool {
         throw new IllegalArgumentException(
             "'queryVector' has " + queryVector.length + " dimensions, but index '" + indexName + "' requires "
                 + resolved.dimensions());
+      requireNonZeroDenseVector(queryVector);
       parameters.put("queryVector", queryVector);
       functionCall = "`vector.neighbors`(:indexName, :queryVector, :candidateLimit, :options)";
     }
 
-    final int candidateLimit = filter == null ? k : (int) Math.min((long) k * FILTER_OVERFETCH, MAX_K);
+    final int candidateLimit =
+        filter == null ? k : (int) Math.min((long) k * FILTER_OVERFETCH, MAX_FILTER_CANDIDATES);
     parameters.put("candidateLimit", candidateLimit);
 
     final StringBuilder sql = new StringBuilder("SELECT FROM (SELECT expand(").append(functionCall).append("))");
@@ -183,6 +188,8 @@ public class VectorSearchTool {
       final ResultSet analyzedResultSet = analyzed.execute(parameters);
       try (final ResultSet resultSet =
           analyzedResultSet != null ? analyzedResultSet : database.query("sql", sql.toString(), parameters)) {
+        // A stale/deleted hit or malformed row is skipped and cannot be backfilled because the vector candidate
+        // window is already fixed. The response therefore reports possible truncation for filtered short results.
         while (resultSet.hasNext() && results.length() < k)
           appendResult(database, resultSet.next(), sparse, serializer, results);
       }
@@ -196,6 +203,8 @@ public class VectorSearchTool {
         .put("indexName", resolved.typeIndex().getName())
         .put("sparse", sparse)
         .put("scoring", resolved.scoring())
+        .put("candidateLimit", candidateLimit)
+        .put("truncated", results.length() == k || filter != null && results.length() < k)
         .put("count", results.length())
         .put("results", results);
   }
@@ -284,6 +293,13 @@ public class VectorSearchTool {
     return result;
   }
 
+  private static void requireNonZeroDenseVector(final float[] queryVector) {
+    for (final float value : queryVector)
+      if (value != 0.0f)
+        return;
+    throw new IllegalArgumentException("Dense 'queryVector' must contain at least one non-zero value");
+  }
+
   private static SparseQuery buildSparseQuery(final JSONObject args, final float[] queryVector,
       final int dimensions) {
     final JSONArray queryIndices = args.getJSONArray("queryIndices", null);
@@ -352,20 +368,27 @@ public class VectorSearchTool {
     if (!(rawScore instanceof final Number score))
       return;
 
-    final Record record;
-    try {
-      record = database.lookupByRID(rid, true);
-    } catch (final RecordNotFoundException e) {
-      return;
+    final Object embeddedRecord = row.getProperty("record");
+    final Document document;
+    if (embeddedRecord instanceof final Document candidate) {
+      document = candidate;
+    } else {
+      try {
+        final Object loaded = database.lookupByRID(rid, true);
+        if (!(loaded instanceof final Document candidate))
+          return;
+        document = candidate;
+      } catch (final RecordNotFoundException e) {
+        return;
+      }
     }
-    if (!(record instanceof final Document document))
-      return;
 
     final JSONObject result = new JSONObject()
         .put("rid", rid.toString())
-        .put("score", score)
         .put("properties", serializer.serializeDocument(document));
-    if (!sparse)
+    if (sparse)
+      result.put("score", score);
+    else
       result.put("distance", score);
     results.put(result);
   }

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
@@ -199,12 +199,14 @@ public class VectorSearchTool {
       throw invalidExpression(e);
     }
 
+    final long indexedEntries = resolved.typeIndex().countEntries();
     return new JSONObject()
         .put("indexName", resolved.typeIndex().getName())
         .put("sparse", sparse)
         .put("scoring", resolved.scoring())
+        .put("indexedEntries", indexedEntries)
         .put("candidateLimit", candidateLimit)
-        .put("truncated", results.length() == k || filter != null && results.length() < k)
+        .put("truncated", indexedEntries > candidateLimit || filter != null && results.length() == k)
         .put("count", results.length())
         .put("results", results);
   }

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -96,6 +96,59 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     });
   }
 
+  private void seedVectorIndexes() {
+    final Database db = getServerDatabase(0, getDatabaseName());
+    if (db.getSchema().existsType("McpVectorRecord"))
+      return;
+
+    db.transaction(() -> {
+      db.command("sql", "CREATE DOCUMENT TYPE McpVectorRecord BUCKETS 1");
+      db.command("sql", "CREATE PROPERTY McpVectorRecord.name STRING");
+      db.command("sql", "CREATE PROPERTY McpVectorRecord.category STRING");
+      db.command("sql", "CREATE PROPERTY McpVectorRecord.embedding ARRAY_OF_FLOATS");
+      db.command("sql", """
+          CREATE INDEX ON McpVectorRecord (embedding) LSM_VECTOR
+          METADATA { dimensions: 3, similarity: 'COSINE' }
+          """);
+
+      db.newDocument("McpVectorRecord")
+          .set("name", "dense-a")
+          .set("category", "keep")
+          .set("embedding", new float[] { 1.0f, 0.0f, 0.0f })
+          .save();
+      db.newDocument("McpVectorRecord")
+          .set("name", "dense-b")
+          .set("category", "drop")
+          .set("embedding", new float[] { 0.9f, 0.1f, 0.0f })
+          .save();
+      db.newDocument("McpVectorRecord")
+          .set("name", "dense-c")
+          .set("category", "keep")
+          .set("embedding", new float[] { 0.0f, 1.0f, 0.0f })
+          .save();
+
+      db.command("sql", "CREATE DOCUMENT TYPE McpSparseVectorRecord BUCKETS 1");
+      db.command("sql", "CREATE PROPERTY McpSparseVectorRecord.name STRING");
+      db.command("sql", "CREATE PROPERTY McpSparseVectorRecord.tokens ARRAY_OF_INTEGERS");
+      db.command("sql", "CREATE PROPERTY McpSparseVectorRecord.weights ARRAY_OF_FLOATS");
+      db.command("sql", """
+          CREATE INDEX ON McpSparseVectorRecord (tokens, weights) LSM_SPARSE_VECTOR
+          METADATA { dimensions: 8, weightQuantization: 'FP32' }
+          """);
+
+      db.newDocument("McpSparseVectorRecord")
+          .set("name", "sparse-low")
+          .set("tokens", new int[] { 1, 5 })
+          .set("weights", new float[] { 0.1f, 0.3f })
+          .save();
+      db.newDocument("McpSparseVectorRecord")
+          .set("name", "sparse-high")
+          .set("tokens", new int[] { 2, 5 })
+          .set("weights", new float[] { 0.2f, 0.6f })
+          .save();
+    });
+  }
+
   @Test
   void initialize() throws Exception {
     final JSONObject response = mcpRequest(new JSONObject()
@@ -121,7 +174,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
 
     assertThat(response.has("result")).isTrue();
     final JSONArray tools = response.getJSONObject("result").getJSONArray("tools");
-    assertThat(tools.length()).isEqualTo(13);
+    assertThat(tools.length()).isEqualTo(14);
 
     // Verify tool names
     boolean hasListDatabases = false;
@@ -134,6 +187,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     boolean hasProfilerStatus = false;
     boolean hasGetServerSettings = false;
     boolean hasSetServerSetting = false;
+    boolean hasVectorSearch = false;
     boolean hasFullTextSearch = false;
     boolean hasUpsertEntity = false;
     boolean hasUpsertRelationship = false;
@@ -151,6 +205,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
       case "profiler_status" -> hasProfilerStatus = true;
       case "get_server_settings" -> hasGetServerSettings = true;
       case "set_server_setting" -> hasSetServerSetting = true;
+      case "vector_search" -> hasVectorSearch = true;
       case "full_text_search" -> hasFullTextSearch = true;
       case "upsert_entity" -> hasUpsertEntity = true;
       case "upsert_relationship" -> hasUpsertRelationship = true;
@@ -166,6 +221,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     assertThat(hasProfilerStatus).isTrue();
     assertThat(hasGetServerSettings).isTrue();
     assertThat(hasSetServerSetting).isTrue();
+    assertThat(hasVectorSearch).isTrue();
     assertThat(hasFullTextSearch).isTrue();
     assertThat(hasUpsertEntity).isTrue();
     assertThat(hasUpsertRelationship).isTrue();
@@ -882,6 +938,160 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     assertThat(errorText).contains("nonexistent_db");
     assertThat(errorText).containsIgnoringCase("available databases");
     assertThat(errorText).contains("graph");
+  }
+
+  @Test
+  void vectorSearchDenseReturnsDistanceAndProperties() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject response = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("k", 2));
+
+    assertThat(response.getBoolean("isError", true)).isFalse();
+    final JSONObject payload = new JSONObject(
+        response.getJSONArray("content").getJSONObject(0).getString("text"));
+
+    assertThat(payload.getString("indexName")).isEqualTo("McpVectorRecord[embedding]");
+    assertThat(payload.getBoolean("sparse")).isFalse();
+    assertThat(payload.getString("scoring")).startsWith("distance_lower_is_better");
+    assertThat(payload.getInt("count")).isEqualTo(2);
+
+    final JSONObject first = payload.getJSONArray("results").getJSONObject(0);
+    assertThat(first.getString("rid")).startsWith("#");
+    assertThat(first.getDouble("score")).isEqualTo(first.getDouble("distance"));
+    assertThat(first.getJSONObject("properties").getString("name")).isEqualTo("dense-a");
+  }
+
+  @Test
+  void vectorSearchAppliesReadOnlyFilterToBoundedCandidates() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject response = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("filter", "category = 'keep'")
+        .put("k", 2));
+
+    assertThat(response.getBoolean("isError", true)).isFalse();
+    final JSONObject payload = new JSONObject(
+        response.getJSONArray("content").getJSONObject(0).getString("text"));
+    assertThat(payload.getInt("count")).isEqualTo(2);
+    for (int i = 0; i < payload.getJSONArray("results").length(); i++)
+      assertThat(payload.getJSONArray("results").getJSONObject(i)
+          .getJSONObject("properties").getString("category")).isEqualTo("keep");
+  }
+
+  @Test
+  void vectorSearchSparseAcceptsCompactIndicesAndWeights() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject response = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryIndices", new JSONArray().put(5))
+        .put("queryVector", new JSONArray().put(1.0))
+        .put("sparse", true)
+        .put("k", 2));
+
+    assertThat(response.getBoolean("isError", true)).isFalse();
+    final JSONObject payload = new JSONObject(
+        response.getJSONArray("content").getJSONObject(0).getString("text"));
+
+    assertThat(payload.getBoolean("sparse")).isTrue();
+    assertThat(payload.getString("scoring")).contains("score_higher_is_better");
+    assertThat(payload.getInt("count")).isEqualTo(2);
+    final JSONArray results = payload.getJSONArray("results");
+    assertThat(results.getJSONObject(0).getJSONObject("properties").getString("name")).isEqualTo("sparse-high");
+    assertThat(results.getJSONObject(0).getDouble("score"))
+        .isGreaterThan(results.getJSONObject(1).getDouble("score"));
+  }
+
+  @Test
+  void vectorSearchValidatesIndexModeAndDimensions() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject wrongMode = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryVector", new JSONArray().put(1.0))
+        .put("k", 1));
+    assertThat(wrongMode.getBoolean("isError", false)).isTrue();
+    assertThat(wrongMode.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("LSM_SPARSE_VECTOR").contains("sparse=true");
+
+    final JSONObject wrongDimensions = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0))
+        .put("k", 1));
+    assertThat(wrongDimensions.getBoolean("isError", false)).isTrue();
+    assertThat(wrongDimensions.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("2 dimensions").contains("requires 3");
+  }
+
+  @Test
+  void vectorSearchRejectsMalformedSparseVectors() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject response = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryIndices", new JSONArray().put(1).put(5))
+        .put("queryVector", new JSONArray().put(1.0))
+        .put("sparse", true)
+        .put("k", 2));
+
+    assertThat(response.getBoolean("isError", false)).isTrue();
+    assertThat(response.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("same length");
+  }
+
+  @Test
+  void vectorSearchRejectsMalformedFilterWithoutExecutingWrites() throws Exception {
+    seedVectorIndexes();
+    final Database db = getServerDatabase(0, getDatabaseName());
+    final long before = db.countType("McpVectorRecord", false);
+
+    final JSONObject response = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("filter", "category = 'keep'); DELETE FROM McpVectorRecord")
+        .put("k", 2));
+
+    assertThat(response.getBoolean("isError", false)).isTrue();
+    assertThat(response.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("Invalid vector search");
+    assertThat(db.countType("McpVectorRecord", false)).isEqualTo(before);
+  }
+
+  @Test
+  void vectorSearchEnforcesBoundsAndReadPermission() throws Exception {
+    for (final int invalidK : new int[] { 0, 1_001 }) {
+      final JSONObject response = callTool("vector_search", new JSONObject()
+          .put("database", getDatabaseName())
+          .put("indexName", "McpVectorRecord[embedding]")
+          .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+          .put("k", invalidK));
+      assertThat(response.getBoolean("isError", false)).isTrue();
+      assertThat(response.getJSONArray("content").getJSONObject(0).getString("text")).contains("'k'");
+    }
+
+    saveMCPConfig(new JSONObject()
+        .put("enabled", true)
+        .put("allowReads", false)
+        .put("allowedUsers", new JSONArray().put("root")));
+    final JSONObject denied = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("k", 1));
+    assertThat(denied.getBoolean("isError", false)).isTrue();
+    assertThat(denied.getJSONArray("content").getJSONObject(0).getString("text")).contains("not allowed");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -1011,6 +1011,34 @@ class MCPServerPluginTest extends BaseGraphServerTest {
   }
 
   @Test
+  void vectorSearchSupportsDenseOptionsAndFullSparseVectors() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject dense = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("efSearch", 20)
+        .put("filter", "   ")
+        .put("k", 1));
+    assertThat(dense.getBoolean("isError", true)).isFalse();
+
+    final JSONObject sparse = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryVector",
+            new JSONArray().put(0.0).put(0.0).put(0.0).put(0.0).put(0.0).put(1.0).put(0.0).put(0.0))
+        .put("sparse", true)
+        .put("k", 2));
+    assertThat(sparse.getBoolean("isError", true)).isFalse();
+    final JSONObject payload = new JSONObject(
+        sparse.getJSONArray("content").getJSONObject(0).getString("text"));
+    assertThat(payload.getInt("count")).isEqualTo(2);
+    assertThat(payload.getJSONArray("results").getJSONObject(0)
+        .getJSONObject("properties").getString("name")).isEqualTo("sparse-high");
+  }
+
+  @Test
   void vectorSearchValidatesIndexModeAndDimensions() throws Exception {
     seedVectorIndexes();
 
@@ -1034,6 +1062,75 @@ class MCPServerPluginTest extends BaseGraphServerTest {
   }
 
   @Test
+  void vectorSearchRejectsInvalidOptionsAndIndexSelection() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject invalidEfSearch = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("efSearch", 0)
+        .put("k", 1));
+    assertThat(invalidEfSearch.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("'efSearch' must be at least 1");
+
+    final JSONObject sparseEfSearch = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryIndices", new JSONArray().put(5))
+        .put("queryVector", new JSONArray().put(1.0))
+        .put("efSearch", 20)
+        .put("sparse", true)
+        .put("k", 1));
+    assertThat(sparseEfSearch.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("'efSearch' applies only to dense");
+
+    final JSONObject denseIndices = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryIndices", new JSONArray().put(0))
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("k", 1));
+    assertThat(denseIndices.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("'queryIndices' requires sparse=true");
+
+    final JSONObject oversizedFilter = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("filter", "x".repeat(4_097))
+        .put("k", 1));
+    assertThat(oversizedFilter.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("'filter' must not exceed 4096");
+
+    final JSONObject unknownIndex = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "Missing[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("k", 1));
+    assertThat(unknownIndex.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("does not exist").contains("McpVectorRecord[embedding]");
+
+    final JSONObject denseAsSparse = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryIndices", new JSONArray().put(0))
+        .put("queryVector", new JSONArray().put(1.0))
+        .put("sparse", true)
+        .put("k", 1));
+    assertThat(denseAsSparse.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("LSM_VECTOR").contains("sparse=false");
+
+    final JSONObject nonVector = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "Article[title]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("k", 1));
+    assertThat(nonVector.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("LSM_TREE").contains("not LSM_VECTOR");
+  }
+
+  @Test
   void vectorSearchRejectsMalformedSparseVectors() throws Exception {
     seedVectorIndexes();
 
@@ -1048,6 +1145,86 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     assertThat(response.getBoolean("isError", false)).isTrue();
     assertThat(response.getJSONArray("content").getJSONObject(0).getString("text"))
         .contains("same length");
+  }
+
+  @Test
+  void vectorSearchRejectsInvalidVectorValuesAndSparseDimensions() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject empty = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray())
+        .put("k", 1));
+    assertThat(empty.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("must not be empty");
+
+    final JSONObject nonNumeric = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put("bad").put(0.0))
+        .put("k", 1));
+    assertThat(nonNumeric.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("must contain only numbers");
+
+    final JSONObject wrongFullDimensions = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryVector", new JSONArray().put(0.0).put(1.0))
+        .put("sparse", true)
+        .put("k", 1));
+    assertThat(wrongFullDimensions.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("index requires 8").contains("Pass queryIndices");
+
+    final JSONObject zeroFullVector = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryVector",
+            new JSONArray().put(0.0).put(0.0).put(0.0).put(0.0).put(0.0).put(0.0).put(0.0).put(0.0))
+        .put("sparse", true)
+        .put("k", 1));
+    assertThat(zeroFullVector.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("at least one non-zero weight");
+
+    final JSONObject fractionalIndex = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryIndices", new JSONArray().put(1.5))
+        .put("queryVector", new JSONArray().put(1.0))
+        .put("sparse", true)
+        .put("k", 1));
+    assertThat(fractionalIndex.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("non-negative integers");
+
+    final JSONObject duplicateIndex = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryIndices", new JSONArray().put(5).put(5))
+        .put("queryVector", new JSONArray().put(1.0).put(0.5))
+        .put("sparse", true)
+        .put("k", 1));
+    assertThat(duplicateIndex.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("duplicate dimension 5");
+
+    final JSONObject outOfRange = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryIndices", new JSONArray().put(8))
+        .put("queryVector", new JSONArray().put(1.0))
+        .put("sparse", true)
+        .put("k", 1));
+    assertThat(outOfRange.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("outside index dimensions 0-7");
+
+    final JSONObject zeroCompactVector = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpSparseVectorRecord[tokens,weights]")
+        .put("queryIndices", new JSONArray().put(5))
+        .put("queryVector", new JSONArray().put(0.0))
+        .put("sparse", true)
+        .put("k", 1));
+    assertThat(zeroCompactVector.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("at least one non-zero weight");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -174,7 +174,6 @@ class MCPServerPluginTest extends BaseGraphServerTest {
 
     assertThat(response.has("result")).isTrue();
     final JSONArray tools = response.getJSONObject("result").getJSONArray("tools");
-    assertThat(tools.length()).isEqualTo(14);
 
     // Verify tool names
     boolean hasListDatabases = false;
@@ -961,7 +960,8 @@ class MCPServerPluginTest extends BaseGraphServerTest {
 
     final JSONObject first = payload.getJSONArray("results").getJSONObject(0);
     assertThat(first.getString("rid")).startsWith("#");
-    assertThat(first.getDouble("score")).isEqualTo(first.getDouble("distance"));
+    assertThat(first.has("score")).isFalse();
+    assertThat(first.getDouble("distance")).isGreaterThanOrEqualTo(0.0);
     assertThat(first.getJSONObject("properties").getString("name")).isEqualTo("dense-a");
   }
 
@@ -980,6 +980,8 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     final JSONObject payload = new JSONObject(
         response.getJSONArray("content").getJSONObject(0).getString("text"));
     assertThat(payload.getInt("count")).isEqualTo(2);
+    assertThat(payload.getInt("candidateLimit")).isEqualTo(16);
+    assertThat(payload.getBoolean("truncated")).isTrue();
     for (int i = 0; i < payload.getJSONArray("results").length(); i++)
       assertThat(payload.getJSONArray("results").getJSONObject(i)
           .getJSONObject("properties").getString("category")).isEqualTo("keep");
@@ -1006,8 +1008,28 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     assertThat(payload.getInt("count")).isEqualTo(2);
     final JSONArray results = payload.getJSONArray("results");
     assertThat(results.getJSONObject(0).getJSONObject("properties").getString("name")).isEqualTo("sparse-high");
+    assertThat(results.getJSONObject(0).has("distance")).isFalse();
     assertThat(results.getJSONObject(0).getDouble("score"))
         .isGreaterThan(results.getJSONObject(1).getDouble("score"));
+  }
+
+  @Test
+  void vectorSearchUsesIndependentFilteredCandidateBudget() throws Exception {
+    seedVectorIndexes();
+
+    final JSONObject response = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("filter", "category = 'missing'")
+        .put("k", 1_000));
+
+    assertThat(response.getBoolean("isError", true)).isFalse();
+    final JSONObject payload = new JSONObject(
+        response.getJSONArray("content").getJSONObject(0).getString("text"));
+    assertThat(payload.getInt("candidateLimit")).isEqualTo(8_000);
+    assertThat(payload.getInt("count")).isZero();
+    assertThat(payload.getBoolean("truncated")).isTrue();
   }
 
   @Test
@@ -1185,6 +1207,14 @@ class MCPServerPluginTest extends BaseGraphServerTest {
         .put("k", 1));
     assertThat(zeroFullVector.getJSONArray("content").getJSONObject(0).getString("text"))
         .contains("at least one non-zero weight");
+
+    final JSONObject zeroDenseVector = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorRecord[embedding]")
+        .put("queryVector", new JSONArray().put(0.0).put(0.0).put(0.0))
+        .put("k", 1));
+    assertThat(zeroDenseVector.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("at least one non-zero value");
 
     final JSONObject fractionalIndex = callTool("vector_search", new JSONObject()
         .put("database", getDatabaseName())

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -1029,7 +1029,8 @@ class MCPServerPluginTest extends BaseGraphServerTest {
         response.getJSONArray("content").getJSONObject(0).getString("text"));
     assertThat(payload.getInt("candidateLimit")).isEqualTo(8_000);
     assertThat(payload.getInt("count")).isZero();
-    assertThat(payload.getBoolean("truncated")).isTrue();
+    assertThat(payload.getLong("indexedEntries")).isEqualTo(3);
+    assertThat(payload.getBoolean("truncated")).isFalse();
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -149,6 +149,44 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     });
   }
 
+  /**
+   * Seeds a type holding more vectors than a filtered search inspects, so truncation reporting can be observed
+   * on a candidate window that is genuinely smaller than the index. Exactly one record carries category 'solo'
+   * and sits close to the probe vector, so a filtered search for it returns fewer hits than requested while
+   * still having examined every match the filter can ever produce.
+   */
+  private void seedVectorBudgetRecords() {
+    final Database db = getServerDatabase(0, getDatabaseName());
+    if (db.getSchema().existsType("McpVectorBudgetRecord"))
+      return;
+
+    db.transaction(() -> {
+      db.command("sql", "CREATE DOCUMENT TYPE McpVectorBudgetRecord BUCKETS 1");
+      db.command("sql", "CREATE PROPERTY McpVectorBudgetRecord.name STRING");
+      db.command("sql", "CREATE PROPERTY McpVectorBudgetRecord.category STRING");
+      db.command("sql", "CREATE PROPERTY McpVectorBudgetRecord.embedding ARRAY_OF_FLOATS");
+      db.command("sql", """
+          CREATE INDEX ON McpVectorBudgetRecord (embedding) LSM_VECTOR
+          METADATA { dimensions: 3, similarity: 'COSINE' }
+          """);
+
+      db.newDocument("McpVectorBudgetRecord")
+          .set("name", "budget-solo")
+          .set("category", "solo")
+          .set("embedding", new float[] { 0.95f, 0.05f, 0.0f })
+          .save();
+
+      // Comfortably more than the 16-candidate window a k=2 filtered search uses, so the index is larger than
+      // the window regardless of which neighbors the graph returns.
+      for (int i = 0; i < 24; i++)
+        db.newDocument("McpVectorBudgetRecord")
+            .set("name", "budget-bulk-" + i)
+            .set("category", "bulk")
+            .set("embedding", new float[] { 0.9f - i * 0.01f, 0.1f + i * 0.01f, 0.0f })
+            .save();
+    });
+  }
+
   @Test
   void initialize() throws Exception {
     final JSONObject response = mcpRequest(new JSONObject()
@@ -1029,8 +1067,55 @@ class MCPServerPluginTest extends BaseGraphServerTest {
         response.getJSONArray("content").getJSONObject(0).getString("text"));
     assertThat(payload.getInt("candidateLimit")).isEqualTo(8_000);
     assertThat(payload.getInt("count")).isZero();
-    assertThat(payload.getLong("indexedEntries")).isEqualTo(3);
     assertThat(payload.getBoolean("truncated")).isFalse();
+  }
+
+  /**
+   * Truncation must describe the result window, not the size of the index. A filtered search that returns fewer
+   * hits than requested has exhausted its matches, so reporting truncation there tells the caller to widen a
+   * search that cannot yield more. The index deliberately holds more vectors than the candidate window.
+   */
+  @Test
+  void vectorSearchDoesNotReportTruncationWhenResultWindowIsNotFilled() throws Exception {
+    seedVectorBudgetRecords();
+
+    final JSONObject response = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorBudgetRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("filter", "category = 'solo'")
+        .put("k", 2));
+
+    assertThat(response.getBoolean("isError", true)).isFalse();
+    final JSONObject payload = new JSONObject(
+        response.getJSONArray("content").getJSONObject(0).getString("text"));
+
+    assertThat(payload.getInt("candidateLimit")).isEqualTo(16);
+    assertThat(payload.getInt("count")).isEqualTo(1);
+    assertThat(payload.getJSONArray("results").getJSONObject(0)
+        .getJSONObject("properties").getString("name")).isEqualTo("budget-solo");
+    assertThat(payload.getBoolean("truncated")).isFalse();
+  }
+
+  /**
+   * A filled result window is the one case where more matches may exist beyond what was returned.
+   */
+  @Test
+  void vectorSearchReportsTruncationWhenResultWindowIsFilled() throws Exception {
+    seedVectorBudgetRecords();
+
+    final JSONObject response = callTool("vector_search", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "McpVectorBudgetRecord[embedding]")
+        .put("queryVector", new JSONArray().put(1.0).put(0.0).put(0.0))
+        .put("k", 2));
+
+    assertThat(response.getBoolean("isError", true)).isFalse();
+    final JSONObject payload = new JSONObject(
+        response.getJSONArray("content").getJSONObject(0).getString("text"));
+
+    assertThat(payload.getInt("count")).isEqualTo(2);
+    assertThat(payload.getBoolean("truncated")).isTrue();
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
@@ -74,7 +74,12 @@ class MCPStdioServerTest extends BaseGraphServerTest {
 
     assertThat(response.has("result")).isTrue();
     final JSONArray tools = response.getJSONObject("result").getJSONArray("tools");
-    assertThat(tools.length()).isEqualTo(13);
+    assertThat(tools.length()).isEqualTo(14);
+    boolean hasVectorSearch = false;
+    for (int i = 0; i < tools.length(); i++)
+      if ("vector_search".equals(tools.getJSONObject(i).getString("name")))
+        hasVectorSearch = true;
+    assertThat(hasVectorSearch).isTrue();
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
@@ -74,7 +74,6 @@ class MCPStdioServerTest extends BaseGraphServerTest {
 
     assertThat(response.has("result")).isTrue();
     final JSONArray tools = response.getJSONObject("result").getJSONArray("tools");
-    assertThat(tools.length()).isEqualTo(14);
     boolean hasVectorSearch = false;
     for (int i = 0; i < tools.length(); i++)
       if ("vector_search".equals(tools.getJSONObject(i).getString("name")))


### PR DESCRIPTION
## Summary

- add `vector_search` for dense `LSM_VECTOR` and sparse `LSM_SPARSE_VECTOR` indexes
- validate index type, dimensions, sparse coordinates, `k`, and dense-only `efSearch` before querying
- return stable record payloads with explicit lower-is-better distance or higher-is-better sparse-score semantics
- support a bounded read-only SQL filter and compact sparse vectors via `queryIndices`
- register the tool centrally for both HTTP and stdio transports and avoid logging full vector payloads

## Safety

- enforces `allowReads` and the authenticated database permission path
- binds vector/index values as query parameters
- parses the generated SQL and requires the query engine to classify it as idempotent
- caps `k` and filtered candidate over-fetch at 1,000

## Verification

- focused vector/tool-list tests: 10 passed
- all `MCP*Test` server tests: 152 passed, 0 failed, 0 errors
- focused JaCoCo coverage for `VectorSearchTool`: 91.8% lines, 81.0% branches
- full engine suite not run

The MCP documentation lives in the separate `arcadedb-docs` repository, so this code PR does not edit docs in this repository.

Closes #4860