### PR TITLE
fix: return HTTP 400 instead of 500 for abs() invalid argument type (fixes #5484)

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/math/AbsFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/math/AbsFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.math;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
 
@@ -37,13 +37,13 @@ public class AbsFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     if (args.length != 1)
-      throw new CommandExecutionException("abs() requires exactly one argument");
+      throw new CommandParsingException("abs() requires exactly one argument");
     if (args[0] == null)
       return null;
     if (args[0] instanceof Byte || args[0] instanceof Short || args[0] instanceof Integer || args[0] instanceof Long)
       return Math.abs(((Number) args[0]).longValue());
     if (args[0] instanceof Number)
       return Math.abs(((Number) args[0]).doubleValue());
-    throw new CommandExecutionException("abs() requires a numeric argument");
+    throw new CommandParsingException("abs() requires a numeric argument");
   }
 }


### PR DESCRIPTION
## Summary

Changes `CommandExecutionException` to `CommandParsingException` in `AbsFunction.java` so that invalid argument types (e.g. `abs('hello')`) return HTTP 400 (client error) instead of HTTP 500 (internal server error).

## Problem

`abs()` with a non-numeric argument correctly detects the error and returns the message `abs() requires a numeric argument`, but wraps it in `CommandExecutionException` which triggers HTTP 500. This is incorrect — the error is a client-side validation error, not an internal server failure.

## Fix

Changed both `throw new CommandExecutionException(...)` calls in `AbsFunction.java` to `throw new CommandParsingException(...)`, which produces HTTP 400. The error message is preserved unchanged.

## Related

All other math functions (e.g. `floor()`, `ceil()`, `round()`, `sign()`) already use `CommandParsingException` for argument validation errors. This brings `abs()` in line with the rest of the codebase.