### PR TITLE
fix(#5463, #5462): pin count(*) against a relationship inline WHERE predicate

### DIFF
--- a/docs/5463-count-star-rel-inline-where.md
+++ b/docs/5463-count-star-rel-inline-where.md
@@ -1,0 +1,111 @@
+# #5463 / #5462 - `count(*)` returns 0 for a relationship inline `WHERE` predicate
+
+Two issues, one defect, one reproducer. Both are closed by this change.
+
+- #5463 - "`count(*)` returns 0 while `count(r)` returns 1 for a relationship inline `WHERE` predicate"
+- #5462 - "`count(*)` returns 0 for relationship inline `WHERE` while `count(r)` returns the correct result"
+
+## Reported behavior
+
+Graph: two `(:A {v:1})-[:E]->(:A {v:2})` edges, tagged `ok` and `bad`.
+
+```cypher
+MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(*) AS c;  -- 0, expected 1
+MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(r) AS c;  -- 1, correct
+MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN r.tag AS t;     -- "ok", correct
+```
+
+Changing only the aggregate expression changed the result of the preceding `MATCH`. #5462 adds a
+sharper control: keeping `count(*)` and merely adding `collect(r.tag)` to the same projection
+flipped the count from 0 to 1.
+
+## Root cause
+
+The Cypher variable-usage analysis that decides which pattern bindings the plan has to materialize
+did not look inside inline pattern predicates. When nothing *outside* the pattern referenced `r`,
+the edge binding was elided from the plan, so the inline predicate `r.tag = 'ok'` was evaluated
+against an unbound variable, yielded false and rejected every row - hence 0.
+
+Any downstream mention of `r` (`count(r)`, `r.tag`, or a `collect(r.tag)` sitting next to the
+`count(*)`) kept the binding alive and masked the defect. That is exactly the
+"downstream-usage-dependent correctness" asymmetry both reporters observed, and it explains why a
+literal predicate such as `WHERE 1=1` behaved correctly: it references no variable at all.
+
+## Status on `main`
+
+The behavioral fix is already on `main`. It landed in `475582108`
+("fix(cypher) #5464: honor inline WHERE predicates in node and relationship patterns"), whose third
+listed defect is this one, tracked there as #5466:
+
+> A relationship inline predicate lost its edge binding whenever nothing else in the query
+> referenced the relationship variable, so it evaluated against an unbound variable and filtered out
+> every row - `count(*)` returned 0 while `count(r)` returned 1 (issue #5466). The variable-usage
+> analysis now looks inside inline pattern predicates.
+
+Both reporters ran build `1134185d5494f5ab0583da4a508d846449f8e04c`, which predates that commit, so
+#5463 and #5462 were filed against a build that could not yet contain the fix. The pattern
+comprehension leg of the same defect class was closed separately by `043309f61` (PR #5471, #5460).
+
+This was verified rather than assumed. The regression test below was run at `475582108^`
+(`116278160`, the reporters' era) and at current `main`:
+
+| Commit | Result |
+|---|---|
+| `116278160` (pre-fix) | 8 of 10 test methods FAIL, `count(*)` answers 0 exactly as reported |
+| `043309f61` (current `main`) | 10 of 10 PASS |
+
+## Change in this PR
+
+Regression coverage only - no production code change is needed, and none is made. The two reported
+shapes had no dedicated test pinning them, so the behavior could silently regress again.
+
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue5463CountStarRelInlineWhereTest.java`
+(10 test methods) covers:
+
+- `count(*)` agreeing with `count(r)` and with the materialized `r.tag` rows;
+- the inline predicate honored for every tag value, including the empty and the match-all case;
+- #5462's control - a second projection item (`collect(r.tag)`) must not change `count(*)`;
+- the literal-predicate and clause-level-`WHERE` controls from both issue reports;
+- anonymous source, anonymous target and both-ends-anonymous endpoint shapes;
+- right-to-left, undirected and untyped relationship variants;
+- `count(b)`, `count(DISTINCT b)`, `sum(b.v)` and `count(*)` routed through `WITH`;
+- `count(*)` under a grouping key;
+- `OPTIONAL MATCH`, hit and miss;
+- both pattern-parsing paths that accept a relationship inline predicate - the `MATCH` path and the
+  pattern-comprehension / `COUNT {}` / `EXISTS {}` path.
+
+## Verification
+
+```
+mvn -o test -Dtest='Issue5463CountStarRelInlineWhereTest,CypherInlinePatternWhereTest,\
+Issue5464ExistsRelInlineWhereTest,OpenCypherPatternComprehensionInlineWhereTest,\
+CypherInlinePropertyFilterTest,CypherInlinePropertyNormalizationTest,OpenCypherPatternPredicateTest,\
+CypherPatternPredicateTest,CypherExistsTest,CypherCountSubqueryTest,CypherCountSubqueryCorrelatedTest,\
+CypherCollectSubqueryTest,CountEdgesOptimizationTest,CypherCountNonExistingLabelTest,GAVEligibilityTest'
+```
+
+`Tests run: 170, Failures: 0, Errors: 0, Skipped: 0` - `BUILD SUCCESS`.
+
+## Adjacent gap found, deliberately not fixed here
+
+While probing the surrounding defect class on current `main`, the relationship inline `WHERE` is
+still ignored outright inside a **variable-length** relationship pattern:
+
+```cypher
+MATCH (a:A {v:1})-[r:E*1..1 WHERE r.tag = 'ok']->(b:A)  RETURN count(*) AS c;  -- 2
+MATCH (a:A {v:1})-[r:E*1..1 WHERE r.tag = 'zzz']->(b:A) RETURN count(*) AS c;  -- 2
+```
+
+The predicate changes nothing, so it is dropped rather than misevaluated - a different failure mode
+from the one #5463/#5462 report (which is 0, not 2, and uses a single-hop pattern). It is left
+alone on purpose:
+
+- it is out of scope for these two issues;
+- the `shortestPath` half of it is already tracked by #5481, which is being worked in its own
+  worktree, and the node-pattern half by #5480;
+- the plain variable-length case has no open issue yet and should be triaged separately.
+
+## Recommendation
+
+After merge, confirm #5463 and #5462 against a released build rather than `latest`, since both
+reporters hit a snapshot image that predated `475582108`.

--- a/docs/5463-count-star-rel-inline-where.md
+++ b/docs/5463-count-star-rel-inline-where.md
@@ -5,7 +5,7 @@ Two issues, one defect, one reproducer. Both are closed by this change.
 - #5463 - "`count(*)` returns 0 while `count(r)` returns 1 for a relationship inline `WHERE` predicate"
 - #5462 - "`count(*)` returns 0 for relationship inline `WHERE` while `count(r)` returns the correct result"
 
-## Reported behavior
+## Problem
 
 Graph: two `(:A {v:1})-[:E]->(:A {v:2})` edges, tagged `ok` and `bad`.
 
@@ -31,9 +31,9 @@ Any downstream mention of `r` (`count(r)`, `r.tag`, or a `collect(r.tag)` sittin
 "downstream-usage-dependent correctness" asymmetry both reporters observed, and it explains why a
 literal predicate such as `WHERE 1=1` behaved correctly: it references no variable at all.
 
-## Status on `main`
+## Fix
 
-The behavioral fix is already on `main`. It landed in `475582108`
+None required. The behavioral fix is already on `main`, in `475582108`
 ("fix(cypher) #5464: honor inline WHERE predicates in node and relationship patterns"), whose third
 listed defect is this one, tracked there as #5466:
 
@@ -46,21 +46,14 @@ Both reporters ran build `1134185d5494f5ab0583da4a508d846449f8e04c`, which preda
 #5463 and #5462 were filed against a build that could not yet contain the fix. The pattern
 comprehension leg of the same defect class was closed separately by `043309f61` (PR #5471, #5460).
 
-This was verified rather than assumed. The regression test below was run at `475582108^`
-(`116278160`, the reporters' era) and at current `main`:
+This PR therefore changes no production code and carries regression coverage only. What was
+genuinely missing is the test: neither reported shape had anything pinning it, so the behavior could
+silently regress again.
 
-| Commit | Result |
-|---|---|
-| `116278160` (pre-fix) | 8 of 10 test methods FAIL, `count(*)` answers 0 exactly as reported |
-| `043309f61` (current `main`) | 10 of 10 PASS |
+## Tests
 
-## Change in this PR
-
-Regression coverage only - no production code change is needed, and none is made. The two reported
-shapes had no dedicated test pinning them, so the behavior could silently regress again.
-
-`engine/src/test/java/com/arcadedb/query/opencypher/Issue5463CountStarRelInlineWhereTest.java`
-(10 test methods) covers:
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue5463CountStarRelInlineWhereTest.java`,
+10 methods:
 
 - `count(*)` agreeing with `count(r)` and with the materialized `r.tag` rows;
 - the inline predicate honored for every tag value, including the empty and the match-all case;
@@ -76,6 +69,16 @@ shapes had no dedicated test pinning them, so the behavior could silently regres
 
 ## Verification
 
+The test was not assumed to guard the defect, it was proven to. It was run at `475582108^`
+(`116278160`, the reporters' era) and at current `main`:
+
+| Commit | Result |
+|---|---|
+| `116278160` (pre-fix) | **8 of 10 methods FAIL**, `count(*)` answers 0 exactly as reported |
+| `043309f61` (current `main`) | **10 of 10 PASS** |
+
+Surrounding suites, run together:
+
 ```
 mvn -o test -Dtest='Issue5463CountStarRelInlineWhereTest,CypherInlinePatternWhereTest,\
 Issue5464ExistsRelInlineWhereTest,OpenCypherPatternComprehensionInlineWhereTest,\
@@ -86,10 +89,45 @@ CypherCollectSubqueryTest,CountEdgesOptimizationTest,CypherCountNonExistingLabel
 
 `Tests run: 170, Failures: 0, Errors: 0, Skipped: 0` - `BUILD SUCCESS`.
 
-## Adjacent gap found, deliberately not fixed here
+## Impact and notes
 
-While probing the surrounding defect class on current `main`, the relationship inline `WHERE` is
-still ignored outright inside a **variable-length** relationship pattern:
+No production code is touched, so behavior-change risk is nil. The value is purely in pinning a
+fix that landed without dedicated coverage for either reported shape.
+
+When closing the issues, confirm them against a released build rather than `latest`: both reporters
+hit a snapshot image that predated `475582108`, so an unchanged `latest` tag can still reproduce the
+old behavior.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5485
+
+## Review cycles
+
+**Cycle 1** - `cace1273` - claude reviewed: **LGTM**, "clean, well-scoped, regression-coverage-only
+PR", no blocking concerns. gemini-code-assist posted nothing within the 15-minute window, and
+nothing in a further 8 minutes of polling, consistent with its ongoing sunset.
+
+| Note | Decision |
+|---|---|
+| Preserve the "fails 8/10 at `475582108^`" provenance, since a regression test that never failed is worthless | **Already present.** It is in the commit message, the PR body and the Verification section above. No change. |
+| The tracking doc overlaps the PR body, so it is a second place to keep in sync | **Kept.** The reviewer scoped this as consistent with repo convention. The most recent tracking docs on `main` (`docs/5460-*`, `docs/5454-*`) carry the same overlap, so trimming it would depart from convention rather than follow it. |
+| Add a `// see #...` breadcrumb or a `@Disabled` placeholder test for the plain variable-length gap, which has no issue yet | **Skipped, with the gap recorded below instead.** A `@Disabled` test pointing at no tracking issue is dead weight that goes stale, and a breadcrumb comment in a test class about a defect that class does not exercise is misplaced. Filing the issue is the right home for it, but filing issues is outside the scope authorized for this PR, so it is documented under Known gaps for the maintainer. |
+
+No code changes resulted from this cycle.
+
+## Final state
+
+`timeout` - claude approved on the only cycle with no blocking items; gemini-code-assist never
+responded, so the loop's both-bots gate could not be satisfied. The PR is review-clean as far as the
+one responding reviewer is concerned.
+
+## Known gaps
+
+Found while probing the surrounding defect class on current `main`, **not** fixed here.
+
+The relationship inline `WHERE` is still ignored outright inside a **variable-length** relationship
+pattern:
 
 ```cypher
 MATCH (a:A {v:1})-[r:E*1..1 WHERE r.tag = 'ok']->(b:A)  RETURN count(*) AS c;  -- 2
@@ -97,15 +135,7 @@ MATCH (a:A {v:1})-[r:E*1..1 WHERE r.tag = 'zzz']->(b:A) RETURN count(*) AS c;  -
 ```
 
 The predicate changes nothing, so it is dropped rather than misevaluated - a different failure mode
-from the one #5463/#5462 report (which is 0, not 2, and uses a single-hop pattern). It is left
-alone on purpose:
-
-- it is out of scope for these two issues;
-- the `shortestPath` half of it is already tracked by #5481, which is being worked in its own
-  worktree, and the node-pattern half by #5480;
-- the plain variable-length case has no open issue yet and should be triaged separately.
-
-## Recommendation
-
-After merge, confirm #5463 and #5462 against a released build rather than `latest`, since both
-reporters hit a snapshot image that predated `475582108`.
+from the 0 that #5463/#5462 report on a single-hop pattern. Left alone deliberately: it is out of
+scope for these two issues, its `shortestPath` half is already tracked by #5481 and the node-pattern
+half by #5480 (both being worked separately), and the plain variable-length case has no open issue
+yet and warrants its own triage.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5463CountStarRelInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5463CountStarRelInlineWhereTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issues #5463 and #5462, two reports of the same defect with the same
+ * reproducer.
+ * <p>
+ * A relationship inline {@code WHERE} predicate that reads an edge property must select the same
+ * rows no matter what the projection does with the relationship variable afterwards. The reported
+ * symptom was that {@code RETURN count(*)} answered 0 while {@code RETURN count(r)} answered 1 for
+ * one and the same {@code MATCH}: the edge binding was elided from the plan whenever nothing
+ * outside the pattern referenced {@code r}, so the inline predicate was evaluated against an
+ * unbound variable and rejected every row. Referencing {@code r} anywhere downstream - through
+ * {@code count(r)}, {@code r.tag} or even a {@code collect(r.tag)} sitting next to the
+ * {@code count(*)} - kept the binding alive and masked the defect.
+ * <p>
+ * The behavior is pinned here for both pattern-parsing paths that accept a relationship inline
+ * predicate: the {@code MATCH} path and the pattern-comprehension / {@code EXISTS} path.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5463CountStarRelInlineWhereTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-5463-count-star-rel-inline-where").create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (a:A {v:1}), (b:A {v:2})");
+      database.command("opencypher", "MATCH (a:A {v:1}), (b:A {v:2}) "
+          + "CREATE (a)-[:E {tag: 'ok'}]->(b), (a)-[:E {tag: 'bad'}]->(b)");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  private long count(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      final long value = rs.next().<Number>getProperty("c").longValue();
+      assertThat(rs.hasNext()).as("a single aggregate row").isFalse();
+      return value;
+    }
+  }
+
+  private List<Object> column(final String query, final String name) {
+    final List<Object> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        values.add(rs.next().getProperty(name));
+    }
+    return values;
+  }
+
+  @Test
+  void countStarAgreesWithCountRelationshipOnInlinePropertyPredicate() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(*) AS c"))
+        .as("countStar").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(r) AS c"))
+        .as("countRelationship").isEqualTo(1);
+    assertThat(column("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN r.tag AS tag", "tag"))
+        .as("materializedRows").containsExactly("ok");
+  }
+
+  @Test
+  void countStarHonoursTheInlinePredicateOnEveryTagValue() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'bad']->(b:A) RETURN count(*) AS c"))
+        .as("bad").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'nope']->(b:A) RETURN count(*) AS c"))
+        .as("noMatch").isZero();
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag IS NOT NULL]->(b:A) RETURN count(*) AS c"))
+        .as("allTagged").isEqualTo(2);
+  }
+
+  @Test
+  void aSecondProjectionItemDoesNotChangeTheCount() {
+    // issue #5462: adding a non-filtering output expression that mentions r used to flip count(*)
+    // from 0 to 1, because it was the only thing keeping the edge binding alive
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(*) AS c, collect(r.tag) AS tags")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.<Number>getProperty("c").longValue()).as("countStar").isEqualTo(1);
+      assertThat(row.<List<Object>>getProperty("tags")).as("tags").containsExactly("ok");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void literalInlinePredicateAndClauseLevelWhereKeepWorking() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE 1=1]->(b:A) RETURN count(*) AS c"))
+        .as("literalInline").isEqualTo(2);
+    assertThat(count("MATCH (a:A {v:1})-[r:E]->(b:A) WHERE r.tag = 'ok' RETURN count(*) AS c"))
+        .as("clauseLevel").isEqualTo(1);
+  }
+
+  @Test
+  void countStarWithAnonymousEndpointsAndUnlabelledTarget() {
+    assertThat(count("MATCH (:A {v:1})-[r:E WHERE r.tag = 'ok']->(b) RETURN count(*) AS c"))
+        .as("anonymousSource").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->() RETURN count(*) AS c"))
+        .as("anonymousTarget").isEqualTo(1);
+    assertThat(count("MATCH ()-[r:E WHERE r.tag = 'ok']->() RETURN count(*) AS c"))
+        .as("bothEndsAnonymous").isEqualTo(1);
+  }
+
+  @Test
+  void directionVariantsHonourTheInlinePredicate() {
+    assertThat(count("MATCH (b:A {v:2})<-[r:E WHERE r.tag = 'ok']-(a:A) RETURN count(*) AS c"))
+        .as("rightToLeft").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']-(b:A) RETURN count(*) AS c"))
+        .as("undirected").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1})-[r WHERE r.tag = 'ok']->(b:A) RETURN count(*) AS c"))
+        .as("untypedRelationship").isEqualTo(1);
+  }
+
+  @Test
+  void otherAggregatesSeeTheSameRows() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(b) AS c"))
+        .as("countTargetNode").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(DISTINCT b) AS c"))
+        .as("countDistinctTargetNode").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) WITH count(*) AS c RETURN c AS c"))
+        .as("countStarThroughWith").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN sum(b.v) AS c"))
+        .as("sumOverTargetProperty").isEqualTo(2);
+  }
+
+  @Test
+  void countStarGroupedByTheSourceNode() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN a.v AS v, count(*) AS c")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.<Number>getProperty("v").intValue()).isEqualTo(1);
+      assertThat(row.<Number>getProperty("c").longValue()).isEqualTo(1);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void optionalMatchKeepsTheRowAndStillFilters() {
+    assertThat(count("MATCH (a:A {v:1}) OPTIONAL MATCH (a)-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(b) AS c"))
+        .as("optionalHit").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1}) OPTIONAL MATCH (a)-[r:E WHERE r.tag = 'zz']->(b:A) RETURN count(b) AS c"))
+        .as("optionalMiss").isZero();
+  }
+
+  @Test
+  void patternComprehensionAndExistsShareTheSamePredicateSemantics() {
+    assertThat(count("MATCH (a:A {v:1}) RETURN size([(a)-[r:E WHERE r.tag = 'ok']->(b:A) | b.v]) AS c"))
+        .as("patternComprehension").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1}) RETURN size([(a)-[r:E WHERE r.tag = 'nope']->(b:A) | b.v]) AS c"))
+        .as("patternComprehensionNoMatch").isZero();
+    assertThat(count("MATCH (a:A {v:1}) RETURN COUNT { (a)-[r:E WHERE r.tag = 'ok']->(:A) } AS c"))
+        .as("countSubquery").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1}) WHERE EXISTS { (a)-[r:E WHERE r.tag = 'ok']->(:A) } RETURN count(*) AS c"))
+        .as("existsSubquery").isEqualTo(1);
+    assertThat(count("MATCH (a:A {v:1}) WHERE EXISTS { (a)-[r:E WHERE r.tag = 'nope']->(:A) } RETURN count(*) AS c"))
+        .as("existsSubqueryNoMatch").isZero();
+  }
+}


