### PR TITLE
fix(e2e-ha): restore the nightly HA resilience suite to green

### DIFF
--- a/.github/workflows/ha-resilience-tests.yml
+++ b/.github/workflows/ha-resilience-tests.yml
@@ -2,6 +2,11 @@ name: HA Resilence Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      it_test:
+        description: "Failsafe -Dit.test filter (e.g. SplitBrainIT or SplitBrainIT#testFoo). Empty runs the whole suite."
+        required: false
+        default: ""
   schedule:
     - cron: "0 0 * * *" # Runs daily at midnight
 
@@ -51,9 +56,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run HA Tests
-        run: ./mvnw verify -DskipTests -Pintegration --batch-mode --errors --fail-never --show-version -pl e2e-ha
+        run: |
+          if [ -n "${IT_TEST}" ]; then
+            ./mvnw verify -DskipTests -Pintegration --batch-mode --errors --fail-never --show-version -pl e2e-ha -Dit.test="${IT_TEST}"
+          else
+            ./mvnw verify -DskipTests -Pintegration --batch-mode --errors --fail-never --show-version -pl e2e-ha
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IT_TEST: ${{ inputs.it_test }}
+
+      - name: Upload failsafe reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: success() || failure()
+        with:
+          name: e2e-ha-failsafe-reports
+          path: e2e-ha/target/failsafe-reports/
+          retention-days: 7
+          if-no-files-found: warn
 
       - name: Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/ha-resilience-tests.yml
+++ b/.github/workflows/ha-resilience-tests.yml
@@ -75,6 +75,15 @@ jobs:
           retention-days: 7
           if-no-files-found: warn
 
+      - name: Upload container server logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: success() || failure()
+        with:
+          name: e2e-ha-server-logs
+          path: e2e-ha/target/logs/
+          retention-days: 7
+          if-no-files-found: warn
+
       - name: Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()

