### PR TITLE
fix(#5480): apply node inline WHERE predicates in pattern comprehensions

### DIFF
--- a/docs/5480-node-inline-where-predicates.md
+++ b/docs/5480-node-inline-where-predicates.md
@@ -46,12 +46,15 @@ Two files, both minimal:
    like the relationship form directly below it: `new BooleanCoercionExpression(parseExpression(ctx.expression()))`,
    passed to the full `NodePattern` constructor.
 
-2. `ast/PatternComprehensionExpression` now enforces it. A new private helper
-   `matchesNodeWhereExpression(vertex, nodePattern, bindings, context)` copies the visible bindings
-   into a private evaluation row, binds the node variable to the candidate vertex and evaluates the
-   predicate. It is called from the three places a node is accepted:
+2. `ast/PatternComprehensionExpression` now enforces it. `inlineWhereRow(nodePattern, bindings)`
+   builds a private evaluation row by copying the visible bindings once per expansion (and returns
+   `null` when the pattern carries no predicate), and `matchesNodeWhereExpression(vertex,
+   nodePattern, whereEvalRow, context)` rebinds the node variable on that row per candidate and
+   evaluates the predicate. This mirrors the `whereEvalRow` reuse the relationship form already
+   used, so a high-fan-out expansion copies the bindings once rather than once per candidate. The
+   check is called from the three places a node is accepted:
    - `matchesEndPattern(...)` - every hop's target node (fixed-length, variable-length and the
-     zero-length case), which now also receives `currentResult` for the evaluation scope.
+     zero-length case), which now also receives the hoisted evaluation row.
    - `matchesStartPattern(...)` - candidates of an uncorrelated leading node.
    - `traversePattern(...)` - the leading node of the first hop when it is resolved from an
      outer-scope binding. Later hops start from the previous hop's end node, already validated by
@@ -63,18 +66,19 @@ predicate-free path stays allocation-free.
 
 ## Tests
 
-`engine/src/test/java/com/arcadedb/query/opencypher/Issue5480NodeInlineWhereTest.java` - 9 tests:
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue5480NodeInlineWhereTest.java` - 10 tests:
 
 - plain `MATCH`: single node, both endpoints of a path, inline combined with a clause-level `WHERE`
 - `EXISTS {}`: pattern-only form and explicit-`MATCH` form, matching and non-matching predicate
 - `COUNT {}`: predicate applied, and control without predicate
-- pattern comprehension: target node, uncorrelated/anchor node, inline combined with the
+- pattern comprehension: target node, uncorrelated/anchor node, a variable-length hop (which
+  exercises the reused evaluation row across candidates), and inline combined with the
   comprehension's trailing `WHERE`
 
 Verification:
 
-- `mvn -o test -Dtest=Issue5480NodeInlineWhereTest` - 9/9 pass (3 of the 9 failed before the fix)
-- `mvn -o test -Dtest='com.arcadedb.query.opencypher.**'` - 7578 tests, 0 failures. The only 3
+- `mvn -o test -Dtest=Issue5480NodeInlineWhereTest` - 10/10 pass (3 failed before the fix)
+- `mvn -o test -Dtest='com.arcadedb.query.opencypher.**'` - 7579 tests, 0 failures. The only 3
   errors are `OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s, reproduced
   identically on a stashed (unmodified) tree, so they are environmental and pre-existing.
 
@@ -90,3 +94,43 @@ Verification:
 
 Silent wrong answers become correct answers. Any query using `[(a)-[:R]->(x:L WHERE ...) | x]` in
 `size()`, `count()`, aggregation or a projection previously saw the unfiltered set.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5486
+
+## Review cycles
+
+### Cycle 1 - head `97ab46ec`
+
+- `claude[bot]`: reviewed, **no blocking items**, three minor suggestions.
+  1. GC pressure - the end-node check re-copied the bindings per candidate instead of once per
+     expansion like the relationship form. **Applied** (`inlineWhereRow(...)` hoisted out of the
+     candidate loops), plus a variable-length regression test that would catch a stale-row bug.
+  2. Test class javadoc listed `shortestPath` among the covered contexts although no such test
+     exists. **Applied** - javadoc rewritten to name the three covered contexts and point at #5481.
+  3. `ShortestPathExpression` now receives a parsed-but-ignored node predicate. **No change** - the
+     reviewer flagged it as a non-regression; that evaluator is issue #5481, fixed separately.
+- `gemini-code-assist`: did not respond within the 15-minute per-cycle window.
+
+### Cycle 2 - head after the review fixes
+
+- Pushed the two applied items above plus the extra variable-length test. Reviewer outcome for this
+  head is appended below once the bots report.
+
+## Deferred items
+
+Recorded in the (uncommitted) session note `docs/review-deferred-97ab46ec.md`:
+
+- A node inline predicate that references the relationship variable of the same hop, e.g.
+  `[(a)-[r:E]->(x:A WHERE x.v > r.w) | x]`, sees `r` unbound on the comprehension path, because the
+  evaluation row is copied from the bindings visible before the hop. The equivalent `MATCH`
+  spelling hoists the predicate into the clause `WHERE`, where `r` is bound, so the two spellings
+  can disagree for this shape. Out of scope for #5480 (the predicate being dropped entirely) and it
+  needs its own triage, including what `r` should mean on a variable-length hop. Worth a separate
+  issue.
+
+## Final state
+
+`timeout` - `gemini-code-assist` did not review either head within the per-cycle window.
+`claude[bot]` reviewed with no blocking items and its actionable suggestions were applied.

