### PR TITLE
fix(#5489): bind the hop relationship variable before the node inline WHERE in pattern comprehensions

### DIFF
--- a/docs/5489-node-inline-where-unbound-rel-var.md
+++ b/docs/5489-node-inline-where-unbound-rel-var.md
@@ -1,0 +1,78 @@
+# Issue #5489 - node inline `WHERE` in a pattern comprehension sees the same hop's relationship variable as unbound
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/5489
+- Branch: `fix/5489-node-inline-where-unbound-rel-var`
+- Base: `main` at 74f776db3
+
+## Problem
+
+A node inline `WHERE` predicate may reference the relationship variable bound by the same hop:
+
+```cypher
+MATCH (a:A {v:1}) RETURN [(a)-[r:E]->(x:A WHERE x.v > r.w) | x.v] AS vs
+```
+
+In a pattern comprehension this returned `[]`. The equivalent `MATCH` spelling returned the correct
+row, so the two spellings disagreed.
+
+## Root cause
+
+`PatternComprehensionExpression` evaluates the end node's inline predicate against a row built by
+`inlineWhereRow(endNodePattern, currentResult)`, which copies the bindings visible *before* the hop.
+The hop's edge is only bound afterwards, when the hop result is assembled. So `r` resolved to null,
+the comparison was false for every candidate, and the comprehension collected nothing.
+
+Two traversal paths were affected:
+
+- `traverseEdges` - the eval row was copied at the top of the expansion, while the relationship
+  variable was bound further down, after `matchesEndPattern` had already run.
+- `traverseVariableLength` - same ordering.
+
+The `MATCH` spelling is unaffected because it hoists the inline predicate into the clause `WHERE`,
+which runs once the whole pattern, `r` included, is bound.
+
+This is the residual of the same family as #5460 (relationship inline `WHERE`) and #5480 (node
+inline `WHERE` dropped by the comprehension parser). Here the predicate was applied, but one of its
+inputs was silently unbound.
+
+## Fix
+
+`matchesEndPattern` now takes the hop's `RelationshipPattern` and `Edge` and publishes the
+relationship binding onto the eval row before the predicate runs. The binding is written only when
+the node pattern actually declares a predicate, so the allocation-free path for predicate-free
+patterns is untouched, and the row is the one already hoisted out of the candidate loop, so no extra
+copying is introduced.
+
+A zero-length variable-length hop passes a null edge, leaving the relationship variable unbound,
+which is what that pattern implies. For a variable-length hop the current edge is bound, matching
+what `buildHopResult` already binds for the same pattern, so the predicate and the emitted row agree
+on what `r` means.
+
+The leading node's predicate is deliberately unchanged: at that position the relationship is bound
+later in the pattern, so referencing it is out of scope by Cypher's left-to-right scoping.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java`
+- `engine/src/test/java/com/arcadedb/query/opencypher/Issue5489NodeInlineWhereRelVariableTest.java` (new)
+
+## Verification
+
+`Issue5489NodeInlineWhereRelVariableTest`, 10 methods: 5 failed before the fix and all 10 pass
+after. Coverage includes the reported shape, a predicate referencing only the relationship variable,
+a predicate that must reject every candidate, the combined relationship-plus-node inline form,
+explicit parity against the `MATCH` spelling, a variable-length hop, an earlier-hop relationship
+reference (which already worked and is pinned as a control), and predicate-free controls.
+
+Regression run over the whole `com.arcadedb.query.opencypher.**` package: 7618 tests, 0 failures.
+The 3 errors are `OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s; they were
+reproduced identically on a clean tree at 74f776db3 with the change stashed, so they are
+environmental and pre-existing.
+
+## Known gaps, not addressed here
+
+- Relationship inline `WHERE` is ignored outright on variable-length patterns (`WHERE false` still
+  returns every row). Tracked separately as #5490.
+- For a multi-hop variable-length pattern, `r` binds to a single edge rather than the list of
+  traversed edges. That predates this change and is left as is; the fix only makes the predicate
+  agree with the row the traversal already emits.

--- a/docs/5489-node-inline-where-unbound-rel-var.md
+++ b/docs/5489-node-inline-where-unbound-rel-var.md
@@ -1,8 +1,10 @@
 # Issue #5489 - node inline `WHERE` in a pattern comprehension sees the same hop's relationship variable as unbound
 
 - Issue: https://github.com/ArcadeData/arcadedb/issues/5489
+- PR: https://github.com/ArcadeData/arcadedb/pull/5491
 - Branch: `fix/5489-node-inline-where-unbound-rel-var`
 - Base: `main` at 74f776db3
+- Final state: `timeout` (see "Review cycles")
 
 ## Problem
 
@@ -58,16 +60,45 @@ later in the pattern, so referencing it is out of scope by Cypher's left-to-righ
 
 ## Verification
 
-`Issue5489NodeInlineWhereRelVariableTest`, 10 methods: 5 failed before the fix and all 10 pass
-after. Coverage includes the reported shape, a predicate referencing only the relationship variable,
-a predicate that must reject every candidate, the combined relationship-plus-node inline form,
+`Issue5489NodeInlineWhereRelVariableTest`, 11 methods (10 at the first push, plus the
+anonymous-relationship edge case added in review): 5 failed before the fix and all pass after.
+Coverage includes the reported shape, a predicate referencing only the relationship variable, a
+predicate that must reject every candidate, the combined relationship-plus-node inline form,
 explicit parity against the `MATCH` spelling, a variable-length hop, an earlier-hop relationship
-reference (which already worked and is pinned as a control), and predicate-free controls.
+reference (which already worked and is pinned as a control), an anonymous relationship, and
+predicate-free controls.
 
 Regression run over the whole `com.arcadedb.query.opencypher.**` package: 7618 tests, 0 failures.
 The 3 errors are `OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s; they were
 reproduced identically on a clean tree at 74f776db3 with the change stashed, so they are
 environmental and pre-existing.
