### PR TITLE
fix(#5443): a follower's index can be short after an LSM compaction

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1432,15 +1432,19 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final boolean sealedOnlyEntry = isEmptyMap(decoded.filesToAdd()) && isEmptyMap(decoded.filesToRemove())
         && decoded.sealedFileBlobs() != null && !decoded.sealedFileBlobs().isEmpty();
 
-    // #4743: an intermediate chunk of a split schema change (see
-    // RaftTransactionBroker.replicateSchemaInChunks) carries WAL pages only - no files, no schema JSON,
-    // no sealed blobs. The change is published by the LAST chunk, so reloading the schema here would
-    // re-instantiate every component from the still-unchanged schema.json for nothing, on the single
-    // Raft apply thread, once per chunk. Apply the pages and move on.
-    final boolean walOnlyEntry = isEmptyMap(decoded.filesToAdd()) && isEmptyMap(decoded.filesToRemove())
-        && (decoded.schemaJson() == null || decoded.schemaJson().isEmpty())
-        && (decoded.sealedFileBlobs() == null || decoded.sealedFileBlobs().isEmpty())
-        && decoded.walEntries() != null && !decoded.walEntries().isEmpty();
+    // A non-final chunk of a schema change split across several entries (see
+    // RaftTransactionBroker.splitSchemaEntry) only DELIVERS pages: the change is published by the last
+    // chunk. Reloading the schema on such a chunk re-instantiates every component from a state that is
+    // still half-delivered - and that is not merely wasted work on the single Raft apply thread, it is
+    // STICKY: a compacted sub-index that cannot be resolved yet gets detached, and the later publication
+    // reuses the same in-memory component, so the follower keeps serving only its mutable pages for good
+    // (#5443: ~1897 of 60000 entries).
+    //
+    // The producer marks these chunks explicitly. Inferring them from "no schema JSON" was tried and is
+    // WRONG: the first chunk carries filesToAdd and no schema JSON, which is indistinguishable from a
+    // standalone DDL that adds files without changing the schema version - and skipping the reload for
+    // that would leave the new files unregistered in the schema.
+    final boolean deliveryOnlyEntry = decoded.moreChunksFollow();
 
     try {
       if (decoded.filesToAdd() != null)
@@ -1496,8 +1500,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // Reload schema after WAL pages are on disk so new index files have valid content
       // and are correctly registered (page counts, type links, in-memory structures).
       // Skipped for sealed-only TimeSeries compaction entries (see sealedOnlyEntry above) and for
-      // intermediate chunks of a split schema change (see walOnlyEntry above).
-      if (!sealedOnlyEntry && !walOnlyEntry)
+      // delivery-only chunks of a split schema change (see deliveryOnlyEntry above).
+      if (!sealedOnlyEntry && !deliveryOnlyEntry)
         db.getSchema().getEmbedded().load(ComponentFile.MODE.READ_WRITE, true);
 
     } catch (final IOException e) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -245,6 +245,9 @@ public final class RaftLogEntryCodec {
         dos.write(compressed);
       }
 
+      // KEEP THIS LAST. The decoder detects it with available() > 0, so it can only be the final field:
+      // anything appended after it would make a false flag indistinguishable from an older entry that
+      // never wrote one. A future trailing section needs its own presence byte written BEFORE this.
       dos.writeBoolean(moreChunksFollow);
 
       dos.flush();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -80,7 +80,16 @@ public final class RaftLogEntryCodec {
       long bootstrapLastTxId,
       // TimeSeries sealed-store blobs embedded in a SCHEMA_ENTRY (issue #4382). Empty for all other
       // entry types and for SCHEMA_ENTRYs produced by nodes that predate this section.
-      List<TsSealedBlob> sealedFileBlobs
+      List<TsSealedBlob> sealedFileBlobs,
+      /**
+       * True on every chunk of a SCHEMA_ENTRY that was split across several Raft entries except the last
+       * (issue #5443). Such a chunk only DELIVERS pages - the change is published by the final chunk - so
+       * the applier must not reload the schema for it. This is carried explicitly rather than inferred:
+       * a chunk that creates files but carries no schema JSON is indistinguishable from a legitimate
+       * standalone DDL that adds files without changing the schema version, and skipping the reload for
+       * THAT would leave the new files unregistered.
+       */
+      boolean moreChunksFollow
   ) {
   }
 
@@ -162,6 +171,20 @@ public final class RaftLogEntryCodec {
       final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
       final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
       final List<TsSealedBlob> sealedFileBlobs) {
+    return encodeSchemaEntry(databaseName, schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas,
+        sealedFileBlobs, false);
+  }
+
+  /**
+   * @param moreChunksFollow marks a non-final chunk of a schema change split across several entries
+   *                         (issue #5443). Written as a trailing self-describing byte, so a node running
+   *                         an older codec simply stops after the sealed-blob section and decodes it as
+   *                         false - the pre-split behaviour.
+   */
+  public static ByteString encodeSchemaEntry(final String databaseName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
+      final List<TsSealedBlob> sealedFileBlobs, final boolean moreChunksFollow) {
     try {
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
       final DataOutputStream dos = new DataOutputStream(baos);
@@ -212,6 +235,8 @@ public final class RaftLogEntryCodec {
         dos.writeInt(compressed.length);   // compressed length
         dos.write(compressed);
       }
+
+      dos.writeBoolean(moreChunksFollow);
 
       dos.flush();
       return ByteString.copyFrom(baos.toByteArray());
@@ -346,7 +371,7 @@ public final class RaftLogEntryCodec {
       final RaftLogEntryType type = RaftLogEntryType.fromId(typeByte);
       if (type == null)
         return new DecodedEntry(null, null, null, null, null, null, null, null, null, null, false, null, -1L,
-            Collections.emptyList());
+            Collections.emptyList(), false);
       final String databaseName = dis.readUTF();
 
       final DecodedEntry result = switch (type) {
@@ -354,7 +379,7 @@ public final class RaftLogEntryCodec {
         case SCHEMA_ENTRY -> decodeSchemaEntry(dis, databaseName);
         case INSTALL_DATABASE_ENTRY -> decodeInstallDatabaseEntry(dis, databaseName);
         case DROP_DATABASE_ENTRY -> new DecodedEntry(RaftLogEntryType.DROP_DATABASE_ENTRY, databaseName,
-            null, null, null, null, null, null, null, null, false, null, -1L, Collections.emptyList());
+            null, null, null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false);
         case SECURITY_USERS_ENTRY -> decodeSecurityUsersEntry(dis);
         case BOOTSTRAP_FINGERPRINT_ENTRY -> decodeBootstrapFingerprintEntry(dis, databaseName);
       };
@@ -392,7 +417,7 @@ public final class RaftLogEntryCodec {
     }
 
     return new DecodedEntry(RaftLogEntryType.TX_ENTRY, databaseName, walData, bucketRecordDelta,
-        null, null, null, null, null, null, false, null, -1L, Collections.emptyList());
+        null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false);
   }
 
   private static DecodedEntry decodeSchemaEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -471,8 +496,13 @@ public final class RaftLogEntryCodec {
       }
     }
 
+    // Trailing continuation flag (issue #5443), same presence rule as the sections above: absent on
+    // entries produced by an older codec, which decode as false.
+    final boolean moreChunksFollow = dis.available() > 0 && dis.readBoolean();
+
     return new DecodedEntry(RaftLogEntryType.SCHEMA_ENTRY, databaseName, null, null,
-        schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, null, false, null, -1L, sealedFileBlobs);
+        schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, null, false, null, -1L, sealedFileBlobs,
+        moreChunksFollow);
   }
 
   private static DecodedEntry decodeInstallDatabaseEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -483,7 +513,7 @@ public final class RaftLogEntryCodec {
       forceSnapshot = dis.readBoolean();
     }
     return new DecodedEntry(RaftLogEntryType.INSTALL_DATABASE_ENTRY, databaseName,
-        null, null, null, null, null, null, null, null, forceSnapshot, null, -1L, Collections.emptyList());
+        null, null, null, null, null, null, null, null, forceSnapshot, null, -1L, Collections.emptyList(), false);
   }
 
   private static DecodedEntry decodeBootstrapFingerprintEntry(final DataInputStream dis, final String databaseName)
