### PR TITLE
fix(#5508): mask previousValue for hidden settings in set_server_setting

### DIFF
--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.mcp;
 
 import com.arcadedb.Constants;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
@@ -271,7 +272,7 @@ public class MCPDispatcher {
     final JSONObject args = params.getJSONObject("arguments", new JSONObject());
 
     LogManager.instance()
-        .log(this, Level.INFO, "MCP[%s] tools/call '%s' %s (user=%s)", transport, toolName, formatArgs(args), user.getName());
+        .log(this, Level.INFO, "MCP[%s] tools/call '%s' %s (user=%s)", transport, toolName, formatArgs(toolName, args), user.getName());
 
     try {
       if (!REGISTERED_TOOL_NAMES.contains(toolName))
@@ -382,15 +383,27 @@ public class MCPDispatcher {
     }
   }
 
-  private static String formatArgs(final JSONObject args) {
+  /**
+   * Renders a tool's arguments for the request log. The value a caller writes to a secret setting is masked here,
+   * because this line is emitted before the tool runs and would otherwise place the secret in the log regardless of
+   * how the tool's own response is redacted. Masking is deliberately limited to the one argument that is a secret by
+   * definition: arguments elsewhere carry caller data, which cannot be told apart from a secret without guessing, and
+   * blanking it would leave the log unable to explain what a call did.
+   */
+  static String formatArgs(final String toolName, final JSONObject args) {
     if (args.length() == 0)
       return "{}";
+    final boolean maskValue = "set_server_setting".equals(toolName) && isHiddenSetting(args.getString("key", null));
     final StringBuilder sb = new StringBuilder("{");
     boolean first = true;
     for (final String key : args.keySet()) {
       if (!first)
         sb.append(", ");
       first = false;
+      if (maskValue && "value".equals(key)) {
+        sb.append(key).append("=\"*****\"");
+        continue;
+      }
       final Object value = args.get(key);
       if (value instanceof String s) {
         final String sanitized = sanitizeForLog(s);
@@ -404,6 +417,18 @@ public class MCPDispatcher {
         sb.append(key).append("=").append(value);
     }
     return sb.append("}").toString();
+  }
+
+  /**
+   * Reports whether a configuration key names a setting the server treats as secret, using the same
+   * {@link GlobalConfiguration#isHidden()} rule the settings tools apply. An unresolvable key is not secret: the
+   * tool rejects it before it can change anything.
+   */
+  private static boolean isHiddenSetting(final String key) {
+    if (key == null || key.isEmpty())
+      return false;
+    final GlobalConfiguration cfg = GlobalConfiguration.findByKey(key);
+    return cfg != null && cfg.isHidden();
   }
 
   private static String sanitizeForLog(final String value) {

--- a/server/src/main/java/com/arcadedb/server/mcp/tools/SetServerSettingTool.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/tools/SetServerSettingTool.java
@@ -71,7 +71,12 @@ public class SetServerSettingTool {
 
     final JSONObject result = new JSONObject();
     result.put("key", key);
-    result.put("previousValue", oldValue != null ? oldValue.toString() : JSONObject.NULL);
+    // A secret is masked on the way out here for the same reason it is masked when read: this response
+    // hands the caller the value it just replaced, so echoing it would disclose through the setter what
+    // the getter refuses to disclose. Masking is keyed on the setting, not on whether it held a value,
+    // so an unset secret cannot be distinguished from a set one either.
+    result.put("previousValue",
+        cfg.isHidden() ? "*****" : oldValue != null ? oldValue.toString() : JSONObject.NULL);
     result.put("newValue", value);
     result.put("message", "Setting '" + key + "' updated successfully.");
     return result;

--- a/server/src/test/java/com/arcadedb/server/mcp/GetServerSettingsToolRedactionIT.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/GetServerSettingsToolRedactionIT.java
@@ -24,6 +24,7 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.mcp.tools.GetServerSettingsTool;
+import com.arcadedb.server.mcp.tools.SetServerSettingTool;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,6 +70,27 @@ class GetServerSettingsToolRedactionIT extends BaseGraphServerTest {
         }
       }
       assertThat(found).as("clusterToken setting must be present in the exported settings").isTrue();
+    });
+  }
+
+  @Test
+  void clusterTokenIsRedactedInMcpSetServerSetting() throws Exception {
+    testEachServer((serverIndex) -> {
+      final MCPConfiguration config = new MCPConfiguration("./target/test");
+      config.setAllowAdmin(true);
+
+      final JSONObject args = new JSONObject()
+          .put("key", "arcadedb.ha.clusterToken")
+          .put("value", "replacement-token");
+
+      final JSONObject result = SetServerSettingTool.execute(getServer(serverIndex), null, args, config);
+
+      // The setter echoes the value it replaced, so a secret reaches the caller through previousValue
+      // unless it is masked with the same rule the getter applies.
+      assertThat(result.toString()).as("cluster token must not leak through the MCP set_server_setting tool")
+          .doesNotContain(SECRET_TOKEN);
+      assertThat(result.getString("previousValue")).as("clusterToken previousValue must be masked")
+          .isEqualTo("*****");
     });
   }
 }

--- a/server/src/test/java/com/arcadedb/server/mcp/GetServerSettingsToolRedactionIT.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/GetServerSettingsToolRedactionIT.java
@@ -83,7 +83,17 @@ class GetServerSettingsToolRedactionIT extends BaseGraphServerTest {
           .put("key", "arcadedb.ha.clusterToken")
           .put("value", "replacement-token");
 
-      final JSONObject result = SetServerSettingTool.execute(getServer(serverIndex), null, args, config);
+      final JSONObject result;
+      try {
+        result = SetServerSettingTool.execute(getServer(serverIndex), null, args, config);
+      } finally {
+        // This exercises the real setter, so it genuinely replaces the running server's cluster token.
+        // Restore it before leaving: the token authenticates cluster-forwarded requests, and a later
+        // test sharing this server lifecycle would otherwise inherit the replacement. The original is
+        // restored from the constant rather than from the response, because the response now masks it.
+        getServer(serverIndex).getConfiguration()
+            .setValue(GlobalConfiguration.HA_CLUSTER_TOKEN.getKey(), SECRET_TOKEN);
+      }
 
       // The setter echoes the value it replaced, so a secret reaches the caller through previousValue
       // unless it is masked with the same rule the getter applies.
@@ -91,6 +101,12 @@ class GetServerSettingsToolRedactionIT extends BaseGraphServerTest {
           .doesNotContain(SECRET_TOKEN);
       assertThat(result.getString("previousValue")).as("clusterToken previousValue must be masked")
           .isEqualTo("*****");
+
+      // Pin the restore itself, so removing it fails here rather than leaking a replaced cluster token
+      // into whatever runs next on this server.
+      assertThat(getServer(serverIndex).getConfiguration().getValueAsString(GlobalConfiguration.HA_CLUSTER_TOKEN))
+          .as("the original cluster token must be restored after the setter test")
+          .isEqualTo(SECRET_TOKEN);
     });
   }
 }

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPDispatcherArgumentLoggingTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPDispatcherArgumentLoggingTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.mcp;
+
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The tools/call request log is written before the tool runs, so a secret passed as an argument reaches the log
+ * whatever the tool's own response redaction does. These tests pin that the value written to a secret setting is
+ * masked there, and that ordinary arguments still appear so the log can still explain what a call did.
+ */
+class MCPDispatcherArgumentLoggingTest {
+
+  private static final String SECRET = "s3cr3t-cluster-token-should-never-leak";
+
+  @Test
+  void theValueWrittenToASecretSettingIsMaskedInTheRequestLog() {
+    final JSONObject args = new JSONObject()
+        .put("key", "arcadedb.ha.clusterToken")
+        .put("value", SECRET);
+
+    final String logged = MCPDispatcher.formatArgs("set_server_setting", args);
+
+    assertThat(logged).doesNotContain(SECRET);
+    assertThat(logged).contains("value=\"*****\"");
+    // The key itself is not secret and is what makes the log line useful.
+    assertThat(logged).contains("arcadedb.ha.clusterToken");
+  }
+
+  @Test
+  void aPasswordSettingIsMaskedTheSameWay() {
+    final JSONObject args = new JSONObject()
+        .put("key", "arcadedb.server.rootPassword")
+        .put("value", SECRET);
+
+    assertThat(MCPDispatcher.formatArgs("set_server_setting", args)).doesNotContain(SECRET);
+  }
+
+  @Test
+  void anOrdinarySettingValueIsStillLogged() {
+    final JSONObject args = new JSONObject()
+        .put("key", "arcadedb.asyncWorkerThreads")
+        .put("value", "8");
+
+    // Masking every value would leave the log unable to explain what a call changed.
+    assertThat(MCPDispatcher.formatArgs("set_server_setting", args)).contains("value=\"8\"");
+  }
+
+  @Test
+  void anArgumentNamedValueOnAnotherToolIsNotMasked() {
+    final JSONObject args = new JSONObject()
+        .put("key", "arcadedb.ha.clusterToken")
+        .put("value", "ordinary-payload");
+
+    // The mask is keyed on the tool as well as the setting, so it cannot silently blank an unrelated
+    // argument that happens to share the name.
+    assertThat(MCPDispatcher.formatArgs("upsert_entity", args)).contains("value=\"ordinary-payload\"");
+  }
+
+  @Test
+  void anUnresolvableSettingKeyDoesNotMask() {
+    final JSONObject args = new JSONObject()
+        .put("key", "arcadedb.no.such.setting")
+        .put("value", "plain");
+
+    // An unknown key is rejected by the tool before it changes anything, so its value is not a secret.
+    assertThat(MCPDispatcher.formatArgs("set_server_setting", args)).contains("value=\"plain\"");
+  }
+}


