### PR TITLE
feat(mcp): scope permissions per database

### DIFF
--- a/docs/superpowers/specs/2026-07-24-mcp-database-scoping-4868-design.md
+++ b/docs/superpowers/specs/2026-07-24-mcp-database-scoping-4868-design.md
@@ -1,0 +1,104 @@
+# MCP per-database configuration scoping (#4868)
+
+**Issue:** [#4868](https://github.com/ArcadeData/arcadedb/issues/4868)
+**Epic:** [#4859 - MCP GraphRAG & Agent-Memory Surface](https://github.com/ArcadeData/arcadedb/issues/4859)
+**Date:** 2026-07-24
+**Status:** implemented
+
+## Decision
+
+Database overrides are restrictions on the server-global Model Context Protocol (MCP)
+configuration. The global configuration is a hard permission ceiling:
+
+- A local `false` denies an operation allowed globally.
+- A local `true` cannot grant an operation denied globally.
+- A local `allowedUsers` entry must also pass the global `allowedUsers` list.
+- An omitted local field inherits the corresponding global value.
+- A database with no override retains the existing global behavior.
+
+This is the conservative choice for a server-wide endpoint. A root administrator can reason
+about the global settings as the maximum authority the endpoint can ever exercise, and adding
+an override cannot accidentally widen that authority.
+
+## Configuration
+
+Overrides live under `databases` in `config/mcp-config.json`:
+
+```json
+{
+  "enabled": true,
+  "allowReads": true,
+  "allowInsert": true,
+  "allowUpdate": true,
+  "allowDelete": false,
+  "allowSchemaChange": false,
+  "allowAdmin": false,
+  "allowedUsers": ["root", "tenant-agent"],
+  "databases": {
+    "tenant_graph": {
+      "allowInsert": false,
+      "allowUpdate": false,
+      "allowedUsers": ["tenant-agent"]
+    }
+  }
+}
+```
+
+For `tenant_graph`, the example permits reads to `tenant-agent` but denies writes. `root`
+remains globally authorized but is excluded by the database allowlist. Other databases inherit
+the global policy.
+
+The supported override fields are:
+
+- `allowReads`
+- `allowInsert`
+- `allowUpdate`
+- `allowDelete`
+- `allowSchemaChange`
+- `allowAdmin`
+- `allowedUsers`
+
+Unknown override fields are rejected so a misspelled security setting cannot silently inherit a
+more permissive global value. An explicit `allowedUsers: null` is an empty local allowlist,
+matching the existing global configuration behavior. API token names retain the existing bare
+token matching behavior.
+
+## Enforcement
+
+`MCPConfiguration.getPermissionsForDatabase()` returns one immutable effective-permission
+snapshot. Database-targeted tools resolve that snapshot together with the authenticated
+database:
+
+- `get_schema`
+- `query`
+- `execute_command`
+- `full_text_search`
+- `upsert_entity`
+- `upsert_relationship`
+
+Database discovery in `list_databases`, `server_status`, and schema resources omits databases
+whose effective policy denies the user or read access. ArcadeDB's native database authorization
+remains an independent required check; MCP configuration does not replace it.
+
+Future database-targeted tools must use the same resolver so they cannot bypass database-local
+read, write, or user restrictions.
+
+Tools without a database argument remain server-global and continue to use only global
+permissions: profiler controls, server settings, and server-level status details. Per-database
+`allowAdmin` still applies when `execute_command` analyzes a database command as an
+administrative operation.
+
+## Out of scope
+
+- No `/mcp/{database}` HTTP route is added. A database-bound endpoint needs a separate design
+  for transport configuration, discovery, initialization, and tool-list behavior.
+- Tool profiles and browser-origin controls remain server-global because the current endpoint
+  advertises one tool surface and has one HTTP origin policy.
+- Overrides do not grant authority above the global ceiling.
+
+## Validation
+
+Focused tests cover persistence, inheritance, stricter overrides, attempted grants above the
+global ceiling, user restrictions, API-token matching, invalid settings, all database read
+surfaces, command/upsert writes, resource discovery, database listing, and server-status
+filtering.

--- a/docs/superpowers/specs/2026-07-24-mcp-database-scoping-4868-design.md
+++ b/docs/superpowers/specs/2026-07-24-mcp-database-scoping-4868-design.md
@@ -63,6 +63,13 @@ more permissive global value. An explicit `allowedUsers: null` is an empty local
 matching the existing global configuration behavior. API token names retain the existing bare
 token matching behavior.
 
+Configuration API updates merge the `databases` object by database name: an update to one
+database leaves other overrides intact. A supplied database object replaces that database's
+override, an explicit null value removes that one override, and `"databases": null` clears all
+database overrides. The serialized configuration omits `databases` when no overrides exist.
+At startup, an override whose database is not currently loaded produces a warning but remains
+valid so it can apply if the database is created later.
+
 ## Enforcement
 
 `MCPConfiguration.getPermissionsForDatabase()` returns one immutable effective-permission
@@ -80,8 +87,9 @@ Database discovery in `list_databases`, `server_status`, and schema resources om
 whose effective policy denies the user or read access. ArcadeDB's native database authorization
 remains an independent required check; MCP configuration does not replace it.
 
-Future database-targeted tools must use the same resolver so they cannot bypass database-local
-read, write, or user restrictions.
+Future database-targeted tools must use the same resolver and explicitly select `READ` or
+`ACCESS` as their required access. There is no default resolver mode, so a new read tool cannot
+silently bypass database-local read restrictions.
 
 Tools without a database argument remain server-global and continue to use only global
 permissions: profiler controls, server settings, and server-level status details. Per-database

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -312,6 +312,7 @@ public class ArcadeDBServer {
     // INITIALIZE MCP CONFIGURATION (always available, disabled by default)
     mcpConfiguration = new MCPConfiguration(serverRootPath);
     mcpConfiguration.load();
+    mcpConfiguration.warnUnknownDatabaseOverrides(getDatabaseNames());
 
     // INITIALIZE AI CONFIGURATION (always available, inactive until subscription token is set)
     aiConfiguration = new AiConfiguration(serverRootPath);

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -30,14 +30,20 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public class MCPConfiguration {
+public class MCPConfiguration implements MCPPermissions {
+  private static final Set<String> DATABASE_OVERRIDE_KEYS = Set.of(
+      "allowReads", "allowInsert", "allowUpdate", "allowDelete", "allowSchemaChange", "allowAdmin", "allowedUsers");
+
   private final String rootPath;
 
   private volatile boolean      enabled          = false;
@@ -48,6 +54,7 @@ public class MCPConfiguration {
   private volatile boolean      allowSchemaChange = false;
   private volatile boolean      allowAdmin        = false;
   private volatile List<String> allowedUsers     = new CopyOnWriteArrayList<>(List.of("root"));
+  private volatile Map<String, DatabaseOverride> databaseOverrides = Map.of();
   // Extra browser origins accepted by the HTTP transport, on top of always-allowed loopback origins.
   // Empty by default: a non-loopback browser page must be opted in explicitly, because deriving trust
   // from its Host header would not prevent DNS rebinding.
@@ -67,6 +74,8 @@ public class MCPConfiguration {
     try {
       final String content = new String(Files.readAllBytes(configFile.toPath()), StandardCharsets.UTF_8);
       final JSONObject json = new JSONObject(content);
+      final Map<String, DatabaseOverride> loadedDatabaseOverrides =
+          parseDatabaseOverrides(json.getJSONObject("databases", null));
 
       enabled = json.getBoolean("enabled", false);
       allowReads = json.getBoolean("allowReads", true);
@@ -75,6 +84,7 @@ public class MCPConfiguration {
       allowDelete = json.getBoolean("allowDelete", false);
       allowSchemaChange = json.getBoolean("allowSchemaChange", false);
       allowAdmin = json.getBoolean("allowAdmin", false);
+      databaseOverrides = loadedDatabaseOverrides;
 
       final JSONArray usersArray = json.getJSONArray("allowedUsers", null);
       if (usersArray != null) {
@@ -203,15 +213,25 @@ public class MCPConfiguration {
    * also matches the bare token name against the allowed list.
    */
   public boolean isUserAllowed(final String username) {
-    if (username == null)
-      return false;
-    if (allowedUsers.contains("*") || allowedUsers.contains(username))
-      return true;
-    // API token users have synthetic names like "apitoken:<tokenName>".
-    // Allow matching by the bare token name so users don't need to know the internal prefix.
-    if (username.startsWith("apitoken:"))
-      return allowedUsers.contains(username.substring("apitoken:".length()));
-    return false;
+    return matchesUser(allowedUsers, username);
+  }
+
+  /**
+   * Returns an immutable permission snapshot for one database. Database values are restrictions on the global
+   * configuration: a local {@code true} cannot enable an operation denied globally, and local users must also pass
+   * the global user allowlist. An absent override inherits every global setting.
+   */
+  public synchronized MCPPermissions getPermissionsForDatabase(final String databaseName) {
+    final DatabaseOverride override = databaseOverrides.get(databaseName);
+    return new EffectivePermissions(
+        allowReads && valueOrTrue(override != null ? override.allowReads : null),
+        allowInsert && valueOrTrue(override != null ? override.allowInsert : null),
+        allowUpdate && valueOrTrue(override != null ? override.allowUpdate : null),
+        allowDelete && valueOrTrue(override != null ? override.allowDelete : null),
+        allowSchemaChange && valueOrTrue(override != null ? override.allowSchemaChange : null),
+        allowAdmin && valueOrTrue(override != null ? override.allowAdmin : null),
+        List.copyOf(allowedUsers),
+        override != null && override.allowedUsers != null ? List.copyOf(override.allowedUsers) : null);
   }
 
   public synchronized JSONObject toJSON() {
@@ -225,10 +245,18 @@ public class MCPConfiguration {
     json.put("allowAdmin", allowAdmin);
     json.put("allowedUsers", new JSONArray(allowedUsers));
     json.put("allowedOrigins", new JSONArray(allowedOrigins));
+    final JSONObject databases = new JSONObject();
+    for (final Map.Entry<String, DatabaseOverride> entry : databaseOverrides.entrySet())
+      databases.put(entry.getKey(), entry.getValue().toJSON());
+    json.put("databases", databases);
     return json;
   }
 
   public synchronized void updateFrom(final JSONObject json) {
+    final Map<String, DatabaseOverride> updatedDatabaseOverrides = json.has("databases")
+        ? parseDatabaseOverrides(json.getJSONObject("databases", null))
+        : databaseOverrides;
+
     if (json.has("enabled"))
       enabled = json.getBoolean("enabled");
     if (json.has("allowReads"))
@@ -243,6 +271,7 @@ public class MCPConfiguration {
       allowSchemaChange = json.getBoolean("allowSchemaChange");
     if (json.has("allowAdmin"))
       allowAdmin = json.getBoolean("allowAdmin");
+    databaseOverrides = updatedDatabaseOverrides;
     if (json.has("allowedUsers")) {
       final JSONArray usersArray = json.getJSONArray("allowedUsers", null);
       // Treat explicit null as an empty list (client intent to clear all users)
@@ -265,5 +294,141 @@ public class MCPConfiguration {
 
   private File getConfigFile() {
     return Paths.get(rootPath, "config", "mcp-config.json").toFile();
+  }
+
+  private static Map<String, DatabaseOverride> parseDatabaseOverrides(final JSONObject databases) {
+    if (databases == null)
+      return Map.of();
+
+    final Map<String, DatabaseOverride> result = new LinkedHashMap<>();
+    for (final String databaseName : databases.keySet()) {
+      if (databaseName.isBlank())
+        throw new IllegalArgumentException("MCP database override names must not be blank");
+      result.put(databaseName, DatabaseOverride.fromJSON(databases.getJSONObject(databaseName)));
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  private static boolean valueOrTrue(final Boolean value) {
+    return value == null || value;
+  }
+
+  private static boolean matchesUser(final List<String> users, final String username) {
+    if (username == null)
+      return false;
+    if (users.contains("*") || users.contains(username))
+      return true;
+    // API token users have synthetic names like "apitoken:<tokenName>".
+    // Allow matching by the bare token name so users don't need to know the internal prefix.
+    return username.startsWith("apitoken:")
+        && users.contains(username.substring("apitoken:".length()));
+  }
+
+  private record DatabaseOverride(
+      Boolean allowReads,
+      Boolean allowInsert,
+      Boolean allowUpdate,
+      Boolean allowDelete,
+      Boolean allowSchemaChange,
+      Boolean allowAdmin,
+      List<String> allowedUsers) {
+
+    private static DatabaseOverride fromJSON(final JSONObject json) {
+      for (final String name : json.keySet())
+        if (!DATABASE_OVERRIDE_KEYS.contains(name))
+          throw new IllegalArgumentException("Unknown MCP database override setting '" + name + "'");
+
+      return new DatabaseOverride(
+          optionalBoolean(json, "allowReads"),
+          optionalBoolean(json, "allowInsert"),
+          optionalBoolean(json, "allowUpdate"),
+          optionalBoolean(json, "allowDelete"),
+          optionalBoolean(json, "allowSchemaChange"),
+          optionalBoolean(json, "allowAdmin"),
+          optionalUsers(json));
+    }
+
+    private JSONObject toJSON() {
+      final JSONObject json = new JSONObject();
+      putIfNotNull(json, "allowReads", allowReads);
+      putIfNotNull(json, "allowInsert", allowInsert);
+      putIfNotNull(json, "allowUpdate", allowUpdate);
+      putIfNotNull(json, "allowDelete", allowDelete);
+      putIfNotNull(json, "allowSchemaChange", allowSchemaChange);
+      putIfNotNull(json, "allowAdmin", allowAdmin);
+      if (allowedUsers != null)
+        json.put("allowedUsers", new JSONArray(allowedUsers));
+      return json;
+    }
+
+    private static Boolean optionalBoolean(final JSONObject json, final String name) {
+      return json.has(name) && !json.isNull(name) ? json.getBoolean(name) : null;
+    }
+
+    private static List<String> optionalUsers(final JSONObject json) {
+      if (!json.has("allowedUsers"))
+        return null;
+
+      final JSONArray usersArray = json.getJSONArray("allowedUsers", null);
+      if (usersArray == null)
+        return List.of();
+
+      final List<String> users = new ArrayList<>();
+      for (int i = 0; i < usersArray.length(); i++)
+        users.add(usersArray.getString(i));
+      return List.copyOf(users);
+    }
+
+    private static void putIfNotNull(final JSONObject json, final String name, final Boolean value) {
+      if (value != null)
+        json.put(name, value);
+    }
+  }
+
+  private record EffectivePermissions(
+      boolean allowReads,
+      boolean allowInsert,
+      boolean allowUpdate,
+      boolean allowDelete,
+      boolean allowSchemaChange,
+      boolean allowAdmin,
+      List<String> globalUsers,
+      List<String> databaseUsers) implements MCPPermissions {
+
+    @Override
+    public boolean isAllowReads() {
+      return allowReads;
+    }
+
+    @Override
+    public boolean isAllowInsert() {
+      return allowInsert;
+    }
+
+    @Override
+    public boolean isAllowUpdate() {
+      return allowUpdate;
+    }
+
+    @Override
+    public boolean isAllowDelete() {
+      return allowDelete;
+    }
+
+    @Override
+    public boolean isAllowSchemaChange() {
+      return allowSchemaChange;
+    }
+
+    @Override
+    public boolean isAllowAdmin() {
+      return allowAdmin;
+    }
+
+    @Override
+    public boolean isUserAllowed(final String username) {
+      return matchesUser(globalUsers, username)
+          && (databaseUsers == null || matchesUser(databaseUsers, username));
+    }
   }
 }

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -221,17 +221,32 @@ public class MCPConfiguration implements MCPPermissions {
    * configuration: a local {@code true} cannot enable an operation denied globally, and local users must also pass
    * the global user allowlist. An absent override inherits every global setting.
    */
-  public synchronized MCPPermissions getPermissionsForDatabase(final String databaseName) {
-    final DatabaseOverride override = databaseOverrides.get(databaseName);
-    return new EffectivePermissions(
-        allowReads && valueOrTrue(override != null ? override.allowReads : null),
-        allowInsert && valueOrTrue(override != null ? override.allowInsert : null),
-        allowUpdate && valueOrTrue(override != null ? override.allowUpdate : null),
-        allowDelete && valueOrTrue(override != null ? override.allowDelete : null),
-        allowSchemaChange && valueOrTrue(override != null ? override.allowSchemaChange : null),
-        allowAdmin && valueOrTrue(override != null ? override.allowAdmin : null),
-        List.copyOf(allowedUsers),
-        override != null && override.allowedUsers != null ? List.copyOf(override.allowedUsers) : null);
+  public MCPPermissions getPermissionsForDatabase(final String databaseName) {
+    if (!databaseOverrides.containsKey(databaseName))
+      return this;
+
+    synchronized (this) {
+      final DatabaseOverride override = databaseOverrides.get(databaseName);
+      if (override == null)
+        return this;
+      return new EffectivePermissions(
+          allowReads && valueOrTrue(override.allowReads),
+          allowInsert && valueOrTrue(override.allowInsert),
+          allowUpdate && valueOrTrue(override.allowUpdate),
+          allowDelete && valueOrTrue(override.allowDelete),
+          allowSchemaChange && valueOrTrue(override.allowSchemaChange),
+          allowAdmin && valueOrTrue(override.allowAdmin),
+          allowedUsers,
+          override.allowedUsers);
+    }
+  }
+
+  public void warnUnknownDatabaseOverrides(final Set<String> databaseNames) {
+    for (final String databaseName : databaseOverrides.keySet())
+      if (!databaseNames.contains(databaseName))
+        LogManager.instance().log(this, Level.WARNING,
+            "MCP configuration contains an override for unknown database '%s'; it will apply if that database is created",
+            databaseName);
   }
 
   public synchronized JSONObject toJSON() {
@@ -248,13 +263,14 @@ public class MCPConfiguration implements MCPPermissions {
     final JSONObject databases = new JSONObject();
     for (final Map.Entry<String, DatabaseOverride> entry : databaseOverrides.entrySet())
       databases.put(entry.getKey(), entry.getValue().toJSON());
-    json.put("databases", databases);
+    if (databases.length() > 0)
+      json.put("databases", databases);
     return json;
   }
 
   public synchronized void updateFrom(final JSONObject json) {
     final Map<String, DatabaseOverride> updatedDatabaseOverrides = json.has("databases")
-        ? parseDatabaseOverrides(json.getJSONObject("databases", null))
+        ? mergeDatabaseOverrides(databaseOverrides, json.getJSONObject("databases", null))
         : databaseOverrides;
 
     if (json.has("enabled"))
@@ -305,6 +321,23 @@ public class MCPConfiguration implements MCPPermissions {
       if (databaseName.isBlank())
         throw new IllegalArgumentException("MCP database override names must not be blank");
       result.put(databaseName, DatabaseOverride.fromJSON(databases.getJSONObject(databaseName)));
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  private static Map<String, DatabaseOverride> mergeDatabaseOverrides(
+      final Map<String, DatabaseOverride> current, final JSONObject updates) {
+    if (updates == null)
+      return Map.of();
+
+    final Map<String, DatabaseOverride> result = new LinkedHashMap<>(current);
+    for (final String databaseName : updates.keySet()) {
+      if (databaseName.isBlank())
+        throw new IllegalArgumentException("MCP database override names must not be blank");
+      if (updates.isNull(databaseName))
+        result.remove(databaseName);
+      else
+        result.put(databaseName, DatabaseOverride.fromJSON(updates.getJSONObject(databaseName)));
     }
     return Collections.unmodifiableMap(result);
   }

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPPermissions.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPPermissions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp;
+
+/**
+ * Permission view used by Model Context Protocol operations.
+ */
+public interface MCPPermissions {
+  boolean isAllowReads();
+
+  boolean isAllowInsert();
+
+  boolean isAllowUpdate();
+
+  boolean isAllowDelete();
+
+  boolean isAllowSchemaChange();
+
+  boolean isAllowAdmin();
+
+  boolean isUserAllowed(String username);
+}

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPResources.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPResources.java
@@ -49,7 +49,7 @@ public class MCPResources {
 
     if (config.isAllowReads())
       for (final String databaseName : new TreeSet<>(server.getDatabaseNames())) {
-        if (!user.canAccessToDatabase(databaseName))
+        if (!MCPToolUtils.canReadDatabase(user, config, databaseName))
           continue;
 
         resources.put(new JSONObject()
@@ -73,7 +73,8 @@ public class MCPResources {
       throw new SecurityException("Read operations are not allowed by MCP configuration");
 
     final String databaseName = parseSchemaURI(uri);
-    if (databaseName == null || !server.existsDatabase(databaseName) || !user.canAccessToDatabase(databaseName))
+    if (databaseName == null || !server.existsDatabase(databaseName)
+        || !MCPToolUtils.canReadDatabase(user, config, databaseName))
       throw new MCPResourceNotFoundException("Resource not found: " + uri);
 
     final ServerDatabase database = server.getDatabase(databaseName);

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/ExecuteCommandTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/ExecuteCommandTool.java
@@ -21,13 +21,14 @@ package com.arcadedb.server.mcp.tools;
 import com.arcadedb.database.Database;
 import com.arcadedb.query.OperationType;
 import com.arcadedb.query.QueryEngine;
-import com.arcadedb.server.mcp.MCPConfiguration;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.serializer.JsonSerializer;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.mcp.MCPConfiguration;
+import com.arcadedb.server.mcp.MCPPermissions;
 import com.arcadedb.server.security.ServerSecurityUser;
 
 import java.util.Collections;
@@ -73,12 +74,13 @@ public class ExecuteCommandTool {
     final String command = args.getString("command");
     final int limit = args.getInt("limit", DEFAULT_LIMIT);
 
-    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(server, user, databaseName, config);
+    final Database database = access.database();
 
     // Analyze once for both permission checking and execution (avoids double parsing)
     final QueryEngine engine = database.getQueryEngine(language);
     final QueryEngine.AnalyzedQuery analyzed = engine.analyze(command);
-    checkPermission(analyzed.getOperationTypes(), config);
+    checkPermission(analyzed.getOperationTypes(), access.permissions());
 
     final JsonSerializer serializer = JsonSerializer.createJsonSerializer()
         .setIncludeVertexEdges(false)
@@ -111,45 +113,45 @@ public class ExecuteCommandTool {
    * Uses the query engine's analyze() method to determine the actual operation types
    * from the parsed AST, avoiding text-based pattern matching vulnerabilities.
    *
-   * @param database the database to use for query analysis
-   * @param command  the command text
-   * @param language the query language
-   * @param config   MCP configuration with permission settings
+   * @param database    the database to use for query analysis
+   * @param command     the command text
+   * @param language    the query language
+   * @param permissions MCP permission settings
    */
   public static void checkPermission(final Database database, final String command, final String language,
-      final MCPConfiguration config) {
+      final MCPPermissions permissions) {
     final Set<OperationType> operationTypes = getOperationTypes(database, command, language);
-    checkPermission(operationTypes, config);
+    checkPermission(operationTypes, permissions);
   }
 
   /**
    * Checks MCP permissions against a set of operation types.
    */
-  public static void checkPermission(final Set<OperationType> operationTypes, final MCPConfiguration config) {
+  public static void checkPermission(final Set<OperationType> operationTypes, final MCPPermissions permissions) {
     for (final OperationType op : operationTypes) {
       switch (op) {
       case CREATE:
-        if (!config.isAllowInsert())
+        if (!permissions.isAllowInsert())
           throw new SecurityException("Insert operations are not allowed by MCP configuration");
         break;
       case UPDATE:
-        if (!config.isAllowUpdate())
+        if (!permissions.isAllowUpdate())
           throw new SecurityException("Update operations are not allowed by MCP configuration");
         break;
       case DELETE:
-        if (!config.isAllowDelete())
+        if (!permissions.isAllowDelete())
           throw new SecurityException("Delete operations are not allowed by MCP configuration");
         break;
       case SCHEMA:
-        if (!config.isAllowSchemaChange())
+        if (!permissions.isAllowSchemaChange())
           throw new SecurityException("Schema change operations are not allowed by MCP configuration");
         break;
       case ADMIN:
-        if (!config.isAllowAdmin())
+        if (!permissions.isAllowAdmin())
           throw new SecurityException("Admin operations are not allowed by MCP configuration");
         break;
       case READ:
-        if (!config.isAllowReads())
+        if (!permissions.isAllowReads())
           throw new SecurityException("Read operations are not allowed by MCP configuration");
         break;
       }

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/ExecuteCommandTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/ExecuteCommandTool.java
@@ -74,7 +74,8 @@ public class ExecuteCommandTool {
     final String command = args.getString("command");
     final int limit = args.getInt("limit", DEFAULT_LIMIT);
 
-    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(server, user, databaseName, config);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
+        server, user, databaseName, config, MCPToolUtils.RequiredAccess.ACCESS);
     final Database database = access.database();
 
     // Analyze once for both permission checking and execution (avoids double parsing)

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/FullTextSearchTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/FullTextSearchTool.java
@@ -85,9 +85,6 @@ public class FullTextSearchTool {
 
   public static JSONObject execute(final ArcadeDBServer server, final ServerSecurityUser user, final JSONObject args,
       final MCPConfiguration config) {
-    if (!config.isAllowReads())
-      throw new SecurityException("Read operations are not allowed by MCP configuration");
-
     final String databaseName = args.getString("database");
     final String queryText = args.getString("queryText");
     // A blank query reaches the Lucene parser as an empty clause set and surfaces as IndexException("Invalid search
@@ -100,7 +97,8 @@ public class FullTextSearchTool {
     if (limit < 1)
       throw new IllegalArgumentException("'limit' must be at least 1, got " + limit);
 
-    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveReadableDatabase(server, user, databaseName, config);
+    final Database database = access.database();
 
     final TypeIndex typeIndex = resolveIndex(database, args);
     final String indexName = typeIndex.getName();

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/FullTextSearchTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/FullTextSearchTool.java
@@ -97,7 +97,8 @@ public class FullTextSearchTool {
     if (limit < 1)
       throw new IllegalArgumentException("'limit' must be at least 1, got " + limit);
 
-    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveReadableDatabase(server, user, databaseName, config);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
+        server, user, databaseName, config, MCPToolUtils.RequiredAccess.READ);
     final Database database = access.database();
 
     final TypeIndex typeIndex = resolveIndex(database, args);

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java
@@ -52,14 +52,11 @@ public class GetSchemaTool {
 
   public static JSONObject execute(final ArcadeDBServer server, final ServerSecurityUser user, final JSONObject args,
       final MCPConfiguration config) {
-    if (!config.isAllowReads())
-      throw new SecurityException("Read operations are not allowed by MCP configuration");
-
     final String databaseName = args.getString("database");
 
-    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveReadableDatabase(server, user, databaseName, config);
 
-    return buildSchema(database, databaseName);
+    return buildSchema(access.database(), databaseName);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/GetSchemaTool.java
@@ -54,7 +54,8 @@ public class GetSchemaTool {
       final MCPConfiguration config) {
     final String databaseName = args.getString("database");
 
-    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveReadableDatabase(server, user, databaseName, config);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
+        server, user, databaseName, config, MCPToolUtils.RequiredAccess.READ);
 
     return buildSchema(access.database(), databaseName);
   }

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/ListDatabasesTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/ListDatabasesTool.java
@@ -24,8 +24,8 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.security.ServerSecurityUser;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -47,11 +47,8 @@ public class ListDatabasesTool {
     if (!config.isAllowReads())
       throw new SecurityException("Read operations are not allowed by MCP configuration");
 
-    final Set<String> installedDatabases = new HashSet<>(server.getDatabaseNames());
-    final Set<String> allowedDatabases = user.getAuthorizedDatabases();
-
-    if (!allowedDatabases.contains("*"))
-      installedDatabases.retainAll(allowedDatabases);
+    final Set<String> installedDatabases = new TreeSet<>(server.getDatabaseNames());
+    installedDatabases.removeIf(databaseName -> !MCPToolUtils.canReadDatabase(user, config, databaseName));
 
     final JSONObject result = new JSONObject();
     result.put("databases", new JSONArray(installedDatabases));

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/MCPToolUtils.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/MCPToolUtils.java
@@ -33,9 +33,13 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerDatabase;
 import com.arcadedb.server.mcp.MCPConfiguration;
+import com.arcadedb.server.mcp.MCPPermissions;
 import com.arcadedb.server.security.ServerSecurityUser;
 
 public class MCPToolUtils {
+
+  public record DatabaseAccess(ServerDatabase database, MCPPermissions permissions) {
+  }
 
   private MCPToolUtils() {
   }
@@ -45,11 +49,30 @@ public class MCPToolUtils {
    * accessible to the user when the requested database does not exist — so the LLM can self-correct
    * without a separate list_databases round-trip.
    */
-  public static ServerDatabase resolveDatabase(final ArcadeDBServer server, final ServerSecurityUser user,
-      final String databaseName) {
+  public static DatabaseAccess resolveDatabase(final ArcadeDBServer server, final ServerSecurityUser user,
+      final String databaseName, final MCPConfiguration config) {
+    return resolveDatabase(server, user, databaseName, config, false);
+  }
+
+  public static DatabaseAccess resolveReadableDatabase(final ArcadeDBServer server, final ServerSecurityUser user,
+      final String databaseName, final MCPConfiguration config) {
+    return resolveDatabase(server, user, databaseName, config, true);
+  }
+
+  private static DatabaseAccess resolveDatabase(final ArcadeDBServer server, final ServerSecurityUser user,
+      final String databaseName, final MCPConfiguration config, final boolean requireRead) {
+    final MCPPermissions permissions = config.getPermissionsForDatabase(databaseName);
+    if (!permissions.isUserAllowed(user.getName()))
+      throw new SecurityException(
+          "User '" + user.getName() + "' is not authorized for MCP access to database '" + databaseName + "'");
+    if (requireRead && !permissions.isAllowReads())
+      throw new SecurityException("Read operations are not allowed by MCP configuration");
+
     if (!server.existsDatabase(databaseName)) {
       final Set<String> installed = new TreeSet<>(server.getDatabaseNames());
-      installed.removeIf(db -> !user.canAccessToDatabase(db));
+      installed.removeIf(db -> requireRead
+          ? !canReadDatabase(user, config, db)
+          : !canAccessDatabase(user, config, db));
       throw new IllegalArgumentException(
           "Database '" + databaseName + "' does not exist. Available databases: " + installed
               + ". Use one of these names or call list_databases to refresh the list.");
@@ -59,7 +82,21 @@ public class MCPToolUtils {
 
     final ServerDatabase database = server.getDatabase(databaseName);
     bindCurrentUser(database, user);
-    return database;
+    return new DatabaseAccess(database, permissions);
+  }
+
+  public static boolean canAccessDatabase(final ServerSecurityUser user, final MCPConfiguration config,
+      final String databaseName) {
+    return user.canAccessToDatabase(databaseName)
+        && config.getPermissionsForDatabase(databaseName).isUserAllowed(user.getName());
+  }
+
+  public static boolean canReadDatabase(final ServerSecurityUser user, final MCPConfiguration config,
+      final String databaseName) {
+    final MCPPermissions permissions = config.getPermissionsForDatabase(databaseName);
+    return user.canAccessToDatabase(databaseName)
+        && permissions.isUserAllowed(user.getName())
+        && permissions.isAllowReads();
   }
 
   /**
@@ -174,10 +211,10 @@ public class MCPToolUtils {
    * write/read tools use.
    */
   public static JSONObject executeParameterizedWrite(final Database database, final String cypher,
-      final Map<String, Object> params, final MCPConfiguration config) {
+      final Map<String, Object> params, final MCPPermissions permissions) {
     final QueryEngine engine = database.getQueryEngine("cypher");
     final QueryEngine.AnalyzedQuery analyzed = engine.analyze(cypher);
-    ExecuteCommandTool.checkPermission(analyzed.getOperationTypes(), config);
+    ExecuteCommandTool.checkPermission(analyzed.getOperationTypes(), permissions);
 
     final JsonSerializer serializer = JsonSerializer.createJsonSerializer()
         .setIncludeVertexEdges(false)

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/MCPToolUtils.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/MCPToolUtils.java
@@ -38,6 +38,11 @@ import com.arcadedb.server.security.ServerSecurityUser;
 
 public class MCPToolUtils {
 
+  public enum RequiredAccess {
+    ACCESS,
+    READ
+  }
+
   public record DatabaseAccess(ServerDatabase database, MCPPermissions permissions) {
   }
 
@@ -50,17 +55,8 @@ public class MCPToolUtils {
    * without a separate list_databases round-trip.
    */
   public static DatabaseAccess resolveDatabase(final ArcadeDBServer server, final ServerSecurityUser user,
-      final String databaseName, final MCPConfiguration config) {
-    return resolveDatabase(server, user, databaseName, config, false);
-  }
-
-  public static DatabaseAccess resolveReadableDatabase(final ArcadeDBServer server, final ServerSecurityUser user,
-      final String databaseName, final MCPConfiguration config) {
-    return resolveDatabase(server, user, databaseName, config, true);
-  }
-
-  private static DatabaseAccess resolveDatabase(final ArcadeDBServer server, final ServerSecurityUser user,
-      final String databaseName, final MCPConfiguration config, final boolean requireRead) {
+      final String databaseName, final MCPConfiguration config, final RequiredAccess requiredAccess) {
+    final boolean requireRead = requiredAccess == RequiredAccess.READ;
     final MCPPermissions permissions = config.getPermissionsForDatabase(databaseName);
     if (!permissions.isUserAllowed(user.getName()))
       throw new SecurityException(

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/QueryTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/QueryTool.java
@@ -66,15 +66,13 @@ public class QueryTool {
 
   public static JSONObject execute(final ArcadeDBServer server, final ServerSecurityUser user, final JSONObject args,
       final MCPConfiguration config) {
-    if (!config.isAllowReads())
-      throw new SecurityException("Read operations are not allowed by MCP configuration");
-
     final String databaseName = args.getString("database");
     final String language = args.getString("language", "cypher");
     final String query = args.getString("query");
     final int limit = args.getInt("limit", DEFAULT_LIMIT);
 
-    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveReadableDatabase(server, user, databaseName, config);
+    final Database database = access.database();
 
     // Verify the query is actually read-only using semantic analysis
     final QueryEngine engine = database.getQueryEngine(language);

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/QueryTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/QueryTool.java
@@ -71,7 +71,8 @@ public class QueryTool {
     final String query = args.getString("query");
     final int limit = args.getInt("limit", DEFAULT_LIMIT);
 
-    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveReadableDatabase(server, user, databaseName, config);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
+        server, user, databaseName, config, MCPToolUtils.RequiredAccess.READ);
     final Database database = access.database();
 
     // Verify the query is actually read-only using semantic analysis

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/SampleRecordsTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/SampleRecordsTool.java
@@ -82,7 +82,9 @@ public class SampleRecordsTool {
     if (limit < 1 || limit > MAX_LIMIT)
       throw new IllegalArgumentException("'limit' must be between 1 and " + MAX_LIMIT);
 
-    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
+        server, user, databaseName, config, MCPToolUtils.RequiredAccess.READ);
+    final Database database = access.database();
     final ResolvedTypes resolvedTypes = resolveTypeNames(database, databaseName, args);
 
     final JsonSerializer serializer = JsonSerializer.createJsonSerializer()

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/ServerStatusTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/ServerStatusTool.java
@@ -27,8 +27,8 @@ import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.security.ServerSecurityUser;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -54,10 +54,8 @@ public class ServerStatusTool {
     result.put("version", Constants.getVersion());
     result.put("serverName", server.getServerName());
     result.put("languages", QueryEngineManager.getInstance().getAvailableLanguages());
-    final Set<String> installedDatabases = new HashSet<>(server.getDatabaseNames());
-    final Set<String> allowedDatabases = user.getAuthorizedDatabases();
-    if (!allowedDatabases.contains("*"))
-      installedDatabases.retainAll(allowedDatabases);
+    final Set<String> installedDatabases = new TreeSet<>(server.getDatabaseNames());
+    installedDatabases.removeIf(databaseName -> !MCPToolUtils.canReadDatabase(user, config, databaseName));
     result.put("databases", new JSONArray(installedDatabases));
 
     final HAServerPlugin ha = server.getHA();

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/UpsertEntityTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/UpsertEntityTool.java
@@ -66,7 +66,8 @@ public class UpsertEntityTool {
     final JSONObject matchKeys = MCPToolUtils.requireNonEmptyObject(args, "matchKeys");
     final JSONObject setProperties = args.getJSONObject("setProperties", null);
 
-    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(server, user, databaseName, config);
+    final Database database = access.database();
 
     final Map<String, Object> params = new HashMap<>();
     final StringBuilder cypher = new StringBuilder();
@@ -76,6 +77,6 @@ public class UpsertEntityTool {
       MCPToolUtils.appendSetClause(cypher, params, "n", setProperties, "s");
     cypher.append(" RETURN n");
 
-    return MCPToolUtils.executeParameterizedWrite(database, cypher.toString(), params, config);
+    return MCPToolUtils.executeParameterizedWrite(database, cypher.toString(), params, access.permissions());
   }
 }

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/UpsertEntityTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/UpsertEntityTool.java
@@ -66,7 +66,8 @@ public class UpsertEntityTool {
     final JSONObject matchKeys = MCPToolUtils.requireNonEmptyObject(args, "matchKeys");
     final JSONObject setProperties = args.getJSONObject("setProperties", null);
 
-    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(server, user, databaseName, config);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
+        server, user, databaseName, config, MCPToolUtils.RequiredAccess.ACCESS);
     final Database database = access.database();
 
     final Map<String, Object> params = new HashMap<>();

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/UpsertRelationshipTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/UpsertRelationshipTool.java
@@ -82,7 +82,8 @@ public class UpsertRelationshipTool {
     final JSONObject toMatchKeys = MCPToolUtils.requireNonEmptyObject(args, "toMatchKeys");
     final JSONObject relProperties = args.getJSONObject("relProperties", null);
 
-    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(server, user, databaseName, config);
+    final Database database = access.database();
 
     final Map<String, Object> params = new HashMap<>();
     final StringBuilder cypher = new StringBuilder();
@@ -99,7 +100,7 @@ public class UpsertRelationshipTool {
       MCPToolUtils.appendSetClause(cypher, params, "r", relProperties, "r");
     cypher.append(" RETURN r");
 
-    return MCPToolUtils.executeParameterizedWrite(database, cypher.toString(), params, config);
+    return MCPToolUtils.executeParameterizedWrite(database, cypher.toString(), params, access.permissions());
   }
 
 }

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/UpsertRelationshipTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/UpsertRelationshipTool.java
@@ -82,7 +82,8 @@ public class UpsertRelationshipTool {
     final JSONObject toMatchKeys = MCPToolUtils.requireNonEmptyObject(args, "toMatchKeys");
     final JSONObject relProperties = args.getJSONObject("relProperties", null);
 
-    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(server, user, databaseName, config);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
+        server, user, databaseName, config, MCPToolUtils.RequiredAccess.ACCESS);
     final Database database = access.database();
 
     final Map<String, Object> params = new HashMap<>();

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/VectorSearchTool.java
@@ -134,7 +134,9 @@ public class VectorSearchTool {
       throw new IllegalArgumentException("'queryIndices' requires sparse=true");
 
     final String filter = normalizeFilter(args.getString("filter", null));
-    final Database database = MCPToolUtils.resolveDatabase(server, user, databaseName);
+    final MCPToolUtils.DatabaseAccess access = MCPToolUtils.resolveDatabase(
+        server, user, databaseName, config, MCPToolUtils.RequiredAccess.READ);
+    final Database database = access.database();
     final ResolvedVectorIndex resolved = resolveIndex(database, indexName, sparse);
     final float[] queryVector = readFloatArray(args.getJSONArray("queryVector", null), "queryVector");
 

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MCPConfigurationTest {
   private static final String TEST_ROOT = "./target/mcp-config-test";
@@ -64,6 +65,11 @@ class MCPConfigurationTest {
     config.setAllowInsert(true);
     config.setAllowUpdate(true);
     config.setAllowedUsers(List.of("root", "admin"));
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject()
+            .put("tenant", new JSONObject()
+                .put("allowUpdate", false)
+                .put("allowedUsers", new JSONArray().put("admin")))));
     config.save();
 
     final MCPConfiguration loaded = new MCPConfiguration(TEST_ROOT);
@@ -74,6 +80,10 @@ class MCPConfigurationTest {
     assertThat(loaded.isAllowUpdate()).isTrue();
     assertThat(loaded.isAllowDelete()).isFalse();
     assertThat(loaded.getAllowedUsers()).containsExactly("root", "admin");
+    assertThat(loaded.getPermissionsForDatabase("tenant").isAllowInsert()).isTrue();
+    assertThat(loaded.getPermissionsForDatabase("tenant").isAllowUpdate()).isFalse();
+    assertThat(loaded.getPermissionsForDatabase("tenant").isUserAllowed("admin")).isTrue();
+    assertThat(loaded.getPermissionsForDatabase("tenant").isUserAllowed("root")).isFalse();
   }
 
   @Test
@@ -128,6 +138,107 @@ class MCPConfigurationTest {
     assertThat(json.getBoolean("allowInsert")).isFalse();
     assertThat(json.getJSONArray("allowedUsers").length()).isEqualTo(1);
     assertThat(json.getJSONArray("allowedUsers").getString(0)).isEqualTo("root");
+    assertThat(json.getJSONObject("databases").length()).isZero();
+  }
+
+  @Test
+  void databaseOverrideInheritsUnspecifiedGlobalValues() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.setAllowInsert(true);
+    config.setAllowUpdate(true);
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject()
+            .put("tenant", new JSONObject().put("allowUpdate", false))));
+
+    final MCPPermissions tenant = config.getPermissionsForDatabase("tenant");
+    assertThat(tenant.isAllowReads()).isTrue();
+    assertThat(tenant.isAllowInsert()).isTrue();
+    assertThat(tenant.isAllowUpdate()).isFalse();
+
+    final MCPPermissions inherited = config.getPermissionsForDatabase("unconfigured");
+    assertThat(inherited.isAllowReads()).isTrue();
+    assertThat(inherited.isAllowInsert()).isTrue();
+    assertThat(inherited.isAllowUpdate()).isTrue();
+  }
+
+  @Test
+  void databaseOverrideCannotGrantPermissionsDeniedGlobally() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.setAllowReads(true);
+    config.setAllowInsert(false);
+    config.setAllowUpdate(false);
+    config.setAllowDelete(false);
+    config.setAllowSchemaChange(false);
+    config.setAllowAdmin(false);
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject()
+            .put("tenant", new JSONObject()
+                .put("allowReads", false)
+                .put("allowInsert", true)
+                .put("allowUpdate", true)
+                .put("allowDelete", true)
+                .put("allowSchemaChange", true)
+                .put("allowAdmin", true))));
+
+    final MCPPermissions tenant = config.getPermissionsForDatabase("tenant");
+    assertThat(tenant.isAllowReads()).isFalse();
+    assertThat(tenant.isAllowInsert()).isFalse();
+    assertThat(tenant.isAllowUpdate()).isFalse();
+    assertThat(tenant.isAllowDelete()).isFalse();
+    assertThat(tenant.isAllowSchemaChange()).isFalse();
+    assertThat(tenant.isAllowAdmin()).isFalse();
+  }
+
+  @Test
+  void databaseAllowedUsersAreAnAdditionalRestriction() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.setAllowedUsers(List.of("root", "tenant-token"));
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject()
+            .put("tenant", new JSONObject()
+                .put("allowedUsers", new JSONArray().put("tenant-token")))));
+
+    final MCPPermissions tenant = config.getPermissionsForDatabase("tenant");
+    assertThat(tenant.isUserAllowed("root")).isFalse();
+    assertThat(tenant.isUserAllowed("apitoken:tenant-token")).isTrue();
+
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject()
+            .put("tenant", new JSONObject()
+                .put("allowedUsers", new JSONArray().put("*")))));
+    assertThat(config.getPermissionsForDatabase("tenant").isUserAllowed("root")).isTrue();
+    assertThat(config.getPermissionsForDatabase("tenant").isUserAllowed("unknown")).isFalse();
+  }
+
+  @Test
+  void explicitNullClearsDatabaseOverrides() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject()
+            .put("tenant", new JSONObject().put("allowReads", false))));
+    assertThat(config.getPermissionsForDatabase("tenant").isAllowReads()).isFalse();
+
+    final JSONObject update = new JSONObject();
+    update.put("databases", (Object) null);
+    config.updateFrom(update);
+
+    assertThat(config.getPermissionsForDatabase("tenant").isAllowReads()).isTrue();
+    assertThat(config.toJSON().getJSONObject("databases").length()).isZero();
+  }
+
+  @Test
+  void unknownDatabaseOverrideSettingIsRejectedWithoutPartialUpdate() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+
+    assertThatThrownBy(() -> config.updateFrom(new JSONObject()
+        .put("allowInsert", true)
+        .put("databases", new JSONObject()
+            .put("tenant", new JSONObject().put("allowRead", false)))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("allowRead");
+
+    assertThat(config.isAllowInsert()).isFalse();
+    assertThat(config.getPermissionsForDatabase("tenant").isAllowReads()).isTrue();
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
@@ -138,7 +138,7 @@ class MCPConfigurationTest {
     assertThat(json.getBoolean("allowInsert")).isFalse();
     assertThat(json.getJSONArray("allowedUsers").length()).isEqualTo(1);
     assertThat(json.getJSONArray("allowedUsers").getString(0)).isEqualTo("root");
-    assertThat(json.getJSONObject("databases").length()).isZero();
+    assertThat(json.has("databases")).isFalse();
   }
 
   @Test
@@ -156,6 +156,7 @@ class MCPConfigurationTest {
     assertThat(tenant.isAllowUpdate()).isFalse();
 
     final MCPPermissions inherited = config.getPermissionsForDatabase("unconfigured");
+    assertThat(inherited).isSameAs(config);
     assertThat(inherited.isAllowReads()).isTrue();
     assertThat(inherited.isAllowInsert()).isTrue();
     assertThat(inherited.isAllowUpdate()).isTrue();
@@ -223,7 +224,33 @@ class MCPConfigurationTest {
     config.updateFrom(update);
 
     assertThat(config.getPermissionsForDatabase("tenant").isAllowReads()).isTrue();
-    assertThat(config.toJSON().getJSONObject("databases").length()).isZero();
+    assertThat(config.toJSON().has("databases")).isFalse();
+  }
+
+  @Test
+  void databaseUpdatesMergeByNameAndNullRemovesOneOverride() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject()
+            .put("tenant_a", new JSONObject().put("allowReads", false))
+            .put("tenant_b", new JSONObject().put("allowInsert", false))));
+
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject()
+            .put("tenant_a", new JSONObject().put("allowUpdate", false))));
+
+    assertThat(config.toJSON().getJSONObject("databases").keySet())
+        .containsExactlyInAnyOrder("tenant_a", "tenant_b");
+    assertThat(config.getPermissionsForDatabase("tenant_a").isAllowUpdate()).isFalse();
+    assertThat(config.toJSON().getJSONObject("databases")
+        .getJSONObject("tenant_a").has("allowReads")).isFalse();
+
+    final JSONObject removal = new JSONObject();
+    removal.put("tenant_a", (Object) null);
+    config.updateFrom(new JSONObject().put("databases", removal));
+
+    assertThat(config.toJSON().getJSONObject("databases").keySet())
+        .containsExactly("tenant_b");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPDatabaseScopingTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPDatabaseScopingTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.mcp.tools.ExecuteCommandTool;
+import com.arcadedb.server.mcp.tools.FullTextSearchTool;
+import com.arcadedb.server.mcp.tools.GetSchemaTool;
+import com.arcadedb.server.mcp.tools.ListDatabasesTool;
+import com.arcadedb.server.mcp.tools.QueryTool;
+import com.arcadedb.server.mcp.tools.ServerStatusTool;
+import com.arcadedb.server.mcp.tools.UpsertEntityTool;
+import com.arcadedb.server.mcp.tools.UpsertRelationshipTool;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MCPDatabaseScopingTest extends BaseGraphServerTest {
+  private MCPConfiguration   config;
+  private ServerSecurityUser user;
+
+  @BeforeEach
+  void setupMCP() {
+    config = getServer(0).getMCPConfiguration();
+    config.setEnabled(true);
+    config.setAllowReads(true);
+    config.setAllowInsert(true);
+    config.setAllowUpdate(true);
+    config.setAllowDelete(true);
+    config.setAllowSchemaChange(true);
+    config.setAllowAdmin(true);
+    config.setAllowedUsers(List.of("root"));
+    final JSONObject clearOverrides = new JSONObject();
+    clearOverrides.put("databases", (Object) null);
+    config.updateFrom(clearOverrides);
+    user = getServer(0).getSecurity().authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
+  }
+
+  @Test
+  void noOverridePreservesGlobalReadBehavior() {
+    final JSONObject result = QueryTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("query", "SELECT 1 AS value"), config);
+
+    assertThat(result.getInt("count")).isEqualTo(1);
+    assertThat(contains(ListDatabasesTool.execute(getServer(0), user, new JSONObject(), config)
+        .getJSONArray("databases"), getDatabaseName())).isTrue();
+    assertThat(containsResource(MCPResources.list(getServer(0), user, config)
+        .getJSONArray("resources"), MCPResources.schemaURI(getDatabaseName()))).isTrue();
+  }
+
+  @Test
+  void readOverrideRestrictsEveryDatabaseReadSurface() {
+    setDatabaseOverride(new JSONObject().put("allowReads", false));
+
+    assertReadDenied(() -> QueryTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("query", "SELECT 1"), config));
+    assertReadDenied(() -> GetSchemaTool.execute(getServer(0), user,
+        new JSONObject().put("database", getDatabaseName()), config));
+    assertReadDenied(() -> FullTextSearchTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "missing")
+        .put("queryText", "term"), config));
+
+    assertThat(contains(ListDatabasesTool.execute(getServer(0), user, new JSONObject(), config)
+        .getJSONArray("databases"), getDatabaseName())).isFalse();
+    assertThat(contains(ServerStatusTool.execute(getServer(0), user, new JSONObject(), config)
+        .getJSONArray("databases"), getDatabaseName())).isFalse();
+    assertThat(containsResource(MCPResources.list(getServer(0), user, config)
+        .getJSONArray("resources"), MCPResources.schemaURI(getDatabaseName()))).isFalse();
+    assertThatThrownBy(() -> MCPResources.read(getServer(0), user, config,
+        MCPResources.schemaURI(getDatabaseName())))
+        .isInstanceOf(MCPResourceNotFoundException.class);
+  }
+
+  @Test
+  void writeOverrideRestrictsCommandAndUpsertTools() {
+    setDatabaseOverride(new JSONObject()
+        .put("allowInsert", false)
+        .put("allowUpdate", false)
+        .put("allowDelete", false)
+        .put("allowSchemaChange", false)
+        .put("allowAdmin", false));
+
+    assertThatThrownBy(() -> ExecuteCommandTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("command", "CREATE VERTEX V"), config))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("Insert operations");
+
+    assertThatThrownBy(() -> UpsertEntityTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("typeName", "V")
+        .put("matchKeys", new JSONObject().put("name", "scoped")), config))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("operations are not allowed");
+
+    assertThatThrownBy(() -> UpsertRelationshipTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("fromType", "V")
+        .put("fromMatchKeys", new JSONObject().put("name", "from"))
+        .put("toType", "V")
+        .put("toMatchKeys", new JSONObject().put("name", "to"))
+        .put("relType", "E"), config))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("operations are not allowed");
+  }
+
+  @Test
+  void databaseAllowedUsersHideAndRejectTheDatabase() {
+    setDatabaseOverride(new JSONObject()
+        .put("allowedUsers", new JSONArray().put("another-user")));
+
+    assertThatThrownBy(() -> QueryTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("query", "SELECT 1"), config))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not authorized for MCP access");
+    assertThat(contains(ListDatabasesTool.execute(getServer(0), user, new JSONObject(), config)
+        .getJSONArray("databases"), getDatabaseName())).isFalse();
+    assertThat(containsResource(MCPResources.list(getServer(0), user, config)
+        .getJSONArray("resources"), MCPResources.schemaURI(getDatabaseName()))).isFalse();
+  }
+
+  private void setDatabaseOverride(final JSONObject override) {
+    config.updateFrom(new JSONObject()
+        .put("databases", new JSONObject().put(getDatabaseName(), override)));
+  }
+
+  private static void assertReadDenied(final Runnable operation) {
+    assertThatThrownBy(operation::run)
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("Read operations");
+  }
+
+  private static boolean contains(final JSONArray values, final String expected) {
+    for (int i = 0; i < values.length(); i++)
+      if (expected.equals(values.getString(i)))
+        return true;
+    return false;
+  }
+
+  private static boolean containsResource(final JSONArray resources, final String uri) {
+    for (int i = 0; i < resources.length(); i++)
+      if (uri.equals(resources.getJSONObject(i).getString("uri")))
+        return true;
+    return false;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPDatabaseScopingTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPDatabaseScopingTest.java
@@ -29,6 +29,7 @@ import com.arcadedb.server.mcp.tools.QueryTool;
 import com.arcadedb.server.mcp.tools.ServerStatusTool;
 import com.arcadedb.server.mcp.tools.UpsertEntityTool;
 import com.arcadedb.server.mcp.tools.UpsertRelationshipTool;
+import com.arcadedb.server.mcp.tools.VectorSearchTool;
 import com.arcadedb.server.security.ServerSecurityUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,6 +88,10 @@ class MCPDatabaseScopingTest extends BaseGraphServerTest {
         .put("database", getDatabaseName())
         .put("indexName", "missing")
         .put("queryText", "term"), config));
+    assertReadDenied(() -> VectorSearchTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName())
+        .put("indexName", "missing")
+        .put("queryVector", new JSONArray().put(1.0)), config));
 
     assertThat(contains(ListDatabasesTool.execute(getServer(0), user, new JSONObject(), config)
         .getJSONArray("databases"), getDatabaseName())).isFalse();

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPDatabaseScopingTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPDatabaseScopingTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.server.mcp.tools.FullTextSearchTool;
 import com.arcadedb.server.mcp.tools.GetSchemaTool;
 import com.arcadedb.server.mcp.tools.ListDatabasesTool;
 import com.arcadedb.server.mcp.tools.QueryTool;
+import com.arcadedb.server.mcp.tools.SampleRecordsTool;
 import com.arcadedb.server.mcp.tools.ServerStatusTool;
 import com.arcadedb.server.mcp.tools.UpsertEntityTool;
 import com.arcadedb.server.mcp.tools.UpsertRelationshipTool;
@@ -92,6 +93,8 @@ class MCPDatabaseScopingTest extends BaseGraphServerTest {
         .put("database", getDatabaseName())
         .put("indexName", "missing")
         .put("queryVector", new JSONArray().put(1.0)), config));
+    assertReadDenied(() -> SampleRecordsTool.execute(getServer(0), user, new JSONObject()
+        .put("database", getDatabaseName()), config));
 
     assertThat(contains(ListDatabasesTool.execute(getServer(0), user, new JSONObject(), config)
         .getJSONArray("databases"), getDatabaseName())).isFalse();


### PR DESCRIPTION
## Summary

- add optional per-database Model Context Protocol (MCP) permission overrides
- resolve one immutable effective permission snapshot for every database-targeted operation
- enforce database-local read, write, administrative, and user restrictions across tools, resources, discovery, and status
- document the configuration format, global-ceiling semantics, and HTTP routing boundary

## Permission model

Database overrides can only restrict the server-global policy:

- local `false` values deny operations that are globally allowed
- local `true` values cannot grant operations denied globally
- local `allowedUsers` is an additional restriction on the global allowlist
- omitted fields inherit their global values
- databases without overrides preserve existing behavior

Unknown database override fields are rejected before any part of an update is applied, preventing misspelled security settings from silently inheriting a more permissive value.

Example:

```json
{
  "enabled": true,
  "allowReads": true,
  "allowInsert": true,
  "allowedUsers": ["root", "tenant-agent"],
  "databases": {
    "tenant_graph": {
      "allowInsert": false,
      "allowedUsers": ["tenant-agent"]
    }
  }
}
```

This does not add `/mcp/{database}` or another database-bound HTTP route. The existing endpoint and origin policy remain server-global.

## Validation

- focused configuration, permission, resource, and database-scoping tests: 42 passed
- complete MCP-only server test set: 151 passed
- no failures or skipped tests

Closes #4868
