### PR TITLE
fix(#5460): apply relationship inline WHERE predicates in pattern comprehensions

### DIFF
--- a/docs/5460-pattern-comprehension-rel-inline-where.md
+++ b/docs/5460-pattern-comprehension-rel-inline-where.md
@@ -35,9 +35,15 @@ Two independent gaps on the pattern-comprehension path, both of which had to be 
 
 **`parser/CypherExpressionBuilder.java`** - `parseRelationshipPattern(...)` now parses
 `ctx.expression()` and passes it to the 8-argument `RelationshipPattern` constructor. The body is
-parsed with the existing `parseExpression(...)` and adapted through `BooleanCoercionExpression`,
-the adapter already used by `CypherASTBuilder` for the same purpose. That keeps comparisons,
-`AND`/`OR`/`NOT` and boolean-typed properties all working without duplicating boolean-parsing logic.
+parsed with the existing `parseExpression(...)` and adapted through `BooleanCoercionExpression`.
+
+Note this is not the identical route the `MATCH` path takes: `CypherASTBuilder` uses its private
+`parseBooleanExpression(...)`, which builds a structured `BooleanExpression` tree, and falls back to
+`BooleanCoercionExpression` only for non-comparison forms. Sharing that method would mean exposing a
+private method across builder classes, so the comprehension path coerces instead.
+`parseExpression(...)` covers the whole precedence hierarchy including `AND`/`OR`/`NOT`, and the
+coercion maps a `NULL` result to "no match", which is the correct Cypher filter semantics. The two
+routes were therefore checked for behavioral parity rather than assumed equal - see Tests.
 
 **`ast/PatternComprehensionExpression.java`** - both expansion paths now apply the predicate
 directly after the existing property-map filter:
@@ -55,7 +61,7 @@ carries no inline `WHERE`, no row is allocated at all and the hot path is unchan
 ## Tests
 
 `engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java`
-- 12 tests, using the exact data and queries from the issue report.
+- 17 tests, using the exact data and queries from the issue report.
 
 | Test | Asserts |
 |---|---|
@@ -69,13 +75,18 @@ carries no inline `WHERE`, no row is allocated at all and the hot path is unchan
 | `inlineWherePredicateAppliesToAnIncomingPattern` | `<-[r:E WHERE ...]-` filters the same relationship |
 | `inlineWherePredicateAppliesToAnUndirectedPattern` | direction-agnostic expansion honors the predicate |
 | `inlineWherePredicateResolvesAQueryParameter` | `WHERE r.tag = $tag` resolves the query parameter |
+| `inlineWherePredicateSupportsConjunction` | `AND` in the predicate body |
+| `inlineWherePredicateSupportsDisjunction` | `OR` in the predicate body |
+| `inlineWherePredicateExcludesRelationshipsWhoseComparisonIsNull` | a comparison over a missing property is `NULL`, so no match |
+| `inlineWhereIsNullPredicateSelectsTheMissingProperty` | `IS NULL` selects the untagged relationship |
+| `negatedInlineWherePredicateMatchesTheRegularMatchPath` | `NOT (...)` under three-valued logic gives the same answer as the equivalent `MATCH` |
 | `noInlineWherePredicateStillReturnsEveryRelationship` | control: no predicate, no filtering |
 | `comprehensionLevelWhereStillWorks` | control: documented workaround unaffected |
 
 ## Verification
 
 Before the fix, 4 of the original 8 tests failed with precisely the reported symptom (`c = 2`
-instead of `0` / `1`); the 4 control tests passed. After the fix all 12 pass.
+instead of `0` / `1`); the 4 control tests passed. After the fix all 17 pass.
 
 Per-hop enforcement was verified by mutation rather than by inspection: temporarily removing the
 predicate check from `traverseVariableLength(...)` makes
@@ -124,6 +135,14 @@ gemini-code-assist again posted nothing.
 | The var-length test had only one reachable hop, so it never exercised a path whose *later* hop fails the predicate | **Applied.** Added a two-hop `:C` chain to the fixture and a test asserting the path is truncated at the first failing hop. Verified by mutation (see Verification) that it genuinely fails without per-hop enforcement. The chain is label-scoped so the single-hop tests, which all pin the far end to `:A`, are unaffected. |
 | The inline predicate cannot reference the target node | **No change - expected behavior.** Consistent with `MatchRelationshipStep` ordering; now documented under Impact and notes. |
 | PR body said 8 tests where the doc and test class say more | **Applied.** PR body corrected to 12. |
+
+**Cycle 3** - `9096d47f` - claude reviewed again (approving), one substantive note plus a doc nit.
+gemini-code-assist again posted nothing.
+
+| Note | Decision |
+|---|---|
+| The comprehension parses the inline `WHERE` through `BooleanCoercionExpression` while `MATCH` uses `parseBooleanExpression(...)`; three-valued logic under `NOT` / `AND` / `OR` / `NULL` was therefore unverified | **Applied.** Five tests added covering `AND`, `OR`, a `NULL` comparison, `IS NULL`, and a `NOT (...)` case asserted equal to the answer the equivalent `MATCH` gives. All pass: the two routes agree, so the divergence is theoretical rather than real. The Fix section above no longer claims the two builders take the identical route. |
+| Trim the "Review cycles" section - it reads oddly as a committed repo doc | **Kept.** Checked against the repo: the most recent tracking docs on `main` (`docs/5454-*`, `docs/5453-*`) both carry a `## Review cycles` section, so this matches current convention rather than departing from it. |
 
 ## Known gaps
 

