### PR TITLE
feat(mcp) #4867: add configurable tool profiles

### DIFF
--- a/docs/superpowers/specs/2026-07-24-mcp-tool-profiles-4867-design.md
+++ b/docs/superpowers/specs/2026-07-24-mcp-tool-profiles-4867-design.md
@@ -1,0 +1,77 @@
+# MCP tool profiles (#4867)
+
+**Issue:** [#4867](https://github.com/ArcadeData/arcadedb/issues/4867)
+**Epic:** [#4859 - MCP GraphRAG & Agent-Memory Surface](https://github.com/ArcadeData/arcadedb/issues/4859)
+**Date:** 2026-07-24
+**Status:** implemented
+
+## Decision
+
+The Model Context Protocol (MCP) configuration supports three named tool profiles:
+
+- `all`: every registered tool; this is the default and preserves existing behavior.
+- `rag`: retrieval-focused tools only.
+- `admin`: the existing operator and database-administration surface.
+
+Profiles are allowlists. They filter `tools/list` and are enforced again by `tools/call`, so a
+client cannot invoke a hidden tool by name. Unknown tools remain rejected independently of the
+selected profile.
+
+## Configuration
+
+Set `profile` in `config/mcp-config.json` or through the existing MCP configuration endpoint:
+
+```json
+{
+  "enabled": true,
+  "profile": "rag",
+  "allowReads": true,
+  "allowedUsers": ["retrieval-agent"]
+}
+```
+
+The field is persisted with the rest of the MCP configuration. Values are case-insensitive when
+parsed and serialized as lowercase. Unknown values are rejected before any other setting in the
+same update is applied.
+
+## Profile contents
+
+The `rag` profile permits these registered tool names:
+
+- `query`
+- `full_text_search`
+- `sample_records`
+- `vector_search`
+- `hybrid_search`
+
+Only tools actually registered by the running server are advertised. This lets retrieval tools
+join the profile as they are installed without exposing an unavailable tool.
+
+The `admin` profile contains:
+
+- `list_databases`
+- `get_schema`
+- `query`
+- `execute_command`
+- `server_status`
+- `profiler_start`
+- `profiler_stop`
+- `profiler_status`
+- `get_server_settings`
+- `set_server_setting`
+
+Schema resources remain available through the MCP Resources capability and are not tool-profile
+entries. Existing read, write, schema, administrative, user, and origin permissions remain
+independent mandatory checks; a profile never grants an operation.
+
+## Transport behavior
+
+Both HTTP and standard input/output transports use the shared `MCPDispatcher`, so discovery,
+execution denial, and profile-specific initialization instructions have one implementation.
+Changing a profile through the configuration endpoint takes effect on subsequent requests.
+
+## Validation
+
+Tests cover default compatibility, persistence, case-insensitive parsing, invalid-update
+atomicity, HTTP and standard input/output discovery filtering, execution denial for hidden
+tools, and successful execution of allowed tools.

--- a/docs/superpowers/specs/2026-07-24-mcp-tool-profiles-4867-design.md
+++ b/docs/superpowers/specs/2026-07-24-mcp-tool-profiles-4867-design.md
@@ -10,7 +10,7 @@
 The Model Context Protocol (MCP) configuration supports three named tool profiles:
 
 - `all`: every registered tool; this is the default and preserves existing behavior.
-- `rag`: retrieval-focused tools only.
+- `rag`: retrieval and agent-memory tools.
 - `admin`: the existing operator and database-administration surface.
 
 Profiles are allowlists. They filter `tools/list` and are enforced again by `tools/call`, so a
@@ -38,11 +38,15 @@ same update is applied.
 
 The `rag` profile permits these registered tool names:
 
+- `list_databases`
+- `get_schema`
 - `query`
 - `full_text_search`
 - `sample_records`
 - `vector_search`
 - `hybrid_search`
+- `upsert_entity`
+- `upsert_relationship`
 
 Only tools actually registered by the running server are advertised. This lets retrieval tools
 join the profile as they are installed without exposing an unavailable tool.
@@ -60,9 +64,11 @@ The `admin` profile contains:
 - `get_server_settings`
 - `set_server_setting`
 
-Schema resources remain available through the MCP Resources capability and are not tool-profile
-entries. Existing read, write, schema, administrative, user, and origin permissions remain
-independent mandatory checks; a profile never grants an operation.
+Schema resources remain available through the MCP Resources capability, while `get_schema`
+supports clients that expose only tools. Existing read, write, schema, administrative, user,
+and origin permissions remain independent mandatory checks; a profile never grants an
+operation. In particular, the two upsert tools remain unusable unless their existing write
+permissions are enabled.
 
 ## Transport behavior
 
@@ -75,3 +81,11 @@ Changing a profile through the configuration endpoint takes effect on subsequent
 Tests cover default compatibility, persistence, case-insensitive parsing, invalid-update
 atomicity, HTTP and standard input/output discovery filtering, execution denial for hidden
 tools, and successful execution of allowed tools.
+
+## Out of scope
+
+The profile setting remains server-global in this implementation. It cannot yet present a
+retrieval agent and an administrative agent with different tool lists when they share one MCP
+endpoint, so it does not by itself satisfy the per-agent part of #4859. Per-principal profile
+selection and enforcement is tracked in
+[#5445](https://github.com/ArcadeData/arcadedb/issues/5445).

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfigHandler.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfigHandler.java
@@ -52,7 +52,11 @@ public class MCPConfigHandler extends AbstractServerHttpHandler {
     if (Methods.POST.equals(exchange.getRequestMethod())) {
       if (payload == null)
         return new ExecutionResponse(400, new JSONObject().put("error", "Request body is required").toString());
-      config.updateFrom(payload);
+      try {
+        config.updateFrom(payload);
+      } catch (final IllegalArgumentException e) {
+        return new ExecutionResponse(400, new JSONObject().put("error", e.getMessage()).toString());
+      }
       config.save();
       return new ExecutionResponse(200, config.toJSON().toString());
     }

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfigHandler.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfigHandler.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.mcp;
 
+import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.AbstractServerHttpHandler;
@@ -54,7 +55,7 @@ public class MCPConfigHandler extends AbstractServerHttpHandler {
         return new ExecutionResponse(400, new JSONObject().put("error", "Request body is required").toString());
       try {
         config.updateFrom(payload);
-      } catch (final IllegalArgumentException e) {
+      } catch (final IllegalArgumentException | JSONException e) {
         return new ExecutionResponse(400, new JSONObject().put("error", e.getMessage()).toString());
       }
       config.save();

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 
@@ -38,6 +39,25 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class MCPConfiguration {
+  public enum ToolProfile {
+    ALL, RAG, ADMIN;
+
+    static ToolProfile parse(final String value) {
+      if (value == null)
+        return ALL;
+      try {
+        return valueOf(value.trim().toUpperCase(Locale.ROOT));
+      } catch (final IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            "Unknown MCP tool profile '" + value + "'. Expected one of: all, rag, admin", e);
+      }
+    }
+
+    String configName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+  }
+
   private final String rootPath;
 
   private volatile boolean      enabled          = false;
@@ -48,6 +68,7 @@ public class MCPConfiguration {
   private volatile boolean      allowSchemaChange = false;
   private volatile boolean      allowAdmin        = false;
   private volatile List<String> allowedUsers     = new CopyOnWriteArrayList<>(List.of("root"));
+  private volatile ToolProfile  toolProfile      = ToolProfile.ALL;
   // Extra browser origins accepted by the HTTP transport, on top of always-allowed loopback origins.
   // Empty by default: a non-loopback browser page must be opted in explicitly, because deriving trust
   // from its Host header would not prevent DNS rebinding.
@@ -67,6 +88,7 @@ public class MCPConfiguration {
     try {
       final String content = new String(Files.readAllBytes(configFile.toPath()), StandardCharsets.UTF_8);
       final JSONObject json = new JSONObject(content);
+      final ToolProfile loadedProfile = ToolProfile.parse(json.getString("profile", "all"));
 
       enabled = json.getBoolean("enabled", false);
       allowReads = json.getBoolean("allowReads", true);
@@ -75,6 +97,7 @@ public class MCPConfiguration {
       allowDelete = json.getBoolean("allowDelete", false);
       allowSchemaChange = json.getBoolean("allowSchemaChange", false);
       allowAdmin = json.getBoolean("allowAdmin", false);
+      toolProfile = loadedProfile;
 
       final JSONArray usersArray = json.getJSONArray("allowedUsers", null);
       if (usersArray != null) {
@@ -171,6 +194,20 @@ public class MCPConfiguration {
     this.allowedUsers = new CopyOnWriteArrayList<>(allowedUsers);
   }
 
+  public ToolProfile getToolProfile() {
+    return toolProfile;
+  }
+
+  public void setToolProfile(final ToolProfile toolProfile) {
+    if (toolProfile == null)
+      throw new IllegalArgumentException("MCP tool profile must not be null");
+    this.toolProfile = toolProfile;
+  }
+
+  public void setToolProfile(final String toolProfile) {
+    this.toolProfile = ToolProfile.parse(toolProfile);
+  }
+
   public List<String> getAllowedOrigins() {
     return Collections.unmodifiableList(allowedOrigins);
   }
@@ -223,12 +260,17 @@ public class MCPConfiguration {
     json.put("allowDelete", allowDelete);
     json.put("allowSchemaChange", allowSchemaChange);
     json.put("allowAdmin", allowAdmin);
+    json.put("profile", toolProfile.configName());
     json.put("allowedUsers", new JSONArray(allowedUsers));
     json.put("allowedOrigins", new JSONArray(allowedOrigins));
     return json;
   }
 
   public synchronized void updateFrom(final JSONObject json) {
+    final ToolProfile updatedProfile = json.has("profile")
+        ? ToolProfile.parse(json.getString("profile", null))
+        : toolProfile;
+
     if (json.has("enabled"))
       enabled = json.getBoolean("enabled");
     if (json.has("allowReads"))
@@ -243,6 +285,7 @@ public class MCPConfiguration {
       allowSchemaChange = json.getBoolean("allowSchemaChange");
     if (json.has("allowAdmin"))
       allowAdmin = json.getBoolean("allowAdmin");
+    toolProfile = updatedProfile;
     if (json.has("allowedUsers")) {
       final JSONArray usersArray = json.getJSONArray("allowedUsers", null);
       // Treat explicit null as an empty list (client intent to clear all users)

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.mcp;
 
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
 
@@ -272,19 +273,19 @@ public class MCPConfiguration {
         : toolProfile;
 
     if (json.has("enabled"))
-      enabled = json.getBoolean("enabled");
+      enabled = booleanValue(json, "enabled");
     if (json.has("allowReads"))
-      allowReads = json.getBoolean("allowReads");
+      allowReads = booleanValue(json, "allowReads");
     if (json.has("allowInsert"))
-      allowInsert = json.getBoolean("allowInsert");
+      allowInsert = booleanValue(json, "allowInsert");
     if (json.has("allowUpdate"))
-      allowUpdate = json.getBoolean("allowUpdate");
+      allowUpdate = booleanValue(json, "allowUpdate");
     if (json.has("allowDelete"))
-      allowDelete = json.getBoolean("allowDelete");
+      allowDelete = booleanValue(json, "allowDelete");
     if (json.has("allowSchemaChange"))
-      allowSchemaChange = json.getBoolean("allowSchemaChange");
+      allowSchemaChange = booleanValue(json, "allowSchemaChange");
     if (json.has("allowAdmin"))
-      allowAdmin = json.getBoolean("allowAdmin");
+      allowAdmin = booleanValue(json, "allowAdmin");
     toolProfile = updatedProfile;
     if (json.has("allowedUsers")) {
       final JSONArray usersArray = json.getJSONArray("allowedUsers", null);
@@ -308,5 +309,12 @@ public class MCPConfiguration {
 
   private File getConfigFile() {
     return Paths.get(rootPath, "config", "mcp-config.json").toFile();
+  }
+
+  private static boolean booleanValue(final JSONObject json, final String name) {
+    final Object value = json.opt(name);
+    if (value instanceof Boolean bool)
+      return bool;
+    throw new JSONException("MCP configuration field '" + name + "' must be a boolean");
   }
 }

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -64,18 +64,24 @@ public class MCPDispatcher {
 
   private static final String RAG_INSTRUCTIONS =
       """
-      You are connected to an ArcadeDB multi-model database server for retrieval. Follow these rules:
-      1. Read the arcadedb://{database}/schema Resource before searching an unfamiliar database.
-      2. Use query for custom read-only SQL or Cypher retrieval.
-      3. Prefer the dedicated vector, hybrid, full-text, or sampling tools shown by tools/list when they match the task.
-      4. ArcadeDB does not generate embeddings; supply vectors produced by your embedding model.""";
+      You are connected to an ArcadeDB multi-model database server for retrieval and agent memory. Follow these rules:
+      1. Call list_databases when you do not know the target database name.
+      2. Call get_schema before searching an unfamiliar database. If your client supports MCP Resources, prefer reading arcadedb://{database}/schema instead.
+      3. Use query for custom read-only SQL or Cypher retrieval.
+      4. Prefer the dedicated vector, hybrid, full-text, or sampling tools shown by tools/list when they match the task.
+      5. Use upsert_entity and upsert_relationship to maintain agent memory when the corresponding write permissions are enabled.
+      6. ArcadeDB does not generate embeddings; supply vectors produced by your embedding model.""";
 
   private static final Set<String> RAG_TOOL_NAMES = Set.of(
+      "list_databases",
+      "get_schema",
       "query",
       "sample_records",
       "vector_search",
       "hybrid_search",
-      "full_text_search");
+      "full_text_search",
+      "upsert_entity",
+      "upsert_relationship");
 
   private static final Set<String> ADMIN_TOOL_NAMES = Set.of(
       "list_databases",
@@ -304,9 +310,6 @@ public class MCPDispatcher {
   }
 
   private static JSONArray toolsForProfile(final MCPConfiguration.ToolProfile profile) {
-    if (profile == MCPConfiguration.ToolProfile.ALL)
-      return TOOLS_LIST;
-
     final JSONArray filtered = new JSONArray();
     for (int i = 0; i < TOOLS_LIST.length(); i++) {
       final JSONObject definition = TOOLS_LIST.getJSONObject(i);

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -40,6 +40,8 @@ import com.arcadedb.server.mcp.tools.UpsertRelationshipTool;
 import com.arcadedb.server.mcp.tools.VectorSearchTool;
 import com.arcadedb.server.security.ServerSecurityUser;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -49,6 +51,7 @@ import java.util.logging.Level;
 public class MCPDispatcher {
   public static final  String    MCP_PROTOCOL_VERSION = "2025-03-26";
   private static final JSONArray TOOLS_LIST;
+  private static final Set<String> REGISTERED_TOOL_NAMES;
 
   private static final String INSTRUCTIONS =
       """
@@ -58,6 +61,33 @@ public class MCPDispatcher {
       3. Use the 'query' tool for read-only operations (SELECT, MATCH, RETURN) and 'execute_command' for writes (CREATE, INSERT, UPDATE, DELETE, MERGE).
       4. Call get_schema before writing queries against an unfamiliar database to understand its types and properties. If your client supports MCP Resources, prefer reading arcadedb://{database}/schema instead: it carries the same content without spending a tool call.
       5. If a query returns no results, verify the type/property names with get_schema before concluding the data does not exist.""";
+
+  private static final String RAG_INSTRUCTIONS =
+      """
+      You are connected to an ArcadeDB multi-model database server for retrieval. Follow these rules:
+      1. Read the arcadedb://{database}/schema Resource before searching an unfamiliar database.
+      2. Use query for custom read-only SQL or Cypher retrieval.
+      3. Prefer the dedicated vector, hybrid, full-text, or sampling tools shown by tools/list when they match the task.
+      4. ArcadeDB does not generate embeddings; supply vectors produced by your embedding model.""";
+
+  private static final Set<String> RAG_TOOL_NAMES = Set.of(
+      "query",
+      "sample_records",
+      "vector_search",
+      "hybrid_search",
+      "full_text_search");
+
+  private static final Set<String> ADMIN_TOOL_NAMES = Set.of(
+      "list_databases",
+      "get_schema",
+      "query",
+      "execute_command",
+      "server_status",
+      "profiler_start",
+      "profiler_stop",
+      "profiler_status",
+      "get_server_settings",
+      "set_server_setting");
 
   static {
     TOOLS_LIST = new JSONArray();
@@ -75,6 +105,11 @@ public class MCPDispatcher {
     TOOLS_LIST.put(ProfilerStatusTool.getDefinition());
     TOOLS_LIST.put(GetServerSettingsTool.getDefinition());
     TOOLS_LIST.put(SetServerSettingTool.getDefinition());
+
+    final Set<String> registered = new HashSet<>();
+    for (int i = 0; i < TOOLS_LIST.length(); i++)
+      registered.add(TOOLS_LIST.getJSONObject(i).getString("name"));
+    REGISTERED_TOOL_NAMES = Set.copyOf(registered);
   }
 
   /**
@@ -149,7 +184,7 @@ public class MCPDispatcher {
     try {
       return switch (method) {
         case "initialize" -> result(id, initialize());
-        case "tools/list" -> result(id, new JSONObject().put("tools", TOOLS_LIST));
+        case "tools/list" -> result(id, new JSONObject().put("tools", toolsForProfile(config.getToolProfile())));
         case "tools/call" -> toolsCall(id, params, user);
         case "resources/list" -> resourcesList(id, user);
         case "resources/read" -> resourcesRead(id, params, user);
@@ -180,7 +215,8 @@ public class MCPDispatcher {
     capabilities.put("resources", new JSONObject().put("listChanged", false).put("subscribe", false));
     result.put("capabilities", capabilities);
 
-    result.put("instructions", INSTRUCTIONS);
+    result.put("instructions",
+        config.getToolProfile() == MCPConfiguration.ToolProfile.RAG ? RAG_INSTRUCTIONS : INSTRUCTIONS);
 
     return result;
   }
@@ -220,6 +256,12 @@ public class MCPDispatcher {
         .log(this, Level.INFO, "MCP[%s] tools/call '%s' %s (user=%s)", transport, toolName, formatArgs(args), user.getName());
 
     try {
+      if (!REGISTERED_TOOL_NAMES.contains(toolName))
+        throw new IllegalArgumentException("Unknown tool: " + toolName);
+      if (!isToolAllowed(config.getToolProfile(), toolName))
+        throw new SecurityException(
+            "Tool '" + toolName + "' is not available in MCP profile '" + config.getToolProfile().configName() + "'");
+
       final JSONObject toolResult = switch (toolName) {
         case "list_databases" -> ListDatabasesTool.execute(server, user, args, config);
         case "get_schema" -> GetSchemaTool.execute(server, user, args, config);
@@ -259,6 +301,29 @@ public class MCPDispatcher {
           .log(this, Level.WARNING, "MCP[%s] tools/call '%s' -> error: %s", transport, toolName, e.getMessage());
       return toolError(id, e.getMessage());
     }
+  }
+
+  private static JSONArray toolsForProfile(final MCPConfiguration.ToolProfile profile) {
+    if (profile == MCPConfiguration.ToolProfile.ALL)
+      return TOOLS_LIST;
+
+    final JSONArray filtered = new JSONArray();
+    for (int i = 0; i < TOOLS_LIST.length(); i++) {
+      final JSONObject definition = TOOLS_LIST.getJSONObject(i);
+      if (isToolAllowed(profile, definition.getString("name")))
+        filtered.put(definition);
+    }
+    return filtered;
+  }
+
+  static boolean isToolAllowed(final MCPConfiguration.ToolProfile profile, final String toolName) {
+    if (!REGISTERED_TOOL_NAMES.contains(toolName))
+      return false;
+    return switch (profile) {
+      case ALL -> true;
+      case RAG -> RAG_TOOL_NAMES.contains(toolName);
+      case ADMIN -> ADMIN_TOOL_NAMES.contains(toolName);
+    };
   }
 
   private static String formatArgs(final JSONObject args) {

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MCPConfigurationTest {
   private static final String TEST_ROOT = "./target/mcp-config-test";
@@ -55,6 +56,7 @@ class MCPConfigurationTest {
     assertThat(config.isAllowDelete()).isFalse();
     assertThat(config.isAllowSchemaChange()).isFalse();
     assertThat(config.getAllowedUsers()).containsExactly("root");
+    assertThat(config.getToolProfile()).isEqualTo(MCPConfiguration.ToolProfile.ALL);
   }
 
   @Test
@@ -63,6 +65,7 @@ class MCPConfigurationTest {
     config.setEnabled(true);
     config.setAllowInsert(true);
     config.setAllowUpdate(true);
+    config.setToolProfile(MCPConfiguration.ToolProfile.RAG);
     config.setAllowedUsers(List.of("root", "admin"));
     config.save();
 
@@ -73,6 +76,7 @@ class MCPConfigurationTest {
     assertThat(loaded.isAllowInsert()).isTrue();
     assertThat(loaded.isAllowUpdate()).isTrue();
     assertThat(loaded.isAllowDelete()).isFalse();
+    assertThat(loaded.getToolProfile()).isEqualTo(MCPConfiguration.ToolProfile.RAG);
     assertThat(loaded.getAllowedUsers()).containsExactly("root", "admin");
   }
 
@@ -126,6 +130,7 @@ class MCPConfigurationTest {
     assertThat(json.getBoolean("enabled")).isFalse();
     assertThat(json.getBoolean("allowReads")).isTrue();
     assertThat(json.getBoolean("allowInsert")).isFalse();
+    assertThat(json.getString("profile")).isEqualTo("all");
     assertThat(json.getJSONArray("allowedUsers").length()).isEqualTo(1);
     assertThat(json.getJSONArray("allowedUsers").getString(0)).isEqualTo("root");
   }
@@ -138,16 +143,43 @@ class MCPConfigurationTest {
     final JSONObject update = new JSONObject()
         .put("allowInsert", true)
         .put("allowDelete", true)
+        .put("profile", "admin")
         .put("allowedUsers", new JSONArray().put("root").put("editor"));
 
     config.updateFrom(update);
 
     assertThat(config.isAllowInsert()).isTrue();
     assertThat(config.isAllowDelete()).isTrue();
+    assertThat(config.getToolProfile()).isEqualTo(MCPConfiguration.ToolProfile.ADMIN);
     assertThat(config.getAllowedUsers()).containsExactly("root", "editor");
     // Unchanged values should remain
     assertThat(config.isEnabled()).isFalse();
     assertThat(config.isAllowUpdate()).isFalse();
+  }
+
+  @Test
+  void invalidProfileIsRejectedWithoutPartialUpdate() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.load();
+
+    assertThatThrownBy(() -> config.updateFrom(new JSONObject()
+        .put("allowInsert", true)
+        .put("profile", "retrieval")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("all").hasMessageContaining("rag").hasMessageContaining("admin");
+
+    assertThat(config.isAllowInsert()).isFalse();
+    assertThat(config.getToolProfile()).isEqualTo(MCPConfiguration.ToolProfile.ALL);
+  }
+
+  @Test
+  void profileNamesAreCaseInsensitive() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+
+    config.updateFrom(new JSONObject().put("profile", "RaG"));
+
+    assertThat(config.getToolProfile()).isEqualTo(MCPConfiguration.ToolProfile.RAG);
+    assertThat(config.toJSON().getString("profile")).isEqualTo("rag");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
@@ -173,6 +173,18 @@ class MCPConfigurationTest {
   }
 
   @Test
+  void invalidBooleanTypeIsRejected() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.load();
+
+    assertThatThrownBy(() -> config.updateFrom(new JSONObject().put("enabled", "yes")))
+        .isInstanceOf(com.arcadedb.serializer.json.JSONException.class)
+        .hasMessageContaining("enabled").hasMessageContaining("boolean");
+
+    assertThat(config.isEnabled()).isFalse();
+  }
+
+  @Test
   void profileNamesAreCaseInsensitive() {
     final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
 

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPPermissionsTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPPermissionsTest.java
@@ -180,4 +180,20 @@ class MCPPermissionsTest {
 
     assertThat(config.isUserAllowed(null)).isFalse();
   }
+
+  @Test
+  void toolProfilesAreAllowlists() {
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ALL, "full_text_search")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ALL, "execute_command")).isTrue();
+
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "full_text_search")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "query")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "execute_command")).isFalse();
+
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ADMIN, "execute_command")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ADMIN, "server_status")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ADMIN, "full_text_search")).isFalse();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ALL, "hybrid_search")).isFalse();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ALL, "unknown")).isFalse();
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPPermissionsTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPPermissionsTest.java
@@ -187,7 +187,11 @@ class MCPPermissionsTest {
     assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ALL, "execute_command")).isTrue();
 
     assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "full_text_search")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "list_databases")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "get_schema")).isTrue();
     assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "query")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "upsert_entity")).isTrue();
+    assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "upsert_relationship")).isTrue();
     assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.RAG, "execute_command")).isFalse();
 
     assertThat(MCPDispatcher.isToolAllowed(MCPConfiguration.ToolProfile.ADMIN, "execute_command")).isTrue();

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -213,6 +213,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
 
     assertThat(response.has("result")).isTrue();
     final JSONArray tools = response.getJSONObject("result").getJSONArray("tools");
+    assertThat(tools.length()).isPositive();
 
     // Verify tool names
     boolean hasListDatabases = false;
@@ -274,8 +275,10 @@ class MCPServerPluginTest extends BaseGraphServerTest {
         .put("id", 20)
         .put("method", "tools/list")
         .put("params", new JSONObject()));
-    assertThat(toolNames(response)).containsExactlyInAnyOrder(
-        "query", "full_text_search");
+    assertThat(toolNames(response))
+        .contains("list_databases", "get_schema", "query", "full_text_search",
+            "upsert_entity", "upsert_relationship")
+        .doesNotContain("server_status", "execute_command");
 
     JSONObject denied = callTool("server_status", new JSONObject());
     assertThat(denied.getBoolean("isError", false)).isTrue();
@@ -294,7 +297,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
         .put("id", 21)
         .put("method", "tools/list")
         .put("params", new JSONObject()));
-    assertThat(toolNames(response)).containsExactlyInAnyOrder(
+    assertThat(toolNames(response)).contains(
         "list_databases", "get_schema", "query", "execute_command", "server_status",
         "profiler_start", "profiler_stop", "profiler_status", "get_server_settings", "set_server_setting");
 
@@ -490,6 +493,29 @@ class MCPServerPluginTest extends BaseGraphServerTest {
       assertThat(config.has("allowReads")).isTrue();
       assertThat(config.getString("profile")).isEqualTo("all");
       assertThat(config.has("allowedUsers")).isTrue();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  @Test
+  void invalidConfigTypeReturnsBadRequest() throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(getMcpConfigUrl()).toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", getBasicAuth());
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+
+    final byte[] data = new JSONObject().put("enabled", "yes").toString().getBytes(StandardCharsets.UTF_8);
+    try (final DataOutputStream out = new DataOutputStream(connection.getOutputStream())) {
+      out.write(data);
+    }
+
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(400);
+      assertThat(FileUtils.readStreamAsString(connection.getErrorStream(), "utf8"))
+          .contains("enabled").contains("boolean");
     } finally {
       connection.disconnect();
     }

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -52,6 +52,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
     saveMCPConfig(new JSONObject()
         .put("enabled", true)
         .put("allowReads", true)
+        .put("profile", "all")
         .put("allowedUsers", new JSONArray().put("root")));
     seedFullTextIndex();
   }
@@ -265,6 +266,48 @@ class MCPServerPluginTest extends BaseGraphServerTest {
   }
 
   @Test
+  void toolProfilesFilterDiscoveryAndExecution() throws Exception {
+    saveMCPConfig(new JSONObject().put("profile", "rag"));
+
+    JSONObject response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 20)
+        .put("method", "tools/list")
+        .put("params", new JSONObject()));
+    assertThat(toolNames(response)).containsExactlyInAnyOrder(
+        "query", "full_text_search");
+
+    JSONObject denied = callTool("server_status", new JSONObject());
+    assertThat(denied.getBoolean("isError", false)).isTrue();
+    assertThat(denied.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("server_status").contains("rag");
+
+    final JSONObject allowed = callTool("query", new JSONObject()
+        .put("database", getDatabaseName())
+        .put("language", "sql")
+        .put("query", "SELECT FROM V1 LIMIT 1"));
+    assertThat(allowed.getBoolean("isError", true)).isFalse();
+
+    saveMCPConfig(new JSONObject().put("profile", "admin"));
+    response = mcpRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 21)
+        .put("method", "tools/list")
+        .put("params", new JSONObject()));
+    assertThat(toolNames(response)).containsExactlyInAnyOrder(
+        "list_databases", "get_schema", "query", "execute_command", "server_status",
+        "profiler_start", "profiler_stop", "profiler_status", "get_server_settings", "set_server_setting");
+
+    denied = callTool("full_text_search", new JSONObject());
+    assertThat(denied.getBoolean("isError", false)).isTrue();
+    assertThat(denied.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("full_text_search").contains("admin");
+
+    final JSONObject adminAllowed = callTool("server_status", new JSONObject());
+    assertThat(adminAllowed.getBoolean("isError", true)).isFalse();
+  }
+
+  @Test
   void listDatabases() throws Exception {
     final JSONObject response = callTool("list_databases", new JSONObject());
 
@@ -445,6 +488,7 @@ class MCPServerPluginTest extends BaseGraphServerTest {
       final JSONObject config = new JSONObject(body);
       assertThat(config.has("enabled")).isTrue();
       assertThat(config.has("allowReads")).isTrue();
+      assertThat(config.getString("profile")).isEqualTo("all");
       assertThat(config.has("allowedUsers")).isTrue();
     } finally {
       connection.disconnect();
@@ -2220,6 +2264,14 @@ class MCPServerPluginTest extends BaseGraphServerTest {
 
     assertThat(response.has("result")).isTrue();
     return response.getJSONObject("result");
+  }
+
+  private static Set<String> toolNames(final JSONObject response) {
+    final Set<String> names = new HashSet<>();
+    final JSONArray tools = response.getJSONObject("result").getJSONArray("tools");
+    for (int i = 0; i < tools.length(); i++)
+      names.add(tools.getJSONObject(i).getString("name"));
+    return names;
   }
 
   private void saveMCPConfig(final JSONObject config) throws Exception {

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
@@ -76,12 +76,25 @@ class MCPStdioServerTest extends BaseGraphServerTest {
     final JSONObject response = sendSingleRequest(request);
 
     assertThat(response.has("result")).isTrue();
-    final JSONArray tools = response.getJSONObject("result").getJSONArray("tools");
-    boolean hasVectorSearch = false;
-    for (int i = 0; i < tools.length(); i++)
-      if ("vector_search".equals(tools.getJSONObject(i).getString("name")))
-        hasVectorSearch = true;
-    assertThat(hasVectorSearch).isTrue();
+    assertThat(toolNames(response)).contains(
+        "list_databases", "get_schema", "query", "execute_command", "vector_search", "full_text_search",
+        "upsert_entity", "upsert_relationship", "server_status");
+  }
+
+  @Test
+  void toolsListReturnsIndependentArrays() throws Exception {
+    final JSONObject request = new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 3)
+        .put("method", "tools/list")
+        .put("params", new JSONObject());
+
+    final JSONArray first = sendSingleRequest(request).getJSONObject("result").getJSONArray("tools");
+    final int registeredToolCount = first.length();
+    first.remove(0);
+
+    final JSONArray second = sendSingleRequest(request).getJSONObject("result").getJSONArray("tools");
+    assertThat(second.length()).isEqualTo(registeredToolCount);
   }
 
   @Test
@@ -92,8 +105,10 @@ class MCPStdioServerTest extends BaseGraphServerTest {
         .put("id", 20)
         .put("method", "tools/list")
         .put("params", new JSONObject()));
-    assertThat(toolNames(response)).containsExactlyInAnyOrder(
-        "query", "full_text_search");
+    assertThat(toolNames(response))
+        .contains("list_databases", "get_schema", "query", "vector_search", "full_text_search",
+            "upsert_entity", "upsert_relationship")
+        .doesNotContain("server_status", "execute_command");
 
     JSONObject denied = callTool("server_status", new JSONObject());
     assertThat(denied.getBoolean("isError", false)).isTrue();
@@ -106,7 +121,7 @@ class MCPStdioServerTest extends BaseGraphServerTest {
         .put("id", 21)
         .put("method", "tools/list")
         .put("params", new JSONObject()));
-    assertThat(toolNames(response)).containsExactlyInAnyOrder(
+    assertThat(toolNames(response)).contains(
         "list_databases", "get_schema", "query", "execute_command", "server_status",
         "profiler_start", "profiler_stop", "profiler_status", "get_server_settings", "set_server_setting");
 

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
@@ -29,6 +29,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,6 +44,7 @@ class MCPStdioServerTest extends BaseGraphServerTest {
     config = getServer(0).getMCPConfiguration();
     config.setEnabled(true);
     config.setAllowReads(true);
+    config.setToolProfile(MCPConfiguration.ToolProfile.ALL);
     user = getServer(0).getSecurity().authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
   }
 
@@ -79,6 +82,38 @@ class MCPStdioServerTest extends BaseGraphServerTest {
       if ("vector_search".equals(tools.getJSONObject(i).getString("name")))
         hasVectorSearch = true;
     assertThat(hasVectorSearch).isTrue();
+  }
+
+  @Test
+  void toolProfilesFilterDiscoveryAndExecution() throws Exception {
+    config.setToolProfile(MCPConfiguration.ToolProfile.RAG);
+    JSONObject response = sendSingleRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 20)
+        .put("method", "tools/list")
+        .put("params", new JSONObject()));
+    assertThat(toolNames(response)).containsExactlyInAnyOrder(
+        "query", "full_text_search");
+
+    JSONObject denied = callTool("server_status", new JSONObject());
+    assertThat(denied.getBoolean("isError", false)).isTrue();
+    assertThat(denied.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("server_status").contains("rag");
+
+    config.setToolProfile(MCPConfiguration.ToolProfile.ADMIN);
+    response = sendSingleRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 21)
+        .put("method", "tools/list")
+        .put("params", new JSONObject()));
+    assertThat(toolNames(response)).containsExactlyInAnyOrder(
+        "list_databases", "get_schema", "query", "execute_command", "server_status",
+        "profiler_start", "profiler_stop", "profiler_status", "get_server_settings", "set_server_setting");
+
+    denied = callTool("full_text_search", new JSONObject());
+    assertThat(denied.getBoolean("isError", false)).isTrue();
+    assertThat(denied.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("full_text_search").contains("admin");
   }
 
   @Test
@@ -307,5 +342,13 @@ class MCPStdioServerTest extends BaseGraphServerTest {
     final JSONObject response = sendSingleRequest(request);
     assertThat(response.has("result")).isTrue();
     return response.getJSONObject("result");
+  }
+
+  private static Set<String> toolNames(final JSONObject response) {
+    final Set<String> names = new HashSet<>();
+    final JSONArray tools = response.getJSONObject("result").getJSONArray("tools");
+    for (int i = 0; i < tools.length(); i++)
+      names.add(tools.getJSONObject(i).getString("name"));
+    return names;
   }
 }


### PR DESCRIPTION
## Summary

- add persisted `all`, `rag`, and `admin` Model Context Protocol (MCP) tool profiles
- filter `tools/list` through the active profile
- enforce the same allowlist in `tools/call` so hidden tools cannot be invoked directly
- provide retrieval-focused initialization instructions for the `rag` profile
- document profile contents, configuration, and permission boundaries

## Behavior

`profile` defaults to `all`, preserving the current tool surface exactly.

The `rag` profile permits registered retrieval tools:

- `query`
- `full_text_search`
- `sample_records`
- `vector_search`
- `hybrid_search`

Only tools registered by the running server are advertised. This lets pending retrieval tools join the existing profile allowlist when installed without advertising unavailable tools.

The `admin` profile exposes the original operator and database-administration surface. Schema Resources remain available through the MCP Resources capability rather than consuming a tool slot.

Profiles restrict tool visibility and invocation; they do not grant read, write, schema, administrative, user, or origin permissions. Those existing checks remain mandatory.

Unknown profile values return HTTP 400 from the configuration endpoint and are rejected before any other field in the same update is applied.

## Validation

- focused profile, configuration, HTTP, and standard input/output tests: 109 passed
- complete MCP-only server test set: 146 passed
- final mixed-case configuration regression test: 12 passed
- no failures or skipped tests

Closes #4867
