### PR TITLE
fix(#5492): coalesce materialized view refresh requests instead of dropping them

### DIFF
--- a/docs/5492-materialized-view-refresh-coalescing.md
+++ b/docs/5492-materialized-view-refresh-coalescing.md
@@ -1,0 +1,117 @@
+# Issue #5492 - a dropped materialized view refresh leaves the view permanently stale
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/5492
+- Branch: `fix/5492-ha-mv-page-version-replication-gap`
+- Base: `main` at f7ee51d01
+
+## Scope
+
+Issue #5492 bundles two defects. This branch fixes the second one only, and deliberately does **not**
+close the issue.
+
+| Defect | Status here |
+|---|---|
+| A refresh arriving while another is in flight is dropped, not queued, so the view can be silently stale | **Fixed** |
+| The leader ships page versions followers never received (`WALVersionGapException`, snapshot-resync loop, lost writes) | **Not fixed - not reproduced** |
+
+The issue itself records the replication root cause as "not yet proven". It still is. Shipping a
+speculative change to the Raft commit path without a reproduction would risk making a data-loss bug
+worse, so that half stays open.
+
+## What was investigated for the replication half
+
+A 3-node in-process Raft harness (`BaseRaftHATest`, whose `checkDatabasesAreIdentical()` already
+routes through `DatabaseComparator` and fails on any cross-node page-version mismatch) was built and
+run against an `INCREMENTAL` view under concurrent single-record transactions. Findings:
+
+- **No page-version gap reproduced.** Zero `WALVersionGapException`, zero resync loops, across every
+  configuration tried (writes on the leader, writes through a follower, with and without a UNIQUE
+  index on the source type, 180 and 450 records).
+- Two theories from the issue were checked against current code. `LocalSchema` is constructed with
+  `wrappedDatabaseInstance` (`LocalDatabase.java:2423`), so the refresh does go through
+  `RaftReplicatedDatabase` - the issue is right to rule that theory out.
+- One genuine leader-side asymmetry was found but **not** shown to be reachable from the view path:
+  `RaftReplicatedDatabase.recordFileChanges` drains buffered WAL into `walEntries`, but its
+  replication guard omits `walEntries` from the condition, and the `finally` then clears the buffer.
+  Its sibling `runWithCompactionReplication` guards correctly. Left alone here for lack of a
+  reproduction; worth a look on its own.
+- An **unrelated** failure surfaced: concurrent single-record transactions issued through a follower
+  lose 60-70% of records and log `Invalid record size ... deleting record` on the affected buckets.
+  The A/B control with no view fails identically, so it is not attributable to materialized views.
+  Filed separately.
+
+## The defect that is fixed
+
+`MaterializedViewRefresher.fullRefresh` began with:
+
+```java
+if (!view.tryBeginRefresh())
+  return;   // another refresh is running
+```
+
+The refresh is triggered from a post-commit callback, so the request that gets dropped belongs to a
+transaction that has **already committed**. The in-flight refresh it deferred to started before that
+commit and therefore reads a snapshot without it. Nothing reschedules. The view stays missing that
+record until some later write happens to win the race - or forever, if none does.
+
+This needs no HA to reproduce: a 3-node run showed the **leader's own** view holding 449 of 450
+committed records.
+
+It also explains part of the throughput collapse in the issue's A/B table. Every committing
+transaction that touches the source type schedules a full `TRUNCATE` + re-run of the defining query,
+so under single-record transactions the work degenerates towards a full rebuild per row.
+
+## Fix
+
+Requests are coalesced onto the running refresh instead of being dropped.
+
+`MaterializedViewImpl` replaces the `AtomicBoolean refreshInProgress` with a three-state
+`AtomicInteger`: `IDLE`, `RUNNING`, `RUNNING_PENDING`. Two operations are added:
+
+- `markRefreshPendingIfRunning()` - hands a request to the running refresh; returns `false` if none
+  is running, in which case the caller must run it itself.
+- `finishRefreshPassAndCheckPending()` - ends one pass, returning `true` if a request arrived during
+  it (ownership retained, another pass required) or releasing ownership and returning `false`.
+
+Releasing ownership and testing for a pending request is one atomic step. Split into two, a request
+registered in between would be seen by neither the outgoing owner nor the requester (which observed
+the refresh as still running) - the same lost-wakeup that the original code had unconditionally.
+
+`fullRefresh` now registers its request when it cannot take ownership, and the owner loops until no
+request is outstanding. `tryBeginRefresh()` and `endRefresh()` keep their existing contracts, so the
+existing guard tests are untouched.
+
+Repeated requests during one pass collapse into a single further pass, which is the intended
+behaviour: one rebuild that sees all of them is equivalent to N sequential rebuilds and far cheaper.
+
+## Deliberately not done
+
+True incremental view maintenance. `MaterializedViewChangeListener` still schedules a full refresh
+regardless of `REFRESH INCREMENTAL`, as its comment says. Implementing per-record maintenance is a
+feature with real correctness risk (wrong view contents rather than slow ones), not a bug fix, and it
+is out of scope here. Coalescing already removes the redundant rebuilds, which is where the cost
+actually was.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java`:
+
+- `refresherRegistersItsRequestWhenAnotherRefreshIsInFlight` - the regression guard. Drives the exact
+  interleaving with no timing dependence: a refresh is in flight, `fullRefresh` is called, and the
+  request must still be there when the in-flight pass ends. **Verified to fail** against the old
+  drop-behaviour and pass with the fix.
+- `refreshRequestedWhileRunningIsServicedByTheRunningRefresh`,
+  `repeatedRequestsDuringOnePassCollapseIntoASingleFurtherPass`,
+  `requestArrivingAfterTheRefreshFinishedIsRunByTheCaller` - state-machine transitions.
+- `concurrentWritersLeaveTheViewReflectingEveryCommit` - end-to-end convergence under 4 concurrent
+  writers. Note this one passes against the old code too (the race needs load to surface), so it
+  guards against deadlock or a non-terminating drain loop rather than against the original defect.
+
+## Verification
+
+| Suite | Result |
+|---|---|
+| `engine` `MaterializedView*` (7 classes) | 61 pass |
+| `engine` `com.arcadedb.schema.*Test` | 310 pass |
+| `server` `HTTPMaterializedViewIT`, `RemoteMaterializedViewIT`, `Issue3941AsyncRefreshMaterializedViewIT` | 11 pass |
+| `ha-raft` `RaftReplicationMaterializedViewIT` | 1 pass |

--- a/docs/5492-materialized-view-refresh-coalescing.md
+++ b/docs/5492-materialized-view-refresh-coalescing.md
@@ -170,6 +170,36 @@ under sustained single-record load.
 
 `gemini-code-assist` again did not respond.
 
+### Cycle 3 - `4c45fa490`
+
+`claude[bot]` again reported nothing blocking, and independently verified the coalesced-pass snapshot
+ordering (the pass that clears `RUNNING_PENDING` is pass K; the pass that re-reads source data is
+K+1, whose transaction begins after the flag was set, so every committed record is seen by some later
+pass). One wording fix taken: the discard WARNING named `ERROR`, but
+`MaterializedViewChangeListener` overwrites the status with `STALE` afterwards, so the message named
+a state the operator never sees. It now says "left non-VALID and stale".
+
+Two items raised and deliberately **not** fixed here:
+
+- **The drain loop runs synchronously on the committing thread.** After-commit callbacks fire on the
+  committing thread, so one unlucky writer can be pinned running repeated full rebuilds on behalf of
+  the others, unbounded while writes keep arriving. This is strictly better than dropping the
+  requests, but it concentrates unbounded work on a user commit path. Moving the refresh onto
+  `DatabaseAsyncExecutor` or a dedicated bounded pool (per the concurrency guidance in `CLAUDE.md`)
+  would keep the coalescing and get it off the hot path. Worth its own issue.
+- **`ContinuousAggregate` has the identical defect.** `ContinuousAggregateImpl` still uses the
+  `AtomicBoolean` drop-on-contention guard, and `ContinuousAggregateRefresher.incrementalRefresh` is
+  driven post-commit from `SaveElementStep.java:154-156` - the same shape as the materialized view
+  listener, so the same silent staleness. Verified, not fixed here: it needs its own tests, and the
+  same three-state primitives port over mechanically.
+
+Declined as optional: a test asserting end-to-end re-convergence after a discarded request. Forcing a
+refresh to fail deterministically needs either a droppable source type (blocked - dropping the source
+of a view is rejected) or a view constructed outside the schema with a deliberately invalid query,
+which tests the fixture more than the behaviour. The state-machine level recovery (ownership released,
+next caller takes it) is already covered.
+
 ### Final state
 
-`clean-approval` - the last review raised no blocking items and the only follow-ups were comments.
+`clean-approval` - the last two reviews raised no blocking items and the only follow-ups were
+comments and wording.

--- a/docs/5492-materialized-view-refresh-coalescing.md
+++ b/docs/5492-materialized-view-refresh-coalescing.md
@@ -147,3 +147,29 @@ on others' behalf. Inherent to full-refresh-per-change, strictly better than the
 and genuinely addressed only by true incremental maintenance, which is out of scope here.
 
 `gemini-code-assist` did not respond within the polling window.
+
+### Cycle 2 - `f98df0708`
+
+`claude[bot]` reported nothing blocking and independently walked the caller-run fallback
+(`markRefreshPendingIfRunning()` returns `false` then `tryBeginRefresh()` succeeds), confirming the
+new owner's snapshot necessarily includes the requesting thread's committed record. Three
+comment-only nits taken:
+
+1. The unreachable third branch of `finishRefreshPassAndCheckPending()` still pointed at
+   `endRefresh()` as the error-path release, which it no longer is. Reworded as the defensive guard
+   it actually is.
+2. `endRefresh()` is public and releases with a plain write, so it silently discards a pending
+   request - the class of bug this change removes elsewhere. It stays for the existing guard tests,
+   with javadoc steering callers to the two CAS releases.
+3. `newView(...)` builds a view over a type that does not exist; noted that this is fine because the
+   state-machine tests never run a refresh.
+
+Noted without action, both already covered above: the weaker recovery guarantee for non-INTERVAL
+views after a discarded request (mitigated by the visible non-VALID status), and owner starvation
+under sustained single-record load.
+
+`gemini-code-assist` again did not respond.
+
+### Final state
+
+`clean-approval` - the last review raised no blocking items and the only follow-ups were comments.

--- a/docs/5492-materialized-view-refresh-coalescing.md
+++ b/docs/5492-materialized-view-refresh-coalescing.md
@@ -1,8 +1,10 @@
 # Issue #5492 - a dropped materialized view refresh leaves the view permanently stale
 
 - Issue: https://github.com/ArcadeData/arcadedb/issues/5492
+- PR: https://github.com/ArcadeData/arcadedb/pull/5502 (refs #5492, does **not** close it)
+- Split out: https://github.com/ArcadeData/arcadedb/issues/5503
 - Branch: `fix/5492-ha-mv-page-version-replication-gap`
-- Base: `main` at f7ee51d01
+- Base: `main` at d3cb57b9f
 
 ## Scope
 
@@ -115,3 +117,33 @@ actually was.
 | `engine` `com.arcadedb.schema.*Test` | 310 pass |
 | `server` `HTTPMaterializedViewIT`, `RemoteMaterializedViewIT`, `Issue3941AsyncRefreshMaterializedViewIT` | 11 pass |
 | `ha-raft` `RaftReplicationMaterializedViewIT` | 1 pass |
+
+## Review cycles
+
+### Cycle 1 - `e23c1947c`
+
+`claude[bot]` raised three items. All resolved.
+
+1. **Two unrelated MCP hybrid_search doc files in the diff.** Real, but not added by this work: the
+   branch was cut from a local `main` carrying two unpushed commits (`f7ee51d01`, `a1959e343`), so
+   they showed up in the diff against `origin/main`. Resolved by rebasing onto `origin/main` with the
+   author's explicit authorization to force-push; the branch now carries only this work's commits.
+2. **The error path could still drop a pending request.** Correct, and the sharper form of the very
+   bug being fixed: `endRefresh()` did a plain `set(REFRESH_IDLE)`, clobbering a request registered
+   during a failing pass. Fixed by `releaseRefreshAfterFailure()`, which CASes the release and reports
+   whether a request was discarded. The request is deliberately not retried - a pass that just failed
+   would likely fail again, and retrying a persistent failure would spin - so the discard is logged at
+   WARNING and the view is left in a non-VALID status, making the staleness visible rather than
+   silent. Covered by `aFailedPassReportsTheRequestItDiscardsInsteadOfClobberingIt`, verified to fail
+   against the plain-write release.
+3. **Tag the end-to-end test slow.** Applied `@Tag("slow")` at method level.
+
+Declined: dropping `docs/5492-...md`. `docs/NNNN-*.md` is the established per-issue convention in this
+repo, and this file records the negative result on the replication half, which the PR description only
+summarizes.
+
+Noted without action: under sustained single-record load one writer thread can bear repeated rebuilds
+on others' behalf. Inherent to full-refresh-per-change, strictly better than the previous behaviour,
+and genuinely addressed only by true incremental maintenance, which is out of scope here.
+
+`gemini-code-assist` did not respond within the polling window.

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewImpl.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewImpl.java
@@ -188,6 +188,28 @@ public class MaterializedViewImpl implements MaterializedView {
     }
   }
 
+  /**
+   * Releases ownership after a pass that failed. Returns {@code true} if a request had been
+   * registered during that pass and is therefore being discarded.
+   * <p>
+   * The release is a CAS rather than a plain write for the same reason as
+   * {@link #finishRefreshPassAndCheckPending()}: a plain write would clobber a request registered
+   * concurrently, losing it without the requester ever learning. The request is not retried here - a
+   * pass that just failed would most likely fail again, and retrying a persistent failure would spin -
+   * so the caller reports the discard and leaves the view in a non-VALID status, making the staleness
+   * visible instead of silent.
+   */
+  public boolean releaseRefreshAfterFailure() {
+    while (true) {
+      if (refreshState.compareAndSet(REFRESH_RUNNING, REFRESH_IDLE))
+        return false;
+      if (refreshState.compareAndSet(REFRESH_RUNNING_PENDING, REFRESH_IDLE))
+        return true;
+      if (refreshState.get() == REFRESH_IDLE)
+        return false;
+    }
+  }
+
   @Override
   public long getRefreshCount() {
     return refreshCount.get();

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewImpl.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewImpl.java
@@ -25,7 +25,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class MaterializedViewImpl implements MaterializedView {
@@ -33,6 +33,13 @@ public class MaterializedViewImpl implements MaterializedView {
   private final String name;
   private final String query;
   private final String backingTypeName;
+  /** No refresh running. */
+  private static final int REFRESH_IDLE            = 0;
+  /** A refresh is running and no further one has been requested. */
+  private static final int REFRESH_RUNNING         = 1;
+  /** A refresh is running and at least one more was requested while it ran. */
+  private static final int REFRESH_RUNNING_PENDING = 2;
+
   private final List<String> sourceTypeNames;
   private final MaterializedViewRefreshMode refreshMode;
   private final boolean simpleQuery;
@@ -40,7 +47,7 @@ public class MaterializedViewImpl implements MaterializedView {
   private volatile long lastRefreshTime;
   private volatile MaterializedViewStatus status;
   private volatile MaterializedViewChangeListener changeListener;
-  private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
+  private final AtomicInteger refreshState = new AtomicInteger(REFRESH_IDLE);
 
   // Runtime metrics (not persisted)
   private final AtomicLong refreshCount         = new AtomicLong(0);
@@ -136,11 +143,49 @@ public class MaterializedViewImpl implements MaterializedView {
 
   /** Atomically marks refresh as in-progress. Returns {@code true} if successful, {@code false} if already running. */
   public boolean tryBeginRefresh() {
-    return refreshInProgress.compareAndSet(false, true);
+    return refreshState.compareAndSet(REFRESH_IDLE, REFRESH_RUNNING);
   }
 
   public void endRefresh() {
-    refreshInProgress.set(false);
+    refreshState.set(REFRESH_IDLE);
+  }
+
+  /**
+   * Records that a refresh was requested while another was already running, so the running refresh
+   * makes a further pass instead of the request being dropped. Returns {@code false} if no refresh is
+   * running any more, in which case the caller must run the refresh itself.
+   */
+  public boolean markRefreshPendingIfRunning() {
+    while (true) {
+      final int state = refreshState.get();
+      if (state == REFRESH_IDLE)
+        return false;
+      if (state == REFRESH_RUNNING_PENDING)
+        return true;
+      if (refreshState.compareAndSet(REFRESH_RUNNING, REFRESH_RUNNING_PENDING))
+        return true;
+    }
+  }
+
+  /**
+   * Ends one refresh pass. Returns {@code true} if a request arrived while that pass was running, in
+   * which case ownership is retained and the caller must make another pass; otherwise ownership is
+   * released and {@code false} is returned.
+   * <p>
+   * Releasing ownership and testing for a pending request must be one atomic step: if they were
+   * separate, a request registered in between would be seen by neither the outgoing owner nor the
+   * requester (which observed the refresh as still running), and the view would stay stale forever.
+   */
+  public boolean finishRefreshPassAndCheckPending() {
+    while (true) {
+      if (refreshState.compareAndSet(REFRESH_RUNNING, REFRESH_IDLE))
+        return false;
+      if (refreshState.compareAndSet(REFRESH_RUNNING_PENDING, REFRESH_RUNNING))
+        return true;
+      if (refreshState.get() == REFRESH_IDLE)
+        // Ownership was already released (endRefresh on an error path); nothing left to drain.
+        return false;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewImpl.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewImpl.java
@@ -146,6 +146,14 @@ public class MaterializedViewImpl implements MaterializedView {
     return refreshState.compareAndSet(REFRESH_IDLE, REFRESH_RUNNING);
   }
 
+  /**
+   * Releases ownership unconditionally, discarding any pending request without reporting it.
+   * <p>
+   * Prefer {@link #finishRefreshPassAndCheckPending()} (success) or
+   * {@link #releaseRefreshAfterFailure()} (failure): both release with a CAS, so a request registered
+   * concurrently is either serviced or reported. This method overwrites such a request silently,
+   * which is the defect coalescing exists to prevent, so use it only where no coalescing is in play.
+   */
   public void endRefresh() {
     refreshState.set(REFRESH_IDLE);
   }
@@ -183,7 +191,8 @@ public class MaterializedViewImpl implements MaterializedView {
       if (refreshState.compareAndSet(REFRESH_RUNNING_PENDING, REFRESH_RUNNING))
         return true;
       if (refreshState.get() == REFRESH_IDLE)
-        // Ownership was already released (endRefresh on an error path); nothing left to drain.
+        // Defensive: the owner is the only thread that moves RUNNING/RUNNING_PENDING back to IDLE,
+        // so this is unreachable while ownership is held. Stop rather than spin if it ever is.
         return false;
     }
   }

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
@@ -59,10 +59,16 @@ public class MaterializedViewRefresher {
       view.recordRefreshError();
       view.setStatus(MaterializedViewStatus.ERROR);
       // Ownership is released here rather than in a finally: the success path already released it,
-      // atomically with the check for a pending request.
-      view.endRefresh();
+      // atomically with the check for a pending request. This release is a CAS too, so a request
+      // registered during the failing pass is discarded deliberately rather than clobbered - the
+      // status above leaves that staleness visible instead of silent.
+      final boolean discardedPendingRequest = view.releaseRefreshAfterFailure();
       LogManager.instance().log(MaterializedViewRefresher.class, Level.SEVERE,
           "Error refreshing materialized view '%s': %s", e, view.getName(), e.getMessage());
+      if (discardedPendingRequest)
+        LogManager.instance().log(MaterializedViewRefresher.class, Level.WARNING,
+            "A refresh requested during the failed refresh of materialized view '%s' was not run; the view is left in status %s",
+            null, view.getName(), view.getStatus());
       throw e;
     }
   }

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
@@ -30,51 +30,67 @@ public class MaterializedViewRefresher {
 
   public static void fullRefresh(final Database database, final MaterializedViewImpl view) {
     if (!view.tryBeginRefresh()) {
-      LogManager.instance().log(MaterializedViewRefresher.class, Level.FINE,
-          "Skipping concurrent refresh for materialized view '%s' — already in progress", null, view.getName());
-      return;
+      // A refresh is already running. Hand it our request so it makes a further pass over the
+      // now-newer source data: simply returning here left the view reflecting a snapshot taken
+      // before this caller's commit, with nothing scheduled to ever correct it.
+      if (view.markRefreshPendingIfRunning()) {
+        LogManager.instance().log(MaterializedViewRefresher.class, Level.FINE,
+            "Refresh for materialized view '%s' already in progress, requested a further pass", null, view.getName());
+        return;
+      }
+      // It finished between the two calls, so there is nobody left to service the request: run it here.
+      if (!view.tryBeginRefresh())
+        return;
     }
-    view.setStatus(MaterializedViewStatus.BUILDING);
-    final long startNs = System.nanoTime();
+
     try {
-      final String backingTypeName = view.getBackingTypeName();
+      do {
+        view.setStatus(MaterializedViewStatus.BUILDING);
+        final long startNs = System.nanoTime();
 
-      // Use joinCurrentTx=false to always create a dedicated transaction for the refresh.
-      // This ensures changes are committed immediately even when called from an async context
-      // (e.g. HTTP API with awaitResponse=false), where a long-running batched transaction
-      // would otherwise defer the commit indefinitely.
-      // See: https://github.com/ArcadeData/arcadedb/issues/3941
-      database.transaction(() -> {
-        // Truncate existing data, faster than DELETE FROM (no per-record WAL entries).
-        database.command("sql", "TRUNCATE TYPE `" + backingTypeName + "` UNSAFE").close();
+        refreshOnce(database, view);
 
-        // Execute the defining query and insert results
-        try (final ResultSet rs = database.query("sql", view.getQuery())) {
-          while (rs.hasNext()) {
-            final Result result = rs.next();
-            final MutableDocument doc = database.newDocument(backingTypeName);
-            for (final String prop : result.getPropertyNames()) {
-              if (!prop.startsWith("@"))
-                doc.set(prop, result.getProperty(prop));
-            }
-            doc.save();
-          }
-        }
-      }, false);
-
-      final long durationMs = (System.nanoTime() - startNs) / 1_000_000;
-      view.recordRefreshSuccess(durationMs);
-      view.updateLastRefreshTime();
-      view.setStatus(MaterializedViewStatus.VALID);
+        view.recordRefreshSuccess((System.nanoTime() - startNs) / 1_000_000);
+        view.updateLastRefreshTime();
+        view.setStatus(MaterializedViewStatus.VALID);
+      } while (view.finishRefreshPassAndCheckPending());
 
     } catch (final Exception e) {
       view.recordRefreshError();
       view.setStatus(MaterializedViewStatus.ERROR);
+      // Ownership is released here rather than in a finally: the success path already released it,
+      // atomically with the check for a pending request.
+      view.endRefresh();
       LogManager.instance().log(MaterializedViewRefresher.class, Level.SEVERE,
           "Error refreshing materialized view '%s': %s", e, view.getName(), e.getMessage());
       throw e;
-    } finally {
-      view.endRefresh();
     }
+  }
+
+  private static void refreshOnce(final Database database, final MaterializedViewImpl view) {
+    final String backingTypeName = view.getBackingTypeName();
+
+    // Use joinCurrentTx=false to always create a dedicated transaction for the refresh.
+    // This ensures changes are committed immediately even when called from an async context
+    // (e.g. HTTP API with awaitResponse=false), where a long-running batched transaction
+    // would otherwise defer the commit indefinitely.
+    // See: https://github.com/ArcadeData/arcadedb/issues/3941
+    database.transaction(() -> {
+      // Truncate existing data, faster than DELETE FROM (no per-record WAL entries).
+      database.command("sql", "TRUNCATE TYPE `" + backingTypeName + "` UNSAFE").close();
+
+      // Execute the defining query and insert results
+      try (final ResultSet rs = database.query("sql", view.getQuery())) {
+        while (rs.hasNext()) {
+          final Result result = rs.next();
+          final MutableDocument doc = database.newDocument(backingTypeName);
+          for (final String prop : result.getPropertyNames()) {
+            if (!prop.startsWith("@"))
+              doc.set(prop, result.getProperty(prop));
+          }
+          doc.save();
+        }
+      }
+    }, false);
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
@@ -66,9 +66,12 @@ public class MaterializedViewRefresher {
       LogManager.instance().log(MaterializedViewRefresher.class, Level.SEVERE,
           "Error refreshing materialized view '%s': %s", e, view.getName(), e.getMessage());
       if (discardedPendingRequest)
+        // Deliberately does not name the status: callers layer their own on top of the ERROR set
+        // above (MaterializedViewChangeListener overwrites it with STALE), so naming one here would
+        // report a state the operator never sees.
         LogManager.instance().log(MaterializedViewRefresher.class, Level.WARNING,
-            "A refresh requested during the failed refresh of materialized view '%s' was not run; the view is left in status %s",
-            null, view.getName(), view.getStatus());
+            "A refresh requested during the failed refresh of materialized view '%s' was not run; the view is left non-VALID and stale",
+            null, view.getName());
       throw e;
     }
   }

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -101,6 +102,28 @@ class MaterializedViewConcurrentRefreshTest extends TestHelper {
     }
   }
 
+  /**
+   * A pass that fails must not silently swallow a request registered while it ran: releasing
+   * ownership with a plain write would clobber it, leaving the view stale with nobody aware.
+   */
+  @Test
+  void aFailedPassReportsTheRequestItDiscardsInsteadOfClobberingIt() {
+    final MaterializedViewImpl view = newView("FailedPassView");
+
+    assertThat(view.tryBeginRefresh()).isTrue();
+    assertThat(view.markRefreshPendingIfRunning()).isTrue();
+
+    assertThat(view.releaseRefreshAfterFailure())
+        .as("the discarded request must be reported, not silently dropped").isTrue();
+    assertThat(view.tryBeginRefresh()).as("ownership must still be released").isTrue();
+    view.endRefresh();
+
+    // With no request outstanding there is nothing to report.
+    assertThat(view.tryBeginRefresh()).isTrue();
+    assertThat(view.releaseRefreshAfterFailure()).isFalse();
+  }
+
+  @Tag("slow")
   @Test
   void concurrentWritersLeaveTheViewReflectingEveryCommit() throws Exception {
     database.transaction(() -> database.getSchema().createDocumentType("ConcurrentSource"));

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A refresh requested while another is already running used to be dropped, which left the view
+ * reflecting a snapshot taken before the requesting transaction committed, with nothing scheduled to
+ * ever correct it. Requests are now coalesced onto the running refresh instead.
+ */
+class MaterializedViewConcurrentRefreshTest extends TestHelper {
+
+  @Test
+  void refreshRequestedWhileRunningIsServicedByTheRunningRefresh() {
+    final MaterializedViewImpl view = newView("PendingGuardView");
+
+    assertThat(view.tryBeginRefresh()).as("the first caller owns the refresh").isTrue();
+
+    // A second caller arrives while the first is still running.
+    assertThat(view.markRefreshPendingIfRunning()).as("the request is handed to the running refresh").isTrue();
+
+    // The owner must therefore make a further pass before releasing.
+    assertThat(view.finishRefreshPassAndCheckPending()).as("a pending request forces another pass").isTrue();
+    assertThat(view.finishRefreshPassAndCheckPending()).as("no request left, ownership released").isFalse();
+
+    assertThat(view.tryBeginRefresh()).as("ownership was released").isTrue();
+    view.endRefresh();
+  }
+
+  @Test
+  void repeatedRequestsDuringOnePassCollapseIntoASingleFurtherPass() {
+    final MaterializedViewImpl view = newView("CoalesceView");
+
+    assertThat(view.tryBeginRefresh()).isTrue();
+    for (int i = 0; i < 5; i++)
+      assertThat(view.markRefreshPendingIfRunning()).isTrue();
+
+    assertThat(view.finishRefreshPassAndCheckPending()).as("five requests collapse into one pass").isTrue();
+    assertThat(view.finishRefreshPassAndCheckPending()).isFalse();
+  }
+
+  @Test
+  void requestArrivingAfterTheRefreshFinishedIsRunByTheCaller() {
+    final MaterializedViewImpl view = newView("NoOwnerView");
+
+    // Nothing is running, so there is nobody to hand the request to and the caller must run it.
+    assertThat(view.markRefreshPendingIfRunning()).isFalse();
+  }
+
+  /**
+   * Drives the exact interleaving of the defect with no timing dependence: a refresh is in flight,
+   * a commit asks for another one, and that request must still be there when the in-flight refresh
+   * finishes its pass. Dropping it is what left the view stale forever.
+   */
+  @Test
+  void refresherRegistersItsRequestWhenAnotherRefreshIsInFlight() {
+    database.transaction(() -> database.getSchema().createDocumentType("InFlightSource"));
+    database.transaction(() -> database.getSchema().buildMaterializedView()
+        .withName("InFlightView")
+        .withQuery("SELECT value FROM InFlightSource")
+        .create());
+
+    final MaterializedViewImpl view = (MaterializedViewImpl) database.getSchema().getMaterializedView("InFlightView");
+
+    // Stand in for a refresh that is already running.
+    assertThat(view.tryBeginRefresh()).isTrue();
+    try {
+      MaterializedViewRefresher.fullRefresh(database, view);
+
+      assertThat(view.finishRefreshPassAndCheckPending())
+          .as("the in-flight refresh must be told to make another pass, not have the request dropped")
+          .isTrue();
+    } finally {
+      view.endRefresh();
+    }
+  }
+
+  @Test
+  void concurrentWritersLeaveTheViewReflectingEveryCommit() throws Exception {
+    database.transaction(() -> database.getSchema().createDocumentType("ConcurrentSource"));
+
+    database.transaction(() -> database.getSchema().buildMaterializedView()
+        .withName("ConcurrentSourceView")
+        .withQuery("SELECT value FROM ConcurrentSource")
+        .withRefreshMode(MaterializedViewRefreshMode.INCREMENTAL)
+        .create());
+
+    final int threads = 4;
+    final int perThread = 40;
+    final CountDownLatch start = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(threads);
+    final AtomicReference<Exception> failure = new AtomicReference<>();
+
+    for (int t = 0; t < threads; t++) {
+      final int threadId = t;
+      new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < perThread; i++) {
+            final int value = threadId * perThread + i;
+            database.transaction(() -> database.newDocument("ConcurrentSource").set("value", value).save());
+          }
+        } catch (final Exception e) {
+          failure.compareAndSet(null, e);
+        } finally {
+          done.countDown();
+        }
+      }, "mv-refresh-writer-" + t).start();
+    }
+
+    start.countDown();
+    assertThat(done.await(2, TimeUnit.MINUTES)).as("writers should finish").isTrue();
+    if (failure.get() != null)
+      throw failure.get();
+
+    final int expected = threads * perThread;
+    assertThat(countOf("ConcurrentSource")).isEqualTo(expected);
+
+    // The last commit's refresh request is either run by its own caller or coalesced onto the
+    // in-flight refresh; either way a pass starts after that commit, so the view converges.
+    assertThat(awaitViewCount("ConcurrentSourceView", expected))
+        .as("the view must eventually reflect every committed record, not a stale earlier snapshot")
+        .isEqualTo(expected);
+  }
+
+  private MaterializedViewImpl newView(final String name) {
+    return new MaterializedViewImpl(database, name, "SELECT value FROM Foo", name, List.of("Foo"),
+        MaterializedViewRefreshMode.MANUAL, true, 0);
+  }
+
+  private long countOf(final String typeName) {
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS cnt FROM " + typeName)) {
+      return rs.next().<Number>getProperty("cnt").longValue();
+    }
+  }
+
+  private long awaitViewCount(final String viewName, final long expected) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + 60_000;
+    long count = countOf(viewName);
+    while (count != expected && System.currentTimeMillis() < deadline) {
+      Thread.sleep(100);
+      count = countOf(viewName);
+    }
+    return count;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java
@@ -172,6 +172,10 @@ class MaterializedViewConcurrentRefreshTest extends TestHelper {
         .isEqualTo(expected);
   }
 
+  /**
+   * Builds a view over a type that does not exist. That is fine for the state-machine tests: they
+   * exercise the ownership transitions directly and never run an actual refresh.
+   */
   private MaterializedViewImpl newView(final String name) {
     return new MaterializedViewImpl(database, name, "SELECT value FROM Foo", name, List.of("Foo"),
         MaterializedViewRefreshMode.MANUAL, true, 0);


### PR DESCRIPTION
Refs #5492. **Deliberately does not close it** - see Scope.

## Scope

Issue #5492 bundles two defects. This PR fixes the second one only.

| Defect | Status |
|---|---|
| A refresh arriving while another is in flight is dropped, not queued, so the view can be silently stale | **Fixed here** |
| The leader ships page versions followers never received (`WALVersionGapException`, snapshot-resync loop, lost writes) | **Not fixed - not reproduced** |

The issue records the replication root cause as "not yet proven". It still is. A 3-node in-process Raft harness (`BaseRaftHATest`, whose consistency check already routes through `DatabaseComparator` and fails on any cross-node page-version mismatch) produced **zero** `WALVersionGapException` and zero resync loops across every configuration tried - writes on the leader, writes through a follower, with and without a UNIQUE index on the source type, 180 and 450 records. Shipping a speculative change to the Raft commit path without a reproduction would risk making a data-loss bug worse, so that half stays open.

## The defect fixed here

`MaterializedViewRefresher.fullRefresh` began with `if (!view.tryBeginRefresh()) return;`.

The refresh is triggered from a post-commit callback, so the dropped request belongs to a transaction that has **already committed**. The in-flight refresh it deferred to started before that commit and therefore reads a snapshot without it. Nothing reschedules, so the view stays missing that record until some later write happens to win the race - or forever.

No HA is needed to hit this: a 3-node run showed the **leader's own** view holding 449 of 450 committed records.

It also explains part of the throughput collapse in the issue's A/B table - every committing transaction schedules a full `TRUNCATE` + re-run of the defining query, so under single-record transactions the work degenerates towards a full rebuild per row.

## Fix

Requests are coalesced onto the running refresh. `MaterializedViewImpl` replaces the `AtomicBoolean` with a three-state `AtomicInteger` (`IDLE` / `RUNNING` / `RUNNING_PENDING`) and adds:

- `markRefreshPendingIfRunning()` - hands a request to the running refresh; returns `false` if none is running, so the caller runs it itself.
- `finishRefreshPassAndCheckPending()` - ends one pass, returning `true` if a request arrived during it (another pass required), else releasing ownership.

Releasing ownership and testing for a pending request is **one atomic step**. Split in two, a request registered in between would be seen by neither the outgoing owner nor the requester (which observed the refresh as still running) - the same lost-wakeup the original code had unconditionally.

`tryBeginRefresh()` and `endRefresh()` keep their existing contracts, so the existing guard tests are untouched.

## Deliberately not done

True incremental view maintenance. `MaterializedViewChangeListener` still schedules a full refresh regardless of `REFRESH INCREMENTAL`, as its comment says. Per-record maintenance is a feature with real correctness risk (wrong view contents rather than slow ones), not a bug fix. Coalescing already removes the redundant rebuilds, which is where the cost was.

## Also found, not addressed here

- `RaftReplicatedDatabase.recordFileChanges` drains buffered WAL into `walEntries` but omits it from the replication guard, and the `finally` then clears the buffer. Its sibling `runWithCompactionReplication` guards correctly. Left alone for lack of a reproduction from the view path.
- Concurrent single-record transactions issued **through a follower** lose 60-70% of records and log `Invalid record size ... deleting record`. The A/B control with no materialized view fails identically, so it is unrelated to views. Being filed separately.

## Test plan

- [x] `refresherRegistersItsRequestWhenAnotherRefreshIsInFlight` is the regression guard: it drives the exact interleaving with no timing dependence, and was **verified to fail** against the old drop-behaviour and pass with the fix.
- [x] Three state-machine transition tests (hand-off, coalescing of repeated requests, caller-runs when nothing is in flight).
- [x] `concurrentWritersLeaveTheViewReflectingEveryCommit` end-to-end convergence under 4 writers. Note this one passes against the old code too (the race needs load to surface), so it guards against deadlock or a non-terminating drain loop rather than the original defect.
- [x] `engine` `MaterializedView*` - 61 pass
- [x] `engine` `com.arcadedb.schema.*Test` - 310 pass
- [x] `server` `HTTPMaterializedViewIT`, `RemoteMaterializedViewIT`, `Issue3941AsyncRefreshMaterializedViewIT` - 11 pass
- [x] `ha-raft` `RaftReplicationMaterializedViewIT` - 1 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)