### PR TITLE
fix(e2e-studio): make DataTables assertions version-agnostic for v3

### DIFF
--- a/e2e-studio/tests/datatables-compatibility.spec.ts
+++ b/e2e-studio/tests/datatables-compatibility.spec.ts
@@ -16,15 +16,12 @@
 */
 
 /**
- * DataTables v2.3.3 Compatibility Test Suite
+ * DataTables Compatibility Test Suite
  *
- * This test suite validates the major DataTables upgrade from v1.13.x to v2.3.x
- * across all critical ArcadeDB Studio table functionality.
- *
- * UPGRADE CONTEXT:
- * - DataTables: 1.13.11 → 2.3.3 (MAJOR BREAKING CHANGES)
- * - All extensions upgraded to v3.x (buttons, responsive, select)
- * - Bootstrap integration: 5.3.6 → 5.3.7 (SAFE)
+ * This test suite validates ArcadeDB Studio's table functionality against the
+ * bundled DataTables release. It was written for the v1.13.x -> v2.x upgrade and
+ * is kept version-agnostic so it keeps guarding behavior across later majors
+ * (Studio currently ships DataTables v3.x with the v4.x extensions).
  *
  * CRITICAL TEST AREAS:
  * 1. Query result tables (highest priority)
@@ -40,7 +37,7 @@
 import { test, expect } from '@playwright/test';
 import { ArcadeStudioTestHelper, assertGraphState } from '../utils/test-utils';
 
-test.describe('DataTables v2.3.3 Compatibility Suite', () => {
+test.describe('DataTables Compatibility Suite', () => {
   let studioHelper: ArcadeStudioTestHelper;
 
   test.beforeEach(async ({ page }) => {
@@ -390,7 +387,7 @@ test.describe('DataTables v2.3.3 Compatibility Suite', () => {
   });
 
   test.describe('DataTables Configuration Validation', () => {
-    test('should validate v2.x initialization options', async ({ page }) => {
+    test('should validate initialization options', async ({ page }) => {
       await studioHelper.login('Beer');
       await studioHelper.executeQuery('SELECT name FROM Beer LIMIT 5', false);
 
@@ -399,20 +396,24 @@ test.describe('DataTables v2.3.3 Compatibility Suite', () => {
       await page.waitForTimeout(500);
       await expect(page.locator('#result')).toBeVisible();
 
-      // Check that DataTables v2.x configuration options are working
+      // Check that the DataTables configuration options are applied. Feature flags
+      // live under `settings.features` (camelCase) from v3 onwards; v2 exposed the
+      // same flags under the Hungarian-notation `settings.oFeatures`.
       const dtConfig = await page.evaluate(() => {
         const table = $('#result').DataTable();
+        const settings = table.settings()[0] as any;
+        const features = settings.features ?? settings.oFeatures ?? {};
         return {
           version: $.fn.dataTable.version,
           pageLength: table.page.len(),
-          ordering: table.settings()[0].oFeatures.bSort,
-          paging: table.settings()[0].oFeatures.bPaginate,
-          searching: table.settings()[0].oFeatures.bFilter
+          ordering: features.ordering ?? features.bSort,
+          paging: features.paging ?? features.bPaginate,
+          searching: features.searching ?? features.bFilter
         };
       });
 
-      // Verify v2.x version
-      expect(dtConfig.version).toMatch(/^2\./);
+      // A modern DataTables (v2 or newer) must be loaded - v1 is not supported
+      expect(parseInt(dtConfig.version.split('.')[0], 10)).toBeGreaterThanOrEqual(2);
 
       // Verify configuration options
       expect(dtConfig.pageLength).toBe(20); // As set in studio-table.js

--- a/e2e-studio/tests/datatables-critical-validation.spec.ts
+++ b/e2e-studio/tests/datatables-critical-validation.spec.ts
@@ -19,7 +19,9 @@
  * DataTables Critical Validation - Focused Test Suite
  *
  * This focused test suite validates the most critical DataTables functionality
- * after the v2.3.3 upgrade to identify specific breaking changes.
+ * against the bundled DataTables release, to surface breaking changes introduced
+ * by a major upgrade. Assertions are kept version-agnostic so the suite keeps
+ * guarding behavior across majors.
  */
 
 import { test, expect } from '@playwright/test';
@@ -32,7 +34,7 @@ test.describe('DataTables Critical Validation', () => {
     studioHelper = new ArcadeStudioTestHelper(page);
   });
 
