### PR TITLE
fix(#5496): raise instead of returning null for an unbound shortestPath endpoint

### DIFF
--- a/docs/5496-shortestpath-expr-unbound-target.md
+++ b/docs/5496-shortestpath-expr-unbound-target.md
@@ -1,0 +1,97 @@
+# Issue #5496 - expression-form `shortestPath` returns null for an unbound endpoint
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/5496
+- Branch: `fix/5496-shortestpath-expr-unbound-target`
+- Base: `main` at 2dfc3c75b
+
+## Problem
+
+```cypher
+MATCH (a:A {v:1}) RETURN shortestPath((a)-[*]->(x:A)) AS p
+```
+
+returned `null`. The caller had no way to tell "no path exists" from "this query shape is not
+supported". A pattern whose endpoint carried no variable at all raised a bare
+`IllegalArgumentException` instead, so two spellings of the same mistake failed in two different ways
+and neither was actionable.
+
+## Why the originally proposed fix was dropped
+
+The issue as filed recommended teaching the expression form to resolve an unbound endpoint, "matching
+the `MATCH` form". Probing the `MATCH` form before implementing showed that is not well defined.
+
+`ShortestPathStep`, the `MATCH` evaluator, also requires both endpoints to be bound vertices and
+skips the row otherwise. The `MATCH` spelling works because the **planner** binds the endpoint with a
+node scan first and then computes one path per candidate, so it **multiplies rows**:
+
+```cypher
+MATCH p = shortestPath((a:A {v:1})-[*]->(x:A)) RETURN x.v, [n IN nodes(p) | n.v]
+-- 3 rows: x=1 -> [1], x=10 -> [1,10], x=2 -> [1,10,2]
+```
+
+An expression produces a single value per input row and cannot multiply rows, so it can never return
+what the `MATCH` spelling returns for the same written pattern. "Make the two agree" is not
+implementable. The remaining choices were to invent a different scalar semantics for the expression
+form (nearest matching node) or to reject the shape. Rejecting was chosen: it removes the real
+user-facing harm, the silent `null`, without introducing two spellings of one pattern that
+legitimately disagree.
+
+This also corrected a mistake in the issue as filed: a reported zero-length path `[1]` was a
+misreading of the first of those three rows, not a defect. A comment on the issue records both
+corrections.
+
+## Fix
+
+`ShortestPathExpression.evaluate` now raises `CommandExecutionException` when an endpoint cannot be
+resolved, naming the offending endpoint and the spelling that does support searching:
+
+> `shortestPath() as an expression requires both endpoints bound to vertices, but 'x' is not bound.`
+> `Use MATCH p = shortestPath(...) to search for an unbound endpoint.`
+
+Four cases raise: a start or end pattern with no variable, and a start or end variable that is not
+bound in the current row. `allShortestPaths()` names itself in the message.
+
+**Null still propagates.** A variable that *is* present in the row but does not hold a vertex, the
+usual case being null from a non-matching `OPTIONAL MATCH`, keeps returning null rather than raising.
+That is standard Cypher null propagation and is a different situation from an unbound variable. The
+two are distinguished by whether the row carries the name at all, not by whether the value is a
+vertex. A genuine "no path between two bound vertices" answer also stays null, which is what the new
+error must not be confused with.
+
+The class Javadoc previously said only "Both endpoints must be bound to variables"; it now states the
+rule and why the `MATCH` spelling differs.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java`
+- `engine/src/test/java/com/arcadedb/query/opencypher/Issue5496ShortestPathExpressionUnboundEndpointTest.java` (new)
+
+## Verification
+
+`Issue5496ShortestPathExpressionUnboundEndpointTest`, 11 methods: 6 failed before the fix and all 11
+pass after. Coverage: unbound target, unbound source, anonymous target, anonymous source,
+`allShortestPaths`, and an assertion on message content (names the variable and the working
+spelling). Controls that must not regress: bound endpoints still compute the path, bound endpoints
+with an inline relationship `WHERE` still work (guards the #5481 path), an unsatisfiable predicate
+between bound endpoints still returns null, an endpoint bound to null still propagates as null, and
+the `MATCH` spelling still resolves an unbound endpoint across three candidate rows.
+
+Regression run over `com.arcadedb.query.opencypher.**`: 7643 tests, 0 failures. Turning a silent
+null into a thrown exception is the kind of change that breaks tests relying on the old behavior, so
+this run was the main risk check; nothing depended on it. The 3 errors are
+`OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s, reproduced identically on a
+clean tree at 2dfc3c75b with the change stashed, so they are environmental and pre-existing.
+
+Consumers of `ShortestPathExpression` were enumerated: all are inside the OpenCypher engine and
+covered by that run. Hits for `shortestPath` elsewhere in the repo (Studio function reference, Python
+bindings, graph/OLAP tests) are the SQL `SQLFunctionShortestPath`, a different entry point that this
+change does not touch.
+
+## Deliberately not changed
+
+- The arity guard at the top of `evaluate` still raises `IllegalArgumentException` for a pattern
+  without exactly 2 nodes. Converting it would be consistent, but it is a different error class and
+  is not reachable from a query shape covered by a test here, and the repo requires new behavior to
+  come with a test.
+- Whether an `x = source` candidate should yield a zero-length path under `[*]`, which is
+  one-or-more, is a separate question about the `MATCH` form and is untouched.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.ast;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep;
 import com.arcadedb.query.opencypher.executor.steps.ShortestPathStep.EdgeConstraint;
@@ -39,7 +40,13 @@ import java.util.List;
  * The path pattern must:
  * - Have exactly 2 nodes (start and end)
  * - Have exactly 1 relationship (with variable length allowed)
- * - Both endpoints must be bound to variables
+ * - Both endpoints must already be bound to vertices in the current row
+ * <p>
+ * The last rule is what separates this from the {@code MATCH p = shortestPath(...)} spelling. That
+ * one searches for an unbound endpoint, because the planner binds it with a node scan and then emits
+ * one path per candidate; an expression yields a single value per row and cannot multiply rows that
+ * way. An unbound endpoint here therefore raises rather than returning null, so the unsupported
+ * shape stays distinguishable from a genuine "no path" answer.
  * <p>
  * This expression uses the existing SQLFunctionShortestPath for path computation.
  *
@@ -70,15 +77,27 @@ public class ShortestPathExpression implements Expression {
     final String startVar = startNode.getVariable();
     final String endVar = endNode.getVariable();
 
-    if (startVar == null || endVar == null) {
-      throw new IllegalArgumentException("shortestPath endpoints must be bound to variables");
-    }
+    // Both endpoints must already be bound in this row. The expression form deliberately does not
+    // search for an unbound endpoint: the MATCH form does that by having the planner bind it with a
+    // node scan and then emitting one path per candidate, which multiplies rows, and an expression
+    // yields a single value per row. Raising here keeps an unsupported shape distinguishable from a
+    // genuine "no path" answer, which is null (issue #5496).
+    if (startVar == null || startVar.isEmpty())
+      throw unboundEndpoint("the start endpoint declares no variable");
+    if (endVar == null || endVar.isEmpty())
+      throw unboundEndpoint("the end endpoint declares no variable");
+    if (!result.getPropertyNames().contains(startVar))
+      throw unboundEndpoint("'" + startVar + "' is not bound");
+    if (!result.getPropertyNames().contains(endVar))
+      throw unboundEndpoint("'" + endVar + "' is not bound");
 
     final Object startValue = result.getProperty(startVar);
     final Object endValue = result.getProperty(endVar);
 
     if (!(startValue instanceof Vertex) || !(endValue instanceof Vertex)) {
-      // If either endpoint is not resolved, return null (no path)
+      // The variable exists but does not hold a vertex, typically null from a non-matching OPTIONAL
+      // MATCH. Null propagates through the expression as it does elsewhere in Cypher, so this stays a
+      // null answer rather than an error: only a variable that is not bound at all is unsupported.
       return null;
     }
 
@@ -170,6 +189,17 @@ public class ShortestPathExpression implements Expression {
     final List<Object> allPathsList = new ArrayList<>(1);
     allPathsList.add(path);
     return allPathsList;
+  }
+
+  /**
+   * Builds the error raised when an endpoint is not bound to a vertex in the current row. The message
+   * names the offending endpoint and the spelling that does support searching for it, because the
+   * failure is a query-shape problem the author can fix rather than a data-dependent outcome.
+   */
+  private CommandExecutionException unboundEndpoint(final String detail) {
+    return new CommandExecutionException((allPaths ? "allShortestPaths()" : "shortestPath()")
+        + " as an expression requires both endpoints bound to vertices, but " + detail
+        + ". Use MATCH p = shortestPath(...) to search for an unbound endpoint.");
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5496ShortestPathExpressionUnboundEndpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5496ShortestPathExpressionUnboundEndpointTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for GitHub issue #5496.
+ * <p>
+ * {@code shortestPath()} in expression position, {@code RETURN shortestPath(...)}, computes between
+ * two vertices that are already bound in the current row. When an endpoint was not bound it returned
+ * {@code null}, which is indistinguishable from "no path exists", and when an endpoint carried no
+ * variable at all it raised a bare {@code IllegalArgumentException}. Both now raise a
+ * {@link CommandExecutionException} naming the offending endpoint and pointing at the {@code MATCH}
+ * spelling.
+ * <p>
+ * The expression form deliberately does not search for an unbound endpoint. The {@code MATCH} form
+ * does, but only because the planner binds the endpoint with a node scan first and then computes one
+ * path per candidate, which multiplies rows. An expression yields a single value per row and cannot
+ * reproduce that, so the two spellings answer different questions and the unsupported one fails loudly.
+ * <p>
+ * A variable bound to {@code null}, e.g. by a non-matching {@code OPTIONAL MATCH}, is a different
+ * case: null propagates as it does everywhere else in Cypher, so it must not raise.
+ */
+class Issue5496ShortestPathExpressionUnboundEndpointTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-5496-shortestpath-expr-unbound").create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (a:A {v:1}), (b:A {v:10}), (d:A {v:2})");
+      database.command("opencypher", "MATCH (a:A {v:1}), (b:A {v:10}), (d:A {v:2}) "
+          + "CREATE (a)-[:E {tag:'ok'}]->(b), (b)-[:E {tag:'ok'}]->(d)");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  private List<Integer> pathValues(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).as("query returned no row: %s", query).isTrue();
+      final List<Object> list = rs.next().getProperty("vs");
+      final List<Integer> values = new ArrayList<>();
+      if (list != null)
+        for (final Object o : list)
+          values.add(o == null ? null : ((Number) o).intValue());
+      return values;
+    }
+  }
+
+  /** Drains the result set so the expression is actually evaluated, then returns the rows. */
+  private List<Result> rows(final String query) {
+    final List<Result> all = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        all.add(rs.next());
+    }
+    return all;
+  }
+
+  // ---------------------------------------------------------------- unbound endpoints must raise
+
+  @Test
+  void unboundTargetVariableRaisesInsteadOfReturningNull() {
+    assertThatThrownBy(() -> rows("MATCH (a:A {v:1}) RETURN shortestPath((a)-[*]->(x:A)) AS p"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("x")
+        .hasMessageContaining("MATCH");
+  }
+
+  @Test
+  void unboundSourceVariableRaisesInsteadOfReturningNull() {
+    assertThatThrownBy(() -> rows("MATCH (d:A {v:2}) RETURN shortestPath((x:A)-[*]->(d)) AS p"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("x")
+        .hasMessageContaining("MATCH");
+  }
+
+  @Test
+  void anonymousTargetRaisesTheSameExceptionType() {
+    assertThatThrownBy(() -> rows("MATCH (a:A {v:1}) RETURN shortestPath((a)-[*]->(:A)) AS p"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("MATCH");
+  }
+
+  @Test
+  void anonymousSourceRaisesTheSameExceptionType() {
+    assertThatThrownBy(() -> rows("MATCH (d:A {v:2}) RETURN shortestPath((:A)-[*]->(d)) AS p"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("MATCH");
+  }
+
+  @Test
+  void allShortestPathsExpressionRaisesForAnUnboundEndpoint() {
+    assertThatThrownBy(() -> rows("MATCH (a:A {v:1}) RETURN allShortestPaths((a)-[*]->(x:A)) AS p"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("MATCH");
+  }
+
+  @Test
+  void theMessageNamesTheOffendingVariableAndTheWorkingSpelling() {
+    assertThatThrownBy(() -> rows("MATCH (a:A {v:1}) RETURN shortestPath((a)-[*]->(x:A)) AS p"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("shortestPath")
+        .hasMessageContaining("x")
+        .hasMessageContaining("MATCH p = shortestPath");
+  }
+
+  // ---------------------------------------------------------------- null propagation must NOT raise
+
+  @Test
+  void anEndpointBoundToNullStillPropagatesAsNull() {
+    // The OPTIONAL MATCH does not match, so z is bound to null. Cypher propagates null through the
+    // expression rather than failing, and that must not be confused with an unbound variable.
+    final List<Result> result = rows(
+        "MATCH (a:A {v:1}) OPTIONAL MATCH (z:DoesNotExist) RETURN shortestPath((a)-[*]->(z)) AS p");
+    assertThat(result).hasSize(1);
+    assertThat((Object) result.get(0).getProperty("p")).isNull();
+  }
+
+  // ---------------------------------------------------------------- controls that must keep working
+
+  @Test
+  void boundEndpointsStillComputeThePath() {
+    assertThat(pathValues("MATCH (a:A {v:1}), (d:A {v:2}) "
+        + "RETURN [n IN nodes(shortestPath((a)-[*]->(d))) | n.v] AS vs")).containsExactly(1, 10, 2);
+  }
+
+  @Test
+  void boundEndpointsWithAnInlineRelationshipWhereStillWork() {
+    // Guards the #5481 edge-constraint path in the expression form.
+    assertThat(pathValues("MATCH (a:A {v:1}), (d:A {v:2}) "
+        + "RETURN [n IN nodes(shortestPath((a)-[r:E* WHERE r.tag = 'ok']->(d))) | n.v] AS vs"))
+        .containsExactly(1, 10, 2);
+  }
+
+  @Test
+  void boundEndpointsWithAnUnsatisfiableRelationshipWhereStillReturnNull() {
+    // A genuine "no path" answer stays null: that is what the raised error must not be confused with.
+    final List<Result> result = rows("MATCH (a:A {v:1}), (d:A {v:2}) "
+        + "RETURN shortestPath((a)-[r:E* WHERE r.tag = 'nope']->(d)) AS p");
+    assertThat(result).hasSize(1);
+    assertThat((Object) result.get(0).getProperty("p")).isNull();
+  }
+
+  @Test
+  void theMatchSpellingStillResolvesAnUnboundEndpoint() {
+    // The MATCH form is unaffected: the planner binds x with a scan and emits one row per candidate.
+    final List<Result> result = rows(
+        "MATCH p = shortestPath((a:A {v:1})-[*]->(x:A)) RETURN x.v AS xv ORDER BY xv");
+    assertThat(result).hasSize(3);
+    final List<Integer> targets = new ArrayList<>();
+    for (final Result r : result) {
+      final Number n = r.getProperty("xv");
+      targets.add(n == null ? null : n.intValue());
+    }
+    assertThat(targets).containsExactly(1, 2, 10);
+  }
+}


### PR DESCRIPTION
Closes #5496

`shortestPath()` in expression position returned `null` when an endpoint was not bound, which a caller cannot tell apart from a genuine "no path exists" answer, and raised a bare `IllegalArgumentException` when an endpoint carried no variable at all. Both now raise `CommandExecutionException` naming the offending endpoint and the spelling that does support searching for it:

> `shortestPath() as an expression requires both endpoints bound to vertices, but 'x' is not bound. Use MATCH p = shortestPath(...) to search for an unbound endpoint.`

## Why this rejects rather than resolving the endpoint

The issue as filed recommended teaching the expression form to resolve an unbound endpoint "matching the `MATCH` form". Probing before implementing showed that is not well defined, so the approach changed. `ShortestPathStep`, the `MATCH` evaluator, **also** requires both endpoints to be bound vertices. The `MATCH` spelling works because the *planner* binds the endpoint with a node scan first and then computes one path per candidate, so it multiplies rows:

```cypher
MATCH p = shortestPath((a:A {v:1})-[*]->(x:A)) RETURN x.v, [n IN nodes(p) | n.v]
-- 3 rows: x=1 -> [1], x=10 -> [1,10], x=2 -> [1,10,2]
```

An expression yields a single value per input row and cannot multiply rows, so it can never return what the `MATCH` spelling returns for the same written pattern. The remaining options were to invent a different scalar semantics for the expression form (nearest matching node) or to reject the shape. Rejecting removes the actual user-facing harm, the silent `null`, without creating two spellings of one pattern that legitimately disagree.

The same probing corrected a mistake in the issue: a reported zero-length path `[1]` was a misreading of the first of those three rows, not a defect. Both corrections are recorded in a comment on #5496.

## Null still propagates

A variable that *is* present in the row but does not hold a vertex, the usual case being null from a non-matching `OPTIONAL MATCH`, keeps returning null rather than raising. That is standard Cypher null propagation and is a different situation from an unbound variable; the two are distinguished by whether the row carries the name at all. A genuine "no path between two bound vertices" answer also stays null, which is exactly what the new error must not be confused with. Both are pinned by tests.

## Test plan

- [x] `Issue5496ShortestPathExpressionUnboundEndpointTest`, 11 methods: **6 fail before the fix, all 11 pass after**
  - [x] unbound target variable, unbound source variable
  - [x] anonymous target, anonymous source (previously `IllegalArgumentException`)
  - [x] `allShortestPaths()`, which names itself in the message
  - [x] message content: names the offending variable and `MATCH p = shortestPath`
  - [x] control: an endpoint bound to null still propagates as null (must NOT raise)
  - [x] control: an unsatisfiable relationship `WHERE` between bound endpoints still returns null
  - [x] controls: bound endpoints still compute the path, including with an inline relationship `WHERE` (guards the #5481 path)
  - [x] control: the `MATCH` spelling still resolves an unbound endpoint across three candidate rows
- [x] Full `com.arcadedb.query.opencypher.**`: **7643 tests, 0 failures**. Turning a silent null into a thrown exception is the change most likely to break tests relying on the old behavior, so this run was the main risk check; nothing depended on it.
- [x] Consumers of `ShortestPathExpression` enumerated: all inside the OpenCypher engine and covered by that run. Other `shortestPath` hits in the repo (Studio function reference, Python bindings, graph/OLAP tests) are the SQL `SQLFunctionShortestPath`, a different entry point this does not touch.
- [x] The 3 `OpenCypherCustomFunctionTest` GraalVM polyglot `NoClassDefFoundError`s are pre-existing: reproduced identically on a clean tree at 2dfc3c75b with the change stashed

## Deliberately not changed

- The arity guard at the top of `evaluate` still raises `IllegalArgumentException` for a pattern without exactly 2 nodes. Converting it would be consistent, but it is a different error class not reachable from a query shape covered by a test here, and new behavior should come with a test.
- Whether an `x = source` candidate should yield a zero-length path under `[*]` (one-or-more) is a separate question about the `MATCH` form.
