### PR TITLE
fix(#5481): enforce relationship inline WHERE and property map in both shortestPath evaluators

### DIFF
--- a/docs/5481-shortestpath-relationship-inline-where.md
+++ b/docs/5481-shortestpath-relationship-inline-where.md
@@ -52,6 +52,30 @@ covers the full 2x2 matrix (both evaluators x property map / inline `WHERE`), pl
 `allShortestPaths`, the combination of both constraints, `$parameter` predicates, and unconstrained
 control cases.
 
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5487
+
+## Review cycles
+
+### Cycle 1 - head `2fcad506`
+
+`claude[bot]` reviewed (no blocking findings). `gemini-code-assist` did not respond inside the
+15-minute window.
+
+| Finding | Outcome |
+|---|---|
+| 1. A relationship property map supplied as a bare parameter (`-[:LINK* $props]->`) is still dropped | Partly applied. Verified: on the `MATCH` form there is no gap - `CypherASTBuilder.validateNoParameterProperties` rejects a parameter map in a `MATCH` pattern at parse time (`InvalidParameterUse`), so it can never be silently dropped. The expression form is not covered by that validation, and there `$props` really was dropped; `EdgeConstraint.from` now resolves it from the query parameters. Both behaviors are pinned by tests. |
+| 2. `allShortestPaths()` in expression position returns one path while the `MATCH` form returns all co-shortest paths | No change - intentional. The expression form has always returned a single path; this PR only adds constraint enforcement and deliberately leaves cardinality untouched. Changing it belongs in its own issue. |
+| 3. `matchesProperties` duplicates the numeric-coercion rules of `GraphTraverser.matchesPropertyFilter` | Applied. Extracted `GraphTraverser.matchesPropertyFilter(Edge, Map)` as a static helper; the existing protected instance method delegates to it, and `EdgeConstraint` calls it. One definition now serves the variable-length MATCH traversers and both `shortestPath` evaluators. |
+
+## Test results
+
+`mvn test -Dtest='*ShortestPath*,*Cypher*,*OpenCypher*,*Traverse*,*Traversal*'` in `engine`:
+6646 tests, 0 failures. The 3 errors are `OpenCypherCustomFunctionTest` GraalVM
+`polyglot.Engine$ImplHolder` `NoClassDefFound`, verified pre-existing on the base commit with the
+change stashed.
+
 ## Scope note
 
 Sibling work is fixing relationship inline `WHERE` in other contexts (node inline `WHERE`, #5480).

--- a/docs/5481-shortestpath-relationship-inline-where.md
+++ b/docs/5481-shortestpath-relationship-inline-where.md
@@ -82,10 +82,33 @@ two-bot approval.
 | 3. `EdgeConstraint` reuses a mutable evaluation row | No change needed - confirmed safe, the contract is documented on the class. |
 | 4. Expression-form `allShortestPaths` cardinality | No change - agreed it belongs in a separate issue. |
 
+### Cycle 3 - head `3ea5867e`
+
+`claude[bot]` re-reviewed, no blocking findings. `gemini-code-assist` did not respond in this window
+either (three consecutive windows), so the loop terminates on a reviewer timeout.
+
+| Finding | Outcome |
+|---|---|
+| 1. The `*1..3` in the tests is decorative since bounds are unenforced; add a note so a future reader is not misled | Applied. Note added to the first `*1..3` test. |
+| 2. Property map (`longValue()` coercion) and inline `WHERE` (exact numerics) can disagree on fractional values now that they sit side by side | No change - pre-existing, and changing it would move variable-length MATCH semantics. Listed as a follow-up candidate below. |
+| 3. `computeFilteredShortestPath` / `computeFilteredAllShortestPaths` are now `public static`, widening the step class surface | No change. Both callers are shortestPath evaluators and they live in different packages; the alternative is duplicating the BFS, which is the defect this PR removes. |
+| 4. `EdgeConstraint` mutable-row reuse | No change needed - confirmed safe and documented. |
+
+CI on the final head: `build-and-package`, all five e2e suites, CodeQL and `claude-review` pass.
+`Meterian client scan` fails on the pre-existing dependency advisories already present on `main`
+(this PR adds no dependencies).
+
 ## Follow-up candidates (not filed)
 
 - `shortestPath()` / `allShortestPaths()` ignore the `*min..max` hop bounds on every path.
 - `allShortestPaths()` in expression position returns a single path instead of every co-shortest path.
+- Inline property map and inline `WHERE` disagree on fractional numerics: the map coerces through
+  `longValue()` (so `{w: 1.5}` matches a stored `1`), the predicate compares exactly.
+
+## Final state
+
+`timeout` - `gemini-code-assist` did not review in any of the three windows. `claude[bot]` reviewed on
+every head and its final verdict is "looks good to merge". Merge remains the developer's decision.
 
 ## Test results
 

--- a/docs/5481-shortestpath-relationship-inline-where.md
+++ b/docs/5481-shortestpath-relationship-inline-where.md
@@ -69,6 +69,24 @@ https://github.com/ArcadeData/arcadedb/pull/5487
 | 2. `allShortestPaths()` in expression position returns one path while the `MATCH` form returns all co-shortest paths | No change - intentional. The expression form has always returned a single path; this PR only adds constraint enforcement and deliberately leaves cardinality untouched. Changing it belongs in its own issue. |
 | 3. `matchesProperties` duplicates the numeric-coercion rules of `GraphTraverser.matchesPropertyFilter` | Applied. Extracted `GraphTraverser.matchesPropertyFilter(Edge, Map)` as a static helper; the existing protected instance method delegates to it, and `EdgeConstraint` calls it. One definition now serves the variable-length MATCH traversers and both `shortestPath` evaluators. |
 
+### Cycle 2 - head `315b3533`
+
+`claude[bot]` re-reviewed: "Looks good to merge", no blocking findings. `gemini-code-assist` again did
+not respond inside the 15-minute window, so the loop ends on a reviewer timeout rather than a clean
+two-bot approval.
+
+| Finding | Outcome |
+|---|---|
+| 1. `*min..max` hop bounds are ignored by every `shortestPath` traversal, so the `*1..3` in the new tests is decorative | Documented. Added the invariant to the `ShortestPathStep` class Javadoc. Pre-existing (`SQLFunctionShortestPath` and the #5096 filtered path behave the same), out of scope here - worth a follow-up issue for actual bound enforcement. |
+| 2. `longValue()` coercion means `{w: 1.5}` compares as `1`, so the property map and the inline `WHERE` can disagree on fractional numerics | No change. Carried over verbatim by the extraction, not introduced here. Changing the coercion would alter variable-length MATCH semantics too. |
+| 3. `EdgeConstraint` reuses a mutable evaluation row | No change needed - confirmed safe, the contract is documented on the class. |
+| 4. Expression-form `allShortestPaths` cardinality | No change - agreed it belongs in a separate issue. |
+
+## Follow-up candidates (not filed)
+
+- `shortestPath()` / `allShortestPaths()` ignore the `*min..max` hop bounds on every path.
+- `allShortestPaths()` in expression position returns a single path instead of every co-shortest path.
+
 ## Test results
 
 `mvn test -Dtest='*ShortestPath*,*Cypher*,*OpenCypher*,*Traverse*,*Traversal*'` in `engine`:

--- a/docs/5481-shortestpath-relationship-inline-where.md
+++ b/docs/5481-shortestpath-relationship-inline-where.md
@@ -1,0 +1,59 @@
+# 5481 - `shortestPath` ignores relationship inline `WHERE` (and the property map on the expression form)
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5481
+
+## Problem
+
+`shortestPath()` / `allShortestPaths()` have two independent evaluators in the OpenCypher engine:
+
+| Evaluator | Used by | Property map `{tag: 'ok'}` | Inline `WHERE` |
+|---|---|---|---|
+| `executor/steps/ShortestPathStep` | `MATCH p = shortestPath(...)` | enforced (#5096) | ignored |
+| `ast/ShortestPathExpression` | `RETURN shortestPath(...)` | ignored | ignored |
+
+Three of the four combinations silently dropped the constraint, so a `shortestPath` that reads as
+constrained returned a path through relationships the query excluded.
+
+## Root cause
+
+Both evaluators read only `RelationshipPattern.getTypes()` and `getDirection()` from the pattern:
+
+- `ShortestPathStep.edgePropertyFilters()` looked at `getProperties()` only. When it returned `null`
+  the step fell through to `SQLFunctionShortestPath`, a vertex-only BFS that cannot see edge
+  properties at all. An inline `WHERE` never switched the step onto the edge-aware BFS, and even on
+  the edge-aware BFS the predicate was never evaluated.
+- `ShortestPathExpression.evaluate()` always called `SQLFunctionShortestPath` directly. It never
+  consulted `getProperties()` nor `getWhereExpression()`, so both constraints were dropped.
+
+Both AST builders (`CypherASTBuilder.visitRelationshipPattern` for the `MATCH` form,
+`CypherExpressionBuilder.parseRelationshipPattern` for the expression form, the latter since #5460)
+already populate `whereExpression` on the AST node, so the parse side needed no change: the
+predicate reached the evaluators and was silently ignored.
+
+## Fix
+
+1. Extracted the per-edge constraint into `ShortestPathStep.EdgeConstraint` - a small holder for the
+   inline property map plus the inline `WHERE` predicate, with a `matches(Edge)` method. It is built
+   once per source/target pair (`EdgeConstraint.from(rel, inputRow)`) and returns `null` when the
+   pattern carries neither constraint, so the unconstrained hot path stays exactly as it was
+   (`SQLFunctionShortestPath`, CSR-accelerated).
+2. `ShortestPathStep` now routes onto the existing edge-aware BFS whenever an `EdgeConstraint` is
+   present (previously: only when a property map was present), and the BFS checks the full
+   constraint rather than just the property map. This covers both the optimizer and the legacy
+   planner paths, since both construct the same `ShortestPathStep`.
+3. `ShortestPathExpression` now builds the same `EdgeConstraint` and delegates to the shared
+   edge-aware BFS helpers when one is present, keeping `SQLFunctionShortestPath` for the
+   unconstrained case.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathInlineWhereTest.java`
+covers the full 2x2 matrix (both evaluators x property map / inline `WHERE`), plus
+`allShortestPaths`, the combination of both constraints, `$parameter` predicates, and unconstrained
+control cases.
+
+## Scope note
+
+Sibling work is fixing relationship inline `WHERE` in other contexts (node inline `WHERE`, #5480).
+This change is confined to the two `shortestPath` evaluators and does not touch the shared
+`MatchRelationshipStep` / pattern-comprehension paths.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.ast;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep;
+import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep.EdgeConstraint;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.function.sql.graph.SQLFunctionShortestPath;
@@ -84,30 +85,48 @@ public class ShortestPathExpression implements Expression {
     final Vertex startVertex = (Vertex) startValue;
     final Vertex endVertex = (Vertex) endValue;
 
+    final RelationshipPattern relationship = pathPattern.getRelationships().size() == 1 ?
+        pathPattern.getRelationships().get(0) :
+        null;
+
     // Collect every relationship type declared in the pattern. With [:R1|R2*] all of them
     // must reach SQLFunctionShortestPath, otherwise paths that walk across more than one type
     // are silently dropped (issue #4190).
     List<String> edgeTypes = null;
-    if (pathPattern.getRelationships().size() == 1) {
-      final RelationshipPattern rel = pathPattern.getRelationships().get(0);
-      if (rel.getTypes() != null && !rel.getTypes().isEmpty())
-        edgeTypes = rel.getTypes();
+    if (relationship != null && relationship.getTypes() != null && !relationship.getTypes().isEmpty())
+      edgeTypes = relationship.getTypes();
+
+    // Get direction. SQLFunctionShortestPath takes it as a string, the edge-aware traversals as an enum.
+    final Direction patternDirection = relationship != null ? relationship.getDirection() : Direction.BOTH;
+    final String direction;
+    final Vertex.DIRECTION traversalDirection;
+    switch (patternDirection) {
+      case OUT:
+        direction = "OUT";
+        traversalDirection = Vertex.DIRECTION.OUT;
+        break;
+      case IN:
+        direction = "IN";
+        traversalDirection = Vertex.DIRECTION.IN;
+        break;
+      default:
+        direction = "BOTH";
+        traversalDirection = Vertex.DIRECTION.BOTH;
     }
 
-    // Get direction
-    String direction = "BOTH";
-    if (pathPattern.getRelationships().size() == 1) {
-      final RelationshipPattern rel = pathPattern.getRelationships().get(0);
-      switch (rel.getDirection()) {
-        case OUT:
-          direction = "OUT";
-          break;
-        case IN:
-          direction = "IN";
-          break;
-        default:
-          direction = "BOTH";
-      }
+    // The inline property map and the inline WHERE predicate constrain every relationship on the path.
+    // SQLFunctionShortestPath only sees vertices, so a constrained pattern must run the edge-aware BFS
+    // shared with the MATCH form instead.
+    final EdgeConstraint constraint = EdgeConstraint.from(relationship, result, context);
+    if (constraint != null) {
+      final String[] typesArray = edgeTypes == null || edgeTypes.isEmpty() ? null : edgeTypes.toArray(new String[0]);
+      final List<Object> filtered = ShortestPathStep.computeFilteredShortestPath(startVertex, endVertex,
+          traversalDirection, typesArray, constraint);
+      if (filtered == null || filtered.isEmpty())
+        return allPaths ? new ArrayList<>() : null;
+      // allShortestPaths() in expression position still yields the single shortest path found, matching the
+      // unconstrained branch below; enumerating every co-shortest path here is a separate concern.
+      return allPaths ? singlePathList(filtered) : filtered;
     }
 
     // Use SQLFunctionShortestPath to compute the path (returns vertex RIDs only).
@@ -131,31 +150,26 @@ public class ShortestPathExpression implements Expression {
       return allPaths ? new ArrayList<>() : null;
 
     // Resolve vertex RIDs and find connecting edges to build a proper path
-    final Vertex.DIRECTION vertexDirection;
-    switch (direction) {
-      case "OUT":
-        vertexDirection = Vertex.DIRECTION.OUT;
-        break;
-      case "IN":
-        vertexDirection = Vertex.DIRECTION.IN;
-        break;
-      default:
-        vertexDirection = Vertex.DIRECTION.BOTH;
-    }
-
-    final List<Object> resolved = ShortestPathStep.resolvePathWithEdges(pathRids, vertexDirection, edgeTypes,
+    final List<Object> resolved = ShortestPathStep.resolvePathWithEdges(pathRids, traversalDirection, edgeTypes,
         context.getDatabase());
 
     if (allPaths) {
       // For allShortestPaths, we return a list containing the single shortest path
       // (In a complete implementation, this would find ALL paths of the same length)
-      final List<Object> allPathsList = new ArrayList<>();
-      allPathsList.add(resolved);
-      return allPathsList;
+      return singlePathList(resolved);
     } else {
       // For shortestPath, return the single path
       return resolved;
     }
+  }
+
+  /**
+   * Wraps a single path into the list shape allShortestPaths() returns in expression position.
+   */
+  private static List<Object> singlePathList(final List<Object> path) {
+    final List<Object> allPathsList = new ArrayList<>(1);
+    allPathsList.add(path);
+    return allPathsList;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -26,6 +26,7 @@ import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
 import com.arcadedb.query.opencypher.ast.ShortestPathPattern;
@@ -152,9 +153,9 @@ public class ShortestPathStep extends AbstractExecutionStep {
             // so existing behaviour and CSR-accelerated lookups in SQLFunctionShortestPath stay in play.
             final List<List<Object>> paths;
             if (pattern.isAllPaths()) {
-              paths = computeAllShortestPaths(sourceVertex, targetVertex, context);
+              paths = computeAllShortestPaths(sourceVertex, targetVertex, inputResult, context);
             } else {
-              final List<Object> single = computeShortestPath(sourceVertex, targetVertex, context);
+              final List<Object> single = computeShortestPath(sourceVertex, targetVertex, inputResult, context);
               paths = single == null || single.isEmpty() ? Collections.emptyList() : Collections.singletonList(single);
             }
 
@@ -196,12 +197,15 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * Computes the shortest path between source and target vertices.
    * Returns a list of alternating Vertex and Edge objects representing the path.
    */
-  private List<Object> computeShortestPath(final Vertex source, final Vertex target, final CommandContext context) {
-    // Inline edge property filters (e.g. shortestPath((a)-[:LINK*1..3 {w: 1}]->(b))) are not honoured
-    // by SQLFunctionShortestPath, so route through an edge-aware BFS that only walks matching edges (issue #5096).
-    final Map<String, Object> edgeFilters = edgePropertyFilters();
-    if (edgeFilters != null)
-      return computeShortestPathFiltered(source, target, edgeFilters, context);
+  private List<Object> computeShortestPath(final Vertex source, final Vertex target, final Result inputResult,
+      final CommandContext context) {
+    // Inline edge constraints (the property map in shortestPath((a)-[:LINK*1..3 {w: 1}]->(b)) and the
+    // inline WHERE in shortestPath((a)-[r:LINK* WHERE r.tag = 'ok']->(b))) are not honoured by
+    // SQLFunctionShortestPath, which only sees vertices. Route through an edge-aware BFS that walks
+    // matching edges only.
+    final EdgeConstraint constraint = edgeConstraint(inputResult, context);
+    if (constraint != null)
+      return computeFilteredShortestPath(source, target, patternDirection(), patternEdgeTypesArray(), constraint);
 
     // Collect every relationship type declared in the pattern. Variable-length type alternation
     // (e.g. [:R1|R2*]) is expressed as a single relationship with multiple types - all of them
@@ -268,12 +272,14 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * one. The legacy implementation returned the single path that {@link SQLFunctionShortestPath} happened
    * to find first, violating the OpenCypher contract.
    */
-  private List<List<Object>> computeAllShortestPaths(final Vertex source, final Vertex target, final CommandContext context) {
-    // Inline edge property filters must be enforced on every hop (issue #5096); the vertex-only BFS below
-    // cannot see edge properties, so delegate to the edge-aware variant when a filter is declared.
-    final Map<String, Object> edgeFilters = edgePropertyFilters();
-    if (edgeFilters != null)
-      return computeAllShortestPathsFiltered(source, target, edgeFilters, context);
+  private List<List<Object>> computeAllShortestPaths(final Vertex source, final Vertex target, final Result inputResult,
+      final CommandContext context) {
+    // Inline edge constraints must be enforced on every hop; the vertex-only BFS below cannot see edge
+    // properties, so delegate to the edge-aware variant when a property map or inline WHERE is declared.
+    final EdgeConstraint constraint = edgeConstraint(inputResult, context);
+    if (constraint != null)
+      return computeFilteredAllShortestPaths(source, target, patternDirection(), patternEdgeTypesArray(), constraint,
+          context.getDatabase());
 
     final List<String> edgeTypes;
     if (pattern.getRelationshipCount() > 0 && pattern.getRelationship(0).hasTypes())
@@ -372,17 +378,13 @@ public class ShortestPathStep extends AbstractExecutionStep {
   }
 
   /**
-   * Returns the inline edge property filters declared on the pattern relationship (e.g. {@code {w: 1}}),
-   * or {@code null} when none are present. Mirrors what the standard variable-length MATCH path feeds into
-   * {@code VariableLengthPathTraverser}, so shortestPath()/allShortestPaths() enforce the same constraint.
+   * Returns the inline edge constraint declared on the pattern relationship, or {@code null} when the
+   * pattern carries neither a property map nor an inline WHERE.
    */
-  private Map<String, Object> edgePropertyFilters() {
-    if (pattern.getRelationshipCount() > 0) {
-      final RelationshipPattern rel = pattern.getRelationship(0);
-      if (rel.hasProperties() && !rel.getProperties().isEmpty())
-        return rel.getProperties();
-    }
-    return null;
+  private EdgeConstraint edgeConstraint(final Result inputResult, final CommandContext context) {
+    if (pattern.getRelationshipCount() == 0)
+      return null;
+    return EdgeConstraint.from(pattern.getRelationship(0), inputResult, context);
   }
 
   private Vertex.DIRECTION patternDirection() {
@@ -409,32 +411,105 @@ public class ShortestPathStep extends AbstractExecutionStep {
   }
 
   /**
-   * Checks an edge against the inline property filters. Uses the same numeric-coercion rules as
-   * {@code GraphTraverser.matchesPropertyFilter} so filtered shortestPath() behaves identically to a
-   * variable-length MATCH pattern carrying the same {@code {prop: value}} constraint.
+   * Per-edge constraint declared on a pattern relationship: the inline property map (e.g. {@code {w: 1}})
+   * and/or the inline WHERE predicate (e.g. {@code WHERE r.tag = 'ok'}). Every relationship on a candidate
+   * path must satisfy all declared constraints, mirroring what a variable-length MATCH enforces.
+   * <p>
+   * Shared by both shortestPath() evaluators: {@link ShortestPathStep} (the {@code MATCH p = shortestPath(...)}
+   * form) and {@code ShortestPathExpression} (the {@code RETURN shortestPath(...)} form).
+   * <p>
+   * Not thread-safe and not reentrant: the row used to evaluate the WHERE predicate is allocated once and
+   * the relationship variable is rebound on it for each candidate edge. One instance belongs to a single
+   * traversal.
    */
-  private static boolean edgeMatchesFilter(final Edge edge, final Map<String, Object> filters) {
-    for (final Map.Entry<String, Object> entry : filters.entrySet()) {
-      final Object actual = edge.get(entry.getKey());
-      final Object expected = entry.getValue();
-      if (actual == null)
-        return false;
-      if (actual instanceof Number && expected instanceof Number) {
-        if (((Number) actual).longValue() != ((Number) expected).longValue())
-          return false;
-      } else if (!actual.equals(expected))
-        return false;
+  public static final class EdgeConstraint {
+    private final Map<String, Object> properties;
+    private final BooleanExpression  whereExpression;
+    private final String             relationshipVariable;
+    private final ResultInternal     whereEvalRow;
+    private final CommandContext     context;
+
+    private EdgeConstraint(final Map<String, Object> properties, final BooleanExpression whereExpression,
+        final String relationshipVariable, final ResultInternal whereEvalRow, final CommandContext context) {
+      this.properties = properties;
+      this.whereExpression = whereExpression;
+      this.relationshipVariable = relationshipVariable;
+      this.whereEvalRow = whereEvalRow;
+      this.context = context;
     }
-    return true;
+
+    /**
+     * Builds the constraint declared by {@code rel}, or returns {@code null} when the relationship carries
+     * neither an inline property map nor an inline WHERE. Returning {@code null} keeps the unconstrained
+     * traversal on the faster vertex-only path and leaves it allocation-free.
+     *
+     * @param currentRow bindings visible to the inline WHERE predicate; copied once so the enclosing scope
+     *                   stays reachable while the relationship variable is rebound per candidate edge
+     */
+    public static EdgeConstraint from(final RelationshipPattern rel, final Result currentRow,
+        final CommandContext context) {
+      if (rel == null)
+        return null;
+
+      final Map<String, Object> properties = rel.getProperties().isEmpty() ? null : rel.getProperties();
+      final BooleanExpression whereExpression = rel.getWhereExpression();
+      if (properties == null && whereExpression == null)
+        return null;
+
+      ResultInternal whereEvalRow = null;
+      if (whereExpression != null) {
+        whereEvalRow = new ResultInternal();
+        if (currentRow != null)
+          for (final String prop : currentRow.getPropertyNames())
+            whereEvalRow.setProperty(prop, currentRow.getProperty(prop));
+      }
+
+      return new EdgeConstraint(properties, whereExpression, rel.getVariable(), whereEvalRow, context);
+    }
+
+    /**
+     * Returns true when the edge satisfies every declared constraint.
+     */
+    public boolean matches(final Edge edge) {
+      if (properties != null && !matchesProperties(edge))
+        return false;
+      if (whereExpression == null)
+        return true;
+      if (relationshipVariable != null && !relationshipVariable.isEmpty())
+        whereEvalRow.setProperty(relationshipVariable, edge);
+      return whereExpression.evaluate(whereEvalRow, context);
+    }
+
+    /**
+     * Checks an edge against the inline property map. Uses the same numeric-coercion rules as
+     * {@code GraphTraverser.matchesPropertyFilter} so a filtered shortestPath() behaves identically to a
+     * variable-length MATCH pattern carrying the same {@code {prop: value}} constraint.
+     */
+    private boolean matchesProperties(final Edge edge) {
+      for (final Map.Entry<String, Object> entry : properties.entrySet()) {
+        final Object actual = edge.get(entry.getKey());
+        final Object expected = entry.getValue();
+        if (actual == null)
+          return false;
+        if (actual instanceof Number && expected instanceof Number) {
+          if (((Number) actual).longValue() != ((Number) expected).longValue())
+            return false;
+        } else if (!actual.equals(expected))
+          return false;
+      }
+      return true;
+    }
   }
 
   /**
    * Edge-aware BFS returning a single shortest path (alternating Vertex/Edge objects) that only traverses
-   * edges satisfying {@code edgeFilters}. Tracks the actual edge used to reach each vertex so parallel edges
+   * edges satisfying {@code constraint}. Tracks the actual edge used to reach each vertex so parallel edges
    * with different property values are disambiguated correctly.
+   *
+   * @param edgeTypes restrict edges to these types, or null/empty to allow any type
    */
-  private List<Object> computeShortestPathFiltered(final Vertex source, final Vertex target,
-      final Map<String, Object> edgeFilters, final CommandContext context) {
+  public static List<Object> computeFilteredShortestPath(final Vertex source, final Vertex target,
+      final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint) {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
@@ -443,8 +518,8 @@ public class ShortestPathStep extends AbstractExecutionStep {
       return single;
     }
 
-    final Vertex.DIRECTION[] directions = expandDirections(patternDirection());
-    final String[] typesArray = patternEdgeTypesArray();
+    final Vertex.DIRECTION[] directions = expandDirections(direction);
+    final String[] typesArray = edgeTypes == null || edgeTypes.length == 0 ? null : edgeTypes;
 
     final Map<RID, Vertex> parentVertex = new HashMap<>();
     final Map<RID, Edge> incomingEdge = new HashMap<>();
@@ -463,7 +538,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
         for (final Vertex.DIRECTION dir : directions) {
           final Iterable<Edge> edges = typesArray != null ? v.getEdges(dir, typesArray) : v.getEdges(dir);
           for (final Edge edge : edges) {
-            if (!edgeMatchesFilter(edge, edgeFilters))
+            if (!constraint.matches(edge))
               continue;
             final Vertex neighbor;
             try {
@@ -507,12 +582,15 @@ public class ShortestPathStep extends AbstractExecutionStep {
   }
 
   /**
-   * Edge-aware layered BFS returning EVERY co-shortest path honouring {@code edgeFilters}. Records each
+   * Edge-aware layered BFS returning EVERY co-shortest path honouring {@code constraint}. Records each
    * co-shortest predecessor together with the edge that reached the vertex, so parallel edges yield the
    * distinct paths OpenCypher requires.
+   *
+   * @param edgeTypes restrict edges to these types, or null/empty to allow any type
    */
-  private List<List<Object>> computeAllShortestPathsFiltered(final Vertex source, final Vertex target,
-      final Map<String, Object> edgeFilters, final CommandContext context) {
+  public static List<List<Object>> computeFilteredAllShortestPaths(final Vertex source, final Vertex target,
+      final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint,
+      final Database database) {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
@@ -521,9 +599,8 @@ public class ShortestPathStep extends AbstractExecutionStep {
       return Collections.singletonList(single);
     }
 
-    final Vertex.DIRECTION[] directions = expandDirections(patternDirection());
-    final String[] typesArray = patternEdgeTypesArray();
-    final Database database = context.getDatabase();
+    final Vertex.DIRECTION[] directions = expandDirections(direction);
+    final String[] typesArray = edgeTypes == null || edgeTypes.length == 0 ? null : edgeTypes;
 
     final Map<RID, Integer> distance = new HashMap<>();
     final Map<RID, List<PredecessorLink>> predecessors = new HashMap<>();
@@ -549,7 +626,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
         for (final Vertex.DIRECTION dir : directions) {
           final Iterable<Edge> edges = typesArray != null ? v.getEdges(dir, typesArray) : v.getEdges(dir);
           for (final Edge edge : edges) {
-            if (!edgeMatchesFilter(edge, edgeFilters))
+            if (!constraint.matches(edge))
               continue;
             final Vertex neighbor;
             try {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -30,6 +30,7 @@ import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
 import com.arcadedb.query.opencypher.ast.ShortestPathPattern;
+import com.arcadedb.query.opencypher.traversal.GraphTraverser;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -451,7 +452,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
       if (rel == null)
         return null;
 
-      final Map<String, Object> properties = rel.getProperties().isEmpty() ? null : rel.getProperties();
+      final Map<String, Object> properties = resolveProperties(rel, context);
       final BooleanExpression whereExpression = rel.getWhereExpression();
       if (properties == null && whereExpression == null)
         return null;
@@ -471,7 +472,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
      * Returns true when the edge satisfies every declared constraint.
      */
     public boolean matches(final Edge edge) {
-      if (properties != null && !matchesProperties(edge))
+      if (!GraphTraverser.matchesPropertyFilter(edge, properties))
         return false;
       if (whereExpression == null)
         return true;
@@ -481,23 +482,25 @@ public class ShortestPathStep extends AbstractExecutionStep {
     }
 
     /**
-     * Checks an edge against the inline property map. Uses the same numeric-coercion rules as
-     * {@code GraphTraverser.matchesPropertyFilter} so a filtered shortestPath() behaves identically to a
-     * variable-length MATCH pattern carrying the same {@code {prop: value}} constraint.
+     * Returns the inline property map declared by the relationship, or {@code null} when there is none.
+     * A map supplied as a bare parameter (e.g. {@code -[:LINK* $props]->}) is resolved against the query
+     * parameters here, so the parameter form constrains the traversal exactly like an inline map.
      */
-    private boolean matchesProperties(final Edge edge) {
-      for (final Map.Entry<String, Object> entry : properties.entrySet()) {
-        final Object actual = edge.get(entry.getKey());
-        final Object expected = entry.getValue();
-        if (actual == null)
-          return false;
-        if (actual instanceof Number && expected instanceof Number) {
-          if (((Number) actual).longValue() != ((Number) expected).longValue())
-            return false;
-        } else if (!actual.equals(expected))
-          return false;
-      }
-      return true;
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> resolveProperties(final RelationshipPattern rel, final CommandContext context) {
+      if (!rel.getProperties().isEmpty())
+        return rel.getProperties();
+
+      final String parameterName = rel.getPropertiesParameterName();
+      if (parameterName == null || context == null || context.getInputParameters() == null)
+        return null;
+
+      final Object parameterValue = context.getInputParameters().get(parameterName);
+      if (!(parameterValue instanceof Map))
+        return null;
+
+      final Map<String, Object> resolved = (Map<String, Object>) parameterValue;
+      return resolved.isEmpty() ? null : resolved;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -57,6 +57,10 @@ import java.util.Set;
  * - MATCH p = allShortestPaths((a)-[:KNOWS*]-(b))
  * <p>
  * Uses the existing SQLFunctionShortestPath for path computation.
+ * <p>
+ * Relationship constraints honoured on every hop: the type list, the direction, the inline property map
+ * and the inline WHERE predicate. The {@code *min..max} hop bounds are NOT enforced - every traversal here
+ * runs unbounded until it reaches the target - so {@code [:LINK*1..3]} currently behaves as {@code [:LINK*]}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/GraphTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/GraphTraverser.java
@@ -177,10 +177,25 @@ public abstract class GraphTraverser {
    * @return true if edge matches all property filters (or no filters set)
    */
   protected boolean matchesPropertyFilter(final Edge edge) {
-    if (edgePropertyFilters.isEmpty())
+    return matchesPropertyFilter(edge, edgePropertyFilters);
+  }
+
+  /**
+   * Checks an edge against an inline {@code {prop: value}} filter map. Single definition of the
+   * comparison rules (including the Integer/Long numeric coercion) so every evaluator that enforces an
+   * inline relationship property map - the variable-length MATCH traversers and both shortestPath()
+   * evaluators - stays in agreement.
+   *
+   * @param edge    edge to check
+   * @param filters property constraints, may be null or empty
+   *
+   * @return true if edge matches all property filters (or no filters set)
+   */
+  public static boolean matchesPropertyFilter(final Edge edge, final Map<String, Object> filters) {
+    if (filters == null || filters.isEmpty())
       return true;
 
-    for (final Map.Entry<String, Object> entry : edgePropertyFilters.entrySet()) {
+    for (final Map.Entry<String, Object> entry : filters.entrySet()) {
       final Object actual = edge.get(entry.getKey());
       final Object expected = entry.getValue();
       if (actual == null)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathInlineWhereTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for https://github.com/ArcadeData/arcadedb/issues/5481
@@ -139,6 +141,22 @@ class CypherShortestPathInlineWhereTest extends TestHelper {
         .as("contradictory property map and inline WHERE cannot both be satisfied").isZero();
   }
 
+  /**
+   * A parameter map cannot be a predicate in a MATCH pattern, so the MATCH form rejects it up front
+   * rather than dropping it: there is no silent-drop gap to close on this path.
+   */
+  @Test
+  void matchFormRejectsParameterisedPropertyMap() {
+    assertThatThrownBy(() -> database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 4})
+            MATCH p = shortestPath((a)-[:LINK*1..3 $props]->(b))
+            RETURN count(p) AS c""",
+        Map.of("props", Map.of("tag", "ok"))))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("Parameters cannot be used as predicates");
+  }
+
   @Test
   void matchFormAllShortestPathsAppliesInlineWhere() {
     final ResultSet rs = database.query("opencypher",
@@ -230,6 +248,19 @@ class CypherShortestPathInlineWhereTest extends TestHelper {
 
     assertThat(rs.hasNext()).isTrue();
     assertThat(ids(rs)).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  void expressionFormAppliesParameterisedPropertyMap() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 4})
+            RETURN shortestPath((a)-[:LINK*1..3 $props]->(b)) AS p""",
+        Map.of("props", Map.of("tag", "ok")));
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("p"))
+        .as("a $props relationship property map must be enforced on the expression form too").isNull();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathInlineWhereTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/ArcadeData/arcadedb/issues/5481
+ * <p>
+ * {@code shortestPath()} / {@code allShortestPaths()} have two independent evaluators: the
+ * {@code MATCH p = shortestPath(...)} form goes through {@code ShortestPathStep} while the
+ * expression form ({@code RETURN shortestPath(...)}) goes through {@code ShortestPathExpression}.
+ * Both must apply the relationship inline property map AND the relationship inline {@code WHERE}
+ * predicate to every relationship on the path. Before this fix three of the four combinations
+ * silently ignored the constraint (#5096 fixed only the property map on the {@code MATCH} form).
+ */
+class CypherShortestPathInlineWhereTest extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    // Graph - two equal-length corridors between 1 and 3, distinguished only by the edge tag:
+    //   1 --LINK{tag:'ok'}--> 2 --LINK{tag:'ok'}--> 3
+    //   1 --LINK{tag:'bad'}-> 4 --LINK{tag:'bad'}-> 3
+    // Node 4 is only reachable through a 'bad' edge, so a tag='ok' constraint makes it unreachable.
+    database.transaction(() -> {
+      final MutableVertex n1 = database.newVertex("Node").set("id", 1L).save();
+      final MutableVertex n2 = database.newVertex("Node").set("id", 2L).save();
+      final MutableVertex n3 = database.newVertex("Node").set("id", 3L).save();
+      final MutableVertex n4 = database.newVertex("Node").set("id", 4L).save();
+
+      n1.newEdge("LINK", n2, true, new Object[] { "tag", "ok" }).save();
+      n2.newEdge("LINK", n3, true, new Object[] { "tag", "ok" }).save();
+      n1.newEdge("LINK", n4, true, new Object[] { "tag", "bad" }).save();
+      n4.newEdge("LINK", n3, true, new Object[] { "tag", "bad" }).save();
+    });
+  }
+
+  // ==========================================================================================
+  // MATCH form - handled by ShortestPathStep
+  // ==========================================================================================
+
+  /**
+   * The exact reproduction from the issue: an unsatisfiable inline WHERE must yield no path.
+   */
+  @Test
+  void matchFormUnsatisfiableInlineWhereFindsNoPath() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 3})
+            MATCH p = shortestPath((a)-[r:LINK* WHERE 1 = 0]->(b))
+            RETURN count(p) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("c").longValue()).isZero();
+  }
+
+  /**
+   * Node 4 is only reachable via a tag='bad' edge, so the inline WHERE must exclude it entirely.
+   */
+  @Test
+  void matchFormInlineWhereRejectsUnreachableTarget() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 4})
+            MATCH p = shortestPath((a)-[r:LINK*1..3 WHERE r.tag = 'ok']->(b))
+            RETURN p""");
+
+    assertThat(rs.hasNext()).as("shortestPath must not cross tag='bad' edges when the inline WHERE excludes them")
+        .isFalse();
+  }
+
+  @Test
+  void matchFormInlineWhereSelectsMatchingCorridor() {
+    assertThat(matchFormNodeIds("r.tag = 'ok'")).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  void matchFormInlineWhereSelectsAlternateCorridor() {
+    assertThat(matchFormNodeIds("r.tag = 'bad'")).containsExactly(1L, 4L, 3L);
+  }
+
+  @Test
+  void matchFormInlineWhereSupportsCompoundPredicate() {
+    assertThat(matchFormNodeIds("r.tag <> 'bad' AND r.tag IS NOT NULL")).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  void matchFormInlineWhereSupportsParameters() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 3})
+            MATCH p = shortestPath((a)-[r:LINK*1..3 WHERE r.tag = $tag]->(b))
+            RETURN [n IN nodes(p) | n.id] AS ids""",
+        Map.of("tag", "bad"));
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(ids(rs)).containsExactly(1L, 4L, 3L);
+  }
+
+  /**
+   * Property map and inline WHERE are independent constraints: both must hold on every hop.
+   */
+  @Test
+  void matchFormAppliesPropertyMapAndInlineWhereTogether() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 3})
+            MATCH p = shortestPath((a)-[r:LINK*1..3 {tag: 'ok'} WHERE r.tag = 'bad']->(b))
+            RETURN count(p) AS c""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("c").longValue())
+        .as("contradictory property map and inline WHERE cannot both be satisfied").isZero();
+  }
+
+  @Test
+  void matchFormAllShortestPathsAppliesInlineWhere() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 3})
+            MATCH p = allShortestPaths((a)-[r:LINK*1..3 WHERE r.tag = 'ok']->(b))
+            RETURN [n IN nodes(p) | n.id] AS ids""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(ids(rs)).containsExactly(1L, 2L, 3L);
+    assertThat(rs.hasNext()).as("only the tag='ok' corridor qualifies").isFalse();
+  }
+
+  /**
+   * Control: without any relationship constraint both corridors are co-shortest.
+   */
+  @Test
+  void matchFormWithoutConstraintStillReturnsBothCorridors() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 3})
+            MATCH p = allShortestPaths((a)-[:LINK*1..3]->(b))
+            RETURN [n IN nodes(p) | n.id] AS ids""");
+
+    int count = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      count++;
+    }
+    assertThat(count).isEqualTo(2);
+  }
+
+  // ==========================================================================================
+  // Expression form - handled by ShortestPathExpression
+  // ==========================================================================================
+
+  @Test
+  void expressionFormPropertyMapRejectsUnreachableTarget() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 4})
+            RETURN shortestPath((a)-[:LINK*1..3 {tag: 'ok'}]->(b)) AS p""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("p"))
+        .as("the expression form must honour the inline property map too").isNull();
+  }
+
+  @Test
+  void expressionFormInlineWhereRejectsUnreachableTarget() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 4})
+            RETURN shortestPath((a)-[r:LINK*1..3 WHERE r.tag = 'ok']->(b)) AS p""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("p"))
+        .as("the expression form must honour the inline WHERE predicate").isNull();
+  }
+
+  @Test
+  void expressionFormUnsatisfiableInlineWhereFindsNoPath() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 3})
+            RETURN shortestPath((a)-[r:LINK* WHERE 1 = 0]->(b)) AS p""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("p")).isNull();
+  }
+
+  @Test
+  void expressionFormPropertyMapSelectsMatchingCorridor() {
+    assertThat(expressionFormNodeIds("[:LINK*1..3 {tag: 'ok'}]")).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  void expressionFormInlineWhereSelectsAlternateCorridor() {
+    assertThat(expressionFormNodeIds("[r:LINK*1..3 WHERE r.tag = 'bad']")).containsExactly(1L, 4L, 3L);
+  }
+
+  @Test
+  void expressionFormInlineWhereSupportsParameters() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 3})
+            RETURN [n IN nodes(shortestPath((a)-[r:LINK*1..3 WHERE r.tag = $tag]->(b))) | n.id] AS ids""",
+        Map.of("tag", "ok"));
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(ids(rs)).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  void expressionFormAllShortestPathsAppliesInlineWhere() {
+    final ResultSet rs = database.query("opencypher",
+        """
+            MATCH (a:Node {id: 1}), (b:Node {id: 4})
+            RETURN allShortestPaths((a)-[r:LINK*1..3 WHERE r.tag = 'ok']->(b)) AS paths""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<List<Object>>getProperty("paths")).isEmpty();
+  }
+
+  /**
+   * Control: the unconstrained expression form keeps returning the two-hop path.
+   */
+  @Test
+  void expressionFormWithoutConstraintStillWorks() {
+    assertThat(expressionFormNodeIds("[:LINK*1..3]")).hasSize(3).startsWith(1L).endsWith(3L);
+  }
+
+  // ==========================================================================================
+  // Helpers
+  // ==========================================================================================
+
+  private List<Number> matchFormNodeIds(final String predicate) {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {id: 1}), (b:Node {id: 3})\n"
+            + "MATCH p = shortestPath((a)-[r:LINK*1..3 WHERE " + predicate + "]->(b))\n"
+            + "RETURN [n IN nodes(p) | n.id] AS ids");
+
+    assertThat(rs.hasNext()).isTrue();
+    return ids(rs);
+  }
+
+  private List<Number> expressionFormNodeIds(final String relationship) {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {id: 1}), (b:Node {id: 3})\n"
+            + "RETURN [n IN nodes(shortestPath((a)-" + relationship + "->(b))) | n.id] AS ids");
+
+    assertThat(rs.hasNext()).isTrue();
+    return ids(rs);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Number> ids(final ResultSet rs) {
+    return (List<Number>) rs.next().<Object>getProperty("ids");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathInlineWhereTest.java
@@ -84,6 +84,10 @@ class CypherShortestPathInlineWhereTest extends TestHelper {
 
   /**
    * Node 4 is only reachable via a tag='bad' edge, so the inline WHERE must exclude it entirely.
+   * <p>
+   * Note: the {@code *1..3} bounds spelled out here and below are not enforced by either shortestPath
+   * evaluator (see the ShortestPathStep class Javadoc) - they read naturally but behave as a bare
+   * {@code *}. These tests exercise the relationship constraints, not the hop bounds.
    */
   @Test
   void matchFormInlineWhereRejectsUnreachableTarget() {


### PR DESCRIPTION
Closes #5481

## Summary

`shortestPath()` / `allShortestPaths()` are evaluated by two independent code paths: `ShortestPathStep` for the `MATCH p = shortestPath(...)` form, and `ShortestPathExpression` for the expression form (`RETURN shortestPath(...)`). Both read only `getTypes()` and `getDirection()` off the relationship pattern, so three of the four constraint/form combinations silently dropped the constraint: the step ignored the inline `WHERE` (it only switched onto its edge-aware BFS when a property map was present, and never evaluated a predicate), and the expression form ignored both the property map and the inline `WHERE` because it always delegated to `SQLFunctionShortestPath`, a vertex-only BFS that cannot see edge properties at all. #5096 fixed only the property map on the `MATCH` form.

The parse side already worked: `CypherASTBuilder.visitRelationshipPattern` and (since #5460) `CypherExpressionBuilder.parseRelationshipPattern` both populate `whereExpression` on the AST node - the predicate reached the evaluators and was ignored. This PR introduces `ShortestPathStep.EdgeConstraint`, a small holder for the inline property map plus the inline `WHERE` predicate with a `matches(Edge)` method, built once per source/target pair. It returns `null` when the pattern declares neither constraint, so the unconstrained hot path keeps using the CSR-accelerated `SQLFunctionShortestPath` and stays allocation-free. `ShortestPathStep` now routes onto its existing edge-aware BFS whenever a constraint is present and checks the full constraint on each hop; `ShortestPathExpression` builds the same constraint and delegates to the shared BFS helpers. Both the optimizer and the legacy planner paths construct the same `ShortestPathStep`, so both are covered by the one change.

`allShortestPaths()` in expression position still yields the single shortest path found, exactly as before this PR - only constraint enforcement was added there, cardinality is unchanged.

## Test plan

New regression test `engine/src/test/java/com/arcadedb/query/opencypher/CypherShortestPathInlineWhereTest.java` (17 cases, 12 of which fail on `main`) over a graph with two equal-length corridors distinguished only by an edge `tag`:

- [x] `MATCH` form, unsatisfiable inline `WHERE` (`WHERE 1 = 0`) returns no path - the exact repro from the issue
- [x] `MATCH` form, inline `WHERE` makes an only-`bad`-reachable target unreachable
- [x] `MATCH` form, inline `WHERE` selects the matching corridor and the alternate corridor
- [x] `MATCH` form, compound predicate (`AND` / `IS NOT NULL`) and `$parameter` predicate
- [x] `MATCH` form, contradictory property map + inline `WHERE` together yield no path
- [x] `MATCH` form, `allShortestPaths` applies the inline `WHERE`
- [x] Expression form, property map rejects an unreachable target (was broken even after #5096)
- [x] Expression form, inline `WHERE` rejects an unreachable target and an unsatisfiable predicate
- [x] Expression form, property map and inline `WHERE` select the right corridor, incl. `$parameter`
- [x] Expression form, `allShortestPaths` applies the inline `WHERE`
- [x] Controls: unconstrained `MATCH` form still returns both co-shortest corridors; unconstrained expression form unchanged

Regression run of the whole Cypher + shortestPath surface in the `engine` module: `mvn test -Dtest='*ShortestPath*,*Cypher*,*OpenCypher*'` - 6609 tests, 0 failures. The only 3 errors are `OpenCypherCustomFunctionTest` GraalVM `polyglot.Engine$ImplHolder` `NoClassDefFound`, verified pre-existing on the base commit with the change stashed.

## Scope note

Sibling work is fixing relationship/node inline `WHERE` in other contexts (#5480). This change is confined to the two `shortestPath` evaluators and does not touch `MatchRelationshipStep` or the pattern-comprehension path, so it should not conflict.
