### PR TITLE
fix(mcp) #5445: a principal profile keyed by a bare API-token name applies

### DIFF
--- a/docs/5445-mcp-principal-profile-token-lookup.md
+++ b/docs/5445-mcp-principal-profile-token-lookup.md
@@ -141,7 +141,7 @@ Observations raised and how they were resolved:
   parsed up front. The test's payload is rejected atomically only because the invalid field is one of the three
   parsed first. The behaviour predates this PR - the inline boolean block arrives with #5402 (`68d6596dc`) - so
   it is left alone here and the test now carries a comment stating exactly what it proves. Making `updateFrom`
-  atomic for every field is the follow-up.
+  atomic for every field is the follow-up, tracked as #5482.
 
 ## Known gaps
 
@@ -154,8 +154,9 @@ Observations raised and how they were resolved:
 - **`principalProfiles` is undocumented.** The MCP reference page lives in the separate
   `ArcadeData/arcadedb-docs` repository at `src/main/asciidoc/reference/mcp/mcp.adoc` and documents
   the `mcp-config.json` keys. It does not mention `principalProfiles`, nor the `profile` key from
-  #5402, nor the `databases` key from #5401. A docs PR is owed there.
+  #5402, nor the `databases` key from #5401, and it never mentions the Resources surface from #4865.
+  Tracked as #5483.
 - **`updateFrom` is not atomic across every field.** Raised in review and confirmed: the `allow*` booleans are
   assigned inline, so a payload whose invalid field is a boolean commits the booleans that precede it before
   throwing. Pre-existing since #5402 and untouched here. The fix is to parse every field into locals before
-  assigning any, mirroring what `databases`, `profile` and `principalProfiles` already do.
+  assigning any, mirroring what `databases`, `profile` and `principalProfiles` already do. Tracked as #5482.

--- a/docs/5445-mcp-principal-profile-token-lookup.md
+++ b/docs/5445-mcp-principal-profile-token-lookup.md
@@ -1,6 +1,6 @@
 # Issue #5445 follow-up - a principal profile written with a bare API-token name is silently inert
 
-PR: (to be filled after opening)
+PR: https://github.com/ArcadeData/arcadedb/pull/5479
 
 Follow-up to #5468, which implemented per-principal MCP tool profiles and merged as `ec3447a96`.
 Two defects found reviewing that change after the merge.

--- a/docs/5445-mcp-principal-profile-token-lookup.md
+++ b/docs/5445-mcp-principal-profile-token-lookup.md
@@ -118,6 +118,31 @@ fix was applied.
 | `server` `MCPToolUtilsTest` | 4/4 |
 | `server` MCP suite (`MCPConfigurationTest,MCPStdioServerTest,MCPServerPluginTest,MCPPermissionsTest,MCPResourcesTest,MCPToolUtilsTest`) | 161/161 |
 
+## Review cycles
+
+| # | Head | Review outcome | Applied |
+|---|---|---|---|
+| 1 | `1ef55c671` | LGTM, two non-blocking observations | Scoped the `invalidPrincipalProfileIsRejectedWithoutPartialUpdate` claim with a comment - see below. Nothing else applied. |
+
+`gemini-code-assist` did not review this head; `claude[bot]` posted twice.
+
+Observations raised and how they were resolved:
+
+- *`objectValue` throws `IllegalArgumentException` while the sibling `booleanValue` throws `JSONException` for
+  the same class of wrong-type error.* Not changed. `IllegalArgumentException` is the convention the rest of
+  `MCPConfiguration` already uses for a rejected configuration value - blank override and principal names, an
+  unknown override key, an unknown profile name, a non-string profile, a null tool profile. `booleanValue` is
+  the single outlier, so aligning `objectValue` with it would spread the inconsistency rather than remove it.
+  Both land on `400` through `MCPConfigHandler`'s combined catch, so no behaviour depends on the choice.
+
+- *The "without partial update" guarantee is narrower than the test name suggests.* Correct, and confirmed by
+  probe: `updateFrom({"enabled": true, "allowReads": "yes"})` leaves `enabled` set to `true` after throwing,
+  because the `allow*` booleans are assigned inline while `databases`, `profile` and `principalProfiles` are
+  parsed up front. The test's payload is rejected atomically only because the invalid field is one of the three
+  parsed first. The behaviour predates this PR - the inline boolean block arrives with #5402 (`68d6596dc`) - so
+  it is left alone here and the test now carries a comment stating exactly what it proves. Making `updateFrom`
+  atomic for every field is the follow-up.
+
 ## Known gaps
 
 - **MCP Resources are not profile-gated.** `arcadedb://{database}/schema` is governed by the read,