@@ -495,7 +525,7 @@ public final class RaftLogEntryCodec {
     final String fingerprint = new String(fpBytes, StandardCharsets.UTF_8);
     final long lastTxId = dis.readLong();
     return new DecodedEntry(RaftLogEntryType.BOOTSTRAP_FINGERPRINT_ENTRY, databaseName,
-        null, null, null, null, null, null, null, null, false, fingerprint, lastTxId, Collections.emptyList());
+        null, null, null, null, null, null, null, null, false, fingerprint, lastTxId, Collections.emptyList(), false);
   }
 
   private static DecodedEntry decodeSecurityUsersEntry(final DataInputStream dis) throws IOException {
@@ -505,7 +535,7 @@ public final class RaftLogEntryCodec {
     dis.readFully(bytes);
     final String usersJson = new String(bytes, StandardCharsets.UTF_8);
     return new DecodedEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, "",
-        null, null, null, null, null, null, null, usersJson, false, null, -1L, Collections.emptyList());
+        null, null, null, null, null, null, null, usersJson, false, null, -1L, Collections.emptyList(), false);
   }
 
   private static void writeFileMap(final DataOutputStream dos, final Map<Integer, String> fileMap) throws IOException {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -180,6 +180,15 @@ public final class RaftLogEntryCodec {
    *                         (issue #5443). Written as a trailing self-describing byte, so a node running
    *                         an older codec simply stops after the sealed-blob section and decodes it as
    *                         false - the pre-split behaviour.
+   *                         <p>
+   *                         <b>During a rolling upgrade</b> that means a node still running the older
+   *                         codec keeps the pre-fix behaviour for split entries: it reloads its schema on
+   *                         a delivery-only chunk and can detach a compacted sub-index for good, ending
+   *                         up with a short index. The wire format stays compatible in both directions,
+   *                         but the FIX only takes effect on a node once it is upgraded, and the symptom
+   *                         is silent - fewer rows from that node, no error. Upgrade the followers, and
+   *                         where a node was live through a compaction under the old codec, REBUILD INDEX
+   *                         on it (or let a snapshot install replace its files) to repair what it missed.
    */
   public static ByteString encodeSchemaEntry(final String databaseName, final String schemaJson,
       final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1676,7 +1676,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       if (componentFile == null)
         continue;
       final int fileId = componentFile.getFileId();
-      if (proxied.getSchema().getEmbedded().getFileById(fileId) instanceof PaginatedComponent component)
+      // getFileByIdIfExists(), not getFileById(): the latter THROWS on an id the schema does not know,
+      // and this walks every file the FileManager holds - a dropped file leaves a null slot in the
+      // schema's list, so one of those would abort the whole compaction replication instead of being
+      // skipped, which is what the type test below reads as if it were doing.
+      if (proxied.getSchema().getEmbedded().getFileByIdIfExists(fileId) instanceof PaginatedComponent component)
         counts.put(fileId, component.getTotalPages());
     }
     return counts;
@@ -1761,11 +1765,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     if (totalPages <= fromPage)
       return 0;
 
-    final int deltaSize = walPageDeltaSize(pageSize);
-    // Per-page WAL record: fileId(4) + pageNum(4) + changesFrom(4) + changesTo(4) + version(4) + contentSize(4) + delta
     final int perPageWalSize = walPerPageSize(pageSize);
-    // Per-chunk framing: txId(8) + timestamp(8) + pageCount(4) + segmentSize(4) + pages + segmentSize(4) + MAGIC(8)
-
 
     // The root page carries the series registry: an appended series is invisible until page 0 says it
     // exists, so a partial ship must always include it. Without this the follower stores the new pages

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1747,20 +1747,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // unfindable there while the records themselves replicated normally. The component knows the real
     // count, and getImmutablePage() resolves each page through the cache and the pending-flush queue
     // before falling back to disk, so both are correct regardless of flush timing.
-    // getFileById() THROWS when the id is unknown, so the guard has to be getFileByIdIfExists() plus the
-    // type test - the same shape snapshotPageCounts() uses. The on-disk count is the only fallback left
-    // for a file the schema does not know, and it is the very number that made this bug silent, so say so
-    // rather than degrade quietly. No current caller can reach it: the ids come either from addFiles or
-    // from snapshotPageCounts(), which already filtered on PaginatedComponent.
-    final int totalPages;
-    if (proxied.getSchema().getEmbedded().getFileByIdIfExists(fileId) instanceof PaginatedComponent component)
-      totalPages = component.getTotalPages();
-    else {
-      totalPages = (int) file.getTotalPages();
-      LogManager.instance().log(this, Level.WARNING,
-          "File id '%d' of database '%s' is not a registered paginated component: replicating the %d pages "
-              + "already on disk, which may be short if a flush is still pending", fileId, getName(), totalPages);
-    }
+    // Only the component knows how many pages really exist: the file's own count is what is on disk, and
+    // trusting it is exactly what left followers with a short index. No caller can hand us anything else -
+    // the ids come from addFiles or from snapshotPageCounts(), which already filtered on PaginatedComponent -
+    // so a miss here is a bug in the caller, and it fails rather than quietly shipping a truncated range.
+    if (!(proxied.getSchema().getEmbedded().getFileByIdIfExists(fileId) instanceof PaginatedComponent component))
+      throw new IllegalStateException(
+          "Cannot replicate file id '" + fileId + "' of database '" + getName()
+              + "': it is not a registered paginated component, so its real page count is unknown");
+
+    final int totalPages = component.getTotalPages();
 
     if (totalPages <= fromPage)
       return 0;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1743,8 +1743,20 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // unfindable there while the records themselves replicated normally. The component knows the real
     // count, and getImmutablePage() resolves each page through the cache and the pending-flush queue
     // before falling back to disk, so both are correct regardless of flush timing.
-    final PaginatedComponent component = (PaginatedComponent) proxied.getSchema().getEmbedded().getFileById(fileId);
-    final int totalPages = component != null ? component.getTotalPages() : (int) file.getTotalPages();
+    // getFileById() THROWS when the id is unknown, so the guard has to be getFileByIdIfExists() plus the
+    // type test - the same shape snapshotPageCounts() uses. The on-disk count is the only fallback left
+    // for a file the schema does not know, and it is the very number that made this bug silent, so say so
+    // rather than degrade quietly. No current caller can reach it: the ids come either from addFiles or
+    // from snapshotPageCounts(), which already filtered on PaginatedComponent.
+    final int totalPages;
+    if (proxied.getSchema().getEmbedded().getFileByIdIfExists(fileId) instanceof PaginatedComponent component)
+      totalPages = component.getTotalPages();
+    else {
+      totalPages = (int) file.getTotalPages();
+      LogManager.instance().log(this, Level.WARNING,
+          "File id '%d' of database '%s' is not a registered paginated component: replicating the %d pages "
+              + "already on disk, which may be short if a flush is still pending", fileId, getName(), totalPages);
+    }
 
     if (totalPages <= fromPage)
       return 0;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1686,6 +1686,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * File ids of pre-existing paginated components that gained pages during the compaction session, mapped
    * to the page number the new pages start at. Files created by the session are excluded: they are shipped
    * whole. A file that shrank (or is new) contributes nothing.
+   * <p>
+   * <b>Invariant this relies on:</b> a compaction only ever APPENDS to a pre-existing file, and touches no
+   * interior page other than the root page 0 that registers the appended series - which is why the caller
+   * ships page 0 alongside the appended range. A compaction path that rewrote an interior page in place
+   * would not be replicated by this, and the follower's index would go short again exactly as in #5443.
+   * Any change to the compaction write path has to preserve that, or teach this method to track the pages
+   * it dirtied instead of only how many it added.
    */
   private Map<Integer, Integer> pagesGrownDuringSession(final Map<Integer, Integer> before,
       final Map<Integer, String> createdFiles) {
@@ -1801,9 +1808,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       walBuf.putInt((int) page.getVersion());
       walBuf.putInt(page.getContentSize());
 
-      final ByteBuffer pageBuffer = page.getContent();
-      for (int i = 0; i < deltaSize; i++)
-        walBuf.put(pageBuffer.get(BasePage.PAGE_HEADER_SIZE + i));
+      // Absolute bulk copy: it leaves both positions alone, so the shared page buffer is never
+      // disturbed, and it does not care whether either side is heap-backed.
+      walBuf.put(walBuf.position(), page.getContent(), BasePage.PAGE_HEADER_SIZE, deltaSize);
+      walBuf.position(walBuf.position() + deltaSize);
     }
 
     walBuf.putInt(segmentSize);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -44,7 +44,9 @@ import com.arcadedb.engine.BasePage;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.ErrorRecordCallback;
 import com.arcadedb.engine.FileManager;
+import com.arcadedb.engine.PageId;
 import com.arcadedb.engine.PageManager;
+import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.engine.TransactionManager;
 import com.arcadedb.engine.WALFile;
@@ -1498,6 +1500,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     compactionSealedBuffer.get().clear();
     isSchemaCommitThread.set(Boolean.TRUE);
     try {
+      // #5443: remember how long every paginated file is BEFORE the compaction, so the pages it appends
+      // to already-existing files can be shipped afterwards (see the loop below).
+      final Map<Integer, Integer> pageCountsBefore = snapshotPageCounts();
+
       final boolean result = invokeCompaction(compaction);
       if (!result)
         return false;
@@ -1527,7 +1533,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       final RaftTransactionBroker broker = requireRaftServer().getTransactionBroker();
       final long walChunkBudget = Math.max(1024L, broker.maxEntrySize() / 2);
       for (final int fileId : addFiles.keySet())
-        appendFilePagesAsWal(fileId, walChunkBudget, walEntries, bucketDeltas);
+        appendFilePagesAsWal(fileId, walChunkBudget, walEntries, bucketDeltas, 0);
+
+      // #5443: a compaction does not only CREATE files - an incremental round APPENDS a new series to the
+      // already-existing compacted file. Those pages are written eagerly and deliberately without WAL, and
+      // the file is not in addFiles because it is not new, so nothing replicated them: the follower kept
+      // the shorter file and every key in the appended series became unfindable there, silently, while the
+      // records themselves replicated normally through their own transactions. Ship the appended range of
+      // every pre-existing paginated component that grew during this session.
+      for (final Map.Entry<Integer, Integer> grown : pagesGrownDuringSession(pageCountsBefore, addFiles).entrySet())
+        appendFilePagesAsWal(grown.getKey(), walChunkBudget, walEntries, bucketDeltas, grown.getValue());
 
       final List<RaftLogEntryCodec.TsSealedBlob> sealedBlobs = new ArrayList<>(compactionSealedBuffer.get());
 
@@ -1652,6 +1667,41 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   /**
+   * Page count of every registered paginated component, keyed by file id. Taken before a compaction so
+   * {@link #pagesGrownDuringSession} can tell which pre-existing files it appended to (issue #5443).
+   */
+  private Map<Integer, Integer> snapshotPageCounts() {
+    final Map<Integer, Integer> counts = new HashMap<>();
+    for (final ComponentFile componentFile : proxied.getFileManager().getFiles()) {
+      if (componentFile == null)
+        continue;
+      final int fileId = componentFile.getFileId();
+      if (proxied.getSchema().getEmbedded().getFileById(fileId) instanceof PaginatedComponent component)
+        counts.put(fileId, component.getTotalPages());
+    }
+    return counts;
+  }
+
+  /**
+   * File ids of pre-existing paginated components that gained pages during the compaction session, mapped
+   * to the page number the new pages start at. Files created by the session are excluded: they are shipped
+   * whole. A file that shrank (or is new) contributes nothing.
+   */
+  private Map<Integer, Integer> pagesGrownDuringSession(final Map<Integer, Integer> before,
+      final Map<Integer, String> createdFiles) {
+    final Map<Integer, Integer> grown = new HashMap<>();
+    for (final Map.Entry<Integer, Integer> entry : snapshotPageCounts().entrySet()) {
+      final int fileId = entry.getKey();
+      if (createdFiles.containsKey(fileId))
+        continue;
+      final Integer pagesBefore = before.get(fileId);
+      if (pagesBefore != null && entry.getValue() > pagesBefore)
+        grown.put(fileId, pagesBefore);
+    }
+    return grown;
+  }
+
+  /**
    * Serializes every page of a newly created paginated file (e.g. an LSM index compaction output) as
    * synthetic WAL, split into as many self-contained WAL transactions as needed to keep each one
    * within {@code maxChunkBytes}.
@@ -1674,12 +1724,22 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * @return number of chunks appended to {@code walOut}
    */
   private int appendFilePagesAsWal(final int fileId, final long maxChunkBytes, final List<byte[]> walOut,
-      final List<Map<Integer, Integer>> bucketDeltasOut) throws IOException {
+      final List<Map<Integer, Integer>> bucketDeltasOut, final int fromPage) throws IOException {
     final PaginatedComponentFile file = (PaginatedComponentFile) proxied.getFileManager().getFile(fileId);
     final int pageSize = file.getPageSize();
-    final int totalPages = (int) file.getTotalPages();
 
-    if (totalPages == 0)
+    // #5443: the page COUNT and the page CONTENT must both come from the page manager, never from the
+    // file on disk. PaginatedComponentFile.getTotalPages() is channel.size()/pageSize, so it only sees
+    // what the asynchronous writer has already persisted: a compaction that has just published 13 pages
+    // can still measure 10 on disk. Serializing from the file then shipped a TRUNCATED index - the
+    // follower's compacted sub-index came out three pages short, and every key that lived in them became
+    // unfindable there while the records themselves replicated normally. The component knows the real
+    // count, and getImmutablePage() resolves each page through the cache and the pending-flush queue
+    // before falling back to disk, so both are correct regardless of flush timing.
+    final PaginatedComponent component = (PaginatedComponent) proxied.getSchema().getEmbedded().getFileById(fileId);
+    final int totalPages = component != null ? component.getTotalPages() : (int) file.getTotalPages();
+
+    if (totalPages <= fromPage)
       return 0;
 
     final int deltaSize = pageSize - BasePage.PAGE_HEADER_SIZE;
@@ -1688,46 +1748,69 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // Per-chunk framing: txId(8) + timestamp(8) + pageCount(4) + segmentSize(4) + pages + segmentSize(4) + MAGIC(8)
     final int chunkFramingSize = 2 * Long.BYTES + 3 * Integer.BYTES + Long.BYTES;
 
+    // The root page carries the series registry: an appended series is invisible until page 0 says it
+    // exists, so a partial ship must always include it. Without this the follower stores the new pages
+    // and still reports the old entry count - which is exactly how issue #5443 stayed silent.
+    if (fromPage > 0)
+      appendPageRangeAsWal(fileId, pageSize, 0, 1, walOut, bucketDeltasOut);
+
     final long budget = maxChunkBytes - chunkFramingSize;
-    final int pagesPerChunk = budget >= perPageWalSize ? (int) Math.min(totalPages, budget / perPageWalSize) : 1;
+    final int pagesToShip = totalPages - fromPage;
+    final int pagesPerChunk = budget >= perPageWalSize ? (int) Math.min(pagesToShip, budget / perPageWalSize) : 1;
 
-    final ByteBuffer pageBuf = ByteBuffer.allocate(pageSize);
     int chunks = 0;
-    for (int firstPage = 0; firstPage < totalPages; firstPage += pagesPerChunk) {
-      final int pagesInChunk = Math.min(pagesPerChunk, totalPages - firstPage);
-      final int segmentSize = pagesInChunk * perPageWalSize;
-
-      final ByteBuffer walBuf = ByteBuffer.allocate(chunkFramingSize + segmentSize);
-      walBuf.putLong(-1L); // txId=-1 → forceApply on followers
-      walBuf.putLong(System.currentTimeMillis());
-      walBuf.putInt(pagesInChunk);
-      walBuf.putInt(segmentSize);
-
-      for (int pageNum = firstPage; pageNum < firstPage + pagesInChunk; pageNum++) {
-        file.readPage(pageNum, pageBuf);
-
-        final int version = pageBuf.getInt(0);                 // PAGE_VERSION_OFFSET
-        final int rawContentSize = pageBuf.getInt(Integer.BYTES); // PAGE_CONTENTSIZE_OFFSET (stored as full size)
-
-        walBuf.putInt(fileId);
-        walBuf.putInt(pageNum);
-        walBuf.putInt(BasePage.PAGE_HEADER_SIZE);  // changesFrom = 8
-        walBuf.putInt(pageSize - 1);               // changesTo
-        walBuf.putInt(version);
-        walBuf.putInt(rawContentSize - BasePage.PAGE_HEADER_SIZE); // contentSize in WAL = stored minus header
-
-        walBuf.put(pageBuf.array(), BasePage.PAGE_HEADER_SIZE, deltaSize);
-      }
-
-      walBuf.putInt(segmentSize);
-      walBuf.putLong(WALFile.MAGIC_NUMBER);
-
-      walOut.add(walBuf.array());
-      bucketDeltasOut.add(Collections.emptyMap());
+    for (int firstPage = fromPage; firstPage < totalPages; firstPage += pagesPerChunk) {
+      appendPageRangeAsWal(fileId, pageSize, firstPage, Math.min(pagesPerChunk, totalPages - firstPage),
+          walOut, bucketDeltasOut);
       chunks++;
     }
 
     return chunks;
+  }
+
+  /**
+   * Serializes {@code pageCount} pages starting at {@code firstPage} as one synthetic WAL transaction.
+   * <p>
+   * Both the page count and the content come from the page manager, never from the file:
+   * {@code PaginatedComponentFile.getTotalPages()} is {@code channel.size()/pageSize}, so it only sees
+   * what the asynchronous writer has already persisted, and reading the file directly can serialize a
+   * page that has not been written yet.
+   */
+  private void appendPageRangeAsWal(final int fileId, final int pageSize, final int firstPage,
+      final int pageCount, final List<byte[]> walOut, final List<Map<Integer, Integer>> bucketDeltasOut)
+      throws IOException {
+    final int deltaSize = pageSize - BasePage.PAGE_HEADER_SIZE;
+    final int perPageWalSize = 6 * Integer.BYTES + deltaSize;
+    final int chunkFramingSize = 2 * Long.BYTES + 3 * Integer.BYTES + Long.BYTES;
+    final int segmentSize = pageCount * perPageWalSize;
+
+    final ByteBuffer walBuf = ByteBuffer.allocate(chunkFramingSize + segmentSize);
+    walBuf.putLong(-1L); // txId=-1 → forceApply on followers
+    walBuf.putLong(System.currentTimeMillis());
+    walBuf.putInt(pageCount);
+    walBuf.putInt(segmentSize);
+
+    for (int pageNum = firstPage; pageNum < firstPage + pageCount; pageNum++) {
+      final BasePage page = proxied.getPageManager()
+          .getImmutablePage(new PageId(proxied, fileId, pageNum), pageSize, false, true);
+
+      walBuf.putInt(fileId);
+      walBuf.putInt(pageNum);
+      walBuf.putInt(BasePage.PAGE_HEADER_SIZE);  // changesFrom = 8
+      walBuf.putInt(pageSize - 1);               // changesTo
+      walBuf.putInt((int) page.getVersion());
+      walBuf.putInt(page.getContentSize());
+
+      final ByteBuffer pageBuffer = page.getContent();
+      for (int i = 0; i < deltaSize; i++)
+        walBuf.put(pageBuffer.get(BasePage.PAGE_HEADER_SIZE + i));
+    }
+
+    walBuf.putInt(segmentSize);
+    walBuf.putLong(WALFile.MAGIC_NUMBER);
+
+    walOut.add(walBuf.array());
+    bucketDeltasOut.add(Collections.emptyMap());
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1761,11 +1761,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     if (totalPages <= fromPage)
       return 0;
 
-    final int deltaSize = pageSize - BasePage.PAGE_HEADER_SIZE;
+    final int deltaSize = walPageDeltaSize(pageSize);
     // Per-page WAL record: fileId(4) + pageNum(4) + changesFrom(4) + changesTo(4) + version(4) + contentSize(4) + delta
-    final int perPageWalSize = 6 * Integer.BYTES + deltaSize;
+    final int perPageWalSize = walPerPageSize(pageSize);
     // Per-chunk framing: txId(8) + timestamp(8) + pageCount(4) + segmentSize(4) + pages + segmentSize(4) + MAGIC(8)
-    final int chunkFramingSize = 2 * Long.BYTES + 3 * Integer.BYTES + Long.BYTES;
+
 
     // The root page carries the series registry: an appended series is invisible until page 0 says it
     // exists, so a partial ship must always include it. Without this the follower stores the new pages
@@ -1773,7 +1773,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     if (fromPage > 0)
       appendPageRangeAsWal(fileId, pageSize, 0, 1, walOut, bucketDeltasOut);
 
-    final long budget = maxChunkBytes - chunkFramingSize;
+    final long budget = maxChunkBytes - WAL_CHUNK_FRAMING_SIZE;
     final int pagesToShip = totalPages - fromPage;
     final int pagesPerChunk = budget >= perPageWalSize ? (int) Math.min(pagesToShip, budget / perPageWalSize) : 1;
 
@@ -1788,6 +1788,23 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   /**
+   * Framing a WAL chunk carries: txId, timestamp, page count, segment size, then the trailing segment
+   * size and magic number. Both the chunking maths and the buffer that gets written have to agree on
+   * these three, so neither computes them for itself.
+   */
+  private static final int WAL_CHUNK_FRAMING_SIZE = 2 * Long.BYTES + 3 * Integer.BYTES + Long.BYTES;
+
+  /** Bytes of a page that travel in the WAL: everything after the page header. */
+  private static int walPageDeltaSize(final int pageSize) {
+    return pageSize - BasePage.PAGE_HEADER_SIZE;
+  }
+
+  /** Per-page WAL cost: the six ints of the page record, plus the delta itself. */
+  private static int walPerPageSize(final int pageSize) {
+    return 6 * Integer.BYTES + walPageDeltaSize(pageSize);
+  }
+
+  /**
    * Serializes {@code pageCount} pages starting at {@code firstPage} as one synthetic WAL transaction.
    * <p>
    * Both the page count and the content come from the page manager, never from the file:
@@ -1798,12 +1815,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private void appendPageRangeAsWal(final int fileId, final int pageSize, final int firstPage,
       final int pageCount, final List<byte[]> walOut, final List<Map<Integer, Integer>> bucketDeltasOut)
       throws IOException {
-    final int deltaSize = pageSize - BasePage.PAGE_HEADER_SIZE;
-    final int perPageWalSize = 6 * Integer.BYTES + deltaSize;
-    final int chunkFramingSize = 2 * Long.BYTES + 3 * Integer.BYTES + Long.BYTES;
-    final int segmentSize = pageCount * perPageWalSize;
+    final int deltaSize = walPageDeltaSize(pageSize);
+    final int segmentSize = pageCount * walPerPageSize(pageSize);
 
-    final ByteBuffer walBuf = ByteBuffer.allocate(chunkFramingSize + segmentSize);
+    final ByteBuffer walBuf = ByteBuffer.allocate(WAL_CHUNK_FRAMING_SIZE + segmentSize);
     walBuf.putLong(-1L); // txId=-1 → forceApply on followers
     walBuf.putLong(System.currentTimeMillis());
     walBuf.putInt(pageCount);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -220,7 +220,8 @@ public class RaftTransactionBroker {
           first ? filesToAdd : Collections.emptyMap(),
           last ? filesToRemove : Collections.emptyMap(),
           walGroups.get(g), deltaGroups.get(g),
-          last ? sealedFileBlobs : Collections.emptyList());
+          last ? sealedFileBlobs : Collections.emptyList(),
+          !last);
 
       if (chunk.size() > cap)
         // A single WAL entry (or the header plus one WAL entry) still does not fit. Fail loudly rather

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseCompactionIndexCompletenessTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseCompactionIndexCompletenessTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.VertexType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The guarantee issue #5443 is about: after an LSM index compaction every node holds the WHOLE index,
+ * not a truncated one. The records themselves always replicate, so a short index is silent - a query
+ * answered by that node simply returns fewer rows than the same query on the leader.
+ * <p>
+ * The scenario is shared because the bug has two independent causes that need the same setup and the
+ * same assertions, and differ only in how the compaction's schema change reaches the followers: in one
+ * Raft entry, or split across many. A subclass supplies that difference and nothing else.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+abstract class BaseCompactionIndexCompletenessTest extends BaseRaftHATest {
+  protected static final int    TOTAL_RECORDS = 60_000;
+  private static final   int    TX_CHUNK      = 250;
+  private static final   String INDEX_NAME    = "Address[uid]";
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 30_000L);
+    // Only the explicit compact() below may run, so the assertion cannot race a background compaction.
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 1);
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Override
+  protected void checkDatabasesAreIdentical() {
+    // Compaction replaces the mutable index file and its name embeds a per-node nanoTime, so
+    // DatabaseComparator's type-level check (which pairs bucket indexes BY NAME) cannot pass after a
+    // compaction. Equality that matters is asserted in the test body instead.
+  }
+
+  /**
+   * Fills an indexed type, compacts it once, waits for replication and then requires every node to hold
+   * the complete index - by entry count, and by looking up keys spread across the whole range, which is
+   * how the incompleteness shows itself to a client.
+   */
+  protected void assertEveryNodeHoldsTheWholeIndexAfterACompaction() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database database = getServerDatabase(leaderIndex, getDatabaseName());
+    final VertexType v = database.getSchema().buildVertexType().withName("Address").withTotalBuckets(1).create();
+    v.createProperty("uid", String.class);
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Address", "uid");
+
+    for (int from = 0; from < TOTAL_RECORDS; from += TX_CHUNK) {
+      final int start = from;
+      database.transaction(() -> {
+        for (int i = start; i < Math.min(start + TX_CHUNK, TOTAL_RECORDS); i++)
+          database.newVertex("Address").set("uid", uid(i)).save();
+      });
+    }
+
+    final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName(INDEX_NAME);
+    index.scheduleCompaction();
+    index.compact();
+
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+
+    testEachServer(serverIndex -> {
+      final Database serverDb = getServerDatabase(serverIndex, getDatabaseName());
+      assertThat(serverDb.countType("Address", false))
+          .as("every record must replicate to server %d", serverIndex).isEqualTo(TOTAL_RECORDS);
+
+      final Index serverIdx = serverDb.getSchema().getIndexByName(INDEX_NAME);
+      assertThat(serverIdx.countEntries())
+          .as("server %d must hold the WHOLE index after the compaction, not a truncated one", serverIndex)
+          .isEqualTo(TOTAL_RECORDS);
+    });
+
+    // Spot-check lookups across the whole key range on every node: a short index shows up as specific
+    // keys that cannot be found, which is what makes the bug silent for a client.
+    testEachServer(serverIndex -> {
+      final Index serverIdx = getServerDatabase(serverIndex, getDatabaseName()).getSchema().getIndexByName(INDEX_NAME);
+      for (int i = 0; i < TOTAL_RECORDS; i += TOTAL_RECORDS / 40)
+        assertThat(serverIdx.get(new Object[] { uid(i) }).hasNext())
+            .as("key %d must be findable on server %d", i, serverIndex).isTrue();
+    });
+  }
+
+  /** High-entropy key so the compacted index does not compress away to a trivial size. */
+  private static String uid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-" + i;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseCompactionIndexCompletenessTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseCompactionIndexCompletenessTest.java
@@ -53,8 +53,9 @@ abstract class BaseCompactionIndexCompletenessTest extends BaseRaftHATest {
   protected void onServerConfiguration(final ContextConfiguration config) {
     super.onServerConfiguration(config);
     config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 30_000L);
-    // Only the explicit compact() below may run, so the assertion cannot race a background compaction.
-    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 1);
+    // 0 = automatic compaction disabled, so only the explicit compact() below runs and the assertion
+    // cannot race a background one.
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
   }
 
   @Override

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4743CompactionEntrySizeIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4743CompactionEntrySizeIT.java
@@ -120,16 +120,14 @@ class Issue4743CompactionEntrySizeIT extends BaseRaftHATest {
       assertThat(serverDb.countType("Address", false))
           .as("every record must replicate to server %d", serverIndex).isEqualTo(TOTAL_RECORDS);
       assertThat(serverDb.getSchema().getIndexByName(indexName).countEntries())
-          .as("the compacted index must be live and populated on server %d", serverIndex).isPositive();
+          .as("server %d must hold the WHOLE index after a split compaction", serverIndex)
+          .isEqualTo(TOTAL_RECORDS);
     });
 
-    // Follower index completeness is asserted by Issue5443FollowerIndexGapIT, not here. #5443 fixed the
-    // gap on the normal path (an incremental compaction round appends a series to the already-existing
-    // compacted file, and nothing replicated those pages). A SECOND, still-open defect shows up only in
-    // this test's artificial configuration: with a 512KB append buffer the schema change is split ~12
-    // ways, and a follower then detaches its compacted sub-index entirely and serves just its mutable
-    // pages (~1897 of 60000 entries). Publishing the schema in its own trailing chunk was tried and did
-    // NOT fix it, so the trigger is elsewhere. Tracked on #5443.
+    // Follower index completeness held back this assertion until #5443 fixed both of its causes: the
+    // pages an incremental round appends to the already-existing compacted file were never replicated,
+    // and a delivery-only chunk of a split schema change triggered a schema reload that detached the
+    // compacted sub-index for good. Issue5443SplitCompactionEntryIT covers the split path directly.
     final Index leaderIdx = getServerDatabase(leaderIndex, getDatabaseName()).getSchema().getIndexByName(indexName);
     assertThat(leaderIdx.countEntries()).as("the leader's index must hold every key").isEqualTo(TOTAL_RECORDS);
     assertThat(leaderIdx.get(new Object[] { uid(12_345) }).hasNext())

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4743CompactionEntrySizeIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4743CompactionEntrySizeIT.java
@@ -123,14 +123,13 @@ class Issue4743CompactionEntrySizeIT extends BaseRaftHATest {
           .as("the compacted index must be live and populated on server %d", serverIndex).isPositive();
     });
 
-    // The leader's index is complete and the compacted content is queryable there.
-    //
-    // NOTE: a FOLLOWER's index can end up short of TOTAL_RECORDS after a compaction. That is a
-    // pre-existing gap in compaction replication and NOT a side effect of the entry splitting under
-    // test: the same follower ends up with the exact same entry count on the unpatched code, and also
-    // with the stock 4MB append buffer where the compaction entry is never split at all. Asserting
-    // follower index completeness here would attribute another bug to this fix, so this test does not -
-    // it is reported separately.
+    // Follower index completeness is asserted by Issue5443FollowerIndexGapIT, not here. #5443 fixed the
+    // gap on the normal path (an incremental compaction round appends a series to the already-existing
+    // compacted file, and nothing replicated those pages). A SECOND, still-open defect shows up only in
+    // this test's artificial configuration: with a 512KB append buffer the schema change is split ~12
+    // ways, and a follower then detaches its compacted sub-index entirely and serves just its mutable
+    // pages (~1897 of 60000 entries). Publishing the schema in its own trailing chunk was tried and did
+    // NOT fix it, so the trigger is elsewhere. Tracked on #5443.
     final Index leaderIdx = getServerDatabase(leaderIndex, getDatabaseName()).getSchema().getIndexByName(indexName);
     assertThat(leaderIdx.countEntries()).as("the leader's index must hold every key").isEqualTo(TOTAL_RECORDS);
     assertThat(leaderIdx.get(new Object[] { uid(12_345) }).hasNext())

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4743CompactionEntrySizeIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4743CompactionEntrySizeIT.java
@@ -67,7 +67,7 @@ class Issue4743CompactionEntrySizeIT extends BaseRaftHATest {
     // Only the explicit compact() below may run: a background auto-compaction racing the end-of-test
     // identity check would leave the nodes on different sub-index generations for reasons unrelated to
     // this regression.
-    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 1);
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0); // 0 = automatic compaction disabled
   }
 
   @Override

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5443FollowerIndexGapIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5443FollowerIndexGapIT.java
@@ -18,108 +18,25 @@
  */
 package com.arcadedb.server.ha.raft;
 