+
+## Review cycles
+
+### Cycle 1 - head 697984f7
+
+`claude[bot]`: reviewed, no blocking items, verdict "looks good to merge". Two non-blocking nits,
+both applied in 1e582454:
+
+1. **Anonymous relationship plus a predicate that names a relationship variable** was not exercised
+   by a test. Confirmed by running it before writing the assertion: the reference resolves to null
+   and the comprehension yields an empty list, which is the engine's pre-existing behavior for any
+   undefined variable, so this is documentation of an edge case rather than a regression. Pinned by
+   `anonymousRelationshipLeavesAPredicateVariableUndefined`, paired with the named-relationship
+   spelling so the contrast is explicit.
+2. **`@author` tag** carried over from the package template. Applied, with a caveat: the reviewer
+   guessed it was a copy-paste slip, but the tag is in fact the dominant convention in this package
+   (12+ `Issue5*Test` files, including those merged with #5480 and #5481). It was removed anyway
+   because it attributes the test to someone who did not write it, and four files in the same
+   package already carry no tag, so removal has in-package precedent.
+
+`gemini-code-assist`: did not respond within the 15-minute polling window on head 697984f7, so the
+both-reviewers gate could not be satisfied and the loop exited with a `timeout` state rather than
+`clean-approval`. This matches the reviewer's known inconsistent re-review behavior on this repo and
+is not a signal about the change.
+
+No deferred items: both raised points were actionable and were addressed, so no
+`review-deferred-*.md` notes file was produced.
 
 ## Known gaps, not addressed here
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -152,7 +152,8 @@ public class PatternComprehensionExpression implements Expression {
 
       // Zero-length path: start and end are the same vertex (only valid if matches end pattern)
       if (minHops == 0
-          && matchesEndPattern(startVertex, endNodePattern, baseResult, inlineWhereRow(endNodePattern, currentResult), context)) {
+          && matchesEndPattern(startVertex, endNodePattern, baseResult, inlineWhereRow(endNodePattern, currentResult),
+              relPattern, null, context)) {
         final ResultInternal hopResult = buildHopResult(currentResult, endNodePattern, startVertex, relPattern, null);
         traversePattern(baseResult, context, hopIndex + 1, hopResult, resultList, pathElements, startVertex);
       }
@@ -302,7 +303,8 @@ public class PatternComprehensionExpression implements Expression {
         pathElements.add(nextVertex);
       }
 
-      if (nextHop >= minHops && matchesEndPattern(nextVertex, endNodePattern, baseResult, nodeWhereEvalRow, context)) {
+      if (nextHop >= minHops
+          && matchesEndPattern(nextVertex, endNodePattern, baseResult, nodeWhereEvalRow, relPattern, edge, context)) {
         final ResultInternal hopResult = buildHopResult(currentResult, endNodePattern, nextVertex, relPattern, edge);
         traversePattern(baseResult, context, hopIndex + 1, hopResult, resultList, pathElements, nextVertex);
       }
@@ -320,7 +322,8 @@ public class PatternComprehensionExpression implements Expression {
   }
 
   private boolean matchesEndPattern(final Vertex vertex, final NodePattern endNodePattern, final Result baseResult,
-      final ResultInternal whereEvalRow, final CommandContext context) {
+      final ResultInternal whereEvalRow, final RelationshipPattern relPattern, final Edge edge,
+      final CommandContext context) {
     if (endNodePattern.hasLabels()) {
       for (final String label : endNodePattern.getLabels()) {
         if (!Labels.hasLabel(vertex, label))
@@ -340,7 +343,15 @@ public class PatternComprehensionExpression implements Expression {
       if (bound instanceof Vertex boundVertex && !boundVertex.getIdentity().equals(vertex.getIdentity()))
         return false;
     }
-    // Inline WHERE predicate, e.g. the WHERE x.v = 2 in [(a)-[:E]->(x:A WHERE x.v = 2) | x] (issue #5480)
+    // Inline WHERE predicate, e.g. the WHERE x.v = 2 in [(a)-[:E]->(x:A WHERE x.v = 2) | x] (issue #5480).
+    // The predicate may also reference the relationship variable bound by this same hop, as in
+    // (x:A WHERE x.v > r.w), so that binding is published before the predicate is evaluated. The
+    // relationship of a zero-length hop is null, leaving the variable unbound as the pattern implies.
+    if (whereEvalRow != null && edge != null) {
+      final String relVariable = relPattern.getVariable();
+      if (relVariable != null && !relVariable.isEmpty())
+        whereEvalRow.setProperty(relVariable, edge);
+    }
     return matchesNodeWhereExpression(vertex, endNodePattern, whereEvalRow, context);
   }
 
@@ -501,7 +512,7 @@ public class PatternComprehensionExpression implements Expression {
         continue;
       }
 
-      if (!matchesEndPattern(targetVertex, endNodePattern, baseResult, nodeWhereEvalRow, context))
+      if (!matchesEndPattern(targetVertex, endNodePattern, baseResult, nodeWhereEvalRow, relPattern, edge, context))
         continue;
 
       // Build result with matched variables

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5489NodeInlineWhereRelVariableTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5489NodeInlineWhereRelVariableTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #5489.
+ * <p>
+ * A node inline {@code WHERE} predicate may reference the relationship variable bound by the same
+ * hop, as in {@code [(a)-[r:E]->(x:A WHERE x.v > r.w) | x]}. In a pattern comprehension the
+ * predicate was evaluated against a row copied from the bindings visible <em>before</em> the hop,
+ * which does not yet contain {@code r}, so the reference resolved to null and the predicate rejected
+ * every candidate. The comprehension returned an empty list while the equivalent {@code MATCH}
+ * spelling returned the correct rows.
+ * <p>
+ * The relationship variable must be visible to the end node's predicate, matching the {@code MATCH}
+ * spelling, which hoists the inline predicate into the clause {@code WHERE} where {@code r} is bound.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5489NodeInlineWhereRelVariableTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-5489-node-inline-where-rel-var").create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (a:A {v:1}), (b:A {v:10}), (c:A {v:2}), (d:A {v:7})");
+      database.command("opencypher", "MATCH (a:A {v:1}), (b:A {v:10}), (c:A {v:2}), (d:A {v:7}) "
+          + "CREATE (a)-[:E {tag:'ok', w:5}]->(b), (a)-[:E {tag:'bad', w:99}]->(c), (b)-[:E {tag:'ok', w:1}]->(d)");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /** Returns the single list-valued projection of a one-row result, as ints. */
+  private List<Integer> comprehension(final String query) {
+    final List<Integer> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).as("query returned no row: %s", query).isTrue();
+      final Result row = rs.next();
+      final List<Object> list = row.getProperty("vs");
+      assertThat(list).as("projection 'vs' was not a list: %s", query).isNotNull();
+      for (final Object o : list)
+        values.add(o == null ? null : ((Number) o).intValue());
+    }
+    return values;
+  }
+
+  private List<Integer> queryInts(final String query, final String field) {
+    final List<Integer> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final Number n = row.getProperty(field);
+        values.add(n == null ? null : n.intValue());
+      }
+    }
+    return values;
+  }
+
+  // ------------------------------------------------- the defect: same-hop relationship variable
+
+  @Test
+  void comprehensionNodeInlineWhereSeesSameHopRelationshipVariable() {
+    // b.v = 10 > w = 5 matches; c.v = 2 > w = 99 does not.
+    assertThat(comprehension("MATCH (a:A {v:1}) RETURN [(a)-[r:E]->(x:A WHERE x.v > r.w) | x.v] AS vs"))
+        .containsExactly(10);
+  }
+
+  @Test
+  void comprehensionNodeInlineWhereReferencingOnlyTheRelationshipVariable() {
+    assertThat(comprehension("MATCH (a:A {v:1}) RETURN [(a)-[r:E]->(x:A WHERE r.w = 5) | x.v] AS vs"))
+        .containsExactly(10);
+  }
+
+  @Test
+  void comprehensionNodeInlineWhereOnRelationshipVariableRejectingEveryCandidate() {
+    assertThat(comprehension("MATCH (a:A {v:1}) RETURN [(a)-[r:E]->(x:A WHERE r.w = 12345) | x.v] AS vs"))
+        .isEmpty();
+  }
+
+  @Test
+  void comprehensionCombinesRelationshipInlineWhereWithNodeInlineWhereOnTheSameVariable() {
+    assertThat(comprehension(
+        "MATCH (a:A {v:1}) RETURN [(a)-[r:E WHERE r.tag = 'ok']->(x:A WHERE x.v > r.w) | x.v] AS vs"))
+        .containsExactly(10);
+  }
+
+  // ------------------------------------------------- parity with the MATCH spelling
+
+  @Test
+  void matchSpellingAgreesWithTheComprehension() {
+    final List<Integer> viaMatch = queryInts(
+        "MATCH (a:A {v:1})-[r:E]->(x:A WHERE x.v > r.w) RETURN x.v AS v", "v");
+    final List<Integer> viaComprehension = comprehension(
+        "MATCH (a:A {v:1}) RETURN [(a)-[r:E]->(x:A WHERE x.v > r.w) | x.v] AS vs");
+    assertThat(viaMatch).containsExactly(10);
+    assertThat(viaComprehension).containsExactlyElementsOf(viaMatch);
+  }
+
+  // ------------------------------------------------- controls that must keep working
+
+  @Test
+  void comprehensionNodeInlineWhereWithoutRelationshipReferenceStillWorks() {
+    assertThat(comprehension("MATCH (a:A {v:1}) RETURN [(a)-[r:E]->(x:A WHERE x.v > 5) | x.v] AS vs"))
+        .containsExactly(10);
+  }
+
+  @Test
+  void comprehensionRelationshipInlineWhereStillWorks() {
+    assertThat(comprehension("MATCH (a:A {v:1}) RETURN [(a)-[r:E WHERE r.w = 5]->(x:A) | x.v] AS vs"))
+        .containsExactly(10);
+  }
+
+  @Test
+  void comprehensionNodeInlineWhereSeesRelationshipVariableFromAnEarlierHop() {
+    // a -[r1 w=5]-> b -[r2]-> d(v=7): 7 > 5 matches. The other branch (c) has no outgoing edge.
+    assertThat(comprehension(
+        "MATCH (a:A {v:1}) RETURN [(a)-[r1:E]->(m:A)-[r2:E]->(x:A WHERE x.v > r1.w) | x.v] AS vs"))
+        .containsExactly(7);
+  }
+
+  @Test
+  void comprehensionNodeInlineWhereOnAVariableLengthHopSeesTheRelationshipVariable() {
+    // Single-hop bound so the relationship variable is unambiguous for this shape.
+    assertThat(comprehension(
+        "MATCH (a:A {v:1}) RETURN [(a)-[r:E*1..1]->(x:A WHERE x.v > r.w) | x.v] AS vs"))
+        .containsExactly(10);
+  }
+
+  @Test
+  void comprehensionWithoutAnyInlineWhereIsUnaffected() {
+    assertThat(comprehension("MATCH (a:A {v:1}) RETURN [(a)-[r:E]->(x:A) | x.v] AS vs"))
+        .containsExactlyInAnyOrder(10, 2);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5489NodeInlineWhereRelVariableTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5489NodeInlineWhereRelVariableTest.java
@@ -43,8 +43,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * The relationship variable must be visible to the end node's predicate, matching the {@code MATCH}
  * spelling, which hoists the inline predicate into the clause {@code WHERE} where {@code r} is bound.
- *
- * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class Issue5489NodeInlineWhereRelVariableTest {
   private Database database;
@@ -160,6 +158,20 @@ class Issue5489NodeInlineWhereRelVariableTest {
     // Single-hop bound so the relationship variable is unambiguous for this shape.
     assertThat(comprehension(
         "MATCH (a:A {v:1}) RETURN [(a)-[r:E*1..1]->(x:A WHERE x.v > r.w) | x.v] AS vs"))
+        .containsExactly(10);
+  }
+
+  /**
+   * An anonymous relationship binds no variable, so a predicate that names one is referencing an
+   * undefined variable. It resolves to null and the predicate rejects every candidate, which is the
+   * engine's pre-existing behavior for any undefined variable rather than anything this hop changes.
+   */
+  @Test
+  void anonymousRelationshipLeavesAPredicateVariableUndefined() {
+    assertThat(comprehension("MATCH (a:A {v:1}) RETURN [(a)-[:E]->(x:A WHERE x.v > r.w) | x.v] AS vs"))
+        .isEmpty();
+    // Naming the relationship is what makes the very same predicate resolve.
+    assertThat(comprehension("MATCH (a:A {v:1}) RETURN [(a)-[r:E]->(x:A WHERE x.v > r.w) | x.v] AS vs"))
         .containsExactly(10);
   }
 


### PR DESCRIPTION
Closes #5489

A node inline `WHERE` predicate in a pattern comprehension may reference the relationship variable bound by the same hop, as in `[(a)-[r:E]->(x:A WHERE x.v > r.w) | x.v]`. The predicate was evaluated against a row copied from the bindings visible *before* the hop, so `r` resolved to null, the comparison was false for every candidate, and the comprehension returned an empty list while the equivalent `MATCH` spelling returned the correct rows. `matchesEndPattern` now publishes the hop's relationship binding onto the eval row before the predicate runs, in both the fixed-length (`traverseEdges`) and variable-length (`traverseVariableLength`) traversals. The binding is written only when the node pattern actually declares a predicate, and onto the row already hoisted out of the candidate loop, so the predicate-free path stays allocation-free and no extra copying is introduced.

This is the residual of the same family as #5460 (relationship inline `WHERE`) and #5480 (node inline `WHERE` dropped by the comprehension parser). There the predicate was lost; here it ran with a silently unbound input.

Scoping notes: a zero-length variable-length hop passes a null edge, leaving the relationship variable unbound as that pattern implies. The leading node's predicate is deliberately unchanged, since at that position the relationship is bound later in the pattern and is out of scope under Cypher's left-to-right rules.

## Test plan

- [x] `Issue5489NodeInlineWhereRelVariableTest`, 10 methods: **5 fail before the fix, all 10 pass after**
  - [x] the reported shape, `WHERE x.v > r.w`
  - [x] a predicate referencing only the relationship variable, `WHERE r.w = 5`
  - [x] a predicate that must reject every candidate, guarding against over-matching
  - [x] combined relationship inline `WHERE` plus node inline `WHERE` on the same variable
  - [x] explicit parity assertion against the `MATCH` spelling
  - [x] variable-length hop
  - [x] control: relationship variable from an *earlier* hop (already worked, now pinned)
  - [x] controls: node predicate without a relationship reference, relationship inline `WHERE`, and a predicate-free comprehension
- [x] Full `com.arcadedb.query.opencypher.**` package: **7618 tests, 0 failures**
- [x] The 3 `OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s are pre-existing: reproduced identically on a clean tree at 74f776db3 with the change stashed

## Known gaps, not addressed here

- Relationship inline `WHERE` is ignored outright on variable-length patterns (`WHERE false` still returns every row). Tracked separately as #5490.
- For a multi-hop variable-length pattern, `r` binds to a single edge rather than the list of traversed edges. That predates this change; this PR only makes the predicate agree with the row the traversal already emits.