### PR DESCRIPTION
Closes #5463
Closes #5462

Two issues, one defect, one reproducer, so they are fixed and closed together.

## Summary

With two `(:A {v:1})-[:E]->(:A {v:2})` edges tagged `ok` and `bad`, `MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(b:A) RETURN count(*)` answered `0` while `RETURN count(r)` on the identical `MATCH` answered `1`. The root cause is that the Cypher variable-usage analysis, which decides which pattern bindings the plan must materialize, did not look inside inline pattern predicates. When nothing *outside* the pattern referenced `r`, the edge binding was elided from the plan, the inline predicate `r.tag = 'ok'` was then evaluated against an unbound variable, and every row was rejected. Any downstream mention of `r` kept the binding alive and masked the defect, which is why `count(r)`, `r.tag`, and even a `collect(r.tag)` sitting next to the `count(*)` (issue #5462's sharpest control) all looked correct, and why a literal `WHERE 1=1` was fine: it references no variable at all.

**The behavioral fix is already on `main`.** It landed in `475582108` ("fix(cypher) #5464: honor inline WHERE predicates in node and relationship patterns"), whose third listed defect is precisely this one, tracked there as #5466: *"the variable-usage analysis now looks inside inline pattern predicates."* Both reporters ran build `1134185d5494f5ab0583da4a508d846449f8e04c`, which predates that commit, so #5463 and #5462 were filed against a build that could not yet contain the fix. The pattern-comprehension leg of the same defect class was closed separately by `043309f61` (PR #5471, #5460).

This was verified, not assumed. The new test was run at `475582108^` (`116278160`, the reporters' era) and at current `main`:

| Commit | Result |
|---|---|
| `116278160` (pre-fix) | **8 of 10 methods FAIL**, `count(*)` answers `0` exactly as reported |
| `043309f61` (current `main`) | **10 of 10 PASS** |

So this PR carries **regression coverage only** and changes no production code, because none needs changing. What was genuinely missing is a test: neither reported shape had anything pinning it, so the behavior could silently regress again.

`Issue5463CountStarRelInlineWhereTest` (10 methods) covers `count(*)` agreeing with `count(r)` and with the materialized `r.tag` rows; the predicate honored across every tag value including the empty and match-all cases; #5462's `collect(r.tag)` control; the literal-predicate and clause-level-`WHERE` controls from both reports; anonymous source, anonymous target and both-ends-anonymous shapes; right-to-left, undirected and untyped variants; `count(b)`, `count(DISTINCT b)`, `sum(b.v)` and `count(*)` through `WITH`; `count(*)` under a grouping key; `OPTIONAL MATCH` hit and miss; and **both** pattern-parsing paths that accept a relationship inline predicate, the `MATCH` path and the pattern-comprehension / `COUNT {}` / `EXISTS {}` path.

## Scope note: adjacent gap found, deliberately not fixed here

While probing the surrounding defect class on current `main`, the relationship inline `WHERE` is still ignored outright inside a **variable-length** pattern:

```cypher
MATCH (a:A {v:1})-[r:E*1..1 WHERE r.tag = 'ok']->(b:A)  RETURN count(*) AS c;  -- 2
MATCH (a:A {v:1})-[r:E*1..1 WHERE r.tag = 'zzz']->(b:A) RETURN count(*) AS c;  -- 2
```

The predicate changes nothing, so it is dropped rather than misevaluated, which is a different failure mode from the `0` these two issues report on a single-hop pattern. It is left alone on purpose: it is out of scope here, its `shortestPath` half is already tracked by #5481 and the node-pattern half by #5480 (both being worked separately), and the plain variable-length case has no open issue yet and deserves its own triage.

## Test plan

- [x] `Issue5463CountStarRelInlineWhereTest` fails 8 of 10 methods at `475582108^`, reproducing `count(*) = 0` as reported in both issues
- [x] `Issue5463CountStarRelInlineWhereTest` passes 10 of 10 on current `main`
- [x] No production code touched, so no behavior change risk
- [x] Surrounding Cypher suites green: `Issue5463CountStarRelInlineWhereTest`, `CypherInlinePatternWhereTest`, `Issue5464ExistsRelInlineWhereTest`, `OpenCypherPatternComprehensionInlineWhereTest`, `CypherInlinePropertyFilterTest`, `CypherInlinePropertyNormalizationTest`, `OpenCypherPatternPredicateTest`, `CypherPatternPredicateTest`, `CypherExistsTest`, `CypherCountSubqueryTest`, `CypherCountSubqueryCorrelatedTest`, `CypherCollectSubqueryTest`, `CountEdgesOptimizationTest`, `CypherCountNonExistingLabelTest`, `GAVEligibilityTest` - `Tests run: 170, Failures: 0, Errors: 0, Skipped: 0`
- [ ] Reviewer: confirm both issues against a released build rather than `latest`, since both reporters hit a snapshot image predating `475582108`
