### PR TITLE
perf(#5496): use hasProperty instead of building a name set per row

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -86,9 +86,12 @@ public class ShortestPathExpression implements Expression {
       throw unboundEndpoint("the start endpoint declares no variable");
     if (endVar == null || endVar.isEmpty())
       throw unboundEndpoint("the end endpoint declares no variable");
-    if (!result.getPropertyNames().contains(startVar))
+    // hasProperty rather than getPropertyNames().contains: the latter allocates a set of every name
+    // on the row, twice, on the valid both-bound path. Both answer the same question here, including
+    // for a name mapped to null, which is the distinction the null-propagation branch below relies on.
+    if (!result.hasProperty(startVar))
       throw unboundEndpoint("'" + startVar + "' is not bound");
-    if (!result.getPropertyNames().contains(endVar))
+    if (!result.hasProperty(endVar))
       throw unboundEndpoint("'" + endVar + "' is not bound");
 
     final Object startValue = result.getProperty(startVar);


### PR DESCRIPTION
Follow-up to #5497 (closes nothing; #5496 is already fixed and closed).

The unbound-endpoint guards added in #5497 called `result.getPropertyNames().contains(...)` twice. `ResultInternal.getPropertyNames()` builds a fresh `LinkedHashSet` containing every property name on the row, so the **valid** both-bound path paid two throwaway set allocations per input row. `Result.hasProperty(String)` answers the same question allocation-free.

`claude[bot]` raised this reviewing #5497, but that PR merged before the change was pushed, so it lands separately.

## Why the two are equivalent here

This guard is what separates "variable not bound at all" (raises) from "variable bound to null" (propagates as null, per Cypher), so the swap is only safe if both agree for a name mapped to `null`. They do:

- `getPropertyNames()` includes `content.keySet()`, which contains a key mapped to null.
- `hasProperty()` ends in `content.containsKey(propName)`, which is true for a key mapped to null.
- Both consult `tombstones` and `element` the same way.

They diverge only for `$score` / `$similarity`: `hasProperty` always reports them present, while `getPropertyNames` includes them only when the corresponding value is greater than zero. Neither can be a Cypher node variable name, so it cannot be reached from this call site.

## Test plan

- [x] `Issue5496ShortestPathExpressionUnboundEndpointTest` 11/11 pass on the merged base, including the two controls that would catch a semantic difference: an endpoint bound to null still propagates as null, and a genuine "no path" between bound endpoints still returns null
- [x] All `*ShortestPath*` suites: 82 tests, 0 failures
- [x] Verified earlier against the full `com.arcadedb.query.opencypher.**` sweep (7643 tests, 0 failures) on the pre-merge branch