--- a/docs/5460-pattern-comprehension-rel-inline-where.md
+++ b/docs/5460-pattern-comprehension-rel-inline-where.md
@@ -1,0 +1,101 @@
+# Issue #5460 - Pattern comprehension ignores relationship inline `WHERE` predicates
+
+## Problem
+
+A relationship inline `WHERE` predicate inside a pattern comprehension was silently discarded:
+
+```cypher
+MATCH (a:A {v: 1})
+RETURN size([(a)-[r:E WHERE r.tag = 'ok']->(b:A) | b]) AS c;   -- returned 2, Neo4j returns 1
+RETURN size([(a)-[r:E WHERE 1=0]->(b:A) | b]) AS c;            -- returned 2, Neo4j returns 0
+```
+
+The same syntax works in a regular `MATCH` (fixed for that path by #3953), and the
+comprehension-level `WHERE` (after the pattern) also worked. Only the relationship inline form
+inside a comprehension was affected.
+
+Distinct from #5111, which covers the inline property-map form `[:E {tag: 'ok'}]`.
+
+## Root cause
+
+Two independent gaps on the pattern-comprehension path, both of which had to be closed:
+
+1. **The predicate never reached the AST.** Pattern comprehensions are parsed by
+   `CypherExpressionBuilder`, not by `CypherASTBuilder`. Its private
+   `parseRelationshipPattern(...)` read the variable, labels, property map, path length and
+   direction, but never read `ctx.expression()` - the inline `WHERE` body. It then called the
+   7-argument `RelationshipPattern` constructor, so `whereExpression` was always `null`.
+   `CypherASTBuilder.visitRelationshipPattern(...)`, which feeds regular `MATCH`, does read it.
+
+2. **The evaluator never applied it.** `PatternComprehensionExpression` filtered candidate edges
+   only through `matchesEdgeProperties(...)` (the inline property map, #5139). Even with a
+   populated `whereExpression` on the AST node, nothing consulted it.
+
+## Fix
+
+**`parser/CypherExpressionBuilder.java`** - `parseRelationshipPattern(...)` now parses
+`ctx.expression()` and passes it to the 8-argument `RelationshipPattern` constructor. The body is
+parsed with the existing `parseExpression(...)` and adapted through `BooleanCoercionExpression`,
+the adapter already used by `CypherASTBuilder` for the same purpose. That keeps comparisons,
+`AND`/`OR`/`NOT` and boolean-typed properties all working without duplicating boolean-parsing logic.
+
+**`ast/PatternComprehensionExpression.java`** - both expansion paths now apply the predicate
+directly after the existing property-map filter:
+
+- `traverseEdges(...)` - single-hop patterns
+- `traverseVariableLength(...)` - `*min..max` patterns, where every relationship on the path must
+  satisfy the predicate, matching the existing property-map semantics
+
+The new `matchesEdgeWhereExpression(...)` mirrors `MatchRelationshipStep.matchesEdgeWhereExpression`
+so both engines share the same semantics. The evaluation row is built once per expansion by
+`copyBindings(...)` and only the relationship variable is rebound per candidate edge, so the
+predicate sees outer-scope bindings without a per-edge copy of the whole row. When the pattern
+carries no inline `WHERE`, no row is allocated at all and the hot path is unchanged.
+
+## Verification
+
+New regression test:
+`engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java`
+(8 tests, using the exact data and queries from the issue report).
+
+Before the fix 4 of the 8 failed with precisely the reported symptom (`c = 2` instead of `0` / `1`);
+the 4 control tests passed. After the fix all 8 pass.
+
+Coverage:
+
+| Test | Asserts |
+|---|---|
+| `alwaysFalseInlineWherePredicateFiltersEverything` | `WHERE 1=0` returns 0 |
+| `inlineWherePredicateOnRelationshipPropertyIsApplied` | `WHERE r.tag = 'ok'` returns 1 |
+| `inlineWherePredicateProjectsTheMatchingRelationship` | the surviving relationship is the right one |
+| `inlineWherePredicateCombinesWithComprehensionLevelWhere` | inline and comprehension-level `WHERE` compose |
+| `inlineWherePredicateCanReferenceOuterBoundVariable` | the predicate sees outer-scope bindings |
+| `inlineWherePredicateAppliesToEveryHopOfAVariableLengthPattern` | `*1..2` filters every hop |
+| `noInlineWherePredicateStillReturnsEveryRelationship` | control: no predicate, no filtering |
+| `comprehensionLevelWhereStillWorks` | control: documented workaround unaffected |
+
+Regression run: full `com.arcadedb.query.opencypher.**` package - **7495 tests, 0 failures**.
+The 3 errors reported are `OpenCypherCustomFunctionTest` GraalVM polyglot classloading failures
+(`NoClassDefFoundError: org.graalvm.polyglot.Engine$ImplHolder`), confirmed pre-existing by
+running that class unchanged on the base checkout.
+
+## Impact and notes
+
+- Queries that previously received unfiltered lists from a pattern comprehension now receive the
+  correctly filtered list. Any consumer of that list (`size()`, indexing, `UNWIND`, aggregation)
+  changes result accordingly - this is the intended correction, but it is a behavior change for
+  queries that were silently relying on the unfiltered output.
+- No change to the regular `MATCH` path, which already applied the predicate.
+
+### Adjacent gaps observed but deliberately left out of scope
+
+`CypherExpressionBuilder.parseRelationshipPattern` is also used by `exists(pattern)`
+(`PatternPredicateExpression`) and by `shortestPath`. Those evaluators do not consult
+`getWhereExpression()` either, so an inline `WHERE` remains ignored there. The parser change makes
+the predicate available on their AST nodes but does not alter their behavior, so this fix is
+regression-free for them. Applying it in those evaluators is a separate change and warrants its own
+issue.
+
+Separately, node inline `WHERE` - `(b:A WHERE ...)` - is accepted by the grammar but stored nowhere
+(`NodePattern` has no such field), so it is dropped on *every* path including regular `MATCH`. That
+is a distinct defect and is not addressed here.

--- a/docs/5460-pattern-comprehension-rel-inline-where.md
+++ b/docs/5460-pattern-comprehension-rel-inline-where.md
@@ -52,16 +52,10 @@ so both engines share the same semantics. The evaluation row is built once per e
 predicate sees outer-scope bindings without a per-edge copy of the whole row. When the pattern
 carries no inline `WHERE`, no row is allocated at all and the hot path is unchanged.
 
-## Verification
+## Tests
 
-New regression test:
 `engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java`
-(8 tests, using the exact data and queries from the issue report).
-
-Before the fix 4 of the 8 failed with precisely the reported symptom (`c = 2` instead of `0` / `1`);
-the 4 control tests passed. After the fix all 8 pass.
-
-Coverage:
+- 11 tests, using the exact data and queries from the issue report.
 
 | Test | Asserts |
 |---|---|
@@ -71,8 +65,16 @@ Coverage:
 | `inlineWherePredicateCombinesWithComprehensionLevelWhere` | inline and comprehension-level `WHERE` compose |
 | `inlineWherePredicateCanReferenceOuterBoundVariable` | the predicate sees outer-scope bindings |
 | `inlineWherePredicateAppliesToEveryHopOfAVariableLengthPattern` | `*1..2` filters every hop |
+| `inlineWherePredicateAppliesToAnIncomingPattern` | `<-[r:E WHERE ...]-` filters the same relationship |
+| `inlineWherePredicateAppliesToAnUndirectedPattern` | direction-agnostic expansion honors the predicate |
+| `inlineWherePredicateResolvesAQueryParameter` | `WHERE r.tag = $tag` resolves the query parameter |
 | `noInlineWherePredicateStillReturnsEveryRelationship` | control: no predicate, no filtering |
 | `comprehensionLevelWhereStillWorks` | control: documented workaround unaffected |
+
+## Verification
+
+Before the fix, 4 of the original 8 tests failed with precisely the reported symptom (`c = 2`
+instead of `0` / `1`); the 4 control tests passed. After the fix all 11 pass.
 
 Regression run: full `com.arcadedb.query.opencypher.**` package - **7495 tests, 0 failures**.
 The 3 errors reported are `OpenCypherCustomFunctionTest` GraalVM polyglot classloading failures
@@ -87,12 +89,28 @@ running that class unchanged on the base checkout.
   queries that were silently relying on the unfiltered output.
 - No change to the regular `MATCH` path, which already applied the predicate.
 
-### Adjacent gaps observed but deliberately left out of scope
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5471
+
+## Review cycles
+
+**Cycle 1** - `6b4acb31` - claude reviewed (approving; "correct, performant, and ready to merge"),
+with three non-blocking suggestions. gemini-code-assist posted nothing within the 15-minute window,
+consistent with its ongoing sunset.
+
+| Suggestion | Decision |
+|---|---|
+| Broaden test coverage to incoming/`BOTH` directions and a parameter reference in the inline `WHERE` | **Applied.** Three tests added. All pass unchanged, confirming direction handling and parameter resolution already work through the fix - no further code change needed. |
+| Collapse the pre-existing inline binding-copy loops in this file onto the new `copyBindings(...)` helper | **Skipped.** A bug fix should not carry surrounding cleanup; the reviewer itself scoped this as a follow-up. The four call sites are untouched by this change, so folding them in would widen the regression surface for no behavioral gain. |
+| File a follow-up issue for `exists(pattern)` / `shortestPath` carrying the predicate but ignoring it | **Deferred to the maintainer.** Filing issues is outside the scope authorized for this PR. Documented under Known gaps below. |
+
+## Known gaps
 
 `CypherExpressionBuilder.parseRelationshipPattern` is also used by `exists(pattern)`
 (`PatternPredicateExpression`) and by `shortestPath`. Those evaluators do not consult
-`getWhereExpression()` either, so an inline `WHERE` remains ignored there. The parser change makes
-the predicate available on their AST nodes but does not alter their behavior, so this fix is
+`getWhereExpression()`, so an inline `WHERE` remains ignored there. The parser change makes the
+predicate available on their AST nodes but does not alter their behavior, so this fix is
 regression-free for them. Applying it in those evaluators is a separate change and warrants its own
 issue.
 

--- a/docs/5460-pattern-comprehension-rel-inline-where.md
+++ b/docs/5460-pattern-comprehension-rel-inline-where.md
@@ -144,6 +144,20 @@ gemini-code-assist again posted nothing.
 | The comprehension parses the inline `WHERE` through `BooleanCoercionExpression` while `MATCH` uses `parseBooleanExpression(...)`; three-valued logic under `NOT` / `AND` / `OR` / `NULL` was therefore unverified | **Applied.** Five tests added covering `AND`, `OR`, a `NULL` comparison, `IS NULL`, and a `NOT (...)` case asserted equal to the answer the equivalent `MATCH` gives. All pass: the two routes agree, so the divergence is theoretical rather than real. The Fix section above no longer claims the two builders take the identical route. |
 | Trim the "Review cycles" section - it reads oddly as a committed repo doc | **Kept.** Checked against the repo: the most recent tracking docs on `main` (`docs/5454-*`, `docs/5453-*`) both carry a `## Review cycles` section, so this matches current convention rather than departing from it. |
 
+**Cycle 4** - `9fa98e2c` - claude reviewed: **LGTM**, no blocking items. gemini-code-assist posted
+nothing across all four cycles.
+
+| Note | Decision |
+|---|---|
+| The test Javadoc carried a copy-pasted `@author` tag, misattributing the file | **Applied.** Tag removed rather than reassigned; 78 of the 183 tests in this package carry no `@author`, so omitting it is within convention. |
+| `exists(pattern)` / `shortestPath` now silently ignore a parsed predicate rather than never parsing it - worth its own tracking issue | **Deferred to the maintainer**, as in cycle 1. Recorded under Known gaps. |
+| `copyBindings(...)` duplicates property-copy loops in `MatchRelationshipStep` and `buildHopResult` | **Skipped**, as in cycle 1: consolidation is a follow-up, not part of this fix. |
+
+## Final state
+
+`max-cycles-reached` (4 of 4) with a clean approval on the last cycle - the remaining items are all
+explicitly non-blocking and either deferred to the maintainer or scoped to follow-ups.
+
 ## Known gaps
 
 `CypherExpressionBuilder.parseRelationshipPattern` is also used by `exists(pattern)`

--- a/docs/5460-pattern-comprehension-rel-inline-where.md
+++ b/docs/5460-pattern-comprehension-rel-inline-where.md
@@ -55,7 +55,7 @@ carries no inline `WHERE`, no row is allocated at all and the hot path is unchan
 ## Tests
 
 `engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java`
-- 11 tests, using the exact data and queries from the issue report.
+- 12 tests, using the exact data and queries from the issue report.
 
 | Test | Asserts |
 |---|---|
@@ -65,6 +65,7 @@ carries no inline `WHERE`, no row is allocated at all and the hot path is unchan
 | `inlineWherePredicateCombinesWithComprehensionLevelWhere` | inline and comprehension-level `WHERE` compose |
 | `inlineWherePredicateCanReferenceOuterBoundVariable` | the predicate sees outer-scope bindings |
 | `inlineWherePredicateAppliesToEveryHopOfAVariableLengthPattern` | `*1..2` filters every hop |
+| `inlineWherePredicateTruncatesAVariableLengthPathAtTheFirstFailingHop` | a 2-hop chain is cut at the first hop that fails the predicate |
 | `inlineWherePredicateAppliesToAnIncomingPattern` | `<-[r:E WHERE ...]-` filters the same relationship |
 | `inlineWherePredicateAppliesToAnUndirectedPattern` | direction-agnostic expansion honors the predicate |
 | `inlineWherePredicateResolvesAQueryParameter` | `WHERE r.tag = $tag` resolves the query parameter |
@@ -74,7 +75,13 @@ carries no inline `WHERE`, no row is allocated at all and the hot path is unchan
 ## Verification
 
 Before the fix, 4 of the original 8 tests failed with precisely the reported symptom (`c = 2`
-instead of `0` / `1`); the 4 control tests passed. After the fix all 11 pass.
+instead of `0` / `1`); the 4 control tests passed. After the fix all 12 pass.
+
+Per-hop enforcement was verified by mutation rather than by inspection: temporarily removing the
+predicate check from `traverseVariableLength(...)` makes
+`inlineWherePredicateTruncatesAVariableLengthPathAtTheFirstFailingHop` fail (it then collects
+`badEnd` as well), confirming the test actually pins that behavior. The check was restored
+afterwards.
 
 Regression run: full `com.arcadedb.query.opencypher.**` package - **7495 tests, 0 failures**.
 The 3 errors reported are `OpenCypherCustomFunctionTest` GraalVM polyglot classloading failures
@@ -88,6 +95,10 @@ running that class unchanged on the base checkout.
   changes result accordingly - this is the intended correction, but it is a behavior change for
   queries that were silently relying on the unfiltered output.
 - No change to the regular `MATCH` path, which already applied the predicate.
+- The inline predicate is evaluated before the target vertex is resolved, so it cannot reference the
+  far-end node - `-[r:E WHERE b.v = 2]->(b)` does not see `b`. This matches the ordering in
+  `MatchRelationshipStep` (inline `WHERE` runs ahead of the target label/property filters), so the
+  two engines stay consistent. Predicates on the far end belong in the comprehension-level `WHERE`.
 
 ## PR
 
@@ -104,6 +115,15 @@ consistent with its ongoing sunset.
 | Broaden test coverage to incoming/`BOTH` directions and a parameter reference in the inline `WHERE` | **Applied.** Three tests added. All pass unchanged, confirming direction handling and parameter resolution already work through the fix - no further code change needed. |
 | Collapse the pre-existing inline binding-copy loops in this file onto the new `copyBindings(...)` helper | **Skipped.** A bug fix should not carry surrounding cleanup; the reviewer itself scoped this as a follow-up. The four call sites are untouched by this change, so folding them in would widen the regression surface for no behavioral gain. |
 | File a follow-up issue for `exists(pattern)` / `shortestPath` carrying the predicate but ignoring it | **Deferred to the maintainer.** Filing issues is outside the scope authorized for this PR. Documented under Known gaps below. |
+
+**Cycle 2** - `15ee8697` - claude reviewed again (approving; "safe to merge"), three minor notes.
+gemini-code-assist again posted nothing.
+
+| Note | Decision |
+|---|---|
+| The var-length test had only one reachable hop, so it never exercised a path whose *later* hop fails the predicate | **Applied.** Added a two-hop `:C` chain to the fixture and a test asserting the path is truncated at the first failing hop. Verified by mutation (see Verification) that it genuinely fails without per-hop enforcement. The chain is label-scoped so the single-hop tests, which all pin the far end to `:A`, are unaffected. |
+| The inline predicate cannot reference the target node | **No change - expected behavior.** Consistent with `MatchRelationshipStep` ordering; now documented under Impact and notes. |
+| PR body said 8 tests where the doc and test class say more | **Applied.** PR body corrected to 12. |
 
 ## Known gaps
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -262,11 +262,20 @@ public class PatternComprehensionExpression implements Expression {
     else
       edges = currentVertex.getEdges(edgeDirection).iterator();
 
+    // Row reused across every candidate edge of this expansion: only the relationship variable
+    // changes per edge, so the enclosing bindings are copied once. Stays null when the pattern
+    // carries no inline WHERE, leaving the common path allocation-free.
+    final ResultInternal whereEvalRow = relPattern.hasWhereExpression() ? copyBindings(currentResult) : null;
+
     while (edges.hasNext()) {
       final Edge edge = edges.next();
       // Inline relationship property filter, e.g. [p = (a)-[:VE*1..4 {w:1}]->(c) | ...] (issue #5139).
       // Every relationship in the path must satisfy the map, so skip non-matching edges before recursing.
       if (!matchesEdgeProperties(edge, relPattern, context))
+        continue;
+      // Inline relationship WHERE predicate, e.g. [(a)-[r:E*1..2 WHERE r.tag = 'ok']->(b) | b]. As with
+      // the property map, every relationship in the path must satisfy it.
+      if (whereEvalRow != null && !matchesEdgeWhereExpression(edge, relPattern, whereEvalRow, context))
         continue;
       final RID edgeRid = edge.getIdentity();
       // Trail semantics: do not repeat the same edge in a single path
@@ -352,6 +361,31 @@ public class PatternComprehensionExpression implements Expression {
   }
 
   /**
+   * Returns true if an edge satisfies the relationship pattern's inline {@code WHERE} predicate
+   * (e.g. the {@code WHERE r.tag = 'ok'} in {@code -[r:E WHERE r.tag = 'ok']->}). Mirrors the
+   * enforcement done by the regular MATCH path (MatchRelationshipStep.matchesEdgeWhereExpression),
+   * so pattern comprehensions apply the same predicate semantics.
+   *
+   * @param evalRow bindings visible to the predicate, pre-populated with the enclosing scope. The
+   *                relationship variable is rebound on it for each candidate edge.
+   */
+  private boolean matchesEdgeWhereExpression(final Edge edge, final RelationshipPattern relPattern,
+      final ResultInternal evalRow, final CommandContext context) {
+    final String variable = relPattern.getVariable();
+    if (variable != null && !variable.isEmpty())
+      evalRow.setProperty(variable, edge);
+    return relPattern.getWhereExpression().evaluate(evalRow, context);
+  }
+
+  private static ResultInternal copyBindings(final Result source) {
+    final ResultInternal copy = new ResultInternal();
+    if (source != null)
+      for (final String prop : source.getPropertyNames())
+        copy.setProperty(prop, source.getProperty(prop));
+    return copy;
+  }
+
+  /**
    * Compares an inline pattern property value against the stored value, mirroring the regular MATCH
    * path (MatchNodeStep.matchesProperties): resolves {@code $param} references and applies numeric
    * coercion so an inline literal (parsed as {@code Long}) matches a stored {@code Integer} and vice
@@ -409,10 +443,18 @@ public class PatternComprehensionExpression implements Expression {
     else
       edges = startVertex.getEdges(edgeDirection).iterator();
 
+    // Row reused across every candidate edge of this expansion: only the relationship variable
+    // changes per edge, so the enclosing bindings are copied once. Stays null when the pattern
+    // carries no inline WHERE, leaving the common path allocation-free.
+    final ResultInternal whereEvalRow = relPattern.hasWhereExpression() ? copyBindings(currentResult) : null;
+
     while (edges.hasNext()) {
       final Edge edge = edges.next();
       // Inline relationship property filter, e.g. [(a)-[:VE {w:1}]->(x) | ...] (issue #5139).
       if (!matchesEdgeProperties(edge, relPattern, context))
+        continue;
+      // Inline relationship WHERE predicate, e.g. [(a)-[r:E WHERE r.tag = 'ok']->(x) | ...].
+      if (whereEvalRow != null && !matchesEdgeWhereExpression(edge, relPattern, whereEvalRow, context))
         continue;
 
       final Vertex targetVertex;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -2567,7 +2567,15 @@ class CypherExpressionBuilder {
       direction = Direction.BOTH;
     }
 
-    return new RelationshipPattern(variable, types, direction, properties, propertiesParameterName, minHops, maxHops);
+    // Inline WHERE predicate, e.g. the WHERE r.tag = 'ok' in -[r:E WHERE r.tag = 'ok']->. Parsed as
+    // a generic expression and coerced to a predicate so comparisons, AND/OR/NOT and boolean-typed
+    // properties are all covered without duplicating the boolean-parsing hierarchy.
+    BooleanExpression whereExpression = null;
+    if (ctx.expression() != null)
+      whereExpression = new BooleanCoercionExpression(parseExpression(ctx.expression()));
+
+    return new RelationshipPattern(variable, types, direction, properties, propertiesParameterName, minHops, maxHops,
+        whereExpression);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A pattern comprehension must honor the relationship inline {@code WHERE} predicate, i.e. the
+ * {@code WHERE r.tag = 'ok'} in {@code [(a)-[r:E WHERE r.tag = 'ok']->(b) | b]}. Over two
+ * relationships tagged {@code 'ok'} and {@code 'bad'}, an always-false predicate must collect
+ * nothing and a predicate on the relationship property must collect exactly the matching one -
+ * the same results Neo4j produces, and the same semantics a regular {@code MATCH} already applies.
+ * <p>
+ * The comprehension-level {@code WHERE} (placed after the pattern) and the inline property-map form
+ * {@code [:E {tag: 'ok'}]} are covered elsewhere; both are exercised here only as controls.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("A");
+    database.getSchema().createEdgeType("E");
+
+    // a -[E {tag: 'ok'}]->  b
+    // a -[E {tag: 'bad'}]-> b
+    database.command("opencypher",
+        """
+        CREATE (a:A {v: 1}), (b:A {v: 2}), \
+        (a)-[:E {tag: 'ok'}]->(b), \
+        (a)-[:E {tag: 'bad'}]->(b)""");
+  }
+
+  @Test
+  void alwaysFalseInlineWherePredicateFiltersEverything() {
+    // Neo4j returns 0: the always-false predicate discards both relationships.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[r:E WHERE 1=0]->(b:A) | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(0);
+  }
+
+  @Test
+  void inlineWherePredicateOnRelationshipPropertyIsApplied() {
+    // Neo4j returns 1: only the relationship tagged 'ok' survives.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[r:E WHERE r.tag = 'ok']->(b:A) | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void inlineWherePredicateProjectsTheMatchingRelationship() {
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN [(a)-[r:E WHERE r.tag = 'ok']->(b:A) | r.tag] AS tags""");
+
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> tags = rs.next().getProperty("tags");
+    assertThat(tags).containsExactly("ok");
+  }
+
+  @Test
+  void inlineWherePredicateCombinesWithComprehensionLevelWhere() {
+    // Both predicates apply: the inline one keeps 'ok', the outer one rejects every row.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[r:E WHERE r.tag = 'ok']->(b:A) WHERE b.v = 99 | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(0);
+  }
+
+  @Test
+  void inlineWherePredicateCanReferenceOuterBoundVariable() {
+    // The predicate body must see variables bound outside the comprehension.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[r:E WHERE a.v = 1]->(b:A) | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(2);
+  }
+
+  @Test
+  void inlineWherePredicateAppliesToEveryHopOfAVariableLengthPattern() {
+    // Every relationship traversed by the var-length expansion must satisfy the predicate.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[r:E*1..2 WHERE r.tag = 'ok']->(b:A) | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void noInlineWherePredicateStillReturnsEveryRelationship() {
+    // Control: without a predicate both relationships are collected.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[:E]->(b:A) | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(2);
+  }
+
+  @Test
+  void comprehensionLevelWhereStillWorks() {
+    // Control: the documented workaround must keep returning 0.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[r:E]->(b:A) WHERE 1=0 | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(0);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
@@ -36,8 +36,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * The comprehension-level {@code WHERE} (placed after the pattern) and the inline property-map form
  * {@code [:E {tag: 'ok'}]} are covered elsewhere; both are exercised here only as controls.
- *
- * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
   @Override

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
@@ -43,6 +43,7 @@ class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
   @Override
   protected void beginTest() {
     database.getSchema().createVertexType("A");
+    database.getSchema().createVertexType("C");
     database.getSchema().createEdgeType("E");
 
     // a -[E {tag: 'ok'}]->  b
@@ -52,6 +53,18 @@ class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
         CREATE (a:A {v: 1}), (b:A {v: 2}), \
         (a)-[:E {tag: 'ok'}]->(b), \
         (a)-[:E {tag: 'bad'}]->(b)""");
+
+    // A two-hop chain used only by the variable-length tests. Its nodes carry label C, so the
+    // single-hop tests above - which all pin the far end to :A - are unaffected by it.
+    //   a -ok-> mid -ok->  okEnd     (both hops satisfy the predicate)
+    //   a -ok-> mid -bad-> badEnd    (second hop fails it)
+    database.command("opencypher",
+        """
+        MATCH (a:A {v: 1}) \
+        CREATE (mid:C {name: 'mid'}), (okEnd:C {name: 'okEnd'}), (badEnd:C {name: 'badEnd'}), \
+        (a)-[:E {tag: 'ok'}]->(mid), \
+        (mid)-[:E {tag: 'ok'}]->(okEnd), \
+        (mid)-[:E {tag: 'bad'}]->(badEnd)""");
   }
 
   @Test
@@ -124,6 +137,21 @@ class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
 
     assertThat(rs.hasNext()).isTrue();
     assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void inlineWherePredicateTruncatesAVariableLengthPathAtTheFirstFailingHop() {
+    // Over the chain a -ok-> mid -ok-> okEnd and mid -bad-> badEnd, a 2-hop expansion must keep
+    // 'mid' and 'okEnd' and drop 'badEnd': the predicate has to be enforced on every hop, not just
+    // the first. Without per-hop enforcement all three would be collected.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN [(a)-[r:E*1..2 WHERE r.tag = 'ok']->(x:C) | x.name] AS names""");
+
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> names = rs.next().getProperty("names");
+    assertThat(names).containsExactlyInAnyOrder("mid", "okEnd");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -120,6 +121,43 @@ class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
         """
         MATCH (a:A {v: 1})
         RETURN size([(a)-[r:E*1..2 WHERE r.tag = 'ok']->(b:A) | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void inlineWherePredicateAppliesToAnIncomingPattern() {
+    // Traversed from the target side, the predicate must filter the same single relationship.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (b:A {v: 2})
+        RETURN size([(b)<-[r:E WHERE r.tag = 'ok']-(a:A) | a]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void inlineWherePredicateAppliesToAnUndirectedPattern() {
+    // Direction-agnostic expansion must still honor the predicate.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[r:E WHERE r.tag = 'ok']-(b:A) | b]) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void inlineWherePredicateResolvesAQueryParameter() {
+    // The predicate body must resolve $tag from the query parameters.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN size([(a)-[r:E WHERE r.tag = $tag]->(b:A) | b]) AS c""",
+        Map.of("tag", "ok"));
 
     assertThat(rs.hasNext()).isTrue();
     assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(1);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPatternComprehensionInlineWhereTest.java
@@ -44,6 +44,7 @@ class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
   protected void beginTest() {
     database.getSchema().createVertexType("A");
     database.getSchema().createVertexType("C");
+    database.getSchema().createVertexType("N");
     database.getSchema().createEdgeType("E");
 
     // a -[E {tag: 'ok'}]->  b
@@ -65,6 +66,16 @@ class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
         (a)-[:E {tag: 'ok'}]->(mid), \
         (mid)-[:E {tag: 'ok'}]->(okEnd), \
         (mid)-[:E {tag: 'bad'}]->(badEnd)""");
+
+    // Nodes for the three-valued-logic tests, again on their own label so the tests above are
+    // unaffected. 'tagged' is reached by an edge carrying tag and w; 'untagged' by an edge with no
+    // tag property at all, so predicates over r.tag evaluate to NULL for it.
+    database.command("opencypher",
+        """
+        MATCH (a:A {v: 1}) \
+        CREATE (tagged:N {name: 'tagged'}), (untagged:N {name: 'untagged'}), \
+        (a)-[:E {tag: 'ok', w: 1}]->(tagged), \
+        (a)-[:E]->(untagged)""");
   }
 
   @Test
@@ -189,6 +200,81 @@ class OpenCypherPatternComprehensionInlineWhereTest extends TestHelper {
 
     assertThat(rs.hasNext()).isTrue();
     assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void inlineWherePredicateSupportsConjunction() {
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN [(a)-[r:E WHERE r.tag = 'ok' AND r.w = 1]->(x:N) | x.name] AS names""");
+
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> names = rs.next().getProperty("names");
+    assertThat(names).containsExactly("tagged");
+  }
+
+  @Test
+  void inlineWherePredicateSupportsDisjunction() {
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN [(a)-[r:E WHERE r.tag = 'zzz' OR r.w = 1]->(x:N) | x.name] AS names""");
+
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> names = rs.next().getProperty("names");
+    assertThat(names).containsExactly("tagged");
+  }
+
+  @Test
+  void inlineWherePredicateExcludesRelationshipsWhoseComparisonIsNull() {
+    // The 'untagged' edge has no tag property, so r.tag = 'ok' is NULL and the edge is excluded -
+    // NULL is not a match in Cypher.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN [(a)-[r:E WHERE r.tag = 'ok']->(x:N) | x.name] AS names""");
+
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> names = rs.next().getProperty("names");
+    assertThat(names).containsExactly("tagged");
+  }
+
+  @Test
+  void inlineWhereIsNullPredicateSelectsTheMissingProperty() {
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN [(a)-[r:E WHERE r.tag IS NULL]->(x:N) | x.name] AS names""");
+
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> names = rs.next().getProperty("names");
+    assertThat(names).containsExactly("untagged");
+  }
+
+  @Test
+  void negatedInlineWherePredicateMatchesTheRegularMatchPath() {
+    // Three-valued logic under NOT: for 'tagged' NOT(true) is false; for 'untagged' the comparison
+    // is NULL and NOT NULL stays NULL, so neither is a match. The comprehension parses the predicate
+    // through a different builder than MATCH does, so pin both engines to the same answer.
+    final ResultSet comprehension = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})
+        RETURN [(a)-[r:E WHERE NOT (r.tag = 'ok')]->(x:N) | x.name] AS names""");
+
+    assertThat(comprehension.hasNext()).isTrue();
+    final List<Object> names = comprehension.next().getProperty("names");
+
+    final ResultSet match = database.query("opencypher",
+        """
+        MATCH (a:A {v: 1})-[r:E WHERE NOT (r.tag = 'ok')]->(x:N)
+        RETURN collect(x.name) AS names""");
+
+    assertThat(match.hasNext()).isTrue();
+    final List<Object> matchNames = match.next().getProperty("names");
+
+    assertThat(names).isEmpty();
+    assertThat(names).isEqualTo(matchNames);
   }
 
   @Test


### PR DESCRIPTION
Closes #5460

## Summary

A relationship inline `WHERE` predicate inside a pattern comprehension - the `WHERE r.tag = 'ok'` in `[(a)-[r:E WHERE r.tag = 'ok']->(b) | b]` - was silently discarded, so every matching relationship was collected as though no predicate were present. Even `WHERE 1=0` returned all matches. Two independent gaps had to be closed. First, pattern comprehensions are parsed by `CypherExpressionBuilder`, whose `parseRelationshipPattern(...)` never read the inline `WHERE` body and always passed `null` for `whereExpression` (the regular `MATCH` builder, `CypherASTBuilder`, does read it - which is why the same syntax works there). Second, `PatternComprehensionExpression` filtered candidate edges only through the inline property map, so it would have ignored the predicate even had the AST carried one. The fix parses the predicate with the existing `parseExpression(...)` adapted through `BooleanCoercionExpression`, and applies it on both the single-hop and variable-length expansion paths, mirroring `MatchRelationshipStep`.

## Test plan

- [ ] New regression test `OpenCypherPatternComprehensionInlineWhereTest` (17 tests) uses the exact data and queries from the report. Before the fix 4 failed with the reported symptom (`c = 2` instead of `0` / `1`) and the 4 controls passed; after the fix all 17 pass.
- [ ] `WHERE 1=0` returns `0`; `WHERE r.tag = 'ok'` returns `1` and projects the correct relationship - matching Neo4j.
- [ ] Inline and comprehension-level `WHERE` compose; the predicate can reference outer-scope bindings and resolve query parameters.
- [ ] Incoming (`<-[r:E WHERE ...]-`) and undirected patterns filter the same relationship.
- [ ] A two-hop chain is truncated at the first hop that fails the predicate, proving per-hop enforcement on the variable-length path. Verified by mutation: removing the check from `traverseVariableLength(...)` makes that test fail.
- [ ] Controls confirm no behavior change without a predicate and for the comprehension-level `WHERE` workaround.
- [ ] Full `com.arcadedb.query.opencypher.**` package: 7495 tests, 0 failures. The 3 reported errors are `OpenCypherCustomFunctionTest` GraalVM polyglot classloading failures, confirmed pre-existing by running that class unchanged on the base checkout.

Scope note: the same parse helper also feeds `exists(pattern)` and `shortestPath`, whose evaluators still do not consult `getWhereExpression()`. The parser change makes the predicate available on their AST nodes without altering their behavior, so this is regression-free for them; wiring it into those evaluators warrants its own issue. Details, including why the inline predicate cannot reference the far-end node, are in `docs/5460-pattern-comprehension-rel-inline-where.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)