--- a/docs/5480-node-inline-where-predicates.md
+++ b/docs/5480-node-inline-where-predicates.md
@@ -1,0 +1,92 @@
+# Issue #5480 - Node inline `WHERE` predicates are ignored
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5480
+Branch: `fix/5480-node-inline-where-predicates`
+
+## Problem
+
+The node inline `WHERE` predicate, the `WHERE n.v = 2` in `(n:A WHERE n.v = 2)`, is accepted by the
+grammar but was not enforced in every context. The issue reported three contexts: plain `MATCH`,
+`EXISTS {}` subqueries and pattern comprehensions.
+
+## Reproduction and triage
+
+A reproduction test (`Issue5480NodeInlineWhereTest`) was written first, covering all three reported
+contexts. Against `main` at `043309f61` only the pattern-comprehension case reproduced:
+
+| Context | Status on `043309f61` |
+|---|---|
+| plain `MATCH` | already correct (`InlineNodeWhereHoister`, #5464) |
+| `EXISTS {}` / `COUNT {}` | already correct (`PatternPredicateExpression.matchesNodePattern`, #5464) |
+| pattern comprehension | **broken** |
+
+The `MATCH` and `EXISTS {}` cases were fixed by #5464 after the issue text was drafted. Their tests
+are kept as regressions so the two paths stay covered.
+
+## Root cause
+
+Node and relationship patterns are parsed by two independent builders:
+
+- `parser/CypherASTBuilder` - the `MATCH` / `CREATE` / `MERGE` path. Its `visitNodePattern(...)`
+  already parsed `ctx.expression()` into `NodePattern.whereExpression`, and `visitMatchClause(...)`
+  hoisted it into the clause `WHERE` via `rewriter/InlineNodeWhereHoister`.
+- `parser/CypherExpressionBuilder` - the pattern-comprehension / `shortestPath` path. Its
+  `parseNodePattern(...)` built `new NodePattern(variable, labels, properties, propertiesParameterName)`
+  and **never read `ctx.expression()`**, so the predicate was dropped at parse time.
+
+Consequently `PatternComprehensionExpression` received a `NodePattern` whose `whereExpression` was
+always `null`, and it had no code to enforce one either. #5460 had fixed the same gap for the
+*relationship* form on this builder; the node form was left behind.
+
+## Fix
+
+Two files, both minimal:
+
+1. `parser/CypherExpressionBuilder.parseNodePattern(...)` now parses the inline predicate exactly
+   like the relationship form directly below it: `new BooleanCoercionExpression(parseExpression(ctx.expression()))`,
+   passed to the full `NodePattern` constructor.
+
+2. `ast/PatternComprehensionExpression` now enforces it. A new private helper
+   `matchesNodeWhereExpression(vertex, nodePattern, bindings, context)` copies the visible bindings
+   into a private evaluation row, binds the node variable to the candidate vertex and evaluates the
+   predicate. It is called from the three places a node is accepted:
+   - `matchesEndPattern(...)` - every hop's target node (fixed-length, variable-length and the
+     zero-length case), which now also receives `currentResult` for the evaluation scope.
+   - `matchesStartPattern(...)` - candidates of an uncorrelated leading node.
+   - `traversePattern(...)` - the leading node of the first hop when it is resolved from an
+     outer-scope binding. Later hops start from the previous hop's end node, already validated by
+     `matchesEndPattern`, so the check is guarded on `hopIndex == 0 && knownStartVertex == null`
+     and never runs twice for the same node.
+
+The evaluation row is only allocated when the pattern actually carries a predicate, so the common
+predicate-free path stays allocation-free.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue5480NodeInlineWhereTest.java` - 9 tests:
+
+- plain `MATCH`: single node, both endpoints of a path, inline combined with a clause-level `WHERE`
+- `EXISTS {}`: pattern-only form and explicit-`MATCH` form, matching and non-matching predicate
+- `COUNT {}`: predicate applied, and control without predicate
+- pattern comprehension: target node, uncorrelated/anchor node, inline combined with the
+  comprehension's trailing `WHERE`
+
+Verification:
+
+- `mvn -o test -Dtest=Issue5480NodeInlineWhereTest` - 9/9 pass (3 of the 9 failed before the fix)
+- `mvn -o test -Dtest='com.arcadedb.query.opencypher.**'` - 7578 tests, 0 failures. The only 3
+  errors are `OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s, reproduced
+  identically on a stashed (unmodified) tree, so they are environmental and pre-existing.
+
+## Scope notes
+
+- `shortestPath` is deliberately **not** touched. `ast/ShortestPathExpression` shares
+  `CypherExpressionBuilder.parseNodePattern(...)`, so after this change it receives a node predicate
+  it still ignores - the same situation #5460 created for the relationship form. That evaluator is
+  the subject of issue #5481 and is being fixed separately.
+- No overlap with `InlineNodeWhereHoister` or `PatternPredicateExpression`; neither is modified.
+
+## Impact
+
+Silent wrong answers become correct answers. Any query using `[(a)-[:R]->(x:L WHERE ...) | x]` in
+`size()`, `count()`, aggregation or a projection previously saw the unfiltered set.

--- a/docs/5480-node-inline-where-predicates.md
+++ b/docs/5480-node-inline-where-predicates.md
@@ -113,22 +113,26 @@ https://github.com/ArcadeData/arcadedb/pull/5486
      reviewer flagged it as a non-regression; that evaluator is issue #5481, fixed separately.
 - `gemini-code-assist`: did not respond within the 15-minute per-cycle window.
 
-### Cycle 2 - head after the review fixes
+### Cycle 2 - head `1af2fe5f`
 
-- Pushed the two applied items above plus the extra variable-length test. Reviewer outcome for this
-  head is appended below once the bots report.
+- Pushed the two applied items above plus the extra variable-length test.
+- `claude[bot]`: re-reviewed, **no blocking items**. Confirmed the double-evaluation guard, the
+  allocation-free predicate-free path and the row hoisting. Two minor points: the same-hop
+  relationship-reference divergence recorded below (agreed it deserves its own issue), and a stale
+  test count in the PR description (corrected to 10).
+- `gemini-code-assist`: did not respond within the 15-minute per-cycle window, as in cycle 1.
 
 ## Deferred items
-
-Recorded in the (uncommitted) session note `docs/review-deferred-97ab46ec.md`:
 
 - A node inline predicate that references the relationship variable of the same hop, e.g.
   `[(a)-[r:E]->(x:A WHERE x.v > r.w) | x]`, sees `r` unbound on the comprehension path, because the
   evaluation row is copied from the bindings visible before the hop. The equivalent `MATCH`
   spelling hoists the predicate into the clause `WHERE`, where `r` is bound, so the two spellings
   can disagree for this shape. Out of scope for #5480 (the predicate being dropped entirely) and it
-  needs its own triage, including what `r` should mean on a variable-length hop. Worth a separate
-  issue.
+  needs its own triage, including what `r` should mean on a variable-length hop. On the
+  fixed-length path the edge is already in hand at the `matchesEndPattern` call, so binding it into
+  the node evaluation row would be cheap; the variable-length path is the part that needs a
+  semantic decision. Worth a separate issue.
 
 ## Final state
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -122,6 +122,14 @@ public class PatternComprehensionExpression implements Expression {
       return;
     }
 
+    // Inline WHERE predicate on the leading node, e.g. [(a WHERE a.v = 1)-[:E]->(x) | x]. Only the
+    // first hop needs the check here: every later hop starts from the previous hop's end node, which
+    // matchesEndPattern already validated, and an uncorrelated start is validated while iterating
+    // candidates in traverseUncorrelatedStart.
+    if (hopIndex == 0 && knownStartVertex == null
+        && !matchesNodeWhereExpression(startVertex, startNodePattern, currentResult, context))
+      return;
+
     // Add start vertex to path at first hop
     if (hopIndex == 0 && pathVariable != null)
       pathElements.add(startVertex);
@@ -143,7 +151,7 @@ public class PatternComprehensionExpression implements Expression {
       final int maxHops = relPattern.getEffectiveMaxHops();
 
       // Zero-length path: start and end are the same vertex (only valid if matches end pattern)
-      if (minHops == 0 && matchesEndPattern(startVertex, endNodePattern, baseResult, context)) {
+      if (minHops == 0 && matchesEndPattern(startVertex, endNodePattern, baseResult, currentResult, context)) {
         final ResultInternal hopResult = buildHopResult(currentResult, endNodePattern, startVertex, relPattern, null);
         traversePattern(baseResult, context, hopIndex + 1, hopResult, resultList, pathElements, startVertex);
       }
@@ -185,7 +193,7 @@ public class PatternComprehensionExpression implements Expression {
     for (final Record record : candidates) {
       if (!(record instanceof Vertex candidate))
         continue;
-      if (!matchesStartPattern(candidate, startNodePattern, context))
+      if (!matchesStartPattern(candidate, startNodePattern, currentResult, context))
         continue;
 
       final ResultInternal candidateResult = new ResultInternal();
@@ -203,9 +211,11 @@ public class PatternComprehensionExpression implements Expression {
   }
 
   /**
-   * Returns true if a vertex matches the start node pattern's labels and inline properties.
+   * Returns true if a vertex matches the start node pattern's labels, inline properties and inline
+   * {@code WHERE} predicate.
    */
-  private boolean matchesStartPattern(final Vertex vertex, final NodePattern startNodePattern, final CommandContext context) {
+  private boolean matchesStartPattern(final Vertex vertex, final NodePattern startNodePattern, final Result currentResult,
+      final CommandContext context) {
     if (startNodePattern.hasLabels()) {
       for (final String label : startNodePattern.getLabels()) {
         if (!Labels.hasLabel(vertex, label))
@@ -218,7 +228,7 @@ public class PatternComprehensionExpression implements Expression {
           return false;
       }
     }
-    return true;
+    return matchesNodeWhereExpression(vertex, startNodePattern, currentResult, context);
   }
 
   /**
@@ -285,7 +295,7 @@ public class PatternComprehensionExpression implements Expression {
         pathElements.add(nextVertex);
       }
 
-      if (nextHop >= minHops && matchesEndPattern(nextVertex, endNodePattern, baseResult, context)) {
+      if (nextHop >= minHops && matchesEndPattern(nextVertex, endNodePattern, baseResult, currentResult, context)) {
         final ResultInternal hopResult = buildHopResult(currentResult, endNodePattern, nextVertex, relPattern, edge);
         traversePattern(baseResult, context, hopIndex + 1, hopResult, resultList, pathElements, nextVertex);
       }
@@ -303,7 +313,7 @@ public class PatternComprehensionExpression implements Expression {
   }
 
   private boolean matchesEndPattern(final Vertex vertex, final NodePattern endNodePattern, final Result baseResult,
-      final CommandContext context) {
+      final Result currentResult, final CommandContext context) {
     if (endNodePattern.hasLabels()) {
       for (final String label : endNodePattern.getLabels()) {
         if (!Labels.hasLabel(vertex, label))
@@ -323,7 +333,30 @@ public class PatternComprehensionExpression implements Expression {
       if (bound instanceof Vertex boundVertex && !boundVertex.getIdentity().equals(vertex.getIdentity()))
         return false;
     }
-    return true;
+    // Inline WHERE predicate, e.g. the WHERE x.v = 2 in [(a)-[:E]->(x:A WHERE x.v = 2) | x] (issue #5480)
+    return matchesNodeWhereExpression(vertex, endNodePattern, currentResult, context);
+  }
+
+  /**
+   * Returns true if a vertex satisfies the node pattern's inline {@code WHERE} predicate, e.g. the
+   * {@code WHERE x.v = 2} in {@code [(a)-[:E]->(x:A WHERE x.v = 2) | x]}. Mirrors the enforcement
+   * done by the regular MATCH path, where the same predicate is hoisted into the clause WHERE, so
+   * both spellings filter identically.
+   *
+   * @param bindings variables visible to the predicate. They are copied into a private evaluation
+   *                 row on which the node variable is bound to the candidate, leaving the caller's
+   *                 row untouched.
+   */
+  private boolean matchesNodeWhereExpression(final Vertex vertex, final NodePattern nodePattern, final Result bindings,
+      final CommandContext context) {
+    if (nodePattern == null || !nodePattern.hasWhereExpression())
+      return true;
+
+    final ResultInternal evalRow = copyBindings(bindings);
+    final String variable = nodePattern.getVariable();
+    if (variable != null && !variable.isEmpty())
+      evalRow.setProperty(variable, vertex);
+    return nodePattern.getWhereExpression().evaluate(evalRow, context);
   }
 
   /**
@@ -448,7 +481,7 @@ public class PatternComprehensionExpression implements Expression {
         continue;
       }
 
-      if (!matchesEndPattern(targetVertex, endNodePattern, baseResult, context))
+      if (!matchesEndPattern(targetVertex, endNodePattern, baseResult, currentResult, context))
         continue;
 
       // Build result with matched variables

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -127,7 +127,7 @@ public class PatternComprehensionExpression implements Expression {
     // matchesEndPattern already validated, and an uncorrelated start is validated while iterating
     // candidates in traverseUncorrelatedStart.
     if (hopIndex == 0 && knownStartVertex == null
-        && !matchesNodeWhereExpression(startVertex, startNodePattern, currentResult, context))
+        && !matchesNodeWhereExpression(startVertex, startNodePattern, inlineWhereRow(startNodePattern, currentResult), context))
       return;
 
     // Add start vertex to path at first hop
@@ -151,7 +151,8 @@ public class PatternComprehensionExpression implements Expression {
       final int maxHops = relPattern.getEffectiveMaxHops();
 
       // Zero-length path: start and end are the same vertex (only valid if matches end pattern)
-      if (minHops == 0 && matchesEndPattern(startVertex, endNodePattern, baseResult, currentResult, context)) {
+      if (minHops == 0
+          && matchesEndPattern(startVertex, endNodePattern, baseResult, inlineWhereRow(endNodePattern, currentResult), context)) {
         final ResultInternal hopResult = buildHopResult(currentResult, endNodePattern, startVertex, relPattern, null);
         traversePattern(baseResult, context, hopIndex + 1, hopResult, resultList, pathElements, startVertex);
       }
@@ -190,10 +191,14 @@ public class PatternComprehensionExpression implements Expression {
       candidates = collectAllVertices(context);
     }
 
+    // Row reused across every candidate vertex, for the same reason as the edge expansions below:
+    // only the node variable changes per candidate, so the enclosing bindings are copied once.
+    final ResultInternal whereEvalRow = inlineWhereRow(startNodePattern, currentResult);
+
     for (final Record record : candidates) {
       if (!(record instanceof Vertex candidate))
         continue;
-      if (!matchesStartPattern(candidate, startNodePattern, currentResult, context))
+      if (!matchesStartPattern(candidate, startNodePattern, whereEvalRow, context))
         continue;
 
       final ResultInternal candidateResult = new ResultInternal();
@@ -214,7 +219,7 @@ public class PatternComprehensionExpression implements Expression {
    * Returns true if a vertex matches the start node pattern's labels, inline properties and inline
    * {@code WHERE} predicate.
    */
-  private boolean matchesStartPattern(final Vertex vertex, final NodePattern startNodePattern, final Result currentResult,
+  private boolean matchesStartPattern(final Vertex vertex, final NodePattern startNodePattern, final ResultInternal whereEvalRow,
       final CommandContext context) {
     if (startNodePattern.hasLabels()) {
       for (final String label : startNodePattern.getLabels()) {
@@ -228,7 +233,7 @@ public class PatternComprehensionExpression implements Expression {
           return false;
       }
     }
-    return matchesNodeWhereExpression(vertex, startNodePattern, currentResult, context);
+    return matchesNodeWhereExpression(vertex, startNodePattern, whereEvalRow, context);
   }
 
   /**
@@ -263,6 +268,8 @@ public class PatternComprehensionExpression implements Expression {
     // changes per edge, so the enclosing bindings are copied once. Stays null when the pattern
     // carries no inline WHERE, leaving the common path allocation-free.
     final ResultInternal whereEvalRow = relPattern.hasWhereExpression() ? copyBindings(currentResult) : null;
+    // Same reuse for the end node's inline WHERE: only the node variable changes per candidate.
+    final ResultInternal nodeWhereEvalRow = inlineWhereRow(endNodePattern, currentResult);
 
     while (edges.hasNext()) {
       final Edge edge = edges.next();
@@ -295,7 +302,7 @@ public class PatternComprehensionExpression implements Expression {
         pathElements.add(nextVertex);
       }
 
-      if (nextHop >= minHops && matchesEndPattern(nextVertex, endNodePattern, baseResult, currentResult, context)) {
+      if (nextHop >= minHops && matchesEndPattern(nextVertex, endNodePattern, baseResult, nodeWhereEvalRow, context)) {
         final ResultInternal hopResult = buildHopResult(currentResult, endNodePattern, nextVertex, relPattern, edge);
         traversePattern(baseResult, context, hopIndex + 1, hopResult, resultList, pathElements, nextVertex);
       }
@@ -313,7 +320,7 @@ public class PatternComprehensionExpression implements Expression {
   }
 
   private boolean matchesEndPattern(final Vertex vertex, final NodePattern endNodePattern, final Result baseResult,
-      final Result currentResult, final CommandContext context) {
+      final ResultInternal whereEvalRow, final CommandContext context) {
     if (endNodePattern.hasLabels()) {
       for (final String label : endNodePattern.getLabels()) {
         if (!Labels.hasLabel(vertex, label))
@@ -334,7 +341,18 @@ public class PatternComprehensionExpression implements Expression {
         return false;
     }
     // Inline WHERE predicate, e.g. the WHERE x.v = 2 in [(a)-[:E]->(x:A WHERE x.v = 2) | x] (issue #5480)
-    return matchesNodeWhereExpression(vertex, endNodePattern, currentResult, context);
+    return matchesNodeWhereExpression(vertex, endNodePattern, whereEvalRow, context);
+  }
+
+  /**
+   * Builds the row an inline node {@code WHERE} predicate is evaluated against: a private copy of
+   * the bindings visible at that point, on which the node variable is later rebound per candidate.
+   * Returns {@code null} when the pattern carries no predicate, leaving the common path
+   * allocation-free. Callers hoist the call out of their candidate loop so a high-fan-out expansion
+   * copies the bindings once rather than once per candidate.
+   */
+  private static ResultInternal inlineWhereRow(final NodePattern nodePattern, final Result bindings) {
+    return nodePattern != null && nodePattern.hasWhereExpression() ? copyBindings(bindings) : null;
   }
 
   /**
@@ -343,20 +361,20 @@ public class PatternComprehensionExpression implements Expression {
    * done by the regular MATCH path, where the same predicate is hoisted into the clause WHERE, so
    * both spellings filter identically.
    *
-   * @param bindings variables visible to the predicate. They are copied into a private evaluation
-   *                 row on which the node variable is bound to the candidate, leaving the caller's
-   *                 row untouched.
+   * @param whereEvalRow the row produced by {@link #inlineWhereRow(NodePattern, Result)} for this
+   *                     pattern. The node variable is rebound on it for each candidate, so the
+   *                     caller's own row is never mutated. Only read when the pattern actually
+   *                     declares a predicate, so a {@code null} row is fine otherwise.
    */
-  private boolean matchesNodeWhereExpression(final Vertex vertex, final NodePattern nodePattern, final Result bindings,
-      final CommandContext context) {
+  private boolean matchesNodeWhereExpression(final Vertex vertex, final NodePattern nodePattern,
+      final ResultInternal whereEvalRow, final CommandContext context) {
     if (nodePattern == null || !nodePattern.hasWhereExpression())
       return true;
 
-    final ResultInternal evalRow = copyBindings(bindings);
     final String variable = nodePattern.getVariable();
     if (variable != null && !variable.isEmpty())
-      evalRow.setProperty(variable, vertex);
-    return nodePattern.getWhereExpression().evaluate(evalRow, context);
+      whereEvalRow.setProperty(variable, vertex);
+    return nodePattern.getWhereExpression().evaluate(whereEvalRow, context);
   }
 
   /**
@@ -463,6 +481,8 @@ public class PatternComprehensionExpression implements Expression {
     // changes per edge, so the enclosing bindings are copied once. Stays null when the pattern
     // carries no inline WHERE, leaving the common path allocation-free.
     final ResultInternal whereEvalRow = relPattern.hasWhereExpression() ? copyBindings(currentResult) : null;
+    // Same reuse for the end node's inline WHERE: only the node variable changes per candidate.
+    final ResultInternal nodeWhereEvalRow = inlineWhereRow(endNodePattern, currentResult);
 
     while (edges.hasNext()) {
       final Edge edge = edges.next();
@@ -481,7 +501,7 @@ public class PatternComprehensionExpression implements Expression {
         continue;
       }
 
-      if (!matchesEndPattern(targetVertex, endNodePattern, baseResult, currentResult, context))
+      if (!matchesEndPattern(targetVertex, endNodePattern, baseResult, nodeWhereEvalRow, context))
         continue;
 
       // Build result with matched variables

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -2512,7 +2512,14 @@ class CypherExpressionBuilder {
         properties = parseMapProperties(ctx.properties().map());
     }
 
-    return new NodePattern(variable, labels, properties, propertiesParameterName);
+    // Inline WHERE predicate, e.g. the WHERE x.v = 2 in [(a)-[:E]->(x:A WHERE x.v = 2) | x]. Parsed
+    // as a generic expression and coerced to a predicate, mirroring the relationship form below, so
+    // comparisons, AND/OR/NOT and boolean-typed properties are all covered.
+    BooleanExpression whereExpression = null;
+    if (ctx.expression() != null)
+      whereExpression = new BooleanCoercionExpression(parseExpression(ctx.expression()));
+
+    return new NodePattern(variable, labels, null, properties, propertiesParameterName, false, whereExpression);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5480NodeInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5480NodeInlineWhereTest.java
@@ -35,9 +35,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Regression test for GitHub issue #5480.
  * <p>
  * A node inline {@code WHERE} predicate - the {@code WHERE n.v = 2} in {@code (n:A WHERE n.v = 2)} -
- * must filter candidate nodes in every context that accepts the syntax: plain {@code MATCH},
- * {@code EXISTS {}} subqueries, pattern comprehensions and {@code shortestPath}. Before the fix the
- * predicate was parsed but silently discarded, so every candidate node matched.
+ * must filter candidate nodes in plain {@code MATCH}, in {@code EXISTS {}} / {@code COUNT {}}
+ * subqueries and in pattern comprehensions. Before the fix the predicate was parsed but silently
+ * discarded by the pattern-comprehension parser path, so every candidate node matched.
+ * <p>
+ * {@code shortestPath} is deliberately not covered here: that evaluator ignores inline predicates
+ * altogether and is tracked by issue #5481.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -135,6 +138,15 @@ class Issue5480NodeInlineWhereTest {
   void patternComprehensionAppliesNodeInlineWhereOnTheAnchorNode() {
     assertThat(queryInt("MATCH (a:A {v:1}) RETURN size([(a WHERE a.v = 99)-[:E]->(x:A) | x]) AS c", "c")).isEqualTo(0);
     assertThat(queryInt("MATCH (a:A {v:1}) RETURN size([(a WHERE a.v = 1)-[:E]->(x:A) | x]) AS c", "c")).isEqualTo(2);
+  }
+
+  @Test
+  void patternComprehensionAppliesNodeInlineWhereOnAVariableLengthHop() {
+    // The evaluation row is reused across candidates of one expansion, so a predicate that matches
+    // only some of them must still reject the others.
+    assertThat(queryInt("MATCH (a:A {v:1}) RETURN size([(a)-[:E*1..2]->(x:A WHERE x.v = 3) | x]) AS c", "c"))
+        .isEqualTo(1);
+    assertThat(queryInt("MATCH (a:A {v:1}) RETURN size([(a)-[:E*1..2]->(x:A) | x]) AS c", "c")).isEqualTo(2);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5480NodeInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5480NodeInlineWhereTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #5480.
+ * <p>
+ * A node inline {@code WHERE} predicate - the {@code WHERE n.v = 2} in {@code (n:A WHERE n.v = 2)} -
+ * must filter candidate nodes in every context that accepts the syntax: plain {@code MATCH},
+ * {@code EXISTS {}} subqueries, pattern comprehensions and {@code shortestPath}. Before the fix the
+ * predicate was parsed but silently discarded, so every candidate node matched.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5480NodeInlineWhereTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-5480-node-inline-where").create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (a:A {v:1}), (b:A {v:2}), (c:A {v:3})");
+      database.command("opencypher", "MATCH (a:A {v:1}), (b:A {v:2}), (c:A {v:3}) "
+          + "CREATE (a)-[:E]->(b), (a)-[:E]->(c)");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  private List<Integer> queryInts(final String query, final String field) {
+    final List<Integer> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final Number n = row.getProperty(field);
+        values.add(n == null ? null : n.intValue());
+      }
+    }
+    return values;
+  }
+
+  private int queryInt(final String query, final String field) {
+    final List<Integer> values = queryInts(query, field);
+    assertThat(values).hasSize(1);
+    return values.get(0);
+  }
+
+  // ---------------------------------------------------------------- plain MATCH
+
+  @Test
+  void plainMatchAppliesNodeInlineWhere() {
+    assertThat(queryInts("MATCH (n:A WHERE n.v = 2) RETURN n.v AS v ORDER BY v", "v")).containsExactly(2);
+  }
+
+  @Test
+  void plainMatchAppliesNodeInlineWhereOnEveryNodeOfThePath() {
+    assertThat(queryInts("MATCH (a:A WHERE a.v = 1)-[:E]->(b:A WHERE b.v = 3) RETURN b.v AS v", "v"))
+        .containsExactly(3);
+  }
+
+  @Test
+  void plainMatchCombinesNodeInlineWhereWithClauseWhere() {
+    assertThat(queryInts("MATCH (n:A WHERE n.v > 1) WHERE n.v < 3 RETURN n.v AS v", "v")).containsExactly(2);
+  }
+
+  // ---------------------------------------------------------------- EXISTS {}
+
+  @Test
+  void existsSubqueryAppliesNodeInlineWhere() {
+    assertThat(queryInts("MATCH (a:A {v:1}) WHERE EXISTS { (a)-[:E]->(x:A WHERE x.v = 99) } RETURN a.v AS v", "v"))
+        .isEmpty();
+    assertThat(queryInts("MATCH (a:A {v:1}) WHERE EXISTS { (a)-[:E]->(x:A WHERE x.v = 2) } RETURN a.v AS v", "v"))
+        .containsExactly(1);
+  }
+
+  @Test
+  void existsSubqueryWithExplicitMatchAppliesNodeInlineWhere() {
+    assertThat(queryInts(
+        "MATCH (a:A {v:1}) WHERE EXISTS { MATCH (a)-[:E]->(x:A WHERE x.v = 99) } RETURN a.v AS v", "v")).isEmpty();
+    assertThat(queryInts(
+        "MATCH (a:A {v:1}) WHERE EXISTS { MATCH (a)-[:E]->(x:A WHERE x.v = 3) } RETURN a.v AS v", "v"))
+        .containsExactly(1);
+  }
+
+  @Test
+  void countSubqueryAppliesNodeInlineWhere() {
+    assertThat(queryInt("MATCH (a:A {v:1}) RETURN COUNT { (a)-[:E]->(x:A WHERE x.v = 2) } AS c", "c")).isEqualTo(1);
+    assertThat(queryInt("MATCH (a:A {v:1}) RETURN COUNT { (a)-[:E]->(x:A) } AS c", "c")).isEqualTo(2);
+  }
+
+  // ---------------------------------------------------------------- pattern comprehension
+
+  @Test
+  void patternComprehensionAppliesNodeInlineWhere() {
+    assertThat(queryInt("MATCH (a:A {v:1}) RETURN size([(a)-[:E]->(x:A WHERE x.v = 2) | x]) AS c", "c")).isEqualTo(1);
+    assertThat(queryInt("MATCH (a:A {v:1}) RETURN size([(a)-[:E]->(x:A) | x]) AS c", "c")).isEqualTo(2);
+  }
+
+  @Test
+  void patternComprehensionAppliesNodeInlineWhereOnTheAnchorNode() {
+    assertThat(queryInt("MATCH (a:A {v:1}) RETURN size([(a WHERE a.v = 99)-[:E]->(x:A) | x]) AS c", "c")).isEqualTo(0);
+    assertThat(queryInt("MATCH (a:A {v:1}) RETURN size([(a WHERE a.v = 1)-[:E]->(x:A) | x]) AS c", "c")).isEqualTo(2);
+  }
+
+  @Test
+  void patternComprehensionCombinesNodeInlineWhereWithTrailingWhere() {
+    assertThat(queryInt(
+        "MATCH (a:A {v:1}) RETURN size([(a)-[:E]->(x:A WHERE x.v > 1) WHERE x.v < 3 | x]) AS c", "c")).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
Closes #5480

## Summary

A node inline `WHERE` predicate - the `WHERE n.v = 2` in `(n:A WHERE n.v = 2)` - was parsed by the grammar but silently discarded in pattern comprehensions, so every candidate node matched and any downstream `size()`/`count()`/aggregation produced a wrong answer with no error. The root cause is that node and relationship patterns are parsed by two independent builders: `CypherASTBuilder` (the `MATCH` path, which already parsed the predicate and hoisted it into the clause `WHERE` via `InlineNodeWhereHoister`) and `CypherExpressionBuilder` (the pattern-comprehension / `shortestPath` path), whose `parseNodePattern(...)` never read `ctx.expression()`. #5460 fixed exactly this gap for the *relationship* form on the same builder; the node form was left behind. The fix parses the predicate in `CypherExpressionBuilder.parseNodePattern(...)` the same way the relationship form directly below it does, and makes `PatternComprehensionExpression` enforce it at the three points a node is accepted (every hop's end node, uncorrelated leading-node candidates, and the first hop's leading node when it comes from an outer binding), with the check guarded so a node is never tested twice.

## Triage note

The issue listed three broken contexts. Against `main` at `043309f61` only pattern comprehensions actually reproduced: plain `MATCH` and `EXISTS {}` were already fixed by #5464 after the issue text was drafted. Regression tests are included for all three anyway so both parser paths stay covered.

## Scope

`shortestPath` is deliberately not touched. `ShortestPathExpression` shares `CypherExpressionBuilder.parseNodePattern(...)`, so it now receives a node predicate it still ignores - the same residual state #5460 left for the relationship form. That evaluator is issue #5481 and is being fixed separately; keeping it out avoids overlapping with that work.

## Test plan

- [x] `mvn -o test -Dtest=Issue5480NodeInlineWhereTest -pl engine` - 10/10 pass (3 fail before the fix)
- [x] Plain `MATCH`: `MATCH (n:A WHERE n.v = 2) RETURN n.v` returns only `2`; inline predicate on both endpoints of a path; inline combined with a clause-level `WHERE`
- [x] `EXISTS {}`: pattern-only and explicit-`MATCH` forms, matching and non-matching predicate; `COUNT {}` with and without a predicate
- [x] Pattern comprehension: predicate on the target node, on the uncorrelated/anchor node, on a variable-length hop (which exercises the evaluation row reused across candidates), and combined with the comprehension's own trailing `WHERE`
- [x] `mvn -o test -Dtest='com.arcadedb.query.opencypher.**' -pl engine` - 7579 tests, 0 failures. The 3 `OpenCypherCustomFunctionTest` errors are GraalVM polyglot `NoClassDefFoundError`s reproduced identically on an unmodified tree (environmental, pre-existing).