@@ -130,3 +155,7 @@ fix was applied.
   `ArcadeData/arcadedb-docs` repository at `src/main/asciidoc/reference/mcp/mcp.adoc` and documents
   the `mcp-config.json` keys. It does not mention `principalProfiles`, nor the `profile` key from
   #5402, nor the `databases` key from #5401. A docs PR is owed there.
+- **`updateFrom` is not atomic across every field.** Raised in review and confirmed: the `allow*` booleans are
+  assigned inline, so a payload whose invalid field is a boolean commits the booleans that precede it before
+  throwing. Pre-existing since #5402 and untouched here. The fix is to parse every field into locals before
+  assigning any, mirroring what `databases`, `profile` and `principalProfiles` already do.

--- a/docs/5445-mcp-principal-profile-token-lookup.md
+++ b/docs/5445-mcp-principal-profile-token-lookup.md
@@ -1,0 +1,132 @@
+# Issue #5445 follow-up - a principal profile written with a bare API-token name is silently inert
+
+PR: (to be filled after opening)
+
+Follow-up to #5468, which implemented per-principal MCP tool profiles and merged as `ec3447a96`.
+Two defects found reviewing that change after the merge.
+
+
+## Symptom 1 - the restriction an operator writes does nothing
+
+MCP accepts an API token under either spelling in `allowedUsers`: the canonical authenticated
+principal name `apitoken:<token-name>`, or the bare token name. So this configuration admits the
+token and looks like it confines it to the retrieval surface:
+
+```json
+{
+  "profile": "all",
+  "allowedUsers": ["retrieval-token"],
+  "principalProfiles": { "retrieval-token": "rag" }
+}
+```
+
+It does not. The token authenticates as `apitoken:retrieval-token`, the profile map is keyed on
+`retrieval-token`, and the lookup is an exact match, so no override is found and the principal falls
+back to the global profile - `all`. `tools/list` shows `execute_command`, `set_server_setting` and
+the rest, and each is callable. There is no error, no warning, and nothing in the serialized
+configuration that reads as wrong: the entry the operator wrote is still there, and still says
+`rag`.
+
+The two keys spell the same principal the same way and disagree about who they address. That is the
+whole defect: a configuration that reads as a restriction is not one.
+
+## Symptom 2 - a malformed configuration value answers 500
+
+`POST /api/v1/mcp/config` with a `principalProfiles` that is not an object:
+
+```json
+{ "principalProfiles": "rag" }
+```
+
+answers `500` with an internal-error body instead of `400`. The same holds for the pre-existing
+`databases` key.
+
+## Root cause
+
+**Symptom 1.** `MCPConfiguration` resolves the two lookups differently.
+
+`isUserAllowed` delegates to `matchesUser`, which falls back to the bare token name:
+
+```java
+return username.startsWith("apitoken:")
+    && users.contains(username.substring("apitoken:".length()));
+```
+
+`getPrincipalToolProfile` does not:
+
+```java
+public ToolProfile getPrincipalToolProfile(final String principalName) {
+  return principalName == null ? null : principalProfiles.get(principalName);
+}
+```
+
+The design note for #5445 called the canonical prefix "required only for the profile map because
+that map identifies one exact principal". The disambiguation argument holds, but requiring the
+canonical form and then silently ignoring anything else turns a typo-shaped mistake into a
+privilege the operator did not intend to leave open.
+
+**Symptom 2.** Both `load()` and `updateFrom()` read the nested object with
+`json.getJSONObject(name, null)`, whose default applies only when the value is JSON null. A string
+value reaches Gson's `getAsJsonObject()` and raises `IllegalStateException`, which `MCPConfigHandler`
+does not catch - it catches `IllegalArgumentException | JSONException` and maps those to `400`.
+
+## Fix
+
+1. `getPrincipalToolProfile` matches the canonical name first, then falls back to the bare token
+   name for an `apitoken:` principal - the same convention `isUserAllowed` already accepts. An
+   explicit `apitoken:<name>` entry therefore stays authoritative when both spellings are present.
+
+2. A new `objectValue(json, name)` helper reads a nested configuration object, maps absent and
+   explicitly null to `null` (the caller's clear-everything intent) and rejects any other non-object
+   value with `IllegalArgumentException`. Used for `principalProfiles` and for `databases`, in
+   `load()` and in `updateFrom()`.
+
+### Why the bare-name fallback cannot widen the surface
+
+A principal profile is only ever intersected with the global one
+(`MCPDispatcher.EffectiveToolProfile.allows`), so finding an override can only remove tools, never
+add them. The worst case for a collision - a named user and an API token sharing a name - is that
+the token is confined to the named user's profile. That is a narrowing, and it is the collision
+`matchesUser` already lives with on the allowlist.
+
+The reverse direction cannot collide at all: `PostUserHandler` rejects creating a user whose name
+starts with `apitoken:`, so an `apitoken:<name>` key can only ever denote a token.
+
+## Tests
+
+- `MCPConfigurationTest.apiTokenPrincipalProfileMatchesBareTokenName` - a bare-name entry resolves
+  for an `apitoken:` principal; a canonical entry wins when both are configured; a named user is
+  never matched by the fallback; an unrelated token still resolves to no override.
+- `MCPConfigurationTest.invalidPrincipalProfileIsRejectedWithoutPartialUpdate` - extended: a
+  non-object `principalProfiles` and a non-object `databases` are both rejected as
+  `IllegalArgumentException` (so the endpoint answers `400`), and a sibling setting in the same
+  update is not applied. This replaces the merged assertion on `IllegalStateException`, which locked
+  in the `500`.
+- `MCPServerPluginTest.apiTokenPrincipalProfileAcceptsBareTokenName` - end to end over HTTP: a token
+  allowlisted and profiled by its bare name sees the `rag` tool list and is denied `server_status`
+  on a direct `tools/call`.
+
+`apiTokenPrincipalProfileMatchesBareTokenName` was confirmed red against the unfixed code before the
+fix was applied.
+
+## Verification
+
+| Suite | Result |
+|---|---|
+| `server` `MCPConfigurationTest` | 24/24 |
+| `server` `MCPPermissionsTest` | 15/15 |
+| `server` `MCPToolUtilsTest` | 4/4 |
+| `server` MCP suite (`MCPConfigurationTest,MCPStdioServerTest,MCPServerPluginTest,MCPPermissionsTest,MCPResourcesTest,MCPToolUtilsTest`) | 161/161 |
+
+## Known gaps
+
+- **MCP Resources are not profile-gated.** `arcadedb://{database}/schema` is governed by the read,
+  database and user permission layers alone. That is currently equivalent to the tool gate, because
+  every profile exposes `get_schema` and a database schema is the only resource, so no profile can
+  deny content the resource would reveal. A resource added later without a matching tool would break
+  the equivalence and would need its own profile mapping. Recorded in the design note; not addressed
+  here.
+- **`principalProfiles` is undocumented.** The MCP reference page lives in the separate
+  `ArcadeData/arcadedb-docs` repository at `src/main/asciidoc/reference/mcp/mcp.adoc` and documents
+  the `mcp-config.json` keys. It does not mention `principalProfiles`, nor the `profile` key from
+  #5402, nor the `databases` key from #5401. A docs PR is owed there.

--- a/docs/5445-mcp-principal-profile-token-lookup.md
+++ b/docs/5445-mcp-principal-profile-token-lookup.md
@@ -123,8 +123,9 @@ fix was applied.
 | # | Head | Review outcome | Applied |
 |---|---|---|---|
 | 1 | `1ef55c671` | LGTM, two non-blocking observations | Scoped the `invalidPrincipalProfileIsRejectedWithoutPartialUpdate` claim with a comment - see below. Nothing else applied. |
+| 2 | `810a30832` | LGTM, two non-blocking observations | Nothing applied. One repeats cycle 1 and is agreed settled; the other rests on a wrong premise about `load()` - see below. |
 
-`gemini-code-assist` did not review this head; `claude[bot]` posted twice.
+`gemini-code-assist` did not review either head; `claude[bot]` posted three times.
 
 Observations raised and how they were resolved:
 
@@ -142,6 +143,23 @@ Observations raised and how they were resolved:
   parsed first. The behaviour predates this PR - the inline boolean block arrives with #5402 (`68d6596dc`) - so
   it is left alone here and the test now carries a comment stating exactly what it proves. Making `updateFrom`
   atomic for every field is the follow-up, tracked as #5482.
+
+- *`load()` now raises `IllegalArgumentException` where it used to raise `IllegalStateException`, so check
+  whether a caller keys on the type* (cycle 2). The conclusion - not a regression, no caller affected - is
+  right, but not for the reason given: neither exception ever escaped `load()`. Its `catch (Exception)` absorbs
+  both and falls back to defaults. Probed on `810a30832` against a `config/mcp-config.json` holding
+  `{"enabled": true, "principalProfiles": "rag"}`:
+
+  ```
+  load() threw nothing
+  WARNING  Corrupt MCP configuration file, using defaults:
+           MCP configuration field 'principalProfiles' must be an object
+  isEnabled() == false     // the whole file is discarded, including the valid "enabled": true
+  ```
+
+  So no caller can observe the exception type, and `ArcadeDBServer:314` - the only caller - invokes `load()`
+  bare. The one behavioural difference is the log line, which now names the offending field instead of
+  reporting Gson's `Not a JSON Object: "rag"`. Nothing applied.
 
 ## Known gaps
 

--- a/docs/superpowers/specs/2026-07-27-mcp-principal-tool-profiles-5445-design.md
+++ b/docs/superpowers/specs/2026-07-27-mcp-principal-tool-profiles-5445-design.md
@@ -37,9 +37,14 @@ Named users use their user name. API tokens use the canonical authenticated prin
 token's display name. Profile names are case-insensitive when parsed and serialized as
 lowercase.
 
-The global `allowedUsers` gate still decides whether a principal may reach MCP at all. Its
-existing bare-token convenience remains unchanged; the canonical prefix is required only for
-the profile map because that map identifies one exact principal.
+The global `allowedUsers` gate still decides whether a principal may reach MCP at all, and it
+accepts either the canonical or the bare token spelling. Profile lookup accepts both spellings
+too: an API-token principal is matched first by `apitoken:<token-name>` and, failing that, by
+the bare token name. The canonical entry therefore stays authoritative when both are present,
+while an operator who writes the same name in `allowedUsers` and in `principalProfiles` gets
+the restriction they configured instead of a silently inert entry. Matching the bare form
+cannot widen the surface, because a principal profile is only ever intersected with the global
+one.
 
 ## Update semantics
 
@@ -50,12 +55,15 @@ Configuration API updates merge `principalProfiles` by principal name:
 - `"principalProfiles": null` clears every override.
 - Omitting `principalProfiles` leaves the map unchanged.
 
-Blank principal names, non-string values, and unknown profile names are rejected before any
-other setting in the same update is applied. The serialized configuration omits
-`principalProfiles` when no overrides exist.
+Blank principal names, non-string values, unknown profile names, and a `principalProfiles` value
+that is not an object are rejected before any other setting in the same update is applied. All
+four are reported as a client error, so the configuration endpoint answers `400` rather than
+surfacing a malformed payload as an internal error. The same rule now covers the `databases`
+key, which shares the parsing path. The serialized configuration omits `principalProfiles` when
+no overrides exist.
 
 An override for a principal that does not currently exist remains valid and inert. It starts
-applying only if authentication later produces that exact principal name. This supports
+applying only if authentication later produces that principal name. This supports
 pre-provisioning and token rotation without making configuration persistence depend on the
 current user registry.
 
@@ -75,6 +83,12 @@ selection and enforcement rules.
 The global profile and principal override are both allowlists. For example, global `rag` plus
 principal `admin` exposes only the tools common to both profiles. A hidden tool remains denied
 when called directly by name.
+
+Profiles gate tools only. The MCP Resources surface stays governed by the read, database, and
+user permission layers alone. That is currently equivalent, because every profile exposes
+`get_schema` and the only resource is a database schema, so no profile can deny content the
+resource would reveal. A resource added later without a matching tool would break that
+equivalence and would need its own profile mapping.
 
 ## Validation
 

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -98,10 +98,10 @@ public class MCPConfiguration implements MCPPermissions {
       final String content = new String(Files.readAllBytes(configFile.toPath()), StandardCharsets.UTF_8);
       final JSONObject json = new JSONObject(content);
       final Map<String, DatabaseOverride> loadedDatabaseOverrides =
-          parseDatabaseOverrides(json.getJSONObject("databases", null));
+          parseDatabaseOverrides(objectValue(json, "databases"));
       final ToolProfile loadedProfile = ToolProfile.parse(json.getString("profile", "all"));
       final Map<String, ToolProfile> loadedPrincipalProfiles =
-          parsePrincipalProfiles(json.getJSONObject("principalProfiles", null));
+          parsePrincipalProfiles(objectValue(json, "principalProfiles"));
 
       enabled = json.getBoolean("enabled", false);
       allowReads = json.getBoolean("allowReads", true);
@@ -225,10 +225,22 @@ public class MCPConfiguration implements MCPPermissions {
 
   /**
    * Returns the profile override for the authenticated principal, or {@code null} when the global profile applies
-   * without an additional restriction. API tokens use their canonical security name, {@code apitoken:<name>}.
+   * without an additional restriction. API tokens are matched first by their canonical security name,
+   * {@code apitoken:<name>}, then by the bare token name, the same convention {@link #isUserAllowed(String)} accepts.
+   * The bare form can only narrow the surface further, because a principal profile is intersected with the global one
+   * and never grants a tool; matching it keeps an allowlist entry and a profile entry written the same way from
+   * silently disagreeing about which principal they address.
    */
   public ToolProfile getPrincipalToolProfile(final String principalName) {
-    return principalName == null ? null : principalProfiles.get(principalName);
+    if (principalName == null)
+      return null;
+
+    final ToolProfile canonical = principalProfiles.get(principalName);
+    if (canonical != null)
+      return canonical;
+    if (principalName.startsWith("apitoken:"))
+      return principalProfiles.get(principalName.substring("apitoken:".length()));
+    return null;
   }
 
   public List<String> getAllowedOrigins() {
@@ -327,13 +339,13 @@ public class MCPConfiguration implements MCPPermissions {
 
   public synchronized void updateFrom(final JSONObject json) {
     final Map<String, DatabaseOverride> updatedDatabaseOverrides = json.has("databases")
-        ? mergeDatabaseOverrides(databaseOverrides, json.getJSONObject("databases", null))
+        ? mergeDatabaseOverrides(databaseOverrides, objectValue(json, "databases"))
         : databaseOverrides;
     final ToolProfile updatedProfile = json.has("profile")
         ? ToolProfile.parse(json.getString("profile", null))
         : toolProfile;
     final Map<String, ToolProfile> updatedPrincipalProfiles = json.has("principalProfiles")
-        ? mergePrincipalProfiles(principalProfiles, json.getJSONObject("principalProfiles", null))
+        ? mergePrincipalProfiles(principalProfiles, objectValue(json, "principalProfiles"))
         : principalProfiles;
 
     if (json.has("enabled"))
@@ -557,6 +569,20 @@ public class MCPConfiguration implements MCPPermissions {
       return matchesUser(globalUsers, username)
           && (databaseUsers == null || matchesUser(databaseUsers, username));
     }
+  }
+
+  /**
+   * Reads a nested configuration object, mapping an absent or explicitly null value to {@code null} (the caller's
+   * clear-everything intent) and any other non-object value to a rejected update. Returning the value untyped would
+   * surface a malformed payload as an internal error instead of a client error.
+   */
+  private static JSONObject objectValue(final JSONObject json, final String name) {
+    if (json.isNull(name))
+      return null;
+    final Object value = json.opt(name);
+    if (value instanceof JSONObject object)
+      return object;
+    throw new IllegalArgumentException("MCP configuration field '" + name + "' must be an object");
   }
 
   private static boolean booleanValue(final JSONObject json, final String name) {

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
@@ -423,10 +423,43 @@ class MCPConfigurationTest {
         .hasMessageContaining("must be a profile name");
 
     assertThatThrownBy(() -> config.updateFrom(new JSONObject()
+        .put("allowInsert", true)
         .put("principalProfiles", "rag")))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("principalProfiles").hasMessageContaining("must be an object");
+    assertThat(config.isAllowInsert()).isFalse();
     assertThat(config.getPrincipalToolProfile("retrieval-user"))
         .isEqualTo(MCPConfiguration.ToolProfile.RAG);
+
+    assertThatThrownBy(() -> config.updateFrom(new JSONObject().put("databases", "graph")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("databases").hasMessageContaining("must be an object");
+  }
+
+  @Test
+  void apiTokenPrincipalProfileMatchesBareTokenName() {
+    final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);
+    config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject().put("retrieval-token", "rag")));
+
+    // An allowedUsers entry accepts the bare token name, so the same spelling must select the profile too;
+    // otherwise an operator restricting a token would silently leave it on the wider global profile.
+    assertThat(config.isUserAllowed("apitoken:retrieval-token")).isFalse();
+    config.setAllowedUsers(List.of("retrieval-token"));
+    assertThat(config.isUserAllowed("apitoken:retrieval-token")).isTrue();
+    assertThat(config.getPrincipalToolProfile("apitoken:retrieval-token"))
+        .isEqualTo(MCPConfiguration.ToolProfile.RAG);
+
+    // The canonical entry stays authoritative when both spellings are configured.
+    config.updateFrom(new JSONObject()
+        .put("principalProfiles", new JSONObject().put("apitoken:retrieval-token", "admin")));
+    assertThat(config.getPrincipalToolProfile("apitoken:retrieval-token"))
+        .isEqualTo(MCPConfiguration.ToolProfile.ADMIN);
+
+    // A named user is never matched by the token fallback.
+    assertThat(config.getPrincipalToolProfile("retrieval-token"))
+        .isEqualTo(MCPConfiguration.ToolProfile.RAG);
+    assertThat(config.getPrincipalToolProfile("apitoken:other-token")).isNull();
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPConfigurationTest.java
@@ -396,6 +396,10 @@ class MCPConfigurationTest {
     assertThat(config.toJSON().has("principalProfiles")).isFalse();
   }
 
+  // The "without partial update" this asserts comes from field ordering: databases, profile and
+  // principalProfiles are parsed before updateFrom mutates anything, so rejecting one of them leaves every
+  // other setting alone. It is not general atomicity - the allow* booleans are still assigned inline, so an
+  // invalid boolean can commit the booleans that precede it. That is out of scope here.
   @Test
   void invalidPrincipalProfileIsRejectedWithoutPartialUpdate() {
     final MCPConfiguration config = new MCPConfiguration(TEST_ROOT);

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPServerPluginTest.java
@@ -1157,6 +1157,49 @@ class MCPServerPluginTest extends BaseGraphServerTest {
   }
 
   @Test
+  void apiTokenPrincipalProfileAcceptsBareTokenName() throws Exception {
+    final JSONObject permissions = new JSONObject()
+        .put("types", new JSONObject()
+            .put("*", new JSONObject().put("access", new JSONArray().put("readRecord"))))
+        .put("database", new JSONArray());
+
+    final JSONObject tokenResult = getServer(0).getSecurity().getApiTokenConfiguration()
+        .createToken("baretoken", "graph", 0, permissions);
+    final String tokenValue = tokenResult.getString("token");
+
+    try {
+      // The bare token name is the spelling allowedUsers accepts, so a profile written the same way must apply.
+      saveMCPConfig(new JSONObject()
+          .put("profile", "all")
+          .put("allowedUsers", new JSONArray().put("root").put("baretoken"))
+          .put("principalProfiles", new JSONObject().put("baretoken", "rag")));
+
+      final String tokenAuth = "Bearer " + tokenValue;
+      final JSONObject listed = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 505)
+          .put("method", "tools/list")
+          .put("params", new JSONObject()), tokenAuth);
+      assertThat(toolNames(listed))
+          .contains("sample_records", "vector_search")
+          .doesNotContain("server_status", "execute_command");
+
+      final JSONObject denied = mcpRequest(new JSONObject()
+          .put("jsonrpc", "2.0")
+          .put("id", 506)
+          .put("method", "tools/call")
+          .put("params", new JSONObject()
+              .put("name", "server_status")
+              .put("arguments", new JSONObject())), tokenAuth)
+          .getJSONObject("result");
+      assertThat(denied.getBoolean("isError", false)).isTrue();
+    } finally {
+      getServer(0).getSecurity().getApiTokenConfiguration()
+          .deleteToken(tokenResult.getString("tokenHash"));
+    }
+  }
+
+  @Test
   void apiTokenUserDeniedWhenNotInAllowedUsers() throws Exception {
     // Create an API token
     final JSONObject permissions = new JSONObject()


### PR DESCRIPTION
Follow-up to #5445 / #5468, which merged as `ec3447a96`. Two defects found reviewing that change after the merge.

MCP accepts an API token in `allowedUsers` under either spelling: the canonical authenticated principal name `apitoken:<token-name>`, or the bare token name. The `principalProfiles` map added by #5468 accepted only the canonical one, and looked it up by exact match. So this configuration admits the token and then leaves it on the global profile:

```json
{
  "profile": "all",
  "allowedUsers": ["retrieval-token"],
  "principalProfiles": { "retrieval-token": "rag" }
}
```

The token authenticates as `apitoken:retrieval-token`, no override is found, and a configuration that reads as a confinement to the retrieval surface exposes `execute_command` and `set_server_setting` instead. There is no error, no warning, and nothing in the serialized configuration that reads as wrong: the entry is still there, and still says `rag`. The two keys spell the same principal the same way and disagree about who they address.

`getPrincipalToolProfile` now matches the canonical name first and falls back to the bare token name for an `apitoken:` principal, the same convention `isUserAllowed` already accepts, so an explicit `apitoken:<name>` entry stays authoritative when both spellings are configured. The fallback cannot widen the surface: a principal profile is only ever intersected with the global one (`MCPDispatcher.EffectiveToolProfile.allows`), so resolving one can remove tools and never add them. The worst case for a name collision is that a token is confined to a same-named user's profile, which is a narrowing, and it is the collision `matchesUser` already lives with on the allowlist. The reverse direction cannot collide at all, since `PostUserHandler` rejects creating a user whose name starts with `apitoken:`.

Second, `POST /api/v1/mcp/config` with a `principalProfiles` (or the pre-existing `databases`) value that is not an object answered `500` instead of `400`. Both `load()` and `updateFrom()` read the nested object with `getJSONObject(name, null)`, whose default applies only to JSON null, so a string value reached Gson's `getAsJsonObject()` and raised `IllegalStateException` - which `MCPConfigHandler` does not catch. A new `objectValue()` helper rejects it with `IllegalArgumentException`, which the handler already maps to `400`. The merged test asserted `IllegalStateException`, locking the `500` in; that assertion is replaced.

## Test plan

- [ ] `mvn -pl server test -Dtest=MCPConfigurationTest` - 24 tests, including the new `apiTokenPrincipalProfileMatchesBareTokenName` (bare-name entry resolves for an `apitoken:` principal, a canonical entry wins when both are configured, a named user is never matched by the fallback) and the extended `invalidPrincipalProfileIsRejectedWithoutPartialUpdate` (non-object `principalProfiles` and non-object `databases` both rejected as a client error, sibling settings in the same update not applied).
- [ ] `mvn -pl server test -Dtest=MCPServerPluginTest` - includes the new `apiTokenPrincipalProfileAcceptsBareTokenName`, end to end over HTTP: a token allowlisted and profiled by its bare name sees the `rag` tool list and is denied `server_status` on a direct `tools/call`.
- [ ] `mvn -pl server test -Dtest='MCPConfigurationTest,MCPStdioServerTest,MCPServerPluginTest,MCPPermissionsTest,MCPResourcesTest,MCPToolUtilsTest'` - 161 tests.

All of the above were run green on this branch. `apiTokenPrincipalProfileMatchesBareTokenName` was confirmed red against the unfixed code before the fix was applied.

Tracking notes, including the two known gaps left open (MCP Resources are not profile-gated, and `principalProfiles` is undocumented in the separate `arcadedb-docs` repository), are in `docs/5445-mcp-principal-profile-token-lookup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