### PR DESCRIPTION
Closes #5508.

`set_server_setting` returns the value it replaced, without redaction. `get_server_settings` masks any setting flagged by `GlobalConfiguration.isHidden()` — `clusterToken`, `*Password*`, `*password*` — so a caller could read back through the setter what the getter refuses to disclose.

Before the fix, the response was literally:

```json
{"key":"arcadedb.ha.clusterToken","previousValue":"s3cr3t-cluster-token-should-never-leak","newValue":"replacement-token"}
```

`previousValue` now applies the same `isHidden()` rule as the getter. The mask is keyed on the setting rather than on whether it currently holds a value, so an unset secret cannot be distinguished from a set one by probing.

## Reachability

Not remotely exploitable in a default deployment: it needs the MCP server enabled (`enabled` defaults to false), `allowAdmin` enabled (defaults to false), and a principal already authorized for admin operations. That is why it was filed as a normal issue rather than through private disclosure. It still matters — an admin-scoped MCP principal is not necessarily one that should learn the cluster token, and the getter's redaction exists precisely because that token enables cluster-forwarded-auth root impersonation.

## Testing

The regression test is added to `GetServerSettingsToolRedactionIT`, beside the getter's, so both disclosure paths are pinned by one class. Verified to fail before the change with the secret visible in `previousValue`, and to pass after.

Note that `mvn -pl server verify` runs the unit tests before failsafe, and two of those fail locally on a pre-existing GraalVM `NoClassDefFoundError` unrelated to this change, which prevents the ITs from starting. To run the IT in isolation:

```
mvn -pl server verify -Dtest=ZzzNoSuchUnitTest -DfailIfNoTests=false \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipITs=false -Dit.test=GetServerSettingsToolRedactionIT
```

`mvn -pl server test -Dtest='MCP*'` is 217 passing.
