### PR TITLE
fix(#5410): release the phase-2 ticket when an abandoned entry applies

### DIFF
--- a/docs/5410-abandoned-phase2-ticket-release.md
+++ b/docs/5410-abandoned-phase2-ticket-release.md
@@ -48,6 +48,20 @@ Ordering note: `lastAppliedIndex` advances in `applyTransaction` *after* `applyT
 at the moment of release a concurrent `takeSnapshot()` cannot yet report a checkpoint covering this
 entry.
 
+## Known gaps
+
+`applyTxEntry` consumes the abandoned mark before `applyChanges` runs. If `applyChanges` throws
+`WALVersionGapException`, the mark is gone but the ticket is (correctly) not released, and a snapshot
+resync is triggered. Once the resync makes the entry durable, nothing releases that ticket: every
+later replay origin-skips the entry because the mark is gone, so the checkpoint stays pinned until
+the node restarts.
+
+This is not a regression - before this change no release existed on any path - and the
+version-gap-during-abandoned-apply combination is exotic. Retaining is also the safe direction, since
+the resync may itself fail. It is left as a documented gap rather than fixed here because releasing on
+a failed apply is exactly the shape of the #5407 bug, and the condition is not silent: it trips
+`warnIfPhase2StallingCompaction` and shows up on the `arcadedb.ha.phase2.*` gauges below.
+
 ### Observability
 
 The issue also asked for the pinned-compaction condition to be visible on a dashboard rather than

--- a/docs/5410-abandoned-phase2-ticket-release.md
+++ b/docs/5410-abandoned-phase2-ticket-release.md
@@ -1,0 +1,72 @@
+# #5410 - Release the phase-2 ticket when an abandoned entry applies
+
+Follow-up to #5407 / PR #5408. Operational bug, not data loss.
+
+## Problem
+
+PR #5408 made `RaftReplicatedDatabase.commit()` take a phase-2 ticket from `ArcadeStateMachine`
+before replication. The ticket records a Raft replay floor, and `takeSnapshot()` clamps its
+durability checkpoint to the lowest in-flight floor so a Raft-committed but locally-unapplied entry
+can never be buried below the replay position.
+
+Tickets are retained by default and released only where the local pages are provably settled.
+
+The `ReplicationDispatchedTimeoutException` branch (#4790, indeterminate replication outcome)
+deliberately retains its ticket - correct, because the entry may still reach quorum and the retained
+ticket is what keeps it replayable across a crash.
+
+But the *normal* resolution of a #4790 timeout is that the entry later reaches quorum and is applied
+by `ArcadeStateMachine.applyTxEntry` through the `abandonedLocalTransactions` consumption path. At
+that moment the pages become durable, yet nothing released the ticket. The checkpoint stayed pinned
+and Ratis stopped purging the Raft log past that index until the process restarted - on a healthy
+node, with no crash involved.
+
+Related to #5345 (unbounded Raft log growth until disk-full).
+
+### Why it was not fixed in #5408
+
+The release needs a ticket-to-`walTxId` correlation that did not exist: the ticket is created in
+`commit()` before replication (no WAL txId associated yet), while
+`markTransactionAbandonedForLocalApply` knows the `walTxId` but not the ticket.
+
+## Fix
+
+Carry the ticket alongside the abandoned marker so the two reconcile.
+
+1. `abandonedLocalTransactions` changes from `Map<String, Long>` (key -> insertion time) to
+   `Map<String, AbandonedPhase2>`, where `AbandonedPhase2(phase2Ticket, insertedAt)` records both.
+2. `markLocalTransactionAbandoned(databaseName, walTxId, phase2Ticket)` stores the ticket;
+   `RaftReplicatedDatabase` passes the ticket it already holds on the dispatched-timeout branch.
+3. `applyTxEntry` releases the recorded ticket **only** on the branch that actually applied the
+   transaction, and only **after** `applyChanges` returned without throwing - i.e. once the pages are
+   on disk. The origin-skip branch never releases: releasing there would reintroduce #5407.
+4. TTL pruning of markers is unchanged, and a pruned marker deliberately does **not** release its
+   ticket: pruning is not proof the entry never committed, and if it does commit later it will be
+   origin-skipped (unapplied), so the entry must stay replayable.
+
+Ordering note: `lastAppliedIndex` advances in `applyTransaction` *after* `applyTxEntry` returns, so
+at the moment of release a concurrent `takeSnapshot()` cannot yet report a checkpoint covering this
+entry.
+
+### Observability
+
+The issue also asked for the pinned-compaction condition to be visible on a dashboard rather than
+only in the throttled WARNING. Added, reusing the existing framework-agnostic provider seam so the
+`ha-raft` module still needs no Micrometer dependency:
+
+- `ArcadeStateMachine` exposes `pendingLocalPhase2Count()`, `oldestPendingLocalPhase2HeldMs()` and
+  `lowestPendingLocalPhase2ReplayFloor()`.
+- `HAReplicationStatsProvider.PendingPhase2Stats` carries them; `RaftHAServer` / `RaftHAPlugin`
+  implement it.
+- `HAReplicationMetrics` registers `arcadedb.ha.phase2.pending`,
+  `arcadedb.ha.phase2.oldest_held_ms` and `arcadedb.ha.phase2.lowest_replay_floor`.
+
+## Verification
+
+Written before the fix (TDD), failing on the pre-fix code:
+
+- `Issue5410AbandonedPhase2TicketTest` - unit tests over the correlation and the release/retain
+  branches, driving the real `replicateAndCommitLocally` dispatched-timeout path.
+- `Issue5410AbandonedTicketReleaseIT` - end-to-end on a 3-node Raft cluster, reusing the #4790
+  fault injection: after the abandoned entry converges, the leader's pending phase-2 count must
+  return to zero and `takeSnapshot()` must advance again.

--- a/docs/5410-abandoned-phase2-ticket-release.md
+++ b/docs/5410-abandoned-phase2-ticket-release.md
@@ -79,8 +79,36 @@ only in the throttled WARNING. Added, reusing the existing framework-agnostic pr
 
 Written before the fix (TDD), failing on the pre-fix code:
 
-- `Issue5410AbandonedPhase2TicketTest` - unit tests over the correlation and the release/retain
-  branches, driving the real `replicateAndCommitLocally` dispatched-timeout path.
+- `Issue5410AbandonedPhase2TicketTest` (9 cases) - the correlation and the release/retain branches,
+  driving the real `replicateAndCommitLocally` dispatched-timeout path, plus the TTL-prune retain
+  invariant this doc leans on.
 - `Issue5410AbandonedTicketReleaseIT` - end-to-end on a 3-node Raft cluster, reusing the #4790
   fault injection: after the abandoned entry converges, the leader's pending phase-2 count must
-  return to zero and `takeSnapshot()` must advance again.
+  return to zero and no replay floor may stay pinned.
+- `HAPendingPhase2MetricsTest` (4 cases) - the new gauges, including the HA-disabled and
+  provider-default fallbacks.
+
+The IT was confirmed to fail on the pre-fix code (the ticket stayed held through a 30 s poll) and to
+pass after, with its clean-commit baseline assertion passing in both runs so the test is known to
+discriminate. Regression: `Issue4790PhantomCommitOriginSkipIT`,
+`RaftLeaderCrashBetweenCommitAndApplyIT`, `RaftLeaderCrashWithExternalPropertyIT`,
+`Issue5407Phase2TicketLifecycleTest`, `ArcadeStateMachinePendingPhase2SnapshotTest` all pass; full
+`ha-raft` unit suite 769 tests green, server monitor suite 46 tests green.
+
+## PR and review history
+
+https://github.com/ArcadeData/arcadedb/pull/5472
+
+| Cycle | Head | Outcome |
+|---|---|---|
+| 1 | `7f2219c1a` | claude[bot]: "high-quality, well-scoped fix", nothing blocking. Flagged the WAL-version-gap residual edge and the unnecessarily widened accessor visibility. |
+| 2 | `74a621f65` | Documented the residual edge in code and here; narrowed the three stat accessors back to package-private. claude[bot]: "nothing blocking", suggested reusing the named ticket sentinel. |
+| 3 | `38640d8cd` | Replaced the bare `-1L` in `commit()` with `ArcadeStateMachine.NO_PHASE2_TICKET`. claude[bot]: "looks correct and safe to merge", suggested pinning the TTL-prune retain invariant in a test. |
+| 4 | this commit | Added `aTtlPrunedMarkerKeepsItsTicketHeld`. |
+
+gemini-code-assist did not respond in any cycle.
+
+Deferred, for the developer to decide: claude[bot] suggested filing a follow-up issue so the two
+"pinned until restart" residuals (TTL-pruned marker, WAL-version-gap) stay tracked against #5345.
+Not filed here - the #5408 precedent was that filing the follow-up (#5410) was explicitly authorized
+by the owner first.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -249,13 +249,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // Locally-originated transactions whose leader-side phase 2 was abandoned because replication
   // returned an INDETERMINATE result (the entry was dispatched to Ratis but submitAndWait timed out
   // before quorum was confirmed - see ReplicationDispatchedTimeoutException). Keyed by
-  // "<databaseName>/<walTxId>" -> insertion time. If such an entry later reaches quorum and is
-  // applied here, applyTxEntry MUST apply it locally instead of origin-skipping it, otherwise the
-  // write lands on every follower but never on this leader: a silent, permanent divergence (issue
-  // #4790). Marking is always safe: it only changes behaviour IF the entry actually commits on this
-  // node's state machine (applying is then correct because the followers have it); if the entry
-  // never commits, the mark is inert and is pruned by TTL. Bounded by time-based pruning on insert.
-  private final        Map<String, Long> abandonedLocalTransactions    = new ConcurrentHashMap<>();
+  // "<databaseName>/<walTxId>". If such an entry later reaches quorum and is applied here,
+  // applyTxEntry MUST apply it locally instead of origin-skipping it, otherwise the write lands on
+  // every follower but never on this leader: a silent, permanent divergence (issue #4790). Marking
+  // is always safe: it only changes behaviour IF the entry actually commits on this node's state
+  // machine (applying is then correct because the followers have it); if the entry never commits,
+  // the mark is inert and is pruned by TTL. Bounded by time-based pruning on insert.
+  private final        Map<String, AbandonedPhase2> abandonedLocalTransactions = new ConcurrentHashMap<>();
   // Entries older than this are pruned on the next mark. Generous because a dispatched-but-stuck
   // entry can take a long time to either commit or be overwritten by a new leader.
   private static final long              ABANDONED_TX_TTL_MS           = 10 * 60 * 1000L;
@@ -282,6 +282,30 @@ public class ArcadeStateMachine extends BaseStateMachine {
   /** One in-flight leader-side phase 2: the replay floor to protect, and when it started. */
   private record PendingPhase2(long replayFloor, long startedAtMs) {
   }
+
+  /**
+   * One abandoned locally-originated transaction: the phase-2 ticket its commit is still holding,
+   * and when the mark was inserted (for TTL pruning). Carrying the ticket is what lets
+   * {@link #applyTxEntry} release it once the entry finally applies here, instead of leaving the
+   * snapshot checkpoint - and therefore Raft log purging - pinned until the node restarts (#5410).
+   */
+  private record AbandonedPhase2(long phase2Ticket, long insertedAt) {
+  }
+
+  /**
+   * Sentinel for "this entry carries no phase-2 ticket to release". Real tickets come from an
+   * {@link AtomicLong#incrementAndGet()} and are therefore always positive.
+   */
+  static final long NO_PHASE2_TICKET = -1L;
+
+  /**
+   * Sentinel for "this transaction was never marked abandoned", i.e. the origin-skip case. Kept
+   * distinct from {@link #NO_PHASE2_TICKET} on purpose: a transaction CAN be abandoned while holding
+   * no ticket (the commit took none because this node was not the leader), and conflating the two
+   * would make {@link #applyTxEntry} origin-skip an abandoned entry and reintroduce the #4790 lost
+   * write.
+   */
+  static final long NO_ABANDONED_MARK = Long.MIN_VALUE;
 
 
   public void setServer(final ArcadeDBServer server) {
@@ -1220,17 +1244,37 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * returned an indeterminate result ({@link ReplicationDispatchedTimeoutException}). If the entry
    * later commits, {@link #applyTxEntry} applies it here instead of origin-skipping it (issue #4790).
    * Called from {@link RaftReplicatedDatabase#commit()} on the dispatched-timeout path.
+   * <p>
+   * {@code phase2Ticket} is the still-held ticket of the commit that abandoned this transaction, or
+   * {@link #NO_PHASE2_TICKET} when it took none. Recording it here is the correlation the ticket
+   * lacks at {@link #beginLocalPhase2()} time (the WAL txId does not exist yet), and it is what lets
+   * the eventual apply release the ticket instead of pinning the checkpoint until restart (#5410).
    */
-  void markLocalTransactionAbandoned(final String databaseName, final long walTxId) {
+  void markLocalTransactionAbandoned(final String databaseName, final long walTxId, final long phase2Ticket) {
     final long now = System.currentTimeMillis();
     // Prune stale marks (entries that were dispatched but never committed, e.g. the slot was
-    // overwritten by a new leader) so the map cannot grow unbounded.
+    // overwritten by a new leader) so the map cannot grow unbounded. A pruned mark deliberately does
+    // NOT release its ticket: pruning is not proof the entry never committed, and if it does commit
+    // later it will now be origin-skipped (unapplied here), so it must stay inside the replay window.
     if (!abandonedLocalTransactions.isEmpty())
-      abandonedLocalTransactions.values().removeIf(insertedAt -> now - insertedAt > ABANDONED_TX_TTL_MS);
-    abandonedLocalTransactions.put(abandonedKey(databaseName, walTxId), now);
+      abandonedLocalTransactions.values().removeIf(abandoned -> now - abandoned.insertedAt() > ABANDONED_TX_TTL_MS);
+    abandonedLocalTransactions.put(abandonedKey(databaseName, walTxId), new AbandonedPhase2(phase2Ticket, now));
     HALog.log(this, HALog.BASIC,
         "Marked locally-originated tx %d on database '%s' for local apply on commit (replication was indeterminate, #4790)",
         walTxId, databaseName);
+  }
+
+  /**
+   * Consumes the abandoned mark for a locally-originated transaction, returning the phase-2 ticket
+   * to release once its pages are written (possibly {@link #NO_PHASE2_TICKET} when its commit held
+   * none), or {@link #NO_ABANDONED_MARK} when the transaction was not abandoned at all - the
+   * origin-skip case, where phase 2 already wrote the pages and released its own ticket.
+   * <p>
+   * Consuming is one-shot so a later replay of the same entry correctly origin-skips again.
+   */
+  long consumeAbandonedLocalTransaction(final String databaseName, final long walTxId) {
+    final AbandonedPhase2 abandoned = abandonedLocalTransactions.remove(abandonedKey(databaseName, walTxId));
+    return abandoned != null ? abandoned.phase2Ticket() : NO_ABANDONED_MARK;
   }
 
   private static String abandonedKey(final String databaseName, final long walTxId) {
@@ -1260,12 +1304,34 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * is holding a committed entry it never applied.
    */
   void endLocalPhase2(final long ticket) {
+    if (ticket == NO_PHASE2_TICKET)
+      return;
     pendingLocalPhase2.remove(ticket);
   }
 
   /** Number of leader-side phase 2 applies still holding the snapshot checkpoint back. */
-  int pendingLocalPhase2Count() {
+  public int pendingLocalPhase2Count() {
     return pendingLocalPhase2.size();
+  }
+
+  /**
+   * How long (ms) the oldest in-flight phase 2 has been holding the snapshot checkpoint, or {@code 0}
+   * when none is in flight. Exposed for the {@code arcadedb.ha.phase2.*} gauges so a node whose log
+   * compaction is pinned is visible on a dashboard rather than only in the throttled WARNING (#5410).
+   */
+  public long oldestPendingLocalPhase2HeldMs() {
+    final long oldest = oldestPendingLocalPhase2StartMs();
+    return oldest == Long.MAX_VALUE ? 0L : Math.max(0L, System.currentTimeMillis() - oldest);
+  }
+
+  /**
+   * The Raft replay floor currently pinning the snapshot checkpoint, or {@code -1} when nothing is
+   * in flight. Companion gauge to {@link #oldestPendingLocalPhase2HeldMs()}: it names the index past
+   * which the Raft log cannot be purged.
+   */
+  public long lowestPendingLocalPhase2ReplayFloor() {
+    final long lowest = lowestPendingLocalPhase2Floor();
+    return lowest == Long.MAX_VALUE ? -1L : lowest;
   }
 
   /**
@@ -1344,11 +1410,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // was confirmed). For such an entry phase 2 never ran, so it must be applied HERE instead of
     // origin-skipped, otherwise this leader silently loses a write the followers already have. The
     // mark is consumed (removed) so a later replay of the same entry correctly skips again.
+    // The ticket that commit() is still holding for this entry, when it was abandoned. Released
+    // below once applyChanges has written the pages - never on the origin-skip branch above, where
+    // releasing would reintroduce #5407.
+    long abandonedPhase2Ticket = NO_PHASE2_TICKET;
     if (originatedLocally) {
-      if (abandonedLocalTransactions.remove(abandonedKey(decoded.databaseName(), walTx.txId)) == null) {
+      final long abandoned = consumeAbandonedLocalTransaction(decoded.databaseName(), walTx.txId);
+      if (abandoned == NO_ABANDONED_MARK) {
         HALog.log(this, HALog.TRACE, "Skipping tx apply on originator for database '%s'", decoded.databaseName());
         return;
       }
+      abandonedPhase2Ticket = abandoned;
       HALog.log(this, HALog.BASIC,
           "Applying locally-originated tx %d on database '%s' whose phase 2 was abandoned (replication indeterminate, #4790)",
           walTx.txId, decoded.databaseName());
@@ -1390,6 +1462,14 @@ public class ArcadeStateMachine extends BaseStateMachine {
       throw new ReplicationException(
           "WAL version gap detected - snapshot resync required (db=" + decoded.databaseName() + ")", e);
     }
+
+    // The abandoned entry's pages are now on disk, so the commit that gave up on it in phase 2 no
+    // longer needs to hold the Raft replay window open: release its ticket and let log compaction
+    // resume (#5410). Reached only when applyChanges returned normally - a failed apply leaves the
+    // entry unapplied here and the ticket deliberately held. A no-op for every other entry.
+    // lastAppliedIndex still trails this entry at this point (applyTransaction advances it after we
+    // return), so a concurrent takeSnapshot cannot yet checkpoint over what we just applied.
+    endLocalPhase2(abandonedPhase2Ticket);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1310,7 +1310,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   /** Number of leader-side phase 2 applies still holding the snapshot checkpoint back. */
-  public int pendingLocalPhase2Count() {
+  int pendingLocalPhase2Count() {
     return pendingLocalPhase2.size();
   }
 
@@ -1319,7 +1319,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * when none is in flight. Exposed for the {@code arcadedb.ha.phase2.*} gauges so a node whose log
    * compaction is pinned is visible on a dashboard rather than only in the throttled WARNING (#5410).
    */
-  public long oldestPendingLocalPhase2HeldMs() {
+  long oldestPendingLocalPhase2HeldMs() {
     final long oldest = oldestPendingLocalPhase2StartMs();
     return oldest == Long.MAX_VALUE ? 0L : Math.max(0L, System.currentTimeMillis() - oldest);
   }
@@ -1329,7 +1329,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * in flight. Companion gauge to {@link #oldestPendingLocalPhase2HeldMs()}: it names the index past
    * which the Raft log cannot be purged.
    */
-  public long lowestPendingLocalPhase2ReplayFloor() {
+  long lowestPendingLocalPhase2ReplayFloor() {
     final long lowest = lowestPendingLocalPhase2Floor();
     return lowest == Long.MAX_VALUE ? -1L : lowest;
   }
@@ -1469,6 +1469,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // entry unapplied here and the ticket deliberately held. A no-op for every other entry.
     // lastAppliedIndex still trails this entry at this point (applyTransaction advances it after we
     // return), so a concurrent takeSnapshot cannot yet checkpoint over what we just applied.
+    //
+    // Residual edge: a WAL version gap above consumed the mark but threw, so the ticket stays held
+    // and the entry origin-skips on every later replay - the snapshot resync the gap triggers is what
+    // makes it durable, and nothing releases the ticket afterwards. The checkpoint then stays pinned
+    // until this node restarts. Retaining is the safe direction (the resync may itself fail), and the
+    // pinned checkpoint is surfaced by warnIfPhase2StallingCompaction and the arcadedb.ha.phase2.*
+    // gauges rather than being silent.
     endLocalPhase2(abandonedPhase2Ticket);
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -213,6 +213,12 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   }
 
   @Override
+  public PendingPhase2Stats getPendingPhase2Stats() {
+    final RaftHAServer s = raftHAServer;
+    return s != null ? s.getPendingPhase2Stats() : new PendingPhase2Stats(0, 0, -1);
+  }
+
+  @Override
   public String getLeaderName() {
     return raftHAServer != null ? raftHAServer.getLeaderName() : null;
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2383,6 +2383,19 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
+   * In-flight leader-side phase-2 holds on the Raft snapshot checkpoint (issue #5410). Reported on
+   * every node, not just the leader: a ticket taken while this node WAS the leader keeps pinning log
+   * compaction after it steps down, which is exactly the case an operator needs to see.
+   */
+  public HAReplicationStatsProvider.PendingPhase2Stats getPendingPhase2Stats() {
+    final ArcadeStateMachine sm = stateMachine;
+    if (sm == null)
+      return new HAReplicationStatsProvider.PendingPhase2Stats(0, 0, -1);
+    return new HAReplicationStatsProvider.PendingPhase2Stats(
+        sm.pendingLocalPhase2Count(), sm.oldestPendingLocalPhase2HeldMs(), sm.lowestPendingLocalPhase2ReplayFloor());
+  }
+
+  /**
    * Leader-&gt;follower replication round-trip latency, in milliseconds, keyed by follower peer id.
    * Unlike {@code lastRpcElapsedMs} (age of the last RPC, which on an idle cluster just tracks the
    * heartbeat cadence - issue #5314), this is the actual measured RTT of the {@code appendEntries}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -435,7 +435,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // silently dropping the write on the leader. Mark the transaction so that, if the entry does
       // commit, applyTxEntry applies it locally instead of skipping. Then roll back the in-flight
       // (un-applied) local transaction and surface the retryable error to the client.
-      markTransactionAbandonedForLocalApply(payload);
+      // The ticket travels with the mark (#5410): this branch keeps holding it so a crash before the
+      // entry applies still replays it, and whoever finally applies the entry releases it from the
+      // mark - without that correlation the checkpoint stayed pinned until the node restarted.
+      markTransactionAbandonedForLocalApply(payload, phase2Ticket);
       rollback();
       throw e;
     } catch (final ArcadeDBException e) {
@@ -579,14 +582,18 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * so the state machine sees the identical value when the entry commits. Best-effort: if anything
    * goes wrong while extracting the txId we log and continue (the caller still rolls back and throws
    * a retryable error), rather than masking the original replication failure.
+   * <p>
+   * {@code phase2Ticket} rides along so the eventual apply can release it (issue #5410). When the
+   * txId cannot be extracted the ticket stays held, which is the safe direction: an entry we cannot
+   * correlate is one we cannot prove was applied.
    */
-  private void markTransactionAbandonedForLocalApply(final ReplicationPayload payload) {
+  private void markTransactionAbandonedForLocalApply(final ReplicationPayload payload, final long phase2Ticket) {
     final ArcadeStateMachine stateMachine = stateMachineOrNull();
     if (stateMachine == null)
       return;
     try {
       final long walTxId = ArcadeStateMachine.deserializeWalTransaction(payload.walData()).txId;
-      stateMachine.markLocalTransactionAbandoned(getName(), walTxId);
+      stateMachine.markLocalTransactionAbandoned(getName(), walTxId, phase2Ticket);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING,
           "Could not mark transaction for local apply after indeterminate replication (db=%s): %s",

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -393,7 +393,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // one taken here would make the write unreplayable and lost on this node forever (issue #5407).
     // Only the leader runs phase 2 (see the !leader early return below), so only it needs the ticket.
     final ArcadeStateMachine stateMachine = leader ? stateMachineOrNull() : null;
-    final long phase2Ticket = stateMachine != null ? stateMachine.beginLocalPhase2() : -1L;
+    final long phase2Ticket = stateMachine != null ?
+        stateMachine.beginLocalPhase2() :
+        ArcadeStateMachine.NO_PHASE2_TICKET;
     replicateAndCommitLocally(payload, leader, stateMachine, phase2Ticket);
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5410AbandonedPhase2TicketTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5410AbandonedPhase2TicketTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -182,6 +184,53 @@ class Issue5410AbandonedPhase2TicketTest {
     assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 7L))
         .as("a replayed entry must not release a ticket a second time")
         .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
+  }
+
+  /**
+   * A marker dropped by TTL pruning must NOT release its ticket. Pruning is not proof the entry never
+   * committed: if it commits afterwards it is origin-skipped (so it never applies here), and the entry
+   * must stay inside the replay window. The docs lean on this invariant, so it is pinned here.
+   */
+  @Test
+  void aTtlPrunedMarkerKeepsItsTicketHeld() throws Exception {
+    final long staleTicket = stateMachine.beginLocalPhase2();
+    stateMachine.markLocalTransactionAbandoned(DB_NAME, 11L, staleTicket);
+
+    backdateAbandonedMark(DB_NAME, 11L);
+
+    // Marking any other transaction runs the prune pass that evicts the backdated entry.
+    final long freshTicket = stateMachine.beginLocalPhase2();
+    stateMachine.markLocalTransactionAbandoned(DB_NAME, 12L, freshTicket);
+
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 11L))
+        .as("the stale marker must have been pruned")
+        .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("pruning a marker must not release its ticket - the entry may still commit unapplied")
+        .isEqualTo(2);
+  }
+
+  /**
+   * Rewrites one abandoned mark's insertion time to just beyond {@code ABANDONED_TX_TTL_MS} so the
+   * next mark prunes it, without making the test wait out the real 10-minute TTL.
+   */
+  @SuppressWarnings("unchecked")
+  private void backdateAbandonedMark(final String databaseName, final long walTxId) throws Exception {
+    final Field marksField = ArcadeStateMachine.class.getDeclaredField("abandonedLocalTransactions");
+    marksField.setAccessible(true);
+    final Map<String, Object> marks = (Map<String, Object>) marksField.get(stateMachine);
+
+    final Field ttlField = ArcadeStateMachine.class.getDeclaredField("ABANDONED_TX_TTL_MS");
+    ttlField.setAccessible(true);
+    final long ttlMs = (long) ttlField.get(null);
+
+    final String key = databaseName + "/" + walTxId;
+    final Object mark = marks.get(key);
+    final Constructor<?> ctor = mark.getClass().getDeclaredConstructor(long.class, long.class);
+    ctor.setAccessible(true);
+    final Field ticketField = mark.getClass().getDeclaredField("phase2Ticket");
+    ticketField.setAccessible(true);
+    marks.put(key, ctor.newInstance(ticketField.get(mark), System.currentTimeMillis() - ttlMs - 1_000L));
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5410AbandonedPhase2TicketTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5410AbandonedPhase2TicketTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #5410: the #4790 dispatched-timeout branch retains its phase-2 ticket on purpose - the entry
+ * may still reach quorum, and the retained ticket is what keeps it replayable if this node dies
+ * before applying it. But when the abandoned entry later DOES commit and
+ * {@code ArcadeStateMachine.applyTxEntry} applies it, its pages become durable and nothing released
+ * the ticket, so the snapshot checkpoint - and with it Raft log purging - stayed pinned until the
+ * process restarted.
+ * <p>
+ * The fix records the ticket alongside the abandoned marker so the two can be reconciled, and
+ * releases it on the branch that actually applies the transaction. The release must never move to
+ * the origin-skip branch: that would reintroduce #5407.
+ *
+ * @see Issue5407Phase2TicketLifecycleTest for the surrounding ticket-lifecycle contract
+ */
+class Issue5410AbandonedPhase2TicketTest {
+
+  private static final String DB_NAME = "issue5410";
+
+  // Only ever used as the DatabaseContext key (proxied is a mock, nothing touches the filesystem).
+  private final String dbPath = "issue5410-abandoned-ticket-" + UUID.randomUUID();
+
+  private LocalDatabase         proxied;
+  private RaftHAServer          raftServer;
+  private TransactionContext    tx;
+  private ArcadeStateMachine    stateMachine;
+  private RaftTransactionBroker broker;
+
+  @BeforeEach
+  void setUp() {
+    proxied = mock(LocalDatabase.class);
+    when(proxied.getDatabasePath()).thenReturn(dbPath);
+    when(proxied.getName()).thenReturn(DB_NAME);
+    when(proxied.getTransactionManager()).thenReturn(mock(TransactionManager.class));
+    when(proxied.getSchema()).thenReturn(mock(Schema.class, RETURNS_DEEP_STUBS));
+    when(proxied.executeInReadLock(any())).thenAnswer(inv -> ((Callable<?>) inv.getArgument(0)).call());
+
+    broker = mock(RaftTransactionBroker.class);
+    raftServer = mock(RaftHAServer.class, RETURNS_DEEP_STUBS);
+    when(raftServer.isLeader()).thenReturn(true);
+    when(raftServer.getTransactionBroker()).thenReturn(broker);
+    when(raftServer.getStateMachine()).thenAnswer(inv -> stateMachine);
+
+    tx = mock(TransactionContext.class);
+    stateMachine = new ArcadeStateMachine();
+  }
+
+  @AfterEach
+  void tearDown() {
+    DatabaseContext.INSTANCE.removeContext(dbPath);
+  }
+
+  /**
+   * The pre-existing #5407 contract, restated here because the fix must not weaken it: an
+   * indeterminate replication outcome keeps the ticket, because the entry may yet commit while this
+   * node never applied it.
+   */
+  @Test
+  void dispatchedTimeoutStillRetainsTheTicket() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    dispatchedTimeoutOnReplicate();
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(ReplicationDispatchedTimeoutException.class);
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("the entry may still commit while unapplied here, so it must stay replayable")
+        .isEqualTo(1);
+  }
+
+  /**
+   * The #5410 fix: the abandoned marker must carry the ticket so the later apply can release it.
+   * Before the fix the marker recorded only an insertion timestamp and the correlation was
+   * impossible.
+   */
+  @Test
+  void abandonedMarkerCarriesThePhase2Ticket() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    dispatchedTimeoutOnReplicate();
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(ReplicationDispatchedTimeoutException.class);
+
+    // The 24-zero-byte payload deserializes to an empty WAL transaction with txId 0.
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 0L))
+        .as("the marker must remember which ticket to release once the entry applies")
+        .isEqualTo(ticket);
+  }
+
+  /**
+   * Consuming the marker and releasing the recorded ticket is what unpins log compaction. This is
+   * the sequence {@code applyTxEntry} performs once the abandoned entry reaches quorum and its
+   * pages are written.
+   */
+  @Test
+  void releasingTheRecordedTicketUnpinsTheCheckpoint() {
+    final RaftReplicatedDatabase database = newDatabase();
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    dispatchedTimeoutOnReplicate();
+
+    assertThatThrownBy(() -> database.replicateAndCommitLocally(payload(), true, stateMachine, ticket))
+        .isInstanceOf(ReplicationDispatchedTimeoutException.class);
+    assertThat(stateMachine.pendingLocalPhase2Count()).isEqualTo(1);
+
+    stateMachine.endLocalPhase2(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 0L));
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("once the abandoned entry's pages are written the checkpoint must be free to advance")
+        .isZero();
+  }
+
+  /**
+   * The origin-skip branch: an entry with no abandoned marker was already applied by phase 2, and
+   * releasing anything on its behalf here would reintroduce #5407. The lookup must report "nothing
+   * to release" rather than a live ticket.
+   */
+  @Test
+  void anEntryWithoutAnAbandonedMarkerReleasesNothing() {
+    stateMachine.beginLocalPhase2();
+
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 42L))
+        .as("no marker means the origin-skip branch, which must never release a ticket")
+        .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("the in-flight phase 2 must be untouched")
+        .isEqualTo(1);
+  }
+
+  /** The marker is consumed exactly once, so a replay of the same entry correctly skips again. */
+  @Test
+  void theMarkerIsConsumedOnlyOnce() {
+    final long ticket = stateMachine.beginLocalPhase2();
+    stateMachine.markLocalTransactionAbandoned(DB_NAME, 7L, ticket);
+
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 7L)).isEqualTo(ticket);
+    assertThat(stateMachine.consumeAbandonedLocalTransaction(DB_NAME, 7L))
+        .as("a replayed entry must not release a ticket a second time")
+        .isEqualTo(ArcadeStateMachine.NO_ABANDONED_MARK);
+  }
+
+  /**
+   * Releasing the sentinel must be a no-op: {@code applyTxEntry} calls the release path for every
+   * applied entry, and the overwhelming majority carry no ticket at all (replica applies, replay).
+   */
+  @Test
+  void releasingTheNoTicketSentinelIsANoOp() {
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    stateMachine.endLocalPhase2(ArcadeStateMachine.NO_PHASE2_TICKET);
+
+    assertThat(stateMachine.pendingLocalPhase2Count())
+        .as("the sentinel must never evict a live ticket")
+        .isEqualTo(1);
+    stateMachine.endLocalPhase2(ticket);
+    assertThat(stateMachine.pendingLocalPhase2Count()).isZero();
+  }
+
+  /**
+   * The stats the Micrometer gauges read: with nothing in flight they must report the idle
+   * placeholders rather than {@code Long.MAX_VALUE} leaking out of the internal scan.
+   */
+  @Test
+  void pendingPhase2StatsReportIdlePlaceholdersWhenNothingIsInFlight() {
+    assertThat(stateMachine.pendingLocalPhase2Count()).isZero();
+    assertThat(stateMachine.oldestPendingLocalPhase2HeldMs())
+        .as("no held ticket means no age to report")
+        .isZero();
+    assertThat(stateMachine.lowestPendingLocalPhase2ReplayFloor())
+        .as("no held ticket means no floor is pinning the checkpoint")
+        .isEqualTo(-1L);
+  }
+
+  /** With a ticket in flight the gauges must expose the pinned floor and a non-negative age. */
+  @Test
+  void pendingPhase2StatsExposeTheHeldFloor() {
+    final long ticket = stateMachine.beginLocalPhase2();
+
+    assertThat(stateMachine.pendingLocalPhase2Count()).isEqualTo(1);
+    assertThat(stateMachine.oldestPendingLocalPhase2HeldMs()).isGreaterThanOrEqualTo(0L);
+    assertThat(stateMachine.lowestPendingLocalPhase2ReplayFloor())
+        .as("a fresh state machine has applied nothing, so the floor is -1")
+        .isEqualTo(-1L);
+
+    stateMachine.endLocalPhase2(ticket);
+    assertThat(stateMachine.oldestPendingLocalPhase2HeldMs()).isZero();
+  }
+
+  private void dispatchedTimeoutOnReplicate() {
+    doThrow(new ReplicationDispatchedTimeoutException("simulated dispatched-then-timed-out replication"))
+        .when(broker).replicateTransaction(anyString(), any(), any());
+  }
+
+  private RaftReplicatedDatabase newDatabase() {
+    final RaftReplicatedDatabase database = new RaftReplicatedDatabase(null, proxied, raftServer);
+    DatabaseContext.INSTANCE.init(proxied, tx);
+    return database;
+  }
+
+  /** 24 zero bytes deserialize to an empty WAL transaction (txId=0, 0 pages). */
+  private RaftReplicatedDatabase.ReplicationPayload payload() {
+    return new RaftReplicatedDatabase.ReplicationPayload(tx, null, new byte[24], Map.of());
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5410AbandonedTicketReleaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5410AbandonedTicketReleaseIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.log.LogManager;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5410, end-to-end through the real {@code applyTxEntry}.
+ * <p>
+ * A #4790 dispatched-timeout leaves a locally-originated entry abandoned by the leader's phase 2,
+ * and the #5407 guard deliberately keeps that entry's phase-2 ticket held so the entry stays inside
+ * the Raft replay window. When the entry then reaches quorum and the state machine applies it
+ * locally - the normal, non-crash resolution of a #4790 timeout - its pages become durable, but
+ * before this fix nothing released the ticket. The snapshot checkpoint stayed clamped to that
+ * entry's replay floor, so Ratis could not purge the Raft log past it for the rest of the node's
+ * uptime (feeding #5345, unbounded Raft log growth).
+ * <p>
+ * The fix carries the ticket on the abandoned marker and releases it on the branch that actually
+ * applies the transaction. This test reuses the #4790 fault injection to produce a real abandoned
+ * entry, and asserts the leader stops pinning the checkpoint once the entry converges.
+ *
+ * @see Issue4790PhantomCommitOriginSkipIT for the lost-write behaviour this builds on
+ */
+@Tag("slow")
+class Issue5410AbandonedTicketReleaseIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE = "AbandonedTicket";
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @AfterEach
+  void clearHooks() {
+    RaftGroupCommitter.TEST_FORCE_DISPATCHED_TIMEOUT = null;
+  }
+
+  @Test
+  void abandonedEntryReleasesItsPhase2TicketOnceApplied() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    final ArcadeStateMachine leaderStateMachine = getRaftPlugin(leaderIndex).getRaftHAServer().getStateMachine();
+
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE, 1);
+    });
+
+    leaderDb.transaction(() -> {
+      final MutableVertex v = leaderDb.newVertex(VERTEX_TYPE);
+      v.set("name", "baseline");
+      v.save();
+    });
+    assertClusterConsistency();
+
+    // A cleanly committed write must leave nothing pinned: this is the baseline the faulted commit
+    // is compared against, and it also proves the assertion below can actually observe a release.
+    assertThat(awaitNoPendingPhase2(leaderStateMachine))
+        .as("a cleanly replicated commit must not pin the snapshot checkpoint")
+        .isTrue();
+
+    // Arm the one-shot #4790 fault: the entry is dispatched to Ratis for real (so it WILL commit on
+    // the followers) but the quorum wait abandons with ReplicationDispatchedTimeoutException.
+    final AtomicBoolean faultFired = new AtomicBoolean(false);
+    RaftGroupCommitter.TEST_FORCE_DISPATCHED_TIMEOUT = entry -> {
+      try {
+        final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(ByteString.copyFrom(entry));
+        if (decoded.type() == RaftLogEntryType.TX_ENTRY
+            && getDatabaseName().equals(decoded.databaseName())
+            && faultFired.compareAndSet(false, true)) {
+          LogManager.instance().log(this, Level.INFO,
+              "TEST: forcing dispatched-timeout for a TX_ENTRY on db=%s", decoded.databaseName());
+          return true;
+        }
+      } catch (final Exception ignore) {
+        // Not a decodable/target entry; never force the timeout for it.
+      }
+      return false;
+    };
+
+    boolean threw = false;
+    try {
+      leaderDb.begin();
+      final MutableVertex v = leaderDb.newVertex(VERTEX_TYPE);
+      v.set("name", "abandoned");
+      v.save();
+      leaderDb.commit();
+    } catch (final ReplicationDispatchedTimeoutException expected) {
+      threw = true;
+    } finally {
+      if (leaderDb.isTransactionActive())
+        leaderDb.rollback();
+    }
+
+    assertThat(faultFired.get()).as("The dispatched-timeout fault must have fired").isTrue();
+    assertThat(threw).as("commit() must surface the indeterminate replication error").isTrue();
+
+    // The abandoned entry reaches quorum and every node - including the leader, via the
+    // abandonedLocalTransactions path - converges on both vertices (the #4790 contract).
+    final long deadline = System.currentTimeMillis() + 30_000;
+    boolean converged = false;
+    while (System.currentTimeMillis() < deadline && !converged) {
+      for (int i = 0; i < getServerCount(); i++)
+        waitForReplicationIsCompleted(i);
+      converged = true;
+      for (int i = 0; i < getServerCount(); i++)
+        if (getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true) != 2L) {
+          converged = false;
+          break;
+        }
+      if (!converged)
+        Thread.sleep(250);
+    }
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
+          .as("Node %d must hold both vertices", i)
+          .isEqualTo(2L);
+
+    // The #5410 assertion: the entry's pages are on disk here, so the ticket taken before the
+    // abandoned replication must have been released. Before the fix this stayed at 1 until restart.
+    assertThat(awaitNoPendingPhase2(leaderStateMachine))
+        .as("applying the abandoned entry must release its phase-2 ticket, unpinning log compaction")
+        .isTrue();
+
+    // With nothing pinned the checkpoint is free to move again, which is what Ratis needs before it
+    // can purge the Raft log - the operational symptom the issue reports.
+    assertThat(leaderStateMachine.lowestPendingLocalPhase2ReplayFloor())
+        .as("no replay floor may remain pinned once the abandoned entry is applied")
+        .isEqualTo(-1L);
+    assertThat(leaderStateMachine.oldestPendingLocalPhase2HeldMs())
+        .as("no ticket age may remain once the abandoned entry is applied")
+        .isZero();
+
+    assertClusterConsistency();
+  }
+
+  /**
+   * Waits for the leader to stop holding phase-2 tickets. Polled rather than asserted outright
+   * because the release happens on the Raft apply thread, asynchronously from the client commit that
+   * observed the timeout.
+   */
+  private static boolean awaitNoPendingPhase2(final ArcadeStateMachine stateMachine) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (System.currentTimeMillis() < deadline) {
+      if (stateMachine.pendingLocalPhase2Count() == 0)
+        return true;
+      Thread.sleep(100);
+    }
+    return false;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/monitor/HAReplicationMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/HAReplicationMetrics.java
@@ -23,6 +23,7 @@ import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.server.monitor.HAReplicationStatsProvider.FollowerSample;
 import com.arcadedb.server.monitor.HAReplicationStatsProvider.HAReplicationStats;
+import com.arcadedb.server.monitor.HAReplicationStatsProvider.PendingPhase2Stats;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -80,7 +81,33 @@ public final class HAReplicationMetrics implements MeterBinder {
         .description("Number of followers the leader is currently tracking. 0 when not leader.")
         .register(registry);
 
+    bindPendingPhase2Gauges(registry);
     bindPerFollowerGauges(registry);
+  }
+
+  /**
+   * Registers the phase-2 hold gauges (issue #5410). A locally-originated entry that Raft committed
+   * but this node has not written yet holds the snapshot checkpoint back so it stays replayable
+   * (issue #5407). A hold that never clears pins Raft log purging until the node restarts, which
+   * surfaces to operators as a Raft log that stops shrinking (issue #5345). Without these gauges the
+   * only signal is a throttled WARNING emitted at most once per compaction interval.
+   */
+  private void bindPendingPhase2Gauges(final MeterRegistry registry) {
+    Gauge.builder("arcadedb.ha.phase2.pending", () -> pendingPhase2().pending())
+        .description("Local phase-2 applies still holding the Raft snapshot checkpoint back. "
+            + "Sustained non-zero means log compaction is pinned until this node restarts.")
+        .register(registry);
+
+    Gauge.builder("arcadedb.ha.phase2.oldest_held_ms", () -> pendingPhase2().oldestHeldMs())
+        .description("Age (ms) of the oldest phase-2 hold; 0 when none. A value that keeps growing "
+            + "identifies a stuck hold rather than ordinary in-flight commits.")
+        .baseUnit("milliseconds")
+        .register(registry);
+
+    Gauge.builder("arcadedb.ha.phase2.lowest_replay_floor", () -> pendingPhase2().lowestReplayFloor())
+        .description("Raft index past which the log cannot be purged while a phase-2 hold is "
+            + "outstanding; -1 when nothing is held.")
+        .register(registry);
   }
 
   /**
@@ -139,6 +166,14 @@ public final class HAReplicationMetrics implements MeterBinder {
       if (plugin instanceof HAReplicationStatsProvider provider)
         return provider.getHAReplicationStats();
     return new HAReplicationStats(false, -1, -1, 0);
+  }
+
+  /** Phase-2 hold state from the started HA plugin, or "nothing held" when HA is disabled. */
+  private PendingPhase2Stats pendingPhase2() {
+    for (final ServerPlugin plugin : server.getPlugins())
+      if (plugin instanceof HAReplicationStatsProvider provider)
+        return provider.getPendingPhase2Stats();
+    return new PendingPhase2Stats(0, 0, -1);
   }
 
   /** Per-follower samples from the started HA plugin, or empty when HA is disabled / not the leader. */

--- a/server/src/main/java/com/arcadedb/server/monitor/HAReplicationStatsProvider.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/HAReplicationStatsProvider.java
@@ -66,10 +66,32 @@ public interface HAReplicationStatsProvider {
   }
 
   /**
+   * In-flight leader-side phase-2 applies, which hold the Raft snapshot checkpoint back so an entry
+   * that is Raft-committed but not yet written locally stays replayable (issue #5407). A ticket that
+   * stays held pins log compaction until the node restarts, so this is the signal that explains a
+   * Raft log which stops shrinking (issues #5410, #5345).
+   *
+   * @param pending           number of phase-2 applies currently holding the checkpoint back
+   * @param oldestHeldMs      how long (ms) the oldest of them has been held ({@code 0} when none)
+   * @param lowestReplayFloor the Raft index past which the log cannot be purged while these are
+   *                          held ({@code -1} when none)
+   */
+  record PendingPhase2Stats(int pending, long oldestHeldMs, long lowestReplayFloor) {
+  }
+
+  /**
    * Returns a live snapshot of replication health. Called on each metrics scrape, so implementations
    * must be cheap and non-blocking.
    */
   HAReplicationStats getHAReplicationStats();
+
+  /**
+   * Returns the in-flight phase-2 hold state. Cheap and non-blocking - it scans a map sized by
+   * concurrent commits. Defaults to "nothing held" for implementations without a Raft state machine.
+   */
+  default PendingPhase2Stats getPendingPhase2Stats() {
+    return new PendingPhase2Stats(0, 0, -1);
+  }
 
   /**
    * Returns a per-follower health sample (leader only; empty otherwise). Cheap and non-blocking - it

--- a/server/src/test/java/com/arcadedb/server/monitor/HAPendingPhase2MetricsTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/HAPendingPhase2MetricsTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerPlugin;
+import com.arcadedb.server.monitor.HAReplicationStatsProvider.HAReplicationStats;
+import com.arcadedb.server.monitor.HAReplicationStatsProvider.PendingPhase2Stats;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #5410: a phase-2 hold that never clears pins Raft log compaction until the node restarts,
+ * and before these gauges the only signal was a WARNING emitted at most once per compaction
+ * interval. Verifies {@link HAReplicationMetrics} publishes the hold state as
+ * {@code arcadedb.ha.phase2.*} and degrades to "nothing held" when HA is disabled.
+ */
+class HAPendingPhase2MetricsTest {
+
+  /** Minimal plugin that is both a ServerPlugin (discoverable) and a stats provider. */
+  private static final class FakeHAPlugin implements ServerPlugin, HAReplicationStatsProvider {
+    private final PendingPhase2Stats phase2;
+
+    FakeHAPlugin(final PendingPhase2Stats phase2) {
+      this.phase2 = phase2;
+    }
+
+    @Override
+    public void startService() {
+    }
+
+    @Override
+    public HAReplicationStats getHAReplicationStats() {
+      return new HAReplicationStats(true, -1, -1, 0);
+    }
+
+    @Override
+    public PendingPhase2Stats getPendingPhase2Stats() {
+      return phase2;
+    }
+  }
+
+  @Test
+  void gaugesExposeAnOutstandingPhase2Hold() {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getPlugins()).thenReturn(List.of(new FakeHAPlugin(new PendingPhase2Stats(2, 620_000L, 4711L))));
+
+    final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    new HAReplicationMetrics(server).bindTo(registry);
+
+    assertThat(registry.find("arcadedb.ha.phase2.pending").gauge().value()).isEqualTo(2.0);
+    assertThat(registry.find("arcadedb.ha.phase2.oldest_held_ms").gauge().value()).isEqualTo(620_000.0);
+    assertThat(registry.find("arcadedb.ha.phase2.lowest_replay_floor").gauge().value())
+        .as("the pinned index is what an operator needs to correlate with Raft-storage disk usage")
+        .isEqualTo(4711.0);
+  }
+
+  @Test
+  void gaugesReportNothingHeldOnAnIdleNode() {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getPlugins()).thenReturn(List.of(new FakeHAPlugin(new PendingPhase2Stats(0, 0, -1))));
+
+    final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    new HAReplicationMetrics(server).bindTo(registry);
+
+    assertThat(registry.find("arcadedb.ha.phase2.pending").gauge().value()).isZero();
+    assertThat(registry.find("arcadedb.ha.phase2.oldest_held_ms").gauge().value()).isZero();
+    assertThat(registry.find("arcadedb.ha.phase2.lowest_replay_floor").gauge().value())
+        .as("-1 marks 'no floor pinned' so dashboards can filter it out")
+        .isEqualTo(-1.0);
+  }
+
+  @Test
+  void gaugesDegradeWhenHAIsDisabled() {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getPlugins()).thenReturn(List.of());
+
+    final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    new HAReplicationMetrics(server).bindTo(registry);
+
+    assertThat(registry.find("arcadedb.ha.phase2.pending").gauge().value()).isZero();
+    assertThat(registry.find("arcadedb.ha.phase2.oldest_held_ms").gauge().value()).isZero();
+    assertThat(registry.find("arcadedb.ha.phase2.lowest_replay_floor").gauge().value()).isEqualTo(-1.0);
+  }
+
+  /** A provider that never overrides the default must still publish usable numbers. */
+  @Test
+  void providerDefaultReportsNothingHeld() {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getPlugins()).thenReturn(List.of(new ServerPlugin() {
+      @Override
+      public void startService() {
+      }
+    }));
+
+    final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    new HAReplicationMetrics(server).bindTo(registry);
+
+    for (final String gauge : new String[] {
+        "arcadedb.ha.phase2.pending", "arcadedb.ha.phase2.oldest_held_ms",
+        "arcadedb.ha.phase2.lowest_replay_floor" })
+      assertThat(registry.find(gauge).gauge().value()).as("%s must be finite", gauge).isFinite();
+  }
+}


### PR DESCRIPTION
Closes #5410

Follow-up to #5407 / PR #5408. Operational bug, not data loss.

PR #5408 made `RaftReplicatedDatabase.commit()` take a phase-2 ticket from `ArcadeStateMachine` before replication; `takeSnapshot()` clamps its durability checkpoint to the lowest in-flight replay floor so a Raft-committed but locally-unapplied entry can never be buried below the replay position. Tickets are retained by default and released only where the local pages are provably settled. The `ReplicationDispatchedTimeoutException` branch (#4790) deliberately retains its ticket, which is correct: the entry may still reach quorum, and the retained ticket is what keeps it replayable across a crash. But the *normal* resolution of a #4790 timeout is that the entry later reaches quorum and `ArcadeStateMachine.applyTxEntry` applies it through the `abandonedLocalTransactions` path. At that point the pages are durable, yet nothing released the ticket, so the checkpoint stayed pinned and Ratis stopped purging the Raft log past that index until the process restarted - on a healthy node, with no crash involved (feeding #5345).

The release needed a ticket-to-`walTxId` correlation that did not exist: the ticket is created in `commit()` before replication (no WAL txId yet), while `markTransactionAbandonedForLocalApply` knows the `walTxId` but not the ticket.

## Changes

- `abandonedLocalTransactions` becomes `Map<String, AbandonedPhase2>`, recording the ticket alongside the insertion time; `markLocalTransactionAbandoned` takes the ticket and `RaftReplicatedDatabase` passes the one it already holds.
- `applyTxEntry` releases the recorded ticket **only** on the branch that actually applied the transaction, and only **after** `applyChanges` returned without throwing. The origin-skip branch never releases - that would reintroduce #5407. `lastAppliedIndex` advances in `applyTransaction` after `applyTxEntry` returns, so a concurrent `takeSnapshot()` cannot checkpoint over the entry at the moment of release.
- Two distinct sentinels (`NO_PHASE2_TICKET` vs `NO_ABANDONED_MARK`) keep "abandoned but holding no ticket" from being mistaken for "not abandoned", which would silently reintroduce the #4790 lost write.
- A TTL-pruned marker deliberately keeps its ticket: pruning is not proof the entry never committed, and a later commit would be origin-skipped (unapplied), so it must stay replayable.
- Observability (the issue's "also worth doing"): `arcadedb.ha.phase2.pending`, `arcadedb.ha.phase2.oldest_held_ms` and `arcadedb.ha.phase2.lowest_replay_floor`, wired through the existing `HAReplicationStatsProvider` seam so `ha-raft` still needs no Micrometer dependency.

## Test plan

- [x] `Issue5410AbandonedTicketReleaseIT` - 3-node Raft cluster reusing the #4790 fault injection. **Verified failing before the fix** (ticket stuck at 1 through a 30s poll) and passing after, with the clean-commit baseline assertion passing in both runs so the test discriminates.
- [x] `Issue5410AbandonedPhase2TicketTest` (8 cases) - correlation and release/retain branches over the real `replicateAndCommitLocally` dispatched-timeout path.
- [x] `HAPendingPhase2MetricsTest` (4 cases) - the new gauges, including the HA-disabled and provider-default paths.
- [x] Regression: `Issue4790PhantomCommitOriginSkipIT`, `RaftLeaderCrashBetweenCommitAndApplyIT`, `RaftLeaderCrashWithExternalPropertyIT`, `Issue5407Phase2TicketLifecycleTest`, `ArcadeStateMachinePendingPhase2SnapshotTest` - all pass.
- [x] Full `ha-raft` unit suite: 769 tests, 0 failures. Server monitor suite: 46 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)