-import com.arcadedb.ContextConfiguration;
-import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.database.Database;
-import com.arcadedb.index.Index;
-import com.arcadedb.index.TypeIndex;
-import com.arcadedb.schema.Schema;
-import com.arcadedb.schema.VertexType;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
- * Regression test for issue #5443: after an LSM index compaction, a FOLLOWER's index can hold fewer
- * entries than the leader's even though every record replicated. Keys that live only in the missing
- * range become unfindable on that node, so a query answered by the follower silently returns fewer rows
- * than the same query on the leader.
+ * Regression test for issue #5443: an incremental compaction appends a new series to the ALREADY
+ * EXISTING compacted file, and those pages are written without WAL and outside {@code addFiles}, so
+ * nothing replicated them. A follower ended up holding fewer index entries than the leader while every
+ * record replicated normally, which makes the keys in the missing range unfindable on that node.
  * <p>
- * This is a correctness bug, not a performance one: the records are all there, only the index is short.
+ * The scenario and its assertions live in {@link BaseCompactionIndexCompletenessTest}; the split-entry
+ * variant of the same guarantee is {@link Issue5443SplitCompactionEntryIT}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5443FollowerIndexGapIT extends BaseRaftHATest {
-
-  private static final int TOTAL_RECORDS = 60_000;
-  private static final int TX_CHUNK      = 250;
-  private static final String INDEX_NAME = "Address[uid]";
-
-  @Override
-  protected int getServerCount() {
-    return 3;
-  }
-
-  @Override
-  protected void onServerConfiguration(final ContextConfiguration config) {
-    super.onServerConfiguration(config);
-    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 30_000L);
-    // Only the explicit compact() below may run, so the assertion cannot race a background compaction.
-    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 1);
-  }
-
-  @Override
-  protected void populateDatabase() {
-  }
-
-  @Override
-  protected void checkDatabasesAreIdentical() {
-    // Compaction replaces the mutable index file and its name embeds a per-node nanoTime, so
-    // DatabaseComparator's type-level check (which pairs bucket indexes BY NAME) cannot pass after a
-    // compaction. Equality that matters is asserted in the test body instead.
-  }
+class Issue5443FollowerIndexGapIT extends BaseCompactionIndexCompletenessTest {
 
   @Test
   @Tag("slow")
   void everyNodeHoldsTheWholeIndexAfterACompaction() throws Exception {
-    final int leaderIndex = findLeaderIndex();
-    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
-
-    final Database database = getServerDatabase(leaderIndex, getDatabaseName());
-    final VertexType v = database.getSchema().buildVertexType().withName("Address").withTotalBuckets(1).create();
-    v.createProperty("uid", String.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Address", "uid");
-
-    for (int from = 0; from < TOTAL_RECORDS; from += TX_CHUNK) {
-      final int start = from;
-      database.transaction(() -> {
-        for (int i = start; i < Math.min(start + TX_CHUNK, TOTAL_RECORDS); i++)
-          database.newVertex("Address").set("uid", uid(i)).save();
-      });
-    }
-
-    final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName(INDEX_NAME);
-    index.scheduleCompaction();
-    index.compact();
-
-    for (int i = 0; i < getServerCount(); i++)
-      waitForReplicationIsCompleted(i);
-
-    testEachServer(serverIndex -> {
-      final Database serverDb = getServerDatabase(serverIndex, getDatabaseName());
-      assertThat(serverDb.countType("Address", false))
-          .as("every record must replicate to server %d", serverIndex).isEqualTo(TOTAL_RECORDS);
-
-      final Index serverIdx = serverDb.getSchema().getIndexByName(INDEX_NAME);
-      assertThat(serverIdx.countEntries())
-          .as("server %d must hold the WHOLE index after the compaction, not a truncated one", serverIndex)
-          .isEqualTo(TOTAL_RECORDS);
-    });
-
-    // Spot-check lookups across the whole key range on every node: a short index shows up as specific
-    // keys that cannot be found, which is what makes the bug silent for a client.
-    testEachServer(serverIndex -> {
-      final Index serverIdx = getServerDatabase(serverIndex, getDatabaseName()).getSchema().getIndexByName(INDEX_NAME);
-      for (int i = 0; i < TOTAL_RECORDS; i += TOTAL_RECORDS / 40)
-        assertThat(serverIdx.get(new Object[] { uid(i) }).hasNext())
-            .as("key %d must be findable on server %d", i, serverIndex).isTrue();
-    });
-  }
-
-  /** High-entropy key so the compacted index does not compress away to a trivial size. */
-  private static String uid(final int i) {
-    final long mixed = i * 0x9E3779B97F4A7C15L;
-    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-" + i;
+    assertEveryNodeHoldsTheWholeIndexAfterACompaction();
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5443FollowerIndexGapIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5443FollowerIndexGapIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5443: after an LSM index compaction, a FOLLOWER's index can hold fewer
+ * entries than the leader's even though every record replicated. Keys that live only in the missing
+ * range become unfindable on that node, so a query answered by the follower silently returns fewer rows
+ * than the same query on the leader.
+ * <p>
+ * This is a correctness bug, not a performance one: the records are all there, only the index is short.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5443FollowerIndexGapIT extends BaseRaftHATest {
+
+  private static final int TOTAL_RECORDS = 60_000;
+  private static final int TX_CHUNK      = 250;
+  private static final String INDEX_NAME = "Address[uid]";
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 30_000L);
+    // Only the explicit compact() below may run, so the assertion cannot race a background compaction.
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 1);
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Override
+  protected void checkDatabasesAreIdentical() {
+    // Compaction replaces the mutable index file and its name embeds a per-node nanoTime, so
+    // DatabaseComparator's type-level check (which pairs bucket indexes BY NAME) cannot pass after a
+    // compaction. Equality that matters is asserted in the test body instead.
+  }
+
+  @Test
+  @Tag("slow")
+  void everyNodeHoldsTheWholeIndexAfterACompaction() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database database = getServerDatabase(leaderIndex, getDatabaseName());
+    final VertexType v = database.getSchema().buildVertexType().withName("Address").withTotalBuckets(1).create();
+    v.createProperty("uid", String.class);
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Address", "uid");
+
+    for (int from = 0; from < TOTAL_RECORDS; from += TX_CHUNK) {
+      final int start = from;
+      database.transaction(() -> {
+        for (int i = start; i < Math.min(start + TX_CHUNK, TOTAL_RECORDS); i++)
+          database.newVertex("Address").set("uid", uid(i)).save();
+      });
+    }
+
+    final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName(INDEX_NAME);
+    index.scheduleCompaction();
+    index.compact();
+
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+
+    testEachServer(serverIndex -> {
+      final Database serverDb = getServerDatabase(serverIndex, getDatabaseName());
+      assertThat(serverDb.countType("Address", false))
+          .as("every record must replicate to server %d", serverIndex).isEqualTo(TOTAL_RECORDS);
+
+      final Index serverIdx = serverDb.getSchema().getIndexByName(INDEX_NAME);
+      assertThat(serverIdx.countEntries())
+          .as("server %d must hold the WHOLE index after the compaction, not a truncated one", serverIndex)
+          .isEqualTo(TOTAL_RECORDS);
+    });
+
+    // Spot-check lookups across the whole key range on every node: a short index shows up as specific
+    // keys that cannot be found, which is what makes the bug silent for a client.
+    testEachServer(serverIndex -> {
+      final Index serverIdx = getServerDatabase(serverIndex, getDatabaseName()).getSchema().getIndexByName(INDEX_NAME);
+      for (int i = 0; i < TOTAL_RECORDS; i += TOTAL_RECORDS / 40)
+        assertThat(serverIdx.get(new Object[] { uid(i) }).hasNext())
+            .as("key %d must be findable on server %d", i, serverIndex).isTrue();
+    });
+  }
+
+  /** High-entropy key so the compacted index does not compress away to a trivial size. */
+  private static String uid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-" + i;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5443SplitCompactionEntryIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5443SplitCompactionEntryIT.java
@@ -20,113 +20,34 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.database.Database;
-import com.arcadedb.index.Index;
-import com.arcadedb.index.TypeIndex;
-import com.arcadedb.schema.Schema;
-import com.arcadedb.schema.VertexType;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
- * Regression test for issue #5443, SPLIT variant: same guarantee as {@link Issue5443FollowerIndexGapIT}
- * but with the compaction's schema change split across many Raft entries.
+ * Regression test for issue #5443, SPLIT variant: the same guarantee as {@link Issue5443FollowerIndexGapIT},
+ * but with the compaction's schema change split across many Raft entries - which is what a large enough
+ * index does at the stock ceiling.
  * <p>
- * After an LSM index compaction, a FOLLOWER's index can hold fewer
- * entries than the leader's even though every record replicated. Keys that live only in the missing
- * range become unfindable on that node, so a query answered by the follower silently returns fewer rows
- * than the same query on the leader.
- * <p>
- * This is a correctness bug, not a performance one: the records are all there, only the index is short.
+ * That path used to fail differently: the first chunk carries {@code filesToAdd} and no schema JSON, so
+ * the follower reloaded its schema from a half-delivered state, could not resolve the compacted
+ * sub-index and detached it. The detach is sticky, so the follower never re-attached and ended up
+ * serving only its mutable pages.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue5443SplitCompactionEntryIT extends BaseRaftHATest {
-
-  private static final int TOTAL_RECORDS = 60_000;
-  private static final int TX_CHUNK      = 250;
-  private static final String INDEX_NAME = "Address[uid]";
-
-  @Override
-  protected int getServerCount() {
-    return 3;
-  }
+class Issue5443SplitCompactionEntryIT extends BaseCompactionIndexCompletenessTest {
 
   @Override
   protected void onServerConfiguration(final ContextConfiguration config) {
     super.onServerConfiguration(config);
-    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 30_000L);
-    // Only the explicit compact() below may run, so the assertion cannot race a background compaction.
-    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 1);
     // Force the compaction's schema change to be SPLIT across many Raft entries (#4743), which is what a
-    // large enough index does at the stock 32MB ceiling. This is the path where a follower used to detach
-    // its compacted sub-index altogether and serve only its mutable pages.
+    // large enough index does at the stock 32MB ceiling.
     config.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, "512KB");
-  }
-
-  @Override
-  protected void populateDatabase() {
-  }
-
-  @Override
-  protected void checkDatabasesAreIdentical() {
-    // Compaction replaces the mutable index file and its name embeds a per-node nanoTime, so
-    // DatabaseComparator's type-level check (which pairs bucket indexes BY NAME) cannot pass after a
-    // compaction. Equality that matters is asserted in the test body instead.
   }
 
   @Test
   @Tag("slow")
   void everyNodeHoldsTheWholeIndexAfterASplitCompaction() throws Exception {
-    final int leaderIndex = findLeaderIndex();
-    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
-
-    final Database database = getServerDatabase(leaderIndex, getDatabaseName());
-    final VertexType v = database.getSchema().buildVertexType().withName("Address").withTotalBuckets(1).create();
-    v.createProperty("uid", String.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Address", "uid");
-
-    for (int from = 0; from < TOTAL_RECORDS; from += TX_CHUNK) {
-      final int start = from;
-      database.transaction(() -> {
-        for (int i = start; i < Math.min(start + TX_CHUNK, TOTAL_RECORDS); i++)
-          database.newVertex("Address").set("uid", uid(i)).save();
-      });
-    }
-
-    final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName(INDEX_NAME);
-    index.scheduleCompaction();
-    index.compact();
-
-    for (int i = 0; i < getServerCount(); i++)
-      waitForReplicationIsCompleted(i);
-
-    testEachServer(serverIndex -> {
-      final Database serverDb = getServerDatabase(serverIndex, getDatabaseName());
-      assertThat(serverDb.countType("Address", false))
-          .as("every record must replicate to server %d", serverIndex).isEqualTo(TOTAL_RECORDS);
-
-      final Index serverIdx = serverDb.getSchema().getIndexByName(INDEX_NAME);
-      assertThat(serverIdx.countEntries())
-          .as("server %d must hold the WHOLE index after the compaction, not a truncated one", serverIndex)
-          .isEqualTo(TOTAL_RECORDS);
-    });
-
-    // Spot-check lookups across the whole key range on every node: a short index shows up as specific
-    // keys that cannot be found, which is what makes the bug silent for a client.
-    testEachServer(serverIndex -> {
-      final Index serverIdx = getServerDatabase(serverIndex, getDatabaseName()).getSchema().getIndexByName(INDEX_NAME);
-      for (int i = 0; i < TOTAL_RECORDS; i += TOTAL_RECORDS / 40)
-        assertThat(serverIdx.get(new Object[] { uid(i) }).hasNext())
-            .as("key %d must be findable on server %d", i, serverIndex).isTrue();
-    });
-  }
-
-  /** High-entropy key so the compacted index does not compress away to a trivial size. */
-  private static String uid(final int i) {
-    final long mixed = i * 0x9E3779B97F4A7C15L;
-    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-" + i;
+    assertEveryNodeHoldsTheWholeIndexAfterACompaction();
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5443SplitCompactionEntryIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5443SplitCompactionEntryIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5443, SPLIT variant: same guarantee as {@link Issue5443FollowerIndexGapIT}
+ * but with the compaction's schema change split across many Raft entries.
+ * <p>
+ * After an LSM index compaction, a FOLLOWER's index can hold fewer
+ * entries than the leader's even though every record replicated. Keys that live only in the missing
+ * range become unfindable on that node, so a query answered by the follower silently returns fewer rows
+ * than the same query on the leader.
+ * <p>
+ * This is a correctness bug, not a performance one: the records are all there, only the index is short.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5443SplitCompactionEntryIT extends BaseRaftHATest {
+
+  private static final int TOTAL_RECORDS = 60_000;
+  private static final int TX_CHUNK      = 250;
+  private static final String INDEX_NAME = "Address[uid]";
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 30_000L);
+    // Only the explicit compact() below may run, so the assertion cannot race a background compaction.
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 1);
+    // Force the compaction's schema change to be SPLIT across many Raft entries (#4743), which is what a
+    // large enough index does at the stock 32MB ceiling. This is the path where a follower used to detach
+    // its compacted sub-index altogether and serve only its mutable pages.
+    config.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, "512KB");
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Override
+  protected void checkDatabasesAreIdentical() {
+    // Compaction replaces the mutable index file and its name embeds a per-node nanoTime, so
+    // DatabaseComparator's type-level check (which pairs bucket indexes BY NAME) cannot pass after a
+    // compaction. Equality that matters is asserted in the test body instead.
+  }
+
+  @Test
+  @Tag("slow")
+  void everyNodeHoldsTheWholeIndexAfterASplitCompaction() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database database = getServerDatabase(leaderIndex, getDatabaseName());
+    final VertexType v = database.getSchema().buildVertexType().withName("Address").withTotalBuckets(1).create();
+    v.createProperty("uid", String.class);
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Address", "uid");
+
+    for (int from = 0; from < TOTAL_RECORDS; from += TX_CHUNK) {
+      final int start = from;
+      database.transaction(() -> {
+        for (int i = start; i < Math.min(start + TX_CHUNK, TOTAL_RECORDS); i++)
+          database.newVertex("Address").set("uid", uid(i)).save();
+      });
+    }
+
+    final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName(INDEX_NAME);
+    index.scheduleCompaction();
+    index.compact();
+
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+
+    testEachServer(serverIndex -> {
+      final Database serverDb = getServerDatabase(serverIndex, getDatabaseName());
+      assertThat(serverDb.countType("Address", false))
+          .as("every record must replicate to server %d", serverIndex).isEqualTo(TOTAL_RECORDS);
+
+      final Index serverIdx = serverDb.getSchema().getIndexByName(INDEX_NAME);
+      assertThat(serverIdx.countEntries())
+          .as("server %d must hold the WHOLE index after the compaction, not a truncated one", serverIndex)
+          .isEqualTo(TOTAL_RECORDS);
+    });
+
+    // Spot-check lookups across the whole key range on every node: a short index shows up as specific
+    // keys that cannot be found, which is what makes the bug silent for a client.
+    testEachServer(serverIndex -> {
+      final Index serverIdx = getServerDatabase(serverIndex, getDatabaseName()).getSchema().getIndexByName(INDEX_NAME);
+      for (int i = 0; i < TOTAL_RECORDS; i += TOTAL_RECORDS / 40)
+        assertThat(serverIdx.get(new Object[] { uid(i) }).hasNext())
+            .as("key %d must be findable on server %d", i, serverIndex).isTrue();
+    });
+  }
+
+  /** High-entropy key so the compacted index does not compress away to a trivial size. */
+  private static String uid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-" + i;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogEntryCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogEntryCodecTest.java
@@ -437,6 +437,35 @@ class RaftLogEntryCodecTest {
   }
 
   @Test
