### PR TITLE
feat(mcp)  : add per-principal tool profiles (#5468) (#5445)

### DIFF
--- a/docs/superpowers/specs/2026-07-27-mcp-principal-tool-profiles-5445-design.md
+++ b/docs/superpowers/specs/2026-07-27-mcp-principal-tool-profiles-5445-design.md
@@ -1,0 +1,91 @@
+# MCP per-principal tool profiles (#5445)
+
+**Issue:** [#5445](https://github.com/ArcadeData/arcadedb/issues/5445)
+**Epic:** [#4859 - MCP GraphRAG & Agent-Memory Surface](https://github.com/ArcadeData/arcadedb/issues/4859)
+**Date:** 2026-07-27
+**Status:** implemented
+
+## Decision
+
+The Model Context Protocol (MCP) configuration may restrict individual authenticated
+principals to one of the existing `all`, `rag`, or `admin` tool profiles. The server-global
+`profile` remains the backward-compatible default and a hard ceiling.
+
+For a principal with an override, a tool is available only when both the global profile and
+the principal profile contain it. This intersection means an override can narrow the endpoint
+but cannot expose a tool hidden globally. Existing read, write, schema, administrative,
+database, user, and origin permissions remain independent mandatory checks.
+
+## Configuration
+
+Overrides live under `principalProfiles` in `config/mcp-config.json`:
+
+```json
+{
+  "enabled": true,
+  "profile": "all",
+  "allowedUsers": ["retrieval-agent", "retrieval-token"],
+  "principalProfiles": {
+    "retrieval-agent": "rag",
+    "apitoken:retrieval-token": "rag"
+  }
+}
+```
+
+Named users use their user name. API tokens use the canonical authenticated principal name
+`apitoken:<token-name>`, which avoids ambiguity with a named user that happens to share the
+token's display name. Profile names are case-insensitive when parsed and serialized as
+lowercase.
+
+The global `allowedUsers` gate still decides whether a principal may reach MCP at all. Its
+existing bare-token convenience remains unchanged; the canonical prefix is required only for
+the profile map because that map identifies one exact principal.
+
+## Update semantics
+
+Configuration API updates merge `principalProfiles` by principal name:
+
+- A supplied profile replaces that principal's override.
+- A null principal value removes that one override.
+- `"principalProfiles": null` clears every override.
+- Omitting `principalProfiles` leaves the map unchanged.
+
+Blank principal names, non-string values, and unknown profile names are rejected before any
+other setting in the same update is applied. The serialized configuration omits
+`principalProfiles` when no overrides exist.
+
+An override for a principal that does not currently exist remains valid and inert. It starts
+applying only if authentication later produces that exact principal name. This supports
+pre-provisioning and token rotation without making configuration persistence depend on the
+current user registry.
+
+## Enforcement
+
+The shared `MCPDispatcher` resolves the effective tool set after authentication on every
+request. That one resolution path governs:
+
+- `initialize` instructions;
+- `tools/list` discovery; and
+- `tools/call` direct invocation.
+
+HTTP supplies the user authenticated for that request. Standard input/output mode supplies
+the user authenticated when the process starts. Both transports therefore use identical
+selection and enforcement rules.
+
+The global profile and principal override are both allowlists. For example, global `rag` plus
+principal `admin` exposes only the tools common to both profiles. A hidden tool remains denied
+when called directly by name.
+
+## Validation
+
+Focused tests cover:
+
+- persistence, canonical named-user and API-token identities;
+- merge, single-entry removal, and full-map clearing;
+- invalid names, values, and profiles without partial updates;
+- two named users receiving different HTTP tool lists on one endpoint;
+- API-token discovery and direct-call enforcement;
+- standard input/output principal resolution;
+- global-profile ceiling intersection;
+- fallback for principals without an override; and
+- initialization instructions matching the effective surface.

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -77,6 +77,7 @@ public class MCPConfiguration implements MCPPermissions {
   private volatile List<String> allowedUsers     = new CopyOnWriteArrayList<>(List.of("root"));
   private volatile Map<String, DatabaseOverride> databaseOverrides = Map.of();
   private volatile ToolProfile  toolProfile      = ToolProfile.ALL;
+  private volatile Map<String, ToolProfile> principalProfiles = Map.of();
   // Extra browser origins accepted by the HTTP transport, on top of always-allowed loopback origins.
   // Empty by default: a non-loopback browser page must be opted in explicitly, because deriving trust
   // from its Host header would not prevent DNS rebinding.
@@ -99,6 +100,8 @@ public class MCPConfiguration implements MCPPermissions {
       final Map<String, DatabaseOverride> loadedDatabaseOverrides =
           parseDatabaseOverrides(json.getJSONObject("databases", null));
       final ToolProfile loadedProfile = ToolProfile.parse(json.getString("profile", "all"));
+      final Map<String, ToolProfile> loadedPrincipalProfiles =
+          parsePrincipalProfiles(json.getJSONObject("principalProfiles", null));
 
       enabled = json.getBoolean("enabled", false);
       allowReads = json.getBoolean("allowReads", true);
@@ -109,6 +112,7 @@ public class MCPConfiguration implements MCPPermissions {
       allowAdmin = json.getBoolean("allowAdmin", false);
       databaseOverrides = loadedDatabaseOverrides;
       toolProfile = loadedProfile;
+      principalProfiles = loadedPrincipalProfiles;
 
       final JSONArray usersArray = json.getJSONArray("allowedUsers", null);
       if (usersArray != null) {
@@ -219,6 +223,14 @@ public class MCPConfiguration implements MCPPermissions {
     this.toolProfile = ToolProfile.parse(toolProfile);
   }
 
+  /**
+   * Returns the profile override for the authenticated principal, or {@code null} when the global profile applies
+   * without an additional restriction. API tokens use their canonical security name, {@code apitoken:<name>}.
+   */
+  public ToolProfile getPrincipalToolProfile(final String principalName) {
+    return principalName == null ? null : principalProfiles.get(principalName);
+  }
+
   public List<String> getAllowedOrigins() {
     return Collections.unmodifiableList(allowedOrigins);
   }
@@ -299,6 +311,12 @@ public class MCPConfiguration implements MCPPermissions {
     json.put("profile", toolProfile.configName());
     json.put("allowedUsers", new JSONArray(allowedUsers));
     json.put("allowedOrigins", new JSONArray(allowedOrigins));
+    if (!principalProfiles.isEmpty()) {
+      final JSONObject principals = new JSONObject();
+      for (final Map.Entry<String, ToolProfile> entry : principalProfiles.entrySet())
+        principals.put(entry.getKey(), entry.getValue().configName());
+      json.put("principalProfiles", principals);
+    }
     final JSONObject databases = new JSONObject();
     for (final Map.Entry<String, DatabaseOverride> entry : databaseOverrides.entrySet())
       databases.put(entry.getKey(), entry.getValue().toJSON());
@@ -314,6 +332,9 @@ public class MCPConfiguration implements MCPPermissions {
     final ToolProfile updatedProfile = json.has("profile")
         ? ToolProfile.parse(json.getString("profile", null))
         : toolProfile;
+    final Map<String, ToolProfile> updatedPrincipalProfiles = json.has("principalProfiles")
+        ? mergePrincipalProfiles(principalProfiles, json.getJSONObject("principalProfiles", null))
+        : principalProfiles;
 
     if (json.has("enabled"))
       enabled = booleanValue(json, "enabled");
@@ -331,6 +352,7 @@ public class MCPConfiguration implements MCPPermissions {
       allowAdmin = booleanValue(json, "allowAdmin");
     databaseOverrides = updatedDatabaseOverrides;
     toolProfile = updatedProfile;
+    principalProfiles = updatedPrincipalProfiles;
     if (json.has("allowedUsers")) {
       final JSONArray usersArray = json.getJSONArray("allowedUsers", null);
       // Treat explicit null as an empty list (client intent to clear all users)
@@ -381,6 +403,35 @@ public class MCPConfiguration implements MCPPermissions {
         result.remove(databaseName);
       else
         result.put(databaseName, DatabaseOverride.fromJSON(updates.getJSONObject(databaseName)));
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  private static Map<String, ToolProfile> parsePrincipalProfiles(final JSONObject profiles) {
+    if (profiles == null)
+      return Map.of();
+    return mergePrincipalProfiles(Map.of(), profiles);
+  }
+
+  private static Map<String, ToolProfile> mergePrincipalProfiles(
+      final Map<String, ToolProfile> current, final JSONObject updates) {
+    if (updates == null)
+      return Map.of();
+
+    final Map<String, ToolProfile> result = new LinkedHashMap<>(current);
+    for (final String principalName : updates.keySet()) {
+      if (principalName.isBlank())
+        throw new IllegalArgumentException("MCP principal profile names must not be blank");
+      if (updates.isNull(principalName)) {
+        result.remove(principalName);
+        continue;
+      }
+
+      final Object value = updates.opt(principalName);
+      if (!(value instanceof String profileName))
+        throw new IllegalArgumentException(
+            "MCP principal profile for '" + principalName + "' must be a profile name");
+      result.put(principalName, ToolProfile.parse(profileName));
     }
     return Collections.unmodifiableMap(result);
   }

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -73,6 +73,14 @@ public class MCPDispatcher {
       5. Use upsert_entity and upsert_relationship to maintain agent memory when the corresponding write permissions are enabled.
       6. ArcadeDB does not generate embeddings; supply vectors produced by your embedding model.""";
 
+  private static final String RESTRICTED_INSTRUCTIONS =
+      """
+      You are connected to an ArcadeDB multi-model database server with a restricted tool surface. Follow these rules:
+      1. Use only tools shown by tools/list; hidden tools cannot be invoked directly by name.
+      2. Call list_databases when you do not know the target database name.
+      3. Call get_schema before querying an unfamiliar database. If your client supports MCP Resources, prefer reading arcadedb://{database}/schema instead.
+      4. Use query for read-only SQL or Cypher retrieval.""";
+
   private static final Set<String> RAG_TOOL_NAMES = Set.of(
       "list_databases",
       "get_schema",
@@ -191,9 +199,9 @@ public class MCPDispatcher {
 
     try {
       return switch (method) {
-        case "initialize" -> result(id, initialize());
-        case "tools/list" -> result(id, new JSONObject().put("tools", toolsForProfile(config.getToolProfile())));
-        case "tools/call" -> toolsCall(id, params, user);
+        case "initialize" -> result(id, initialize(effectiveProfile(user)));
+        case "tools/list" -> result(id, new JSONObject().put("tools", toolsForProfile(effectiveProfile(user))));
+        case "tools/call" -> toolsCall(id, params, user, effectiveProfile(user));
         case "resources/list" -> resourcesList(id, user);
         case "resources/read" -> resourcesRead(id, params, user);
         case "ping" -> result(id, new JSONObject());
@@ -209,7 +217,7 @@ public class MCPDispatcher {
     }
   }
 
-  private JSONObject initialize() {
+  private JSONObject initialize(final EffectiveToolProfile profile) {
     final JSONObject result = new JSONObject();
     result.put("protocolVersion", MCP_PROTOCOL_VERSION);
 
@@ -223,8 +231,7 @@ public class MCPDispatcher {
     capabilities.put("resources", new JSONObject().put("listChanged", false).put("subscribe", false));
     result.put("capabilities", capabilities);
 
-    result.put("instructions",
-        config.getToolProfile() == MCPConfiguration.ToolProfile.RAG ? RAG_INSTRUCTIONS : INSTRUCTIONS);
+    result.put("instructions", instructionsForProfile(profile));
 
     return result;
   }
@@ -256,7 +263,8 @@ public class MCPDispatcher {
     }
   }
 
-  private MCPResponse toolsCall(final Object id, final JSONObject params, final ServerSecurityUser user) {
+  private MCPResponse toolsCall(final Object id, final JSONObject params, final ServerSecurityUser user,
+      final EffectiveToolProfile profile) {
     final String toolName = params.getString("name", "");
     final JSONObject args = params.getJSONObject("arguments", new JSONObject());
 
@@ -266,9 +274,9 @@ public class MCPDispatcher {
     try {
       if (!REGISTERED_TOOL_NAMES.contains(toolName))
         throw new IllegalArgumentException("Unknown tool: " + toolName);
-      if (!isToolAllowed(config.getToolProfile(), toolName))
+      if (!profile.allows(toolName))
         throw new SecurityException(
-            "Tool '" + toolName + "' is not available in MCP profile '" + config.getToolProfile().configName() + "'");
+            "Tool '" + toolName + "' is not available in " + profile.description());
 
       final JSONObject toolResult = switch (toolName) {
         case "list_databases" -> ListDatabasesTool.execute(server, user, args, config);
@@ -312,11 +320,17 @@ public class MCPDispatcher {
     }
   }
 
-  private static JSONArray toolsForProfile(final MCPConfiguration.ToolProfile profile) {
+  private EffectiveToolProfile effectiveProfile(final ServerSecurityUser user) {
+    return new EffectiveToolProfile(
+        config.getToolProfile(),
+        config.getPrincipalToolProfile(user.getName()));
+  }
+
+  private static JSONArray toolsForProfile(final EffectiveToolProfile profile) {
     final JSONArray filtered = new JSONArray();
     for (int i = 0; i < TOOLS_LIST.length(); i++) {
       final JSONObject definition = TOOLS_LIST.getJSONObject(i);
-      if (isToolAllowed(profile, definition.getString("name")))
+      if (profile.allows(definition.getString("name")))
         filtered.put(definition);
     }
     return filtered;
@@ -330,6 +344,39 @@ public class MCPDispatcher {
       case RAG -> RAG_TOOL_NAMES.contains(toolName);
       case ADMIN -> ADMIN_TOOL_NAMES.contains(toolName);
     };
+  }
+
+  private static String instructionsForProfile(final EffectiveToolProfile profile) {
+    if (profile.matches(MCPConfiguration.ToolProfile.RAG))
+      return RAG_INSTRUCTIONS;
+    if (profile.matches(MCPConfiguration.ToolProfile.ALL)
+        || profile.matches(MCPConfiguration.ToolProfile.ADMIN))
+      return INSTRUCTIONS;
+    return RESTRICTED_INSTRUCTIONS;
+  }
+
+  private record EffectiveToolProfile(
+      MCPConfiguration.ToolProfile global,
+      MCPConfiguration.ToolProfile principal) {
+
+    private boolean allows(final String toolName) {
+      return isToolAllowed(global, toolName)
+          && (principal == null || isToolAllowed(principal, toolName));
+    }
+
+    private boolean matches(final MCPConfiguration.ToolProfile profile) {
+      for (final String toolName : REGISTERED_TOOL_NAMES)
+        if (allows(toolName) != isToolAllowed(profile, toolName))
+          return false;
+      return true;
+    }
+
+    private String description() {
+      if (principal == null)
+        return "MCP profile '" + global.configName() + "'";
+      return "global MCP profile '" + global.configName()
+          + "' intersected with principal profile '" + principal.configName() + "'";
+    }
   }
 
   private static String formatArgs(final JSONObject args) {

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
@@ -313,6 +313,17 @@ class MCPConfigurationTest {
   }
 
   @Test
+  void nullToolProfileIsRejected() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+
+    assertThatThrownBy(() -> config.setToolProfile((MCPConfiguration.ToolProfile) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be null");
+
+    assertThat(config.getToolProfile()).isEqualTo(MCPConfiguration.ToolProfile.ALL);
+  }
+
+  @Test
   void invalidBooleanTypeIsRejected() {
     final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
     config.load();

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
@@ -58,6 +58,7 @@ class MCPConfigurationTest {
     assertThat(config.isAllowSchemaChange()).isFalse();
     assertThat(config.getAllowedUsers()).containsExactly("root");
     assertThat(config.getToolProfile()).isEqualTo(MCPConfiguration.ToolProfile.ALL);
+    assertThat(config.getPrincipalToolProfile("root")).isNull();
   }
 
   @Test
@@ -144,6 +145,7 @@ class MCPConfigurationTest {
     assertThat(json.getJSONArray("allowedUsers").length()).isEqualTo(1);
     assertThat(json.getJSONArray("allowedUsers").getString(0)).isEqualTo("root");
     assertThat(json.has("databases")).isFalse();
+    assertThat(json.has("principalProfiles")).isFalse();
   }
 
   @Test
@@ -330,6 +332,90 @@ class MCPConfigurationTest {
 
     assertThat(config.getToolProfile()).isEqualTo(MCPConfiguration.ToolProfile.RAG);
     assertThat(config.toJSON().getString("profile")).isEqualTo("rag");
+  }
+
+  @Test
+  void principalProfilesPersistAndUseCanonicalPrincipalNames() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject()
+            .put("retrieval-user", "RaG")
+            .put("apitoken:admin-token", "ADMIN")));
+    config.save();
+
+    final MCPConfiguration loaded = new MCPConfiguration(TEST_ROOT);
+    loaded.load();
+
+    assertThat(loaded.getPrincipalToolProfile("retrieval-user"))
+        .isEqualTo(MCPConfiguration.ToolProfile.RAG);
+    assertThat(loaded.getPrincipalToolProfile("apitoken:admin-token"))
+        .isEqualTo(MCPConfiguration.ToolProfile.ADMIN);
+    assertThat(loaded.getPrincipalToolProfile("admin-token")).isNull();
+    assertThat(loaded.getPrincipalToolProfile("unknown-user")).isNull();
+    assertThat(loaded.toJSON().getJSONObject("principalProfiles").getString("retrieval-user"))
+        .isEqualTo("rag");
+  }
+
+  @Test
+  void principalProfileUpdatesMergeRemoveAndClear() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject()
+            .put("retrieval-user", "rag")
+            .put("apitoken:admin-token", "admin")));
+
+    config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject().put("retrieval-user", "admin")));
+    assertThat(config.getPrincipalToolProfile("retrieval-user"))
+        .isEqualTo(MCPConfiguration.ToolProfile.ADMIN);
+    assertThat(config.getPrincipalToolProfile("apitoken:admin-token"))
+        .isEqualTo(MCPConfiguration.ToolProfile.ADMIN);
+
+    final JSONObject removal = new JSONObject();
+    removal.put("retrieval-user", (Object) null);
+    config.updateFrom(new JSONObject().put("principalProfiles", removal));
+    assertThat(config.getPrincipalToolProfile("retrieval-user")).isNull();
+    assertThat(config.getPrincipalToolProfile("apitoken:admin-token"))
+        .isEqualTo(MCPConfiguration.ToolProfile.ADMIN);
+
+    final JSONObject clear = new JSONObject();
+    clear.put("principalProfiles", (Object) null);
+    config.updateFrom(clear);
+    assertThat(config.getPrincipalToolProfile("apitoken:admin-token")).isNull();
+    assertThat(config.toJSON().has("principalProfiles")).isFalse();
+  }
+
+  @Test
+  void invalidPrincipalProfileIsRejectedWithoutPartialUpdate() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject().put("retrieval-user", "rag")));
+
+    assertThatThrownBy(() -> config.updateFrom(new JSONObject()
+        .put("allowInsert", true)
+        .put("principalProfiles", new JSONObject().put("retrieval-user", "retrieval"))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("all").hasMessageContaining("rag").hasMessageContaining("admin");
+
+    assertThat(config.isAllowInsert()).isFalse();
+    assertThat(config.getPrincipalToolProfile("retrieval-user"))
+        .isEqualTo(MCPConfiguration.ToolProfile.RAG);
+
+    assertThatThrownBy(() -> config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject().put("", "rag"))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be blank");
+
+    assertThatThrownBy(() -> config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject().put("retrieval-user", 42))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be a profile name");
+
+    assertThatThrownBy(() -> config.updateFrom(new JSONObject()
+        .put("principalProfiles", "rag")))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(config.getPrincipalToolProfile("retrieval-user"))
+        .isEqualTo(MCPConfiguration.ToolProfile.RAG);
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -50,11 +50,13 @@ class MCPServerPluginTest extends BaseGraphServerTest {
   @BeforeEach
   void enableMCP() throws Exception {
     // MCP is disabled by default, enable it for tests
-    saveMCPConfig(new JSONObject()
+    final JSONObject config = new JSONObject()
         .put("enabled", true)
         .put("allowReads", true)
         .put("profile", "all")
-        .put("allowedUsers", new JSONArray().put("root")));
+        .put("allowedUsers", new JSONArray().put("root"));
+    config.put("principalProfiles", (Object) null);
+    saveMCPConfig(config);
     seedFullTextIndex();
     seedSampleRecords();
   }
@@ -333,6 +335,57 @@ class MCPServerPluginTest extends BaseGraphServerTest {
 
     final JSONObject adminAllowed = callTool("server_status", new JSONObject());
     assertThat(adminAllowed.getBoolean("isError", true)).isFalse();
+  }
+
+  @Test
+  void principalProfilesDifferentiateNamedUsersOnOneHttpEndpoint() throws Exception {
+    final String principalName = "mcp-profile-reader";
+    final String password = "principalProfilePass1!";
+    if (getServer(0).getSecurity().existsUser(principalName))
+      getServer(0).getSecurity().dropUser(principalName);
+    getServer(0).getSecurity().createUser(new JSONObject()
+        .put("name", principalName)
+        .put("password", getServer(0).getSecurity().encodePassword(password))
+        .put("databases", new JSONObject().put("graph", new JSONArray().put("admin"))));
+
+    try {
+      saveMCPConfig(new JSONObject()
+          .put("profile", "all")
+          .put("allowedUsers", new JSONArray().put("root").put(principalName))
+          .put("principalProfiles", new JSONObject().put(principalName, "rag")));
+
+      final JSONObject request = new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 22)
+          .put("method", "tools/list")
+          .put("params", new JSONObject());
+      assertThat(toolNames(mcpRequest(request))).contains("server_status", "execute_command");
+
+      final String principalAuth = getBasicAuth(principalName, password);
+      assertThat(toolNames(mcpRequest(request, principalAuth)))
+          .contains("sample_records", "vector_search", "full_text_search")
+          .doesNotContain("server_status", "execute_command");
+
+      final JSONObject denied = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 23)
+          .put("method", "tools/call")
+          .put("params", new JSONObject()
+              .put("name", "server_status")
+              .put("arguments", new JSONObject())), principalAuth)
+          .getJSONObject("result");
+      assertThat(denied.getBoolean("isError", false)).isTrue();
+
+      final JSONObject initialized = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 24)
+          .put("method", "initialize")
+          .put("params", new JSONObject()), principalAuth);
+      assertThat(initialized.getJSONObject("result").getString("instructions"))
+          .contains("retrieval and agent memory");
+    } finally {
+      getServer(0).getSecurity().dropUser(principalName);
+    }
   }
 
   @Test
@@ -1056,6 +1109,48 @@ class MCPServerPluginTest extends BaseGraphServerTest {
       }
     } finally {
       // Cleanup: delete the token
+      getServer(0).getSecurity().getApiTokenConfiguration()
+          .deleteToken(tokenResult.getString("tokenHash"));
+    }
+  }
+
+  @Test
+  void apiTokenPrincipalProfileFiltersDiscoveryAndDirectCalls() throws Exception {
+    final JSONObject permissions = new JSONObject()
+        .put("types", new JSONObject()
+            .put("*", new JSONObject().put("access", new JSONArray().put("readRecord"))))
+        .put("database", new JSONArray());
+
+    final JSONObject tokenResult = getServer(0).getSecurity().getApiTokenConfiguration()
+        .createToken("profiletoken", "graph", 0, permissions);
+    final String tokenValue = tokenResult.getString("token");
+
+    try {
+      saveMCPConfig(new JSONObject()
+          .put("profile", "all")
+          .put("allowedUsers", new JSONArray().put("root").put("profiletoken"))
+          .put("principalProfiles", new JSONObject().put("apitoken:profiletoken", "rag")));
+
+      final String tokenAuth = "Bearer " + tokenValue;
+      final JSONObject listed = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 503)
+          .put("method", "tools/list")
+          .put("params", new JSONObject()), tokenAuth);
+      assertThat(toolNames(listed))
+          .contains("sample_records", "vector_search")
+          .doesNotContain("server_status", "execute_command");
+
+      final JSONObject denied = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 504)
+          .put("method", "tools/call")
+          .put("params", new JSONObject()
+              .put("name", "server_status")
+              .put("arguments", new JSONObject())), tokenAuth)
+          .getJSONObject("result");
+      assertThat(denied.getBoolean("isError", false)).isTrue();
+    } finally {
       getServer(0).getSecurity().getApiTokenConfiguration()
           .deleteToken(tokenResult.getString("tokenHash"));
     }
@@ -2407,9 +2502,13 @@ class MCPServerPluginTest extends BaseGraphServerTest {
   // ---- Helper methods ----
 
   private JSONObject mcpRequest(final JSONObject request) throws Exception {
+    return mcpRequest(request, getBasicAuth());
+  }
+
+  private JSONObject mcpRequest(final JSONObject request, final String authorization) throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) new URI(getMcpUrl()).toURL().openConnection();
     connection.setRequestMethod("POST");
-    connection.setRequestProperty("Authorization", getBasicAuth());
+    connection.setRequestProperty("Authorization", authorization);
     connection.setRequestProperty("Content-Type", "application/json");
     connection.setDoOutput(true);
 
@@ -2470,7 +2569,11 @@ class MCPServerPluginTest extends BaseGraphServerTest {
   }
 
   private static String getBasicAuth() {
+    return getBasicAuth("root", DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private static String getBasicAuth(final String username, final String password) {
     return "Basic " + Base64.getEncoder()
-        .encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8));
+        .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
@@ -128,6 +128,15 @@ class MCPStdioServerTest extends BaseGraphServerTest {
         "list_databases", "get_schema", "query", "execute_command", "server_status",
         "profiler_start", "profiler_stop", "profiler_status", "get_server_settings", "set_server_setting");
 
+    final JSONObject initialized = sendSingleRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 22)
+        .put("method", "initialize")
+        .put("params", new JSONObject()));
+    assertThat(initialized.getJSONObject("result").getString("instructions"))
+        .contains("multi-model database server")
+        .doesNotContain("retrieval and agent memory", "restricted tool surface");
+
     denied = callTool("full_text_search", new JSONObject());
     assertThat(denied.getBoolean("isError", false)).isTrue();
     assertThat(denied.getJSONArray("content").getJSONObject(0).getString("text"))

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPStdioServerTest.java
@@ -45,6 +45,9 @@ class MCPStdioServerTest extends BaseGraphServerTest {
     config.setEnabled(true);
     config.setAllowReads(true);
     config.setToolProfile(MCPConfiguration.ToolProfile.ALL);
+    final JSONObject reset = new JSONObject();
+    reset.put("principalProfiles", (Object) null);
+    config.updateFrom(reset);
     user = getServer(0).getSecurity().authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
   }
 
@@ -129,6 +132,39 @@ class MCPStdioServerTest extends BaseGraphServerTest {
     assertThat(denied.getBoolean("isError", false)).isTrue();
     assertThat(denied.getJSONArray("content").getJSONObject(0).getString("text"))
         .contains("full_text_search").contains("admin");
+  }
+
+  @Test
+  void principalProfileAppliesToStdioAndCannotExceedGlobalProfile() throws Exception {
+    config.setToolProfile(MCPConfiguration.ToolProfile.RAG);
+    config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject().put("root", "admin")));
+
+    final JSONObject response = sendSingleRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 22)
+        .put("method", "tools/list")
+        .put("params", new JSONObject()));
+    assertThat(toolNames(response))
+        .contains("list_databases", "get_schema", "query")
+        .doesNotContain("server_status", "full_text_search", "execute_command");
+
+    JSONObject denied = callTool("server_status", new JSONObject());
+    assertThat(denied.getBoolean("isError", false)).isTrue();
+    assertThat(denied.getJSONArray("content").getJSONObject(0).getString("text"))
+        .contains("global MCP profile 'rag'").contains("principal profile 'admin'");
+
+    denied = callTool("full_text_search", new JSONObject());
+    assertThat(denied.getBoolean("isError", false)).isTrue();
+
+    final JSONObject initialized = sendSingleRequest(new JSONObject()
+        .put("jsonrpc", "2.0")
+        .put("id", 23)
+        .put("method", "initialize")
+        .put("params", new JSONObject()));
+    assertThat(initialized.getJSONObject("result").getString("instructions"))
+        .contains("restricted tool surface")
+        .doesNotContain("execute_command", "upsert_entity");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add optional `principalProfiles` mappings for named users and API-token principals
- resolve each authenticated principal's effective tools as the intersection of its override and the global profile
- apply the same effective profile to initialization instructions, discovery, and direct invocation over HTTP and standard input/output
- define persistent merge, removal, clearing, validation, and unknown-principal behavior

The global profile remains the backward-compatible default and a hard ceiling. Principal profiles cannot grant a tool hidden globally, and the existing read, write, schema, administrative, database, user, and origin permission checks remain mandatory.

API tokens use their canonical authenticated name, `apitoken:<token-name>`, so they cannot be confused with a named user that shares the token's display name.

## Validation

Focused MCP tests:

```text
./mvnw -pl server -am test \
  -Dtest='MCPConfigurationTest,MCPStdioServerTest,MCPServerPluginTest,MCPPermissionsTest' \
  -Dsurefire.failIfNoSpecifiedTests=false
```

Result: 145 tests, 0 failures, 0 errors, 0 skipped.

A subsequent focused configuration regression run passed 22 tests after adding malformed top-level value coverage.

Closes #5445
