### PR TITLE
fix(#5454): drop database no longer deletes the files inside the Raft apply

### DIFF
--- a/docs/5454-ha-drop-database-deferred-deletion.md
+++ b/docs/5454-ha-drop-database-deferred-deletion.md
@@ -84,7 +84,8 @@ it again.
   still openable afterwards; `drop()` still deletes; `closeForDrop()` inside a transaction throws.
 - `ha-raft` `DeferredDatabaseDeleterTest` - the rename is synchronous and the physical delete is not;
   the staged name is reserved; repeated drops of the same name get distinct staging directories; the
-  inline fallback when the rename cannot happen; the orphan sweep removes orphans and nothing else.
+  inline fallback when the rename cannot happen; a saturated queue deleting on the calling thread; the
+  orphan sweep removes orphans and nothing else.
 - `ha-raft` `ArcadeStateMachineDeferredDropTest` - `applyDropDatabaseEntry` deregisters the database
   and clears `databases/<name>` synchronously while leaving the physical delete to the background;
   eviction of the bootstrap baseline is preserved; replay after the rename is a no-op.
@@ -99,7 +100,7 @@ Pre-existing coverage that must stay green: `RaftDropDatabase3NodesIT` (asserts
 | Suite | Result |
 |---|---|
 | `engine` `LocalDatabaseCloseForDropTest` | 4/4 |
-| `ha-raft` full unit suite (`mvn -pl ha-raft test`) | 753/753 |
+| `ha-raft` full unit suite (`mvn -pl ha-raft test`) | 754/754 |
 | `ha-raft` `RaftDropDatabase3NodesIT` | 1/1 |
 | `server` `PostServerCommandHandlerIT` | 23/23 |
 | `engine` `com.arcadedb.database.*` | 149 run, 1 pre-existing failure |
@@ -116,6 +117,13 @@ stashed - it is a local classpath gap for the polyglot engine, unrelated to this
 - The client-visible indeterminate outcome (`ReplicationDispatchedTimeoutException`) is not addressed;
   this change removes the dominant reason to hit it for a drop, but option 1 of the issue (a way to
   confirm a dispatched drop committed) remains open.
+- The deleter's pool is not wired into `PoolMetrics`, so it does not appear on the Studio "Executor
+  Pools" card. `PoolMetrics` lives in `server` and binds JVM-wide engine singletons through their
+  `getInstance()`; `server` cannot depend on `ha-raft` (the dependency runs the other way, `provided`),
+  and this pool is a per-state-machine instance, so surfacing it needs a registration SPI rather than a
+  new `bindPool` call. Every other `ha-raft` pool is unmetered today for the same reason. The saturation
+  signal the card would carry is covered in the meantime by a throttled WARNING (60 s window, matching
+  the engine pools) emitted whenever the queue is full and the delete runs on the calling thread.
 - Physical deletion failures are still swallowed by `FileUtils.deleteRecursively`. A staged directory
   that survives is now retried by the sweep on the next restart, which is strictly better than the
   previous behaviour where a half-deleted `databases/<name>` was reloaded as a live database.

--- a/docs/5454-ha-drop-database-deferred-deletion.md
+++ b/docs/5454-ha-drop-database-deferred-deletion.md
@@ -39,12 +39,15 @@ Split the drop into a bounded synchronous part and an unbounded background part.
    `closeForDrop()` + the recursive delete, so its behaviour is unchanged.
 
 2. **ha-raft** - new `DeferredDatabaseDeleter`:
-   - `dropInBackground(dir)` renames `databases/<name>` to the sibling reserved directory
-     `databases/.dropped-<name>-<nanos>` with `ATOMIC_MOVE`, then enqueues the recursive delete on a
-     dedicated single-thread daemon executor. The rename is O(1) and is the only file work left on
-     the apply thread.
-   - If the rename fails (cross-device, or a platform holding handles) it falls back to deleting
-     inline, so the outcome is never worse than before the fix.
+   - `stageForDeletion(dir)` renames `databases/<name>` to the sibling reserved directory
+     `databases/.dropped-<name>-<nanos>` with `ATOMIC_MOVE`. The rename is O(1) and is the only file
+     work left on the apply thread.
+   - `deleteInBackground(staged)` queues the recursive delete on a dedicated single-thread daemon
+     executor. It is deliberately a separate call so the caller can make it outside the lock it holds
+     across the staging step: on a saturated queue the delete runs on the calling thread, and that
+     must not widen the lock hold.
+   - If the rename fails (cross-device, or a platform holding handles) `stageForDeletion` falls back
+     to deleting inline, so the outcome is never worse than before the fix.
    - `sweepOrphanedStagingDirectories(databasesDir)` enqueues any `.dropped-*` left behind by a crash
      or by an executor shutdown.
 
@@ -80,8 +83,8 @@ it again.
 - `engine` `LocalDatabaseCloseForDropTest` - `closeForDrop()` closes without deleting; the files are
   still openable afterwards; `drop()` still deletes; `closeForDrop()` inside a transaction throws.
 - `ha-raft` `DeferredDatabaseDeleterTest` - the rename is synchronous and the physical delete is not;
-  the staged name is reserved; deletion completes in the background; the inline fallback when the
-  rename cannot happen; the orphan sweep.
+  the staged name is reserved; repeated drops of the same name get distinct staging directories; the
+  inline fallback when the rename cannot happen; the orphan sweep removes orphans and nothing else.
 - `ha-raft` `ArcadeStateMachineDeferredDropTest` - `applyDropDatabaseEntry` deregisters the database
   and clears `databases/<name>` synchronously while leaving the physical delete to the background;
   eviction of the bootstrap baseline is preserved; replay after the rename is a no-op.
@@ -96,7 +99,7 @@ Pre-existing coverage that must stay green: `RaftDropDatabase3NodesIT` (asserts
 | Suite | Result |
 |---|---|
 | `engine` `LocalDatabaseCloseForDropTest` | 4/4 |
-| `ha-raft` full unit suite (`mvn -pl ha-raft test`) | 752/752 |
+| `ha-raft` full unit suite (`mvn -pl ha-raft test`) | 753/753 |
 | `ha-raft` `RaftDropDatabase3NodesIT` | 1/1 |
 | `server` `PostServerCommandHandlerIT` | 23/23 |
 | `engine` `com.arcadedb.database.*` | 149 run, 1 pre-existing failure |

--- a/docs/5454-ha-drop-database-deferred-deletion.md
+++ b/docs/5454-ha-drop-database-deferred-deletion.md
@@ -1,0 +1,118 @@
+# Issue #5454 - drop database deletes synchronously inside the Raft apply
+
+## Symptom
+
+`drop database` performed the full physical deletion of the database on the Ratis apply thread.
+Because `ArcadeStateMachine` multiplexes every database onto one sequential apply loop, a slow drop
+of database A stalled the apply of committed entries for databases B and C on every node, and could
+outlive the caller's `arcadedb.ha.quorumTimeout` budget, producing:
+
+```
+ReplicationDispatchedTimeoutException:
+  Group commit entry failed: TimeoutException (entry was dispatched to Raft; outcome unknown)
+```
+
+for a drop that in fact committed and will be applied everywhere. A follower busy inside a long drop
+also stops applying, so its `commitIndex - appliedIndex` lag grows and `isReadyForTraffic` flaps.
+
+## Root cause
+
+`ArcadeStateMachine.applyDropDatabaseEntry` called `db.getEmbedded().drop()` inline:
+
+```java
+final DatabaseInternal db = (DatabaseInternal) server.getDatabase(databaseName);
+db.getEmbedded().drop();        // close + FileUtils.deleteRecursively, on the apply thread
+server.removeDatabase(databaseName);
+```
+
+`LocalDatabase.drop()` is `closeInternal(true)` followed by `FileUtils.deleteRecursively(databasePath)`.
+The recursive delete is one `unlink` syscall per file (buckets, indexes, WAL segments), unbounded in
+the size of the database, and it ran with the apply loop held. `lastAppliedIndex` only advances after
+apply returns, so nothing else on the state machine progressed meanwhile.
+
+## Fix
+
+Split the drop into a bounded synchronous part and an unbounded background part.
+
+1. **Engine** - `LocalDatabase.closeForDrop()` exposes the close half of `drop()` (drop-time close
+   semantics: no index flush, no file sync) without removing the files. `drop()` is now
+   `closeForDrop()` + the recursive delete, so its behaviour is unchanged.
+
+2. **ha-raft** - new `DeferredDatabaseDeleter`:
+   - `dropInBackground(dir)` renames `databases/<name>` to the sibling reserved directory
+     `databases/.dropped-<name>-<nanos>` with `ATOMIC_MOVE`, then enqueues the recursive delete on a
+     dedicated single-thread daemon executor. The rename is O(1) and is the only file work left on
+     the apply thread.
+   - If the rename fails (cross-device, or a platform holding handles) it falls back to deleting
+     inline, so the outcome is never worse than before the fix.
+   - `sweepOrphanedStagingDirectories(databasesDir)` enqueues any `.dropped-*` left behind by a crash
+     or by an executor shutdown.
+
+3. **ha-raft** - `applyDropDatabaseEntry` now closes the database, deregisters it and stages the
+   rename while holding `server.getDatabasesLock()`, mirroring `SnapshotInstaller.swapAndReopen`, so
+   no concurrent `getDatabase` can reopen the directory between the close and the rename. The
+   background delete runs outside the lock and outside the apply loop.
+
+4. `ArcadeStateMachine.initialize` runs the orphan sweep next to
+   `SnapshotInstaller.recoverPendingSnapshotSwaps`; `close()` shuts the deleter down.
+
+### Why a reserved-prefix rename is safe
+
+`ArcadeDBServer.RESERVED_DATABASE_PREFIX` is `"."`, and every consumer of the databases directory
+already skips dot-prefixed entries: `loadDatabases`, `SnapshotInstaller.recoverPendingSnapshotSwaps`,
+`DatabaseReconciler`, `GetClusterHandler`, `PostBootstrapStateHandler`. So a staged directory is
+invisible to the registry, to the cluster view, and to a restart.
+
+`create database` with the just-dropped name also stops colliding: `ArcadeDBServer.createDatabase`
+rejects on `DatabaseFactory.exists()`, which checks `databases/<name>/schema.json`, and that path no
+longer exists once the rename returns - previously it existed for the whole duration of the delete.
+
+### Idempotent replay
+
+Crash after the rename but before `writePersistedAppliedIndexDroppingDatabase`: on restart the
+directory is dot-prefixed, `loadDatabases` skips it, so `server.existsDatabase(name)` is false and the
+replayed entry takes the existing early-return branch. The staged directory is removed by the sweep.
+Crash before the rename: the directory still carries its real name, is reloaded, and the replay drops
+it again.
+
+## Tests
+
+- `engine` `LocalDatabaseCloseForDropTest` - `closeForDrop()` closes without deleting; the files are
+  still openable afterwards; `drop()` still deletes; `closeForDrop()` inside a transaction throws.
+- `ha-raft` `DeferredDatabaseDeleterTest` - the rename is synchronous and the physical delete is not;
+  the staged name is reserved; deletion completes in the background; the inline fallback when the
+  rename cannot happen; the orphan sweep.
+- `ha-raft` `ArcadeStateMachineDeferredDropTest` - `applyDropDatabaseEntry` deregisters the database
+  and clears `databases/<name>` synchronously while leaving the physical delete to the background;
+  eviction of the bootstrap baseline is preserved; replay after the rename is a no-op.
+
+Pre-existing coverage that must stay green: `RaftDropDatabase3NodesIT` (asserts
+`databases/<name>` is gone on all three peers - still true, the rename happens before apply returns),
+`ArcadeStateMachineBootstrapBaselinePersistenceTest`, `ArcadeStateMachineAppliedIndexPerDatabaseTest`,
+`PostServerCommandHandlerIT`.
+
+## Verification
+
+| Suite | Result |
+|---|---|
+| `engine` `LocalDatabaseCloseForDropTest` | 4/4 |
+| `ha-raft` full unit suite (`mvn -pl ha-raft test`) | 752/752 |
+| `ha-raft` `RaftDropDatabase3NodesIT` | 1/1 |
+| `server` `PostServerCommandHandlerIT` | 23/23 |
+| `engine` `com.arcadedb.database.*` | 149 run, 1 pre-existing failure |
+
+The engine failure is `DatabaseLifecycleBackgroundThreadsTest.engineBackgroundThreadsAreDaemon`
+(`Query engine 'js' was not found`), reproduced identically on the base commit with the change
+stashed - it is a local classpath gap for the polyglot engine, unrelated to this work.
+
+## Known gaps
+
+- The non-HA drop path (`PostServerCommandHandler.dropDatabase` when the database is not
+  `HAReplicatedDatabase`) still deletes inline. It does not run on the apply loop and has no quorum
+  budget, so it is out of scope here.
+- The client-visible indeterminate outcome (`ReplicationDispatchedTimeoutException`) is not addressed;
+  this change removes the dominant reason to hit it for a drop, but option 1 of the issue (a way to
+  confirm a dispatched drop committed) remains open.
+- Physical deletion failures are still swallowed by `FileUtils.deleteRecursively`. A staged directory
+  that survives is now retried by the sweep on the next restart, which is strictly better than the
+  previous behaviour where a half-deleted `databases/<name>` was reloaded as a live database.

--- a/docs/5454-ha-drop-database-deferred-deletion.md
+++ b/docs/5454-ha-drop-database-deferred-deletion.md
@@ -1,5 +1,8 @@
 # Issue #5454 - drop database deletes synchronously inside the Raft apply
 
+PR: https://github.com/ArcadeData/arcadedb/pull/5455
+
+
 ## Symptom
 
 `drop database` performed the full physical deletion of the database on the Ratis apply thread.
@@ -108,6 +111,28 @@ Pre-existing coverage that must stay green: `RaftDropDatabase3NodesIT` (asserts
 The engine failure is `DatabaseLifecycleBackgroundThreadsTest.engineBackgroundThreadsAreDaemon`
 (`Query engine 'js' was not found`), reproduced identically on the base commit with the change
 stashed - it is a local classpath gap for the polyglot engine, unrelated to this work.
+
+## Review cycles
+
+| # | Head | Review outcome | Applied |
+|---|---|---|---|
+| 1 | `9e2f26e07` | non-blocking | Split `dropInBackground` into `stageForDeletion` (under the lock) and `deleteInBackground` (outside it), so a caller-runs fallback cannot widen the lock hold. Retry the staging name on `FileAlreadyExistsException` instead of falling through to the inline delete. Cover the rename-not-possible fallback with a test. |
+| 2 | `b46254973` | non-blocking | Replace `CallerRunsPolicy` with an explicit rejection path that emits a throttled saturation WARNING. Comment the call site so the inline fallback is not moved out of the lock. Close a replaced deleter. Test the saturated-queue path. |
+| 3 | `bb9212bea` | non-blocking | Resolve `getDatabase(...).getEmbedded()` inside the lock. Mint staging names from a JVM-wide sequence, and retry on `DirectoryNotEmptyException` as well - a rename onto a populated staging directory raises that, not `FileAlreadyExistsException`, so a real collision would previously have skipped the retry and fallen through to the inline delete. |
+| 4 | `d04dcfb42` | LGTM, cosmetic notes only | Nothing applied - see below. |
+
+`gemini-code-assist` did not review any of the four head commits.
+
+Cosmetic notes raised on cycle 4 and deliberately not applied:
+
+- The deleter is built in the field initializer rather than in `initialize()`. Tying it to `initialize()`
+  would be more symmetric with `close()`, but the state-machine unit tests drive
+  `applyDropDatabaseEntry` without calling `initialize()`, and the executor starts no thread until the
+  first submit, so the current shape costs nothing.
+- `closeForDrop()` passes `"Cannot drop database"` to `checkDatabaseIsOpen`, which reads slightly oddly
+  when `closeForDrop()` is the direct entry point rather than `drop()`.
+- Background reclaim is serial by construction (one deleter thread). Intended: the goal is getting the
+  delete off the apply loop, not maximizing delete throughput.
 
 ## Known gaps
 

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -62,6 +62,15 @@ public interface DatabaseInternal extends Database {
 
   DatabaseInternal getEmbedded();
 
+  /**
+   * Closes the database with drop semantics but without removing its files, leaving their deletion to the
+   * caller. Only the embedded instance supports it: reach it through {@link #getEmbedded()}, as the wrappers
+   * reject it the way they reject {@code drop()} and {@code close()}.
+   */
+  default void closeForDrop() {
+    throw new UnsupportedOperationException("Only an embedded database instance can be closed for drop");
+  }
+
   DatabaseContext.DatabaseContextTL getContext();
 
   FileManager getFileManager();

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -303,17 +303,28 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
   @Override
   public void drop() {
+    closeForDrop();
+
+    executeInWriteLock(() -> {
+      FileUtils.deleteRecursively(new File(databasePath));
+      return null;
+    });
+  }
+
+  /**
+   * Closes the database with the same semantics {@link #drop()} uses - no index flush and no file sync, since
+   * the content is about to be discarded - but leaves the files at {@link #getDatabasePath()} in place, so the
+   * caller owns their removal. Callers that must not pay for the recursive delete on their own thread use this
+   * to rename the directory aside and delete it elsewhere.
+   */
+  @Override
+  public void closeForDrop() {
     checkDatabaseIsOpen(true, "Cannot drop database");
 
     if (isTransactionActive())
       throw new DatabaseOperationException("Cannot drop the database in transaction");
 
     closeInternal(true);
-
-    executeInWriteLock(() -> {
-      FileUtils.deleteRecursively(new File(databasePath));
-      return null;
-    });
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/database/LocalDatabaseCloseForDropTest.java
+++ b/engine/src/test/java/com/arcadedb/database/LocalDatabaseCloseForDropTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.exception.DatabaseOperationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers {@link LocalDatabase#closeForDrop()}, the close half of {@link LocalDatabase#drop()} split out so a
+ * caller can remove the files itself - for example by renaming the directory aside and deleting it off the
+ * calling thread.
+ */
+class LocalDatabaseCloseForDropTest {
+
+  @TempDir
+  private Path          tempDir;
+  private LocalDatabase database;
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.close();
+  }
+
+  private LocalDatabase createDatabase() {
+    final LocalDatabase db = (LocalDatabase) new DatabaseFactory(tempDir.resolve("mydb").toString()).create();
+    db.transaction(() -> {
+      db.getSchema().createDocumentType("Doc");
+      db.newDocument("Doc").set("name", "first").save();
+    });
+    return db;
+  }
+
+  @Test
+  void closeForDropClosesTheDatabaseButKeepsTheFiles() {
+    database = createDatabase();
+    final File databaseDirectory = new File(database.getDatabasePath());
+
+    database.closeForDrop();
+
+    assertThat(database.isOpen()).isFalse();
+    assertThat(databaseDirectory).as("closeForDrop must leave the files for the caller to remove").exists();
+    assertThat(new File(databaseDirectory, "schema.json")).exists();
+  }
+
+  @Test
+  void aDatabaseClosedForDropCanBeReopened() {
+    database = createDatabase();
+    final String databasePath = database.getDatabasePath();
+
+    database.closeForDrop();
+
+    database = (LocalDatabase) new DatabaseFactory(databasePath).open();
+    assertThat(database.countType("Doc", true)).isEqualTo(1);
+  }
+
+  @Test
+  void dropStillRemovesTheFiles() {
+    database = createDatabase();
+    final File databaseDirectory = new File(database.getDatabasePath());
+
+    database.drop();
+
+    assertThat(database.isOpen()).isFalse();
+    assertThat(databaseDirectory).doesNotExist();
+  }
+
+  @Test
+  void closeForDropIsRejectedInsideATransaction() {
+    database = createDatabase();
+    database.begin();
+    try {
+      assertThatThrownBy(() -> database.closeForDrop()).isInstanceOf(DatabaseOperationException.class);
+    } finally {
+      database.rollback();
+    }
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2006,8 +2006,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
     synchronized (server.getDatabasesLock()) {
       embedded.closeForDrop();
       server.removeDatabase(databaseName);
-      staged = deferredDatabaseDeleter.dropInBackground(databaseDirectory);
+      staged = deferredDatabaseDeleter.stageForDeletion(databaseDirectory);
     }
+    // Queued outside the lock: a saturated deletion queue runs the delete on this thread, and that must not
+    // extend to holding the databases lock for the length of a recursive delete.
+    if (staged != null)
+      deferredDatabaseDeleter.deleteInBackground(staged);
 
     // Evict AFTER the drop succeeded, mirroring the applied-index drop eviction which runs only once
     // apply completes: if drop() had thrown and quarantined this database, the baseline must stay so a

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2000,10 +2000,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // unbounded in the size of the database, and this loop is sequential and shared by every database
     // multiplexed on the state machine. Close, deregister and rename hold the databases lock as one unit -
     // mirroring the snapshot installer's swap - so no concurrent open can reopen the directory in between.
-    final DatabaseInternal embedded = ((DatabaseInternal) server.getDatabase(databaseName)).getEmbedded();
-    final Path databaseDirectory = Path.of(embedded.getDatabasePath());
     final Path staged;
     synchronized (server.getDatabasesLock()) {
+      // Resolved inside the lock: getDatabase reopens a database that is registered-but-closed, so resolving
+      // it outside would let another holder of this lock deregister it between the lookup and the close, and
+      // this thread would reopen the directory from disk only to close it again.
+      final DatabaseInternal embedded = ((DatabaseInternal) server.getDatabase(databaseName)).getEmbedded();
+      final Path databaseDirectory = Path.of(embedded.getDatabasePath());
       embedded.closeForDrop();
       server.removeDatabase(databaseName);
       // stageForDeletion falls back to deleting inline when the rename is impossible, and that fallback

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2006,6 +2006,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
     synchronized (server.getDatabasesLock()) {
       embedded.closeForDrop();
       server.removeDatabase(databaseName);
+      // stageForDeletion falls back to deleting inline when the rename is impossible, and that fallback
+      // belongs inside the lock even though it is slow: the directory still carries its live name, so
+      // releasing the lock first would let a concurrent create of the same name meet a half-deleted one.
       staged = deferredDatabaseDeleter.stageForDeletion(databaseDirectory);
     }
     // Queued outside the lock: a saturated deletion queue runs the delete on this thread, and that must not
@@ -2025,7 +2028,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
   // @VisibleForTesting
   void setDeferredDatabaseDeleter(final DeferredDatabaseDeleter deleter) {
+    final DeferredDatabaseDeleter previous = this.deferredDatabaseDeleter;
     this.deferredDatabaseDeleter = deleter;
+    if (previous != null && previous != deleter)
+      previous.close();
   }
 
   private void applySecurityUsersEntry(final RaftLogEntryCodec.DecodedEntry decoded) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -160,6 +160,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
   });
 
   /**
+   * Removes dropped database directories away from the apply loop. Deliberately not the lifecycleExecutor: a
+   * deletion is unbounded in the size of the database and would delay the snapshot-download triggers that
+   * executor carries.
+   */
+  private volatile DeferredDatabaseDeleter deferredDatabaseDeleter = new DeferredDatabaseDeleter();
+
+  /**
    * Per-database bootstrap baseline committed via {@link RaftLogEntryType#BOOTSTRAP_FINGERPRINT_ENTRY}.
    * Populated when the entry is applied (locally on every peer), used by the catch-up decision
    * tree (locally bootstrapped vs leader-shipped vs late-newer-joiner refusal). Issue #4147.
@@ -315,8 +322,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
     if (server != null) {
       final String dbDir = server.getConfiguration().getValueAsString(
           GlobalConfiguration.SERVER_DATABASE_DIRECTORY);
-      if (dbDir != null)
-        SnapshotInstaller.recoverPendingSnapshotSwaps(Path.of(dbDir));
+      if (dbDir != null) {
+        final Path databasesDirectory = Path.of(dbDir);
+        SnapshotInstaller.recoverPendingSnapshotSwaps(databasesDirectory);
+        // Finish any deletion a crash or a shutdown cut short: the directories are reserved, so nothing else
+        // will ever look at them.
+        deferredDatabaseDeleter.sweepOrphanedStagingDirectories(databasesDirectory);
+      }
     }
     LogManager.instance().log(this, Level.INFO, "ArcadeStateMachine initialized (groupId=%s)", groupId);
   }
@@ -1984,9 +1996,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
       return;
     }
 
-    final DatabaseInternal db = (DatabaseInternal) server.getDatabase(databaseName);
-    db.getEmbedded().drop();
-    server.removeDatabase(databaseName);
+    // Only the rename below runs on the apply thread: the recursive delete costs one unlink per file and is
+    // unbounded in the size of the database, and this loop is sequential and shared by every database
+    // multiplexed on the state machine. Close, deregister and rename hold the databases lock as one unit -
+    // mirroring the snapshot installer's swap - so no concurrent open can reopen the directory in between.
+    final DatabaseInternal embedded = ((DatabaseInternal) server.getDatabase(databaseName)).getEmbedded();
+    final Path databaseDirectory = Path.of(embedded.getDatabasePath());
+    final Path staged;
+    synchronized (server.getDatabasesLock()) {
+      embedded.closeForDrop();
+      server.removeDatabase(databaseName);
+      staged = deferredDatabaseDeleter.dropInBackground(databaseDirectory);
+    }
 
     // Evict AFTER the drop succeeded, mirroring the applied-index drop eviction which runs only once
     // apply completes: if drop() had thrown and quarantined this database, the baseline must stay so a
@@ -1994,7 +2015,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // actually dropped - the #5100 failure mode).
     evictBootstrapBaseline(databaseName);
 
-    LogManager.instance().log(this, Level.INFO, "Database '%s' dropped via Raft drop-database entry", databaseName);
+    LogManager.instance().log(this, Level.INFO, "Database '%s' dropped via Raft drop-database entry%s", databaseName,
+        staged != null ? " (files staged as '" + staged.getFileName() + "' for background deletion)" : "");
+  }
+
+  // @VisibleForTesting
+  void setDeferredDatabaseDeleter(final DeferredDatabaseDeleter deleter) {
+    this.deferredDatabaseDeleter = deleter;
   }
 
   private void applySecurityUsersEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
@@ -2516,6 +2543,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
   @Override
   public void close() throws IOException {
     lifecycleExecutor.shutdownNow();
+    deferredDatabaseDeleter.close();
     super.close();
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleter.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 /**
@@ -67,14 +68,18 @@ class DeferredDatabaseDeleter implements AutoCloseable {
   /** Candidate staging names tried before giving up and deleting inline. */
   private static final int STAGING_NAME_ATTEMPTS = 16;
 
+  /** Throttle window for the queue-saturation warning, matching the engine pools. */
+  private static final long SATURATION_WARNING_WINDOW_MS = 60_000;
+
   private final ExecutorService executor;
+  private final AtomicLong     lastSaturationWarningOn = new AtomicLong(Long.MIN_VALUE);
 
   DeferredDatabaseDeleter() {
     this(new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(MAX_PENDING_DELETIONS), r -> {
       final Thread t = new Thread(r, "arcadedb-sm-database-deleter");
       t.setDaemon(true);
       return t;
-    }, new ThreadPoolExecutor.CallerRunsPolicy()));
+    }, new ThreadPoolExecutor.AbortPolicy()));
   }
 
   // @VisibleForTesting
@@ -184,21 +189,43 @@ class DeferredDatabaseDeleter implements AutoCloseable {
 
   private void submitDeletion(final Path staged) {
     try {
-      executor.execute(() -> {
-        try {
-          FileUtils.deleteRecursively(staged.toFile());
-          LogManager.instance().log(DeferredDatabaseDeleter.class, Level.FINE,
-              "Deleted dropped database directory '%s'", staged);
-        } catch (final Exception e) {
-          LogManager.instance().log(DeferredDatabaseDeleter.class, Level.WARNING,
-              "Error deleting dropped database directory '%s': it will be retried on the next restart", e, staged);
-        }
-      });
+      executor.execute(() -> delete(staged));
+      return;
     } catch (final RejectedExecutionException e) {
-      // Shutting down: the directory is reserved, so it stays invisible to the server and the startup sweep
-      // deletes it on the next start.
-      LogManager.instance().log(this, Level.FINE,
-          "Deferred deletion of '%s' rejected during shutdown: it will be retried on the next restart", staged);
+      if (executor.isShutdown()) {
+        // Shutting down: the directory is reserved, so it stays invisible to the server and the startup
+        // sweep deletes it on the next start.
+        LogManager.instance().log(this, Level.FINE,
+            "Deferred deletion of '%s' rejected during shutdown: it will be retried on the next restart", staged);
+        return;
+      }
+      warnSaturated(staged);
     }
+    // Caller-runs, outside the catch so a failure in delete() is not mistaken for a rejection.
+    delete(staged);
+  }
+
+  private static void delete(final Path staged) {
+    try {
+      FileUtils.deleteRecursively(staged.toFile());
+      LogManager.instance().log(DeferredDatabaseDeleter.class, Level.FINE,
+          "Deleted dropped database directory '%s'", staged);
+    } catch (final Exception e) {
+      LogManager.instance().log(DeferredDatabaseDeleter.class, Level.WARNING,
+          "Error deleting dropped database directory '%s': it will be retried on the next restart", e, staged);
+    }
+  }
+
+  /**
+   * Warns that the deletion queue is saturated and the caller is about to run the delete itself. Throttled to
+   * one message per window, matching the other pools, because a saturated queue produces one rejection per drop.
+   */
+  private void warnSaturated(final Path staged) {
+    final long now = System.currentTimeMillis();
+    final long last = lastSaturationWarningOn.get();
+    if (now - last >= SATURATION_WARNING_WINDOW_MS && lastSaturationWarningOn.compareAndSet(last, now))
+      LogManager.instance().log(this, Level.WARNING, """
+          Dropped-database deletion queue is full (%d pending): deleting '%s' on the calling thread. Sustained \
+          occurrences mean database drops are stalling the Raft apply loop""", MAX_PENDING_DELETIONS, staged);
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleter.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.log.LogManager;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.utility.FileUtils;
+
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+/**
+ * Removes dropped database directories off the caller's thread.
+ * <p>
+ * A physical delete costs one unlink per file and is unbounded in the size of the database, so the Raft apply
+ * loop - which is sequential and shared by every database multiplexed on the state machine - must not perform
+ * it. Instead the caller renames the directory to a sibling whose name carries
+ * {@link ArcadeDBServer#RESERVED_DATABASE_PREFIX}, which is O(1), and the recursive delete happens here.
+ * <p>
+ * A staged directory is invisible to the server: every consumer of the databases directory skips reserved
+ * names, so it is neither reloaded on restart nor reported in the cluster view, and the database name is free
+ * for an immediate re-create. Whatever survives a crash or a shutdown is picked up by
+ * {@link #sweepOrphanedStagingDirectories(Path)} on the next start.
+ */
+class DeferredDatabaseDeleter implements AutoCloseable {
+
+  /** Prefix of the staged directory a dropped database is renamed to. Reserved, so the server ignores it. */
+  static final String STAGING_PREFIX = ArcadeDBServer.RESERVED_DATABASE_PREFIX + "dropped-";
+
+  /**
+   * Bound on directories awaiting deletion. Beyond it the submitting thread runs the delete itself, which is
+   * the behaviour this class exists to avoid - but degrading to it is preferable to growing the queue without
+   * limit, and reaching it needs more concurrently pending drops than a cluster realistically produces.
+   */
+  private static final int MAX_PENDING_DELETIONS = 1024;
+
+  private final ExecutorService executor;
+
+  DeferredDatabaseDeleter() {
+    this(new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(MAX_PENDING_DELETIONS), r -> {
+      final Thread t = new Thread(r, "arcadedb-sm-database-deleter");
+      t.setDaemon(true);
+      return t;
+    }, new ThreadPoolExecutor.CallerRunsPolicy()));
+  }
+
+  // @VisibleForTesting
+  DeferredDatabaseDeleter(final ExecutorService executor) {
+    this.executor = executor;
+  }
+
+  /**
+   * Renames the given database directory to a reserved sibling and queues its recursive deletion, returning the
+   * staged path. Returns {@code null} when the directory does not exist, or when the rename was not possible
+   * and the deletion had to be performed inline.
+   * <p>
+   * The database must already be closed and deregistered from the server: on return its directory is gone, so
+   * an immediate re-create of the same name succeeds.
+   */
+  Path dropInBackground(final Path databaseDirectory) {
+    if (!Files.exists(databaseDirectory))
+      return null;
+
+    final Path staged = stage(databaseDirectory);
+    if (staged == null) {
+      // The rename is not available on this filesystem: fall back to deleting where we stand, which is the
+      // behaviour that predates the deferral - slow, but never leaves the directory behind.
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot stage database directory '%s' for deferred deletion: deleting it inline", databaseDirectory);
+      FileUtils.deleteRecursively(databaseDirectory.toFile());
+      return null;
+    }
+
+    submitDeletion(staged);
+    return staged;
+  }
+
+  /**
+   * Queues the deletion of every staged directory left in the databases directory by a crash, or by a shutdown
+   * that cut a pending deletion short.
+   */
+  void sweepOrphanedStagingDirectories(final Path databasesDirectory) {
+    for (final Path orphan : listStagingDirectories(databasesDirectory)) {
+      LogManager.instance().log(this, Level.INFO, "Resuming deferred deletion of dropped database directory '%s'", orphan);
+      submitDeletion(orphan);
+    }
+  }
+
+  @Override
+  public void close() {
+    executor.shutdownNow();
+  }
+
+  private static List<Path> listStagingDirectories(final Path databasesDirectory) {
+    if (databasesDirectory == null || !Files.isDirectory(databasesDirectory))
+      return List.of();
+
+    final List<Path> staged = new ArrayList<>();
+    try (final var entries = Files.newDirectoryStream(databasesDirectory, STAGING_PREFIX + "*")) {
+      for (final Path entry : entries)
+        if (Files.isDirectory(entry))
+          staged.add(entry);
+    } catch (final IOException e) {
+      LogManager.instance().log(DeferredDatabaseDeleter.class, Level.WARNING,
+          "Cannot scan '%s' for dropped database directories", e, databasesDirectory);
+    }
+    return staged;
+  }
+
+  /**
+   * Moves the directory aside under a name that is unique among its siblings, so a drop-create-drop sequence on
+   * the same database name never collides with a deletion still in flight.
+   */
+  private Path stage(final Path databaseDirectory) {
+    final Path parent = databaseDirectory.getParent();
+    final String name = databaseDirectory.getFileName().toString();
+
+    for (int attempt = 0; attempt < 16; attempt++) {
+      final Path candidate = parent.resolve(STAGING_PREFIX + name + "-" + System.nanoTime());
+      if (Files.exists(candidate))
+        continue;
+      try {
+        Files.move(databaseDirectory, candidate, StandardCopyOption.ATOMIC_MOVE);
+        return candidate;
+      } catch (final AtomicMoveNotSupportedException e) {
+        try {
+          Files.move(databaseDirectory, candidate);
+          return candidate;
+        } catch (final IOException nested) {
+          LogManager.instance().log(this, Level.WARNING, "Cannot move database directory '%s' to '%s'", nested,
+              databaseDirectory, candidate);
+          return null;
+        }
+      } catch (final IOException e) {
+        LogManager.instance().log(this, Level.WARNING, "Cannot move database directory '%s' to '%s'", e,
+            databaseDirectory, candidate);
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private void submitDeletion(final Path staged) {
+    try {
+      executor.execute(() -> {
+        try {
+          FileUtils.deleteRecursively(staged.toFile());
+          LogManager.instance().log(DeferredDatabaseDeleter.class, Level.FINE,
+              "Deleted dropped database directory '%s'", staged);
+        } catch (final Exception e) {
+          LogManager.instance().log(DeferredDatabaseDeleter.class, Level.WARNING,
+              "Error deleting dropped database directory '%s': it will be retried on the next restart", e, staged);
+        }
+      });
+    } catch (final RejectedExecutionException e) {
+      // Shutting down: the directory is reserved, so it stays invisible to the server and the startup sweep
+      // deletes it on the next start.
+      LogManager.instance().log(this, Level.FINE,
+          "Deferred deletion of '%s' rejected during shutdown: it will be retried on the next restart", staged);
+    }
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleter.java
@@ -24,6 +24,7 @@ import com.arcadedb.utility.FileUtils;
 
 import java.io.IOException;
 import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -70,6 +71,9 @@ class DeferredDatabaseDeleter implements AutoCloseable {
 
   /** Throttle window for the queue-saturation warning, matching the engine pools. */
   private static final long SATURATION_WARNING_WINDOW_MS = 60_000;
+
+  /** Makes every staging name minted by this JVM distinct, independently of the clock's granularity. */
+  private static final AtomicLong STAGING_SEQUENCE = new AtomicLong();
 
   private final ExecutorService executor;
   private final AtomicLong     lastSaturationWarningOn = new AtomicLong(Long.MIN_VALUE);
@@ -161,12 +165,16 @@ class DeferredDatabaseDeleter implements AutoCloseable {
     final String name = databaseDirectory.getFileName().toString();
 
     for (int attempt = 0; attempt < STAGING_NAME_ATTEMPTS; attempt++) {
-      final Path candidate = parent.resolve(STAGING_PREFIX + name + "-" + System.nanoTime());
+      // A JVM-wide sequence rather than the clock alone: on a coarse-grained nanoTime two candidates in this
+      // loop could otherwise repeat, making the retry budget spin on the same name.
+      final Path candidate = parent.resolve(
+          STAGING_PREFIX + name + "-" + System.nanoTime() + "-" + STAGING_SEQUENCE.incrementAndGet());
       try {
         moveDirectory(databaseDirectory, candidate);
         return candidate;
-      } catch (final FileAlreadyExistsException e) {
-        // Another staged directory already claimed this name: spend an attempt on the next one.
+      } catch (final FileAlreadyExistsException | DirectoryNotEmptyException e) {
+        // The name is taken - an empty candidate raises FileAlreadyExists, a populated one raises
+        // DirectoryNotEmpty because a rename onto a non-empty directory cannot succeed. Try the next name.
       } catch (final IOException e) {
         LogManager.instance().log(this, Level.WARNING, "Cannot move database directory '%s' to '%s'", e,
             databaseDirectory, candidate);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleter.java
@@ -24,6 +24,7 @@ import com.arcadedb.utility.FileUtils;
 
 import java.io.IOException;
 import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -57,9 +58,14 @@ class DeferredDatabaseDeleter implements AutoCloseable {
   /**
    * Bound on directories awaiting deletion. Beyond it the submitting thread runs the delete itself, which is
    * the behaviour this class exists to avoid - but degrading to it is preferable to growing the queue without
-   * limit, and reaching it needs more concurrently pending drops than a cluster realistically produces.
+   * limit, and reaching it needs more concurrently pending drops than a cluster realistically produces. Callers
+   * holding a lock across the staging step must still call {@link #deleteInBackground(Path)} outside it, so
+   * that a caller-runs fallback never widens the lock hold to the length of a recursive delete.
    */
   private static final int MAX_PENDING_DELETIONS = 1024;
+
+  /** Candidate staging names tried before giving up and deleting inline. */
+  private static final int STAGING_NAME_ATTEMPTS = 16;
 
   private final ExecutorService executor;
 
@@ -77,29 +83,35 @@ class DeferredDatabaseDeleter implements AutoCloseable {
   }
 
   /**
-   * Renames the given database directory to a reserved sibling and queues its recursive deletion, returning the
-   * staged path. Returns {@code null} when the directory does not exist, or when the rename was not possible
-   * and the deletion had to be performed inline.
+   * Renames the given database directory to a reserved sibling and returns the staged path, leaving the caller
+   * to hand it to {@link #deleteInBackground(Path)}. Returns {@code null} when the directory does not exist, or
+   * when the rename was not possible and the deletion had to be performed inline.
    * <p>
-   * The database must already be closed and deregistered from the server: on return its directory is gone, so
-   * an immediate re-create of the same name succeeds.
+   * The database must already be closed and deregistered from the server. On return its directory is gone under
+   * its own name either way, so an immediate re-create of the same name succeeds.
    */
-  Path dropInBackground(final Path databaseDirectory) {
+  Path stageForDeletion(final Path databaseDirectory) {
     if (!Files.exists(databaseDirectory))
       return null;
 
-    final Path staged = stage(databaseDirectory);
+    final Path staged = rename(databaseDirectory);
     if (staged == null) {
       // The rename is not available on this filesystem: fall back to deleting where we stand, which is the
-      // behaviour that predates the deferral - slow, but never leaves the directory behind.
+      // behaviour that predates the deferral - slow, but never leaves the directory behind under a name the
+      // server would reload.
       LogManager.instance().log(this, Level.WARNING,
           "Cannot stage database directory '%s' for deferred deletion: deleting it inline", databaseDirectory);
       FileUtils.deleteRecursively(databaseDirectory.toFile());
-      return null;
     }
-
-    submitDeletion(staged);
     return staged;
+  }
+
+  /**
+   * Queues the recursive deletion of an already staged directory. Call it outside any lock held across
+   * {@link #stageForDeletion(Path)}: on a saturated queue the deletion runs on the calling thread.
+   */
+  void deleteInBackground(final Path staged) {
+    submitDeletion(staged);
   }
 
   /**
@@ -138,33 +150,36 @@ class DeferredDatabaseDeleter implements AutoCloseable {
    * Moves the directory aside under a name that is unique among its siblings, so a drop-create-drop sequence on
    * the same database name never collides with a deletion still in flight.
    */
-  private Path stage(final Path databaseDirectory) {
+  // Package-private and overridable so a test can simulate a filesystem that refuses the rename.
+  Path rename(final Path databaseDirectory) {
     final Path parent = databaseDirectory.getParent();
     final String name = databaseDirectory.getFileName().toString();
 
-    for (int attempt = 0; attempt < 16; attempt++) {
+    for (int attempt = 0; attempt < STAGING_NAME_ATTEMPTS; attempt++) {
       final Path candidate = parent.resolve(STAGING_PREFIX + name + "-" + System.nanoTime());
-      if (Files.exists(candidate))
-        continue;
       try {
-        Files.move(databaseDirectory, candidate, StandardCopyOption.ATOMIC_MOVE);
+        moveDirectory(databaseDirectory, candidate);
         return candidate;
-      } catch (final AtomicMoveNotSupportedException e) {
-        try {
-          Files.move(databaseDirectory, candidate);
-          return candidate;
-        } catch (final IOException nested) {
-          LogManager.instance().log(this, Level.WARNING, "Cannot move database directory '%s' to '%s'", nested,
-              databaseDirectory, candidate);
-          return null;
-        }
+      } catch (final FileAlreadyExistsException e) {
+        // Another staged directory already claimed this name: spend an attempt on the next one.
       } catch (final IOException e) {
         LogManager.instance().log(this, Level.WARNING, "Cannot move database directory '%s' to '%s'", e,
             databaseDirectory, candidate);
         return null;
       }
     }
+    LogManager.instance().log(this, Level.WARNING,
+        "Cannot find a free staging name for database directory '%s' after %d attempts", databaseDirectory,
+        STAGING_NAME_ATTEMPTS);
     return null;
+  }
+
+  private static void moveDirectory(final Path from, final Path to) throws IOException {
+    try {
+      Files.move(from, to, StandardCopyOption.ATOMIC_MOVE);
+    } catch (final AtomicMoveNotSupportedException e) {
+      Files.move(from, to);
+    }
   }
 
   private void submitDeletion(final Path staged) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineDeferredDropTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineDeferredDropTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.BootstrapFingerprint;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5454.
+ * <p>
+ * {@code applyDropDatabaseEntry} runs on the single Ratis apply thread shared by every database multiplexed
+ * on the state machine, and used to perform the whole physical deletion there. It must now leave the apply
+ * thread with nothing but a directory rename, deferring the recursive delete to the deleter's executor.
+ * <p>
+ * The tests drive a real (unstarted) {@link ArcadeDBServer} with a real {@link LocalDatabase} - no mocking
+ * framework - and mirror {@code ArcadeStateMachineBootstrapBaselinePersistenceTest}.
+ */
+class ArcadeStateMachineDeferredDropTest {
+
+  private static final String DB_NAME          = "db-a";
+  private static final long   AWAIT_TIMEOUT_MS = 20_000;
+
+  @TempDir
+  private Path                    serverDir;
+  private ArcadeDBServer          server;
+  private LocalDatabase           localDatabase;
+  private Path                    databaseDirectory;
+  private ExecutorService         executor;
+  private DeferredDatabaseDeleter deleter;
+
+  @BeforeEach
+  void setUp() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+    server = new ArcadeDBServer(config);
+
+    databaseDirectory = serverDir.resolve(DB_NAME);
+    localDatabase = (LocalDatabase) new DatabaseFactory(databaseDirectory.toString()).create();
+    localDatabase.transaction(() -> {
+      localDatabase.getSchema().createDocumentType("Doc");
+      localDatabase.newDocument("Doc").set("name", "first").save();
+    });
+    server.registerDatabase(DB_NAME, localDatabase);
+
+    executor = Executors.newSingleThreadExecutor();
+    deleter = new DeferredDatabaseDeleter(executor);
+  }
+
+  @AfterEach
+  void tearDown() {
+    deleter.close();
+    if (localDatabase != null && localDatabase.isOpen())
+      localDatabase.close();
+    FileUtils.deleteRecursively(new File(databaseDirectory.toString()));
+  }
+
+  private ArcadeStateMachine newStateMachine() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(server);
+    sm.setDeferredDatabaseDeleter(deleter);
+    return sm;
+  }
+
+  private void applyDrop(final ArcadeStateMachine sm) {
+    sm.applyDropDatabaseEntry(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeDropDatabaseEntry(DB_NAME)));
+  }
+
+  private Path findStagingDirectory() throws Exception {
+    try (var entries = Files.list(serverDir)) {
+      final List<Path> staged = entries
+          .filter(p -> p.getFileName().toString().startsWith(DeferredDatabaseDeleter.STAGING_PREFIX))
+          .toList();
+      assertThat(staged).as("exactly one staging directory expected").hasSize(1);
+      return staged.getFirst();
+    }
+  }
+
+  private static void awaitGone(final Path path) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + AWAIT_TIMEOUT_MS;
+    while (Files.exists(path) && System.currentTimeMillis() < deadline)
+      Thread.sleep(20);
+    assertThat(path).doesNotExist();
+  }
+
+  /**
+   * With the deleter's executor blocked, apply still completes and the database is gone from the registry and
+   * from its directory - but its files are still on disk under the staging name, proving the recursive delete
+   * did not run on the apply thread.
+   */
+  @Test
+  void applyDeregistersTheDatabaseWithoutDeletingItsFilesInline() throws Exception {
+    final CountDownLatch gate = new CountDownLatch(1);
+    executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+    applyDrop(newStateMachine());
+
+    assertThat(server.existsDatabase(DB_NAME)).isFalse();
+    assertThat(localDatabase.isOpen()).isFalse();
+    assertThat(databaseDirectory).doesNotExist();
+
+    final Path staged = findStagingDirectory();
+    assertThat(staged.resolve("schema.json")).as("the physical delete must still be pending").exists();
+
+    gate.countDown();
+    awaitGone(staged);
+  }
+
+  /**
+   * Once the rename has happened the database name is free again: a create of the same name must not see the
+   * old directory, which previously survived for the whole duration of the delete.
+   */
+  @Test
+  void theDatabaseNameIsReusableAsSoonAsApplyReturns() throws Exception {
+    final CountDownLatch gate = new CountDownLatch(1);
+    executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+    applyDrop(newStateMachine());
+
+    assertThat(new DatabaseFactory(databaseDirectory.toString()).exists()).isFalse();
+
+    gate.countDown();
+    awaitGone(findStagingDirectory());
+  }
+
+  /**
+   * Replaying the entry after the rename is a no-op: the staged directory is reserved, so the server does not
+   * see the database any more and the early-return branch is taken.
+   */
+  @Test
+  void replayingTheEntryAfterTheRenameIsANoOp() throws Exception {
+    final CountDownLatch gate = new CountDownLatch(1);
+    executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+    final ArcadeStateMachine sm = newStateMachine();
+    applyDrop(sm);
+    final Path staged = findStagingDirectory();
+
+    applyDrop(sm);
+
+    assertThat(findStagingDirectory()).as("the replay must not stage a second directory").isEqualTo(staged);
+
+    gate.countDown();
+    awaitGone(staged);
+  }
+
+  /**
+   * The persisted bootstrap baseline is still evicted by the drop.
+   */
+  @Test
+  void theBootstrapBaselineIsStillEvicted() throws Exception {
+    final ArcadeStateMachine sm = newStateMachine();
+    final String fingerprint = BootstrapFingerprint.compute(new File(databaseDirectory.toString()));
+    sm.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.encodeBootstrapFingerprintEntry(DB_NAME, fingerprint, localDatabase.getLastTransactionId())), 50L);
+    assertThat(sm.getBootstrapBaseline(DB_NAME)).isNotNull();
+
+    applyDrop(sm);
+
+    assertThat(sm.getBootstrapBaseline(DB_NAME)).isNull();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleterTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleterTest.java
@@ -65,6 +65,14 @@ class DeferredDatabaseDeleterTest {
     return directory;
   }
 
+  /** Mirrors the production call site: stage under the caller's lock, queue the deletion outside it. */
+  private Path drop(final Path databaseDirectory) {
+    final Path staged = deleter.stageForDeletion(databaseDirectory);
+    if (staged != null)
+      deleter.deleteInBackground(staged);
+    return staged;
+  }
+
   private static void awaitGone(final Path path) throws InterruptedException {
     final long deadline = System.currentTimeMillis() + AWAIT_TIMEOUT_MS;
     while (Files.exists(path) && System.currentTimeMillis() < deadline)
@@ -84,7 +92,7 @@ class DeferredDatabaseDeleterTest {
     final CountDownLatch gate = new CountDownLatch(1);
     executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-    final Path staged = deleter.dropInBackground(databaseDirectory);
+    final Path staged = drop(databaseDirectory);
 
     assertThat(databaseDirectory).as("the database directory must be gone when the call returns").doesNotExist();
     assertThat(staged).as("the files must still be on disk: the delete is queued, not inline").exists();
@@ -101,7 +109,7 @@ class DeferredDatabaseDeleterTest {
     final CountDownLatch gate = new CountDownLatch(1);
     executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-    final Path staged = deleter.dropInBackground(databaseDirectory);
+    final Path staged = drop(databaseDirectory);
 
     assertThat(staged.getParent()).isEqualTo(databasesDirectory);
     assertThat(ArcadeDBServer.isReservedDatabaseName(staged.getFileName().toString())).isTrue();
@@ -116,8 +124,8 @@ class DeferredDatabaseDeleterTest {
     final CountDownLatch gate = new CountDownLatch(1);
     executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-    final Path first = deleter.dropInBackground(createDatabaseDirectory("mydb"));
-    final Path second = deleter.dropInBackground(createDatabaseDirectory("mydb"));
+    final Path first = drop(createDatabaseDirectory("mydb"));
+    final Path second = drop(createDatabaseDirectory("mydb"));
 
     assertThat(first).isNotEqualTo(second);
     assertThat(first).exists();
@@ -130,7 +138,26 @@ class DeferredDatabaseDeleterTest {
 
   @Test
   void aMissingDatabaseDirectoryIsANoOp() {
-    assertThat(deleter.dropInBackground(databasesDirectory.resolve("absent"))).isNull();
+    assertThat(drop(databasesDirectory.resolve("absent"))).isNull();
+  }
+
+  /**
+   * When the filesystem cannot rename the directory aside, the directory must still be gone when the call
+   * returns - deleted inline, the behaviour that predates the deferral - so the server never reloads a database
+   * the cluster dropped.
+   */
+  @Test
+  void aDirectoryThatCannotBeRenamedIsDeletedInline() throws Exception {
+    final DeferredDatabaseDeleter unrenamable = new DeferredDatabaseDeleter(executor) {
+      @Override
+      Path rename(final Path databaseDirectory) {
+        return null;
+      }
+    };
+    final Path databaseDirectory = createDatabaseDirectory("mydb");
+
+    assertThat(unrenamable.stageForDeletion(databaseDirectory)).isNull();
+    assertThat(databaseDirectory).as("the inline fallback must still remove the directory").doesNotExist();
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleterTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleterTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers {@link DeferredDatabaseDeleter}: the directory rename must complete on the calling thread while the
+ * recursive delete happens on the deleter's own executor, so the Raft apply loop never pays for the deletion.
+ */
+class DeferredDatabaseDeleterTest {
+
+  private static final long AWAIT_TIMEOUT_MS = 20_000;
+
+  @TempDir
+  private Path                    databasesDirectory;
+  private ExecutorService         executor;
+  private DeferredDatabaseDeleter deleter;
+
+  @BeforeEach
+  void setUp() {
+    executor = Executors.newSingleThreadExecutor();
+    deleter = new DeferredDatabaseDeleter(executor);
+  }
+
+  @AfterEach
+  void tearDown() {
+    deleter.close();
+  }
+
+  private Path createDatabaseDirectory(final String name) throws IOException {
+    final Path directory = Files.createDirectories(databasesDirectory.resolve(name));
+    Files.writeString(directory.resolve("schema.json"), "{}");
+    Files.writeString(Files.createDirectories(directory.resolve("nested")).resolve("bucket_0.bucket"), "payload");
+    return directory;
+  }
+
+  private static void awaitGone(final Path path) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + AWAIT_TIMEOUT_MS;
+    while (Files.exists(path) && System.currentTimeMillis() < deadline)
+      Thread.sleep(20);
+    assertThat(path).doesNotExist();
+  }
+
+  /**
+   * The regression this class exists for: when the deleter's executor cannot run, the source directory is
+   * already gone (renamed) but the files are still on disk under the staged name - proving the recursive
+   * delete did not run on the calling thread.
+   */
+  @Test
+  void theRenameIsSynchronousAndTheDeletionIsNot() throws Exception {
+    final Path databaseDirectory = createDatabaseDirectory("mydb");
+
+    final CountDownLatch gate = new CountDownLatch(1);
+    executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+    final Path staged = deleter.dropInBackground(databaseDirectory);
+
+    assertThat(databaseDirectory).as("the database directory must be gone when the call returns").doesNotExist();
+    assertThat(staged).as("the files must still be on disk: the delete is queued, not inline").exists();
+    assertThat(staged.resolve("nested").resolve("bucket_0.bucket")).exists();
+
+    gate.countDown();
+    awaitGone(staged);
+  }
+
+  @Test
+  void theStagedDirectoryIsAReservedSiblingOfTheDatabase() throws Exception {
+    final Path databaseDirectory = createDatabaseDirectory("mydb");
+
+    final CountDownLatch gate = new CountDownLatch(1);
+    executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+    final Path staged = deleter.dropInBackground(databaseDirectory);
+
+    assertThat(staged.getParent()).isEqualTo(databasesDirectory);
+    assertThat(ArcadeDBServer.isReservedDatabaseName(staged.getFileName().toString())).isTrue();
+    assertThat(staged.getFileName().toString()).startsWith(DeferredDatabaseDeleter.STAGING_PREFIX + "mydb-");
+
+    gate.countDown();
+    awaitGone(staged);
+  }
+
+  @Test
+  void concurrentDropsOfTheSameNameGetDistinctStagingDirectories() throws Exception {
+    final CountDownLatch gate = new CountDownLatch(1);
+    executor.submit(() -> gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+    final Path first = deleter.dropInBackground(createDatabaseDirectory("mydb"));
+    final Path second = deleter.dropInBackground(createDatabaseDirectory("mydb"));
+
+    assertThat(first).isNotEqualTo(second);
+    assertThat(first).exists();
+    assertThat(second).exists();
+
+    gate.countDown();
+    awaitGone(first);
+    awaitGone(second);
+  }
+
+  @Test
+  void aMissingDatabaseDirectoryIsANoOp() {
+    assertThat(deleter.dropInBackground(databasesDirectory.resolve("absent"))).isNull();
+  }
+
+  @Test
+  void theSweepRemovesOrphanedStagingDirectoriesAndNothingElse() throws Exception {
+    final Path orphan = Files.createDirectories(
+        databasesDirectory.resolve(DeferredDatabaseDeleter.STAGING_PREFIX + "gone-1234"));
+    Files.writeString(orphan.resolve("schema.json"), "{}");
+    final Path liveDatabase = createDatabaseDirectory("mydb");
+    final Path raftDirectory = Files.createDirectories(databasesDirectory.resolve(".raft"));
+
+    deleter.sweepOrphanedStagingDirectories(databasesDirectory);
+
+    awaitGone(orphan);
+    assertThat(liveDatabase).exists();
+    assertThat(raftDirectory).exists();
+  }
+
+  @Test
+  void theSweepToleratesAMissingDatabasesDirectory() {
+    deleter.sweepOrphanedStagingDirectories(databasesDirectory.resolve("absent"));
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleterTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/DeferredDatabaseDeleterTest.java
@@ -27,9 +27,11 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -158,6 +160,34 @@ class DeferredDatabaseDeleterTest {
 
     assertThat(unrenamable.stageForDeletion(databaseDirectory)).isNull();
     assertThat(databaseDirectory).as("the inline fallback must still remove the directory").doesNotExist();
+  }
+
+  /**
+   * A full queue must degrade to deleting on the calling thread rather than dropping the directory on the
+   * floor: leaking staged directories would grow the disk footprint silently until the next restart sweep.
+   */
+  @Test
+  void aSaturatedQueueDeletesOnTheCallingThread() throws Exception {
+    final ThreadPoolExecutor saturated = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<>(1), new ThreadPoolExecutor.AbortPolicy());
+    final CountDownLatch gate = new CountDownLatch(1);
+    try (final DeferredDatabaseDeleter bounded = new DeferredDatabaseDeleter(saturated)) {
+      saturated.execute(() -> {
+        try {
+          gate.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      });
+      saturated.execute(() -> {
+      });
+
+      final Path staged = bounded.stageForDeletion(createDatabaseDirectory("mydb"));
+      bounded.deleteInBackground(staged);
+
+      assertThat(staged).as("the rejected deletion must have run before the call returned").doesNotExist();
+      gate.countDown();
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes #5454

`drop database` performed the full physical deletion of the database on the Ratis apply thread. That loop is sequential and shared by every database multiplexed on `ArcadeStateMachine`, so a slow drop of one database stalled the apply of committed entries for all the others on every node, and could outlive the caller's `arcadedb.ha.quorumTimeout` budget - producing a `ReplicationDispatchedTimeoutException` ("outcome unknown") for a drop that in fact committed and would be applied everywhere. This splits the drop into a bounded synchronous part and an unbounded background part: the apply closes the database, deregisters it and renames `databases/<name>` to the reserved sibling `databases/.dropped-<name>-<nanos>` with `ATOMIC_MOVE` (O(1)), and a dedicated single-thread executor does the recursive delete. A reserved name is already skipped by every consumer of the databases directory (`loadDatabases`, the snapshot installer's startup reconcile, the cluster view), so the staged directory is invisible to the server, the database name is free for an immediate re-create the moment apply returns, and anything left behind by a crash or a shutdown is swept on the next start.

The engine change is the enabling primitive: `LocalDatabase.closeForDrop()` exposes the close half of `drop()` (drop-time semantics, no index flush and no file sync) without removing the files; `drop()` is now `closeForDrop()` plus the delete, so its behaviour is unchanged. Close, deregister and rename are held together under `server.getDatabasesLock()`, mirroring `SnapshotInstaller.swapAndReopen`, so no concurrent open can reopen the directory in between. If the rename is not possible on the filesystem, the deleter falls back to deleting inline, which is exactly the behaviour that predates this change.

## Test plan

- [ ] `mvn -pl engine test -Dtest=LocalDatabaseCloseForDropTest` - 4 tests: `closeForDrop` keeps the files, the database reopens afterwards, `drop()` still deletes, `closeForDrop` inside a transaction throws.
- [ ] `mvn -pl ha-raft test -Dtest=DeferredDatabaseDeleterTest` - 6 tests: with the executor blocked, the source directory is gone but the files are still on disk under the staged name (the regression assertion); the staged name is a reserved sibling; repeated drops of the same name get distinct directories; missing directory is a no-op; the sweep removes orphans and nothing else.
- [ ] `mvn -pl ha-raft test -Dtest=ArcadeStateMachineDeferredDropTest` - 4 tests: apply deregisters the database without deleting inline, the name is reusable as soon as apply returns, replay after the rename is a no-op, the bootstrap baseline is still evicted.
- [ ] `mvn -pl ha-raft test` - full unit suite, 752 tests.
- [ ] `mvn -pl ha-raft verify -DskipITs=false -Dit.test=RaftDropDatabase3NodesIT` - the existing 3-node drop IT still sees `databases/<name>` gone on every peer.
- [ ] `mvn -pl server verify -DskipITs=false -Dit.test=PostServerCommandHandlerIT` - 23 tests.

All of the above were run green on this branch. Tracking notes, including the two known gaps left open (the non-HA drop path and the client-visible indeterminate outcome), are in `docs/5454-ha-drop-database-deferred-deletion.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