+  void moreChunksFollowSurvivesTheRoundTrip() {
+    // The flag decides whether the applier reloads the schema for a chunk, so a chunk that says "more
+    // follow" must still say it on the other side (issue #5443).
+    final ByteString notLast = RaftLogEntryCodec.encodeSchemaEntry("testdb", null, Map.of(1, "f.pages"), Map.of(),
+        List.of(new byte[] { 1, 2, 3 }), List.of(Map.of()), List.of(), true);
+    final ByteString last = RaftLogEntryCodec.encodeSchemaEntry("testdb", "{\"types\":{}}", Map.of(), Map.of(),
+        List.of(), List.of(), List.of(), false);
+
+    assertThat(RaftLogEntryCodec.decode(notLast).moreChunksFollow()).isTrue();
+    assertThat(RaftLogEntryCodec.decode(last).moreChunksFollow()).isFalse();
+  }
+
+  @Test
+  void anEntryWithoutTheTrailingFlagDecodesAsTheLastChunk() {
+    // What a node running the pre-#5443 codec emits: the byte is simply not there. Reading it as false
+    // is what keeps the format compatible in both directions, so the decoder must not require it.
+    final ByteString withFlag = RaftLogEntryCodec.encodeSchemaEntry("testdb", "{\"types\":{}}", Map.of(), Map.of(),
+        List.of(), List.of(), List.of(), false);
+    final byte[] raw = withFlag.toByteArray();
+    final ByteString withoutFlag = ByteString.copyFrom(raw, 0, raw.length - 1);
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(withoutFlag);
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SCHEMA_ENTRY);
+    assertThat(decoded.moreChunksFollow()).isFalse();
+    assertThat(decoded.schemaJson()).isEqualTo("{\"types\":{}}");
+  }
+
+  @Test
   void schemaEntryWithoutSealedBlobsHasEmptyList() {
     // Entries produced by the pre-#4382 codec (no blob section) must decode with an empty list.
     final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry("testdb", "{}", Map.of(), Map.of());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogEntryCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogEntryCodecTest.java
@@ -474,10 +474,11 @@ class RaftLogEntryCodecTest {
         Map.of(), Map.of(), List.of(), List.of(),
         List.of(new RaftLogEntryCodec.TsSealedBlob("weather", 0, "weather_shard_0.ts.sealed", sealed)));
 
-    // Flip a byte inside the trailing compressed blob payload to corrupt it.
+    // Flip a byte inside the trailing compressed blob payload to corrupt it. NOT the very last byte:
+    // since #5443 that one is the split-continuation flag, and flipping it would leave the blob intact.
     final byte[] corrupted = new byte[encoded.size()];
     encoded.copyTo(corrupted, 0);
-    corrupted[corrupted.length - 1] ^= 0xFF;
+    corrupted[corrupted.length - 2] ^= 0xFF;
 
     Assertions.assertThatThrownBy(
             () -> RaftLogEntryCodec.decode(ByteString.copyFrom(corrupted)))


### PR DESCRIPTION
Closes #5443. Stacked on #5449 (the shutdown-hook fix), which is what makes these HA suites runnable; base retargets to main once that merges.

After an LSM index compaction on a 3-node Raft cluster, a follower's index can hold fewer entries than the leader's while every record replicates: leader `countEntries()` = 60000, follower = 49488, records = 60000 on both. Specific keys are simply unfindable on that node, so a query served there silently returns fewer rows. No data is lost - only the index is short - and `REBUILD INDEX` on the affected node repairs it.

Two independent causes, both fixed here.

## 1. An incremental compaction appends to an existing file, and nothing replicated those pages

A compaction round does not only create files. An **incremental** round appends a new series to the already-existing compacted file. Those pages are written eagerly and deliberately without WAL, and the file is not in `addFiles` because it is not new - so nothing shipped them. A temporary trace showed the session serializing compacted file 5 at 10 pages while the leader ended at 13.

`RaftReplicatedDatabase.runWithCompactionReplication` now snapshots page counts before invoking the compaction and ships the range that grew. Two details were needed to make that correct:

- **the root page must travel with the appended range.** It carries the series registry, so an appended series is invisible until page 0 says it exists. Shipping only `[before, after)` gave followers the right 13 pages and still 49488 entries; prepending page 0 gave 60000.
- **page count and content must come from the page manager, not the file.** `PaginatedComponentFile.getTotalPages()` is `channel.size() / pageSize`, which sees only what has reached disk.

## 2. A split entry reloaded the schema from a half-delivered state, and the detach was sticky

When the schema change is large enough to be split across several Raft entries - which a big index does at the stock `appendBufferSize` - a follower could end up serving only its mutable pages, its compacted sub-index gone entirely (~1897 of 60000).

Only the last chunk publishes, since it carries the schema JSON; earlier chunks only deliver pages. But `applySchemaEntry` reloaded the schema at the end of every chunk that was not "WAL only", and the first chunk carries `filesToAdd`, so it reloaded there too, re-instantiating components from a half-delivered state. `LSMTreeIndexMutable.onAfterLoad` then could not resolve the compacted sub-index and detached it - which is safe in itself, except the detach is **sticky**: the later publication reuses the same in-memory component, so the follower never re-attached.

The guard now keys off an explicit `moreChunksFollow` flag on `SCHEMA_ENTRY`, set on every chunk but the last.

Inferring it instead - "has WAL, no schema JSON" - is unsound, and a full IT batch proved it: a legitimate standalone DDL that adds or removes files without moving the schema version has exactly that shape, and skipping its reload leaves the new files unregistered, surfacing much later as a type missing on one node (`Issue4749SnapshotInstallClosesRegisteredDatabaseIT`, "Types: DB1 5 <> DB2 6"). The flag is a trailing self-describing boolean, the same backward-compatible pattern the WAL and sealed-blob sections already use: an older codec stops earlier and reads false, i.e. pre-split behaviour. Every non-split entry behaves exactly as before.

## Verification

- `Issue5443FollowerIndexGapIT` - the gap scenario, red on the previous code
- `Issue5443SplitCompactionEntryIT` - same scenario with `appendBufferSize=512KB` to force the split path
- `Issue4743CompactionEntrySizeIT` - now asserts follower index completeness too, which it deliberately did not before (its comment pointed here)
- `ha-raft`: 740 unit tests, 0 failures
- `RaftLogEntryCodecTest`: 33 tests. `corruptedSealedBlobFailsCrc` flipped the entry's last byte to corrupt the blob; that byte is now the flag, so it targets `length - 2`.

A full ~85-class HA IT batch completes with one varying failure per run, each of which passes in isolation - batch-order flakiness rather than a regression. Worth knowing when reading CI: concurrent builds on the same 2434/2480-2482 ports cause `BindException` cascades.
