### PR TITLE
fix(#5453): gate leader readiness on the Ratis isLeaderReady signal

### DIFF
--- a/docs/5453-raft-leader-advertised-before-ready.md
+++ b/docs/5453-raft-leader-advertised-before-ready.md
@@ -1,0 +1,129 @@
+# Issue #5453 - Raft leader is advertised as available before it is ready to serve
+
+## Symptom
+
+A freshly elected Raft leader was advertised as available the instant Ratis elected it, while Ratis
+itself still rejected client requests with the retryable `LeaderNotReadyException` until the leader
+had committed a no-op entry in its current term and caught its state machine up.
+
+A client that wrote immediately after seeing `"isLeader": true` absorbed a run of retries. The client
+retry policy is a fixed 1-second cadence and the caller's budget is `arcadedb.ha.quorumTimeout`
+(default 10000 ms), so there is a hard cliff at ten retries and the write surfaced as
+
+```
+ReplicationDispatchedTimeoutException:
+  Group commit entry failed: TimeoutException (entry was dispatched to Raft; outcome unknown)
+```
+
+even though nothing was wrong with the cluster. Observed while investigating the nightly `e2e-ha`
+suite (PR #5452): the durations of successful `drop database` calls issued right after
+`"isLeader": true` were sharply bimodal, with a slow bucket sitting in a 0.38-second band
+immediately below the 10-second timeout - the signature of a fixed retry cadence, not of work
+proportional to data.
+
+## Root cause
+
+`RaftHAServer` never consulted Ratis' own readiness signal. `DivisionInfo` exposes both
+
+```java
+default boolean isLeader();     // current role == LEADER
+boolean isLeaderReady();        // current role == LEADER *and* ready to serve
+```
+
+and `isLeaderReady()` was unused anywhere in the codebase. Two places assumed role implies
+readiness:
+
+1. `isReadyForTraffic` / `isReadyForTrafficState` - the readiness probe added in #4834 carefully
+   checked follower lag, membership and in-flight resync, then short-circuited unconditionally for
+   the leader:
+
+   ```java
+   if (leader)
+     return true;   // "the leader is always caught up with itself"
+   ```
+
+   That holds for a leader in steady state, but not for one that has just won an election and has
+   not yet committed its current-term no-op. The probe therefore advertised Ready on a node that
+   would reject the very next write.
+
+2. `GET /api/v1/cluster` and the HA stats reported only the raw `isLeader` role, so a client had no
+   way to distinguish "is the leader" from "can serve now".
+
+## Fix
+
+### 1. Expose the Ratis readiness signal
+
+`RaftHAServer.isLeaderReady()` mirrors the existing `isLeader()` shape, including the defensive
+try/catch that degrades a status read to "unknown" rather than propagating the
+`IllegalStateException` Ratis throws while an in-place restart re-initializes the division
+(issue #5271).
+
+### 2. Fail the readiness probe closed on a not-yet-ready leader
+
+`isReadyForTrafficState` gains a `leaderReady` parameter and the leader branch becomes
+
+```java
+if (leader)
+  return leaderReady;
+```
+
+`isReadyForTraffic` feeds it `info.isLeaderReady()` from the same single `getDivision(...)` snapshot
+the other inputs come from, so leader/readiness/membership/commit/applied stay a consistent view.
+
+`leaderReady` had to be a distinct input rather than a redefinition of the existing `leader`
+parameter. Passing `isLeaderReady()` in as `leader` would let a not-yet-ready leader fall through to
+the follower lag branch, where a freshly elected leader typically has `commitIndex == appliedIndex`
+and would be reported Ready anyway - defeating the fix.
+
+The pre-existing 6- and 7-argument overloads delegate with `leaderReady = leader`, preserving their
+documented behaviour for existing callers; the 8-argument overload is the production entry point.
+This mirrors how the `resyncInProgress` parameter was added in #5273.
+
+### 3. Report readiness distinctly, without a compatibility break
+
+`isLeader` keeps meaning the raw Raft role on every surface. A new `leaderReady` field is added
+alongside it in:
+
+- `GET /api/v1/cluster` (`GetClusterHandler`)
+- the HA stats map (`RaftHAServer.getStats`)
+- the exported cluster status JSON (`RaftClusterStatusExporter`)
+
+Callers - Studio, the cluster tooling, and application code that polls for a leader before writing -
+opt in to the stricter signal rather than having `isLeader` change meaning underneath them.
+
+### Deliberately not changed
+
+The ~12 `isLeader()` guards on leader-only write paths in `RaftHAServer` and `ArcadeStateMachine`
+keep using the raw role. Those paths submit to Ratis, which rejects with the retryable
+`LeaderNotReadyException` and retries on the client's behalf; gating them on readiness would convert
+a transparent retry into a hard local rejection without improving the outcome. The problem this
+issue describes is that *external* callers had no way to see the distinction, which is what the new
+field and the probe gate address.
+
+## Tests
+
+`ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerReadinessTest.java`
+
+- `freshlyElectedLeaderNotYetReadyIsNotReadyForTraffic` - the regression: leader present, in config,
+  no resync, `commitIndex == appliedIndex` (so the follower lag branch would pass), but
+  `leaderReady = false`. Must be false.
+- `readyLeaderIsReadyForTraffic` - same inputs with `leaderReady = true` are Ready.
+- `notYetReadyLeaderIsNotRescuedByZeroLag` - explicitly pins that the un-ready leader does not fall
+  through to the follower lag calculation.
+- `followerIgnoresLeaderReadyFlag` - a caught-up follower is Ready regardless of `leaderReady`,
+  which is a leader-only signal.
+- `sevenArgOverloadTreatsAnyLeaderAsReady` / `sixArgOverloadTreatsAnyLeaderAsReady` - the legacy
+  overloads keep their previous semantics.
+
+`ha-raft/src/test/java/com/arcadedb/server/ha/raft/GetClusterHandlerIT.java`
+
+- `clusterEndpointReportsLeaderReadiness` - every node carries `leaderReady`; the leader of a
+  settled cluster reports it true and a follower reports it false.
+
+## Verification
+
+```
+mvn -pl ha-raft -am -DskipTests install
+mvn -pl ha-raft test -Dtest=RaftHAServerReadinessTest
+mvn -pl ha-raft test -Dtest=GetClusterHandlerIT
+```

--- a/docs/5453-raft-leader-advertised-before-ready.md
+++ b/docs/5453-raft-leader-advertised-before-ready.md
@@ -108,6 +108,18 @@ a transparent retry into a hard local rejection without improving the outcome. T
 issue describes is that *external* callers had no way to see the distinction, which is what the new
 field and the probe gate address.
 
+## Operational impact
+
+This is not purely an additive JSON field: `isReadyForTraffic` backs the readiness endpoint via
+`RaftHAPlugin`, so a freshly elected leader now reports **not ready** for the brief window between
+winning the election and committing its current-term no-op. That is the intended effect - it is what
+stops a Kubernetes rolling restart from sending traffic to a leader that will reject it - but
+operators who expect a leader to be Ready the instant it is elected will see a short additional
+delay. Worth calling out in the release notes.
+
+A leader stays ready once Ratis marks it ready, until it loses leadership, so steady-state leaders
+are unaffected.
+
 ## Tests
 
 `ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerReadinessTest.java`
@@ -160,3 +172,27 @@ overload delegation. Three non-blocking observations, two of which were applied:
   stays ready once ready until it loses leadership, so steady-state leaders are unaffected.
 
 gemini-code-assist did not review within the 15-minute polling window.
+
+### Cycle 2 - f8d243d (claude[bot])
+
+"Recommend merge", no blocking findings. The reviewer independently confirmed that Ratis 3.2.2
+exposes `isLeaderReady()` and that it implies `isLeader()`, that `studio-cluster.js` reads only
+`isLeader` so nothing breaks, and that no other compile-scope consumer is affected. Three
+non-blocking notes:
+
+- *The readiness probe behaviour changes, not just the JSON* - correct, and worth operator
+  visibility. Captured in the "Operational impact" section above.
+- *WARNING log volume from `getLeadershipState()` on polled surfaces* - no action. The reviewer
+  concluded there is no net increase, since those callers already invoked `isLeader()`, which logs
+  identically.
+- *Studio could render `leaderReady`* - explicitly out of scope for this PR; see "Deferred" below.
+
+gemini-code-assist again did not review within the polling window (a known inconsistency for this
+repository, unrelated to this change).
+
+## Deferred
+
+Studio's `studio-cluster.js` still renders only `isLeader`. Surfacing the new signal - for example a
+"leader (initializing)" state while `leaderReady` is false - would make the UI reflect the same
+distinction the API now exposes. Left out deliberately to keep this PR scoped to the server-side
+defect; worth a follow-up issue.

--- a/docs/5453-raft-leader-advertised-before-ready.md
+++ b/docs/5453-raft-leader-advertised-before-ready.md
@@ -1,5 +1,7 @@
 # Issue #5453 - Raft leader is advertised as available before it is ready to serve
 
+PR: https://github.com/ArcadeData/arcadedb/pull/5458
+
 ## Symptom
 
 A freshly elected Raft leader was advertised as available the instant Ratis elected it, while Ratis
@@ -91,6 +93,12 @@ alongside it in:
 Callers - Studio, the cluster tooling, and application code that polls for a leader before writing -
 opt in to the stricter signal rather than having `isLeader` change meaning underneath them.
 
+All three read the pair through `RaftHAServer.getLeadershipState()`, which resolves the division
+once and returns both flags. Two separate `isLeader()` / `isLeaderReady()` calls could straddle a
+leadership change and publish the impossible pair `isLeader=false, leaderReady=true`; a payload that
+carries both fields should never be internally contradictory. `isLeaderReady()` is retained as the
+public single-flag companion to `isLeader()` and delegates to the same accessor.
+
 ### Deliberately not changed
 
 The ~12 `isLeader()` guards on leader-only write paths in `RaftHAServer` and `ArcadeStateMachine`
@@ -117,13 +125,38 @@ field and the probe gate address.
 
 `ha-raft/src/test/java/com/arcadedb/server/ha/raft/GetClusterHandlerIT.java`
 
-- `clusterEndpointReportsLeaderReadiness` - every node carries `leaderReady`; the leader of a
-  settled cluster reports it true and a follower reports it false.
+- `clusterEndpointReportsLeaderReadiness` - every node carries `leaderReady`; a follower reports it
+  false, and the elected leader reports it true. The leader assertion polls with Awaitility rather
+  than sampling once: the role flips to LEADER before Ratis marks the node ready, which is the very
+  window this issue is about, so a single sample would be racy by construction.
 
 ## Verification
 
 ```
 mvn -pl ha-raft -am -DskipTests install
-mvn -pl ha-raft test -Dtest=RaftHAServerReadinessTest
-mvn -pl ha-raft test -Dtest=GetClusterHandlerIT
+mvn -pl ha-raft test -Dtest=RaftHAServerReadinessTest,GetClusterHandlerIT,RaftClusterStatusExporterReemitTest,RaftHTTP2ServersIT
+mvn -pl server test -Dtest=GetReadyHandlerHATest,HealthProbesIT
 ```
+
+All green (44 + 11 tests). The gate was confirmed to genuinely fail closed by temporarily restoring
+`if (leader) return true;`, which fails exactly
+`freshlyElectedLeaderNotYetReadyIsNotReadyForTraffic` and `notYetReadyLeaderIsNotRescuedByZeroLag`
+and nothing else.
+
+## Review cycles
+
+### Cycle 1 - fa1743d (claude[bot])
+
+No blocking findings; the reviewer confirmed the core semantics, the defensive read and the legacy
+overload delegation. Three non-blocking observations, two of which were applied:
+
+- *Torn read on the reporting surfaces* - flagged as cosmetic, applied anyway. The three payloads
+  now read both flags from one snapshot via `getLeadershipState()`, so the contradictory pair can no
+  longer be published.
+- *IT robustness* - flagged as "only if it actually flakes", applied. The single-sample assertion on
+  the leader's `leaderReady` was racy by construction, for exactly the reason this issue exists; it
+  is now a bounded Awaitility poll.
+- *`isReadyForTraffic` is strictly stricter for leaders* - intended behaviour, no change. A leader
+  stays ready once ready until it loses leadership, so steady-state leaders are unaffected.
+
+gemini-code-assist did not review within the 15-minute polling window.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -81,14 +81,15 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
     // operator can see that the cluster is running without failover margin.
     response.put("raftState", raftHAServer.getRaftLifeCycleState().name());
 
-    final boolean isLeader = raftHAServer.isLeader();
-    response.put("isLeader", isLeader);
-
     // The raw role is not the same as the ability to serve: a node that has just won an election
     // rejects writes with the retryable LeaderNotReadyException until it has committed its
     // current-term no-op. A client that writes as soon as it sees isLeader can burn its whole
     // arcadedb.ha.quorumTimeout budget on retries, so readiness is published separately (issue #5453).
-    response.put("leaderReady", raftHAServer.isLeaderReady());
+    // One snapshot feeds both fields, so the pair can never be contradictory.
+    final RaftHAServer.LeadershipState leadership = raftHAServer.getLeadershipState();
+    final boolean isLeader = leadership.leader();
+    response.put("isLeader", isLeader);
+    response.put("leaderReady", leadership.leaderReady());
 
     final RaftPeerId leaderId = raftHAServer.getLeaderId();
     response.put("leaderId", leaderId != null ? leaderId.toString() : JSONObject.NULL);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -84,6 +84,12 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
     final boolean isLeader = raftHAServer.isLeader();
     response.put("isLeader", isLeader);
 
+    // The raw role is not the same as the ability to serve: a node that has just won an election
+    // rejects writes with the retryable LeaderNotReadyException until it has committed its
+    // current-term no-op. A client that writes as soon as it sees isLeader can burn its whole
+    // arcadedb.ha.quorumTimeout budget on retries, so readiness is published separately (issue #5453).
+    response.put("leaderReady", raftHAServer.isLeaderReady());
+
     final RaftPeerId leaderId = raftHAServer.getLeaderId();
     response.put("leaderId", leaderId != null ? leaderId.toString() : JSONObject.NULL);
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterStatusExporter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterStatusExporter.java
@@ -60,10 +60,11 @@ class RaftClusterStatusExporter {
     haJSON.put("protocol", "ratis");
     haJSON.put("clusterName", haServer.getClusterName());
     haJSON.put("leader", haServer.getLeaderName());
-    haJSON.put("isLeader", haServer.isLeader());
     // Raw role vs. ability to serve: a freshly elected leader rejects writes until it has committed its
-    // current-term no-op (issue #5453).
-    haJSON.put("leaderReady", haServer.isLeaderReady());
+    // current-term no-op (issue #5453). Both come from one snapshot so the pair is never contradictory.
+    final RaftHAServer.LeadershipState leadership = haServer.getLeadershipState();
+    haJSON.put("isLeader", leadership.leader());
+    haJSON.put("leaderReady", leadership.leaderReady());
     haJSON.put("localPeerId", haServer.getLocalPeerId().toString());
     haJSON.put("configuredServers", haServer.getConfiguredServers());
     haJSON.put("quorum", haServer.getQuorum().name());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterStatusExporter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterStatusExporter.java
@@ -61,6 +61,9 @@ class RaftClusterStatusExporter {
     haJSON.put("clusterName", haServer.getClusterName());
     haJSON.put("leader", haServer.getLeaderName());
     haJSON.put("isLeader", haServer.isLeader());
+    // Raw role vs. ability to serve: a freshly elected leader rejects writes until it has committed its
+    // current-term no-op (issue #5453).
+    haJSON.put("leaderReady", haServer.isLeaderReady());
     haJSON.put("localPeerId", haServer.getLocalPeerId().toString());
     haJSON.put("configuredServers", haServer.getConfiguredServers());
     haJSON.put("quorum", haServer.getQuorum().name());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1395,16 +1395,34 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * term and caught its state machine up, so {@link #isLeader()} alone must not be read as "can serve now".
    */
   public boolean isLeaderReady() {
+    return getLeadershipState().leaderReady();
+  }
+
+  /**
+   * The raw Raft role and Ratis' readiness signal, read from one division snapshot.
+   *
+   * @param leader      this node currently holds the LEADER role
+   * @param leaderReady this node is the leader <em>and</em> can serve now
+   */
+  public record LeadershipState(boolean leader, boolean leaderReady) {
+  }
+
+  /**
+   * Returns {@link #isLeader()} and {@link #isLeaderReady()} read from a single {@code getDivision(...)}
+   * snapshot, so a status payload carrying both can never report the impossible pair
+   * {@code leader=false, leaderReady=true} produced by a leadership change landing between two separate
+   * reads. Degrades to {@code (false, false)} on an unreadable division, matching the single-flag getters.
+   */
+  public LeadershipState getLeadershipState() {
     if (raftServer == null)
-      return false;
+      return new LeadershipState(false, false);
 
     try {
-      return raftServer.getDivision(raftGroup.getGroupId()).getInfo().isLeaderReady();
+      final var info = raftServer.getDivision(raftGroup.getGroupId()).getInfo();
+      return new LeadershipState(info.isLeader(), info.isLeaderReady());
     } catch (final Exception e) {
-      // Same contract as isLeader(): status reads degrade to "unknown", never propagate. Guards the
-      // IllegalStateException Ratis throws while an in-place restart re-initializes the division.
-      LogManager.instance().log(this, Level.WARNING, "Error checking leader readiness", e);
-      return false;
+      LogManager.instance().log(this, Level.WARNING, "Error checking leadership state", e);
+      return new LeadershipState(false, false);
     }
   }
 
@@ -1587,8 +1605,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   public Map<String, Object> getStats() {
     final Map<String, Object> stats = new HashMap<>();
     stats.put("localPeerId", localPeerId.toString());
-    stats.put("isLeader", isLeader());
-    stats.put("leaderReady", isLeaderReady());
+    final LeadershipState leadership = getLeadershipState();
+    stats.put("isLeader", leadership.leader());
+    stats.put("leaderReady", leadership.leaderReady());
     stats.put("configuredServers", getConfiguredServers());
 
     if (clusterMonitor != null) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1389,6 +1389,26 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
+   * Returns true if this server is the current Raft leader <em>and</em> Ratis considers it ready to serve.
+   * A node that has just won an election reports the leader role immediately but rejects client requests
+   * with the retryable {@code LeaderNotReadyException} until it has committed a no-op entry in its current
+   * term and caught its state machine up, so {@link #isLeader()} alone must not be read as "can serve now".
+   */
+  public boolean isLeaderReady() {
+    if (raftServer == null)
+      return false;
+
+    try {
+      return raftServer.getDivision(raftGroup.getGroupId()).getInfo().isLeaderReady();
+    } catch (final Exception e) {
+      // Same contract as isLeader(): status reads degrade to "unknown", never propagate. Guards the
+      // IllegalStateException Ratis throws while an in-place restart re-initializes the division.
+      LogManager.instance().log(this, Level.WARNING, "Error checking leader readiness", e);
+      return false;
+    }
+  }
+
+  /**
    * Returns the peer ID of the current Raft leader, or null if unknown.
    */
   public RaftPeerId getLeaderId() {
@@ -1568,6 +1588,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final Map<String, Object> stats = new HashMap<>();
     stats.put("localPeerId", localPeerId.toString());
     stats.put("isLeader", isLeader());
+    stats.put("leaderReady", isLeaderReady());
     stats.put("configuredServers", getConfiguredServers());
 
     if (clusterMonitor != null) {
@@ -1802,9 +1823,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   /**
    * Reports whether this node is ready to serve traffic for the readiness probe (issue #4834): a leader is
    * known, this node is a member of the current Raft configuration, and - for a follower - the local
-   * applied index is within {@code maxLagEntries} of the commit index. The leader is always caught up with
-   * itself. Returns {@code false} before the Raft server has started, during shutdown, or when the state
-   * cannot be read.
+   * applied index is within {@code maxLagEntries} of the commit index. A leader is Ready only once Ratis
+   * reports it ready, which a freshly elected one is not until it has committed its current-term no-op
+   * (issue #5453). Returns {@code false} before the Raft server has started, during shutdown, or when the
+   * state cannot be read.
    * <p>
    * All inputs are read from a single {@code getDivision(...)} snapshot so leader/membership/commit/applied
    * come from one consistent view rather than re-resolving the division per field (cheaper, and avoids a
@@ -1830,7 +1852,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       final ArcadeStateMachine sm = getStateMachine();
       final boolean resyncInProgress = sm != null && sm.isResyncInProgress();
       return isReadyForTrafficState(leaderPresent, localInConfig, info.isLeader(), commitIndex, appliedIndex,
-          maxLagEntries, resyncInProgress);
+          maxLagEntries, resyncInProgress, info.isLeaderReady());
     } catch (final IOException e) {
       LogManager.instance().log(this, Level.FINE, "Cannot read Raft state for readiness probe", e);
       return false;
@@ -1840,11 +1862,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   /**
    * Pure decision function behind {@link #isReadyForTraffic(long)}, split out so the predicate can be
    * unit-tested without the Ratis state plumbing. Returns {@code true} only when a leader is present and
-   * this node is in the current configuration, and either this node is the leader (caught up with itself by
-   * definition) or - as a follower - the lag {@code commitIndex - appliedIndex} is in
+   * this node is in the current configuration, and either this node is the leader (treated as caught up
+   * with itself by this overload) or - as a follower - the lag {@code commitIndex - appliedIndex} is in
    * {@code [0, maxLagEntries]}. A negative {@code commitIndex}/{@code appliedIndex} (state not readable this
    * tick) or a negative lag ({@code appliedIndex > commitIndex}, an inconsistent state) returns
    * {@code false} so the probe fails closed rather than advertising Ready on unreadable/inconsistent state.
+   * Production code calls the 8-argument overload, which additionally requires the leader to be ready.
    */
   static boolean isReadyForTrafficState(final boolean leaderPresent, final boolean localInConfig,
       final boolean leader, final long commitIndex, final long appliedIndex, final long maxLagEntries) {
@@ -1863,12 +1886,32 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   static boolean isReadyForTrafficState(final boolean leaderPresent, final boolean localInConfig,
       final boolean leader, final long commitIndex, final long appliedIndex, final long maxLagEntries,
       final boolean resyncInProgress) {
+    return isReadyForTrafficState(leaderPresent, localInConfig, leader, commitIndex, appliedIndex, maxLagEntries,
+        resyncInProgress, leader);
+  }
+
+  /**
+   * Overload of {@link #isReadyForTrafficState(boolean, boolean, boolean, long, long, long, boolean)} that
+   * gates the leader branch on Ratis' own readiness signal (issue #5453) instead of assuming the role
+   * implies the ability to serve. A node that has just won an election reports the leader role before it
+   * has committed its current-term no-op, and rejects writes with the retryable
+   * {@code LeaderNotReadyException} until then; advertising Ready in that window makes a client's first
+   * write absorb retries until its {@code arcadedb.ha.quorumTimeout} budget expires.
+   * <p>
+   * {@code leaderReady} is a separate input rather than a redefinition of {@code leader} because a
+   * not-yet-ready leader must not fall through to the follower lag branch: a freshly elected leader
+   * typically has {@code commitIndex == appliedIndex} and would be reported Ready there anyway. The flag
+   * is meaningful only when {@code leader} is true; a follower's readiness is decided by its lag.
+   */
+  static boolean isReadyForTrafficState(final boolean leaderPresent, final boolean localInConfig,
+      final boolean leader, final long commitIndex, final long appliedIndex, final long maxLagEntries,
+      final boolean resyncInProgress, final boolean leaderReady) {
     if (!leaderPresent || !localInConfig)
       return false;
     if (resyncInProgress)
       return false;
     if (leader)
-      return true;
+      return leaderReady;
     if (commitIndex < 0 || appliedIndex < 0)
       return false;
     final long lag = commitIndex - appliedIndex;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/GetClusterHandlerIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/GetClusterHandlerIT.java
@@ -20,12 +20,14 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -118,9 +120,12 @@ class GetClusterHandlerIT extends BaseRaftHATest {
         assertThat(response.getBoolean("leaderReady")).as("a follower is never a ready leader").isFalse();
     }
 
-    // The cluster has settled by the time the leader is discoverable, so its leader reports ready.
-    assertThat(queryClusterEndpoint(leaderIndex).getBoolean("leaderReady"))
-        .as("the settled leader must report leaderReady").isTrue();
+    // The leader becomes discoverable (role flips to LEADER) before Ratis marks it ready, which is the
+    // very window this issue is about - so poll rather than assert on the first sample.
+    Awaitility.await("the elected leader reports leaderReady")
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> queryClusterEndpoint(leaderIndex).getBoolean("leaderReady"));
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/GetClusterHandlerIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/GetClusterHandlerIT.java
@@ -100,6 +100,29 @@ class GetClusterHandlerIT extends BaseRaftHATest {
     assertThat(leaderCount).isEqualTo(1);
   }
 
+  /**
+   * Issue #5453: the endpoint must let a client distinguish "is the leader" from "can serve now".
+   * {@code isLeader} keeps reporting the raw Raft role; the new {@code leaderReady} field carries
+   * Ratis' own readiness signal, which is false on a leader that has not yet committed its
+   * current-term no-op (and always false on a follower).
+   */
+  @Test
+  void clusterEndpointReportsLeaderReadiness() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final JSONObject response = queryClusterEndpoint(i);
+      assertThat(response.has("leaderReady")).as("every node must carry leaderReady").isTrue();
+      if (i != leaderIndex)
+        assertThat(response.getBoolean("leaderReady")).as("a follower is never a ready leader").isFalse();
+    }
+
+    // The cluster has settled by the time the leader is discoverable, so its leader reports ready.
+    assertThat(queryClusterEndpoint(leaderIndex).getBoolean("leaderReady"))
+        .as("the settled leader must report leaderReady").isTrue();
+  }
+
   @Test
   void allNodesAgreeOnLeader() throws Exception {
     final JSONObject response0 = queryClusterEndpoint(0);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerReadinessTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerReadinessTest.java
@@ -29,7 +29,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Raft configuration and replayed the committed log. Advertising Ready too early during a Kubernetes
  * StatefulSet rolling restart lets the orchestrator terminate the next pod and drop the write quorum.
  *
- * Argument order: leaderPresent, localInConfig, leader, commitIndex, appliedIndex, maxLagEntries.
+ * Argument order: leaderPresent, localInConfig, leader, commitIndex, appliedIndex, maxLagEntries,
+ * then the optional resyncInProgress and leaderReady flags.
  */
 class RaftHAServerReadinessTest {
 
@@ -117,5 +118,56 @@ class RaftHAServerReadinessTest {
   void sixArgOverloadDefaultsToNoResync() {
     // The legacy 6-arg predicate behaves exactly as before (resyncInProgress defaults to false).
     assertThat(isReadyForTrafficState(true, true, false, 1000, 1000, 100)).isTrue();
+  }
+
+  @Test
+  void freshlyElectedLeaderNotYetReadyIsNotReadyForTraffic() {
+    // Issue #5453: a node that has just won an election reports the LEADER role before it has
+    // committed its current-term no-op, and Ratis rejects writes with the retryable
+    // LeaderNotReadyException until then. The probe must fail closed on that window.
+    assertThat(isReadyForTrafficState(true, true, true, 1000, 1000, 100, false, false)).isFalse();
+  }
+
+  @Test
+  void readyLeaderIsReadyForTraffic() {
+    // Once Ratis reports the leader ready, the same node serves traffic.
+    assertThat(isReadyForTrafficState(true, true, true, 1000, 1000, 100, false, true)).isTrue();
+  }
+
+  @Test
+  void notYetReadyLeaderIsNotRescuedByZeroLag() {
+    // A not-yet-ready leader must not fall through to the follower lag branch: a freshly elected
+    // leader typically has commitIndex == appliedIndex, which would otherwise report Ready and
+    // defeat the gate.
+    assertThat(isReadyForTrafficState(true, true, true, 500, 500, 0, false, false)).isFalse();
+    // ... and a leader whose applied index trails is equally not Ready.
+    assertThat(isReadyForTrafficState(true, true, true, 5000, 100, 0, false, false)).isFalse();
+  }
+
+  @Test
+  void followerIgnoresLeaderReadyFlag() {
+    // leaderReady is a leader-only signal: a caught-up follower is Ready either way.
+    assertThat(isReadyForTrafficState(true, true, false, 1000, 1000, 100, false, false)).isTrue();
+    assertThat(isReadyForTrafficState(true, true, false, 1000, 1000, 100, false, true)).isTrue();
+    // A lagging follower stays not Ready even if the cluster's leader happens to be ready.
+    assertThat(isReadyForTrafficState(true, true, false, 100000, 5, 100, false, true)).isFalse();
+  }
+
+  @Test
+  void resyncStillWinsOverAReadyLeader() {
+    // The resync gate (#5273) is evaluated before the leader branch, so it still fails closed.
+    assertThat(isReadyForTrafficState(true, true, true, 1000, 1000, 100, true, true)).isFalse();
+  }
+
+  @Test
+  void sevenArgOverloadTreatsAnyLeaderAsReady() {
+    // The legacy 7-arg predicate keeps its documented behaviour (leaderReady defaults to leader),
+    // so existing callers are unaffected by the issue #5453 parameter.
+    assertThat(isReadyForTrafficState(true, true, true, 5000, 100, 0, false)).isTrue();
+  }
+
+  @Test
+  void sixArgOverloadTreatsAnyLeaderAsReady() {
+    assertThat(isReadyForTrafficState(true, true, true, 5000, 100, 0)).isTrue();
   }
 }


### PR DESCRIPTION
Closes #5453

A freshly elected Raft leader reports the `LEADER` role the instant Ratis elects it, while Ratis itself still rejects client requests with the retryable `LeaderNotReadyException` until the leader has committed a no-op entry in its current term and caught its state machine up. Both the readiness probe and `GET /api/v1/cluster` treated the raw role as "can serve now", so a client that wrote immediately after seeing `"isLeader": true` absorbed a run of 1-second retries and, if that run outlived `arcadedb.ha.quorumTimeout` (default 10 s), failed with a spurious `ReplicationDispatchedTimeoutException` - "outcome unknown" - with nothing actually wrong with the cluster.

`DivisionInfo.isLeaderReady()` is exactly this distinction and was unused anywhere in the codebase. This PR:

- adds `RaftHAServer.isLeaderReady()`, mirroring `isLeader()`'s defensive read (status reads degrade to "unknown" rather than propagating the `IllegalStateException` Ratis throws mid-restart, per #5271);
- gives `isReadyForTrafficState` a `leaderReady` input so the leader branch returns it instead of an unconditional `true`, fed from the same single `getDivision(...)` snapshot as the other inputs. It has to be a distinct parameter: passing `isLeaderReady()` in as `leader` would let a not-yet-ready leader fall through to the follower lag branch, where `commitIndex == appliedIndex` would report Ready anyway. The pre-existing 6- and 7-arg overloads delegate with `leaderReady = leader` and keep their documented behaviour, mirroring how `resyncInProgress` was added in #5273;
- publishes a new `leaderReady` field alongside the unchanged `isLeader` in `GET /api/v1/cluster`, the HA stats map and the exported cluster status. This is the no-compatibility-break option from the issue: Studio and the cluster tooling keep reading `isLeader` as the raw role and callers opt in to the stricter signal.

The ~12 `isLeader()` guards on leader-only write paths are deliberately left on the raw role. Those paths submit to Ratis, which rejects with the retryable `LeaderNotReadyException` and retries on the client's behalf; gating them on readiness would turn a transparent retry into a hard local rejection without improving the outcome.

Tracking doc: `docs/5453-raft-leader-advertised-before-ready.md`

## Test plan

- [x] `RaftHAServerReadinessTest` - 7 new cases covering the regression (un-ready leader with zero lag must not be Ready), the ready leader, the follower's indifference to the flag, the resync gate still winning, and both legacy overloads keeping their semantics.
- [x] Verified red before the fix: temporarily restoring `if (leader) return true;` fails `freshlyElectedLeaderNotYetReadyIsNotReadyForTraffic` and `notYetReadyLeaderIsNotRescuedByZeroLag`, and only those.
- [x] `GetClusterHandlerIT.clusterEndpointReportsLeaderReadiness` - every node carries `leaderReady`; a follower reports false and the settled leader reports true.
- [x] No regressions in `RaftClusterStatusExporterReemitTest`, `BootstrapElectionGateTest`, `ClusterMonitorTest`, `HealthMonitorTest`, `RaftHTTP2ServersIT` (ha-raft) and `GetReadyHandlerHATest`, `HealthProbesIT` (server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)