### PR TITLE
fix(#5503): lock the modified files on replicas and hold them until the local apply

### DIFF
--- a/docs/5503-follower-concurrent-tx-corruption.md
+++ b/docs/5503-follower-concurrent-tx-corruption.md
@@ -121,7 +121,21 @@ becoming flakier is a plausible - if unproven - interaction worth watching in CI
   round trip, so this is symmetric, but a write-heavy follower workload will see lower throughput and
   more retries. That is the correct trade against silent corruption; writes routed to the leader are
   unaffected.
+- **New failure mode for follower writers: `LockTimeoutException`.** Because the locks are now held across
+  the round trip and the apply wait, concurrent writers to the same bucket can exhaust
+  `COMMIT_LOCK_TIMEOUT` (5000 ms by default) where previously a replica took no locks at all. It is
+  retryable - `LockTimeoutException` extends `NeedRetryException`, as does
+  `ConcurrentModificationException` - but an application that only caught the latter on follower writes
+  will now see the former. Worth a release note.
 - `db.transaction(...)` on a follower now implies read-your-writes on that node, which it did not before.
+- **If the apply wait times out**, the locks are released with the local pages still behind, which is the
+  pre-#5503 condition. `waitForAppliedIndex` already logs, but as a READ_YOUR_WRITES *consistency*
+  warning, which reads like a stale-read risk rather than a corruption one; the replica branch therefore
+  logs its own WARNING naming the risk and pointing at state machine apply lag.
+- `lockFilesFromChanges()` includes `indexChanges.addFilesToLock(...)`, so replicas now take locks on index
+  files even though `indexChanges.commit()` stays leader-only. Harmless for correctness, and it keeps the
+  late-joiner union check consistent, but it is extra contention on index files for follower writes - and
+  another reason the `indexChanges`-on-replica question below deserves its own issue.
 - Not addressed here: `indexChanges.commit()` is still skipped on a replica, so it is worth confirming
   separately whether index entries for follower-originated writes are produced by the leader as the
   comment claims. That is orthogonal to this corruption and out of scope.

--- a/docs/5503-follower-concurrent-tx-corruption.md
+++ b/docs/5503-follower-concurrent-tx-corruption.md
@@ -1,0 +1,127 @@
+# #5503 - concurrent transactions on a shared follower handle corrupt records and lose writes
+
+## Symptom
+
+On a 3-node Raft cluster, several threads sharing one follower's embedded `Database` handle and issuing
+single-record transactions produced:
+
+```
+SEVER [LocalBucket] Invalid record size 570425357 for record #29:20: deleting record
+SEVER [LocalBucket] Error on reusing hole in page PageId(graph/29/0), invalid length 0
+```
+
+Every transaction reported success; a node ended up holding a third of them. Reproduced here at
+155/450 records with **zero** conflicts raised - no transaction was ever told it had lost a race.
+
+The same load against the leader, and single-threaded load against a follower, were both clean.
+
+## Root cause
+
+A replica captured its transaction in `TransactionContext.commit1stPhase(false)`, which deliberately
+skipped the per-file commit locks:
+
+```java
+} else
+  // IN CASE OF REPLICA THIS IS DEMANDED TO THE LEADER EXECUTION
+  lockedFiles = new ArrayList<>();
+```
+
+The page-version validation that follows (`PageManager.checkPageVersion`) still ran, but it is a
+check-then-act and the file lock is what makes it atomic. The assumption recorded in
+`PageManager.publishPages` was that "the single-threaded Raft apply provides the serialization" - but the
+apply only orders the **write** side. Nothing ordered the **capture** side, so:
+
+1. Threads A, B and C each load bucket page `v=N` and allocate a record into it.
+2. All three pass `checkPageVersion` against the local page manager, which still reports `N` - a replica
+   never runs phase 2, so its pages only change when the state machine applies.
+3. All three ship a WAL delta stamped `currentPageVersion = N+1`.
+4. `TransactionManager.applyChanges` applies A (`N` -> `N+1`), then meets B at **equal** version. Equal
+   version is not skipped: it re-applies, by design, because that path repairs torn writes (#4926).
+5. B's delta is a partial byte range computed against a page that no longer exists. Splicing it onto A's
+   page leaves a header, a slot table and record bytes from different transactions - hence the invalid
+   record sizes and the deleted records.
+
+Losing writes and corrupting pages are the same bug: step 4 both discards A's records and produces a
+physically inconsistent page.
+
+## Fix
+
+Two halves, both required.
+
+**1. `TransactionContext.commit1stPhase` - replicas take the commit locks too.** The lock acquisition
+(and the #4937 late-joiner union check that keeps it complete) is no longer gated on `isLeader`.
+`indexChanges.commit()` stays leader-only: that genuinely is the leader's job. This serializes local
+committers, so the second one now fails the version check with a retryable
+`ConcurrentModificationException` instead of shipping a colliding delta.
+
+**2. `RaftReplicatedDatabase` - hold those locks until the entry is applied locally.** Locking alone
+only moved the failure (155 -> 302 records): `reset()` released the locks as soon as the quorum acked,
+while this node's pages were still at `N`, so the next transaction took the lock and read a stale
+version anyway.
+
+The replica now waits for **its own** entry's log index before releasing. The existing
+`waitForLocalApply()` was not usable: it waits for the local commit index, which on a follower still
+trails the leader and therefore does not cover the entry just written. So the committed index is
+plumbed back from Ratis:
+
+- `RaftGroupCommitter.CancellablePendingEntry` gains a `volatile long logIndex`, published by the
+  flusher from `reply.getLogIndex()` before it completes the future.
+- `submitAndWait` and `RaftTransactionBroker.replicateTransaction` return it (-1 when unknown).
+- The replica branch calls `waitForAppliedIndex(committedLogIndex)`.
+
+On timeout the wait returns silently, degrading to the previous behaviour rather than failing a
+transaction the cluster has already committed.
+
+No deadlock: `applyChanges` takes no file locks, so the apply thread never waits on the committer.
+
+## Verification
+
+`Issue5503ConcurrentFollowerWritesIT` - 3 nodes, 3 threads x 150 single-record transactions through a
+follower handle, retrying `NeedRetryException` the way an application must. Asserts a scan count
+(`count(@rid)`, not the cached `count(*)` counter, which would hide a record deleted as malformed) and
+the full set of distinct values on **every** node.
+
+Both halves of the fix were shown to be load-bearing:
+
+| State | Records on a node | Conflicts raised | Corruption log lines |
+|---|---|---|---|
+| Before the fix | 155 / 450 | 0 | 200+ |
+| Locking only | 302 / 450 | 4 | many |
+| Locking + apply wait | 450 / 450 | some, all retried | 0 |
+
+Passed 3 consecutive runs.
+
+### Regression runs
+
+- **ha-raft unit tests**: 770 tests, 0 failures.
+- **ha-raft integration tests**: 69 tests across four targeted batches, 0 failures - the write-against-replica
+  and commit-path suites (`RaftEmbeddedWriteAgainstReplicaIT`, `RaftReplicationWriteAgainstReplicaIT`,
+  `Raft3PhaseCommitIT`, `Issue4740Phase2ReconcileIT`, `Issue4790PhantomCommitOriginSkipIT`,
+  `Issue5064CommittedRemotelyContractIT`, `Issue5410AbandonedTicketReleaseIT`, `OriginNodeSkipIT`), the
+  replication/concurrency/index suites (`RaftReplicationIT`, `RaftHTTPGraphConcurrentIT`,
+  `SuperNodeAppendHAConsistencyIT`, `Issue5381SlotMergeRaftIT`, `Issue5443FollowerIndexGapIT`,
+  `RaftIndexOperations3ServersIT`), the read-consistency suites that share `waitForAppliedIndex`, and the
+  crash/failover suites. The full 105-class IT suite was not run: it takes hours, and CLAUDE.md calls for
+  the connected tests rather than the whole suite.
+- **engine unit tests**: 10074 tests, 50 failures - **all pre-existing**, every one of them
+  `NoClassDefFoundError: org.graalvm.polyglot.Engine$ImplHolder` or "Query engine 'js' was not found".
+  Reproduced identically on a pristine worktree at `origin/main` (eb7739e9d), so the Graal JS language is
+  simply not loadable on this JDK. No transaction, bucket, locking or index test failed.
+
+`RaftDictionaryManyNewKeysIT.httpInsertContentWithProgressivelyMoreKeysOnFollower` failed once inside a
+batch with `DatabaseIsClosedException` (a shutdown race in the HTTP path), then passed on three
+subsequent runs including a re-run of the identical batch. Recorded as an observed flake rather than
+proven pre-existing: this fix does make follower writes slower, so a timing-sensitive follower-write test
+becoming flakier is a plausible - if unproven - interaction worth watching in CI.
+
+## Impact and follow-ups
+
+- Follower writes now hold per-file commit locks across the Raft round trip **and** the local apply, so
+  concurrent writers to the same bucket serialize. The leader already held its locks across its own
+  round trip, so this is symmetric, but a write-heavy follower workload will see lower throughput and
+  more retries. That is the correct trade against silent corruption; writes routed to the leader are
+  unaffected.
+- `db.transaction(...)` on a follower now implies read-your-writes on that node, which it did not before.
+- Not addressed here: `indexChanges.commit()` is still skipped on a replica, so it is worth confirming
+  separately whether index entries for follower-originated writes are produced by the leader as the
+  comment claims. That is orthogonal to this corruption and out of scope.

--- a/docs/5503-follower-concurrent-tx-corruption.md
+++ b/docs/5503-follower-concurrent-tx-corruption.md
@@ -121,6 +121,20 @@ becoming flakier is a plausible - if unproven - interaction worth watching in CI
   round trip, so this is symmetric, but a write-heavy follower workload will see lower throughput and
   more retries. That is the correct trade against silent corruption; writes routed to the leader are
   unaffected.
+- **Lock hold time now exceeds `COMMIT_LOCK_TIMEOUT` by a wide margin.** With defaults, a replica holds a
+  bucket's commit lock for `submitAndWait` (up to `2 * quorumTimeout` = 20 s, plus the grace window) plus
+  the apply wait (up to `quorumTimeout` = 10 s), while other writers give up on that lock after
+  `COMMIT_LOCK_TIMEOUT` = 5 s. On a healthy cluster the apply is sub-millisecond and none of this is
+  observable, but under leader churn or apply lag same-bucket writers serialize and burn retries. Note the
+  20 s half is not new and not replica-specific: the leader has always held its commit locks across
+  `submitAndWait`. What is new is that replicas hold locks at all, plus the apply wait.
+
+  **Shortening the apply wait was considered and rejected.** It looks attractive - the wait is a purely
+  local catch-up, not a quorum operation, so 10 s is generous - but the timeout path is precisely the path
+  that releases the locks with stale pages and reopens the corruption window. A shorter bound makes the
+  dangerous branch *more* reachable to buy back a few seconds of lock contention, which is the wrong
+  direction for a silent-corruption fix. The wait stays at `quorumTimeout`, the timeout is loudly logged,
+  and the contention is accepted and documented instead.
 - **New failure mode for follower writers: `LockTimeoutException`.** Because the locks are now held across
   the round trip and the apply wait, concurrent writers to the same bucket can exhaust
   `COMMIT_LOCK_TIMEOUT` (5000 ms by default) where previously a replica took no locks at all. It is

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -1222,31 +1222,31 @@ public class TransactionContext implements Transaction {
     try {
       // #4937: explicit-lock mode captured before checkExplicitLocks nulls explicitLockedFiles, so the
       // late-joiner block below can still tell an explicit-lock transaction from an auto-locked one.
-      boolean explicitLockMode = false;
-      if (isLeader) {
-        // Determine files to lock — must include files from updatedRecords
-        if (updatedRecords != null)
-          for (final Record rec : updatedRecords.values()) {
-            final RID rid = rec.getIdentity();
-            ((LocalBucket) database.getSchema().getBucketById(rid.getBucketId())).fetchPageInTransaction(rid);
-          }
+      // Determine files to lock — must include files from updatedRecords
+      if (updatedRecords != null)
+        for (final Record rec : updatedRecords.values()) {
+          final RID rid = rec.getIdentity();
+          ((LocalBucket) database.getSchema().getBucketById(rid.getBucketId())).fetchPageInTransaction(rid);
+        }
 
-        final IntHashSet modifiedFiles = lockFilesFromChanges();
+      // #5503: replicas lock the modified files too. The page-version validation below is a
+      // check-then-act, and the lock is what makes it atomic against other local committers. A replica
+      // used to skip it, so two concurrent transactions validated against the same base version and both
+      // shipped a delta stamped with the same next version; the state machine applied the first and then
+      // re-applied the second onto it through the equal-version repair path (#4926), splicing two partial
+      // page images together and dropping the records the first delta carried.
+      final IntHashSet modifiedFiles = lockFilesFromChanges();
 
-        // checkExplicitLocks nulls explicitLockedFiles on success, so remember the mode now for the
-        // late-joiner check further down (#4937): otherwise that check always sees null and would
-        // silently expand an explicit-lock transaction's lock set, defeating the explicit-locking contract.
-        explicitLockMode = explicitLockedFiles != null;
+      // checkExplicitLocks nulls explicitLockedFiles on success, so remember the mode now for the
+      // late-joiner check further down (#4937): otherwise that check always sees null and would
+      // silently expand an explicit-lock transaction's lock set, defeating the explicit-locking contract.
+      final boolean explicitLockMode = explicitLockedFiles != null;
 
-        if (explicitLockedFiles != null)
-          checkExplicitLocks(modifiedFiles);
-        else
-          // LOCK FILES IN ORDER (TO AVOID DEADLOCK)
-          lockedFiles = lockFilesInOrder(modifiedFiles);
-
-      } else
-        // IN CASE OF REPLICA THIS IS DEMANDED TO THE LEADER EXECUTION
-        lockedFiles = new ArrayList<>();
+      if (explicitLockedFiles != null)
+        checkExplicitLocks(modifiedFiles);
+      else
+        // LOCK FILES IN ORDER (TO AVOID DEADLOCK)
+        lockedFiles = lockFilesInOrder(modifiedFiles);
 
       // Process updatedRecords AFTER acquiring locks
       if (updatedRecords != null) {
@@ -1292,7 +1292,7 @@ public class TransactionContext implements Transaction {
       // and re-acquire the UNION in order (lock-ordering discipline forbids acquiring extra locks in
       // place). The version checks below run after this block, so anything that changed while unlocked
       // fails validation with the standard retriable ConcurrentModificationException.
-      if (isLeader && lockedFiles != null) {
+      if (lockedFiles != null) {
         // Fast path first: in the overwhelmingly common case every touched file is already locked, and this
         // is one of the hottest paths in the engine - detect late joiners with a plain scan (no allocation,
         // no boxing) and only build the union set when one is actually found.

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -415,10 +415,14 @@ public class PageManager extends LockContext {
    * Runs AFTER the WAL append (#4936): from the caller's perspective the transaction is committed once the
    * WAL is durable, and a failure here leaves the WAL to replay the pages on recovery. Releasing the global
    * PageManager lock between the two halves is safe only because the caller serializes committers per page
-   * by other means. Two regimes exist: on a leader (commit1stPhase(true)) the per-file commit locks are held
-   * until reset(), so no other transaction can validate, bump or publish these pages in the gap; on an HA
-   * follower (commit1stPhase(false)) lockedFiles is EMPTY and it is the single-threaded Raft apply in
-   * RaftReplicatedDatabase that provides the serialization - do not rely on file locks being held there.
+   * by other means: commit1stPhase holds the per-file commit locks until reset(), so no other transaction can
+   * validate, bump or publish these pages in the gap.
+   * <p>
+   * A replica used to be exempt from that (lockedFiles was left EMPTY, on the assumption that the
+   * single-threaded Raft apply serialized everything), but the apply only orders the WRITE side: concurrent
+   * local transactions still validated against the same base page version and each shipped a delta stamped
+   * with the same next version, which the state machine spliced together. Replicas now take the same locks
+   * and hold them until their entry has been applied locally (#5503).
    */
   public void publishPages(final List<MutablePage> pagesToWrite, final Map<PageId, MutablePage> newPages,
       final boolean asyncFlush) throws IOException, InterruptedException {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
@@ -166,7 +166,12 @@ class RaftGroupCommitter {
     return messageSizeMax;
   }
 
-  void submitAndWait(final byte[] entry) {
+  /**
+   * @return the Raft log index the entry committed at, or -1 when it is not known. Callers that must
+   * observe their own write locally (a replica, whose pages are written asynchronously by the state
+   * machine) wait for this index; see {@code RaftReplicatedDatabase} and issue #5503.
+   */
+  long submitAndWait(final byte[] entry) {
     // Pre-check the entry against the maximum size the cluster can actually replicate - the SMALLER
     // of arcadedb.ha.grpcMessageSizeMax and arcadedb.ha.appendBufferSize (see
     // RaftPropertiesBuilder.maxReplicatedEntrySize). Dispatching an oversized entry is far worse than
@@ -282,6 +287,8 @@ class RaftGroupCommitter {
     } catch (final Exception e) {
       throw dispatchAware(pending, "Group commit failed: " + e.getMessage());
     }
+
+    return pending.logIndex;
   }
 
   /**
@@ -513,6 +520,7 @@ class RaftGroupCommitter {
           }
         }
 
+        batch.get(i).logIndex = reply.getLogIndex();
         batch.get(i).future.complete(null); // success - after ALL check
       } catch (final InterruptedException ie) {
         // The flusher was interrupted (client refresh after leader churn, or shutdown) while
@@ -582,6 +590,11 @@ class RaftGroupCommitter {
     final byte[]                       entry;
     final CompletableFuture<Exception> future = new CompletableFuture<>();
     final AtomicInteger                state  = new AtomicInteger(PENDING);
+
+    // Raft log index this entry landed at, published by the flusher before it completes the future so
+    // the submitting thread can wait for its OWN entry to be applied locally (#5503). Stays -1 on every
+    // failure path, where there is no committed index to wait for.
+    volatile long logIndex = -1;
 
     CancellablePendingEntry(final byte[] entry) {
       this.entry = entry;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -471,10 +471,27 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // would read that stale version, pass its own version check and ship a delta stamped with the same
       // next version, which the state machine then splices onto this one. Wait for THIS entry's index:
       // the replica's own commit index still trails the leader here, so waiting for it would not cover
-      // the entry just written. On timeout the wait returns silently, leaving the pre-#5503 behaviour.
+      // the entry just written.
+      //
+      // The field is read directly instead of through requireRaftServer(): the cluster has already
+      // committed this transaction, so a server that disappeared under a concurrent shutdown must not
+      // turn into a NeedRetryException telling the caller to retry a write that is durably committed.
       final RaftHAServer raft = raftHAServer;
-      if (raft != null && committedLogIndex > 0)
+      if (raft != null && committedLogIndex > 0) {
         raft.waitForAppliedIndex(committedLogIndex);
+
+        // The wait degrades to best-effort on timeout, and releasing the locks below with the pages still
+        // behind is exactly the pre-#5503 condition. waitForAppliedIndex does log, but as a READ_YOUR_WRITES
+        // consistency warning, which reads like a stale-read risk rather than a page-corruption one - so say
+        // plainly here what is being risked and what to look at.
+        final long applied = raft.getLastAppliedIndex();
+        if (applied < committedLogIndex)
+          LogManager.instance().log(this, Level.WARNING,
+              "Replica commit on database '%s' is releasing its commit locks before entry %d was applied locally "
+                  + "(applied=%d). Concurrent transactions on these files can now validate against stale page "
+                  + "versions - the condition behind issue #5503. Investigate the state machine apply lag.",
+              getName(), committedLogIndex, applied);
+      }
       payload.tx().reset();
       final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       ctx.popIfNotLastTransaction();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -419,9 +419,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   void replicateAndCommitLocally(final ReplicationPayload payload, final boolean leader,
       final ArcadeStateMachine stateMachine, final long phase2Ticket) {
     // --- REPLICATION (no lock held): send WAL to Raft and wait for quorum ---
+    long committedLogIndex = -1;
     try {
       final RaftHAServer raft = requireRaftServer();
-      raft.getTransactionBroker().replicateTransaction(getName(), payload.walData(), payload.bucketDeltas());
+      committedLogIndex = raft.getTransactionBroker()
+          .replicateTransaction(getName(), payload.walData(), payload.bucketDeltas());
     } catch (final MajorityCommittedAllFailedException e) {
       // MAJORITY committed (applyTransaction fired with origin-skip, lastAppliedIndex advanced)
       // but ALL-quorum watch failed. We MUST apply locally to prevent permanent divergence.
@@ -463,6 +465,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // --- PHASE 2 (read lock on leader): quorum reached, apply locally ---
     if (!leader) {
       releasePhase2Ticket(stateMachine, phase2Ticket);
+      // #5503: this replica never runs phase 2 - the state machine writes the pages asynchronously - so
+      // the local page cache still holds the pre-commit version of every page this transaction touched.
+      // reset() below releases the commit locks taken in phase 1, and the next transaction to take them
+      // would read that stale version, pass its own version check and ship a delta stamped with the same
+      // next version, which the state machine then splices onto this one. Wait for THIS entry's index:
+      // the replica's own commit index still trails the leader here, so waiting for it would not cover
+      // the entry just written. On timeout the wait returns silently, leaving the pre-#5503 behaviour.
+      final RaftHAServer raft = raftHAServer;
+      if (raft != null && committedLogIndex > 0)
+        raft.waitForAppliedIndex(committedLogIndex);
       payload.tx().reset();
       final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       ctx.popIfNotLastTransaction();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -484,8 +484,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         // behind is exactly the pre-#5503 condition. waitForAppliedIndex does log, but as a READ_YOUR_WRITES
         // consistency warning, which reads like a stale-read risk rather than a page-corruption one - so say
         // plainly here what is being risked and what to look at.
+        // getLastAppliedIndex() reports -1 ("unknown") while an in-place restart re-initializes the Ratis
+        // division (#5271). That is not a race with another committer, so do not raise the alarm for it -
+        // the wait above will simply have run its full deadline, which is inherent to the restart window.
         final long applied = raft.getLastAppliedIndex();
-        if (applied < committedLogIndex)
+        if (applied >= 0 && applied < committedLogIndex)
           LogManager.instance().log(this, Level.WARNING,
               "Replica commit on database '%s' is releasing its commit locks before entry %d was applied locally "
                   + "(applied=%d). Concurrent transactions on these files can now validate against stale page "

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -85,11 +85,13 @@ public class RaftTransactionBroker {
 
   /**
    * Replicates a transaction (WAL data + bucket deltas) via Raft consensus.
+   *
+   * @return the Raft log index the entry committed at, or -1 when it is not known
    */
-  public void replicateTransaction(final String dbName, final byte[] walData,
+  public long replicateTransaction(final String dbName, final byte[] walData,
       final Map<Integer, Integer> bucketDeltas) {
     final ByteString entry = RaftLogEntryCodec.encodeTxEntry(dbName, walData, bucketDeltas);
-    groupCommitter.submitAndWait(entry.toByteArray());
+    return groupCommitter.submitAndWait(entry.toByteArray());
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5503ConcurrentFollowerWritesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5503ConcurrentFollowerWritesIT.java
@@ -21,6 +21,7 @@ package com.arcadedb.server.ha.raft;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
@@ -48,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
+@Tag("slow")
 class Issue5503ConcurrentFollowerWritesIT extends BaseRaftHATest {
 
   private static final String TYPE_NAME       = "Concurrent";

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5503ConcurrentFollowerWritesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5503ConcurrentFollowerWritesIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5503: concurrent transactions issued through a shared follower
+ * {@link Database} handle corrupted records and silently lost committed writes.
+ * <p>
+ * A replica captured its transaction's pages in {@code commit1stPhase} without taking the per-file
+ * commit locks the leader takes, so the MVCC page-version check was a non-atomic check-then-act. Two
+ * threads writing into the same bucket page both validated against the same base version and both
+ * shipped a partial page delta for it. Applying both deltas left the page physically inconsistent -
+ * the engine reported {@code Invalid record size} and deleted the affected records - and the writes
+ * one delta carried were lost even though its transaction had reported success.
+ * <p>
+ * The contract asserted here is that every transaction either commits or fails retryably, and that a
+ * caller that honours the retry contract ends up with every record present and identical on all nodes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5503ConcurrentFollowerWritesIT extends BaseRaftHATest {
+
+  private static final String TYPE_NAME       = "Concurrent";
+  private static final int    WRITER_THREADS  = 3;
+  private static final int    RECORDS_PER_THREAD = 150;
+  private static final int    TOTAL_RECORDS   = WRITER_THREADS * RECORDS_PER_THREAD;
+  private static final int    MAX_RETRIES     = 100;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Test
+  void concurrentWritesOnAFollowerHandleKeepEveryRecord() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a leader must be elected before the test starts").isGreaterThanOrEqualTo(0);
+
+    getServer(leaderIndex).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+    waitForAllServers();
+
+    // ALL WRITES GO THROUGH A FOLLOWER, FROM SEVERAL THREADS SHARING THE SAME EMBEDDED HANDLE
+    final Database follower = getServer((leaderIndex + 1) % getServerCount()).getDatabase(getDatabaseName());
+
+    final ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
+    final AtomicInteger retries = new AtomicInteger();
+    final CountDownLatch start = new CountDownLatch(1);
+    final Thread[] writers = new Thread[WRITER_THREADS];
+
+    for (int t = 0; t < WRITER_THREADS; t++) {
+      final int threadId = t;
+      writers[t] = new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < RECORDS_PER_THREAD; i++) {
+            final int value = threadId * RECORDS_PER_THREAD + i;
+            commitWithRetry(follower, value, retries);
+          }
+        } catch (final Throwable e) {
+          failures.add(e);
+        }
+      }, "issue5503-writer-" + t);
+      writers[t].start();
+    }
+
+    start.countDown();
+    for (final Thread writer : writers)
+      writer.join(TimeUnit.MINUTES.toMillis(5));
+
+    assertThat(failures).as("no writer may fail with a non-retryable error").isEmpty();
+
+    waitForAllServers();
+
+    // EVERY NODE MUST HOLD EVERY RECORD EXACTLY ONCE: A LOST OR CORRUPTED RECORD SHOWS UP AS A GAP
+    for (int i = 0; i < getServerCount(); i++) {
+      final Database db = getServer(i).getDatabase(getDatabaseName());
+      final String role = i == leaderIndex ? "leader" : "follower";
+
+      assertThat(scanCount(db)).as("record count on the %s (server %d), %d retries observed", role, i, retries.get())
+          .isEqualTo(TOTAL_RECORDS);
+      assertThat(distinctValues(db)).as("distinct values on the %s (server %d)", role, i).hasSize(TOTAL_RECORDS);
+    }
+  }
+
+  /**
+   * Commits a single-record transaction, retrying the conflicts the engine is allowed to raise. A
+   * concurrent writer losing the race for a page must surface a retryable {@link NeedRetryException}
+   * rather than silently dropping or corrupting the record.
+   */
+  private void commitWithRetry(final Database db, final int value, final AtomicInteger retries) {
+    for (int attempt = 0; ; attempt++) {
+      try {
+        db.transaction(() -> db.newDocument(TYPE_NAME).set("value", value).save());
+        return;
+      } catch (final NeedRetryException e) {
+        retries.incrementAndGet();
+        if (attempt >= MAX_RETRIES)
+          throw e;
+      }
+    }
+  }
+
+  private long scanCount(final Database db) {
+    // count(@rid) forces a scan: count(*) reads the cached per-bucket counter, which would hide a
+    // record the engine deleted as malformed.
+    try (final ResultSet rs = db.query("sql", "SELECT count(@rid) AS c FROM " + TYPE_NAME)) {
+      return rs.next().<Number>getProperty("c").longValue();
+    }
+  }
+
+  private Set<Integer> distinctValues(final Database db) {
+    final Set<Integer> values = new HashSet<>();
+    try (final ResultSet rs = db.query("sql", "SELECT value FROM " + TYPE_NAME)) {
+      while (rs.hasNext())
+        values.add(rs.next().<Number>getProperty("value").intValue());
+    }
+    return values;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
@@ -452,4 +452,41 @@ class RaftGroupCommitterTest {
       committer.stop();
     }
   }
+
+  /**
+   * Issue #5503: a replica must wait for its OWN entry to be applied locally before releasing the commit
+   * locks it took in phase 1, so {@code submitAndWait} has to hand the committed Raft log index back to
+   * the caller. Waiting on the wrong index (or on the replica's own commit index, which still trails the
+   * leader) silently skips the wait and reopens the page-corruption window.
+   */
+  @Test
+  void submitAndWaitReturnsTheCommittedLogIndex() {
+    final RaftClient client = mock(RaftClient.class, RETURNS_DEEP_STUBS);
+    final RaftClientReply reply = mock(RaftClientReply.class);
+    when(reply.isSuccess()).thenReturn(true);
+    when(reply.getLogIndex()).thenReturn(4242L);
+    when(client.async().send(any(Message.class))).thenReturn(CompletableFuture.completedFuture(reply));
+
+    final RaftGroupCommitter committer = new RaftGroupCommitter(client, Quorum.MAJORITY, 5_000);
+    try {
+      assertThat(committer.submitAndWait(new byte[] { 1, 2, 3 })).isEqualTo(4242L);
+    } finally {
+      committer.stop();
+    }
+  }
+
+  /**
+   * The index is only meaningful when the entry actually committed. Every failure path throws, so a
+   * caller never receives a stale or fabricated index to wait on.
+   */
+  @Test
+  void submitAndWaitThrowsRatherThanReturningAnIndexWhenReplicationFails() {
+    final RaftGroupCommitter committer = new RaftGroupCommitter(null, Quorum.MAJORITY, 500);
+    try {
+      assertThatThrownBy(() -> committer.submitAndWait(new byte[] { 1, 2, 3 }))
+          .isInstanceOf(QuorumNotReachedException.class);
+    } finally {
+      committer.stop();
+    }
+  }
 }


### PR DESCRIPTION
Closes #5503

## Summary

Concurrent transactions issued through a shared follower `Database` handle corrupted records and silently lost committed writes. `TransactionContext.commit1stPhase(false)` skipped the per-file commit locks, on the assumption recorded in `PageManager.publishPages` that "the single-threaded Raft apply provides the serialization". The apply only orders the **write** side; nothing ordered the **capture** side. Concurrent transactions therefore all validated against the same base page version and each shipped a WAL delta stamped with the same next version. `applyChanges` applied the first and then met the others at *equal* version, which is deliberately re-applied to repair torn writes (#4926) - splicing partial page images computed against a page that no longer existed. That single event produces both symptoms: the invalid record sizes and the lost writes.

The fix has two halves, both load-bearing:

1. **Replicas take the same commit locks as the leader** (plus the #4937 late-joiner union check that keeps the lock set complete), so the loser of a race gets a retryable `ConcurrentModificationException` instead of shipping a colliding delta. `indexChanges.commit()` stays leader-only.
2. **Those locks are held until the replica has applied its own entry.** Locking alone only moved the failure, because `reset()` released the locks as soon as the quorum acked while this node's pages were still at the old version. `waitForLocalApply()` could not be reused - a follower's commit index still trails the leader and does not cover the entry just written - so the committed index is carried back from Ratis through `RaftGroupCommitter` and `RaftTransactionBroker`, and the replica waits on `waitForAppliedIndex`. On timeout the wait returns silently, degrading to the previous behaviour rather than failing a transaction the cluster has already committed.

No deadlock: `applyChanges` takes no file locks, so the apply thread never waits on a committer.

Both halves were measured separately:

| | Records on a node | Conflicts raised | Corruption log lines |
|---|---|---|---|
| Before | 155 / 450 | 0 | 200+ |
| Locking only | 302 / 450 | 4 | many |
| Locking + apply wait | 450 / 450 | some, all retried | 0 |

## Test plan

- [x] `Issue5503ConcurrentFollowerWritesIT` - 3 nodes, 3 threads x 150 single-record transactions through a follower handle, retrying `NeedRetryException` as an application must. Asserts a scan count (`count(@rid)`, not the cached `count(*)` counter, which would hide a record deleted as malformed) and the full distinct-value set on every node. Fails on `main`, passes here, stable over 3 consecutive runs.
- [x] `ha-raft` unit tests: 770 tests, 0 failures.
- [x] `ha-raft` ITs, 69 tests across four targeted batches, 0 failures: write-against-replica and commit-path (`RaftEmbeddedWriteAgainstReplicaIT`, `RaftReplicationWriteAgainstReplicaIT`, `Raft3PhaseCommitIT`, `Issue4740Phase2ReconcileIT`, `Issue4790PhantomCommitOriginSkipIT`, `Issue5064CommittedRemotelyContractIT`, `Issue5410AbandonedTicketReleaseIT`, `OriginNodeSkipIT`); replication/concurrency/index (`RaftReplicationIT`, `RaftHTTPGraphConcurrentIT`, `SuperNodeAppendHAConsistencyIT`, `Issue5381SlotMergeRaftIT`, `Issue5443FollowerIndexGapIT`, `RaftIndexOperations3ServersIT`); the read-consistency suites that share `waitForAppliedIndex`; and the crash/failover suites. The full 105-class IT suite was not run locally - it takes hours.
- [x] `engine` unit tests: 10074 tests. The 50 failures are all `NoClassDefFoundError: org.graalvm.polyglot.Engine$ImplHolder` / "Query engine 'js' was not found", reproduced identically on a pristine worktree at `origin/main` (eb7739e9d) - the Graal JS language is not loadable on this JDK. No transaction, bucket, locking or index test failed.

## Reviewer notes

- **Follower write throughput drops.** Replicas now hold per-file commit locks across the Raft round trip *and* the local apply, so concurrent writers to the same bucket serialize and retry. This is symmetric with the leader, which already held its locks across its own round trip, but it is a real cost for write-heavy follower workloads. Writes routed to the leader are unaffected.
- `db.transaction(...)` on a follower now implies read-your-writes on that node, which it did not before.
- `RaftDictionaryManyNewKeysIT.httpInsertContentWithProgressivelyMoreKeysOnFollower` failed once inside a batch with `DatabaseIsClosedException`, then passed on three subsequent runs including a re-run of the identical batch. Reported as an observed flake rather than proven pre-existing, since this change does slow follower writes and could plausibly aggravate a timing-sensitive follower-write test.
- **Not fixed here:** `indexChanges.commit()` is still skipped on a replica, on the same "demanded to the leader" assumption that proved wrong for locking. Whether index entries for follower-originated writes are actually produced deserves its own investigation; it is orthogonal to this corruption and out of scope.