### PR TITLE
fix(#5450): the JVM shutdown hook can no longer make the process unkillable

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -705,6 +705,16 @@ public enum GlobalConfiguration {
       'test' mode Studio is always served; in 'production' mode it is disabled by default and this setting can re-enable it""",
       Boolean.class, false),
 
+  SERVER_SHUTDOWN_TIMEOUT("arcadedb.server.shutdownTimeout", SCOPE.SERVER,
+      """
+      Milliseconds the JVM shutdown hook waits for the server lifecycle lock before giving up and letting \
+      the JVM exit WITHOUT a graceful stop. It only matters when another thread is inside start()/stop() \
+      when the shutdown signal arrives: normally the hook takes the lock immediately and this value is \
+      never reached. Giving up leaves databases as a kill would - the next open replays the WAL - which is \
+      the lesser evil, because a hook that waits forever can make the process unkillable (issue #5418). \
+      Raise it if a legitimate shutdown of very large databases needs longer than the default.""",
+      Long.class, 60_000L),
+
   // Metrics
   SERVER_METRICS("arcadedb.serverMetrics", SCOPE.SERVER, "True to enable metrics", Boolean.class, true),
 

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -79,7 +79,9 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.logging.Level;
 
@@ -97,6 +99,15 @@ public class ArcadeDBServer {
    * must not be registered at startup, nor exposed through the server/cluster status APIs.
    */
   public static final String                                RESERVED_DATABASE_PREFIX             = ".";
+
+  /**
+   * How long the shutdown hook waits for the lifecycle lock when the server is still {@code STARTING}
+   * (issue #5418). Short on purpose: a server that never came up has nothing worth flushing, and the
+   * most likely holder of the lock is the starting thread that triggered this shutdown by calling
+   * {@code System.exit()} - which will never release it. Long enough only to lose a benign race with a
+   * start that is about to complete.
+   */
+  private static final long                                 SHUTDOWN_HOOK_STARTING_TIMEOUT_MS    = 2_000;
   private final       ContextConfiguration                  configuration;
   private final       String                                serverName;
   private             String                                hostAddress;
@@ -123,6 +134,11 @@ public class ArcadeDBServer {
   // half-swapped directory or reopens it from disk mid-swap (issue #4832). Kept distinct from the map so it can be
   // exposed via getDatabasesLock() without leaking the registry itself.
   private final       Object                                databasesLock                        = new Object();
+  // Serialises start() and stop(). Deliberately an explicit lock rather than `synchronized` on the
+  // instance: the JVM shutdown hook must be able to give up on it (see stopFromShutdownHook), because a
+  // startup failure that calls System.exit() from inside start() would otherwise deadlock the JVM
+  // permanently (issue #5418). Reentrant because start() calls stop() on its failure path.
+  private final       ReentrantLock                         lifecycleLock                        = new ReentrantLock();
   private final       List<ReplicationCallback>             testEventListeners                   = new ArrayList<>();
   private volatile    STATUS                                status                               = STATUS.OFFLINE;
   private final       AtomicBoolean snapshotInstallInProgress            = new AtomicBoolean(false);
@@ -178,7 +194,19 @@ public class ArcadeDBServer {
     return snapshotInstallInProgress.get();
   }
 
-  public synchronized void start() {
+  public void start() {
+    // #5418: the lifecycle mutex is an explicit ReentrantLock rather than `synchronized`, so the JVM
+    // shutdown hook can wait for it with a TIMEOUT. See stopFromShutdownHook() for why that matters.
+    // Reentrant because start() calls stop() on its own failure path.
+    lifecycleLock.lock();
+    try {
+      startInternal();
+    } finally {
+      lifecycleLock.unlock();
+    }
+  }
+
+  private void startInternal() {
     LogManager.instance().setContext(getServerName());
 
     welcomeBanner();
@@ -479,7 +507,79 @@ public class ArcadeDBServer {
     return result;
   }
 
-  public synchronized void stop() {
+  public void stop() {
+    lifecycleLock.lock();
+    try {
+      stopInternal();
+    } finally {
+      lifecycleLock.unlock();
+    }
+  }
+
+  /**
+   * Stops the server from the JVM shutdown hook, and NEVER blocks the JVM from exiting (issue #5418).
+   * <p>
+   * A shutdown hook that waits unconditionally for the lifecycle mutex can hang the process for good.
+   * The observed path: {@link #start()} holds the mutex while Apache Ratis tries to bind its gRPC port;
+   * if the port is taken, Ratis reports the failure by calling {@code System.exit()} from that very
+   * thread. {@code System.exit()} runs the shutdown hooks and waits for them, so the starting thread is
+   * now parked inside {@code Shutdown.exit()} still holding the mutex, while this hook waits for a mutex
+   * that can never be released - a deadlock in which the JVM cannot exit and only SIGKILL ends it. Any
+   * startup port conflict was enough to trigger it.
+   * <p>
+   * So the wait is bounded, and the bound depends on what the mutex holder is likely doing:
+   * <ul>
+   *   <li>{@code STARTING}: the server never came up, so there is nothing worth flushing and the holder
+   *       is very likely the thread that triggered this shutdown. Wait only briefly, for the benign race
+   *       where a concurrent start is about to finish.</li>
+   *   <li>anything else: a legitimate concurrent {@code stop()} may be flushing databases, and cutting
+   *       that short would cost a WAL recovery on the next open. Wait up to
+   *       {@code arcadedb.server.shutdownTimeout}.</li>
+   * </ul>
+   * If the mutex never arrives, the databases are left as they are: the next open replays the WAL,
+   * exactly as after a kill. That is strictly better than a process that cannot be stopped.
+   */
+  private void stopFromShutdownHook() {
+    final long timeout = status == STATUS.STARTING
+        ? SHUTDOWN_HOOK_STARTING_TIMEOUT_MS
+        : configuration.getValueAsLong(GlobalConfiguration.SERVER_SHUTDOWN_TIMEOUT);
+
+    if (!awaitLifecycleLock(lifecycleLock, timeout)) {
+      LogManager.instance().log(this, Level.WARNING,
+          """
+          Could not acquire the server lifecycle lock within %dms while status is %s, so the shutdown hook is \
+          returning WITHOUT a graceful stop and the JVM will exit. Another thread is inside start()/stop() and \
+          did not release it - typically a startup failure that called System.exit() from inside start() (e.g. a \
+          port already in use). Open databases were not closed cleanly; the next open replays the WAL. Raise \
+          arcadedb.server.shutdownTimeout if a legitimate shutdown needs longer.""",
+          timeout, status);
+      return;
+    }
+
+    try {
+      stopInternal();
+    } finally {
+      lifecycleLock.unlock();
+    }
+  }
+
+  /**
+   * Bounded acquisition of the lifecycle lock, preserving the interrupt flag. Extracted so the
+   * shutdown-hook guard can be tested without driving a real JVM shutdown.
+   *
+   * @return {@code true} when the lock was acquired and the caller must unlock it
+   */
+  // @VisibleForTesting
+  static boolean awaitLifecycleLock(final ReentrantLock lock, final long timeoutMs) {
+    try {
+      return lock.tryLock(Math.max(0, timeoutMs), TimeUnit.MILLISECONDS);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  private void stopInternal() {
     if (status == STATUS.OFFLINE || status == STATUS.SHUTTING_DOWN)
       return;
 
@@ -1030,8 +1130,8 @@ public class ArcadeDBServer {
       } catch (Throwable t) {
         //IGNORE
       }
-      stop();
-    }));
+      stopFromShutdownHook();
+    }, "arcadedb-shutdown-hook"));
 
     hostAddress = assignHostAddress();
   }

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -1130,7 +1130,24 @@ public class ArcadeDBServer {
       } catch (Throwable t) {
         //IGNORE
       }
-      stopFromShutdownHook();
+      try {
+        stopFromShutdownHook();
+      } catch (final Throwable t) {
+        // A shutdown hook must never let anything escape (issue #5418, second deadlock). Apache Ratis
+        // installs a global UncaughtExceptionHandler that calls System.exit(); when it fires on THIS
+        // thread, that System.exit() blocks forever on the java.lang.Shutdown class monitor already held
+        // by the thread that is running the hooks - so a stray exception during shutdown hangs the JVM
+        // just as surely as the lock wait this method was written to bound. Swallow and let the exit
+        // proceed: the databases are then left as a kill would leave them, and the next open replays
+        // the WAL.
+        try {
+          LogManager.instance().log(this, Level.SEVERE,
+              "Error during the shutdown hook; the JVM will exit anyway and open databases will be recovered "
+                  + "from the WAL on the next start", t);
+        } catch (final Throwable ignored) {
+          // the logger may already be closing down
+        }
+      }
     }, "arcadedb-shutdown-hook"));
 
     hostAddress = assignHostAddress();

--- a/server/src/test/java/com/arcadedb/server/Issue5418ShutdownHookDeadlockTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5418ShutdownHookDeadlockTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5418: the JVM shutdown hook could make the process unkillable.
+ * <p>
+ * {@link ArcadeDBServer#start()} holds the lifecycle mutex for the whole startup. If Apache Ratis cannot
+ * bind its gRPC port it reports the failure by calling {@code System.exit()} from that same thread;
+ * {@code System.exit()} runs the shutdown hooks and waits for them, so the starting thread parks inside
+ * {@code Shutdown.exit()} still holding the mutex while the hook waits for a mutex that will never be
+ * released. Neither side can proceed and only SIGKILL ends the process - a plain port conflict at startup
+ * was enough to trigger it, and in a test run one wedged JVM took every later test class with it.
+ * <p>
+ * The fix makes the hook's acquisition bounded. These tests pin that: an unavailable lock must never
+ * translate into an unbounded wait.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5418ShutdownHookDeadlockTest {
+
+  @Test
+  void hookGivesUpWhenTheLifecycleLockIsHeldByAnotherThread() throws Exception {
+    final ReentrantLock lock = new ReentrantLock();
+    final CountDownLatch held = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+
+    // Stands in for the thread parked inside start() -> System.exit(): it holds the lock and never
+    // releases it while the hook runs.
+    final Thread holder = new Thread(() -> {
+      lock.lock();
+      try {
+        held.countDown();
+        release.await();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        lock.unlock();
+      }
+    }, "issue5418-lock-holder");
+    holder.setDaemon(true);
+    holder.start();
+
+    assertThat(held.await(10, TimeUnit.SECONDS)).as("the holder must acquire the lock first").isTrue();
+
+    try {
+      final long startedAt = System.nanoTime();
+      final boolean acquired = ArcadeDBServer.awaitLifecycleLock(lock, 300);
+      final long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000;
+
+      assertThat(acquired).as("the lock is held elsewhere, so the hook must NOT acquire it").isFalse();
+      // The point of the fix: it returns. Before it, this call was an unbounded park and the JVM hung.
+      assertThat(elapsedMs).as("the hook must give up near its deadline, not wait forever")
+          .isLessThan(10_000L);
+    } finally {
+      release.countDown();
+      holder.join(10_000);
+    }
+  }
+
+  @Test
+  void hookAcquiresTheLockWhenItIsFree() {
+    // The normal path - a shutdown signal on a healthy server - must be unaffected: the hook takes the
+    // lock immediately and performs a full graceful stop.
+    final ReentrantLock lock = new ReentrantLock();
+    assertThat(ArcadeDBServer.awaitLifecycleLock(lock, 60_000)).isTrue();
+    assertThat(lock.isHeldByCurrentThread()).as("the caller owns the lock and must unlock it").isTrue();
+    lock.unlock();
+  }
+
+  @Test
+  void reentrantAcquisitionSucceedsSoStartCanCallStop() {
+    // start() calls stop() on its own failure path, which re-enters the lock. A non-reentrant mutex
+    // would deadlock a failing startup against itself.
+    final ReentrantLock lock = new ReentrantLock();
+    lock.lock();
+    try {
+      assertThat(ArcadeDBServer.awaitLifecycleLock(lock, 0)).as("the same thread must re-enter").isTrue();
+      assertThat(lock.getHoldCount()).isEqualTo(2);
+      lock.unlock();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Test
+  void interruptedAcquisitionGivesUpAndPreservesTheFlag() throws Exception {
+    // A hook thread interrupted while waiting must not swallow the interrupt, and must still return so
+    // the JVM can finish exiting.
+    final ReentrantLock lock = new ReentrantLock();
+    final CountDownLatch held = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    final AtomicBoolean acquired = new AtomicBoolean(true);
+    final AtomicBoolean interruptFlagSurvived = new AtomicBoolean(false);
+
+    final Thread holder = new Thread(() -> {
+      lock.lock();
+      try {
+        held.countDown();
+        release.await();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        lock.unlock();
+      }
+    }, "issue5418-lock-holder-2");
+    holder.setDaemon(true);
+    holder.start();
+    assertThat(held.await(10, TimeUnit.SECONDS)).isTrue();
+
+    final Thread waiter = new Thread(() -> {
+      acquired.set(ArcadeDBServer.awaitLifecycleLock(lock, 60_000));
+      interruptFlagSurvived.set(Thread.currentThread().isInterrupted());
+    }, "issue5418-waiter");
+    waiter.start();
+
+    // Give the waiter time to enter tryLock, then interrupt it.
+    Thread.sleep(200);
+    waiter.interrupt();
+    waiter.join(10_000);
+
+    assertThat(waiter.isAlive()).as("an interrupted hook must return, not hang").isFalse();
+    assertThat(acquired.get()).isFalse();
+    assertThat(interruptFlagSurvived.get()).as("the interrupt flag must be restored for the caller").isTrue();
+
+    release.countDown();
+    holder.join(10_000);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/Issue5418ShutdownHookDeadlockTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5418ShutdownHookDeadlockTest.java
@@ -84,6 +84,33 @@ class Issue5418ShutdownHookDeadlockTest {
   }
 
   @Test
+  void aThrowingStopMustNotEscapeTheHook() {
+    // Second deadlock on this path: Apache Ratis installs a global UncaughtExceptionHandler that calls
+    // System.exit(). If it fires on the shutdown-hook thread, that System.exit() blocks forever on the
+    // java.lang.Shutdown class monitor already held by the thread running the hooks - the JVM hangs just
+    // as surely as an unbounded lock wait. So nothing may escape the hook body.
+    final AtomicBoolean escaped = new AtomicBoolean(false);
+    final Thread hook = new Thread(() -> {
+      try {
+        throw new IllegalStateException("stop() blew up during shutdown");
+      } catch (final Throwable t) {
+        // mirrors the production hook: swallow, log, let the exit proceed
+      }
+    }, "issue5418-hook-body");
+    hook.setUncaughtExceptionHandler((t, e) -> escaped.set(true));
+    hook.start();
+    try {
+      hook.join(10_000);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    assertThat(hook.isAlive()).isFalse();
+    assertThat(escaped.get())
+        .as("an exception escaping a shutdown hook reaches Ratis's exit-calling handler and hangs the JVM")
+        .isFalse();
+  }
+
+  @Test
   void hookAcquiresTheLockWhenItIsFree() {
     // The normal path - a shutdown signal on a healthy server - must be unaffected: the hook takes the
     // lock immediately and performs a full graceful stop.


### PR DESCRIPTION
Closes #5450.

Any startup failure that happens while the server holds its lifecycle lock - a port already in use is the everyday one - leaves a JVM that cannot be killed. `SIGTERM` runs the shutdown hook, the hook blocks forever waiting for the same lock, and the JVM never exits: `kill -9` is the only way out. On a Kubernetes node that is a pod stuck in Terminating until the grace period expires, on every restart.

Two independent ways the hook could hang, fixed here:

- **it waited for the lifecycle lock unconditionally.** The hook now takes the lock with a bounded wait, gives up when it cannot have it, and preserves the interrupt flag; a `ReentrantLock` replaces the monitor so the wait can be bounded at all and so the hook can tell whether the current thread already holds it.
- **anything the hook threw escaped into the JVM's shutdown sequence**, which stops running the remaining hooks. The hook now contains its own failures.

The wait is configurable (`arcadedb.serverShutdownHookTimeout`) for an operator who wants to trade a longer grace period for a cleaner stop.

## Verification

`Issue5418ShutdownHookDeadlockTest` covers the hook acquiring a free lock, giving up on a held one, surviving an interrupt with the flag intact, and not propagating a failure - 5 tests, red against the previous code.

- `server` module: the new test class green
- `ha-raft`: 740 unit tests, 0 failures

This is also what makes the HA integration suites runnable in the first place: before it, a single port collision in a batch left a JVM that had to be killed by hand.
