### PR TITLE
fix(#5490): apply the relationship inline WHERE on variable-length patterns

### DIFF
--- a/docs/5490-varlen-rel-inline-where-ignored.md
+++ b/docs/5490-varlen-rel-inline-where-ignored.md
@@ -1,0 +1,106 @@
+# Issue #5490 - relationship inline `WHERE` is ignored entirely on variable-length patterns
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/5490
+- Branch: `fix/5490-varlen-rel-inline-where-ignored`
+- Base: `main` at 4aaa90c56
+
+## Problem
+
+```cypher
+MATCH (a:A {v:1})-[r:E*1..1 WHERE r.tag = 'ok']->(x:A) RETURN count(*)
+```
+
+returned 2 instead of 1. `WHERE false` also returned 2, which is conclusive: the predicate never
+reached the traversal, rather than being evaluated incorrectly.
+
+## Scope, established by probing before fixing
+
+The issue reported the `MATCH` shape. Probing every surface that parses a variable-length
+relationship showed the defect was wider, and that two of the suspected surfaces were already
+correct:
+
+| Surface | Before | Verdict |
+|---|---|---|
+| `MATCH`, fixed length | correct | not affected |
+| `MATCH`, variable length (`*1..1`, `*1..2`, `*`) | predicate ignored | **broken** |
+| `MATCH`, variable length, property map | correct | not affected |
+| `EXISTS {}`, variable length | predicate ignored | **broken** |
+| `EXISTS {}`, variable length, property map | correct | not affected |
+| Pattern comprehension, variable length | correct | not affected |
+
+Pattern comprehensions were already correct because `PatternComprehensionExpression`
+`traverseVariableLength` enforces the predicate itself rather than delegating to the shared
+traverser.
+
+## Root cause
+
+The predicate was parsed onto the AST but never handed to the traversal engine. Two producers built
+a `VariableLengthPathTraverser` from the relationship pattern and passed only the types, the
+property map, and the hop bounds:
+
+- `ExpandPathStep.createTraverser()` - the `MATCH` executor.
+- `PatternPredicateExpression.evaluateVLPPattern()` - the `EXISTS {}` evaluator, which additionally
+  passed `null` for the property filters.
+
+`GraphTraverser` and its BFS/DFS subclasses had no notion of a per-relationship predicate at all, so
+there was nothing for the producers to pass it to.
+
+## Fix
+
+Threaded a per-relationship predicate through the traversal package, applied at the same per-edge
+choke point as the existing property filter:
+
+- `GraphTraverser` gains an optional `Predicate<Edge> edgePredicate`, a `withEdgePredicate` setter
+  and a `matchesEdgePredicate` check. Null means unconstrained, so patterns without a predicate do
+  no per-edge evaluation.
+- `BreadthFirstTraverser` and `DepthFirstTraverser` apply it immediately after
+  `matchesPropertyFilter`, the single place each already rejects an edge.
+- `VariableLengthPathTraverser` builds its BFS or DFS strategy internally, so it now forwards the
+  predicate to that delegate. Both `traverse` and `traversePaths` route through one `delegate()`
+  helper, which is what keeps the two entry points from drifting.
+- Both producers build the predicate from the pattern's `WHERE`, copying the enclosing bindings once
+  per source row and rebinding only the relationship variable per candidate edge. Copying once
+  rather than per edge matters because a traversal evaluates this for every relationship it walks,
+  and it is what lets the predicate reference outer-scope variables.
+
+Pruning during traversal rather than filtering completed paths afterwards is deliberate: under BFS
+shortest-path semantics a post-filter would discard a target whose shortest path fails the
+predicate, instead of finding the longer path that satisfies it.
+
+### Semantics
+
+Every relationship the path traverses must satisfy the predicate, matching the inline property map
+and the clause-level `all(e IN r WHERE ...)` spelling. A test asserts the inline and clause-level
+spellings agree.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/query/opencypher/traversal/GraphTraverser.java`
+- `engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java`
+- `engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java`
+- `engine/src/main/java/com/arcadedb/query/opencypher/traversal/VariableLengthPathTraverser.java`
+- `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java`
+- `engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java`
+- `engine/src/test/java/com/arcadedb/query/opencypher/Issue5490VarLengthRelInlineWhereTest.java` (new)
+
+## Verification
+
+`Issue5490VarLengthRelInlineWhereTest`, 13 methods: 7 failed before the fix and all 13 pass after.
+Coverage includes the reported shape, always-false and always-true predicates, the multi-hop
+all-relationships-must-satisfy rule, an unbounded `*` pattern, a predicate referencing an outer
+binding, parity against the clause-level `all(...)` spelling, both `EXISTS {}` shapes, and controls
+for fixed length, property map, pattern comprehension and predicate-free patterns.
+
+Regression run over `com.arcadedb.query.opencypher.**`: 7632 tests, 0 failures. The 3 errors are
+`OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s, reproduced identically on a
+clean tree at 4aaa90c56 with the change stashed, so they are environmental and pre-existing.
+
+Every consumer of the traversal classes was checked: `ExpandPathStep`, `PatternPredicateExpression`
+and `ShortestPathStep` are the only ones, all inside the OpenCypher engine and all covered by that
+run. `ShortestPathStep` uses only the static `matchesPropertyFilter` helper, which is untouched.
+
+## Known gaps, not addressed here
+
+- For a multi-hop variable-length pattern the relationship variable binds to a single edge rather
+  than the list of traversed edges when a predicate reads it. That predates this change; the
+  predicate is evaluated per traversed relationship, which is the semantics the fix implements.

--- a/docs/5490-varlen-rel-inline-where-ignored.md
+++ b/docs/5490-varlen-rel-inline-where-ignored.md
@@ -1,8 +1,10 @@
 # Issue #5490 - relationship inline `WHERE` is ignored entirely on variable-length patterns
 
 - Issue: https://github.com/ArcadeData/arcadedb/issues/5490
+- PR: https://github.com/ArcadeData/arcadedb/pull/5493
 - Branch: `fix/5490-varlen-rel-inline-where-ignored`
 - Base: `main` at 4aaa90c56
+- Final state: `timeout` (see "Review cycles")
 
 ## Problem
 
@@ -58,10 +60,12 @@ choke point as the existing property filter:
 - `VariableLengthPathTraverser` builds its BFS or DFS strategy internally, so it now forwards the
   predicate to that delegate. Both `traverse` and `traversePaths` route through one `delegate()`
   helper, which is what keeps the two entry points from drifting.
-- Both producers build the predicate from the pattern's `WHERE`, copying the enclosing bindings once
-  per source row and rebinding only the relationship variable per candidate edge. Copying once
-  rather than per edge matters because a traversal evaluates this for every relationship it walks,
-  and it is what lets the predicate reference outer-scope variables.
+- `RelationshipPattern.buildInlineWherePredicate` is the single place the predicate is built. It
+  copies the enclosing bindings once per source row and rebinds only the relationship variable per
+  candidate edge. Copying once rather than per edge matters because a traversal evaluates this for
+  every relationship it walks, and it is what lets the predicate reference outer-scope variables.
+  Both producers call it, so the `MATCH` and `EXISTS {}` spellings cannot drift in how they build
+  the evaluation scope.
 
 Pruning during traversal rather than filtering completed paths afterwards is deliberate: under BFS
 shortest-path semantics a post-filter would discard a target whose shortest path fails the
@@ -73,8 +77,44 @@ Every relationship the path traverses must satisfy the predicate, matching the i
 and the clause-level `all(e IN r WHERE ...)` spelling. A test asserts the inline and clause-level
 spellings agree.
 
+## Review cycles
+
+### Cycle 1 - head d41bd16f
+
+`claude[bot]`: LGTM, no blocking items. It independently confirmed the two properties the fix turns
+on, that the BFS iterator enumerates all in-bounds paths so pruning a failing edge does not preclude
+reaching a target by a longer satisfying path, and that per-relationship binding of the variable
+matches Neo4j's relationship-pattern-predicate semantics. Three non-blocking suggestions, all
+applied in fe1214d3:
+
+1. **Duplication between the two predicate builders.** Correct: `ExpandPathStep` and
+   `PatternPredicateExpression` each built the evaluation scope themselves, so the two spellings
+   could drift with only tests holding them together. Collapsed onto
+   `RelationshipPattern.buildInlineWherePredicate`.
+
+   Placed there rather than on `GraphTraverser` as the review suggested. `GraphTraverser` is in the
+   traversal package and knows nothing about expression evaluation; hosting scope construction there
+   would make the traversal layer depend on the AST and the evaluator. `RelationshipPattern` already
+   owns both the relationship variable and the `WHERE` expression, so it is the cohesive home and
+   still gives the rule the single definition the review asked for.
+2. **`getWhereExpression()` re-invoked inside the per-edge lambda.** Resolved by the same
+   refactoring, which hoists it into a local before the lambda.
+3. **Thread-safety of the captured, per-edge-mutated scope.** Confirmation rather than a defect, and
+   accurate: it is safe because a fresh predicate is built per source row and variable-length
+   traversal is single-threaded. Recorded in the builder's javadoc so a future parallelization does
+   not silently inherit a shared mutable row.
+
+`gemini-code-assist`: did not respond within the 15-minute polling window on head d41bd16f, so the
+both-reviewers gate could not be satisfied and the loop exited with a `timeout` state rather than
+`clean-approval`. This matches its known inconsistent re-review behavior on this repository and is
+not a signal about the change.
+
+No deferred items: every raised point was actionable and was addressed, so no `review-deferred-*.md`
+notes file was produced.
+
 ## Files changed
 
+- `engine/src/main/java/com/arcadedb/query/opencypher/ast/RelationshipPattern.java`
 - `engine/src/main/java/com/arcadedb/query/opencypher/traversal/GraphTraverser.java`
 - `engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java`
 - `engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java`

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -34,7 +34,6 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 /**
  * Represents a pattern predicate expression in a WHERE clause.
@@ -150,7 +149,7 @@ public class PatternPredicateExpression implements BooleanExpression {
         true, true);
     // Inline WHERE, e.g. EXISTS { (a)-[r:E*1..2 WHERE r.tag = 'ok']->(x) }: every traversed
     // relationship must satisfy it, as in the MATCH spelling.
-    traverser.withEdgePredicate(buildRelationshipPredicate(relPattern, result, context));
+    traverser.withEdgePredicate(relPattern.buildInlineWherePredicate(result, context));
 
     // Get the end node (if bound)
     final NodePattern endNodePattern = pathPattern.getNode(1);
@@ -365,33 +364,6 @@ public class PatternPredicateExpression implements BooleanExpression {
     if (relPattern == null || !relPattern.hasWhereExpression())
       return true;
     return matchesInlineWhere(relPattern.getWhereExpression(), relPattern.getVariable(), edge, row, context);
-  }
-
-  /**
-   * Builds the per-relationship predicate a variable-length traversal applies for an inline
-   * {@code WHERE}. Unlike {@link #matchesInlineWhere}, which rebuilds its scope on every call, the
-   * enclosing bindings are copied once and only the relationship variable is rebound per candidate
-   * edge, because a traversal evaluates this once per relationship it walks. Returns null when the
-   * pattern declares no predicate, leaving the traversal free of per-edge evaluation.
-   */
-  private Predicate<Edge> buildRelationshipPredicate(final RelationshipPattern relPattern, final Result row,
-      final CommandContext context) {
-    if (relPattern == null || !relPattern.hasWhereExpression())
-      return null;
-
-    final BooleanExpression where = relPattern.getWhereExpression();
-    final ResultInternal scope = new ResultInternal();
-    if (row != null)
-      for (final String property : row.getPropertyNames())
-        scope.setProperty(property, row.getProperty(property));
-
-    final String variable = relPattern.getVariable();
-    final boolean bindRelationship = variable != null && !variable.isEmpty();
-    return edge -> {
-      if (bindRelationship)
-        scope.setProperty(variable, edge);
-      return where.evaluate(scope, context);
-    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -34,6 +34,7 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Represents a pattern predicate expression in a WHERE clause.
@@ -147,6 +148,9 @@ public class PatternPredicateExpression implements BooleanExpression {
         relPattern.getDirection(), types, null,
         relPattern.getEffectiveMinHops(), relPattern.getEffectiveMaxHops(),
         true, true);
+    // Inline WHERE, e.g. EXISTS { (a)-[r:E*1..2 WHERE r.tag = 'ok']->(x) }: every traversed
+    // relationship must satisfy it, as in the MATCH spelling.
+    traverser.withEdgePredicate(buildRelationshipPredicate(relPattern, result, context));
 
     // Get the end node (if bound)
     final NodePattern endNodePattern = pathPattern.getNode(1);
@@ -361,6 +365,33 @@ public class PatternPredicateExpression implements BooleanExpression {
     if (relPattern == null || !relPattern.hasWhereExpression())
       return true;
     return matchesInlineWhere(relPattern.getWhereExpression(), relPattern.getVariable(), edge, row, context);
+  }
+
+  /**
+   * Builds the per-relationship predicate a variable-length traversal applies for an inline
+   * {@code WHERE}. Unlike {@link #matchesInlineWhere}, which rebuilds its scope on every call, the
+   * enclosing bindings are copied once and only the relationship variable is rebound per candidate
+   * edge, because a traversal evaluates this once per relationship it walks. Returns null when the
+   * pattern declares no predicate, leaving the traversal free of per-edge evaluation.
+   */
+  private Predicate<Edge> buildRelationshipPredicate(final RelationshipPattern relPattern, final Result row,
+      final CommandContext context) {
+    if (relPattern == null || !relPattern.hasWhereExpression())
+      return null;
+
+    final BooleanExpression where = relPattern.getWhereExpression();
+    final ResultInternal scope = new ResultInternal();
+    if (row != null)
+      for (final String property : row.getPropertyNames())
+        scope.setProperty(property, row.getProperty(property));
+
+    final String variable = relPattern.getVariable();
+    final boolean bindRelationship = variable != null && !variable.isEmpty();
+    return edge -> {
+      if (bindRelationship)
+        scope.setProperty(variable, edge);
+      return where.evaluate(scope, context);
+    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RelationshipPattern.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RelationshipPattern.java
@@ -18,9 +18,15 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
+import com.arcadedb.graph.Edge;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Represents a relationship pattern in a Cypher query.
@@ -163,6 +169,44 @@ public class RelationshipPattern implements PatternElement {
    */
   public boolean hasWhereExpression() {
     return whereExpression != null;
+  }
+
+  /**
+   * Builds the per-relationship predicate for this pattern's inline {@code WHERE}, e.g. the
+   * {@code WHERE r.tag = 'ok'} in {@code -[r:E*1..2 WHERE r.tag = 'ok']->}. Every evaluator that
+   * hands a variable-length traversal its edge predicate builds it here, so the rule for
+   * constructing the evaluation scope has a single definition and the MATCH and EXISTS spellings
+   * cannot drift apart.
+   * <p>
+   * The enclosing bindings are copied once, so the predicate can reference variables from the outer
+   * scope, and only the relationship variable is rebound per candidate edge. Returns null when the
+   * pattern declares no predicate, which lets a traversal skip per-edge evaluation entirely.
+   * <p>
+   * The returned predicate mutates a captured row and is therefore not thread-safe: callers build a
+   * fresh one per source row and variable-length traversal is single-threaded. Parallelizing a
+   * traversal would require giving each worker its own predicate instance.
+   *
+   * @param row     bindings visible where the pattern appears, may be null
+   * @param context command context the predicate is evaluated in
+   *
+   * @return predicate every traversed relationship must satisfy, or null if unconstrained
+   */
+  public Predicate<Edge> buildInlineWherePredicate(final Result row, final CommandContext context) {
+    if (whereExpression == null)
+      return null;
+
+    final ResultInternal scope = new ResultInternal();
+    if (row != null)
+      for (final String property : row.getPropertyNames())
+        scope.setProperty(property, row.getProperty(property));
+
+    final BooleanExpression where = whereExpression;
+    final boolean bindRelationship = variable != null && !variable.isEmpty();
+    return edge -> {
+      if (bindRelationship)
+        scope.setProperty(variable, edge);
+      return where.evaluate(scope, context);
+    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.function.Predicate;
 
 /**
  * Execution step for variable-length path patterns.
@@ -324,35 +323,11 @@ public class ExpandPathStep extends AbstractExecutionStep {
             pattern.getEffectiveMinHops(), pattern.getEffectiveMaxHops(),
             true, useBFS);
 
-    traverser.withEdgePredicate(buildEdgePredicate(currentResult));
+    // Inline WHERE, e.g. -[r:E*1..2 WHERE r.tag = 'ok']->: every traversed relationship must satisfy
+    // it, matching the inline property map and the clause-level all(e IN r WHERE ...) spelling. Built
+    // per source row so the predicate sees that row's bindings.
+    traverser.withEdgePredicate(pattern.buildInlineWherePredicate(currentResult, context));
     return traverser;
-  }
-
-  /**
-   * Builds the per-relationship predicate for an inline {@code WHERE}, e.g. the
-   * {@code WHERE r.tag = 'ok'} in {@code -[r:E*1..2 WHERE r.tag = 'ok']->}. Every relationship the
-   * path traverses must satisfy it, matching the inline property map and the clause-level
-   * {@code all(e IN r WHERE ...)} spelling.
-   * <p>
-   * The enclosing bindings are copied once per source row, so the predicate can reference variables
-   * from the outer scope, and only the relationship variable is rebound per candidate edge. Returns
-   * null when the pattern carries no predicate, leaving the traversal free of per-edge evaluation.
-   */
-  private Predicate<Edge> buildEdgePredicate(final Result currentResult) {
-    if (!pattern.hasWhereExpression())
-      return null;
-
-    final ResultInternal evalRow = new ResultInternal();
-    if (currentResult != null)
-      for (final String prop : currentResult.getPropertyNames())
-        evalRow.setProperty(prop, currentResult.getProperty(prop));
-
-    final boolean bindRelationship = relationshipVariable != null && !relationshipVariable.isEmpty();
-    return edge -> {
-      if (bindRelationship)
-        evalRow.setProperty(relationshipVariable, edge);
-      return pattern.getWhereExpression().evaluate(evalRow, context);
-    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Execution step for variable-length path patterns.
@@ -286,7 +287,7 @@ public class ExpandPathStep extends AbstractExecutionStep {
 
             if (sourceObj instanceof Vertex) {
               final Vertex sourceVertex = (Vertex) sourceObj;
-              currentPaths = createTraverser().traversePaths(sourceVertex);
+              currentPaths = createTraverser(lastResult).traversePaths(sourceVertex);
             } else {
               currentPaths = null;
             }
@@ -304,7 +305,7 @@ public class ExpandPathStep extends AbstractExecutionStep {
   /**
    * Creates a traverser for this pattern.
    */
-  private VariableLengthPathTraverser createTraverser() {
+  private VariableLengthPathTraverser createTraverser(final Result currentResult) {
     final String[] types = pattern.hasTypes() ?
         pattern.getTypes().toArray(new String[0]) :
         null;
@@ -313,16 +314,45 @@ public class ExpandPathStep extends AbstractExecutionStep {
 
     final Direction direction = directionOverride != null ? directionOverride : pattern.getDirection();
 
-    if (pathMode != null)
-      return new VariableLengthPathTraverser(
-          direction, types, props,
-          pattern.getEffectiveMinHops(), pattern.getEffectiveMaxHops(),
-          true, useBFS, pathMode);
+    final VariableLengthPathTraverser traverser = pathMode != null ?
+        new VariableLengthPathTraverser(
+            direction, types, props,
+            pattern.getEffectiveMinHops(), pattern.getEffectiveMaxHops(),
+            true, useBFS, pathMode) :
+        new VariableLengthPathTraverser(
+            direction, types, props,
+            pattern.getEffectiveMinHops(), pattern.getEffectiveMaxHops(),
+            true, useBFS);
 
-    return new VariableLengthPathTraverser(
-        direction, types, props,
-        pattern.getEffectiveMinHops(), pattern.getEffectiveMaxHops(),
-        true, useBFS);
+    traverser.withEdgePredicate(buildEdgePredicate(currentResult));
+    return traverser;
+  }
+
+  /**
+   * Builds the per-relationship predicate for an inline {@code WHERE}, e.g. the
+   * {@code WHERE r.tag = 'ok'} in {@code -[r:E*1..2 WHERE r.tag = 'ok']->}. Every relationship the
+   * path traverses must satisfy it, matching the inline property map and the clause-level
+   * {@code all(e IN r WHERE ...)} spelling.
+   * <p>
+   * The enclosing bindings are copied once per source row, so the predicate can reference variables
+   * from the outer scope, and only the relationship variable is rebound per candidate edge. Returns
+   * null when the pattern carries no predicate, leaving the traversal free of per-edge evaluation.
+   */
+  private Predicate<Edge> buildEdgePredicate(final Result currentResult) {
+    if (!pattern.hasWhereExpression())
+      return null;
+
+    final ResultInternal evalRow = new ResultInternal();
+    if (currentResult != null)
+      for (final String prop : currentResult.getPropertyNames())
+        evalRow.setProperty(prop, currentResult.getProperty(prop));
+
+    final boolean bindRelationship = relationshipVariable != null && !relationshipVariable.isEmpty();
+    return edge -> {
+      if (bindRelationship)
+        evalRow.setProperty(relationshipVariable, edge);
+      return pattern.getWhereExpression().evaluate(evalRow, context);
+    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java
@@ -179,6 +179,9 @@ public class BreadthFirstTraverser extends GraphTraverser {
             if (!matchesPropertyFilter(edge))
               continue;
 
+            if (!matchesEdgePredicate(edge))
+              continue;
+
             // Path mode: TRAIL/ACYCLIC = edge uniqueness, WALK = no restriction
             if (pathMode != PathMode.WALK && pathContainsEdge(path, edge))
               continue;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java
@@ -157,6 +157,9 @@ public class DepthFirstTraverser extends GraphTraverser {
           if (!matchesPropertyFilter(edge))
             continue;
 
+          if (!matchesEdgePredicate(edge))
+            continue;
+
           // Path mode: TRAIL/ACYCLIC = edge uniqueness, WALK = no restriction
           if (pathMode != PathMode.WALK && pathContainsEdge(path, edge))
             continue;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/GraphTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/GraphTraverser.java
@@ -27,6 +27,7 @@ import com.arcadedb.utility.RidHashSet;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Base class for graph traversal implementations.
@@ -41,6 +42,13 @@ public abstract class GraphTraverser {
   protected final boolean trackPaths;
   protected final boolean detectCycles;
   protected final PathMode pathMode;
+  /**
+   * Optional per-relationship predicate, carrying an inline {@code WHERE} such as the
+   * {@code WHERE r.tag = 'ok'} in {@code -[r:E*1..2 WHERE r.tag = 'ok']->}. Every relationship the
+   * path traverses must satisfy it, the same rule the inline property map follows. Null means
+   * unconstrained, which keeps the common path free of any per-edge evaluation.
+   */
+  protected Predicate<Edge> edgePredicate;
 
   /**
    * Creates a graph traverser with specified parameters.
@@ -178,6 +186,30 @@ public abstract class GraphTraverser {
    */
   protected boolean matchesPropertyFilter(final Edge edge) {
     return matchesPropertyFilter(edge, edgePropertyFilters);
+  }
+
+  /**
+   * Attaches the per-relationship inline {@code WHERE} predicate. Traversers that delegate to a
+   * nested traverser must forward it, otherwise the predicate is silently dropped for that strategy.
+   *
+   * @param edgePredicate predicate every traversed relationship must satisfy, null for unconstrained
+   *
+   * @return this traverser, for chaining at the construction site
+   */
+  public GraphTraverser withEdgePredicate(final Predicate<Edge> edgePredicate) {
+    this.edgePredicate = edgePredicate;
+    return this;
+  }
+
+  /**
+   * Checks an edge against the inline {@code WHERE} predicate, if one was attached.
+   *
+   * @param edge edge to check
+   *
+   * @return true if the edge satisfies the predicate (or no predicate is set)
+   */
+  protected boolean matchesEdgePredicate(final Edge edge) {
+    return edgePredicate == null || edgePredicate.test(edge);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/VariableLengthPathTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/VariableLengthPathTraverser.java
@@ -87,28 +87,24 @@ public class VariableLengthPathTraverser extends GraphTraverser {
 
   @Override
   public Iterator<Vertex> traverse(final Vertex startVertex) {
-    if (useBFS) {
-      final BreadthFirstTraverser bfs = new BreadthFirstTraverser(direction, relationshipTypes, edgePropertyFilters,
-          minHops, maxHops, trackPaths, pathMode);
-      return bfs.traverse(startVertex);
-    } else {
-      final DepthFirstTraverser dfs = new DepthFirstTraverser(direction, relationshipTypes, edgePropertyFilters,
-          minHops, maxHops, trackPaths, pathMode);
-      return dfs.traverse(startVertex);
-    }
+    return delegate().traverse(startVertex);
   }
 
   @Override
   public Iterator<TraversalPath> traversePaths(final Vertex startVertex) {
-    if (useBFS) {
-      final BreadthFirstTraverser bfs = new BreadthFirstTraverser(direction, relationshipTypes, edgePropertyFilters,
-          minHops, maxHops, trackPaths, pathMode);
-      return bfs.traversePaths(startVertex);
-    } else {
-      final DepthFirstTraverser dfs = new DepthFirstTraverser(direction, relationshipTypes, edgePropertyFilters,
-          minHops, maxHops, trackPaths, pathMode);
-      return dfs.traversePaths(startVertex);
-    }
+    return delegate().traversePaths(startVertex);
+  }
+
+  /**
+   * Builds the strategy this traverser delegates to. The inline {@code WHERE} predicate is forwarded
+   * to it: the delegate does the per-edge walking, so a predicate left behind here would be silently
+   * dropped for every variable-length pattern.
+   */
+  private GraphTraverser delegate() {
+    final GraphTraverser strategy = useBFS ?
+        new BreadthFirstTraverser(direction, relationshipTypes, edgePropertyFilters, minHops, maxHops, trackPaths, pathMode) :
+        new DepthFirstTraverser(direction, relationshipTypes, edgePropertyFilters, minHops, maxHops, trackPaths, pathMode);
+    return strategy.withEdgePredicate(edgePredicate);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5490VarLengthRelInlineWhereTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5490VarLengthRelInlineWhereTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #5490.
+ * <p>
+ * A relationship inline {@code WHERE} predicate on a variable-length pattern, the
+ * {@code WHERE r.tag = 'ok'} in {@code -[r:E*1..2 WHERE r.tag = 'ok']->}, was discarded: neither the
+ * {@code MATCH} executor nor the {@code EXISTS {}} evaluator handed it to the traverser, so
+ * {@code WHERE false} still returned every row. The fixed-length spelling and the variable-length
+ * property-map spelling were unaffected, as were pattern comprehensions.
+ * <p>
+ * Semantics: as with the inline property map, every relationship traversed by the path must satisfy
+ * the predicate, which is the same rule as the clause-level {@code all(e IN r WHERE ...)} spelling.
+ */
+class Issue5490VarLengthRelInlineWhereTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-5490-varlen-rel-inline-where").create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (a:A {v:1}), (b:A {v:10}), (c:A {v:2}), (d:A {v:7}), (e:A {v:8})");
+      database.command("opencypher", "MATCH (a:A {v:1}), (b:A {v:10}), (c:A {v:2}), (d:A {v:7}), (e:A {v:8}) "
+          + "CREATE (a)-[:E {tag:'ok', w:5}]->(b), (a)-[:E {tag:'bad', w:99}]->(c), "
+          + "(b)-[:E {tag:'ok', w:1}]->(d), (c)-[:E {tag:'ok', w:2}]->(e)");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  private long count(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).as("query returned no row: %s", query).isTrue();
+      final Number n = rs.next().getProperty("c");
+      return n == null ? 0L : n.longValue();
+    }
+  }
+
+  private List<Integer> queryInts(final String query, final String field) {
+    final List<Integer> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final Number n = row.getProperty(field);
+        values.add(n == null ? null : n.intValue());
+      }
+    }
+    return values;
+  }
+
+  // ---------------------------------------------------------------- MATCH, variable length
+
+  @Test
+  void matchVariableLengthAppliesTheRelationshipInlineWhere() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E*1..1 WHERE r.tag = 'ok']->(x:A) RETURN count(*) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void matchVariableLengthHonorsAnAlwaysFalsePredicate() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E*1..1 WHERE false]->(x:A) RETURN count(*) AS c")).isZero();
+  }
+
+  @Test
+  void matchVariableLengthHonorsAnAlwaysTruePredicate() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E*1..1 WHERE true]->(x:A) RETURN count(*) AS c")).isEqualTo(2);
+  }
+
+  /**
+   * Every relationship of the path must satisfy the predicate. From a the all-'ok' paths are
+   * a-&gt;b (one hop) and a-&gt;b-&gt;d (two hops). The a-&gt;c edge is 'bad', so neither a-&gt;c nor
+   * a-&gt;c-&gt;e survives even though the second edge of the latter is 'ok'.
+   */
+  @Test
+  void matchVariableLengthRequiresEveryRelationshipToSatisfyThePredicate() {
+    assertThat(queryInts("MATCH (a:A {v:1})-[r:E*1..2 WHERE r.tag = 'ok']->(x:A) RETURN x.v AS v ORDER BY v", "v"))
+        .containsExactly(7, 10);
+  }
+
+  @Test
+  void matchUnboundedVariableLengthAppliesThePredicate() {
+    assertThat(queryInts("MATCH (a:A {v:1})-[r:E* WHERE r.tag = 'ok']->(x:A) RETURN x.v AS v ORDER BY v", "v"))
+        .containsExactly(7, 10);
+  }
+
+  @Test
+  void matchVariableLengthPredicateSeesOuterBindings() {
+    // r.w = 5 satisfies w < a.v + 10 = 11; the 'bad' edge's w = 99 does not.
+    assertThat(count("MATCH (a:A {v:1})-[r:E*1..1 WHERE r.w < a.v + 10]->(x:A) RETURN count(*) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void matchVariableLengthAgreesWithTheClauseLevelAllSpelling() {
+    final List<Integer> viaInline = queryInts(
+        "MATCH (a:A {v:1})-[r:E*1..2 WHERE r.tag = 'ok']->(x:A) RETURN x.v AS v ORDER BY v", "v");
+    final List<Integer> viaClause = queryInts(
+        "MATCH (a:A {v:1})-[r:E*1..2]->(x:A) WHERE all(e IN r WHERE e.tag = 'ok') RETURN x.v AS v ORDER BY v", "v");
+    assertThat(viaInline).containsExactlyElementsOf(viaClause);
+  }
+
+  // ---------------------------------------------------------------- EXISTS {}, variable length
+
+  @Test
+  void existsVariableLengthAppliesTheRelationshipInlineWhere() {
+    assertThat(count("MATCH (a:A {v:1}) WHERE EXISTS { (a)-[r:E*1..1 WHERE r.tag = 'nope']->(x:A) } "
+        + "RETURN count(*) AS c")).isZero();
+    assertThat(count("MATCH (a:A {v:1}) WHERE EXISTS { (a)-[r:E*1..1 WHERE r.tag = 'ok']->(x:A) } "
+        + "RETURN count(*) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void existsVariableLengthAppliesTheRelationshipPropertyMap() {
+    assertThat(count("MATCH (a:A {v:1}) WHERE EXISTS { (a)-[r:E*1..1 {tag:'nope'}]->(x:A) } "
+        + "RETURN count(*) AS c")).isZero();
+    assertThat(count("MATCH (a:A {v:1}) WHERE EXISTS { (a)-[r:E*1..1 {tag:'ok'}]->(x:A) } "
+        + "RETURN count(*) AS c")).isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------- controls that must keep working
+
+  @Test
+  void fixedLengthRelationshipInlineWhereStillWorks() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E WHERE r.tag = 'ok']->(x:A) RETURN count(*) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void variableLengthPropertyMapStillWorks() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E*1..1 {tag:'ok'}]->(x:A) RETURN count(*) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void patternComprehensionVariableLengthStillWorks() {
+    assertThat(count("MATCH (a:A {v:1}) RETURN size([(a)-[r:E*1..1 WHERE r.tag = 'ok']->(x:A) | x.v]) AS c"))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void variableLengthWithoutAnyPredicateIsUnaffected() {
+    assertThat(count("MATCH (a:A {v:1})-[r:E*1..1]->(x:A) RETURN count(*) AS c")).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
Closes #5490

A relationship inline `WHERE` on a variable-length pattern was parsed onto the AST but never handed to the traversal engine, so `-[r:E*1..1 WHERE r.tag = 'ok']->` returned every row and `WHERE false` returned every row too. Two producers built a `VariableLengthPathTraverser` from the relationship pattern and passed only the types, the property map and the hop bounds: `ExpandPathStep.createTraverser()` (the `MATCH` executor) and `PatternPredicateExpression.evaluateVLPPattern()` (the `EXISTS {}` evaluator). `GraphTraverser` and its BFS/DFS subclasses had no notion of a per-relationship predicate, so there was nothing for the producers to pass it to. This threads an optional `Predicate<Edge>` through the traversal package, applied at the same per-edge choke point as the existing property filter and forwarded by `VariableLengthPathTraverser` to whichever strategy it delegates to.

**Semantics:** every relationship the path traverses must satisfy the predicate, matching the inline property map and the clause-level `all(e IN r WHERE ...)` spelling. A test asserts the inline and clause-level spellings agree.

**Why prune rather than post-filter:** filtering completed paths would be simpler, but under BFS shortest-path semantics it would discard a target whose shortest path fails the predicate instead of finding the longer path that satisfies it.

**Performance:** a null predicate means unconstrained, so patterns without an inline `WHERE` do no per-edge evaluation. Enclosing bindings are copied once per source row, not per edge, since a traversal evaluates this for every relationship it walks.

## Scope

The issue reported the `MATCH` shape. I probed every surface that parses a variable-length relationship before fixing, which found a second broken one and two that were already correct:

| Surface | Before | Verdict |
|---|---|---|
| `MATCH`, fixed length | correct | not affected |
| `MATCH`, variable length (`*1..1`, `*1..2`, `*`) | predicate ignored | **broken** |
| `MATCH`, variable length, property map | correct | not affected |
| `EXISTS {}`, variable length | predicate ignored | **broken** |
| `EXISTS {}`, variable length, property map | correct | not affected |
| Pattern comprehension, variable length | correct | not affected |

Pattern comprehensions were already correct because `PatternComprehensionExpression.traverseVariableLength` enforces the predicate itself instead of delegating to the shared traverser. That is pinned by a control test so the two implementations cannot drift apart silently.

## Test plan

- [x] `Issue5490VarLengthRelInlineWhereTest`, 13 methods: **7 fail before the fix, all 13 pass after**
  - [x] the reported shape, and `WHERE false` / `WHERE true` as conclusive evidence the predicate is reaching the traversal
  - [x] multi-hop: every relationship of the path must satisfy the predicate
  - [x] unbounded `*` pattern
  - [x] predicate referencing an outer-scope binding (`r.w < a.v + 10`)
  - [x] parity against the clause-level `all(e IN r WHERE ...)` spelling
  - [x] both `EXISTS {}` shapes, inline `WHERE` and property map
  - [x] controls: fixed length, variable-length property map, pattern comprehension, predicate-free
- [x] Full `com.arcadedb.query.opencypher.**` package: **7632 tests, 0 failures**
- [x] All consumers of the traversal classes checked: `ExpandPathStep`, `PatternPredicateExpression`, `ShortestPathStep` are the only ones, all inside the OpenCypher engine and all covered by that run. `ShortestPathStep` uses only the static `matchesPropertyFilter` helper, which is untouched.
- [x] The 3 `OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s are pre-existing: reproduced identically on a clean tree at 4aaa90c56 with the change stashed

## Known gaps, not addressed here

- For a multi-hop variable-length pattern the relationship variable binds to a single edge rather than the list of traversed edges when a predicate reads it. That predates this change; the predicate is evaluated per traversed relationship, which is the semantics implemented here.
