### PR TITLE
fix(fulltext) #5267: make BM25 scores comparable across buckets

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchFields.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchFields.java
@@ -22,13 +22,10 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
-import com.arcadedb.index.Index;
-import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.index.TypeIndex;
-import com.arcadedb.index.fulltext.FullTextQueryExecutor;
-import com.arcadedb.index.fulltext.LSMTreeFullTextIndex;
+import com.arcadedb.index.fulltext.FullTextSearch;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
 import com.arcadedb.schema.DocumentType;
@@ -104,7 +101,7 @@ public class SQLFunctionSearchFields extends SQLFunctionAbstract {
 
     // Try to get cached results
     @SuppressWarnings("unchecked")
-    Map<RID, Integer> allResults = (Map<RID, Integer>) iContext.getVariable(cacheKey);
+    Map<RID, Float> allResults = (Map<RID, Float>) iContext.getVariable(cacheKey);
 
     if (allResults == null) {
       allResults = new HashMap<>();
@@ -126,19 +123,9 @@ public class SQLFunctionSearchFields extends SQLFunctionAbstract {
       if (matchingIndex == null)
         throw new CommandExecutionException("No full-text index found for fields: " + fieldNames);
 
-      // Execute search using the found index
-      for (final Index bucketIndex : matchingIndex.getIndexesOnBuckets()) {
-        if (bucketIndex instanceof LSMTreeFullTextIndex) {
-          final FullTextQueryExecutor executor = new FullTextQueryExecutor((LSMTreeFullTextIndex) bucketIndex);
-          final IndexCursor cursor = executor.search(queryString, -1);
-
-          while (cursor.hasNext()) {
-            final Identifiable match = cursor.next();
-            final int score = cursor.getScore();
-            allResults.merge(match.getIdentity(), score, Integer::sum);
-          }
-        }
-      }
+      // Route through the same type-wide scorer as SEARCH_INDEX so BM25 floats retain their precision and remain comparable
+      // when the logical index spans several buckets.
+      allResults.putAll(FullTextSearch.search(matchingIndex, queryString, -1));
 
       // Cache the results
       iContext.setVariable(cacheKey, allResults);
@@ -152,8 +139,7 @@ public class SQLFunctionSearchFields extends SQLFunctionAbstract {
       if (matches) {
         // Store the score for this record in the context variable $score
         // This allows $score projection to work in SELECT
-        final int recordScore = allResults.get(rid);
-        iContext.setVariable("$score", (float) recordScore);
+        iContext.setVariable("$score", allResults.get(rid));
       } else {
         // Clear the score for non-matching records
         iContext.setVariable("$score", 0f);
@@ -164,10 +150,10 @@ public class SQLFunctionSearchFields extends SQLFunctionAbstract {
 
     // Return cursor with all results
     final List<IndexCursorEntry> entries = new ArrayList<>();
-    for (final Map.Entry<RID, Integer> entry : allResults.entrySet()) {
+    for (final Map.Entry<RID, Float> entry : allResults.entrySet()) {
       entries.add(new IndexCursorEntry(new Object[] { queryString }, entry.getKey(), entry.getValue()));
     }
-    entries.sort((a, b) -> Integer.compare(b.score, a.score));
+    entries.sort((a, b) -> Float.compare(b.floatScore, a.floatScore));
 
     return new TempIndexCursor(entries);
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
@@ -29,9 +29,7 @@ import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.index.TypeIndex;
-import com.arcadedb.index.fulltext.FullTextQueryExecutor;
 import com.arcadedb.index.fulltext.FullTextSearch;
-import com.arcadedb.index.fulltext.LSMTreeFullTextIndex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.IndexableSQLFunction;
 import com.arcadedb.query.sql.parser.BinaryCompareOperator;
@@ -39,7 +37,6 @@ import com.arcadedb.query.sql.parser.Expression;
 import com.arcadedb.query.sql.parser.FromClause;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
 import com.arcadedb.schema.Schema;
-import com.arcadedb.serializer.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -220,29 +217,7 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
     if (!(index instanceof final TypeIndex typeIndex))
       return null;
 
-    // BM25 is scored per bucket (per-shard), so document frequency / IDF differ across buckets. EXPLAIN/PROFILE reports a single
-    // representative bucket's statistics (the first full-text bucket index) rather than a global view - enough to understand the
-    // similarity, parameters and relative term weights, but not a type-wide IDF.
-    final Index[] buckets = typeIndex.getIndexesOnBuckets();
-    LSMTreeFullTextIndex firstFt = null;
-    int ftBucketCount = 0; // all full-text bucket indexes of a type share one similarity, so they are all BM25 or all CLASSIC
-    for (final Index bucketIndex : buckets)
-      if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex) {
-        if (firstFt == null)
-          firstFt = ftIndex;
-        ++ftBucketCount;
-      }
-    // Only BM25 indexes carry a scoring explanation; CLASSIC has none.
-    if (firstFt == null || !firstFt.isBM25())
-      return null;
-
-    final JSONObject explain = new FullTextQueryExecutor(firstFt).explainScoring(queryString);
-    // Make it explicit that, on a multi-bucket type, these are the FIRST bucket's statistics so a reader is not misled into
-    // treating the df/IDF as type-wide.
-    if (ftBucketCount > 1)
-      explain.put("note", "statistics shown are for the FIRST of " + ftBucketCount
-          + " buckets; BM25 is scored per bucket, so df/IDF differ across buckets");
-    return explain;
+    return FullTextSearch.explainScoring(typeIndex, queryString);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -24,6 +24,8 @@ import com.arcadedb.database.IndexCursorCollection;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.index.fulltext.FullTextSearch;
+import com.arcadedb.index.fulltext.LSMTreeFullTextIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalDocumentType;
@@ -105,6 +107,9 @@ public class TypeIndex implements RangeIndex, IndexInternal {
         indexesOnBuckets.getFirst().getType() == Schema.INDEX_TYPE.FULL_TEXT;
 
     if (isFullText) {
+      if (indexesOnBuckets.getFirst() instanceof final LSMTreeFullTextIndex fullTextIndex && fullTextIndex.isBM25())
+        return FullTextSearch.searchSimple(this, keys, -1);
+
       // For full-text indexes, collect entries with scores
       final List<IndexCursorEntry> entries = new ArrayList<>();
 
@@ -154,6 +159,9 @@ public class TypeIndex implements RangeIndex, IndexInternal {
         indexesOnBuckets.getFirst().getType() == Schema.INDEX_TYPE.FULL_TEXT;
 
     if (isFullText) {
+      if (indexesOnBuckets.getFirst() instanceof final LSMTreeFullTextIndex fullTextIndex && fullTextIndex.isBM25())
+        return FullTextSearch.searchSimple(this, keys, limit);
+
       // For full-text indexes, collect entries with scores
       final List<IndexCursorEntry> entries = new ArrayList<>();
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/BM25ScoringContext.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/BM25ScoringContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import java.util.Map;
+
+/**
+ * Type-wide corpus statistics shared by every bucket while scoring one BM25 query.
+ */
+record BM25ScoringContext(long totalDocs, double avgDocLength, Map<String, Long> documentFrequencies) {
+  BM25ScoringContext {
+    if (totalDocs < 1)
+      throw new IllegalArgumentException("totalDocs must be at least 1");
+    if (!Double.isFinite(avgDocLength) || avgDocLength <= 0)
+      throw new IllegalArgumentException("avgDocLength must be finite and positive");
+    documentFrequencies = Map.copyOf(documentFrequencies);
+  }
+
+  long documentFrequency(final String token) {
+    return documentFrequencies.getOrDefault(token, 0L);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -130,6 +130,14 @@ public class FullTextQueryExecutor {
   private static final AtomicLong lastPureNegativeWarnMs     = new AtomicLong(0L);
 
   /**
+   * Bucket-local documents that satisfy a parsed query, plus the positive terms that contribute to BM25 scoring. The match set
+   * preserves all Lucene boolean/phrase/wildcard semantics; {@link FullTextSearch} combines these bucket-local matches and
+   * re-scores them with type-wide corpus statistics.
+   */
+  record BM25QueryMatch(Set<RID> candidates, Map<String, Float> scoringTokens) {
+  }
+
+  /**
    * Creates a new FullTextQueryExecutor for the given index.
    *
    * @param index the full-text index to search
@@ -167,14 +175,7 @@ public class FullTextQueryExecutor {
    */
   public IndexCursor search(final String queryString, final int limit) {
     resetState();
-    try {
-      // Create parser per invocation for thread safety
-      final QueryParser parser = createQueryParser();
-      final Query query = parser.parse(queryString);
-      return executeQuery(query, limit);
-    } catch (final ParseException e) {
-      throw new IndexException("Invalid search query: " + queryString, e);
-    }
+    return executeQuery(parseQuery(queryString), limit);
   }
 
   /**
@@ -195,33 +196,50 @@ public class FullTextQueryExecutor {
    * @param queryString the query string in Lucene syntax
    */
   public JSONObject explainScoring(final String queryString) {
+    return index.explainScoring(collectScoringTokens(queryString));
+  }
+
+  /**
+   * Parses a query and discovers its positive scoring terms without materializing matching documents. Package-private so the
+   * type-wide coordinator can union wildcard/fuzzy expansions from every bucket before computing global document frequencies.
+   */
+  Map<String, Float> collectScoringTokens(final String queryString) {
     resetState();
+    final Query query = parseQuery(queryString);
+    tokensOnly = true;
     try {
-      final QueryParser parser = createQueryParser();
-      final Query query = parser.parse(queryString);
-      tokensOnly = true;
-      try {
-        // The score map stays empty in tokens-only mode; we only need the captured scoringTokens.
-        collectMatches(query, new HashMap<>(), new HashSet<>());
-      } finally {
-        tokensOnly = false;
-      }
-      return index.explainScoring(scoringTokens);
+      // The score map stays empty in tokens-only mode; we only need the captured scoringTokens.
+      collectMatches(query, new HashMap<>(), new HashSet<>());
+    } finally {
+      tokensOnly = false;
+    }
+    return Map.copyOf(scoringTokens);
+  }
+
+  /**
+   * Returns the bucket-local candidate set without applying bucket-local BM25 statistics. Used by type-wide search so matching
+   * remains bucket-local while scoring uses one comparable corpus scope across every bucket.
+   */
+  BM25QueryMatch collectBM25Matches(final String queryString) {
+    if (!index.isBM25())
+      throw new IllegalStateException("BM25 matching requires a BM25 full-text index");
+
+    resetState();
+    final Map<RID, AtomicInteger> matches = collectQueryMatches(parseQuery(queryString));
+    return new BM25QueryMatch(Set.copyOf(matches.keySet()), Map.copyOf(scoringTokens));
+  }
+
+  private Query parseQuery(final String queryString) {
+    try {
+      // QueryParser is not thread-safe, so create one per invocation.
+      return createQueryParser().parse(queryString);
     } catch (final ParseException e) {
       throw new IndexException("Invalid search query: " + queryString, e);
     }
   }
 
   private IndexCursor executeQuery(final Query query, final int limit) {
-    final Map<RID, AtomicInteger> scoreMap = new HashMap<>();
-    final Set<RID> excluded = new HashSet<>();
-
-    collectMatches(query, scoreMap, excluded);
-
-    // Remove excluded RIDs
-    for (final RID rid : excluded) {
-      scoreMap.remove(rid);
-    }
+    final Map<RID, AtomicInteger> scoreMap = collectQueryMatches(query);
 
     // BM25 path: collectMatches above determined WHICH documents match (boolean/phrase/wildcard semantics). Re-rank that
     // candidate set with BM25 using the scoring tokens captured during matching.
@@ -250,6 +268,19 @@ public class FullTextQueryExecutor {
       return new TempIndexCursor(list.subList(0, limit));
     }
     return new TempIndexCursor(list);
+  }
+
+  private Map<RID, AtomicInteger> collectQueryMatches(final Query query) {
+    final Map<RID, AtomicInteger> scoreMap = new HashMap<>();
+    final Set<RID> excluded = new HashSet<>();
+
+    collectMatches(query, scoreMap, excluded);
+
+    // Remove excluded RIDs
+    for (final RID rid : excluded) {
+      scoreMap.remove(rid);
+    }
+    return scoreMap;
   }
 
   private void collectMatches(final Query query, final Map<RID, AtomicInteger> scoreMap,

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -111,7 +111,10 @@ public class FullTextQueryExecutor {
   // BM25 scoring (issue #4687): the positive scoring tokens collected during matching, mapped to their field boost. Populated
   // only when the index uses BM25 similarity and only for positive clauses (never for MUST_NOT exclusion). A new executor is
   // created per search, so these instance fields are not shared across queries.
-  private final Map<String, Float> scoringTokens     = new HashMap<>();
+  private final Map<String, Float> scoringTokens       = new HashMap<>();
+  // Document frequency of each scoring token within this bucket, counted during the same posting walk that collects the
+  // matches. A type-wide search sums these across buckets instead of re-scanning every posting list to derive df.
+  private final Map<String, Long>  documentFrequencies = new HashMap<>();
   private       boolean            collectingExclusion = false;
   // When true, matching runs only to capture the scoring tokens (used by EXPLAIN/PROFILE): per-document score accumulation is
   // skipped so no document set is materialized. Token discovery for wildcard/prefix/fuzzy still scans the index as needed.
@@ -134,7 +137,7 @@ public class FullTextQueryExecutor {
    * preserves all Lucene boolean/phrase/wildcard semantics; {@link FullTextSearch} combines these bucket-local matches and
    * re-scores them with type-wide corpus statistics.
    */
-  record BM25QueryMatch(Set<RID> candidates, Map<String, Float> scoringTokens) {
+  record BM25QueryMatch(Set<RID> candidates, Map<String, Float> scoringTokens, Map<String, Long> documentFrequencies) {
   }
 
   /**
@@ -184,6 +187,7 @@ public class FullTextQueryExecutor {
    */
   private void resetState() {
     scoringTokens.clear();
+    documentFrequencies.clear();
     collectingExclusion = false;
     tokensOnly = false;
     currentBoost = 1.0f;
@@ -226,7 +230,7 @@ public class FullTextQueryExecutor {
 
     resetState();
     final Map<RID, AtomicInteger> matches = collectQueryMatches(parseQuery(queryString));
-    return new BM25QueryMatch(Set.copyOf(matches.keySet()), Map.copyOf(scoringTokens));
+    return new BM25QueryMatch(Set.copyOf(matches.keySet()), Map.copyOf(scoringTokens), Map.copyOf(documentFrequencies));
   }
 
   private Query parseQuery(final String queryString) {
@@ -429,6 +433,17 @@ public class FullTextQueryExecutor {
   }
 
   /**
+   * Records how many live documents in this bucket contain {@code storedKey}. A single query can walk the same token more than
+   * once (a repeated term, or overlapping wildcard ranges such as {@code ap*} and {@code app*}); every such walk counts the whole
+   * posting list, so the merge keeps the maximum rather than summing and double-counting.
+   */
+  private void recordDocumentFrequency(final String storedKey, final long frequency) {
+    if (collectingExclusion || !index.isBM25() || frequency < 1)
+      return;
+    documentFrequencies.merge(storedKey, frequency, Math::max);
+  }
+
+  /**
    * Logs the scoring-token-cap WARNING at most once per {@link #EXPANSION_WARN_THROTTLE_MS} across the JVM (a new executor per
    * query means a per-query flag would not suppress it for a repeated huge wildcard). The CAS ensures a single winner per window.
    */
@@ -516,13 +531,18 @@ public class FullTextQueryExecutor {
     // Raw postings lookup: we only need the matching RIDs here. The BM25 score is computed once, later, by scoreCandidatesBM25;
     // going through index.get() would run (and then discard) the full scoring pipeline for every term.
     final IndexCursor cursor = index.getPostings(searchKey);
+    long df = 0L;
     while (cursor.hasNext()) {
       // next() may return null after hasNext()==true (deleted/tombstoned entry, issue #5118); skip it.
       final Identifiable record = cursor.next();
       if (record == null)
         continue;
+      // Deletion markers carry a negative bucket id: they are not live documents and must not inflate the document frequency.
+      if (record.getIdentity().getBucketId() >= 0)
+        ++df;
       scoreMap.computeIfAbsent(record.getIdentity(), k -> new AtomicInteger(0)).incrementAndGet();
     }
+    recordDocumentFrequency(searchKey, df);
   }
 
   private void collectPhraseMatches(final PhraseQuery query, final Map<RID, AtomicInteger> scoreMap) {
@@ -546,13 +566,18 @@ public class FullTextQueryExecutor {
       recordScoringToken(term.text(), 1.0f);
       final Map<RID, AtomicInteger> termMatches = new HashMap<>();
       final IndexCursor cursor = index.getPostings(term.text());
+      long df = 0L;
       while (cursor.hasNext()) {
         // next() may return null after hasNext()==true (deleted/tombstoned entry, issue #5118); skip it.
         final Identifiable record = cursor.next();
         if (record == null)
           continue;
+        // Deletion markers carry a negative bucket id and must not inflate the document frequency.
+        if (record.getIdentity().getBucketId() >= 0)
+          ++df;
         termMatches.put(record.getIdentity(), new AtomicInteger(1));
       }
+      recordDocumentFrequency(term.text(), df);
 
       if (intersection == null) {
         intersection = termMatches;
@@ -672,6 +697,9 @@ public class FullTextQueryExecutor {
     final boolean rangeScan = startKey != null;
     final IndexCursor cursor = index.iterateUnderlying(true,
         rangeScan ? new String[] { startKey } : null, true);
+    // Per-expanded-key document frequency for this walk, accumulated in a primitive cell (one allocation per distinct key
+    // rather than a boxed Long per posting) and flushed once the range has been consumed.
+    final Map<String, long[]> walkFrequencies = new HashMap<>();
     while (cursor.hasNext()) {
       // LSMTreeIndexCursor.next() can legitimately return null after hasNext()==true (a full-key tombstone / deleted entry it
       // steps over while its internal iterators are still considered alive - issue #5118). Skip it instead of dereferencing.
@@ -685,12 +713,18 @@ public class FullTextQueryExecutor {
       final String key = keys[0].toString();
       if (matcher.matches(key)) {
         recordScoringToken(key, boost);
+        // Deletion markers carry a negative bucket id and must not inflate the document frequency.
+        if (rid.getBucketId() >= 0)
+          ++walkFrequencies.computeIfAbsent(key, k -> new long[1])[0];
         if (!tokensOnly)
           scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
       } else if (rangeScan && key.compareTo(startKey) > 0 && !key.startsWith(startKey)) {
         break;
       }
     }
+
+    for (final Map.Entry<String, long[]> frequency : walkFrequencies.entrySet())
+      recordDocumentFrequency(frequency.getKey(), frequency.getValue()[0]);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
@@ -19,27 +19,35 @@
 package com.arcadedb.index.fulltext;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseRID;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.FullTextPostingRID;
 import com.arcadedb.schema.FullTextIndexMetadata;
 import com.arcadedb.schema.Schema;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Shared entry point for full-text search (BM25 or CLASSIC similarity) over a type's full-text index. Used by the
  * SEARCH_INDEX SQL function and by callers that need scored results without going through SQL.
  */
 public class FullTextSearch {
+  private static final int MAX_EXPLAIN_TERMS = 64;
 
   private FullTextSearch() {
   }
@@ -84,36 +92,195 @@ public class FullTextSearch {
    * normalized to {@code -1}, meaning unbounded; the SQL {@code SEARCH_INDEX} function depends on {@code -1}
    * continuing to mean unbounded.
    * <p>
-   * When the normalized limit is not {@code -1}, it is pushed down to each bucket's {@link FullTextQueryExecutor#search},
-   * which keeps only its own top-{@code limit} matches by score: a bounded min-heap on the BM25 path, or a full sort
-   * followed by a truncation on the CLASSIC path (the min-heap only engages when {@code limit} is smaller than the
-   * bucket's match count; below that threshold every match is kept on both paths). A global top-K is contained in the
-   * union of the per-bucket top-K, so narrowing each bucket to {@code limit} before the caller merges and re-ranks
-   * across buckets is sound; the caller still needs to sort and truncate the merged union because it can hold up to
-   * {@code buckets * limit} entries.
+   * BM25 searches spanning several buckets first derive type-wide document frequencies and then apply those same statistics to
+   * every bucket. This makes scores globally comparable without adding shared counters to the write path. The limit is still
+   * pushed down after each bucket's candidates are scored; a global top-K is contained in the union of those now-comparable
+   * per-bucket top-K sets, so callers still sort and truncate a union of at most {@code buckets * limit} entries.
    */
   public static Map<RID, Float> search(final TypeIndex typeIndex, final String queryText, final int limit) {
     final int effectiveLimit = limit < 1 ? -1 : limit;
+    final List<LSMTreeFullTextIndex> bucketIndexes = getBucketIndexes(typeIndex);
+    if (bucketIndexes.isEmpty())
+      return Map.of();
+
+    if (bucketIndexes.size() > 1 && bucketIndexes.getFirst().isBM25())
+      return searchBM25(bucketIndexes, queryText, effectiveLimit);
+
     final Map<RID, Float> allResults = new HashMap<>();
 
-    for (final Index bucketIndex : typeIndex.getIndexesOnBuckets()) {
-      if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex) {
-        final FullTextQueryExecutor executor = new FullTextQueryExecutor(ftIndex);
-        final IndexCursor cursor = executor.search(queryText, effectiveLimit);
-
-        while (cursor.hasNext()) {
-          final Identifiable match = cursor.next();
-          final float score = cursor.getFloatScore();
-          // Float::sum across buckets: a given RID lives in exactly one bucket, so a RID is produced by at most one bucket index
-          // and the merge is effectively an insert (no real summing). For CLASSIC the additive semantics would also be correct;
-          // for BM25 the per-bucket scoping relies on this one-bucket-per-RID invariant - if it ever broke, scores would be
-          // double-counted here rather than failing loudly.
-          allResults.merge(match.getIdentity(), score, Float::sum);
-        }
-      }
+    for (final LSMTreeFullTextIndex ftIndex : bucketIndexes) {
+      final IndexCursor cursor = new FullTextQueryExecutor(ftIndex).search(queryText, effectiveLimit);
+      mergeCursor(allResults, cursor);
     }
 
     return allResults;
+  }
+
+  private static Map<RID, Float> searchBM25(final List<LSMTreeFullTextIndex> bucketIndexes, final String queryText,
+      final int limit) {
+    final Map<String, Float> scoringTokens = collectScoringTokens(bucketIndexes, queryText,
+        FullTextQueryExecutor.MAX_EXPANDED_SCORING_TERMS);
+    final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes, scoringTokens);
+    final Map<RID, Float> allResults = new HashMap<>();
+
+    for (final LSMTreeFullTextIndex ftIndex : bucketIndexes) {
+      final FullTextQueryExecutor.BM25QueryMatch match = new FullTextQueryExecutor(ftIndex).collectBM25Matches(queryText);
+      final IndexCursor cursor = ftIndex.scoreBM25WithContext(match.candidates(), scoringTokens, new Object[] {}, limit,
+          scoringContext);
+      mergeCursor(allResults, cursor);
+    }
+    return allResults;
+  }
+
+  /**
+   * Executes the literal-token lookup used by {@link TypeIndex#get(Object[])} while keeping BM25 scores comparable across bucket
+   * indexes. Lucene boolean/wildcard syntax is intentionally not interpreted on this path.
+   */
+  public static IndexCursor searchSimple(final TypeIndex typeIndex, final Object[] keys, final int limit) {
+    final List<LSMTreeFullTextIndex> bucketIndexes = getBucketIndexes(typeIndex);
+    if (bucketIndexes.isEmpty())
+      return new TempIndexCursor(List.of());
+    if (!bucketIndexes.getFirst().isBM25())
+      throw new IllegalArgumentException("searchSimple requires a BM25 full-text index");
+
+    final int effectiveLimit = limit < 1 ? -1 : limit;
+    final Map<String, Float> scoringTokens = bucketIndexes.getFirst().getSimpleQueryTokenBoosts(keys);
+    final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes, scoringTokens);
+    final Map<RID, Float> allResults = new HashMap<>();
+    for (final LSMTreeFullTextIndex ftIndex : bucketIndexes)
+      mergeCursor(allResults,
+          ftIndex.scoreBM25WithContext(null, scoringTokens, keys, effectiveLimit, scoringContext));
+
+    return rankedCursor(allResults, keys, effectiveLimit);
+  }
+
+  /**
+   * Returns a type-wide BM25 scoring explanation for SQL EXPLAIN/PROFILE. Wildcard expansions are discovered across every bucket,
+   * but at most 64 terms are scanned for the detailed breakdown.
+   */
+  public static JSONObject explainScoring(final TypeIndex typeIndex, final String queryText) {
+    final List<LSMTreeFullTextIndex> bucketIndexes = getBucketIndexes(typeIndex);
+    if (bucketIndexes.isEmpty() || !bucketIndexes.getFirst().isBM25())
+      return null;
+
+    final Map<String, Float> allTokens = collectScoringTokens(bucketIndexes, queryText,
+        FullTextQueryExecutor.MAX_EXPANDED_SCORING_TERMS);
+    final Map<String, Float> shownTokens = firstTokens(allTokens, MAX_EXPLAIN_TERMS);
+    final BM25ScoringContext context = createScoringContext(bucketIndexes, shownTokens);
+    final FullTextIndexMetadata metadata = bucketIndexes.getFirst().getFullTextMetadata();
+
+    final JSONObject explain = new JSONObject()
+        .put("similarity", FullTextIndexMetadata.SIMILARITY_BM25)
+        .put("k1", metadata.getBm25K1())
+        .put("b", metadata.getBm25B())
+        .put("totalDocs", context.totalDocs())
+        .put("avgDocLength", context.avgDocLength())
+        .put("bucketCount", bucketIndexes.size())
+        .put("corpusScope", "type")
+        .put("note", "statistics are type-wide; BM25 scores are comparable across all bucket indexes");
+
+    if (allTokens.size() > shownTokens.size()) {
+      explain.put("termsTruncated", true);
+      explain.put("termsOmitted", allTokens.size() - shownTokens.size());
+      explain.put("termsShown", shownTokens.size());
+    }
+
+    final JSONArray terms = new JSONArray();
+    for (final Map.Entry<String, Float> token : shownTokens.entrySet()) {
+      final long df = context.documentFrequency(token.getKey());
+      terms.put(new JSONObject()
+          .put("term", token.getKey())
+          .put("df", df)
+          .put("idf", BM25Scorer.idf(context.totalDocs(), df))
+          .put("boost", token.getValue()));
+    }
+    explain.put("terms", terms);
+    return explain;
+  }
+
+  private static List<LSMTreeFullTextIndex> getBucketIndexes(final TypeIndex typeIndex) {
+    final List<LSMTreeFullTextIndex> indexes = new ArrayList<>();
+    for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
+      if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex)
+        indexes.add(ftIndex);
+    return indexes;
+  }
+
+  private static Map<String, Float> collectScoringTokens(final List<LSMTreeFullTextIndex> bucketIndexes,
+      final String queryText, final int maxTerms) {
+    final TreeMap<String, Float> tokens = new TreeMap<>();
+    for (final LSMTreeFullTextIndex ftIndex : bucketIndexes)
+      for (final Map.Entry<String, Float> token :
+          new FullTextQueryExecutor(ftIndex).collectScoringTokens(queryText).entrySet())
+        tokens.merge(token.getKey(), token.getValue(), Math::max);
+
+    while (tokens.size() > maxTerms)
+      tokens.pollLastEntry();
+    return tokens;
+  }
+
+  private static Map<String, Float> firstTokens(final Map<String, Float> tokens, final int limit) {
+    if (tokens.size() <= limit)
+      return tokens;
+
+    final TreeMap<String, Float> first = new TreeMap<>();
+    for (final Map.Entry<String, Float> token : tokens.entrySet()) {
+      if (first.size() >= limit)
+        break;
+      first.put(token.getKey(), token.getValue());
+    }
+    return first;
+  }
+
+  private static BM25ScoringContext createScoringContext(final List<LSMTreeFullTextIndex> bucketIndexes,
+      final Map<String, Float> scoringTokens) {
+    final LSMTreeFullTextIndex first = bucketIndexes.getFirst();
+    first.ensureTypeWideBM25Counters();
+
+    final Map<String, Long> documentFrequencies = new HashMap<>();
+    for (final String token : scoringTokens.keySet()) {
+      long df = 0L;
+      for (final LSMTreeFullTextIndex ftIndex : bucketIndexes) {
+        final IndexCursor postings = ftIndex.getPostings(token);
+        while (postings.hasNext()) {
+          final Identifiable posting = postings.next();
+          if (posting != null && posting.getIdentity().getBucketId() >= 0)
+            ++df;
+        }
+      }
+      documentFrequencies.put(token, df);
+    }
+
+    return new BM25ScoringContext(Math.max(1L, first.getTypeWideDocumentCount()),
+        first.getTypeWideAverageDocumentLength(), documentFrequencies);
+  }
+
+  private static void mergeCursor(final Map<RID, Float> target, final IndexCursor cursor) {
+    while (cursor.hasNext()) {
+      final Identifiable match = cursor.next();
+      if (match != null)
+        target.put(canonicalRID(match.getIdentity()), cursor.getFloatScore());
+    }
+  }
+
+  private static IndexCursor rankedCursor(final Map<RID, Float> scores, final Object[] keys, final int limit) {
+    final List<IndexCursorEntry> entries = new ArrayList<>(scores.size());
+    for (final Map.Entry<RID, Float> score : scores.entrySet())
+      entries.add(new IndexCursorEntry(keys, score.getKey(), score.getValue()));
+
+    entries.sort((left, right) -> {
+      final int scoreComparison = Float.compare(right.floatScore, left.floatScore);
+      return scoreComparison != 0 ? scoreComparison :
+          left.record.getIdentity().compareTo(right.record.getIdentity());
+    });
+    if (limit > -1 && entries.size() > limit)
+      return new TempIndexCursor(entries.subList(0, limit));
+    return new TempIndexCursor(entries);
+  }
+
+  private static RID canonicalRID(final RID rid) {
+    return rid instanceof final FullTextPostingRID posting ?
+        new DatabaseRID(posting.getBoundDatabase(), posting) : rid;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
@@ -38,6 +38,8 @@ import com.arcadedb.serializer.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -47,7 +49,10 @@ import java.util.TreeMap;
  * SEARCH_INDEX SQL function and by callers that need scored results without going through SQL.
  */
 public class FullTextSearch {
-  private static final int MAX_EXPLAIN_TERMS = 64;
+  private static final int      MAX_EXPLAIN_TERMS = 64;
+  // The map-returning search paths expose scores by RID and never read the cursor entry keys, so one shared empty array
+  // stands in for them rather than allocating a throwaway per bucket.
+  private static final Object[] NO_KEYS           = new Object[0];
 
   private FullTextSearch() {
   }
@@ -92,10 +97,12 @@ public class FullTextSearch {
    * normalized to {@code -1}, meaning unbounded; the SQL {@code SEARCH_INDEX} function depends on {@code -1}
    * continuing to mean unbounded.
    * <p>
-   * BM25 searches spanning several buckets first derive type-wide document frequencies and then apply those same statistics to
-   * every bucket. This makes scores globally comparable without adding shared counters to the write path. The limit is still
-   * pushed down after each bucket's candidates are scored; a global top-K is contained in the union of those now-comparable
-   * per-bucket top-K sets, so callers still sort and truncate a union of at most {@code buckets * limit} entries.
+   * BM25 searches spanning several buckets match every bucket first, counting each scoring token's document frequency in the
+   * same posting walk, and then score every bucket against those pooled type-wide statistics. This makes scores globally
+   * comparable without adding shared counters to the write path and without a dedicated document-frequency scan. The limit is
+   * still pushed down after each bucket's candidates are scored; a global top-K is contained in the union of those
+   * now-comparable per-bucket top-K sets, so callers still sort and truncate a union of at most {@code buckets * limit}
+   * entries.
    */
   public static Map<RID, Float> search(final TypeIndex typeIndex, final String queryText, final int limit) {
     final int effectiveLimit = limit < 1 ? -1 : limit;
@@ -118,18 +125,56 @@ public class FullTextSearch {
 
   private static Map<RID, Float> searchBM25(final List<LSMTreeFullTextIndex> bucketIndexes, final String queryText,
       final int limit) {
-    final Map<String, Float> scoringTokens = collectScoringTokens(bucketIndexes, queryText,
-        FullTextQueryExecutor.MAX_EXPANDED_SCORING_TERMS);
-    final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes, scoringTokens);
-    final Map<RID, Float> allResults = new HashMap<>();
+    // Pass one: match each bucket and count every scoring token's document frequency during the same posting walk, so global
+    // statistics cost no extra scan. Matching stays bucket-local, preserving Lucene boolean/phrase/wildcard semantics; only the
+    // corpus statistics are pooled. Both passes are needed because no bucket can be scored until every bucket has reported its
+    // share of each token's document frequency.
+    final List<FullTextQueryExecutor.BM25QueryMatch> matches = new ArrayList<>(bucketIndexes.size());
+    final LinkedHashMap<String, Float> scoringTokens = new LinkedHashMap<>();
+    final Map<String, Long> documentFrequencies = new HashMap<>();
 
     for (final LSMTreeFullTextIndex ftIndex : bucketIndexes) {
       final FullTextQueryExecutor.BM25QueryMatch match = new FullTextQueryExecutor(ftIndex).collectBM25Matches(queryText);
-      final IndexCursor cursor = ftIndex.scoreBM25WithContext(match.candidates(), scoringTokens, new Object[] {}, limit,
-          scoringContext);
-      mergeCursor(allResults, cursor);
+      matches.add(match);
+      for (final Map.Entry<String, Float> token : match.scoringTokens().entrySet())
+        scoringTokens.merge(token.getKey(), token.getValue(), Math::max);
+      // Each bucket reports only the tokens it holds postings for, and a wildcard is expanded against every bucket's own key
+      // range, so summing the per-bucket counts yields the type-wide document frequency.
+      for (final Map.Entry<String, Long> frequency : match.documentFrequencies().entrySet())
+        documentFrequencies.merge(frequency.getKey(), frequency.getValue(), Long::sum);
     }
+
+    capScoringTokens(scoringTokens, documentFrequencies, FullTextQueryExecutor.MAX_EXPANDED_SCORING_TERMS);
+
+    // Pass two: every bucket scores against the same corpus statistics, which is what makes the scores globally comparable.
+    final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes, documentFrequencies);
+    final Map<RID, Float> allResults = new HashMap<>();
+    for (int i = 0; i < bucketIndexes.size(); i++)
+      mergeCursor(allResults, bucketIndexes.get(i)
+          .scoreBM25WithContext(matches.get(i).candidates(), scoringTokens, NO_KEYS, limit, scoringContext));
+
     return allResults;
+  }
+
+  /**
+   * Bounds the union of the per-bucket scoring tokens exactly as a single bucket's own cap does: keep the first
+   * {@code maxTerms} discovered and drop the rest, so a pathological wildcard expansion cannot grow the scoring pass without
+   * limit. Matching already happened, so the result set is unaffected - dropped terms simply stop contributing score. Their
+   * document frequencies are dropped too, keeping the context free of statistics it will never consult.
+   */
+  private static void capScoringTokens(final LinkedHashMap<String, Float> scoringTokens,
+      final Map<String, Long> documentFrequencies, final int maxTerms) {
+    if (scoringTokens.size() <= maxTerms)
+      return;
+
+    final Iterator<Map.Entry<String, Float>> tokens = scoringTokens.entrySet().iterator();
+    for (int kept = 0; tokens.hasNext(); kept++) {
+      final Map.Entry<String, Float> token = tokens.next();
+      if (kept >= maxTerms) {
+        documentFrequencies.remove(token.getKey());
+        tokens.remove();
+      }
+    }
   }
 
   /**
@@ -145,7 +190,8 @@ public class FullTextSearch {
 
     final int effectiveLimit = limit < 1 ? -1 : limit;
     final Map<String, Float> scoringTokens = bucketIndexes.getFirst().getSimpleQueryTokenBoosts(keys);
-    final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes, scoringTokens);
+    final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes,
+        scanDocumentFrequencies(bucketIndexes, scoringTokens));
     final Map<RID, Float> allResults = new HashMap<>();
     for (final LSMTreeFullTextIndex ftIndex : bucketIndexes)
       mergeCursor(allResults,
@@ -166,7 +212,8 @@ public class FullTextSearch {
     final Map<String, Float> allTokens = collectScoringTokens(bucketIndexes, queryText,
         FullTextQueryExecutor.MAX_EXPANDED_SCORING_TERMS);
     final Map<String, Float> shownTokens = firstTokens(allTokens, MAX_EXPLAIN_TERMS);
-    final BM25ScoringContext context = createScoringContext(bucketIndexes, shownTokens);
+    final BM25ScoringContext context = createScoringContext(bucketIndexes,
+        scanDocumentFrequencies(bucketIndexes, shownTokens));
     final FullTextIndexMetadata metadata = bucketIndexes.getFirst().getFullTextMetadata();
 
     final JSONObject explain = new JSONObject()
@@ -233,10 +280,24 @@ public class FullTextSearch {
   }
 
   private static BM25ScoringContext createScoringContext(final List<LSMTreeFullTextIndex> bucketIndexes,
-      final Map<String, Float> scoringTokens) {
+      final Map<String, Long> documentFrequencies) {
     final LSMTreeFullTextIndex first = bucketIndexes.getFirst();
     first.ensureTypeWideBM25Counters();
 
+    // Both counters are clamped to the neutral values BM25 uses when no statistics are available. A type whose indexed
+    // properties analyze to no tokens counts every document but sums a zero length, leaving a zero average that would
+    // otherwise be rejected by BM25ScoringContext; length normalization is meaningless for such a corpus anyway.
+    return new BM25ScoringContext(Math.max(1L, first.getTypeWideDocumentCount()),
+        Math.max(1.0, first.getTypeWideAverageDocumentLength()), documentFrequencies);
+  }
+
+  /**
+   * Counts type-wide document frequencies with a dedicated posting scan, one scan per token per bucket. Used by the entry
+   * points that have no matching pass to fold the counting into: the literal {@link #searchSimple} lookup, whose scoring pass
+   * visits only the tokens it was handed, and {@link #explainScoring}.
+   */
+  private static Map<String, Long> scanDocumentFrequencies(final List<LSMTreeFullTextIndex> bucketIndexes,
+      final Map<String, Float> scoringTokens) {
     final Map<String, Long> documentFrequencies = new HashMap<>();
     for (final String token : scoringTokens.keySet()) {
       long df = 0L;
@@ -250,9 +311,7 @@ public class FullTextSearch {
       }
       documentFrequencies.put(token, df);
     }
-
-    return new BM25ScoringContext(Math.max(1L, first.getTypeWideDocumentCount()),
-        first.getTypeWideAverageDocumentLength(), documentFrequencies);
+    return documentFrequencies;
   }
 
   private static void mergeCursor(final Map<RID, Float> target, final IndexCursor cursor) {

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -311,9 +311,18 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * @param candidates  documents to score, or {@code null} to score every matching document
    */
   private Map<RID, double[]> computeBM25Scores(final Map<String, Float> tokenBoosts, final Set<RID> candidates) {
+    return computeBM25Scores(tokenBoosts, candidates, null);
+  }
+
+  /**
+   * Scores this bucket's candidates with either bucket-local statistics ({@code scoringContext == null}) or one type-wide
+   * context supplied by {@link FullTextSearch}. The latter keeps scores comparable when a logical type spans several buckets.
+   */
+  private Map<RID, double[]> computeBM25Scores(final Map<String, Float> tokenBoosts, final Set<RID> candidates,
+      final BM25ScoringContext scoringContext) {
     ensureCounters();
-    final long totalDocs = resolveTotalDocs();
-    final double avgdl = resolveAvgDocLength();
+    final long totalDocs = scoringContext != null ? scoringContext.totalDocs() : resolveTotalDocs();
+    final double avgdl = scoringContext != null ? scoringContext.avgDocLength() : resolveAvgDocLength();
     final double k1 = ftMetadata.getBm25K1();
     final double b = ftMetadata.getBm25B();
 
@@ -337,8 +346,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       final float boost = e.getValue();
 
       if (candidates != null) {
-        // Single pass: count df while collecting only the candidate postings (bounded by the candidate set).
-        long df = 0L;
+        // Single pass over this bucket: collect only candidate postings. For a leaf-index query, count df locally; for a
+        // type-wide query, FullTextSearch already counted df across every bucket and supplied it in the scoring context.
+        long df = scoringContext != null ? scoringContext.documentFrequency(e.getKey()) : 0L;
         hits.clear();
         final IndexCursor cursor = underlyingIndex.get(storedKey);
         while (cursor.hasNext()) {
@@ -346,7 +356,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
           // Skip deletion markers (negative bucket id): they are not live documents and must not inflate the document frequency.
           if (id.getIdentity().getBucketId() < 0)
             continue;
-          ++df;
+          if (scoringContext == null)
+            ++df;
           if (id instanceof FullTextPostingRID s && scoreMap.containsKey(s.getIdentity()))
             hits.add(s);
         }
@@ -356,12 +367,15 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         for (final FullTextPostingRID s : hits)
           scoreMap.get(s.getIdentity())[0] += BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost;
       } else {
-        // No candidate filter: count df first (streaming, no retention), then accumulate every matching document.
-        long df = 0L;
-        final IndexCursor dfCursor = underlyingIndex.get(storedKey);
-        while (dfCursor.hasNext()) {
-          if (dfCursor.next().getIdentity().getBucketId() >= 0) // skip deletion markers
-            ++df;
+        // No candidate filter: a leaf-index query counts df locally with a streaming first pass. A type-wide coordinator has
+        // already counted global df, so it goes straight to the scoring pass over this bucket.
+        long df = scoringContext != null ? scoringContext.documentFrequency(e.getKey()) : 0L;
+        if (scoringContext == null) {
+          final IndexCursor dfCursor = underlyingIndex.get(storedKey);
+          while (dfCursor.hasNext()) {
+            if (dfCursor.next().getIdentity().getBucketId() >= 0) // skip deletion markers
+              ++df;
+          }
         }
         if (df == 0L)
           continue;
@@ -400,6 +414,23 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * {@code SEARCH_INDEX} path is single-pass; prefer it for large or many-term queries.
    */
   private IndexCursor getBM25(final Object[] keys, final int limit) {
+    final Map<String, Float> tokenBoosts = getSimpleQueryTokenBoosts(keys);
+
+    // The no-candidate path streams each token's postings twice (df + accumulate). Log at FINE for a multi-term query so an
+    // operator debugging a slow direct get() can see it doing 2*T scans and switch to SEARCH_INDEX. FINE keeps normal runs quiet.
+    if (tokenBoosts.size() > 1)
+      LogManager.instance().log(this, Level.FINE,
+          "Full-text get() scoring %d terms on index '%s' with two posting scans each; use SEARCH_INDEX(...) for a single-pass scan.",
+          null, tokenBoosts.size(), getName());
+
+    return buildScoredCursor(computeBM25Scores(tokenBoosts, null), keys, limit);
+  }
+
+  /**
+   * Analyzes the direct {@link #get} query into stored-key tokens without applying Lucene query syntax. Package-private so the
+   * logical {@link TypeIndex} can score the same literal query with type-wide statistics across all bucket indexes.
+   */
+  Map<String, Float> getSimpleQueryTokenBoosts(final Object[] keys) {
     final String queryText = keys.length > 0 && keys[0] != null ? keys[0].toString() : "";
     // The direct path does not parse Lucene syntax; a caret boost here is silently treated as part of the token and matches
     // nothing. Log at FINE so this surfaces when debugging an unexpected empty result, without spamming normal queries.
@@ -419,15 +450,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         tokenBoosts.merge(storedKey, boost, Math::max);
       }
     }
-
-    // The no-candidate path streams each token's postings twice (df + accumulate). Log at FINE for a multi-term query so an
-    // operator debugging a slow direct get() can see it doing 2*T scans and switch to SEARCH_INDEX. FINE keeps normal runs quiet.
-    if (tokenBoosts.size() > 1)
-      LogManager.instance().log(this, Level.FINE,
-          "Full-text get() scoring %d terms on index '%s' with two posting scans each; use SEARCH_INDEX(...) for a single-pass scan.",
-          null, tokenBoosts.size(), getName());
-
-    return buildScoredCursor(computeBM25Scores(tokenBoosts, null), keys, limit);
+    return tokenBoosts;
   }
 
   /**
@@ -505,6 +528,15 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
+   * Scores this bucket with corpus statistics already aggregated by {@link FullTextSearch}. A null candidate set means every
+   * posting matching the scoring tokens is eligible, which is the direct TypeIndex.get() path.
+   */
+  IndexCursor scoreBM25WithContext(final Set<RID> candidates, final Map<String, Float> tokenBoosts, final Object[] keys,
+      final int limit, final BM25ScoringContext scoringContext) {
+    return buildScoredCursor(computeBM25Scores(tokenBoosts, candidates, scoringContext), keys, limit);
+  }
+
+  /**
    * Returns the raw postings for an already-resolved stored key (RID-only, no BM25 scoring and no re-analysis), used by
    * {@link FullTextQueryExecutor} to collect candidate documents cheaply before scoring them once via
    * {@link #scoreCandidatesBM25}. Going through {@link #get} here would run the full scoring pipeline only to discard the scores.
@@ -514,6 +546,21 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   IndexCursor getPostings(final String storedKey) {
     return underlyingIndex.get(new String[] { storedKey });
+  }
+
+  /**
+   * Makes the shared type-wide counters trustworthy before a coordinator reads them.
+   */
+  void ensureTypeWideBM25Counters() {
+    ensureCounters();
+  }
+
+  long getTypeWideDocumentCount() {
+    return ftMetadata != null ? ftMetadata.getTotalDocs() : 0L;
+  }
+
+  double getTypeWideAverageDocumentLength() {
+    return resolveAvgDocLength();
   }
 
   /**
@@ -539,12 +586,12 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     json.put("b", ftMetadata.getBm25B());
     json.put("totalDocs", totalDocs);
     json.put("avgDocLength", avgdl);
-    // BM25 is scored per bucket (per-shard): these statistics are this bucket's, so a multi-bucket type's other buckets may have
-    // different df/IDF. Report the bucket and make the per-bucket nature explicit so the explained IDF is not mistaken for global.
+    // This leaf-index explanation is bucket-local. SQL EXPLAIN/PROFILE routes through FullTextSearch and reports type-wide
+    // statistics; retain the local scope here for callers deliberately addressing a bucket index directly.
     final Bucket bucket = associatedBucket();
     if (bucket != null)
       json.put("bucket", bucket.getName());
-    json.put("note", "statistics are per bucket (BM25 is scored per bucket); totalDocs is this bucket's document count");
+    json.put("note", "bucket-level index statistics; use the logical TypeIndex for globally comparable BM25 scores");
 
     // One posting scan per scoring token to derive df. EXPLAIN/PROFILE is an interactive diagnostic, not a hot path, but cap the
     // number of explained terms so a pathological wildcard/fuzzy expansion (which can explode into thousands of tokens) cannot
@@ -575,11 +622,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * BM25 is scored per bucket (per-shard, like Elasticsearch/Lucene): each bucket-level full-text index ranks its own documents
-   * using the document frequency read from its own postings. To keep the IDF unbiased, N must be measured at the same scope as
-   * df, i.e. this bucket - so N is the bucket's live record count. (The corpus counters in {@link FullTextIndexMetadata} are
-   * SHARED type-wide across all of the type's bucket indexes - the same metadata object is passed to each - so they are used only
-   * for the average document length, a length normalizer for which a type-wide value is an appropriate estimate.)
+   * Returns N for a bucket-level lookup. The logical {@link TypeIndex}/{@link FullTextSearch} path supplies type-wide N and df
+   * through {@link BM25ScoringContext}; a caller deliberately addressing this leaf index instead keeps both values scoped to this
+   * bucket. The shared type-wide counters still provide the average document length.
    */
   private long resolveTotalDocs() {
     final long count = associatedBucketCount();
@@ -644,9 +689,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       final String typeName = getTypeName();
       if (typeName != null) {
         // Both sides are TYPE-WIDE: getTotalDocs() is the shared counter accumulated across every bucket index (they share this
-        // metadata instance), and countType() is the type's live record count - so this comparison is scope-consistent and does
-        // NOT spuriously rescan multi-bucket types. (This counter feeds avgdl only; IDF's N is the per-bucket count from
-        // resolveTotalDocs(), a deliberately different scope - see that method.)
+        // metadata instance), and countType() is the type's live record count. The logical TypeIndex search uses this count for
+        // global IDF as well as avgdl; a direct bucket-level lookup uses resolveTotalDocs() instead.
         final long liveCount = underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);
         final long persisted = ftMetadata.getTotalDocs();
         if (liveCount != persisted) {
@@ -684,10 +728,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * Scans the whole type and rebuilds the shared corpus counters used for the average document length. The counters are type-wide
-   * because the {@link FullTextIndexMetadata} instance is shared by all of the type's bucket indexes; scanning a single bucket
-   * would corrupt them. When {@code persist} is true the schema is saved so the counters survive a restart; the lazy read-path
-   * caller passes false to avoid saving the schema during a query.
+   * Scans the whole type and rebuilds the shared corpus counters used for global N and average document length. The counters are
+   * type-wide because the {@link FullTextIndexMetadata} instance is shared by all bucket indexes; scanning a single bucket would
+   * corrupt them. When {@code persist} is true the schema is saved so the counters survive a restart; the lazy read-path caller
+   * passes false to avoid saving the schema during a query.
    */
   private void computeCorpusCounters(final boolean persist) {
     if (ftMetadata == null)

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -87,9 +87,10 @@ public class FullTextIndexMetadata extends IndexMetadata {
   private float              bm25B       = DEFAULT_BM25_B;
   private final Map<String, Float> fieldBoosts = new ConcurrentHashMap<>();
 
-  // PERSISTED CORPUS STATISTICS FOR avgdl (live document count and sum of document lengths).
-  // NOTE (concurrency): concurrent transactions can index documents into the same bucket simultaneously, all mutating this
-  // shared per-bucket metadata, so the counters are AtomicLong (and countersValid is volatile) - bare longs would lose updates.
+  // PERSISTED TYPE-WIDE CORPUS STATISTICS (live document count and sum of document lengths).
+  // NOTE (concurrency): every bucket index of a logical TypeIndex shares this metadata instance, so concurrent transactions can
+  // update it from different buckets. The counters are AtomicLong (and countersValid is volatile) so bare longs cannot lose
+  // updates.
   private final AtomicLong totalDocs     = new AtomicLong(0L);
   private final AtomicLong sumDocLength  = new AtomicLong(0L);
   private volatile boolean countersValid = false;
@@ -537,12 +538,10 @@ public class FullTextIndexMetadata extends IndexMetadata {
   /**
    * Returns the average document length across the collection, or 1.0 when no statistics are available.
    * <p>
-   * SCOPE (intentional, do not "fix" without understanding): these counters are TYPE-WIDE (this metadata instance is shared by
-   * every bucket index of the type), so avgdl is type-wide - whereas BM25's {@code N} and {@code df} are measured PER BUCKET (see
-   * {@code LSMTreeFullTextIndex.resolveTotalDocs}). The mismatch is deliberate: per-bucket {@code df} requires a per-bucket
-   * {@code N} for an unbiased IDF, while avgdl is only a length normalizer for which a type-wide value is a fine estimate and
-   * avoids per-bucket length bookkeeping. For a multi-bucket type with very unequal bucket sizes, length normalization is
-   * therefore slightly biased - a cosmetic inaccuracy, not a correctness bug.
+   * SCOPE: these counters are TYPE-WIDE because every bucket index of the logical type shares this metadata instance.
+   * {@code FullTextSearch} combines them with type-wide document frequencies so scores from different buckets are comparable.
+   * A caller addressing one bucket-level index directly still uses that bucket's local N/df with this type-wide average as a
+   * length-normalization estimate; cross-bucket callers should use the logical {@code TypeIndex} or {@code FullTextSearch}.
    * <p>
    * The two counters are read independently (no shared lock). This method reads {@code totalDocs} first, then {@code sumDocLength};
    * combined with the write ordering in {@link #addDocument}/{@link #removeDocument} (which publish via {@code totalDocs}), the

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -157,25 +157,82 @@ class FullTextBM25Test extends TestHelper {
   @Test
   void bm25RankingHoldsAcrossMultipleBuckets() {
     database.transaction(() -> {
-      // Multiple buckets: BM25 is scored per bucket, so N (doc count) and df must both be per-bucket to keep IDF unbiased.
-      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 4");
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 2");
       database.command("sql", "CREATE PROPERTY Doc.name STRING");
       database.command("sql", "CREATE PROPERTY Doc.content STRING");
       database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
 
-      database.command("sql", "INSERT INTO Doc SET name = 'rare', content = 'quantum data analysis'");
-      for (int i = 0; i < 40; i++)
-        database.command("sql", "INSERT INTO Doc SET name = 'common" + i + "', content = 'data record number " + i + "'");
+      // Inserts alternate between the two buckets. Bucket 0 receives ten documents matching both query terms, while bucket 1
+      // receives one document matching only "alpha" plus nine non-matches. With bucket-local statistics, the one-term match gets
+      // a very high local IDF for alpha and incorrectly outranks every two-term match from bucket 0. Type-wide statistics make
+      // alpha common across the corpus and restore the expected two-term > one-term ordering.
+      for (int i = 0; i < 20; i++) {
+        final String name;
+        final String content;
+        if (i == 0) {
+          name = "twoTerms";
+          content = "alpha beta apple";
+        } else if (i == 1) {
+          name = "oneTerm";
+          content = "alpha filler apricot";
+        } else if (i % 2 == 0) {
+          name = "twoTerms" + i;
+          content = "alpha beta apple";
+        } else {
+          name = "noise" + i;
+          content = "noise filler filler";
+        }
+        database.command("sql", "INSERT INTO Doc SET name = ?, content = ?", name, content);
+      }
     });
 
     database.transaction(() -> {
-      final Map<String, Float> scores = searchScores("Doc[content]", "quantum data");
-      assertThat(scores.get("rare")).isNotNull();
-      // The document with the rare, discriminative term must rank above every common-only document, regardless of which bucket
-      // each landed in.
-      for (final Map.Entry<String, Float> e : scores.entrySet())
-        if (!"rare".equals(e.getKey()))
-          assertThat(scores.get("rare")).isGreaterThan(e.getValue());
+      final ResultSet records = database.query("sql", "SELECT FROM Doc WHERE name IN ['twoTerms', 'oneTerm']");
+      final Map<String, Integer> buckets = new HashMap<>();
+      while (records.hasNext()) {
+        final Result record = records.next();
+        buckets.put(record.getProperty("name"), record.getIdentity().orElseThrow().getBucketId());
+      }
+      assertThat(buckets.get("twoTerms")).isNotEqualTo(buckets.get("oneTerm"));
+
+      final Map<String, Float> scores = searchScores("Doc[content]", "alpha beta");
+      assertThat(scores).containsKeys("twoTerms", "oneTerm");
+      assertThat(scores.get("twoTerms")).isGreaterThan(scores.get("oneTerm"));
+
+      // Wildcard terms differ by bucket ("apple" vs "apricot"). Both must be included in the global scoring-token union, while
+      // Boolean matching remains document-local rather than combining terms found in different buckets.
+      final Map<String, Float> wildcardScores = searchScores("Doc[content]", "ap*");
+      assertThat(wildcardScores.get("twoTerms")).isPositive();
+      assertThat(wildcardScores.get("oneTerm")).isPositive();
+      assertThat(searchScores("Doc[content]", "+apple +apricot")).isEmpty();
+
+      final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+      final Map<String, Float> directScores = new HashMap<>();
+      final IndexCursor direct = typeIndex.get(new Object[] { "alpha beta" });
+      while (direct.hasNext()) {
+        final Document document = (Document) direct.next().getRecord();
+        directScores.put(document.getString("name"), direct.getFloatScore());
+      }
+      assertThat(directScores.get("twoTerms")).isGreaterThan(directScores.get("oneTerm"));
+
+      final Map<String, Float> fieldScores = new HashMap<>();
+      final ResultSet fields = database.query("sql",
+          "SELECT name, $score FROM Doc WHERE SEARCH_FIELDS(['content'], 'alpha beta') = true");
+      while (fields.hasNext()) {
+        final Result result = fields.next();
+        fieldScores.put(result.getProperty("name"), ((Number) result.getProperty("$score")).floatValue());
+      }
+      assertThat(fieldScores.get("twoTerms")).isGreaterThan(fieldScores.get("oneTerm"));
+
+      final ResultSet explain = database.query("sql",
+          "EXPLAIN SELECT name FROM Doc WHERE SEARCH_INDEX('Doc[content]', 'alpha beta') = true");
+      final String plan = explain.next().getProperty("executionPlanAsString");
+      assertThat(plan)
+          .contains("\"corpusScope\":\"type\"")
+          .contains("\"bucketCount\":2")
+          .contains("\"totalDocs\":20")
+          .contains("\"df\":11")
+          .doesNotContain("scored per bucket");
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -236,6 +236,93 @@ class FullTextBM25Test extends TestHelper {
     });
   }
 
+  /**
+   * {@code SEARCH_INDEX} counts document frequencies while it matches, whereas the literal {@code TypeIndex.get()} lookup
+   * derives them with a dedicated posting scan. For a single literal term the two derivations describe the same corpus, so
+   * they must produce byte-identical scores; a drift here means one of the two counting paths is wrong.
+   */
+  @Test
+  void matchTimeAndScanDerivedDocumentFrequenciesAgree() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 3");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+
+      for (int i = 0; i < 15; i++)
+        database.command("sql", "INSERT INTO Doc SET name = ?, content = ?", "d" + i,
+            i % 3 == 0 ? "alpha beta gamma" : "alpha delta");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> searched = searchScores("Doc[content]", "alpha");
+
+      final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+      final Map<String, Float> direct = new HashMap<>();
+      final IndexCursor cursor = typeIndex.get(new Object[] { "alpha" });
+      while (cursor.hasNext()) {
+        final Document document = (Document) cursor.next().getRecord();
+        direct.put(document.getString("name"), cursor.getFloatScore());
+      }
+
+      assertThat(searched).hasSize(15);
+      assertThat(direct.keySet()).isEqualTo(searched.keySet());
+      for (final Map.Entry<String, Float> entry : searched.entrySet())
+        assertThat(direct.get(entry.getKey())).isEqualTo(entry.getValue());
+    });
+  }
+
+  /**
+   * A type whose indexed properties analyze to no tokens at all still counts every document in the corpus counters, so
+   * totalDocs is positive while the summed document length stays zero and the average document length is 0. Scoring must
+   * degrade to an empty result set rather than rejecting the corpus statistics.
+   */
+  @Test
+  void tokenlessCorpusReturnsNoMatchesInsteadOfFailing() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 2");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+
+      for (int i = 0; i < 4; i++)
+        database.command("sql", "INSERT INTO Doc SET name = 'n" + i + "', content = ''");
+    });
+
+    database.transaction(() -> {
+      assertThat(searchScores("Doc[content]", "quantum")).isEmpty();
+
+      final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+      assertThat(typeIndex.get(new Object[] { "quantum" }).hasNext()).isFalse();
+
+      final ResultSet containsText = database.query("sql", "SELECT name FROM Doc WHERE content CONTAINSTEXT 'quantum'");
+      assertThat(containsText.hasNext()).isFalse();
+    });
+  }
+
+  /**
+   * The direct {@code TypeIndex.get()} path scores with type-wide statistics at every bucket count, so the tokenless corpus
+   * must degrade the same way on a single-bucket type.
+   */
+  @Test
+  void tokenlessSingleBucketCorpusReturnsNoMatchesInsteadOfFailing() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 1");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+
+      for (int i = 0; i < 4; i++)
+        database.command("sql", "INSERT INTO Doc SET name = 'n" + i + "', content = ''");
+    });
+
+    database.transaction(() -> {
+      final ResultSet containsText = database.query("sql", "SELECT name FROM Doc WHERE content CONTAINSTEXT 'quantum'");
+      assertThat(containsText.hasNext()).isFalse();
+      assertThat(searchScores("Doc[content]", "quantum")).isEmpty();
+    });
+  }
+
   private void recomputeCounters() {
     final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
     for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -65,9 +65,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
       return;
 
     db.transaction(() -> {
-      // A single bucket keeps BM25 statistics (document frequency, average document length) computed over one
-      // consistent corpus; the index scores per bucket, so a multi-bucket type could otherwise let term frequency
-      // lose to a per-bucket IDF difference and make the ranking assertions flaky.
+      // Keep this MCP fixture on one bucket; the engine's explicit multi-bucket BM25 regression covers global score comparability.
       db.command("sql", "CREATE DOCUMENT TYPE Article BUCKETS 1");
       db.command("sql", "CREATE PROPERTY Article.title STRING");
       db.command("sql", "CREATE PROPERTY Article.content STRING");


### PR DESCRIPTION
## Summary

- compute Best Matching 25 (BM25) document frequencies once across every bucket behind a logical full-text type index
- preserve bucket-local Lucene matching semantics, then rescore candidates with one type-wide corpus context
- apply globally comparable scores to `SEARCH_INDEX`, `SEARCH_FIELDS`, and logical `TypeIndex.get()` lookups
- report type-wide BM25 statistics through SQL `EXPLAIN`/`PROFILE`
- preserve the existing single-bucket path and avoid persisted-format or write-path changes

## Correctness

The regression reproduces the issue with two equal-sized buckets and equal-length documents. Before this change, a one-term match from a bucket where that term was locally rare scored `1.9924302`, while a two-term match from the other bucket scored only `0.093040034`. With type-wide N and document frequencies, the two-term document ranks correctly.

The same regression also verifies bucket-specific wildcard expansions are unioned for global scoring, while Boolean matching remains document-local.

## Performance

Multi-bucket BM25 queries now pay a read-time token-discovery/document-frequency pass before bucket-local candidate scoring. This deliberately trades additional read work for correct cross-bucket ranking without shared write counters or synchronization. Single-bucket queries retain the prior direct path.

## Validation

- 220 focused engine full-text tests: passed
- 14 focused server MCP full-text tests: passed
- `FullTextBM25Test` after the wildcard/Boolean regression extension: 30 passed
- full engine suite not run

Closes #5267