### PR TITLE
fix: broken multi-page records were undeletable by every path

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -39,6 +39,7 @@ import com.arcadedb.engine.WALFileFactoryEmbedded;
 import com.arcadedb.engine.timeseries.TimeSeriesBucket;
 import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DatabaseIsClosedException;
 import com.arcadedb.exception.DatabaseIsReadOnlyException;
 import com.arcadedb.exception.DatabaseMetadataException;
@@ -1218,6 +1219,21 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
           LogManager.instance().log(this, Level.WARNING,
               "Cannot read record %s for index/external cleanup on delete (corrupted buffer): %s. Deleting the record anyway; "
                   + "run a database check to repair any dangling index entries.", record.getIdentity(), e.getMessage());
+        } catch (final ConcurrentModificationException e) {
+          // The record body could not be assembled for a consistent read, so its indexed keys and EXTERNAL pointers could
+          // not be read for cleanup. loadMultiPageRecord throws this after exhausting TX_RETRIES, but exhausted retries do
+          // NOT prove corruption: its page-version validation also fails when concurrent writes touch OTHER records
+          // sharing the chain's pages, so under a busy bucket this can be pure contention. Deleting anyway in that case
+          // would leak index entries for a healthy record. Disambiguate with a version-blind STRUCTURAL walk of the chunk
+          // chain: only a genuinely broken chain (a bad continuation pointer - the case that would otherwise make the
+          // record undeletable forever) takes the tolerant path below; transient contention rethrows, preserving the
+          // NeedRetryException semantics so the retry machinery re-runs the DELETE with intact index cleanup.
+          if (!bucket.isChunkChainBroken(record.getIdentity()))
+            throw e;
+          LogManager.instance().log(this, Level.WARNING,
+              "Cannot read record %s for index/external cleanup on delete (broken multi-page chunk chain): %s. Deleting the "
+                  + "record anyway; run a database check to repair any dangling index entries.", record.getIdentity(),
+              e.getMessage());
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -325,7 +325,20 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   @Override
   public void deleteRecord(final RID rid) {
     database.checkPermissionsOnFile(fileId, SecurityDatabaseUser.ACCESS.DELETE_RECORD);
-    deleteRecordInternal(rid, false, false);
+    deleteRecordInternal(rid, false, false, false);
+  }
+
+  /**
+   * Force-deletes a record even when its multi-page chunk chain is structurally broken. A normal delete walks the
+   * chain to free every chunk and, on a broken link, throws {@link ConcurrentModificationException} as a retry
+   * signal (#4932) so it never orphans chunks. That guard makes a genuinely-corrupt record undeletable by every
+   * path. With {@code force=true} a broken link stops the chain walk instead of aborting: the head slot is still
+   * freed so the record finally disappears, and any chunks past the break are orphaned (a bounded space leak) to be
+   * reclaimed by compaction or a database check. Intended for admin repair (CHECK DATABASE FIX), not the hot path.
+   */
+  public void deleteRecord(final RID rid, final boolean force) {
+    database.checkPermissionsOnFile(fileId, SecurityDatabaseUser.ACCESS.DELETE_RECORD);
+    deleteRecordInternal(rid, false, false, force);
   }
 
   @Override
@@ -591,7 +604,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             ++totalErrors;
             warning = "invalid record offset %d in page for record %s".formatted(recordPositionInPage, rid);
             if (fix) {
-              deleteRecordInternal(rid, true, true);
+              deleteRecordInternal(rid, true, true, true);
               deletedRecordsAfterFix.add(rid);
               ++totalDeletedRecords;
             }
@@ -613,7 +626,26 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 pageActiveRecords++;
                 pageMultiPageRecords++;
                 totalMultiPageRecords++;
-                recordSize[0] = page.readInt((int) (recordPositionInPage + recordSize[1]));
+
+                // Walk the continuation chain to detect a structurally broken multi-page record (a dangling or
+                // overwritten chunk pointer). check() otherwise validates only the first chunk's on-page size and
+                // would never notice a broken chain, leaving the record undeletable by every normal path because
+                // deleteRecordInternal throws the #4932 retry signal on it. On fix, force-delete it: the head slot is
+                // freed so the record finally disappears and any unreachable chunks are reclaimed later by compaction.
+                final String chainProblem = findBrokenChunkChain(rid, page, recordPositionInPage);
+                if (chainProblem != null) {
+                  ++totalErrors;
+                  warning = "broken multi-page chunk chain for record %s: %s".formatted(rid, chainProblem);
+                  if (fix) {
+                    deleteRecordInternal(rid, true, true, true);
+                    deletedRecordsAfterFix.add(rid);
+                    ++totalDeletedRecords;
+                    recordSize[0] = 0;
+                  }
+                }
+
+                if (recordSize[0] == FIRST_CHUNK)
+                  recordSize[0] = page.readInt((int) (recordPositionInPage + recordSize[1]));
               } else if (recordSize[0] == NEXT_CHUNK) {
                 totalChunks++;
                 pageChunks++;
@@ -632,7 +664,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 ++totalErrors;
                 warning = "wrong record size %d found for record %s".formatted(recordSize[1] + recordSize[0], rid);
                 if (fix) {
-                  deleteRecordInternal(rid, true, true);
+                  deleteRecordInternal(rid, true, true, true);
                   deletedRecordsAfterFix.add(rid);
                   ++totalDeletedRecords;
                 }
@@ -646,7 +678,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
               warning = "unknown error on loading record %s: %s".formatted(rid, e.getMessage());
 
               if (fix && !(e instanceof RecordNotFoundException)) {
-                deleteRecordInternal(rid, true, true);
+                deleteRecordInternal(rid, true, true, true);
                 deletedRecordsAfterFix.add(rid);
                 ++totalDeletedRecords;
               }
@@ -1146,7 +1178,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         }
 
         // DELETE OLD PLACEHOLDER, A NEW PLACEHOLDER WILL BE CREATED WITH ENOUGH SPACE
