### PR TITLE
fix: throw ArithmeticException on abs(Long.MIN_VALUE) overflow (#5494)

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/math/AbsFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/math/AbsFunction.java
@@ -40,8 +40,12 @@ public class AbsFunction implements StatelessFunction {
       throw new CommandExecutionException("abs() requires exactly one argument");
     if (args[0] == null)
       return null;
-    if (args[0] instanceof Byte || args[0] instanceof Short || args[0] instanceof Integer || args[0] instanceof Long)
-      return Math.abs(((Number) args[0]).longValue());
+    if (args[0] instanceof Byte || args[0] instanceof Short || args[0] instanceof Integer || args[0] instanceof Long) {
+      final long val = ((Number) args[0]).longValue();
+      if (val == Long.MIN_VALUE)
+        throw new ArithmeticException("abs(Long.MIN_VALUE) overflow");
+      return Math.abs(val);
+    }
     if (args[0] instanceof Number)
       return Math.abs(((Number) args[0]).doubleValue());
     throw new CommandExecutionException("abs() requires a numeric argument");

--- a/engine/src/main/java/com/arcadedb/function/math/AbsFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/math/AbsFunction.java
@@ -41,10 +41,13 @@ public class AbsFunction implements StatelessFunction {
     if (args[0] == null)
       return null;
     if (args[0] instanceof Byte || args[0] instanceof Short || args[0] instanceof Integer || args[0] instanceof Long) {
-      final long val = ((Number) args[0]).longValue();
-      if (val == Long.MIN_VALUE)
-        throw new ArithmeticException("abs(Long.MIN_VALUE) overflow");
-      return Math.abs(val);
+      try {
+        // absExact() fails on Long.MIN_VALUE, whose magnitude is not representable in a signed 64-bit
+        // integer and which Math.abs() would silently return unchanged - a negative "absolute value".
+        return Math.absExact(((Number) args[0]).longValue());
+      } catch (final ArithmeticException e) {
+        throw new CommandExecutionException("long overflow", e);
+      }
     }
     if (args[0] instanceof Number)
       return Math.abs(((Number) args[0]).doubleValue());

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
@@ -54,6 +54,8 @@ public class SQLFunctionAbsoluteValue extends SQLFunctionMathAbstract {
     } else if (inputValue instanceof Integer integer) {
       result = Math.abs(integer);
     } else if (inputValue instanceof Long long1) {
+      if (long1 == Long.MIN_VALUE)
+        throw new ArithmeticException("abs(Long.MIN_VALUE) overflow");
       result = Math.abs(long1);
     } else if (inputValue instanceof Short short1) {
       result = (short) Math.abs(short1);

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.sql.math;
 
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.math.BigDecimal;
@@ -27,10 +28,14 @@ import java.time.Duration;
 
 /**
  * Evaluates the absolute value for numeric types.  The argument must be a
- * BigDecimal, BigInteger, Integer, Long, Double or a Float, or null.  If
- * null is passed in the result will be null.  Otherwise the result will
- * be the mathematical absolute value of the argument passed in and will be
- * of the same type that was passed in.
+ * BigDecimal, BigInteger, Byte, Short, Integer, Long, Double, Float or a
+ * Duration, or null.  If null is passed in the result will be null.
+ * Otherwise the result will be the mathematical absolute value of the
+ * argument passed in and will be of the same type that was passed in.
+ * <p>
+ * Because the result keeps the argument's type, every fixed-width signed type
+ * has exactly one input - its MIN_VALUE - whose magnitude it cannot represent;
+ * those fail the query rather than returning a negative "absolute value".
  *
  * @author Michael MacFadden
  */
@@ -52,13 +57,13 @@ public class SQLFunctionAbsoluteValue extends SQLFunctionMathAbstract {
     } else if (inputValue instanceof BigInteger integer) {
       result = integer.abs();
     } else if (inputValue instanceof Integer integer) {
-      result = Math.abs(integer);
+      result = (int) absExact(integer, Integer.MIN_VALUE, "integer");
     } else if (inputValue instanceof Long long1) {
-      if (long1 == Long.MIN_VALUE)
-        throw new ArithmeticException("abs(Long.MIN_VALUE) overflow");
-      result = Math.abs(long1);
+      result = absExact(long1, Long.MIN_VALUE, "long");
     } else if (inputValue instanceof Short short1) {
-      result = (short) Math.abs(short1);
+      result = (short) absExact(short1, Short.MIN_VALUE, "short");
+    } else if (inputValue instanceof Byte byte1) {
+      result = (byte) absExact(byte1, Byte.MIN_VALUE, "byte");
     } else if (inputValue instanceof Double double1) {
       result = Math.abs(double1);
     } else if (inputValue instanceof Float float1) {
@@ -76,6 +81,22 @@ public class SQLFunctionAbsoluteValue extends SQLFunctionMathAbstract {
     }
 
     return getResult();
+  }
+
+  /**
+   * Every fixed-width signed integer type has exactly one value - its MIN_VALUE - whose magnitude it
+   * cannot represent. {@code Math.abs()} wraps around and returns that value unchanged, so the caller
+   * receives a negative "absolute value" that looks valid and can be persisted. Fail the query
+   * instead, using the same wording as the Cypher arithmetic operators.
+   *
+   * @param value    the input widened to a long, so one guard serves byte, short, int and long
+   * @param minValue the MIN_VALUE of the input's own type, which is the only unrepresentable input
+   * @param typeName the input's type as it appears in the error message
+   */
+  private static long absExact(final long value, final long minValue, final String typeName) {
+    if (value == minValue)
+      throw new CommandExecutionException(typeName + " overflow");
+    return Math.abs(value);
   }
 
   public boolean aggregateResults() {

--- a/engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValueTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValueTest.java
@@ -19,7 +19,9 @@
 package com.arcadedb.function.sql.math;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -105,6 +107,26 @@ class SQLFunctionAbsoluteValueTest {
     assertThat((short) 10).isEqualTo(result);
   }
 
+  /**
+   * BYTE is a persisted ArcadeDB type, but this function had no branch for it at all, so
+   * {@code abs()} over a BYTE property failed with "Argument to absolute value must be a number".
+   */
+  @Test
+  void positiveByte() {
+    function.execute(null, null, null, new Object[] { (byte) 10 }, null);
+    final Object result = function.getResult();
+    assertThat(result instanceof Byte).isTrue();
+    assertThat(result).isEqualTo((byte) 10);
+  }
+
+  @Test
+  void negativeByte() {
+    function.execute(null, null, null, new Object[] { (byte) -10 }, null);
+    final Object result = function.getResult();
+    assertThat(result instanceof Byte).isTrue();
+    assertThat(result).isEqualTo((byte) 10);
+  }
+
   @Test
   void positiveDouble() {
     function.execute(null, null, null, new Object[] { 10.5D }, null);
@@ -174,11 +196,127 @@ class SQLFunctionAbsoluteValueTest {
     assertThatThrownBy(() -> function.execute(null, null, null, new Object[]{"abc"}, null)).isInstanceOf(IllegalArgumentException.class);
   }
 
+  /**
+   * Issue #5494. This function preserves the input type, so every fixed-width signed branch has a
+   * value whose magnitude it cannot represent: {@code Math.abs(MIN_VALUE)} wraps around and returns
+   * the negative input unchanged. Fail the query instead of returning a negative "absolute value".
+   */
+  @Test
+  void longMinValueOverflows() {
+    assertThatThrownBy(() -> function.execute(null, null, null, new Object[] { Long.MIN_VALUE }, null))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("long overflow");
+  }
+
+  @Test
+  void integerMinValueOverflows() {
+    assertThatThrownBy(() -> function.execute(null, null, null, new Object[] { Integer.MIN_VALUE }, null))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("integer overflow");
+  }
+
+  @Test
+  void shortMinValueOverflows() {
+    assertThatThrownBy(() -> function.execute(null, null, null, new Object[] { Short.MIN_VALUE }, null))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("short overflow");
+  }
+
+  @Test
+  void byteMinValueOverflows() {
+    assertThatThrownBy(() -> function.execute(null, null, null, new Object[] { Byte.MIN_VALUE }, null))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("byte overflow");
+  }
+
+  /**
+   * The guard must fire on exactly one value per type, never one early.
+   */
+  @Test
+  void minValuePlusOneIsStillComputedForEveryIntegralType() {
+    function.execute(null, null, null, new Object[] { Long.MIN_VALUE + 1 }, null);
+    assertThat(function.getResult()).isEqualTo(Long.MAX_VALUE);
+
+    function.execute(null, null, null, new Object[] { Integer.MIN_VALUE + 1 }, null);
+    assertThat(function.getResult()).isEqualTo(Integer.MAX_VALUE);
+
+    function.execute(null, null, null, new Object[] { (short) (Short.MIN_VALUE + 1) }, null);
+    assertThat(function.getResult()).isEqualTo(Short.MAX_VALUE);
+
+    function.execute(null, null, null, new Object[] { (byte) (Byte.MIN_VALUE + 1) }, null);
+    assertThat(function.getResult()).isEqualTo(Byte.MAX_VALUE);
+  }
+
+  /**
+   * Every numeric ArcadeDB {@link Type} must round-trip through {@code abs()} keeping its own type,
+   * so a future numeric type cannot silently fall through to the "not a number" error the way BYTE did.
+   */
+  @Test
+  void everyNumericTypeIsHandledAndKeepsItsType() {
+    final Object[] negatives = { (byte) -1, (short) -1, -1, -1L, -1.0F, -1.0D, new BigInteger("-1"), new BigDecimal("-1") };
+    final Class<?>[] expected = { Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, BigInteger.class,
+        BigDecimal.class };
+
+    for (int i = 0; i < negatives.length; i++) {
+      function.execute(null, null, null, new Object[] { negatives[i] }, null);
+      assertThat(function.getResult()).isInstanceOf(expected[i]);
+      assertThat(((Number) function.getResult()).intValue()).isEqualTo(1);
+    }
+  }
+
+  /**
+   * Arbitrary-precision types have no unrepresentable magnitude, so the guard must not leak into them.
+   */
+  @Test
+  void arbitraryPrecisionTypesAreUnaffected() {
+    function.execute(null, null, null, new Object[] { BigInteger.valueOf(Long.MIN_VALUE) }, null);
+    assertThat(function.getResult()).isEqualTo(BigInteger.valueOf(Long.MIN_VALUE).negate());
+
+    function.execute(null, null, null, new Object[] { new BigDecimal(BigInteger.valueOf(Long.MIN_VALUE)) }, null);
+    assertThat(function.getResult()).isEqualTo(new BigDecimal(BigInteger.valueOf(Long.MIN_VALUE).negate()));
+  }
+
   @Test
   void fromQuery() throws Exception {
     TestHelper.executeInNewDatabase("./target/databases/testAbsFunction", db -> {
       final ResultSet result = db.query("sql", "select abs(-45.4) as abs");
       assertThat(((Number) result.next().getProperty("abs")).floatValue()).isEqualTo(45.4F);
+    });
+  }
+
+  /**
+   * End-to-end through the SQL engine. A {@code Long.MIN_VALUE} literal cannot be used here: the SQL
+   * parser rejects it while reading the unsigned digits ("Invalid integer: 9223372036854775808"), so
+   * the value has to reach {@code abs()} as a stored property - which is also how it would arrive in
+   * a real query.
+   */
+  @Test
+  void fromQueryOverStoredLongMinValue() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testAbsFunctionOverflow", db -> {
+      db.getSchema().createDocumentType("Sample").createProperty("v", Type.LONG);
+      db.transaction(() -> db.newDocument("Sample").set("v", Long.MIN_VALUE).save());
+
+      assertThatThrownBy(() -> {
+        try (final ResultSet rs = db.query("sql", "select abs(v) as abs from Sample")) {
+          rs.next().getProperty("abs");
+        }
+      }).isInstanceOf(CommandExecutionException.class).hasMessageContaining("long overflow");
+    });
+  }
+
+  /**
+   * End-to-end witness for the missing BYTE branch: this query used to fail outright with
+   * "Argument to absolute value must be a number" on a perfectly ordinary BYTE column.
+   */
+  @Test
+  void fromQueryOverStoredByte() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testAbsFunctionByte", db -> {
+      db.getSchema().createDocumentType("Sample").createProperty("v", Type.BYTE);
+      db.transaction(() -> db.newDocument("Sample").set("v", (byte) -7).save());
+
+      try (final ResultSet rs = db.query("sql", "select abs(v) as abs from Sample")) {
+        assertThat(rs.next().<Byte>getProperty("abs")).isEqualTo((byte) 7);
+      }
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5494AbsOverflowTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5494AbsOverflowTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5494: {@code abs(-9223372036854775808)} silently returned its own
+ * negative input, because {@code -Long.MIN_VALUE} is not representable in two's-complement 64-bit
+ * arithmetic and {@code Math.abs()} wraps around instead of failing.
+ * <p>
+ * A silently negative "absolute value" is a wrong result that looks valid and can be persisted, so
+ * the query fails instead. This is the same contract the {@code +}, {@code -}, {@code *} and
+ * {@code Long.MIN_VALUE / -1} operators already implement in
+ * {@link com.arcadedb.query.opencypher.ast.ArithmeticExpression#integerArithmetic}: a
+ * {@code CommandExecutionException} carrying Neo4j's {@code long overflow} message.
+ */
+class Issue5494AbsOverflowTest extends TestHelper {
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      final Object value = rs.next().getProperty("v");
+      assertThat(rs.hasNext()).isFalse();
+      return value;
+    }
+  }
+
+  // ---- reporter's query ----
+
+  @Test
+  void absOfLongMinValueLiteralFailsInsteadOfReturningNegative() {
+    assertThatThrownBy(() -> single("RETURN abs(-9223372036854775808) AS v"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("long overflow");
+  }
+
+  /**
+   * The literal path and the stored-property path reach {@code abs()} through different evaluators,
+   * so both need a witness: a persisted Long.MIN_VALUE is how the wrong value would escape into
+   * user data in practice.
+   */
+  @Test
+  void absOfStoredLongMinValuePropertyFails() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Sample {v: $v})", Map.of("v", Long.MIN_VALUE)));
+
+    assertThatThrownBy(() -> single("MATCH (n:Sample) RETURN abs(n.v) AS v"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("long overflow");
+  }
+
+  // ---- the guard must not fire one value early ----
+
+  @Test
+  void absOfLongMinValuePlusOneIsStillComputed() {
+    assertThat(single("RETURN abs(-9223372036854775807) AS v")).isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
+  void absOfLongMaxValueIsStillComputed() {
+    assertThat(single("RETURN abs(9223372036854775807) AS v")).isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
+  void absKeepsWorkingOnOrdinaryValues() {
+    assertThat(single("RETURN abs(-5) AS v")).isEqualTo(5L);
+    assertThat(single("RETURN abs(0) AS v")).isEqualTo(0L);
+    assertThat(single("RETURN abs(null) AS v")).isNull();
+  }
+
+  /**
+   * FLOAT keeps IEEE 754 semantics: there is no unrepresentable magnitude, so the guard must not
+   * leak into the floating-point branch.
+   */
+  @Test
+  void absOfFloatsIsUnaffectedByTheIntegerGuard() {
+    assertThat(single("RETURN abs(-5.5) AS v")).isEqualTo(5.5);
+    assertThat(single("RETURN abs(-1.7976931348623157E308) AS v")).isEqualTo(Double.MAX_VALUE);
+  }
+
+  /**
+   * {@code abs()} must report overflow exactly like the arithmetic operators do (issue #5164), so a
+   * client can handle one error contract rather than two.
+   */
+  @Test
+  void absOverflowMatchesTheArithmeticOperatorContract() {
+    assertThatThrownBy(() -> single("RETURN 9223372036854775807 + 1 AS v"))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("long overflow");
+  }
+}


### PR DESCRIPTION
When `abs(Long.MIN_VALUE)` is called, `Math.abs(Long.MIN_VALUE)` silently returns `Long.MIN_VALUE` because `-Long.MIN_VALUE` overflows in signed 64-bit arithmetic. This affects both the Cypher `abs()` function and the SQL `abs()` function.

**Fix**: Add an explicit check for `Long.MIN_VALUE` before calling `Math.abs()`, and throw `ArithmeticException` when it occurs, matching Neo4j's behaviour.

**Files changed**:
- `engine/src/main/java/com/arcadedb/function/math/AbsFunction.java` — Cypher abs() function
- `engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java` — SQL abs() function

**Related**: https://github.com/ArcadeData/arcadedb/issues/5494