--- a/e2e-ha/src/test/java/com/arcadedb/containers/ha/UserManagementScenarioIT.java
+++ b/e2e-ha/src/test/java/com/arcadedb/containers/ha/UserManagementScenarioIT.java
@@ -41,6 +41,15 @@ class UserManagementScenarioIT extends ContainersTestTemplate {
   private static final String SERVER_LIST    = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
   private static final String ALICE_PASSWORD = "alicepw1234";
 
+  /**
+   * Seconds between login probes. A probe for a user a node has not replicated yet counts as a failed
+   * password authentication, and {@code ServerSecurity} locks a principal out for 30 s once it records
+   * 5 failures inside that same 30 s window. The interval must therefore stay above
+   * {@code lockoutWindow / maxFailures} (30 s / 5 = 6 s), otherwise the probe loop locks the user out
+   * and every later probe is rejected for the lockout rather than answering the question under test.
+   */
+  private static final int    PROBE_INTERVAL_SECONDS = 10;
+
   @AfterEach
   @Override
   public void tearDown() {
@@ -60,6 +69,11 @@ class UserManagementScenarioIT extends ContainersTestTemplate {
 
     final int raftLeader = waitForRaftLeader(servers, 60);
     assertThat(raftLeader).as("Raft leader index").isGreaterThanOrEqualTo(0);
+    // A node can still be outside the Raft group when another node already reports itself leader.
+    // Creating the user in that window commits on the majority while the late peer is absent, so it
+    // only learns about the user once it joins - long after the first login probes below.
+    waitForAllNodesKnowLeader(servers, 60);
+
     // Step A: create alice on the current Raft leader (leadership is non-deterministic, and
     // 'create user' is a leader-only write; routing directly avoids the unreliable
     // follower-to-leader HTTP forwarding path, mirroring the other HA scenario tests)
@@ -73,7 +87,8 @@ class UserManagementScenarioIT extends ContainersTestTemplate {
 
     // Step B: await until alice can log in on every node
     logger.info("Awaiting alice login propagation");
-    Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS)
+    Awaitility.await().atMost(60, TimeUnit.SECONDS)
+        .pollDelay(500, TimeUnit.MILLISECONDS).pollInterval(PROBE_INTERVAL_SECONDS, TimeUnit.SECONDS)
         .until(() -> loginOk(servers.get(0), "alice", ALICE_PASSWORD)
             && loginOk(servers.get(1), "alice", ALICE_PASSWORD)
             && loginOk(servers.get(2), "alice", ALICE_PASSWORD));
@@ -85,7 +100,8 @@ class UserManagementScenarioIT extends ContainersTestTemplate {
 
     // Step D: await until alice can no longer log in on any node
     logger.info("Awaiting alice login rejection propagation");
-    Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS)
+    Awaitility.await().atMost(60, TimeUnit.SECONDS)
+        .pollDelay(500, TimeUnit.MILLISECONDS).pollInterval(PROBE_INTERVAL_SECONDS, TimeUnit.SECONDS)
         .until(() -> !loginOk(servers.get(0), "alice", ALICE_PASSWORD)
             && !loginOk(servers.get(1), "alice", ALICE_PASSWORD)
             && !loginOk(servers.get(2), "alice", ALICE_PASSWORD));
@@ -129,8 +145,11 @@ class UserManagementScenarioIT extends ContainersTestTemplate {
    */
   private boolean loginOk(final ServerWrapper server, final String user, final String password) {
     try {
-      return postServerCommand(server, "list databases", user, password, 5000) == 200;
+      final int status = postServerCommand(server, "list databases", user, password, 5000);
+      logger.info("Login probe for '{}' on {}:{} returned HTTP {}", user, server.host(), server.httpPort(), status);
+      return status == 200;
     } catch (final Exception e) {
+      logger.info("Login probe for '{}' on {}:{} failed: {}", user, server.host(), server.httpPort(), e.toString());
       return false;
     }
   }

--- a/e2e-ha/src/test/java/com/arcadedb/containers/ha/UserSeedOnPeerAddScenarioIT.java
+++ b/e2e-ha/src/test/java/com/arcadedb/containers/ha/UserSeedOnPeerAddScenarioIT.java
@@ -49,6 +49,15 @@ class UserSeedOnPeerAddScenarioIT extends ContainersTestTemplate {
   private static final String SERVER_LIST    = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
   private static final String ALICE_PASSWORD = "alicepw1234";
 
+  /**
+   * Seconds between login probes. A probe for a user a node has not replicated yet counts as a failed
+   * password authentication, and {@code ServerSecurity} locks a principal out for 30 s once it records
+   * 5 failures inside that same 30 s window. The interval must therefore stay above
+   * {@code lockoutWindow / maxFailures} (30 s / 5 = 6 s), otherwise the probe loop locks the user out
+   * and every later probe is rejected for the lockout rather than answering the question under test.
+   */
+  private static final int    PROBE_INTERVAL_SECONDS = 10;
+
   @AfterEach
   @Override
   public void tearDown() {
@@ -67,6 +76,10 @@ class UserSeedOnPeerAddScenarioIT extends ContainersTestTemplate {
     final List<ServerWrapper> servers = startContainers();
     final int leaderIdx = waitForRaftLeader(servers, 60);
     assertThat(leaderIdx).as("Raft leader index").isGreaterThanOrEqualTo(0);
+    // A node can still be outside the Raft group when another node already reports itself leader.
+    // Creating the user in that window commits on the majority while the late peer is absent, so it
+    // only learns about the user once it joins - long after the first login probes below.
+    waitForAllNodesKnowLeader(servers, 60);
 
     // Step A: create alice on the leader
     final JSONObject alice = new JSONObject()
@@ -79,7 +92,8 @@ class UserSeedOnPeerAddScenarioIT extends ContainersTestTemplate {
 
     // Step B: verify alice login works on all three nodes
     logger.info("Verifying alice login on all nodes before peer-add");
-    Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS)
+    Awaitility.await().atMost(60, TimeUnit.SECONDS)
+        .pollDelay(500, TimeUnit.MILLISECONDS).pollInterval(PROBE_INTERVAL_SECONDS, TimeUnit.SECONDS)
         .until(() -> loginOk(servers.get(0), "alice", ALICE_PASSWORD)
             && loginOk(servers.get(1), "alice", ALICE_PASSWORD)
             && loginOk(servers.get(2), "alice", ALICE_PASSWORD));
@@ -176,8 +190,11 @@ class UserSeedOnPeerAddScenarioIT extends ContainersTestTemplate {
    */
   private boolean loginOk(final ServerWrapper server, final String user, final String password) {
     try {
-      return postServerCommand(server, "list databases", user, password, 5000) == 200;
+      final int status = postServerCommand(server, "list databases", user, password, 5000);
+      logger.info("Login probe for '{}' on {}:{} returned HTTP {}", user, server.host(), server.httpPort(), status);
+      return status == 200;
     } catch (final Exception e) {
+      logger.info("Login probe for '{}' on {}:{} failed: {}", user, server.host(), server.httpPort(), e.toString());
       return false;
     }
   }

--- a/load-tests/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
@@ -39,6 +39,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.utility.MountableFile;
@@ -51,7 +52,11 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -178,11 +183,103 @@ public abstract class ContainersTestTemplate {
     Metrics.removeRegistry(loggingMeterRegistry);
   }
 
+  /**
+   * Removes the state a previous scenario left behind, so every test starts from an empty cluster.
+   * <p>
+   * The server writes into the bind mounts as the image's own user, whose uid does not match the one
+   * running the build on Linux CI. Those files then sit in directories the build user cannot unlink
+   * from, so a plain delete leaves the previous scenario's databases <em>and</em> its Raft log and
+   * snapshots in place, and the next cluster silently starts on top of them. When that happens, the
+   * removal is retried from a throwaway privileged container, which does have the rights.
+   * <p>
+   * {@code ./target/logs} is deliberately left alone: it is diagnostic output rather than state that
+   * feeds back into a later run, and keeping it lets a CI job publish the server-side view of every
+   * scenario instead of only the last one.
+   */
   private void deleteContainersDirectories() {
     logger.info("Deleting containers directories");
-    FileUtils.deleteRecursively(Path.of("./target/databases").toFile());
-    FileUtils.deleteRecursively(Path.of("./target/replication").toFile());
-    FileUtils.deleteRecursively(Path.of("./target/logs").toFile());
+
+    final List<Path> stateDirectories = List.of(Path.of("./target/databases"), Path.of("./target/replication"));
+
+    boolean leftovers = false;
+    for (final Path directory : stateDirectories)
+      leftovers |= !quietDeleteRecursively(directory);
+
+    if (!leftovers)
+      return;
+
+    logger.info("Some container-owned files could not be removed directly, retrying from a privileged container");
+    deleteContainersDirectoriesFromContainer();
+
+    for (final Path directory : stateDirectories)
+      if (!quietDeleteRecursively(directory))
+        logger.warn("Directory '{}' still exists after privileged cleanup: the next test may inherit its state", directory);
+  }
+
+  /**
+   * Deletes {@code directory} and everything under it, tolerating individual failures. Unlike
+   * {@link FileUtils#deleteRecursively} this stays silent: on CI most entries are expected to be
+   * undeletable until the privileged pass runs, and logging a stack trace per entry buries the build
+   * log under a six-figure number of warnings.
+   *
+   * @return {@code true} when the directory is gone afterwards
+   */
+  private boolean quietDeleteRecursively(final Path directory) {
+    final File file = directory.toFile();
+    if (!file.exists())
+      return true;
+
+    try {
+      Files.walkFileTree(directory, new SimpleFileVisitor<>() {
+        @Override
+        public FileVisitResult visitFile(final Path path, final BasicFileAttributes attrs) {
+          try {
+            Files.delete(path);
+          } catch (final IOException ignored) {
+            // Left for the privileged pass.
+          }
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(final Path path, final IOException exc) {
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(final Path path, final IOException exc) {
+          try {
+            Files.delete(path);
+          } catch (final IOException ignored) {
+            // Left for the privileged pass.
+          }
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    } catch (final IOException e) {
+      logger.warn("Could not walk '{}' for deletion: {}", directory, e.getMessage());
+    }
+
+    return !file.exists();
+  }
+
+  /**
+   * Removes the bind-mounted state directories from inside a short-lived container running as root,
+   * which can unlink files the build user cannot. The paths are passed literally rather than as globs
+   * so this can only ever touch the three directories the scenarios own.
+   */
+  private void deleteContainersDirectoriesFromContainer() {
+    final String targetPath = Path.of("./target").toAbsolutePath().normalize().toString();
+
+    try (final GenericContainer<?> cleaner = new GenericContainer<>(IMAGE)
+        .withFileSystemBind(targetPath, "/cleanup", BindMode.READ_WRITE)
+        .withCreateContainerCmdModifier(cmd -> cmd.withUser("root"))
+        .withCommand("rm", "-rf", "/cleanup/databases", "/cleanup/replication")
+        .withStartupCheckStrategy(new OneShotStartupCheckStrategy())) {
+      cleaner.start();
+    } catch (final Exception e) {
+      logger.warn("Privileged cleanup container failed: {}", e.getMessage());
+    }
   }
 
   private void makeContainersDirectories(String name) {


### PR DESCRIPTION
## What does this PR do?

Makes the nightly `HA Resilence Tests` suite (`e2e-ha`) pass again. It had failed
every night for at least 11 consecutive runs, most recently
[run 30218768381](https://github.com/ArcadeData/arcadedb/actions/runs/30218768381)
with 9 failing tests of 34.

Three things, in order of importance:

1. **`ContainersTestTemplate` now actually removes container-owned state between
   scenarios.** This was the cause of 7 of the 9 failures.
2. **Two scenario tests no longer poison their own readiness signal** by tripping the
   server's brute-force lockout.
3. **The workflow gained a single-test dispatch input and two artifacts**, without
   which the failure list was not obtainable at all (see Additional Notes).

## Motivation

### The isolation defect

The scenarios bind-mount `target/databases` and `target/replication` into the server
containers. The image runs as its own user (`USER arcadedb`, uid 1000) while the CI
runner is uid 1001, so files the server writes end up in directories the build user
cannot unlink from. `deleteContainersDirectories()` therefore failed on CI and every
cluster started on top of the previous scenario's databases, Raft log and snapshots -
the isolation the `setUp`/`tearDown` hooks were written to provide never existed there.

It never reproduces locally on macOS, where Docker Desktop maps bind-mount ownership
to the host user.

That leak is what produced the failures, through this chain:

1. Databases accumulated across the whole suite.
2. Every test's `createDatabase()` found a leftover `playwithpictures` and issued
   `drop database`.
3. That drop hit a leader that had just been elected but was still applying its
   inherited backlog, so the Ratis client retried on the fixed 1-second cadence set in
   `RaftHAServer.java:1942`
   (`RetryPolicies.retryUpToMaximumCountWithFixedSleep(60, 1 SECOND)`).
4. Nine retries land at 9.3-9.65 s. A tenth crosses the 10 s `HA_QUORUM_TIMEOUT` and
   the caller gets `ReplicationDispatchedTimeoutException` ("outcome unknown") from
   `RaftGroupCommitter:533`.

Step 4 is a knife-edge, which is why the failing *set* moved between runs while the
count stayed at 9-10. The nightly and a rerun of the same commit disagreed on which
tests failed - `RestoreDatabaseScenarioIT` passed in one and `DropDatabaseScenarioIT`
failed instead, and `SplitBrainIT` lost a different test each time. Diagnosing by
"which test fails" was therefore misleading.

What identified the mechanism was the distribution of *successful* `drop database`
durations in the nightly run:

```
0.07 0.07 0.09 0.09 0.13 0.15 0.18 0.18 0.19 0.19 0.26 0.31 0.31 0.35 0.37   <- 15 fast
3.05 4.73 5.61                                                               <- 3 middle
9.27 9.30 9.31 9.43 9.52 9.60 9.65                                           <- 7 slow
                                                                             <- 6 timed out = the failures
```

The slow bucket is packed into a 0.38-second band immediately below the 10 s timeout.
That is the signature of a fixed retry cadence, not of work proportional to data - so
this is not "deleting a big database is slow".

Removing the leftover state removes step 2, and steps 3 and 4 are never entered.

### The login-probe lockout

`UserManagementScenarioIT` and `UserSeedOnPeerAddScenarioIT` polled `list databases`
as a newly created user every 500 ms to detect replication. Each probe against a node
that has not applied the `SECURITY_USERS` entry yet counts as a failed password
authentication, and `ServerSecurity` locks a principal out for 30 s once it records 5
failures inside a 30 s window (`MAX_PASSWORD_FAILURES`, `PASSWORD_LOCKOUT_MS`). The
lockout engaged after ~2.5 s and outlived the 30 s Awaitility budget, so once any node
lagged the probe could never succeed. From the node's log:

```
21:39:08.370  Security error ... User/Password not valid          <- user not replicated here yet
...5 failures...
21:39:10.980  Security error ... Too many failed authentication attempts. Try again later.
21:39:13.941  Leader elected: arcadedb-1 (term=1)                 <- this peer finally joins, 6.3 s late
21:39:14.105  Security error ... Too many failed authentication attempts.   <- forever
```

This one reproduces locally and is independent of the isolation defect.

Underneath it was an ordering bug: `waitForRaftLeader` returns as soon as *any* node
reports `isLeader`, so the user was being created while a peer was still outside the
Raft group. Both tests now call `waitForAllNodesKnowLeader` first, and use a probe
interval above `lockoutWindow / maxFailures` (30 s / 5 = 6 s) so a probe loop can never
accumulate 5 failures in one window. The reasoning is documented on a
`PROBE_INTERVAL_SECONDS` constant so it does not regress.

There is no replication bug here: once the peer is in the group the entry reaches all
three nodes within 600 ms and the first probe succeeds.

## Related issues

None filed. Two product gaps were found while diagnosing this and are deliberately
**not** addressed here, as both are outside "make the suite pass" and deserve their own
discussion:

- `RaftHAServer.isLeader()` returns raw Ratis `getInfo().isLeader()`; `isLeaderReady`
  appears nowhere in the codebase. `/api/v1/cluster` therefore advertises leadership
  before the leader can serve, so any client that writes immediately after seeing
  `isLeader:true` can absorb ~9 s of retries. This is what made step 3 above slow.
- `ArcadeStateMachine.applyDropDatabaseEntry` calls `db.getEmbedded().drop()`
  synchronously inside the Raft apply, so dropping a large database in an HA cluster
  can exceed the quorum timeout and return "outcome unknown" to a client even when the
  drop eventually succeeds.

Happy to open issues for either if wanted.

## Additional Notes

### Why the workflow changes were necessary

The failure list could not be retrieved through normal tooling. `FileUtils.deleteRecursively`
logs one full stack trace per undeletable entry, which produced **124,476 warnings and a
1.6 GB job log**; the failsafe XML reports were 2.3 GB. `dorny/test-reporter` v3 writes
its summary to the job summary, which no REST API exposes, so the checks API showed only
"Failed test were found" with no list.

Hence:

- a `workflow_dispatch` input `it_test` mapped to failsafe's `-Dit.test`, so a single
  scenario can be exercised without running the whole ~40-minute suite;
- `failsafe-reports` published as an artifact, which is now the reliable way to get the
  failure list;
- `target/logs` published as an artifact. Related: `deleteContainersDirectories` no
  longer deletes `target/logs`, since it is diagnostic output rather than state a later
  run reads back, and keeping it lets a job publish the server-side view of every
  scenario instead of only the last one.

### On the cleanup helper

The privileged pass runs `rm` with literal paths rather than globs, so it can only ever
touch the two directories the scenarios own. It only runs when the ordinary delete
leaves something behind, so it is a no-op on macOS. The first pass is also now silent:
logging a stack trace per entry is what buried the build log.

### Verification

Two consecutive full-suite CI runs, verified from the failsafe reports rather than the
job status
([30222333141](https://github.com/ArcadeData/arcadedb/actions/runs/30222333141),
[30223770408](https://github.com/ArcadeData/arcadedb/actions/runs/30223770408)):

```
TOTAL tests=34 failures=0 errors=0
Dropping existing database:            0     (was: nearly every test)
ReplicationDispatchedTimeoutException: 0     (was: 6 of the failures)
Cannot delete directory:               0     (was: 27,456 in SplitBrainIT alone)
privileged container fallback fired:  13
```

Failsafe reports shrank from 2.3 GB to 764 KB.

Both runs are identical, and the 13 fallback invocations confirm the cleanup fix is
doing real work on each run rather than passing by luck - which matters, because the
old failure was decided by fractions of a second and one green run would not have been
evidence of stability.

The two test fixes were additionally verified locally, where they reproduced
deterministically before the change: `UserManagementScenarioIT` three consecutive
passes, `UserSeedOnPeerAddScenarioIT` two.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

Notes on the checklist, to be precise about what was actually run:

- The full build was exercised by `./mvnw clean install -Pdocker -DskipTests` on this
  branch, as the first step of each verification run above, rather than by a local
  `mvn clean package`.
- This PR changes test infrastructure and two integration scenarios rather than
  production code, so it adds no new unit tests. The evidence is the CI A/B above -
  the same suite on the same runner, 10 failures before and 0 after, with the
  intermediate signals (leftover databases, Raft timeouts, cleanup warnings) all going
  to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