-        deleteRecordInternal(placeHolderContentRID, true, false);
+        deleteRecordInternal(placeHolderContentRID, true, false, false);
 
         recordSize[0] = LONG_SERIALIZED_SIZE;
         recordSize[1] = 1L;
@@ -1311,7 +1343,92 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     }
   }
 
-  private void deleteRecordInternal(final RID rid, final boolean deletePlaceholderContent, final boolean deleteChunks) {
+  /**
+   * Structurally walks the chunk chain of a multi-page record WITHOUT MVCC version validation to detect a broken
+   * chain: a continuation pointer to an out-of-range page, a slot that was cleaned, or a marker that is no longer
+   * {@link #NEXT_CHUNK}. Used by {@link #check(int, boolean)}, which otherwise validates only the first chunk's
+   * on-page size and would never notice a broken chain. Returns {@code null} when the chain is intact, or a short
+   * human-readable reason when it is broken. Never throws.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private String findBrokenChunkChain(final RID rid, final BasePage firstPage, final int firstRecordPositionInPage) {
+    try {
+      BasePage chunkPage = firstPage;
+      int chunkPositionInPage = firstRecordPositionInPage;
+      long[] chunkHeader = firstPage.readNumberAndSize(firstRecordPositionInPage); // [FIRST_CHUNK, headerBytes]
+      final int totalPages = getTotalPages();
+
+      // Exact loop detection: a chain can legitimately hold more chunks than the bucket has pages (chunk slots can
+      // share pages after chain reuse/fragmentation), so any count-based heuristic risks a false positive - fatal
+      // here, because check(fix) DELETES the record it flags. Revisiting a continuation pointer is the only certain
+      // loop signal.
+      final Set<Long> visitedPointers = new HashSet<>();
+
+      for (int chunkId = 0; ; ++chunkId) {
+        final long nextChunkPointer = chunkPage.readLong(
+                (int) (chunkPositionInPage + chunkHeader[1] + INT_SERIALIZED_SIZE));
+        if (nextChunkPointer == 0)
+          // REACHED THE LAST CHUNK CLEANLY
+          return null;
+
+        if (!visitedPointers.add(nextChunkPointer))
+          return "chain loop detected at chunk " + chunkId;
+
+        final int nextPageId = (int) (nextChunkPointer / maxRecordsInPage);
+        final int nextPositionInPage = (int) (nextChunkPointer % maxRecordsInPage);
+        if (nextPageId >= totalPages)
+          return "next chunk pointer out of range at chunk " + chunkId;
+
+        chunkPage = database.getTransaction().getPage(new PageId(database, file.getFileId(), nextPageId), pageSize);
+        chunkPositionInPage = getRecordPositionInPage(chunkPage, nextPositionInPage);
+        if (chunkPositionInPage == 0)
+          return "chunk slot cleaned at chunk " + chunkId;
+
+        chunkHeader = chunkPage.readNumberAndSize(chunkPositionInPage);
+        if (chunkHeader[0] != NEXT_CHUNK)
+          return "unexpected marker at chunk " + chunkId;
+      }
+    } catch (final Exception e) {
+      return "error walking chain: " + e.getMessage();
+    }
+  }
+
+  /**
+   * Structural probe for the tolerant delete path: tells whether the record at {@code rid} is a multi-page record
+   * whose chunk chain is structurally broken. Unlike {@link #loadMultiPageRecord} this walk ignores page versions,
+   * so a transient concurrent modification never reports {@code true} - only a genuinely broken chain does. Any
+   * failure to probe (including a record that is not multi-page, or is already gone) conservatively returns
+   * {@code false}, keeping the caller on the strict retry behaviour.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  public boolean isChunkChainBroken(final RID rid) {
+    try {
+      final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+      final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+      if (pageId >= getTotalPages())
+        return false;
+
+      final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
+      final int recordPositionInPage = getRecordPositionInPage(page, positionInPage);
+      if (recordPositionInPage == 0)
+        // DELETED
+        return false;
+
+      final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
+      if (recordSize[0] != FIRST_CHUNK)
+        // NOT A MULTI-PAGE RECORD: A CME ON IT CANNOT COME FROM A BROKEN CHAIN
+        return false;
+
+      return findBrokenChunkChain(rid, page, recordPositionInPage) != null;
+    } catch (final Exception e) {
+      return false;
+    }
+  }
+
+  private void deleteRecordInternal(final RID rid, final boolean deletePlaceholderContent, final boolean deleteChunks,
+      final boolean force) {
     final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
     final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
 
@@ -1353,7 +1470,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           // FOUND PLACEHOLDER POINTER: DELETE THE PLACEHOLDER CONTENT FIRST
           final RID placeHolderContentRID = new RID(fileId, page.readLong((int) (recordPositionInPage + recordSize[1])));
           try {
-            deleteRecordInternal(placeHolderContentRID, true, false);
+            deleteRecordInternal(placeHolderContentRID, true, false, force);
           } catch (RecordNotFoundException e) {
             // PARTIAL RECORD NOT FOUND
           }
@@ -1374,23 +1491,47 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             final int chunkPageId = (int) (nextChunkPointer / maxRecordsInPage);
             final int chunkPositionInPage = (int) (nextChunkPointer % maxRecordsInPage);
 
-            chunkPage = database.getTransaction()
-                    .getPageToModify(new PageId(database, file.getFileId(), chunkPageId), pageSize, false);
-            chunkRecordPositionInPage = getRecordPositionInPage(chunkPage, chunkPositionInPage);
-            if (chunkRecordPositionInPage == 0)
-              // Chunk was deleted by a concurrent update — signal retry
-              throw new ConcurrentModificationException(
-                      "Multi-page record " + rid + " chunk " + chunkId + " was modified concurrently. Please retry");
+            // Resolve the next chunk. A broken link (out-of-range pointer, a slot that was cleaned, or a marker that
+            // is no longer NEXT_CHUNK) means the chain cannot be walked. Without force this is treated as a concurrent
+            // modification and rethrown as the #4932 retry signal, so a half-freed chain is never left behind. With
+            // force (admin repair) the walk stops here instead: the head slot is still freed below, and the chunks
+            // past this break are orphaned - a bounded space leak reclaimed by compaction or a later database check.
+            String chainProblem = null;
+            try {
+              if (chunkPageId >= getTotalPages())
+                chainProblem = "next chunk pointer out of range";
+              else {
+                chunkPage = database.getTransaction()
+                        .getPageToModify(new PageId(database, file.getFileId(), chunkPageId), pageSize, false);
+                chunkRecordPositionInPage = getRecordPositionInPage(chunkPage, chunkPositionInPage);
+                if (chunkRecordPositionInPage == 0)
+                  chainProblem = "chunk slot was cleaned";
+                else {
+                  recordSize = chunkPage.readNumberAndSize(chunkRecordPositionInPage);
+                  if (recordSize[0] != NEXT_CHUNK)
+                    chainProblem = "chunk marker is not NEXT_CHUNK";
+                }
+              }
+            } catch (final IOException e) {
+              if (!force)
+                throw e;
+              chainProblem = "error reading chunk: " + e.getMessage();
+            }
 
-            recordSize = chunkPage.readNumberAndSize(chunkRecordPositionInPage);
+            if (chainProblem != null) {
+              if (!force)
+                // Chunk was modified/removed by a concurrent operation — signal retry (#4932)
+                throw new ConcurrentModificationException(
+                        "Multi-page record " + rid + " chunk " + chunkId + " was modified concurrently. Please retry");
 
-            if (recordSize[0] != NEXT_CHUNK)
-              // Chunk was overwritten by a concurrent operation — signal retry
-              throw new ConcurrentModificationException(
-                      "Multi-page record " + rid + " chunk " + chunkId + " was modified concurrently. Please retry");
+              LogManager.instance().log(this, Level.WARNING,
+                      "Force-deleting multi-page record %s with a broken chunk chain at chunk %d (%s); orphaned chunks (if "
+                              + "any) will be reclaimed by compaction or a database check.", rid, chunkId, chainProblem);
+              break;
+            }
 
             try {
-              deleteRecordInternal(new RID(fileId, nextChunkPointer), false, true);
+              deleteRecordInternal(new RID(fileId, nextChunkPointer), false, true, force);
             } catch (RecordNotFoundException e) {
               // PARTIAL RECORD NOT FOUND
             }

--- a/engine/src/test/java/com/arcadedb/BrokenMultiPageRecordDeleteTest.java
+++ b/engine/src/test/java/com/arcadedb/BrokenMultiPageRecordDeleteTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Regression test: a multi-page record whose chunk chain is structurally broken (a dangling continuation pointer) must
+ * be removable. Before the fix such a record was undeletable by every path: a direct {@code DELETE} first failed while
+ * lazy-loading the body for index cleanup (loadMultiPageRecord threw {@link ConcurrentModificationException}), and even
+ * after that, the physical free walked the chain and threw the same #4932 retry signal on the broken link
+ * ("chunk 0 was modified concurrently"). {@code CHECK DATABASE FIX} could not help either, because it never walked the
+ * continuation chain and its own fix-delete funnels through the same guard.
+ *
+ * <p>The fix adds a {@code force} delete mode that stops at a broken link instead of aborting (freeing the head slot and
+ * leaving unreachable chunks for compaction to reclaim), makes {@code CHECK DATABASE} detect a broken chain, and wires
+ * its fix-delete to use force. The default (non-force) delete keeps the #4932 retry behaviour for transient conflicts.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BrokenMultiPageRecordDeleteTest extends TestHelper {
+
+  private static final String TYPE = "LargeRecord";
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // This test deliberately injects on-disk corruption, which the post-test integrity check would (correctly) flag.
+    return false;
+  }
+
+  @Test
+  void checkDatabaseFixRemovesBrokenMultiPageRecord() {
+    final RID broken = createBrokenMultiPageVertex();
+
+    // The broken record is still allocated and would otherwise stay forever.
+    assertThat(database.countType(TYPE, false)).isEqualTo(3L);
+
+    // A plain check must SEE the broken chain (it used to be invisible - only the first chunk's on-page size was
+    // validated), but must not remove anything.
+    ResultSet result = database.command("sql", "check database");
+    Result row = result.next();
+    assertThat(((Collection<?>) row.getProperty("warnings")).size()).isGreaterThanOrEqualTo(1);
+    assertThat(row.<Collection<?>>getProperty("warnings").toString()).contains("broken multi-page chunk chain");
+    assertThat(database.countType(TYPE, false)).isEqualTo(3L);
+
+    // CHECK DATABASE FIX must force-remove the broken record.
+    result = database.command("sql", "check database fix");
+    row = result.next();
+    assertThat(((Collection<?>) row.getProperty("deletedRecordsAfterFix")).contains(broken)).isTrue();
+    assertThat(database.getSchema().getBucketById(broken.getBucketId()).existsRecord(broken)).isFalse();
+    assertThat(database.countType(TYPE, false)).isEqualTo(2L);
+
+    // A follow-up check must now be clean.
+    result = database.command("sql", "check database");
+    row = result.next();
+    assertThat(row.<Collection<?>>getProperty("warnings").toString()).doesNotContain("broken multi-page chunk chain");
+  }
+
+  @Test
+  void forceDeleteRemovesBrokenMultiPageRecordWhilePlainDeleteRetries() {
+    final RID broken = createBrokenMultiPageVertex();
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(broken.getBucketId());
+
+    // The structural probe (used to gate the tolerant delete path) must flag the broken chain, and must NOT flag an
+    // intact record: a false positive there would let a DELETE under contention skip index cleanup on a healthy record.
+    database.transaction(() -> {
+      assertThat(bucket.isChunkChainBroken(broken)).isTrue();
+      final RID intact = new RID(broken.getBucketId(), 1L); // the first small vertex, same bucket
+      assertThat(bucket.isChunkChainBroken(intact)).isFalse();
+    });
+
+    // The default (non-force) physical delete must still raise the #4932 retry signal on the broken chunk chain, so
+    // transient conflicts keep retrying instead of silently orphaning chunks.
+    database.begin();
+    try {
+      bucket.deleteRecord(broken);
+      fail("Expected ConcurrentModificationException on deleting a record with a broken chunk chain");
+    } catch (final ConcurrentModificationException expected) {
+      // EXPECTED: broken chain surfaces as the retry signal without force.
+    } finally {
+      database.rollback();
+    }
+    assertThat(database.getSchema().getBucketById(broken.getBucketId()).existsRecord(broken)).isTrue();
+
+    // The force delete removes the stuck record. existsRecord is the authoritative physical check; countType is not
+    // used as the oracle here because this low-level bucket.deleteRecord bypasses the database-level record counter.
+    database.transaction(() -> bucket.deleteRecord(broken, true));
+    assertThat(database.getSchema().getBucketById(broken.getBucketId()).existsRecord(broken)).isFalse();
+
+    // A CHECK DATABASE FIX afterwards reconciles the counter and finds nothing else to repair.
+    final Result row = database.command("sql", "check database fix").next();
+    assertThat(row.<Collection<?>>getProperty("warnings").toString()).doesNotContain("broken multi-page chunk chain");
+    assertThat(database.countType(TYPE, false)).isEqualTo(2L);
+  }
+
+  /**
+   * Creates a genuine multi-page vertex at position 0, then corrupts the FIRST_CHUNK's continuation pointer so the
+   * chunk chain is broken at chunk 0 (points to a page well beyond the file). Reopens so the record is re-read from the
+   * corrupted page, not the in-memory cache. Returns the RID of the broken record.
+   */
+  private RID createBrokenMultiPageVertex() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final int[] bucketIdHolder = new int[1];
+    db.transaction(() -> {
+      final VertexType type = db.getSchema().createVertexType(TYPE, 1);
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("data", Type.STRING);
+      bucketIdHolder[0] = type.getBuckets(false).get(0).getFileId();
+    });
+
+    final int bucketId = bucketIdHolder[0];
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(bucketId)).getPageSize();
+
+    // A payload several pages long guarantees a multi-page (FIRST_CHUNK) record spanning multiple chunks.
+    final String bigData = "x".repeat(pageSize * 4);
+
+    final RID[] rids = new RID[3];
+    db.transaction(() -> {
+      // Insert the big record FIRST so it lands at position 0 (page 0, slot 0).
+      rids[0] = db.newVertex(TYPE).set("id", 0).set("data", bigData).save().getIdentity();
+      rids[1] = db.newVertex(TYPE).set("id", 1).set("data", "small1").save().getIdentity();
+      rids[2] = db.newVertex(TYPE).set("id", 2).set("data", "small2").save().getIdentity();
+    });
+
+    assertThat(rids[0].getPosition()).isEqualTo(0L);
+
+    corruptFirstChunkPointer(bucketId);
+
+    reopenDatabase();
+
+    return rids[0];
+  }
+
+  /**
+   * Overwrites the next-chunk pointer of the FIRST_CHUNK at page 0 / slot 0 with a value pointing to a page far beyond
+   * the file, breaking the chain at chunk 0.
+   */
+  private void corruptFirstChunkPointer(final int bucketId) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(bucketId)).getPageSize();
+    final int maxRecordsInPage = ((LocalBucket) db.getSchema().getBucketById(bucketId)).getMaxRecordsInPage();
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, bucketId, 0), pageSize, false);
+        // PAGE_RECORD_TABLE_OFFSET == PAGE_RECORD_COUNT_IN_PAGE_OFFSET(0) + SHORT_SERIALIZED_SIZE; slot 0 holds the
+        // content-relative offset of the first record.
+        final int recordOffset = (int) page.readUnsignedInt(Binary.SHORT_SERIALIZED_SIZE);
+
+        // Confirm the record really is a multi-page head: FIRST_CHUNK (-2) is zigzag-encoded as the single byte 0x03.
+        assertThat(page.readByte(recordOffset)).as("record must be a multi-page FIRST_CHUNK").isEqualTo((byte) 3);
+
+        // Layout after the marker: [chunkSize:int][nextChunkPointer:long][content...]. Point the continuation to a page
+        // that does not exist so the chain is broken at chunk 0.
+        final int nextChunkPointerOffset = recordOffset + 1 + Binary.INT_SERIALIZED_SIZE;
+        page.writeLong(nextChunkPointerOffset, 1_000_000L * maxRecordsInPage);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+}


### PR DESCRIPTION
A multi-page record with a structurally broken chunk chain (dangling continuation pointer) could not be removed: DELETE failed while lazy-loading the body for index cleanup (ConcurrentModificationException from loadMultiPageRecord), and even past that, the physical free rethrew the same #4932 retry signal on the broken link. CHECK DATABASE FIX could not help either: it never walked the continuation chain and its fix-delete funnels through the same guard.

- deleteRecordInternal gains a force mode: on a broken link it stops the walk and frees the head slot instead of aborting; unreachable chunks are a bounded, logged leak reclaimed by compaction or a database check. Default (non-force) keeps the #4932 retry behaviour.
- CHECK DATABASE now detects a broken chain (findBrokenChunkChain, exact visited-pointer loop detection) and, with FIX, force-deletes the record.
- The tolerant-delete path in deleteRecordNoLock also catches CME, gated by a version-blind structural probe (isChunkChainBroken) so transient contention keeps NeedRetryException semantics and only a genuinely broken chain takes the best-effort path.
- Non-force delete on an out-of-range chunk pointer now raises the retry signal instead of silently zeroing the slot and orphaning chunks.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