-  test('should validate DataTables v2.x initialization and basic functionality', async ({ page }) => {
+  test('should validate DataTables initialization and basic functionality', async ({ page }) => {
     await studioHelper.login('Beer');
 
     // Execute a simple query
@@ -48,13 +50,14 @@ test.describe('DataTables Critical Validation', () => {
     // Check specific result table wrapper (v2.x uses .dt-container)
     await expect(page.locator('#result_wrapper.dt-container, #result_wrapper.dataTables_wrapper')).toBeVisible();
 
-    // Verify DataTables v2.x version
+    // Verify a modern DataTables (v2 or newer) is loaded - v1 is not supported
     const dtVersion = await page.evaluate(() => {
       return typeof $.fn.dataTable !== 'undefined' ? $.fn.dataTable.version : 'Not loaded';
     });
 
     console.log(`DataTables version detected: ${dtVersion}`);
-    expect(dtVersion).toMatch(/^2\./);
+    expect(dtVersion).toMatch(/^\d+\.\d+\.\d+/);
+    expect(parseInt(dtVersion.split('.')[0], 10)).toBeGreaterThanOrEqual(2);
 
     // Verify table has data
     const rowCount = await page.locator('#result tbody tr').count();
@@ -83,16 +86,21 @@ test.describe('DataTables Critical Validation', () => {
     await page.waitForTimeout(500);
     await expect(page.locator('#result')).toBeVisible();
 
-    // Check if table initialization used deprecated APIs
+    // Check the table's internal state. Row and column stores are exposed as
+    // `settings.data` / `settings.columns` from v3 onwards; v2 used the
+    // Hungarian-notation `aoData` / `aoColumns` / `sDom` names.
     const configInfo = await page.evaluate(() => {
       const table = $('#result').DataTable();
-      const settings = table.settings()[0];
+      const settings = table.settings()[0] as any;
+
+      const rows = settings.data ?? settings.aoData ?? [];
+      const columns = settings.columns ?? settings.aoColumns ?? [];
 
       return {
-        hasData: settings.aoData && settings.aoData.length > 0,
-        hasColumns: settings.aoColumns && settings.aoColumns.length > 0,
+        hasData: rows.length > 0,
+        hasColumns: columns.length > 0,
         apiVersion: $.fn.dataTable.version,
-        domStructure: settings.sDom || 'undefined'
+        domStructure: settings.dom ?? settings.sDom ?? 'undefined'
       };
     });
 

--- a/e2e-studio/tests/datatables-upgrade-validation.spec.ts
+++ b/e2e-studio/tests/datatables-upgrade-validation.spec.ts
@@ -18,8 +18,8 @@
 import { test, expect } from '../fixtures/test-fixtures';
 import { ArcadeStudioTestHelper, TEST_CONFIG } from '../utils';
 
-test.describe('DataTables v2.3.2 Upgrade Validation Tests', () => {
-  test('should load DataTables v2.3.2 without JavaScript errors', async ({ page }) => {
+test.describe('DataTables Upgrade Validation Tests', () => {
+  test('should load DataTables without JavaScript errors', async ({ page }) => {
     const helper = new ArcadeStudioTestHelper(page);
 
     // Track any JavaScript errors
@@ -317,7 +317,7 @@ test.describe('DataTables v2.3.2 Upgrade Validation Tests', () => {
     expect(responsiveTest.tableVisible).toBe(true, 'Table should be visible');
   });
 
-  test('should validate DataTables v2.x API compatibility fixes', async ({ page }) => {
+  test('should validate DataTables API compatibility fixes', async ({ page }) => {
     const helper = new ArcadeStudioTestHelper(page);
 
     // Login first to load DataTables libraries
@@ -325,21 +325,25 @@ test.describe('DataTables v2.3.2 Upgrade Validation Tests', () => {
 
     // Test that our studio-table.js fixes work correctly
     const apiCompatibilityTest = await page.evaluate(() => {
-      // Check if DataTables v2.x configuration is properly applied
-      const hasV2Features = {
-        // v2.x uses 'columns' instead of 'aoColumns'
+      // Check that the modern (non-Hungarian) option names are the defaults
+      const hasModernFeatures = {
+        // modern DataTables uses 'columns' instead of 'aoColumns'
         columnsProperty: typeof (window as any).$.fn.DataTable.defaults.columns !== 'undefined',
-        // v2.x uses 'data' instead of 'aaData'
+        // modern DataTables uses 'data' instead of 'aaData'
         dataProperty: typeof (window as any).$.fn.DataTable.defaults.data !== 'undefined',
         // Check version
         version: (window as any).$.fn.DataTable.version || 'unknown'
       };
 
-      return hasV2Features;
+      return hasModernFeatures;
     });
 
     console.log('API compatibility test:', apiCompatibilityTest);
-    expect(apiCompatibilityTest.version).toMatch(/^2\./);
+    // A modern DataTables (v2 or newer) must be loaded - v1 is not supported
+    expect(apiCompatibilityTest.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(parseInt(apiCompatibilityTest.version.split('.')[0], 10)).toBeGreaterThanOrEqual(2);
+    expect(apiCompatibilityTest.columnsProperty).toBe(true);
+    expect(apiCompatibilityTest.dataProperty).toBe(true);
 
     // Execute a query to test that our API fixes work
     await helper.executeQuery('SELECT name, brewery FROM Beer LIMIT 5', false);


### PR DESCRIPTION
## What does this PR do?

Fixes the four failing `e2e-studio` DataTables tests by making their assertions version-agnostic, so they pass on DataTables v3 (and still on v2).

DataTables 3 dropped the Hungarian-notation settings in favor of camelCase:

| v2 (removed in v3) | v3 |
|---|---|
| `settings.oFeatures.bSort` / `bPaginate` / `bFilter` | `settings.features.ordering` / `paging` / `searching` |
| `settings.aoData` | `settings.data` |
| `settings.aoColumns` | `settings.columns` |
| `settings.sDom` | `settings.dom` |

Each site now reads the modern name with a `??` fallback to the legacy one, and the hard-coded `/^2\./` version regexes are replaced with a major-version floor (`>= 2`) so the next major bump does not break CI the same way. Suite titles that named releases which were never actually shipped (`DataTables v2.3.3 Compatibility Suite`, `v2.3.2 Upgrade Validation Tests`) lost their version numbers. The upgrade-validation test now also asserts the `columnsProperty` / `dataProperty` values it already computed but never checked.

Mid-test phrasings like "v2.x API" are left alone: there they mean "the modern non-Hungarian API", which is still accurate under v3.

## Motivation

CI on an unrelated PR reported `79 passed, 4 failed, 1 skipped`:

```
❌ should validate v2.x initialization options
   TypeError: Cannot read properties of undefined (reading 'bSort')
❌ should validate DataTables v2.x initialization and basic functionality
   expect(received).toMatch(expected)
❌ should check if deprecated API usage causes issues
   expect(received).toBe(expected)
❌ should validate DataTables v2.x API compatibility fixes
   expect(received).toMatch(expected)
```

Root cause is commit 7e10f2de5 (2026-07-26, dependabot), which bumped `datatables.net` 2.3.8 -> 3.0.0, its extensions 3.x -> 4.0.0, and jQuery to 4.0.0. Two things kept it from being caught on its own commit:

1. That commit is tagged `[skip ci]`, so the studio e2e suite never ran on it.
2. `studio/src/main/resources/static/dist/` is **not tracked in git** — `frontend-maven-plugin` rebuilds it (`npm ci` + `npm run build`) during the Maven package phase. So whatever `studio/package-lock.json` resolves is what the Docker image ships and what `studio-e2e-tests` actually exercises.

The breakage therefore surfaced on the next PR to touch anything.

**Studio itself needed no change.** Its JS uses none of the APIs DataTables 3 or jQuery 4 removed (no `oFeatures`/`aoData`/`aoColumns`/`sDom`, no `$.trim`/`.bind()`/`$.isArray`/`$.isFunction`), and DataTables 3 still honors the legacy `dom: "<Blf>rt<ip>"` option that `studio-table.js` passes, via its `legacyDom` path.

## Related issues

None filed; found via CI on an unrelated PR.

## Additional Notes

**This does not close the CI gap that let it through.** As long as studio dependabot PRs carry `[skip ci]` and `dist/` stays untracked, the next frontend major will land on `main` the same way. Worth a follow-up to `.github/dependabot.yml` or the studio workflow, deliberately out of scope here.

Verification, against a locally built `arcadedata/arcadedb:26.8.1-SNAPSHOT` image (confirmed to bundle DataTables 3.0.0):

| Run | Result |
|---|---|
| DataTables specs, before | **4 failed**, 30 passed — byte-for-byte the same 4 as CI |
| DataTables specs, after | **35 passed**, 0 failed |
| Full `e2e-studio` suite, after | **83 passed, 1 skipped, 0 failed** (84 total, matching CI) |

Repro note for anyone rebuilding: `./mvnw install -Pdocker` from the repo root did *not* refresh the Docker image; it has to be run from the `package` module.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
