### PR TITLE
fix(#5407): keep unapplied phase-2 entries inside the Raft replay window

### DIFF
--- a/docs/5407-ha-leader-crash-phase2-write-loss.md
+++ b/docs/5407-ha-leader-crash-phase2-write-loss.md
@@ -122,12 +122,44 @@ Not applied: a Micrometer gauge for `pendingLocalPhase2` size. This class has no
 today, so adding it is genuine follow-up scope rather than part of this fix; the WARNING covers the
 operator-visibility gap in the meantime.
 
+## Review cycle 2 (head `1dd6ea54e`)
+
+`claude[bot]` re-reviewed and independently confirmed the crux ordering (register the floor before
+replication, release only after pages settle) and the idempotent double-release. Applied:
+
+- **Orphaned Javadoc fixed.** Inserting `releasePhase2Ticket`/`stateMachineOrNull` had split
+  `markTransactionAbandonedForLocalApply`'s Javadoc from its method, leaving two stacked comments on
+  one method and none on the other. A real defect introduced by this PR; the block is back where it
+  belongs.
+- **`Issue5407Phase2TicketLifecycleTest` extended to 7 cases**, closing the branch matrix with the
+  `MajorityCommittedAllFailedException` (ALL-quorum recovery) exit: release when the recovery apply
+  settles the pages, retain when neither it nor reconciliation does.
+
+Considered and **not** changed, with reasons:
+
+- **Drop the `// @VisibleForTesting` marker.** Declined: it is an established convention in this
+  codebase (12 occurrences, 5 of them in `ArcadeStateMachine` in this same package). Removing it here
+  would make the new code inconsistent with its immediate neighbours, against the project's
+  "adhere to the existing code" rule.
+- **Per-commit allocation** (boxed `Long` key + `PendingPhase2` record on each leader commit). The
+  reviewer flagged this for awareness rather than as a request. Kept: the same commit path already
+  allocates the payload, a copy of the bucket-delta map, and the WAL byte array, then makes a gRPC
+  round trip - two small short-lived objects are noise against that, and the map churns back to empty
+  in steady state.
+
 ## Notes for follow-up
 
 - The `ReplicationDispatchedTimeoutException` path (#4790) now also retains its ticket, which makes
   that indeterminate window crash-safe as a side effect. The in-memory
   `abandonedLocalTransactions` marker it relies on is still lost on a real crash; the retained
   ticket means replay covers the entry instead.
+  - **Known rough edge, worth its own issue.** When such an entry *does* later reach quorum and is
+    applied by `applyTxEntry` (the usual resolution of a #4790 timeout), its pages become durable but
+    nothing releases the ticket, so compaction stays pinned until the node restarts. Since #4790
+    timeouts are transient, that is arguably heavier than the crash window it protects. Releasing the
+    ticket when `applyTxEntry` consumes an abandoned-tx marker would fix it, but needs a
+    ticket-to-walTxId correlation that does not exist today, so it is deliberately left out of this
+    PR rather than bolted on to a delicate path. The 5-minute WARNING makes it visible meanwhile.
 - The persisted `.raft/applied-index` file is intentionally left unclamped. It never feeds the
   replay position (only the snapshot-gap check, the per-database bootstrap replay-skip, and the
   "never applied anything" bootstrap signal), so clamping it would change bootstrap behaviour

--- a/docs/5407-ha-leader-crash-phase2-write-loss.md
+++ b/docs/5407-ha-leader-crash-phase2-write-loss.md
@@ -93,6 +93,35 @@ mvn -pl ha-raft verify -DskipTests -Pintegration \
 mvn -pl ha-raft test -Dtest=ArcadeStateMachinePendingPhase2SnapshotTest
 ```
 
+## Review cycle 1 (PR #5408, head `198274bd9`)
+
+`claude[bot]` reviewed and confirmed the correctness of the clamp direction, the no-regression guard,
+and the idempotent ticket release. `gemini-code-assist` did not respond within the polling window.
+Applied:
+
+- **Stalled-compaction observability** (the reviewer's only pre-merge ask). A retained ticket pins the
+  checkpoint until restart, previously signalled only by a `HALog.BASIC` line. `pendingLocalPhase2`
+  now records each ticket's start time and `takeSnapshot()` emits a throttled `WARNING` once a held
+  ticket exceeds 5 minutes, naming the pinned index and pointing at Raft-storage disk usage.
+  Implemented rather than left as a TODO: it is a hazard this change introduces.
+  - One detail in the review was slightly off: a stuck ticket does *not* make every `takeSnapshot()`
+    return `INVALID_LOG_INDEX`. It keeps returning the stalled floor and re-registering the marker
+    there; only a clamp that would regress below an existing marker returns `INVALID_LOG_INDEX`. The
+    operational consequence (log not purged past that index) is the same.
+- **Term/index comment** in `takeSnapshot()` explaining that after a clamp the marker term may not
+  match the clamped index, why that is already tolerated (#575/#593), and why it must not be
+  "corrected" by looking up the term at the clamped index (that entry may be purged).
+- **`Issue5407Phase2TicketLifecycleTest`** (5 cases) pinning which exit releases the ticket -
+  phase-2 success releases, a fault between replication and phase 2 retains, an unreconciled phase-2
+  failure retains, replication failure releases, replica commit releases. `replicateAndCommitLocally`
+  was made package-private for this (existing convention in the module). This is the part of the fix
+  most exposed to a future refactor, and the retain case fails if the guard is moved back into a
+  blanket `finally`.
+
+Not applied: a Micrometer gauge for `pendingLocalPhase2` size. This class has no metrics wiring
+today, so adding it is genuine follow-up scope rather than part of this fix; the WARNING covers the
+operator-visibility gap in the meantime.
+
 ## Notes for follow-up
 
 - The `ReplicationDispatchedTimeoutException` path (#4790) now also retains its ticket, which makes
@@ -103,3 +132,6 @@ mvn -pl ha-raft test -Dtest=ArcadeStateMachinePendingPhase2SnapshotTest
   replay position (only the snapshot-gap check, the per-database bootstrap replay-skip, and the
   "never applied anything" bootstrap signal), so clamping it would change bootstrap behaviour
   without improving durability.
+- Worth a follow-up issue: expose `pendingLocalPhase2Count()` (and the oldest held floor) as a
+  Micrometer gauge so a node whose compaction is pinned is visible on a dashboard, not only in the
+  log.

--- a/docs/5407-ha-leader-crash-phase2-write-loss.md
+++ b/docs/5407-ha-leader-crash-phase2-write-loss.md
@@ -139,10 +139,10 @@ in isolation and the full batch re-ran clean: cross-test startup contention, not
   releases the ticket, so compaction stays pinned until the node restarts. Since those timeouts are
   transient, this can happen without any crash. Releasing on `applyTxEntry` needs a
   ticket-to-`walTxId` correlation that does not exist today; adding one to that path was judged worse
-  than the documented gap for a change whose purpose is durability. **Worth a tracking issue.**
+  than the documented gap for a change whose purpose is durability. Tracked in **#5410**.
 - **No metric for a pinned checkpoint.** `pendingLocalPhase2Count()` exists but this class has no
   Micrometer wiring; exposing it (plus the oldest held floor) as a gauge would make a stalled node
-  visible on a dashboard rather than only in the log.
+  visible on a dashboard rather than only in the log. Also tracked in **#5410**.
 
 ## Design notes
 

--- a/docs/5407-ha-leader-crash-phase2-write-loss.md
+++ b/docs/5407-ha-leader-crash-phase2-write-loss.md
@@ -1,169 +1,153 @@
-# 5407 - HA: leader crash between Raft commit and phase-2 apply permanently loses a locally-originated write
+# Issue #5407 - leader crash between Raft commit and phase-2 apply permanently loses a write
 
-Issue: https://github.com/ArcadeData/arcadedb/issues/5407
+## Symptom
 
-## Problem
+`RaftLeaderCrashBetweenCommitAndApplyIT` and `RaftLeaderCrashWithExternalPropertyIT` failed
+deterministically (4/4 and 3/3). A leader is stopped in the window between Raft replication and its
+local phase-2 apply; on restart it never recovers the injected record:
 
-On the leader, a locally-originated transaction is written to local pages by
-`RaftReplicatedDatabase.commit()`'s **phase 2** (`commit2ndPhase`), which runs *after* Raft
-replication succeeds. When Ratis commits the entry it independently calls
-`ArcadeStateMachine.applyTransaction`, which:
+```
+expected: 101L but was: 100L
+Suppressed: DatabaseAreNotIdentical: Page PageId(graph/28/0) DB1 v2 <> DB2 v1
+```
 
-1. **origin-skips** the data apply (`originatedLocally == true`) - correct, phase 2 owns the write; but
-2. still advances `lastAppliedIndex` to that entry's index.
+Followers keep the write (Raft durability holds), so the cluster majority is correct. The recovered
+ex-leader diverges silently and permanently.
 
-If phase 2 never runs, the node is left holding a committed entry it never applied. That state was
-recoverable in memory, but not durably: `takeSnapshot()` reported `lastAppliedIndex` as the Ratis
-durability checkpoint and wrote a `snapshot.<term>_<index>` marker at it. Since `reinitialize()`
-seeds the replay position **exclusively** from that marker, a restart began replaying *above* the
-unapplied entry. Neither Raft replay nor follower catch-up ever revisited it, so the write was
-silently and permanently lost on that node.
+## Root cause
 
-This is the hard-crash analog of #4790, whose `abandonedLocalTransactions` marker is in-memory only
-and therefore cannot survive the window.
+On the leader the local page write is **phase 2** (`RaftReplicatedDatabase.commit` ->
+`commit2ndPhase`), which runs *after* Raft replication. When Ratis commits the entry it calls
+`ArcadeStateMachine.applyTransaction`, which origin-skips the data apply (`originatedLocally == true`
+- correct, phase 2 owns the write) but still advances `lastAppliedIndex`. If phase 2 never runs, the
+node holds a committed entry it never applied.
 
-## Root cause evidence
+What makes that permanent is `takeSnapshot()`: it reported `lastAppliedIndex` as Ratis's durability
+checkpoint and wrote a `snapshot.<term>_<index>` marker at it. `reinitialize()` seeds the replay
+position **exclusively** from that marker (the persisted `.raft/applied-index` file is *not*
+consulted for it - that file only feeds the snapshot-gap check, the per-database bootstrap
+replay-skip, and `hasNeverAppliedApplicationEntry()`). So the restart began replaying *above* the
+unapplied entry, and neither replay nor follower catch-up ever revisited it.
 
-Reproduced deterministically on `main` (4/4 runs). After the failing run, the crashed old leader's
-on-disk Raft state showed the smoking gun - a snapshot checkpoint covering the entry whose pages
-were never written:
+Evidence from a failing run - a checkpoint sitting exactly on the lost entry (index 9):
 
 ```
 databases1/.raft/applied-index                 {"global":9,"db":{"graph":9}}
-databases1/.raft-storage/.../sm/snapshot.1_9   0B      <- checkpoint at the lost entry (index 9)
+databases1/.raft-storage/.../sm/snapshot.1_9   0B
 ```
 
-The restarted node consequently reported itself caught up within ~125 ms of rejoining, replayed
-nothing, and ended at 100 records instead of 101 (`Page(graph/28/0) DB1 v2 <> DB2 v1`).
+**Ratis takes a snapshot on shutdown**, which is what makes the loss durable. This is therefore not
+only a hard-crash window: any stop after an aborted phase 2 (graceful stop, or `triggerCriticalHalt()`'s
+async `server.stop()`) buries the entry. Under a true SIGKILL no shutdown snapshot is taken at all,
+so the entry would still replay.
 
-Ratis takes a snapshot on shutdown, which is what makes the loss durable: an aborted phase 2
-followed by any shutdown (graceful stop, or the `triggerCriticalHalt()` path) buries the entry.
+This is the crash analog of #4790, whose `abandonedLocalTransactions` marker is in-memory only and
+cannot survive the window.
 
 ## Fix
 
-Keep committed-but-not-locally-applied entries inside the Raft replay window until their local
-apply is proven.
+Keep committed-but-not-locally-applied entries inside the Raft replay window until their local apply
+is proven.
 
 **`ArcadeStateMachine`**
-- New in-memory registry of in-flight leader-side phase-2 applies: `beginLocalPhase2()` records the
-  applied index observed *before* replication (the entry's "replay floor") and returns a ticket;
-  `endLocalPhase2(ticket)` releases it.
+- `beginLocalPhase2()` records the applied index observed *before* replication (the entry's "replay
+  floor") and returns a ticket; `endLocalPhase2(ticket)` releases it. Recording the floor before the
+  entry exists is what makes the clamp race-free: the entry is guaranteed to land above it.
 - `takeSnapshot()` clamps the reported checkpoint to the lowest in-flight floor, so it can never
-  cover an entry whose phase 2 has not confirmed. It also refuses to regress the marker below an
-  existing one (that would ask Ratis to replay from entries a previous checkpoint already authorised
-  for purging), reporting `INVALID_LOG_INDEX` instead.
+  cover an entry whose phase 2 has not confirmed. It refuses to regress the marker below an existing
+  one - that would ask Ratis to replay from entries a previous checkpoint already authorised for
+  purging - reporting `INVALID_LOG_INDEX` instead.
+- After a clamp the marker's term may not match its index. That is deliberate and already tolerated
+  (`reinitialize()` seeds an inflated marker term as-is and realigns on the first replayed entry,
+  issues #575/#593). It must not be "corrected" by looking up the term at the clamped index, since
+  that entry may already be purged.
 
 **`RaftReplicatedDatabase`**
-- `commit()` takes a ticket before replication and delegates to the new
-  `replicateAndCommitLocally(...)`.
-- The ticket is **retained by default** and released only where the local pages are known to be
-  settled: phase 2 succeeded, a failed phase 2 reconciled successfully, ALL-quorum recovery settled
-  the pages, the commit is on a replica (no phase 2 expected), or replication failed outright so no
-  entry exists. Any other exit - notably "replication succeeded but phase 2 never ran" - keeps the
-  hold, which is exactly the #5407 window.
-- `applyLocallyAfterMajorityCommit(...)` now returns whether the pages ended up written, so the
-  caller only releases when they did.
+- `commit()` takes a ticket before replication and delegates to `replicateAndCommitLocally(...)`.
+- The ticket is **retained by default**, released only where the local pages are provably settled:
+  phase 2 succeeded, a failed phase 2 reconciled successfully, ALL-quorum recovery settled the pages,
+  the commit is on a replica (no phase 2 expected), or replication failed outright so no entry
+  exists. Any other exit - notably "replication succeeded but phase 2 never ran" - keeps the hold.
+- `applyLocallyAfterMajorityCommit(...)` returns whether the pages ended up written, so the caller
+  releases only when they did.
 
-Retaining a ticket costs a stalled compaction checkpoint until the node restarts, at which point
-replay applies the entry and the hold disappears with the process. That is a deliberate trade of
-log-compaction progress for durability. Replay is idempotent: `applyChanges` page-version guards
-re-apply an equal-version entry with the same absolute bytes and skip lower-version ones.
+A blanket `try/finally` release does **not** work, and is the trap to avoid here: ordinary exception
+unwinding drops the guard before the shutdown snapshot fires, and both crash ITs still fail. Retain
+by default, release on proof.
+
+Replay is idempotent: `applyChanges` page-version guards re-apply an equal-version entry with the
+same absolute bytes and skip lower-version ones.
+
+## Cost and observability
+
+A retained ticket pins the snapshot checkpoint, and therefore Raft log purge, until the node
+restarts - at which point replay applies the entry and the hold disappears with the process. That is
+a deliberate trade of log-compaction progress for durability.
+
+To keep it from being silent, each ticket records its start time and `takeSnapshot()` emits a
+throttled WARNING once one has been held beyond 5 minutes, naming the pinned index and pointing at
+Raft-storage disk usage. The check runs on a snapshot attempt rather than a timer, so it can lag a
+stuck ticket by up to one compaction interval (`arcadedb.ha.snapshotInterval`, 5 min by default).
+
+Note that a stuck ticket does not make `takeSnapshot()` return `INVALID_LOG_INDEX` every time: it
+keeps returning the stalled floor and re-registering the marker there. Only a clamp that would
+regress below an existing marker returns `INVALID_LOG_INDEX`. Either way the log is not purged past
+the pinned index.
+
+## Tests
+
+- `ArcadeStateMachinePendingPhase2SnapshotTest` (5 cases): the checkpoint clamps to the pending
+  floor; advances again once phase 2 completes; tracks the oldest of several in-flight commits; never
+  regresses below an existing marker; is suppressed entirely when a phase 2 starts before anything
+  has been applied.
+- `Issue5407Phase2TicketLifecycleTest` (7 cases): pins *which* exit releases the ticket - phase-2
+  success, replication failure, replica commit and settled ALL-quorum recovery release; a fault
+  between replication and phase 2, an unreconciled phase-2 failure and an unsettled ALL-quorum
+  recovery retain. This is the surface most exposed to a future refactor: the retain cases fail if
+  the guard is moved back into a blanket `finally`.
 
 ## Verification
 
-How this change was verified:
-
-- **New regression test** `ArcadeStateMachinePendingPhase2SnapshotTest` (5 cases): the checkpoint
-  clamps to the pending floor; it advances again once phase 2 completes; it tracks the oldest of
-  several in-flight commits; it never regresses below an existing marker; and it is suppressed
-  entirely when a phase 2 starts before anything has been applied.
-- **The two ITs from the issue**, which failed 100% before and pass after:
-  - `RaftLeaderCrashBetweenCommitAndApplyIT`
-  - `RaftLeaderCrashWithExternalPropertyIT`
-- **Regression sweep** over the `ha-raft` unit suite and the ITs that exercise the commit path,
-  origin-skip, phase-2 failure handling, snapshot/compaction, and crash recovery.
-
-Repro commands:
+- 730 `ha-raft` unit tests pass.
+- `RaftLeaderCrashBetweenCommitAndApplyIT` and `RaftLeaderCrashWithExternalPropertyIT`, which failed
+  100% before, pass.
+- IT sweep over the commit path, origin-skip, phase-2 failure handling, snapshot/compaction and crash
+  recovery: 22 tests across 15 IT classes, 0 failures (`Issue4790PhantomCommitOriginSkipIT`,
+  `OriginNodeSkipIT`, `Issue4740Phase2ReconcileIT`, `Issue5064CommittedRemotelyContractIT`,
+  `RaftLeaderCrashAndRecoverIT`, `RaftPeriodicSnapshotCompactionIT`, `RaftLogCompactionWiringIT`,
+  `RaftFullSnapshotResyncIT`, `Raft3PhaseCommitIT`, `RaftReplication3NodesIT`,
+  `RaftReplicaCrashAndRecoverIT`, `RaftIdleReplicaRestartIT`, `RaftBootstrapDoesNotEngageOnRestartIT`).
 
 ```
 mvn -pl ha-raft verify -DskipTests -Pintegration \
   -Dit.test='RaftLeaderCrashBetweenCommitAndApplyIT,RaftLeaderCrashWithExternalPropertyIT' \
   -Dfailsafe.failIfNoSpecifiedTests=false
 
-mvn -pl ha-raft test -Dtest=ArcadeStateMachinePendingPhase2SnapshotTest
+mvn -pl ha-raft test -Dtest='ArcadeStateMachinePendingPhase2SnapshotTest,Issue5407Phase2TicketLifecycleTest'
 ```
 
-## Review cycle 1 (PR #5408, head `198274bd9`)
+`Raft3PhaseCommitIT.concurrentWritersReplicateCorrectly` flaked once during a batch run (HTTP
+non-200 on the first insert while the previous IT's servers were still shutting down). It passed 3/3
+in isolation and the full batch re-ran clean: cross-test startup contention, not a regression.
 
-`claude[bot]` reviewed and confirmed the correctness of the clamp direction, the no-regression guard,
-and the idempotent ticket release. `gemini-code-assist` did not respond within the polling window.
-Applied:
+## Known gaps
 
-- **Stalled-compaction observability** (the reviewer's only pre-merge ask). A retained ticket pins the
-  checkpoint until restart, previously signalled only by a `HALog.BASIC` line. `pendingLocalPhase2`
-  now records each ticket's start time and `takeSnapshot()` emits a throttled `WARNING` once a held
-  ticket exceeds 5 minutes, naming the pinned index and pointing at Raft-storage disk usage.
-  Implemented rather than left as a TODO: it is a hazard this change introduces.
-  - One detail in the review was slightly off: a stuck ticket does *not* make every `takeSnapshot()`
-    return `INVALID_LOG_INDEX`. It keeps returning the stalled floor and re-registering the marker
-    there; only a clamp that would regress below an existing marker returns `INVALID_LOG_INDEX`. The
-    operational consequence (log not purged past that index) is the same.
-- **Term/index comment** in `takeSnapshot()` explaining that after a clamp the marker term may not
-  match the clamped index, why that is already tolerated (#575/#593), and why it must not be
-  "corrected" by looking up the term at the clamped index (that entry may be purged).
-- **`Issue5407Phase2TicketLifecycleTest`** (5 cases) pinning which exit releases the ticket -
-  phase-2 success releases, a fault between replication and phase 2 retains, an unreconciled phase-2
-  failure retains, replication failure releases, replica commit releases. `replicateAndCommitLocally`
-  was made package-private for this (existing convention in the module). This is the part of the fix
-  most exposed to a future refactor, and the retain case fails if the guard is moved back into a
-  blanket `finally`.
+- **The #4790 path holds its ticket until restart even on the happy outcome.** The
+  `ReplicationDispatchedTimeoutException` branch retains the ticket, which makes that indeterminate
+  window crash-safe as a side effect. But when such an entry later reaches quorum and is applied by
+  `applyTxEntry` - the usual resolution of a #4790 timeout - its pages become durable and nothing
+  releases the ticket, so compaction stays pinned until the node restarts. Since those timeouts are
+  transient, this can happen without any crash. Releasing on `applyTxEntry` needs a
+  ticket-to-`walTxId` correlation that does not exist today; adding one to that path was judged worse
+  than the documented gap for a change whose purpose is durability. **Worth a tracking issue.**
+- **No metric for a pinned checkpoint.** `pendingLocalPhase2Count()` exists but this class has no
+  Micrometer wiring; exposing it (plus the oldest held floor) as a gauge would make a stalled node
+  visible on a dashboard rather than only in the log.
 
-Not applied: a Micrometer gauge for `pendingLocalPhase2` size. This class has no metrics wiring
-today, so adding it is genuine follow-up scope rather than part of this fix; the WARNING covers the
-operator-visibility gap in the meantime.
+## Design notes
 
-## Review cycle 2 (head `1dd6ea54e`)
-
-`claude[bot]` re-reviewed and independently confirmed the crux ordering (register the floor before
-replication, release only after pages settle) and the idempotent double-release. Applied:
-
-- **Orphaned Javadoc fixed.** Inserting `releasePhase2Ticket`/`stateMachineOrNull` had split
-  `markTransactionAbandonedForLocalApply`'s Javadoc from its method, leaving two stacked comments on
-  one method and none on the other. A real defect introduced by this PR; the block is back where it
-  belongs.
-- **`Issue5407Phase2TicketLifecycleTest` extended to 7 cases**, closing the branch matrix with the
-  `MajorityCommittedAllFailedException` (ALL-quorum recovery) exit: release when the recovery apply
-  settles the pages, retain when neither it nor reconciliation does.
-
-Considered and **not** changed, with reasons:
-
-- **Drop the `// @VisibleForTesting` marker.** Declined: it is an established convention in this
-  codebase (12 occurrences, 5 of them in `ArcadeStateMachine` in this same package). Removing it here
-  would make the new code inconsistent with its immediate neighbours, against the project's
-  "adhere to the existing code" rule.
-- **Per-commit allocation** (boxed `Long` key + `PendingPhase2` record on each leader commit). The
-  reviewer flagged this for awareness rather than as a request. Kept: the same commit path already
-  allocates the payload, a copy of the bucket-delta map, and the WAL byte array, then makes a gRPC
-  round trip - two small short-lived objects are noise against that, and the map churns back to empty
-  in steady state.
-
-## Notes for follow-up
-
-- The `ReplicationDispatchedTimeoutException` path (#4790) now also retains its ticket, which makes
-  that indeterminate window crash-safe as a side effect. The in-memory
-  `abandonedLocalTransactions` marker it relies on is still lost on a real crash; the retained
-  ticket means replay covers the entry instead.
-  - **Known rough edge, worth its own issue.** When such an entry *does* later reach quorum and is
-    applied by `applyTxEntry` (the usual resolution of a #4790 timeout), its pages become durable but
-    nothing releases the ticket, so compaction stays pinned until the node restarts. Since #4790
-    timeouts are transient, that is arguably heavier than the crash window it protects. Releasing the
-    ticket when `applyTxEntry` consumes an abandoned-tx marker would fix it, but needs a
-    ticket-to-walTxId correlation that does not exist today, so it is deliberately left out of this
-    PR rather than bolted on to a delicate path. The 5-minute WARNING makes it visible meanwhile.
-- The persisted `.raft/applied-index` file is intentionally left unclamped. It never feeds the
-  replay position (only the snapshot-gap check, the per-database bootstrap replay-skip, and the
-  "never applied anything" bootstrap signal), so clamping it would change bootstrap behaviour
-  without improving durability.
-- Worth a follow-up issue: expose `pendingLocalPhase2Count()` (and the oldest held floor) as a
-  Micrometer gauge so a node whose compaction is pinned is visible on a dashboard, not only in the
-  log.
+- The persisted `.raft/applied-index` file is intentionally left unclamped: it never feeds the replay
+  position, so clamping it would change bootstrap behaviour without improving durability.
+- `beginLocalPhase2` boxes a `Long` key and allocates one small record per leader commit. Kept: the
+  same path already allocates the payload, a copy of the bucket-delta map and the WAL byte array,
+  then makes a gRPC round trip, and the map churns back to empty in steady state.

--- a/docs/5407-ha-leader-crash-phase2-write-loss.md
+++ b/docs/5407-ha-leader-crash-phase2-write-loss.md
@@ -1,0 +1,105 @@
+# 5407 - HA: leader crash between Raft commit and phase-2 apply permanently loses a locally-originated write
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5407
+
+## Problem
+
+On the leader, a locally-originated transaction is written to local pages by
+`RaftReplicatedDatabase.commit()`'s **phase 2** (`commit2ndPhase`), which runs *after* Raft
+replication succeeds. When Ratis commits the entry it independently calls
+`ArcadeStateMachine.applyTransaction`, which:
+
+1. **origin-skips** the data apply (`originatedLocally == true`) - correct, phase 2 owns the write; but
+2. still advances `lastAppliedIndex` to that entry's index.
+
+If phase 2 never runs, the node is left holding a committed entry it never applied. That state was
+recoverable in memory, but not durably: `takeSnapshot()` reported `lastAppliedIndex` as the Ratis
+durability checkpoint and wrote a `snapshot.<term>_<index>` marker at it. Since `reinitialize()`
+seeds the replay position **exclusively** from that marker, a restart began replaying *above* the
+unapplied entry. Neither Raft replay nor follower catch-up ever revisited it, so the write was
+silently and permanently lost on that node.
+
+This is the hard-crash analog of #4790, whose `abandonedLocalTransactions` marker is in-memory only
+and therefore cannot survive the window.
+
+## Root cause evidence
+
+Reproduced deterministically on `main` (4/4 runs). After the failing run, the crashed old leader's
+on-disk Raft state showed the smoking gun - a snapshot checkpoint covering the entry whose pages
+were never written:
+
+```
+databases1/.raft/applied-index                 {"global":9,"db":{"graph":9}}
+databases1/.raft-storage/.../sm/snapshot.1_9   0B      <- checkpoint at the lost entry (index 9)
+```
+
+The restarted node consequently reported itself caught up within ~125 ms of rejoining, replayed
+nothing, and ended at 100 records instead of 101 (`Page(graph/28/0) DB1 v2 <> DB2 v1`).
+
+Ratis takes a snapshot on shutdown, which is what makes the loss durable: an aborted phase 2
+followed by any shutdown (graceful stop, or the `triggerCriticalHalt()` path) buries the entry.
+
+## Fix
+
+Keep committed-but-not-locally-applied entries inside the Raft replay window until their local
+apply is proven.
+
+**`ArcadeStateMachine`**
+- New in-memory registry of in-flight leader-side phase-2 applies: `beginLocalPhase2()` records the
+  applied index observed *before* replication (the entry's "replay floor") and returns a ticket;
+  `endLocalPhase2(ticket)` releases it.
+- `takeSnapshot()` clamps the reported checkpoint to the lowest in-flight floor, so it can never
+  cover an entry whose phase 2 has not confirmed. It also refuses to regress the marker below an
+  existing one (that would ask Ratis to replay from entries a previous checkpoint already authorised
+  for purging), reporting `INVALID_LOG_INDEX` instead.
+
+**`RaftReplicatedDatabase`**
+- `commit()` takes a ticket before replication and delegates to the new
+  `replicateAndCommitLocally(...)`.
+- The ticket is **retained by default** and released only where the local pages are known to be
+  settled: phase 2 succeeded, a failed phase 2 reconciled successfully, ALL-quorum recovery settled
+  the pages, the commit is on a replica (no phase 2 expected), or replication failed outright so no
+  entry exists. Any other exit - notably "replication succeeded but phase 2 never ran" - keeps the
+  hold, which is exactly the #5407 window.
+- `applyLocallyAfterMajorityCommit(...)` now returns whether the pages ended up written, so the
+  caller only releases when they did.
+
+Retaining a ticket costs a stalled compaction checkpoint until the node restarts, at which point
+replay applies the entry and the hold disappears with the process. That is a deliberate trade of
+log-compaction progress for durability. Replay is idempotent: `applyChanges` page-version guards
+re-apply an equal-version entry with the same absolute bytes and skip lower-version ones.
+
+## Verification
+
+How this change was verified:
+
+- **New regression test** `ArcadeStateMachinePendingPhase2SnapshotTest` (5 cases): the checkpoint
+  clamps to the pending floor; it advances again once phase 2 completes; it tracks the oldest of
+  several in-flight commits; it never regresses below an existing marker; and it is suppressed
+  entirely when a phase 2 starts before anything has been applied.
+- **The two ITs from the issue**, which failed 100% before and pass after:
+  - `RaftLeaderCrashBetweenCommitAndApplyIT`
+  - `RaftLeaderCrashWithExternalPropertyIT`
+- **Regression sweep** over the `ha-raft` unit suite and the ITs that exercise the commit path,
+  origin-skip, phase-2 failure handling, snapshot/compaction, and crash recovery.
+
+Repro commands:
+
+```
+mvn -pl ha-raft verify -DskipTests -Pintegration \
+  -Dit.test='RaftLeaderCrashBetweenCommitAndApplyIT,RaftLeaderCrashWithExternalPropertyIT' \
+  -Dfailsafe.failIfNoSpecifiedTests=false
+
+mvn -pl ha-raft test -Dtest=ArcadeStateMachinePendingPhase2SnapshotTest
+```
+
+## Notes for follow-up
+
+- The `ReplicationDispatchedTimeoutException` path (#4790) now also retains its ticket, which makes
+  that indeterminate window crash-safe as a side effect. The in-memory
+  `abandonedLocalTransactions` marker it relies on is still lost on a real crash; the retained
+  ticket means replay covers the entry instead.
+- The persisted `.raft/applied-index` file is intentionally left unclamped. It never feeds the
+  replay position (only the snapshot-gap check, the per-database bootstrap replay-skip, and the
+  "never applied anything" bootstrap signal), so clamping it would change bootstrap behaviour
+  without improving durability.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -252,6 +252,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // entry can take a long time to either commit or be overwritten by a new leader.
   private static final long              ABANDONED_TX_TTL_MS           = 10 * 60 * 1000L;
 
+  // In-flight leader-side phase 2 applies, ticket -> the applied index observed when the commit
+  // started (its "replay floor"). A locally-originated entry is origin-skipped by applyTxEntry
+  // because RaftReplicatedDatabase.commit's phase 2 writes the pages instead - but phase 2 runs
+  // AFTER Raft commits the entry, so between the two this node has advanced lastAppliedIndex past
+  // an entry whose pages are not on disk yet. takeSnapshot() must not hand that index to Ratis as a
+  // durability checkpoint: the marker it writes is the only thing reinitialize() consults on
+  // restart, so a checkpoint covering an unapplied entry makes the write unreplayable and lost
+  // forever on this node (issue #5407). Registering the floor BEFORE replication and clamping
+  // takeSnapshot() to it keeps the entry inside the replay window until phase 2 confirms.
+  private final Map<Long, Long> pendingLocalPhase2       = new ConcurrentHashMap<>();
+  private final AtomicLong      pendingLocalPhase2Ticket = new AtomicLong();
+
 
   public void setServer(final ArcadeDBServer server) {
     this.server = server;
@@ -798,9 +810,31 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   @Override
   public long takeSnapshot() {
-    final long currentIndex = lastAppliedIndex.get();
+    long currentIndex = lastAppliedIndex.get();
     if (currentIndex < 0)
       return RaftLog.INVALID_LOG_INDEX;
+
+    // Never checkpoint past an entry whose leader-side phase 2 has not confirmed (issue #5407): the
+    // entry is Raft-committed and lastAppliedIndex has moved past it, but its pages reach disk only
+    // when commit2ndPhase runs. Clamping to the oldest in-flight commit's floor keeps such an entry
+    // above the checkpoint, so a restart replays it (with originatedLocally=false) instead of
+    // treating it as durable and dropping it permanently.
+    final long pendingFloor = lowestPendingLocalPhase2Floor();
+    if (pendingFloor < currentIndex)
+      currentIndex = pendingFloor;
+    if (currentIndex < 0)
+      return RaftLog.INVALID_LOG_INDEX;
+
+    // Regressing the marker below an existing one would let Ratis replay from an index whose log
+    // entries a previous checkpoint already authorised for purging. Skip this round instead; the
+    // next snapshot after phase 2 drains advances it normally.
+    final var latest = storage.getLatestSnapshot();
+    if (latest != null && currentIndex < latest.getIndex()) {
+      HALog.log(this, HALog.BASIC,
+          "Skipping snapshot checkpoint at index %d: a phase-2 apply is still in flight and the existing marker is at %d",
+          currentIndex, latest.getIndex());
+      return RaftLog.INVALID_LOG_INDEX;
+    }
 
     final TermIndex applied = getLastAppliedTermIndex();
     final long term = applied != null && applied.getTerm() > 0 ? applied.getTerm() : 0L;
@@ -1146,6 +1180,46 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
   private static String abandonedKey(final String databaseName, final long walTxId) {
     return databaseName + "/" + walTxId;
+  }
+
+  /**
+   * Registers a leader-side phase 2 that is about to start replicating, and returns the ticket that
+   * {@link #endLocalPhase2(long)} must release. The recorded floor is the applied index observed
+   * now, i.e. BEFORE this transaction's entry exists in the Raft log, so the entry is guaranteed to
+   * land above it and stay inside the replay window that {@link #takeSnapshot()} preserves.
+   * <p>
+   * Reading a floor that is lower than the eventual entry index is always safe: it only widens the
+   * replay window, and replay is idempotent (page-version guards in {@code applyChanges} skip pages
+   * that are already at or beyond the WAL version).
+   */
+  long beginLocalPhase2() {
+    final long ticket = pendingLocalPhase2Ticket.incrementAndGet();
+    pendingLocalPhase2.put(ticket, lastAppliedIndex.get());
+    return ticket;
+  }
+
+  /**
+   * Releases a ticket returned by {@link #beginLocalPhase2()}. Call it only once the entry's local
+   * pages are settled - or once the entry provably never committed. A ticket left held keeps the
+   * snapshot checkpoint pinned until the node restarts, which is the intended outcome when this node
+   * is holding a committed entry it never applied.
+   */
+  void endLocalPhase2(final long ticket) {
+    pendingLocalPhase2.remove(ticket);
+  }
+
+  /**
+   * The lowest replay floor among the currently in-flight leader-side phase 2 applies, or
+   * {@link Long#MAX_VALUE} when none is in flight. Scanned on demand rather than maintained
+   * incrementally: {@link #takeSnapshot()} is the only reader and runs rarely (periodic compaction
+   * or shutdown), while the map is sized by concurrent commits.
+   */
+  private long lowestPendingLocalPhase2Floor() {
+    long lowest = Long.MAX_VALUE;
+    for (final long floor : pendingLocalPhase2.values())
+      if (floor < lowest)
+        lowest = floor;
+    return lowest;
   }
 
   private void applyTxEntry(final RaftLogEntryCodec.DecodedEntry decoded, final long entryIndex,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -261,8 +261,19 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // restart, so a checkpoint covering an unapplied entry makes the write unreplayable and lost
   // forever on this node (issue #5407). Registering the floor BEFORE replication and clamping
   // takeSnapshot() to it keeps the entry inside the replay window until phase 2 confirms.
-  private final Map<Long, Long> pendingLocalPhase2       = new ConcurrentHashMap<>();
-  private final AtomicLong      pendingLocalPhase2Ticket = new AtomicLong();
+  private final Map<Long, PendingPhase2> pendingLocalPhase2       = new ConcurrentHashMap<>();
+  private final AtomicLong               pendingLocalPhase2Ticket = new AtomicLong();
+  // A ticket is only released once its pages are settled, so one that is never released pins the
+  // checkpoint - and therefore Raft log purge - until the node restarts. That is the intended
+  // durability trade, but it must not be silent: without a signal an operator meets it as disk
+  // pressure. Warn (throttled) once a held ticket outlives the threshold.
+  private static final long STALLED_PHASE2_WARN_AFTER_MS = 5 * 60 * 1000L;
+  private static final long STALLED_PHASE2_WARN_EVERY_MS = 60 * 1000L;
+  private final AtomicLong  lastStalledPhase2WarnMs      = new AtomicLong();
+
+  /** One in-flight leader-side phase 2: the replay floor to protect, and when it started. */
+  private record PendingPhase2(long replayFloor, long startedAtMs) {
+  }
 
 
   public void setServer(final ArcadeDBServer server) {
@@ -836,6 +847,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
       return RaftLog.INVALID_LOG_INDEX;
     }
 
+    // NOTE: after a clamp, term is the CURRENT applied term while currentIndex is an older index, so
+    // the marker name can pair a term with an index that predates it. That is deliberate and already
+    // tolerated: reinitialize() seeds an inflated marker term as-is and the tolerant
+    // updateLastAppliedTermIndex override realigns it on the first replayed entry (issues #575/#593),
+    // and notifyInstallSnapshotFromLeader writes an upper-bound term for the same reason. Do not
+    // "correct" it by looking up the term at currentIndex - that entry may already be purged.
     final TermIndex applied = getLastAppliedTermIndex();
     final long term = applied != null && applied.getTerm() > 0 ? applied.getTerm() : 0L;
     if (!registerSnapshotMarker(term, currentIndex)) {
@@ -1194,7 +1211,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   long beginLocalPhase2() {
     final long ticket = pendingLocalPhase2Ticket.incrementAndGet();
-    pendingLocalPhase2.put(ticket, lastAppliedIndex.get());
+    pendingLocalPhase2.put(ticket, new PendingPhase2(lastAppliedIndex.get(), System.currentTimeMillis()));
     return ticket;
   }
 
@@ -1208,6 +1225,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
     pendingLocalPhase2.remove(ticket);
   }
 
+  /** Number of leader-side phase 2 applies still holding the snapshot checkpoint back. */
+  int pendingLocalPhase2Count() {
+    return pendingLocalPhase2.size();
+  }
+
   /**
    * The lowest replay floor among the currently in-flight leader-side phase 2 applies, or
    * {@link Long#MAX_VALUE} when none is in flight. Scanned on demand rather than maintained
@@ -1216,10 +1238,38 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   private long lowestPendingLocalPhase2Floor() {
     long lowest = Long.MAX_VALUE;
-    for (final long floor : pendingLocalPhase2.values())
-      if (floor < lowest)
-        lowest = floor;
+    long oldestStartedAt = Long.MAX_VALUE;
+    for (final PendingPhase2 pending : pendingLocalPhase2.values()) {
+      if (pending.replayFloor() < lowest)
+        lowest = pending.replayFloor();
+      if (pending.startedAtMs() < oldestStartedAt)
+        oldestStartedAt = pending.startedAtMs();
+    }
+    if (oldestStartedAt != Long.MAX_VALUE)
+      warnIfPhase2StallingCompaction(oldestStartedAt, lowest);
     return lowest;
+  }
+
+  /**
+   * Surfaces the one failure mode of the #5407 guard: a ticket held long enough to be stuck (its
+   * commit neither settled its pages nor proved the entry absent) pins the checkpoint, so the Raft
+   * log stops being purged until this node restarts. Throttled so a checkpoint attempt during a
+   * genuinely long-running commit does not spam the log.
+   */
+  private void warnIfPhase2StallingCompaction(final long oldestStartedAtMs, final long lowestFloor) {
+    final long heldForMs = System.currentTimeMillis() - oldestStartedAtMs;
+    if (heldForMs < STALLED_PHASE2_WARN_AFTER_MS)
+      return;
+    final long now = System.currentTimeMillis();
+    final long lastWarn = lastStalledPhase2WarnMs.get();
+    if (now - lastWarn < STALLED_PHASE2_WARN_EVERY_MS || !lastStalledPhase2WarnMs.compareAndSet(lastWarn, now))
+      return;
+    LogManager.instance().log(this, Level.WARNING,
+        """
+        A local phase-2 apply has been unconfirmed for %d s (%d in flight): holding the Raft snapshot \
+        checkpoint at index %d so the entry stays replayable. The Raft log will not be purged past that \
+        index until this node restarts and replays it - watch disk usage on the Raft storage volume.""",
+        heldForMs / 1000, pendingLocalPhase2.size(), lowestFloor);
   }
 
   private void applyTxEntry(final RaftLogEntryCodec.DecodedEntry decoded, final long entryIndex,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -831,8 +831,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // above the checkpoint, so a restart replays it (with originatedLocally=false) instead of
     // treating it as durable and dropping it permanently.
     final long pendingFloor = lowestPendingLocalPhase2Floor();
-    if (pendingFloor < currentIndex)
+    if (pendingFloor < currentIndex) {
       currentIndex = pendingFloor;
+      final long oldestStartedAtMs = oldestPendingLocalPhase2StartMs();
+      if (oldestStartedAtMs != Long.MAX_VALUE)
+        warnIfPhase2StallingCompaction(oldestStartedAtMs, currentIndex);
+    }
     if (currentIndex < 0)
       return RaftLog.INVALID_LOG_INDEX;
 
@@ -1238,16 +1242,23 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   private long lowestPendingLocalPhase2Floor() {
     long lowest = Long.MAX_VALUE;
-    long oldestStartedAt = Long.MAX_VALUE;
-    for (final PendingPhase2 pending : pendingLocalPhase2.values()) {
+    for (final PendingPhase2 pending : pendingLocalPhase2.values())
       if (pending.replayFloor() < lowest)
         lowest = pending.replayFloor();
-      if (pending.startedAtMs() < oldestStartedAt)
-        oldestStartedAt = pending.startedAtMs();
-    }
-    if (oldestStartedAt != Long.MAX_VALUE)
-      warnIfPhase2StallingCompaction(oldestStartedAt, lowest);
     return lowest;
+  }
+
+  /**
+   * When the oldest in-flight phase 2 started, or {@link Long#MAX_VALUE} when none is in flight.
+   * Kept separate from {@link #lowestPendingLocalPhase2Floor()} so both stay pure queries; the extra
+   * pass costs nothing on the rare {@link #takeSnapshot()} path.
+   */
+  private long oldestPendingLocalPhase2StartMs() {
+    long oldest = Long.MAX_VALUE;
+    for (final PendingPhase2 pending : pendingLocalPhase2.values())
+      if (pending.startedAtMs() < oldest)
+        oldest = pending.startedAtMs();
+    return oldest;
   }
 
   /**
@@ -1255,6 +1266,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * commit neither settled its pages nor proved the entry absent) pins the checkpoint, so the Raft
    * log stops being purged until this node restarts. Throttled so a checkpoint attempt during a
    * genuinely long-running commit does not spam the log.
+   * <p>
+   * Evaluated on a snapshot attempt, not on a timer: the condition is only interesting when a
+   * checkpoint is actually being held back, but it does mean the warning can lag a stuck ticket by
+   * up to one compaction interval ({@code arcadedb.ha.snapshotInterval}, 5 min by default).
    */
   private void warnIfPhase2StallingCompaction(final long oldestStartedAtMs, final long lowestFloor) {
     final long heldForMs = System.currentTimeMillis() - oldestStartedAtMs;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -406,8 +406,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * position and lose the write for good. Holding the ticket costs a stalled log-compaction
    * checkpoint until the node restarts, at which point replay applies the entry and the hold is gone
    * with the process.
+   * <p>
+   * Package-private for direct unit testing: which exit releases the ticket is the load-bearing part
+   * of the fix, and driving every branch through {@link #commit()} would need the whole phase-1
+   * capture stubbed out.
    */
-  private void replicateAndCommitLocally(final ReplicationPayload payload, final boolean leader,
+  // @VisibleForTesting
+  void replicateAndCommitLocally(final ReplicationPayload payload, final boolean leader,
       final ArcadeStateMachine stateMachine, final long phase2Ticket) {
     // --- REPLICATION (no lock held): send WAL to Raft and wait for quorum ---
     try {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -553,17 +553,6 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   /**
-   * Records (in the state machine) that this leader abandoned phase 2 for a locally-originated
-   * transaction whose replication returned an indeterminate result (issue #4790). If the entry
-   * later reaches quorum and is applied here, {@link ArcadeStateMachine#applyTxEntry} will apply it
-   * locally instead of origin-skipping it, preventing a silent lost write on the leader.
-   * <p>
-   * The WAL txId is the correlation key: it is embedded in the same WAL bytes that were replicated,
-   * so the state machine sees the identical value when the entry commits. Best-effort: if anything
-   * goes wrong while extracting the txId we log and continue (the caller still rolls back and throws
-   * a retryable error), rather than masking the original replication failure.
-   */
-  /**
    * Stops protecting the Raft replay window for one commit (issue #5407). A no-op when no ticket was
    * taken (replica commit, or the Raft server was not wired yet).
    */
@@ -578,6 +567,17 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     return raft != null ? raft.getStateMachine() : null;
   }
 
+  /**
+   * Records (in the state machine) that this leader abandoned phase 2 for a locally-originated
+   * transaction whose replication returned an indeterminate result (issue #4790). If the entry
+   * later reaches quorum and is applied here, {@link ArcadeStateMachine#applyTxEntry} will apply it
+   * locally instead of origin-skipping it, preventing a silent lost write on the leader.
+   * <p>
+   * The WAL txId is the correlation key: it is embedded in the same WAL bytes that were replicated,
+   * so the state machine sees the identical value when the entry commits. Best-effort: if anything
+   * goes wrong while extracting the txId we log and continue (the caller still rolls back and throws
+   * a retryable error), rather than masking the original replication failure.
+   */
   private void markTransactionAbandonedForLocalApply(final ReplicationPayload payload) {
     final ArcadeStateMachine stateMachine = stateMachineOrNull();
     if (stateMachine == null)

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -384,6 +384,31 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     if (payload == null)
       return;
 
+    // The state machine origin-skips this node's own entry because phase 2 below writes the pages -
+    // but phase 2 runs only after Raft has committed, so in between lastAppliedIndex covers an entry
+    // whose pages are not on disk yet. Hold a phase-2 ticket across that window so a snapshot
+    // checkpoint cannot cover the entry: the checkpoint is the only position a restart trusts, and
+    // one taken here would make the write unreplayable and lost on this node forever (issue #5407).
+    // Only the leader runs phase 2 (see the !leader early return below), so only it needs the ticket.
+    final ArcadeStateMachine stateMachine = leader ? stateMachineOrNull() : null;
+    final long phase2Ticket = stateMachine != null ? stateMachine.beginLocalPhase2() : -1L;
+    replicateAndCommitLocally(payload, leader, stateMachine, phase2Ticket);
+  }
+
+  /**
+   * Replicates the captured payload through Raft and, on the leader, applies phase 2 locally.
+   * <p>
+   * <b>Phase-2 ticket lifecycle (issue #5407):</b> the ticket is released ONLY where the local pages
+   * are known to be settled - phase 2 wrote them, a failed phase 2 reconciled them, or the entry
+   * provably never committed. Every other exit keeps it held, deliberately: if replication succeeded
+   * but phase 2 did not run, this node holds a committed entry it never applied, and a snapshot
+   * checkpoint taken afterwards (Ratis takes one on shutdown) would bury the entry below the replay
+   * position and lose the write for good. Holding the ticket costs a stalled log-compaction
+   * checkpoint until the node restarts, at which point replay applies the entry and the hold is gone
+   * with the process.
+   */
+  private void replicateAndCommitLocally(final ReplicationPayload payload, final boolean leader,
+      final ArcadeStateMachine stateMachine, final long phase2Ticket) {
     // --- REPLICATION (no lock held): send WAL to Raft and wait for quorum ---
     try {
       final RaftHAServer raft = requireRaftServer();
@@ -393,7 +418,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // but ALL-quorum watch failed. We MUST apply locally to prevent permanent divergence.
       HALog.log(this, HALog.BASIC,
           "ALL quorum watch failed after MAJORITY commit; applying locally to prevent leader divergence: db=%s", getName());
-      applyLocallyAfterMajorityCommit(payload);
+      if (applyLocallyAfterMajorityCommit(payload))
+        releasePhase2Ticket(stateMachine, phase2Ticket);
       throw e;
     } catch (final ReplicationDispatchedTimeoutException e) {
       // INDETERMINATE outcome (issue #4790): the entry was dispatched to Ratis but the quorum wait
@@ -406,9 +432,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       rollback();
       throw e;
     } catch (final ArcadeDBException e) {
+      // Replication failed outright: the entry never reached the log, so there is nothing this node
+      // could be missing and the replay window does not need protecting.
+      releasePhase2Ticket(stateMachine, phase2Ticket);
       rollback();
       throw e;
     } catch (final Exception e) {
+      releasePhase2Ticket(stateMachine, phase2Ticket);
       rollback();
       throw new TransactionException("Error on commit distributed transaction (replication)", e);
     }
@@ -420,6 +450,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
     // --- PHASE 2 (read lock on leader): quorum reached, apply locally ---
     if (!leader) {
+      releasePhase2Ticket(stateMachine, phase2Ticket);
       payload.tx().reset();
       final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       ctx.popIfNotLastTransaction();
@@ -443,6 +474,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
         payload.tx().commit2ndPhase(payload.phase1());
 
+        // The pages are on disk: the entry is now genuinely durable here, so a snapshot checkpoint
+        // may cover it. Released before saveConfiguration so a failure there (which the catch below
+        // reconciles anyway) does not needlessly keep the checkpoint pinned.
+        releasePhase2Ticket(stateMachine, phase2Ticket);
+
         if (getSchema().getEmbedded().isDirty())
           getSchema().getEmbedded().saveConfiguration();
       } catch (final Exception e) {
@@ -452,6 +488,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         // commit already published - safe by the #4926 replay semantics: an equal-version entry re-applies
         // the same absolute bytes (idempotent), a lower-version one is skipped.
         final boolean reconciled = reconcileLeaderPagesAfterPhase2Failure(payload);
+        // Only a successful reconcile puts the replicated pages on disk. If it failed, the entry
+        // stays unapplied here and must remain replayable, so the ticket is deliberately kept.
+        if (reconciled)
+          releasePhase2Ticket(stateMachine, phase2Ticket);
         recoverLeadershipAfterPhase2Failure(payload.tx().toString());
         // #5064: the user must be able to distinguish 'retry me' from 'already committed cluster-wide'.
         // The generic rethrow here told applications the commit FAILED while the data was durably committed
@@ -474,9 +514,12 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * so we must write the local pages to prevent permanent divergence.
    * Package-private for direct unit testing (the real trigger needs an ALL-quorum cluster whose
    * watch fails after MAJORITY commit, which depends on Ratis watch timeouts).
+   *
+   * @return {@code true} if the local pages ended up written (by phase 2 or by reconciliation), so the
+   * caller may stop protecting this entry's Raft replay window (issue #5407)
    */
-  void applyLocallyAfterMajorityCommit(final ReplicationPayload payload) {
-    proxied.executeInReadLock(() -> {
+  boolean applyLocallyAfterMajorityCommit(final ReplicationPayload payload) {
+    return proxied.executeInReadLock(() -> {
       final DatabaseContext.DatabaseContextTL current = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       try {
         // #5064: MAJORITY already committed - same durability-boundary shift as the main phase-2 path.
@@ -488,18 +531,19 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         payload.tx().commit2ndPhase(payload.phase1());
         if (getSchema().getEmbedded().isDirty())
           getSchema().getEmbedded().saveConfiguration();
+        return true;
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE,
             """
             Phase 2 commit failed during ALL-quorum recovery (db=%s, txId=%s). \
             Leader database may be inconsistent. Stepping down so a node with correct state takes over. Error: %s""",
             getName(), payload.tx(), e.getMessage());
-        reconcileLeaderPagesAfterPhase2Failure(payload);
+        final boolean reconciled = reconcileLeaderPagesAfterPhase2Failure(payload);
         recoverLeadershipAfterPhase2Failure(payload.tx().toString());
+        return reconciled;
       } finally {
         current.popIfNotLastTransaction();
       }
-      return null;
     });
   }
 
@@ -514,11 +558,23 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * goes wrong while extracting the txId we log and continue (the caller still rolls back and throws
    * a retryable error), rather than masking the original replication failure.
    */
-  private void markTransactionAbandonedForLocalApply(final ReplicationPayload payload) {
+  /**
+   * Stops protecting the Raft replay window for one commit (issue #5407). A no-op when no ticket was
+   * taken (replica commit, or the Raft server was not wired yet).
+   */
+  private static void releasePhase2Ticket(final ArcadeStateMachine stateMachine, final long phase2Ticket) {
+    if (stateMachine != null)
+      stateMachine.endLocalPhase2(phase2Ticket);
+  }
+
+  /** The local state machine, or {@code null} when the Raft server is not wired yet (e.g. during startup). */
+  private ArcadeStateMachine stateMachineOrNull() {
     final RaftHAServer raft = raftHAServer;
-    if (raft == null)
-      return;
-    final ArcadeStateMachine stateMachine = raft.getStateMachine();
+    return raft != null ? raft.getStateMachine() : null;
+  }
+
+  private void markTransactionAbandonedForLocalApply(final ReplicationPayload payload) {
+    final ArcadeStateMachine stateMachine = stateMachineOrNull();
     if (stateMachine == null)
       return;
     try {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachinePendingPhase2SnapshotTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachinePendingPhase2SnapshotTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5407.
+ * <p>
+ * On the leader a locally-originated transaction is written locally by
+ * {@code RaftReplicatedDatabase.commit}'s phase 2, which runs AFTER Raft has committed the entry.
+ * The state machine therefore origin-skips the data apply but still advances {@code lastAppliedIndex}
+ * the moment Ratis commits. If a snapshot checkpoint is taken in that window - and Ratis takes one on
+ * shutdown - the marker records an index whose pages were never written. Because
+ * {@code reinitialize()} seeds the replay position exclusively from that marker, a restart starts
+ * replaying above the entry and the write is dropped on this node permanently.
+ * <p>
+ * The fix registers a phase-2 "replay floor" before replication and clamps {@code takeSnapshot()} to
+ * the oldest in-flight floor, so such an entry stays inside the replay window until phase 2 confirms.
+ */
+class ArcadeStateMachinePendingPhase2SnapshotTest {
+
+  /**
+   * The core lost-write scenario: phase 2 is in flight when the entry commits, so the checkpoint must
+   * stay BELOW the committed-but-unapplied entry. Before the fix {@code takeSnapshot()} reported the
+   * entry's own index, which a restart then treated as durable.
+   */
+  @Test
+  void takeSnapshotClampsToPendingPhase2Floor(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    try {
+      sm.initialize(stubServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+
+      // Baseline transactions are applied and durable up to index 8.
+      setLastApplied(sm, 1L, 8L);
+
+      // A locally-originated commit starts replicating: its entry does not exist yet, so the floor is 8.
+      final long ticket = sm.beginLocalPhase2();
+
+      // Raft commits the entry at index 9; applyTransaction origin-skips it and advances the index,
+      // but phase 2 has not written the pages yet.
+      setLastApplied(sm, 1L, 9L);
+
+      assertThat(sm.takeSnapshot())
+          .as("checkpoint must not cover index 9, whose phase 2 has not confirmed")
+          .isEqualTo(8L);
+
+      final SingleFileSnapshotInfo marker = (SingleFileSnapshotInfo) sm.getStateMachineStorage().getLatestSnapshot();
+      assertThat(marker).as("a marker must still be written at the clamped index").isNotNull();
+      assertThat(marker.getIndex())
+          .as("the persisted marker is the only replay position a restart trusts, so it must be 8")
+          .isEqualTo(8L);
+
+      sm.endLocalPhase2(ticket);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * Once phase 2 confirms, the clamp must lift so log compaction is not stalled for the node's lifetime.
+   */
+  @Test
+  void takeSnapshotAdvancesOncePhase2Completes(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    try {
+      sm.initialize(stubServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+
+      setLastApplied(sm, 1L, 8L);
+      final long ticket = sm.beginLocalPhase2();
+      setLastApplied(sm, 1L, 9L);
+      assertThat(sm.takeSnapshot()).isEqualTo(8L);
+
+      sm.endLocalPhase2(ticket);
+
+      assertThat(sm.takeSnapshot())
+          .as("with no phase 2 in flight the checkpoint must reach the applied index again")
+          .isEqualTo(9L);
+      assertThat(sm.getStateMachineStorage().getLatestSnapshot().getIndex()).isEqualTo(9L);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * The clamp is the minimum across all in-flight commits: a single laggard must hold the checkpoint
+   * back even when newer commits have already drained.
+   */
+  @Test
+  void takeSnapshotClampsToTheOldestInFlightCommit(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    try {
+      sm.initialize(stubServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+
+      setLastApplied(sm, 1L, 5L);
+      final long oldest = sm.beginLocalPhase2();
+
+      setLastApplied(sm, 1L, 12L);
+      final long newer = sm.beginLocalPhase2();
+
+      setLastApplied(sm, 1L, 20L);
+
+      sm.endLocalPhase2(newer);
+
+      assertThat(sm.takeSnapshot())
+          .as("the oldest unconfirmed phase 2 governs the checkpoint")
+          .isEqualTo(5L);
+
+      sm.endLocalPhase2(oldest);
+      assertThat(sm.takeSnapshot()).isEqualTo(20L);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * The clamp must never move the marker backwards: a previous checkpoint already authorised Ratis to
+   * purge the log up to it, so replaying from below it could hit purged entries. When the clamp would
+   * regress, no checkpoint is reported and the existing marker is left untouched.
+   */
+  @Test
+  void takeSnapshotNeverRegressesBelowAnExistingMarker(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    try {
+      sm.initialize(stubServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+
+      setLastApplied(sm, 1L, 30L);
+      assertThat(sm.takeSnapshot()).isEqualTo(30L);
+
+      // Reproduces the narrow interleaving that can strand a floor below an existing marker: a commit
+      // reads the applied index, and the checkpoint above completes before the commit registers its
+      // floor. Only the counter beginLocalPhase2 samples is rewound - the Ratis term/index is
+      // strictly monotonic and is left where the checkpoint saw it.
+      setLastAppliedIndexOnly(sm, 10L);
+      final long ticket = sm.beginLocalPhase2();
+      setLastApplied(sm, 1L, 31L);
+
+      assertThat(sm.takeSnapshot())
+          .as("a clamp below the existing marker must not authorise a purge")
+          .isEqualTo(RaftLog.INVALID_LOG_INDEX);
+      assertThat(sm.getStateMachineStorage().getLatestSnapshot().getIndex())
+          .as("the existing marker must be left untouched")
+          .isEqualTo(30L);
+
+      sm.endLocalPhase2(ticket);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * A phase 2 that starts before anything has ever been applied floors at -1, which must suppress the
+   * checkpoint entirely rather than report a negative purge index to Ratis.
+   */
+  @Test
+  void takeSnapshotIsSuppressedWhenPhase2StartsBeforeAnyApply(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    try {
+      sm.initialize(stubServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+
+      final long ticket = sm.beginLocalPhase2();
+      setLastApplied(sm, 1L, 1L);
+
+      assertThat(sm.takeSnapshot())
+          .as("the very first write must stay replayable until its phase 2 confirms")
+          .isEqualTo(RaftLog.INVALID_LOG_INDEX);
+      assertThat(sm.getStateMachineStorage().getLatestSnapshot())
+          .as("no marker may be written while the first write is unconfirmed")
+          .isNull();
+
+      sm.endLocalPhase2(ticket);
+      assertThat(sm.takeSnapshot()).isEqualTo(1L);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  private static RaftStorage newFormattedStorage(final Path dir) throws IOException {
+    return RaftStorage.newBuilder()
+        .setDirectory(dir.toFile())
+        .setOption(RaftStorage.StartupOption.FORMAT)
+        .build();
+  }
+
+  /**
+   * Minimal {@link RaftServer} stub: {@code BaseStateMachine.initialize()} only needs a non-null
+   * {@code getId()}; all other calls are unused on this path.
+   */
+  private RaftServer stubServer() {
+    return (RaftServer) Proxy.newProxyInstance(
+        getClass().getClassLoader(),
+        new Class<?>[] { RaftServer.class },
+        (proxy, method, args) -> {
+          if ("getId".equals(method.getName()))
+            return RaftPeerId.valueOf("test-peer");
+          if ("close".equals(method.getName()) || "start".equals(method.getName()))
+            return null;
+          throw new UnsupportedOperationException("Stub: " + method.getName());
+        });
+  }
+
+  /**
+   * Advances the applied position the way {@code applyTransaction} does: the private
+   * {@code lastAppliedIndex} counter that {@code takeSnapshot()} reads, plus the BaseStateMachine
+   * last-applied term/index that supplies the snapshot term.
+   */
+  private static void setLastApplied(final ArcadeStateMachine sm, final long term, final long index) throws Exception {
+    setLastAppliedIndexOnly(sm, index);
+
+    final Method m = findMethod(sm.getClass(), "updateLastAppliedTermIndex", long.class, long.class);
+    m.setAccessible(true);
+    m.invoke(sm, term, index);
+  }
+
+  /** Sets only the counter {@code takeSnapshot()} and {@code beginLocalPhase2()} read. */
+  private static void setLastAppliedIndexOnly(final ArcadeStateMachine sm, final long index) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("lastAppliedIndex");
+    f.setAccessible(true);
+    ((AtomicLong) f.get(sm)).set(index);
+  }
+
+  private static Method findMethod(final Class<?> type, final String name, final Class<?>... params)
+      throws NoSuchMethodException {
+    for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+      try {
+        return c.getDeclaredMethod(name, params);
+      } catch (final NoSuchMethodException ignored) {
+        // walk up to the superclass
+      }
+    }
+    throw new NoSuchMethodException(name);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5407Phase2TicketLifecycleTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5407Phase2TicketLifecycleTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,7 +58,9 @@ import static org.mockito.Mockito.when;
  */
 class Issue5407Phase2TicketLifecycleTest {
 
-  private static final String DB_PATH = "/tmp/issue5407-phase2-ticket-test";
+  // Only ever used as the DatabaseContext key (proxied is a mock, nothing touches the filesystem).
+  // Made unique per test so parallel runs cannot share a context, and so it carries no POSIX-only path.
+  private final String dbPath = "issue5407-phase2-ticket-" + UUID.randomUUID();
 
   private LocalDatabase         proxied;
   private RaftHAServer          raftServer;
@@ -70,7 +73,7 @@ class Issue5407Phase2TicketLifecycleTest {
   void setUp() {
     txManager = mock(TransactionManager.class);
     proxied = mock(LocalDatabase.class);
-    when(proxied.getDatabasePath()).thenReturn(DB_PATH);
+    when(proxied.getDatabasePath()).thenReturn(dbPath);
     when(proxied.getName()).thenReturn("issue5407");
     when(proxied.getTransactionManager()).thenReturn(txManager);
     when(proxied.getSchema()).thenReturn(mock(Schema.class, RETURNS_DEEP_STUBS));
@@ -88,7 +91,7 @@ class Issue5407Phase2TicketLifecycleTest {
   @AfterEach
   void tearDown() {
     RaftReplicatedDatabase.TEST_POST_REPLICATION_HOOK = null;
-    DatabaseContext.INSTANCE.removeContext(DB_PATH);
+    DatabaseContext.INSTANCE.removeContext(dbPath);
   }
 
   /** The whole point: phase 2 wrote the pages, so the entry is durable here and may be checkpointed. */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5407Phase2TicketLifecycleTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5407Phase2TicketLifecycleTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.exception.TransactionCommittedRemotelyException;
+import com.arcadedb.exception.TransactionException;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #5407: which exit of {@code replicateAndCommitLocally} releases the phase-2 ticket is the
+ * load-bearing part of the fix, so it is pinned here rather than only end-to-end in the crash ITs.
+ * <p>
+ * The ticket protects the Raft replay window for an entry this node has committed but not yet
+ * applied locally. Releasing it too eagerly is exactly the #5407 bug: a snapshot checkpoint taken
+ * afterwards (Ratis takes one on shutdown) buries the entry below the replay position and the write
+ * is lost for good. An earlier iteration of this fix released the ticket in a blanket
+ * {@code finally}, which looked correct but let ordinary exception unwinding drop the guard before
+ * the shutdown snapshot - and both crash ITs still failed. Hence: retain by default, release only
+ * where the local pages are provably settled.
+ */
+class Issue5407Phase2TicketLifecycleTest {
+
+  private static final String DB_PATH = "/tmp/issue5407-phase2-ticket-test";
+
+  private LocalDatabase         proxied;
+  private RaftHAServer          raftServer;
+  private TransactionContext    tx;
+  private ArcadeStateMachine    stateMachine;
+  private TransactionManager    txManager;
+  private RaftTransactionBroker broker;
+
+  @BeforeEach
+  void setUp() {
+    txManager = mock(TransactionManager.class);
+    proxied = mock(LocalDatabase.class);
+    when(proxied.getDatabasePath()).thenReturn(DB_PATH);
+    when(proxied.getName()).thenReturn("issue5407");
+    when(proxied.getTransactionManager()).thenReturn(txManager);
+    when(proxied.getSchema()).thenReturn(mock(Schema.class, RETURNS_DEEP_STUBS));
+    when(proxied.executeInReadLock(any())).thenAnswer(inv -> ((Callable<?>) inv.getArgument(0)).call());
+
+    broker = mock(RaftTransactionBroker.class);
+    raftServer = mock(RaftHAServer.class, RETURNS_DEEP_STUBS);
+    when(raftServer.isLeader()).thenReturn(true);
+    when(raftServer.getTransactionBroker()).thenReturn(broker);
+
+    tx = mock(TransactionContext.class);
+    stateMachine = new ArcadeStateMachine();
+  }
+
+  @AfterEach
+  void tearDown() {
+    RaftReplicatedDatabase.TEST_POST_REPLICATION_HOOK = null;
+    DatabaseContext.INSTANCE.removeContext(DB_PATH);
+  }
+
+  /** The whole point: phase 2 wrote the pages, so the entry is durable here and may be checkpointed. */
+  @Test
+  void successfulPhase2ReleasesTheTicket() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+    assertThat(stateMachine.pendingLocalPhase2Count()).isEqualTo(1);
+
+    database.replicateAndCommitLocally(payload(), true, stateMachine, ticket);
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("a completed phase 2 must stop pinning the snapshot checkpoint")
+        .isZero();
+  }
+
+  /**
+   * The #5407 window itself: replication succeeded, then something threw before phase 2 could run.
+   * This node now holds a committed entry it never applied, so the guard MUST survive the unwind.
+   */
+  @Test
+  void faultBetweenReplicationAndPhase2RetainsTheTicket() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    RaftReplicatedDatabase.TEST_POST_REPLICATION_HOOK = dbName -> {
+      throw new IllegalStateException("simulated crash between Raft commit and phase 2");
+    };
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(IllegalStateException.class);
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("phase 2 never ran, so the entry must stay replayable - releasing here is the #5407 bug")
+        .isEqualTo(1);
+  }
+
+  /** Phase 2 threw and reconciliation could not settle the pages either: the entry stays unapplied. */
+  @Test
+  void unreconciledPhase2FailureRetainsTheTicket() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    doThrow(new IllegalStateException("simulated phase 2 failure")).when(tx).commit2ndPhase(any());
+    // Reconciliation replays the payload WAL through the transaction manager; make that fail too.
+    doThrow(new IllegalStateException("simulated reconcile failure"))
+        .when(txManager).applyChanges(any(), any(), anyBoolean());
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(TransactionCommittedRemotelyException.class);
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("with the pages never settled the entry must remain inside the replay window")
+        .isEqualTo(1);
+  }
+
+  /** Replication failed outright: no entry exists, so there is nothing to protect. */
+  @Test
+  void replicationFailureReleasesTheTicket() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    doThrow(new IllegalStateException("simulated replication failure"))
+        .when(broker).replicateTransaction(anyString(), any(), any());
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(TransactionException.class);
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("a transaction that never reached the log needs no replay protection")
+        .isZero();
+  }
+
+  /** A replica runs no phase 2 - the state machine applies the entry normally - so it holds nothing. */
+  @Test
+  void replicaCommitReleasesTheTicket() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    assertThatCode(() -> database.replicateAndCommitLocally(payload(), false, stateMachine, ticket))
+        .doesNotThrowAnyException();
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("no leader-side phase 2 is pending on a replica")
+        .isZero();
+  }
+
+  private RaftReplicatedDatabase newDatabase() {
+    final RaftReplicatedDatabase database = new RaftReplicatedDatabase(null, proxied, raftServer);
+    DatabaseContext.INSTANCE.init(proxied, tx);
+    return database;
+  }
+
+  /** 24 zero bytes deserialize to an empty WAL transaction (txId=0, 0 pages). */
+  private RaftReplicatedDatabase.ReplicationPayload payload() {
+    return new RaftReplicatedDatabase.ReplicationPayload(tx, null, new byte[24], Map.of());
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5407Phase2TicketLifecycleTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5407Phase2TicketLifecycleTest.java
@@ -162,6 +162,46 @@ class Issue5407Phase2TicketLifecycleTest {
         .isZero();
   }
 
+  /**
+   * ALL-quorum recovery: MAJORITY committed the entry, so this path applies phase 2 locally. When
+   * that succeeds the pages are on disk and the ticket goes.
+   */
+  @Test
+  void majorityCommittedRecoveryReleasesTheTicketWhenPagesSettle() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    doThrow(new MajorityCommittedAllFailedException("simulated ALL-quorum watch failure"))
+        .when(broker).replicateTransaction(anyString(), any(), any());
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(MajorityCommittedAllFailedException.class);
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("ALL-quorum recovery wrote the pages, so the checkpoint may cover the entry")
+        .isZero();
+  }
+
+  /** ...but if that recovery apply fails and reconciliation cannot settle the pages either, it stays. */
+  @Test
+  void majorityCommittedRecoveryRetainsTheTicketWhenPagesNeverSettle() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    doThrow(new MajorityCommittedAllFailedException("simulated ALL-quorum watch failure"))
+        .when(broker).replicateTransaction(anyString(), any(), any());
+    doThrow(new IllegalStateException("simulated recovery apply failure")).when(tx).commit2ndPhase(any());
+    doThrow(new IllegalStateException("simulated reconcile failure"))
+        .when(txManager).applyChanges(any(), any(), anyBoolean());
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(MajorityCommittedAllFailedException.class);
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("the entry is committed cluster-wide but absent here, so it must stay replayable")
+        .isEqualTo(1);
+  }
+
   /** A replica runs no phase 2 - the state machine applies the entry normally - so it holds nothing. */
   @Test
   void replicaCommitReleasesTheTicket() {


### PR DESCRIPTION
Closes #5407

## Summary

On the leader, a locally-originated entry is origin-skipped by `ArcadeStateMachine.applyTransaction` because `RaftReplicatedDatabase.commit()`'s **phase 2** writes the pages - but phase 2 runs only *after* Raft commits. `lastAppliedIndex` therefore advances past an entry whose pages are not on disk yet, and `takeSnapshot()` reported that index to Ratis as the durability checkpoint, writing a `snapshot.<term>_<index>` marker at it. Because `reinitialize()` seeds the replay position **exclusively** from that marker, a restart began replaying *above* the never-applied entry: neither Raft replay nor follower catch-up revisited it, so the acknowledged write was silently and permanently lost on that node.

The detail worth flagging beyond the issue report: **Ratis takes a snapshot on shutdown**, which is what makes the loss durable. It is not only a hard-crash window - any shutdown following an aborted phase 2 (graceful stop, or the `triggerCriticalHalt()` path) buries the entry. The failing run left the smoking gun on disk: the crashed leader had `snapshot.1_9`, a checkpoint sitting exactly on the lost entry at index 9.

**Fix.** `ArcadeStateMachine` tracks in-flight leader-side phase-2 applies: `beginLocalPhase2()` records the applied index observed *before* replication (the entry's replay floor), and `takeSnapshot()` clamps its reported checkpoint to the lowest in-flight floor, so it can never cover an entry whose phase 2 has not confirmed. It also refuses to regress the marker below an existing one - that would ask Ratis to replay from entries a previous checkpoint already authorised for purging - reporting `INVALID_LOG_INDEX` instead.

`RaftReplicatedDatabase` **retains that guard by default** and releases it only where the local pages are provably settled: phase 2 succeeded, a failed phase 2 reconciled successfully, ALL-quorum recovery settled the pages, the commit was on a replica (no phase 2 expected), or replication failed outright so no entry exists. Every other exit - notably "replication succeeded but phase 2 never ran" - keeps the hold, which is exactly the #5407 window. A retained ticket costs a stalled compaction checkpoint until the node restarts, at which point replay applies the entry and the hold disappears with the process: a deliberate trade of log-compaction progress for durability. Replay is idempotent via the existing `applyChanges` page-version guards.

As a side effect this also makes the #4790 `ReplicationDispatchedTimeoutException` window crash-safe: its `abandonedLocalTransactions` marker is in-memory and cannot survive a crash, but the retained ticket means replay now covers the entry.

## Test plan

- [x] New `ArcadeStateMachinePendingPhase2SnapshotTest` (5 cases): checkpoint clamps to the pending floor; advances again once phase 2 completes; tracks the oldest of several in-flight commits; never regresses below an existing marker; suppressed entirely when a phase 2 starts before anything has been applied.
- [x] The two ITs from the issue, which failed **100%** before (4/4 and 3/3) and pass after:
  - `RaftLeaderCrashBetweenCommitAndApplyIT`
  - `RaftLeaderCrashWithExternalPropertyIT`
- [x] Full `ha-raft` unit suite: **723 tests, 0 failures**.
- [x] Targeted IT sweep over the commit path, origin-skip, phase-2 failure handling, snapshot/compaction and crash recovery - **22 tests across 15 IT classes, 0 failures**: `Issue4790PhantomCommitOriginSkipIT`, `OriginNodeSkipIT`, `Issue4740Phase2ReconcileIT`, `Issue5064CommittedRemotelyContractIT`, `RaftLeaderCrashAndRecoverIT`, `RaftPeriodicSnapshotCompactionIT`, `RaftLogCompactionWiringIT`, `RaftFullSnapshotResyncIT`, `Raft3PhaseCommitIT`, `RaftReplication3NodesIT`, `RaftReplicaCrashAndRecoverIT`, `RaftIdleReplicaRestartIT`, `RaftBootstrapDoesNotEngageOnRestartIT` plus the two above.

Reproduce:

```
mvn -pl ha-raft verify -DskipTests -Pintegration \
  -Dit.test='RaftLeaderCrashBetweenCommitAndApplyIT,RaftLeaderCrashWithExternalPropertyIT' \
  -Dfailsafe.failIfNoSpecifiedTests=false

mvn -pl ha-raft test -Dtest=ArcadeStateMachinePendingPhase2SnapshotTest
```

Note: `Raft3PhaseCommitIT.concurrentWritersReplicateCorrectly` flaked once on the first batch run (HTTP non-200 on the very first insert, while the previous IT's servers were still shutting down). It passed 3/3 in isolation and the full batch re-ran clean, so it is cross-test startup contention, not a regression from this change.

## Notes

- The persisted `.raft/applied-index` file is intentionally left unclamped: it never feeds the replay position (only the snapshot-gap check, the per-database bootstrap replay-skip, and the "never applied anything" bootstrap signal), so clamping it would change bootstrap behaviour without improving durability.
- `RaftHAServer.takeLocalSnapshot` already treats an unsuccessful snapshot reply as a FINE-level no-op, so the new `INVALID_LOG_INDEX` path adds no log noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)