### PR TITLE
feat(#4085): split a sparse-vector top-K into parallel RID ranges

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -342,8 +342,11 @@ public enum GlobalConfiguration {
       self-throttling and splits regardless of load. That is a throughput risk on a busy server, \
       and it is paid by the forcing query too: measured independently at 16 concurrent clients, a \
       forced 8-way split returned 0.76x the throughput of no split at all with a median 1.75x \
-      worse, while compressing the tail (p99/p50 1.5x against 5.2x). Force it for tail \
-      predictability under load; leave it at 0 for median or throughput. Re-read on every query.""",
+      worse. What it did buy at that load is a lower tail, p99 297 ms against 579 ms. So the \
+      forced setting inverts as concurrency rises - a clear win on median while the box is quiet, \
+      a median and throughput loss once it is busy, and a tail win throughout. Force it for \
+      tail-sensitive traffic; leave it at 0 for anything else. The crossover is hardware and \
+      workload specific, so no number for it is given here. Re-read on every query.""",
       Integer.class, 0),
 
   SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING("arcadedb.sparseVectorScoringMinPostingsForPartitioning", SCOPE.JVM,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -306,8 +306,10 @@ public enum GlobalConfiguration {
   SPARSE_VECTOR_SCORING_POOL_THREADS("arcadedb.sparseVectorScoringPoolThreads", SCOPE.JVM,
       """
       Maximum number of threads in the JVM-wide pool that backs LSM_SPARSE_VECTOR top-K \
-      fan-out (per-bucket parallel scoring on partitioned types and types with multiple \
-      buckets). Kept on its own pool rather than sharing the QueryEngineManager pool so \
+      fan-out: per-bucket parallel scoring on partitioned types and types with multiple \
+      buckets, and the RID-range split of a single index's traversal (see \
+      arcadedb.sparseVectorScoringMaxPartitions). Kept on its own pool rather than sharing \
+      the QueryEngineManager pool so \
       long-running graph algorithms never queue scoring tasks behind seconds-long graph \
       chunks. 0 = available cores (min 2). REQUIRES JVM RESTART: the pool is a lazy \
       singleton constructed once on first use; later changes to this value have no effect \
@@ -323,6 +325,32 @@ public enum GlobalConfiguration {
       but never fails the query. REQUIRES JVM RESTART: same singleton lifecycle as \
       SPARSE_VECTOR_SCORING_POOL_THREADS.""",
       Integer.class, 1024),
+
+  SPARSE_VECTOR_SCORING_MAX_PARTITIONS("arcadedb.sparseVectorScoringMaxPartitions", SCOPE.JVM,
+      """
+      Maximum number of RID ranges a single LSM_SPARSE_VECTOR top-K query is split into for \
+      parallel scoring. 1 disables intra-query parallelism and keeps every query on the caller \
+      thread; 0 (default) lets the engine decide per query. Splitting buys latency with CPU: each \
+      range prunes against its own top-K watermark, which rises more slowly than the global one, \
+      so a range does more work than its share (measured at roughly 1.9x total CPU for an 8-way \
+      split on a learned-sparse corpus). On the default the engine claims only workers no other \
+      query needs, and does not split at all once enough queries are already in flight to keep \
+      the pool busy on their own - so an idle server spends spare cores on latency while a \
+      saturated one keeps its throughput. Measured on an 18-worker box at 500k documents: one \
+      client 13.7 -> 3.1 ms p50, four clients 13.6 -> 4.1 ms with 61% more throughput, sixteen \
+      clients within 5% of serial throughput. Any explicit value above 1 opts out of that \
+      self-throttling and splits regardless of load, which is a throughput risk on a busy server. \
+      Re-read on every query.""",
+      Integer.class, 0),
+
+  SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING("arcadedb.sparseVectorScoringMinPostingsForPartitioning", SCOPE.JVM,
+      """
+      Minimum number of postings a LSM_SPARSE_VECTOR top-K query has to traverse before it is \
+      worth splitting into parallel ranges. Below this the fan-out (per-range cursor stacks, task \
+      dispatch, result merge) costs more than the traversal it parallelises, so the query stays on \
+      the caller thread. Counted as the summed document frequency of the query's dims, which is \
+      available from segment metadata without reading a page. Re-read on every query.""",
+      Long.class, 200_000L),
 
   SPARSE_VECTOR_SCORING_TIMEOUT_SECONDS("arcadedb.sparseVectorScoringTimeoutSeconds", SCOPE.JVM,
       """

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -336,7 +336,12 @@ public enum GlobalConfiguration {
       split on a learned-sparse corpus). On the default the engine claims only workers no other \
       query needs, and does not split at all once enough queries are already in flight to keep \
       the pool busy on their own - so an idle server spends spare cores on latency while a \
-      saturated one keeps its throughput. Measured on an 18-worker box at 500k documents: one \
+      saturated one keeps its throughput. One cost of the default worth knowing: in a narrow band \
+      of moderate concurrency, where some queries claim a wide split and others get none, the \
+      spread between the two shows up as tail latency. Measured at 4 concurrent clients on an \
+      18-thread pool, p99 was about 1.2x serial's while the median was 3.4x better (7.6 ms against \
+      26.2). The band closes on both sides - below it every query splits, above it none does - and \
+      the median win is large enough that the default keeps the trade rather than flattening it. Measured on an 18-worker box at 500k documents: one \
       client 13.7 -> 3.1 ms p50, four clients 13.6 -> 4.1 ms with 61% more throughput, sixteen \
       clients within 5% of serial throughput. Any explicit value above 1 opts out of that \
       self-throttling and splits regardless of load. That is a throughput risk on a busy server, \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -340,13 +340,14 @@ public enum GlobalConfiguration {
       client 13.7 -> 3.1 ms p50, four clients 13.6 -> 4.1 ms with 61% more throughput, sixteen \
       clients within 5% of serial throughput. Any explicit value above 1 opts out of that \
       self-throttling and splits regardless of load. That is a throughput risk on a busy server, \
-      and it is paid by the forcing query too: measured independently at 16 concurrent clients, a \
-      forced 8-way split returned 0.76x the throughput of no split at all with a median 1.75x \
-      worse. What it did buy at that load is a lower tail, p99 297 ms against 579 ms. So the \
-      forced setting inverts as concurrency rises - a clear win on median while the box is quiet, \
-      a median and throughput loss once it is busy, and a tail win throughout. Force it for \
-      tail-sensitive traffic; leave it at 0 for anything else. The crossover is hardware and \
-      workload specific, so no number for it is given here. Re-read on every query.""",
+      and it is paid by the forcing query too. Measured at 16 concurrent clients on an 18-thread \
+      pool, 1M documents: a forced 8-way split returned 0.52x the throughput of no split at all, a \
+      median 1.85x worse and a p99 2.5x worse, for 1.9x the CPU per query. Above light concurrency \
+      there is no regime where forcing wins - not median, not throughput, not tail - because a \
+      query's own ranges start queueing behind its neighbours'. It is worth setting only when a \
+      single query at a time must be as fast as possible and nothing else is running; for anything \
+      else 0 is faster on every measure. The crossover is hardware and workload specific, so no \
+      number for it is given here. Re-read on every query.""",
       Integer.class, 0),
 
   SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING("arcadedb.sparseVectorScoringMinPostingsForPartitioning", SCOPE.JVM,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -339,8 +339,11 @@ public enum GlobalConfiguration {
       saturated one keeps its throughput. Measured on an 18-worker box at 500k documents: one \
       client 13.7 -> 3.1 ms p50, four clients 13.6 -> 4.1 ms with 61% more throughput, sixteen \
       clients within 5% of serial throughput. Any explicit value above 1 opts out of that \
-      self-throttling and splits regardless of load, which is a throughput risk on a busy server. \
-      Re-read on every query.""",
+      self-throttling and splits regardless of load. That is a throughput risk on a busy server, \
+      and it is paid by the forcing query too: measured independently at 16 concurrent clients, a \
+      forced 8-way split returned 0.76x the throughput of no split at all with a median 1.75x \
+      worse, while compressing the tail (p99/p50 1.5x against 5.2x). Force it for tail \
+      predictability under load; leave it at 0 for median or throughput. Re-read on every query.""",
       Integer.class, 0),
 
   SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING("arcadedb.sparseVectorScoringMinPostingsForPartitioning", SCOPE.JVM,

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/BmwScorer.java
@@ -120,16 +120,41 @@ public final class BmwScorer {
    */
   public static List<RidScore> topK(final int[] queryDims, final float[] queryWeights, final DimCursor[] cursors, final int k)
       throws IOException {
+    return topK(queryDims, queryWeights, cursors, k, null, null);
+  }
+
+  /**
+   * {@link #topK(int[], float[], DimCursor[], int)} restricted to the RID range
+   * {@code [startInclusive, endExclusive)}. This is the unit of work of the parallel fan-out in
+   * {@link PaginatedSparseVectorEngine#topK}: each worker takes one range, and because the ranges
+   * partition the RID space, concatenating their results and keeping the best {@code k} yields
+   * exactly the serial top-K.
+   * <p>
+   * <b>A range costs more than its share.</b> The pruning threshold is per-traversal, so a worker
+   * that sees 1/P of the corpus reaches a lower watermark than the serial scan would at the same
+   * point and therefore prunes less. The partitioned traversal does strictly more total work than
+   * the serial one - measured at about 1.9x total CPU for an 8-way split on a learned-sparse corpus.
+   * It buys latency with CPU, which is why the caller gates the fan-out rather than always taking it.
+   * <p>
+   * Cursors are seeked to {@code startInclusive} <i>before</i> each term's ceiling is captured, so a
+   * worker prunes against the maximum weight remaining in <i>its</i> range rather than the whole
+   * dim's - which claws back part of that amplification.
+   *
+   * @param startInclusive first RID to consider, or {@code null} to start at the beginning
+   * @param endExclusive   first RID <i>not</i> to consider, or {@code null} to run to the end
+   */
+  public static List<RidScore> topK(final int[] queryDims, final float[] queryWeights, final DimCursor[] cursors, final int k,
+      final RID startInclusive, final RID endExclusive) throws IOException {
     validate(queryDims, queryWeights, cursors);
     if (k <= 0)
       return List.of();
 
-    final DimEntry[] terms = openTerms(queryWeights, cursors);
+    final DimEntry[] terms = openTerms(queryWeights, cursors, startInclusive);
     if (terms.length == 0)
       return List.of();
 
     final TopKCollector collector = new TopKCollector(k);
-    scan(terms, collector);
+    scan(terms, collector, endExclusive);
     return collector.drain();
   }
 
@@ -185,12 +210,12 @@ public final class BmwScorer {
     if (limit <= 0 || groupSize <= 0)
       return List.of();
 
-    final DimEntry[] terms = openTerms(queryWeights, cursors);
+    final DimEntry[] terms = openTerms(queryWeights, cursors, null);
     if (terms.length == 0)
       return List.of();
 
     final GroupedCollector collector = new GroupedCollector(limit, groupSize, groupKeyResolver, allowedRIDs);
-    scan(terms, collector);
+    scan(terms, collector, null);
     return collector.drain();
   }
 
@@ -208,7 +233,9 @@ public final class BmwScorer {
    * dominates everything else once the posting mass has been pruned away. The heap turns that into
    * O(aligned * log terms).
    */
-  private static void scan(final DimEntry[] terms, final Collector collector) throws IOException {
+  private static void scan(final DimEntry[] terms, final Collector collector, final RID endExclusive) throws IOException {
+    final int endBucketId = endExclusive != null ? endExclusive.getBucketId() : -1;
+    final long endPosition = endExclusive != null ? endExclusive.getPosition() : -1L;
     final int n = terms.length;
     // prefix[i] == sum of sigma over terms [0, i). prefix[n] is the whole query's ceiling.
     final float[] prefix = new float[n + 1];
@@ -258,6 +285,12 @@ public final class BmwScorer {
       // at or below the threshold by construction of the split.
       final int candidateBucketId = keyBucketIds[heap[0]];
       final long candidatePosition = keyPositions[heap[0]];
+
+      // Range bound: candidates are produced in ascending RID order, so the first one at or past the
+      // end of this worker's range means the range is done - everything left belongs to a sibling.
+      if (endBucketId >= 0
+          && SparseSegmentBuilder.compareRid(candidateBucketId, candidatePosition, endBucketId, endPosition) >= 0)
+        return;
 
       // Detach the whole aligned run so the cursors can be moved without corrupting the heap order.
       int alignedCount = 0;
@@ -537,13 +570,24 @@ public final class BmwScorer {
    * Start every non-null cursor, drop the ones with nothing to iterate, and order the survivors by
    * {@link DimEntry#BY_PRUNING_VALUE promotion order}, i.e. by how much traversal work each term
    * would remove per unit of pruning budget it consumes.
+   * <p>
+   * When a {@code startInclusive} is given, each cursor is seeked there <i>before</i> its
+   * {@link DimEntry} is built. That ordering matters: a term's ceiling is captured from
+   * {@link DimCursor#upperBoundRemaining()}, which on a sealed segment is a suffix max from the
+   * cursor's current position, so seeking first gives a worker the maximum weight remaining in its
+   * own range rather than the whole dim's. A tighter ceiling means a term can be proven
+   * non-essential sooner, which is the one lever that offsets a partitioned traversal's weaker
+   * pruning threshold.
    */
-  private static DimEntry[] openTerms(final float[] queryWeights, final DimCursor[] cursors) throws IOException {
+  private static DimEntry[] openTerms(final float[] queryWeights, final DimCursor[] cursors, final RID startInclusive)
+      throws IOException {
     final List<DimEntry> live = new ArrayList<>(cursors.length);
     for (int i = 0; i < cursors.length; i++) {
       if (cursors[i] == null)
         continue;
       cursors[i].start();
+      if (startInclusive != null)
+        cursors[i].seekTo(startInclusive);
       if (cursors[i].isExhausted())
         continue;
       live.add(new DimEntry(cursors[i], queryWeights[i]));
@@ -576,8 +620,39 @@ public final class BmwScorer {
     void collect(RID rid, float score);
   }
 
-  /** Result ordering handed back to the caller: best score first. */
-  private static final Comparator<RidScore> BY_SCORE_DESC = (a, b) -> Float.compare(b.score(), a.score());
+  /**
+   * Result ordering handed back to the caller: best score first, ties broken by RID ascending.
+   * <p>
+   * The RID leg is what makes a partitioned traversal indistinguishable from the serial one
+   * (issue #4085). It is the same total order {@link RidScoreMinHeap} retains against, so sorting
+   * the concatenated per-range results and keeping the first {@code k} reproduces the serial result
+   * exactly, ties included.
+   */
+  static final Comparator<RidScore> BY_SCORE_DESC = (a, b) -> {
+    final int c = Float.compare(b.score(), a.score());
+    return c != 0 ? c : SparseSegmentBuilder.compareRid(a.rid(), b.rid());
+  };
+
+  /**
+   * Merge the per-range results of a partitioned {@link #topK(int[], float[], DimCursor[], int, RID, RID)}
+   * back into the global top-K.
+   * <p>
+   * Correct because the ranges partition the RID space: every document is scored by exactly one
+   * worker, against the same query, so a document's score does not depend on which range it fell in.
+   * Only the <i>pruning</i> differs - a worker with a weaker local watermark keeps candidates the
+   * serial scan would have discarded - and keeping the best {@code k} of the union discards those
+   * again.
+   */
+  static List<RidScore> mergeRanges(final List<List<RidScore>> ranges, final int k) {
+    int total = 0;
+    for (final List<RidScore> r : ranges)
+      total += r.size();
+    final List<RidScore> all = new ArrayList<>(total);
+    for (final List<RidScore> r : ranges)
+      all.addAll(r);
+    all.sort(BY_SCORE_DESC);
+    return all.size() <= k ? all : new ArrayList<>(all.subList(0, k));
+  }
 
   /** Plain top-K: a K-sized min-heap whose head is the threshold once full. */
   private static final class TopKCollector implements Collector {

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -474,6 +474,13 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
    * the same number of that dim's postings. That is a better proxy for "same amount of work" than
    * cutting the RID space into equal spans, which goes lopsided as soon as a range of RIDs has been
    * deleted or was never dense. Reading them touches in-memory block metadata only - no page reads.
+   * <p>
+   * It is a balance heuristic, not a guarantee, and it reads one dim of one segment. On an index with
+   * several live segments - a freshly loaded one, before compaction has merged them - that segment's
+   * layout need not represent the global RID distribution, and the ranges can come out uneven.
+   * Correctness does not depend on it: the ranges still partition the RID space disjointly and every
+   * document is still scored exactly once. Only the speedup suffers, and it shows up as one range
+   * finishing long after its siblings.
    */
   private RID[] planPartitionBoundaries(final int[] queryDims, final PaginatedSegmentReader[] segSnapshot) throws IOException {
     final int configured = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
@@ -519,6 +526,7 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
       // stacks", and past a small multiple of the pool there are no threads left to run them anyway.
       partitions = Math.min(Math.min(configured, byLayout), pool.getMaxParallelism() * EXPLICIT_PARTITION_OVERSUBSCRIPTION);
       pool.reserveWorkers(partitions - 1);
+      pool.warnExplicitSplitUnderLoad(partitions);
     } else {
       final int wanted = Math.min(pool.getMaxParallelism(), byLayout) - 1;
       final int granted = pool.tryReserveWorkers(wanted);

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -372,6 +372,12 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
     final Memtable mtSnapshot = memtable.get();
     final PaginatedSegmentReader[] segSnapshot = segments.get();
 
+    // Splitting off globally: return before touching the pool at all. getInstance() would build a
+    // ThreadPoolExecutor that this JVM has just been told it will never use, which an embedded
+    // deployment that disabled the feature should not be paying for.
+    if (GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger() == 1)
+      return rangeTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, null, null);
+
     // Registered for the whole call, split or not: the split decision is made against how many
     // queries are running, and a query that stays serial still occupies its caller's thread.
     final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
@@ -441,8 +447,18 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
     final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
     if (ctx == null)
       return false;
-    final TransactionContext tx = ctx.getLastTransaction();
-    return tx != null && tx.isActive() && tx.hasChanges();
+    // Every transaction on the stack, not just the innermost. begin() on an already-active
+    // transaction pushes a nested one, so a caller can sit in a fresh inner transaction with no
+    // changes of its own while an outer one holds modified pages. Asking only the innermost would
+    // report "clean" and let the query split, and the workers - reading committed pages through a
+    // context of their own - would silently not see the outer transaction's writes. That is the
+    // exact class of bug this guard exists to remove, so it has to look at all of them.
+    for (int i = 0; i < ctx.transactions.size(); i++) {
+      final TransactionContext tx = ctx.transactions.get(i);
+      if (tx != null && tx.isActive() && tx.hasChanges())
+        return true;
+    }
+    return false;
   }
 
   /**
@@ -696,6 +712,16 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
     final Memtable mtSnapshot = memtable.get();
     final PaginatedSegmentReader[] segSnapshot = segments.get();
 
+    // Grouped queries never split, but they are still load: they run a full traversal on their
+    // caller's thread and compete for the same cores. Leaving them unregistered would let a plain
+    // topK arriving alongside heavy grouped traffic see an idle gate, split, and take throughput
+    // from them - which is precisely what the gate exists to prevent, merely from a source it could
+    // not see. Registered only when splitting is enabled at all, for the same reason as topK.
+    final boolean registerLoad = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger() != 1;
+    final SparseVectorScoringPool pool = registerLoad ? SparseVectorScoringPool.getInstance() : null;
+    if (pool != null)
+      pool.queryStarted();
+
     final DimCursor[] cursors = new DimCursor[queryDims.length];
     try {
       for (int i = 0; i < queryDims.length; i++)
@@ -705,6 +731,8 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
       for (final DimCursor c : cursors)
         if (c != null)
           c.close();
+      if (pool != null)
+        pool.queryFinished();
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -19,8 +19,10 @@
 package com.arcadedb.index.sparsevector;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.log.LogManager;
@@ -37,6 +39,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
@@ -158,6 +165,23 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
    * subsequent flushes write the new manifest slot and the trigger applies normally.
    */
   static final double TOMBSTONE_RATIO_TRIGGER = 0.30;
+
+  /**
+   * Blocks a parallel range must hold, at minimum, for the split to be worth making (issue #4085).
+   * The cuts are taken at block boundaries of the query's widest dim, so a dim with fewer than
+   * {@code partitions * MIN_BLOCKS_PER_PARTITION} blocks cannot be carved into ranges that are both
+   * distinct and balanced; the partition count is clipped to fit, and falls back to serial when even
+   * two ranges do not.
+   */
+  static final int MIN_BLOCKS_PER_PARTITION = 4;
+
+  /**
+   * Queries that took the partitioned path (issue #4085). Whether a query is split depends on how
+   * busy the scoring pool was at that instant, so this is the only way to tell after the fact which
+   * shape actually ran - results are identical either way by design, which is exactly what makes the
+   * choice invisible without a counter.
+   */
+  private final AtomicLong partitionedQueries = new AtomicLong();
 
   private final DatabaseInternal  database;
   private final String            indexName;
@@ -340,11 +364,46 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
     final Memtable mtSnapshot = memtable.get();
     final PaginatedSegmentReader[] segSnapshot = segments.get();
 
+    // Registered for the whole call, split or not: the split decision is made against how many
+    // queries are running, and a query that stays serial still occupies its caller's thread.
+    final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+    pool.queryStarted();
+    try {
+      final RID[] boundaries = planPartitionBoundaries(queryDims, segSnapshot);
+      if (boundaries != null) {
+        partitionedQueries.incrementAndGet();
+        try {
+          return parallelTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, boundaries);
+        } finally {
+          // Hand the claimed capacity back on every exit, including a timeout or a failed range:
+          // leaking it would permanently shrink what later queries believe the pool has free.
+          pool.releaseWorkers(boundaries.length);
+        }
+      }
+
+      return rangeTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, null, null);
+    } finally {
+      pool.queryFinished();
+    }
+  }
+
+  /**
+   * One range of a (possibly partitioned) top-K: opens a cursor stack of its own and scores
+   * {@code [startInclusive, endExclusive)}. With both bounds null this is the whole query, which is
+   * the serial path.
+   * <p>
+   * Every piece of per-query state lives in the cursor stack built here, so this method is safe to
+   * run concurrently on the scoring pool for disjoint ranges: the segment readers it reads through
+   * cache their per-dim metadata behind a CAS and their pages behind the shared page cache, and the
+   * memtable is a {@code ConcurrentSkipListMap}. Nothing else is shared.
+   */
+  private List<RidScore> rangeTopK(final int[] queryDims, final float[] queryWeights, final int k, final Memtable mtSnapshot,
+      final PaginatedSegmentReader[] segSnapshot, final RID startInclusive, final RID endExclusive) throws IOException {
     final DimCursor[] cursors = new DimCursor[queryDims.length];
     try {
       for (int i = 0; i < queryDims.length; i++)
         cursors[i] = openMergedCursor(queryDims[i], mtSnapshot, segSnapshot);
-      return BmwScorer.topK(queryDims, queryWeights, cursors, k);
+      return BmwScorer.topK(queryDims, queryWeights, cursors, k, startInclusive, endExclusive);
     } finally {
       for (final DimCursor c : cursors)
         if (c != null)
@@ -352,10 +411,227 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
     }
   }
 
+  /** Number of {@link #topK} calls that were split into parallel RID ranges. */
+  public long partitionedQueryCount() {
+    return partitionedQueries.get();
+  }
+
+  /**
+   * True when the calling thread sits in a transaction that has already modified pages.
+   * <p>
+   * Such a query must not be split. A worker resolves its page reads through its own transaction
+   * context, so it sees committed pages only - it cannot see what the caller's open transaction has
+   * written but not committed. That is invisible for the usual read-only query, and wrong for the
+   * one that matters: a {@code put} heavy enough to trigger a memtable flush writes a whole new
+   * segment inside the caller's transaction, and a query issued later in that same transaction has
+   * to score it. Staying serial in that case costs a query that was already paying for a flush
+   * nothing measurable, and removes the whole class of "sees stale data inside its own transaction"
+   * bug.
+   */
+  private boolean callerHoldsUncommittedChanges() {
+    final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath());
+    if (ctx == null)
+      return false;
+    final TransactionContext tx = ctx.getLastTransaction();
+    return tx != null && tx.isActive() && tx.hasChanges();
+  }
+
+  /**
+   * Decide whether to split this query into parallel RID ranges, and where the cuts go (issue #4085).
+   * Returns the interior boundaries - {@code partitions - 1} of them - or {@code null} to stay on the
+   * caller thread.
+   * <p>
+   * <b>Why this is gated rather than always on.</b> Each range runs its own traversal with its own
+   * top-K watermark. A range sees a fraction of the corpus, so its watermark rises more slowly than
+   * the serial scan's and it prunes less: the partitioned query is faster in wall-clock but burns
+   * more CPU in total (measured at ~1.16x for a 2-way split and ~1.89x for 8-way on a learned-sparse
+   * corpus). Spending that on an idle machine is free latency; spending it on a machine already
+   * running other queries takes throughput away from them.
+   * <p>
+   * Five things turn it off:
+   * <ul>
+   *   <li>an explicit {@code maxPartitions == 1};</li>
+   *   <li>the caller is already a scoring-pool worker - a nested fan-out on a pool with a bounded
+   *       queue deadlocks, since the outer tasks hold every worker while waiting on inner tasks that
+   *       nothing is left to run;</li>
+   *   <li>the caller holds uncommitted page changes, which a worker's own transaction cannot see;</li>
+   *   <li>the query is too small for the fan-out to pay for itself;</li>
+   *   <li>no worker can be claimed - either another query holds them all, or enough queries are
+   *       already in flight to keep the pool's worth of threads busy without any help. That last one
+   *       is the load signal that matters and the one the pool's own counters miss, since a query
+   *       runs on its caller's thread and only touches the pool if it decides to split.</li>
+   * </ul>
+   * Boundaries are taken from the block index of the query's widest dim, so each range holds roughly
+   * the same number of that dim's postings. That is a better proxy for "same amount of work" than
+   * cutting the RID space into equal spans, which goes lopsided as soon as a range of RIDs has been
+   * deleted or was never dense. Reading them touches in-memory block metadata only - no page reads.
+   */
+  private RID[] planPartitionBoundaries(final int[] queryDims, final PaginatedSegmentReader[] segSnapshot) throws IOException {
+    final int configured = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    if (configured == 1 || segSnapshot.length == 0)
+      return null;
+    if (SparseVectorScoringPool.isPoolThread())
+      return null;
+    if (callerHoldsUncommittedChanges())
+      return null;
+
+    long totalPostings = 0L;
+    PaginatedDimMetadata widest = null;
+    for (final PaginatedSegmentReader r : segSnapshot) {
+      for (final int dim : queryDims) {
+        final PaginatedDimMetadata md = r.dimMetadata(dim);
+        if (md == null)
+          continue;
+        totalPostings += md.postingCount();
+        if (widest == null || md.postingCount() > widest.postingCount())
+          widest = md;
+      }
+    }
+    if (widest == null)
+      return null;
+    if (totalPostings < GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong())
+      return null;
+
+    final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+    // How many ranges the block layout can carry: below MIN_BLOCKS_PER_PARTITION blocks each, the
+    // cuts stop being distinct RIDs and the ranges stop being balanced enough to be worth making.
+    final int byLayout = widest.blockCount() / MIN_BLOCKS_PER_PARTITION;
+    if (byLayout < 2)
+      return null;
+
+    // The caller scores one range itself, so only the other ranges need a worker. Claiming them up
+    // front - rather than sizing the split from how idle the pool looks - is what keeps concurrent
+    // queries from all deciding to split against the same instantaneously-free capacity.
+    int partitions;
+    if (configured > 1) {
+      // An explicit setting is an operator opting into the CPU cost, so it is granted whether or not
+      // the pool is busy. It still registers the claim, so auto-mode queries running alongside see it.
+      partitions = Math.min(configured, byLayout);
+      pool.reserveWorkers(partitions - 1);
+    } else {
+      final int wanted = Math.min(pool.getMaxParallelism(), byLayout) - 1;
+      final int granted = pool.tryReserveWorkers(wanted);
+      if (granted < 1) {
+        // Nothing free: every worker is already promised to another query. Staying serial here is the
+        // point of the reservation - splitting anyway is what costs throughput under load.
+        return null;
+      }
+      partitions = granted + 1;
+    }
+
+    final RID[] boundaries = new RID[partitions - 1];
+    final int blocks = widest.blockCount();
+    for (int i = 1; i < partitions; i++) {
+      final int b = (int) ((long) blocks * i / partitions);
+      boundaries[i - 1] = new RID(widest.blockFirstBucketId(b), widest.blockFirstPosition(b));
+    }
+    return boundaries;
+  }
+
+  /**
+   * Score every range concurrently on {@link SparseVectorScoringPool} and merge the per-range top-K
+   * lists into the global one.
+   * <p>
+   * The merge is exact, not approximate: the ranges partition the RID space, so every document is
+   * scored exactly once and by the same query, and a document's score does not depend on which range
+   * it landed in. Only pruning differs between the two shapes, and pruning never changes a score - it
+   * only decides which documents are cheap enough to skip.
+   * <p>
+   * Drains every future even when one fails, so a failed query does not leave siblings running and
+   * competing for page reads behind it, and shares one deadline across the whole fan-out so N wedged
+   * ranges cannot cost N timeouts. Same shape as the per-bucket fan-out in
+   * {@code SQLFunctionVectorSparseNeighbors}.
+   */
+  private List<RidScore> parallelTopK(final int[] queryDims, final float[] queryWeights, final int k,
+      final Memtable mtSnapshot, final PaginatedSegmentReader[] segSnapshot, final RID[] boundaries) throws IOException {
+    final int partitions = boundaries.length + 1;
+    final ExecutorService pool = SparseVectorScoringPool.getInstance().getExecutorService();
+    // Ranges [1, partitions) go to workers; the caller scores range 0 itself rather than blocking on
+    // them all. That is one more range running concurrently for the same claimed capacity, and it
+    // keeps a thread that would otherwise be parked doing the work it came to do.
+    final List<Future<List<RidScore>>> futures = new ArrayList<>(partitions - 1);
+    for (int i = 1; i < partitions; i++) {
+      final RID start = boundaries[i - 1];
+      final RID end = i == partitions - 1 ? null : boundaries[i];
+      futures.add(pool.submit(() -> {
+        // A worker thread carries no database context of its own, and the block decoder borrows its
+        // scratch buffer from one, so without this the first page read fails with "Transaction
+        // context not found on current thread". Establishing it explicitly rather than relying on
+        // LocalDatabase.checkDatabaseIsOpen, which creates one as a side effect for any thread that
+        // reaches a checked database method first: that is what keeps the per-bucket fan-out working
+        // today, and it is luck rather than design - the scoring path does not otherwise need it.
+        // Same init/remove pair the parallel bucket scan in FetchFromTypeExecutionStep uses.
+        // The context is a fresh one rather than the caller's: TransactionContext caches the pages it
+        // hands out in plain HashMaps, so several workers sharing one would corrupt it. Reading
+        // committed pages through a fresh context is equivalent here because a caller holding
+        // uncommitted changes is not allowed to fan out at all - see planPartitionBoundaries.
+        DatabaseContext.INSTANCE.init(database);
+        try {
+          return rangeTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, start, end);
+        } finally {
+          DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
+        }
+      }));
+    }
+
+    final int timeoutSeconds = GlobalConfiguration.SPARSE_VECTOR_SCORING_TIMEOUT_SECONDS.getValueAsInteger();
+    final long deadlineNs = timeoutSeconds > 0 ? System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds) : Long.MAX_VALUE;
+    final List<List<RidScore>> ranges = new ArrayList<>(partitions);
+    IOException failure = null;
+
+    // The caller's own range, scored while the workers run. Its failure is handled with the others so
+    // one bad range never leaves siblings running behind a caller that has already given up.
+    try {
+      ranges.add(rangeTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, null, boundaries[0]));
+    } catch (final IOException | RuntimeException e) {
+      failure = e instanceof IOException io ? io : new IOException("sparse-vector range scoring failed", e);
+    }
+
+    for (final Future<List<RidScore>> f : futures) {
+      try {
+        if (timeoutSeconds <= 0) {
+          ranges.add(f.get());
+        } else {
+          final long remainingNs = deadlineNs - System.nanoTime();
+          if (remainingNs <= 0L)
+            throw new TimeoutException("deadline elapsed before draining range");
+          ranges.add(f.get(remainingNs, TimeUnit.NANOSECONDS));
+        }
+      } catch (final InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        for (final Future<?> other : futures)
+          other.cancel(true);
+        throw new IndexException("Interrupted during sparse-vector top-K range fan-out", ie);
+      } catch (final TimeoutException te) {
+        for (final Future<?> other : futures)
+          other.cancel(true);
+        throw new IndexException("Sparse-vector top-K range fan-out timed out after " + timeoutSeconds + "s (configurable via "
+            + GlobalConfiguration.SPARSE_VECTOR_SCORING_TIMEOUT_SECONDS.getKey() + ")", te);
+      } catch (final ExecutionException ee) {
+        final Throwable cause = ee.getCause();
+        if (failure == null)
+          failure = cause instanceof IOException io ? io : new IOException("sparse-vector range scoring failed", cause);
+        else
+          failure.addSuppressed(cause);
+      }
+    }
+    if (failure != null)
+      throw failure;
+
+    return BmwScorer.mergeRanges(ranges, k);
+  }
+
   /**
    * Top-K with traversal-integrated {@code groupBy} / {@code groupSize} (issue #4071). Replaces the
    * MVP's {@code topK} + over-fetch + post-filter pattern with a per-group min-heap inside the BMW
-   * DAAT loop. {@code groupKeyResolver} is consulted once per scored document; {@code allowedRIDs}
+   * DAAT loop.
+   * <p>
+   * <b>Not range-split</b>, unlike {@link #topK} (issue #4085). Merging grouped results is not the
+   * same problem as merging plain ones: the group budget is global, so two ranges that each filled
+   * their {@code limit} groups can hold more distinct keys between them than the query asked for, and
+   * picking which to drop needs the per-group worst scores rather than a flat best-k. That merge
+   * already exists a layer up, in the per-bucket fan-out, and pushing it down here is a separate
+   * piece of work rather than a line of this one. {@code groupKeyResolver} is consulted once per scored document; {@code allowedRIDs}
    * is applied inline so callers no longer need to over-fetch to compensate for selective filters.
    *
    * @see BmwScorer#topKGrouped

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -184,6 +184,19 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
   static final int EXPLICIT_PARTITION_OVERSUBSCRIPTION = 4;
 
   /**
+   * A decided split: where the cuts go, and how many workers were actually claimed for it.
+   * <p>
+   * The two travel together because they are not derivable from each other. An explicit partition
+   * count is honoured in full but its claim saturates at the pool ceiling, so the reservation can be
+   * smaller than {@code boundaries.length} - and releasing the wrong number is not a visible failure,
+   * it is a counter that drifts until splitting stops happening for reasons nobody can see. Carrying
+   * the figure the pool actually recorded is what makes the reserve and the release the same number
+   * by construction rather than by two places computing it alike.
+   */
+  private record PartitionPlan(RID[] boundaries, int reservedWorkers) {
+  }
+
+  /**
    * Queries that took the partitioned path (issue #4085). Whether a query is split depends on how
    * busy the scoring pool was at that instant, so this is the only way to tell after the fact which
    * shape actually ran - results are identical either way by design, which is exactly what makes the
@@ -383,16 +396,17 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
     final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
     pool.queryStarted();
     try {
-      final RID[] boundaries = planPartitionBoundaries(queryDims, segSnapshot);
-      if (boundaries != null) {
+      final PartitionPlan plan = planPartitionBoundaries(queryDims, segSnapshot);
+      if (plan != null) {
         partitionedQueries.incrementAndGet();
         pool.querySplit();
         try {
-          return parallelTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, boundaries);
+          return parallelTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, plan.boundaries());
         } finally {
-          // Hand the claimed capacity back on every exit, including a timeout or a failed range:
-          // leaking it would permanently shrink what later queries believe the pool has free.
-          pool.releaseWorkers(boundaries.length);
+          // Hand back exactly what the pool recorded, not what the split asked for: leaking it would
+          // permanently shrink what later queries believe is free, and over-releasing would let them
+          // over-claim. Either way the damage is a silent drift in a number nothing else checks.
+          pool.releaseWorkers(plan.reservedWorkers());
         }
       }
 
@@ -498,7 +512,8 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
    * document is still scored exactly once. Only the speedup suffers, and it shows up as one range
    * finishing long after its siblings.
    */
-  private RID[] planPartitionBoundaries(final int[] queryDims, final PaginatedSegmentReader[] segSnapshot) throws IOException {
+  private PartitionPlan planPartitionBoundaries(final int[] queryDims, final PaginatedSegmentReader[] segSnapshot)
+      throws IOException {
     final int configured = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
     if (configured == 1 || segSnapshot.length == 0)
       return null;
@@ -535,13 +550,17 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
     // front - rather than sizing the split from how idle the pool looks - is what keeps concurrent
     // queries from all deciding to split against the same instantaneously-free capacity.
     final int partitions;
+    final int reserved;
     if (configured > 1) {
-      // An explicit setting is an operator opting into the CPU cost, so it is granted whether or not
-      // the pool is busy. It still registers the claim, so auto-mode queries running alongside see it.
-      // Clamped all the same: the knob is "do not throttle me", not "let me open a thousand cursor
-      // stacks", and past a small multiple of the pool there are no threads left to run them anyway.
+      // An explicit setting is an operator opting into the CPU cost, so the split itself is granted
+      // whether or not the pool is busy - it never yields. Clamped for sanity all the same: the knob
+      // is "do not throttle me", not "let me open a thousand cursor stacks", and past a small
+      // multiple of the pool there are no threads left to run them anyway.
       partitions = Math.min(Math.min(configured, byLayout), pool.getMaxParallelism() * EXPLICIT_PARTITION_OVERSUBSCRIPTION);
-      pool.reserveWorkers(partitions - 1);
+      // The claim, unlike the split, is capped at what the pool can hold, and may come back smaller
+      // than asked or zero. Claiming more would suppress splitting for every concurrent query for
+      // this one's whole duration, on the strength of ranges that are queued rather than running.
+      reserved = pool.reserveWorkers(partitions - 1);
       pool.warnExplicitSplitUnderLoad(partitions);
     } else {
       final int wanted = Math.min(pool.getMaxParallelism(), byLayout) - 1;
@@ -552,6 +571,7 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
         return null;
       }
       partitions = granted + 1;
+      reserved = granted;
     }
 
     // Everything past the claim hands it back unless it reaches the caller. The boundary walk
@@ -574,10 +594,10 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
         boundaries[i - 1] = new RID(widest.blockFirstBucketId(b), widest.blockFirstPosition(b));
       }
       handedOff = true;
-      return boundaries;
+      return new PartitionPlan(boundaries, reserved);
     } finally {
       if (!handedOff)
-        pool.releaseWorkers(partitions - 1);
+        pool.releaseWorkers(reserved);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -176,6 +176,14 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
   static final int MIN_BLOCKS_PER_PARTITION = 4;
 
   /**
+   * Ceiling on how far an explicit {@code sparseVectorScoringMaxPartitions} may oversubscribe the
+   * scoring pool. The setting exists to opt out of the load gate, not out of arithmetic: each range
+   * costs a full cursor stack, and past a small multiple of the pool there is no thread free to run
+   * it, so the extra ranges buy queueing and memory rather than parallelism.
+   */
+  static final int EXPLICIT_PARTITION_OVERSUBSCRIPTION = 4;
+
+  /**
    * Queries that took the partitioned path (issue #4085). Whether a query is split depends on how
    * busy the scoring pool was at that instant, so this is the only way to tell after the fact which
    * shape actually ran - results are identical either way by design, which is exactly what makes the
@@ -503,11 +511,13 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
     // The caller scores one range itself, so only the other ranges need a worker. Claiming them up
     // front - rather than sizing the split from how idle the pool looks - is what keeps concurrent
     // queries from all deciding to split against the same instantaneously-free capacity.
-    int partitions;
+    final int partitions;
     if (configured > 1) {
       // An explicit setting is an operator opting into the CPU cost, so it is granted whether or not
       // the pool is busy. It still registers the claim, so auto-mode queries running alongside see it.
-      partitions = Math.min(configured, byLayout);
+      // Clamped all the same: the knob is "do not throttle me", not "let me open a thousand cursor
+      // stacks", and past a small multiple of the pool there are no threads left to run them anyway.
+      partitions = Math.min(Math.min(configured, byLayout), pool.getMaxParallelism() * EXPLICIT_PARTITION_OVERSUBSCRIPTION);
       pool.reserveWorkers(partitions - 1);
     } else {
       final int wanted = Math.min(pool.getMaxParallelism(), byLayout) - 1;
@@ -520,13 +530,23 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
       partitions = granted + 1;
     }
 
-    final RID[] boundaries = new RID[partitions - 1];
-    final int blocks = widest.blockCount();
-    for (int i = 1; i < partitions; i++) {
-      final int b = (int) ((long) blocks * i / partitions);
-      boundaries[i - 1] = new RID(widest.blockFirstBucketId(b), widest.blockFirstPosition(b));
+    // Everything past the claim releases it on the way out if it fails. The boundary walk touches
+    // in-memory block metadata only and cannot currently throw, but this method reads segment
+    // metadata and is declared to throw, so a future edit that adds a page read here would otherwise
+    // leak the claim permanently - silently shrinking what every later query believes is free, with
+    // nothing failing to point at it.
+    try {
+      final RID[] boundaries = new RID[partitions - 1];
+      final int blocks = widest.blockCount();
+      for (int i = 1; i < partitions; i++) {
+        final int b = (int) ((long) blocks * i / partitions);
+        boundaries[i - 1] = new RID(widest.blockFirstBucketId(b), widest.blockFirstPosition(b));
+      }
+      return boundaries;
+    } catch (final RuntimeException | Error e) {
+      pool.releaseWorkers(partitions - 1);
+      throw e;
     }
-    return boundaries;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -581,16 +581,29 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
         // LocalDatabase.checkDatabaseIsOpen, which creates one as a side effect for any thread that
         // reaches a checked database method first: that is what keeps the per-bucket fan-out working
         // today, and it is luck rather than design - the scoring path does not otherwise need it.
-        // Same init/remove pair the parallel bucket scan in FetchFromTypeExecutionStep uses.
-        // The context is a fresh one rather than the caller's: TransactionContext caches the pages it
-        // hands out in plain HashMaps, so several workers sharing one would corrupt it. Reading
+        //
+        // Create-only-if-absent, and tear down only what this task created, exactly as
+        // checkDatabaseIsOpen does it. This task does NOT always run on a worker: the pool's queue is
+        // bounded and its rejection policy is caller-runs, so once the queue fills, a submitted range
+        // executes inline on the submitting thread - which is the user's, inside the user's
+        // transaction. An unconditional init() there takes DatabaseContext.init's "ROLLBACK PREVIOUS
+        // TXS" branch and silently rolls the caller's transaction back, and the removeContext below
+        // would then wipe the context the rest of the query still needs. The identical init/remove
+        // pair in FetchFromTypeExecutionStep is safe only because its pool has an unbounded queue and
+        // never runs a task on the caller.
+        //
+        // The context stays a fresh one rather than the caller's: TransactionContext caches the pages
+        // it hands out in plain HashMaps, so several workers sharing one would corrupt it. Reading
         // committed pages through a fresh context is equivalent here because a caller holding
         // uncommitted changes is not allowed to fan out at all - see planPartitionBoundaries.
-        DatabaseContext.INSTANCE.init(database);
+        final boolean contextCreated = DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath()) == null;
+        if (contextCreated)
+          DatabaseContext.INSTANCE.init(database);
         try {
           return rangeTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, start, end);
         } finally {
-          DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
+          if (contextCreated)
+            DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
         }
       }));
     }
@@ -610,7 +623,12 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
 
     for (final Future<List<RidScore>> f : futures) {
       try {
-        if (timeoutSeconds <= 0) {
+        // A range that has already finished is always harvested, deadline or not. The caller scores
+        // its own range before getting here, so it can legitimately consume the whole budget on work
+        // that succeeded; failing the query then, while every worker range sits complete and waiting
+        // to be read, would be a timeout reported for nothing that is actually outstanding. The
+        // deadline governs waiting, not collecting.
+        if (timeoutSeconds <= 0 || f.isDone()) {
           ranges.add(f.get());
         } else {
           final long remainingNs = deadlineNs - System.nanoTime();

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -554,11 +554,18 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
       partitions = granted + 1;
     }
 
-    // Everything past the claim releases it on the way out if it fails. The boundary walk touches
-    // in-memory block metadata only and cannot currently throw, but this method reads segment
-    // metadata and is declared to throw, so a future edit that adds a page read here would otherwise
-    // leak the claim permanently - silently shrinking what every later query believes is free, with
-    // nothing failing to point at it.
+    // Everything past the claim hands it back unless it reaches the caller. The boundary walk
+    // touches in-memory block metadata only and cannot currently throw, but this method reads
+    // segment metadata and is declared to throw, so a future edit that adds a page read here would
+    // otherwise leak the claim permanently - silently shrinking what every later query believes is
+    // free, with nothing failing to point at it.
+    //
+    // Written as a handed-off flag rather than a catch clause on purpose. Enumerating exception
+    // types is how this guard fails quietly: the obvious "catch (RuntimeException | Error)" does not
+    // intercept the IOException that the page read it was written for would actually throw. A
+    // finally covers every abrupt exit - checked, unchecked, Error - and any future early return
+    // that forgets about the claim.
+    boolean handedOff = false;
     try {
       final RID[] boundaries = new RID[partitions - 1];
       final int blocks = widest.blockCount();
@@ -566,10 +573,11 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
         final int b = (int) ((long) blocks * i / partitions);
         boundaries[i - 1] = new RID(widest.blockFirstBucketId(b), widest.blockFirstPosition(b));
       }
+      handedOff = true;
       return boundaries;
-    } catch (final RuntimeException | Error e) {
-      pool.releaseWorkers(partitions - 1);
-      throw e;
+    } finally {
+      if (!handedOff)
+        pool.releaseWorkers(partitions - 1);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -372,6 +372,7 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
       final RID[] boundaries = planPartitionBoundaries(queryDims, segSnapshot);
       if (boundaries != null) {
         partitionedQueries.incrementAndGet();
+        pool.querySplit();
         try {
           return parallelTopK(queryDims, queryWeights, k, mtSnapshot, segSnapshot, boundaries);
         } finally {

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/RidScoreMinHeap.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/RidScoreMinHeap.java
@@ -134,12 +134,36 @@ final class RidScoreMinHeap {
       out.add(new RidScore(rids[i], scores[i]));
   }
 
+  /**
+   * Heap order: lowest score first and, among equal scores, <b>highest RID first</b>, so the entry
+   * sitting at the root - the one an accepted candidate evicts - is always the one the total order
+   * "score descending, then RID ascending" ranks last.
+   * <p>
+   * The RID leg only ever decides ties, but it is what makes the retained set deterministic. Without
+   * it, a heap holding several entries on the same score evicts whichever of them the array layout
+   * happens to put at the root, so the same query over the same data could keep a different one
+   * depending on the order candidates arrived in. That is invisible while there is one traversal, and
+   * becomes visible the moment a query is split into ranges scored independently (issue #4085): the
+   * merged result has to be the one the serial scan would have produced, ties included.
+   * <p>
+   * Admission stays the primitive {@code >} test in {@link #offer}: a DAAT traversal produces
+   * candidates in ascending RID order, so a candidate arriving later always loses a tie against
+   * anything already retained and can never displace it.
+   */
+  private int compareEntry(final float score, final RID rid, final int idx) {
+    final int c = Float.compare(score, scores[idx]);
+    if (c != 0)
+      return c;
+    // Reversed on purpose: the larger RID is the "smaller" heap entry, i.e. the first to be evicted.
+    return SparseSegmentBuilder.compareRid(rids[idx], rid);
+  }
+
   private void siftUp(int i) {
     final RID rid = rids[i];
     final float score = scores[i];
     while (i > 0) {
       final int parent = (i - 1) >>> 1;
-      if (Float.compare(score, scores[parent]) >= 0)
+      if (compareEntry(score, rid, parent) >= 0)
         break;
       rids[i] = rids[parent];
       scores[i] = scores[parent];
@@ -156,9 +180,9 @@ final class RidScoreMinHeap {
     while (i < half) {
       int child = (i << 1) + 1;
       final int right = child + 1;
-      if (right < size && Float.compare(scores[right], scores[child]) < 0)
+      if (right < size && compareEntry(scores[right], rids[right], child) < 0)
         child = right;
-      if (Float.compare(score, scores[child]) <= 0)
+      if (compareEntry(score, rid, child) <= 0)
         break;
       rids[i] = rids[child];
       scores[i] = scores[child];

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/RidScoreMinHeap.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/RidScoreMinHeap.java
@@ -149,6 +149,13 @@ final class RidScoreMinHeap {
    * Admission stays the primitive {@code >} test in {@link #offer}: a DAAT traversal produces
    * candidates in ascending RID order, so a candidate arriving later always loses a tie against
    * anything already retained and can never displace it.
+   * <p>
+   * <b>This applies to every query, not only split ones.</b> The ordering lives in the collector, so
+   * a database with splitting disabled entirely gets it too. That is a visible change for anyone
+   * whose scores tie: the retained set was previously whichever of the tied documents the heap array
+   * happened to hold at the root, and is now the lowest RIDs. The new answer is the better one - the
+   * old one was not stable across insertion orders - but it is not opt-in, and a result set that
+   * ties on score can differ from a previous release.
    */
   private int compareEntry(final float score, final RID rid, final int idx) {
     final int c = Float.compare(score, scores[idx]);

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -123,6 +123,7 @@ public final class SparseVectorScoringPool {
   // first saturation event.
   private static final long        SATURATION_WARN_INTERVAL_MS = 60_000L;
   private final AtomicLong         lastSaturationWarnMs = new AtomicLong(0L);
+  private final AtomicLong         lastExplicitSplitWarnMs = new AtomicLong(0L);
 
   private SparseVectorScoringPool() {
     // 0 = auto-size to available cores (with a floor of {@link #DEFAULT_THREADS_FLOOR}). Any
@@ -313,6 +314,35 @@ public final class SparseVectorScoringPool {
   /** Cumulative queries split into RID ranges since JVM start. */
   public long getSplitQueryCount() {
     return splitQueries.get();
+  }
+
+  /**
+   * Throttled WARNING for a split that only happened because an operator configured an explicit
+   * partition count, at a moment the adaptive default would have refused it.
+   * <p>
+   * Behaviour is unchanged - an explicit setting is a deliberate "do not throttle me" and is still
+   * honoured. The point is that the setting is JVM-wide and long-lived, so whoever configured it
+   * months ago is rarely the person watching latency today; without a signal, the trade it makes
+   * (throughput for latency, under exactly the load where that hurts) is invisible. Same 60-second
+   * throttle as the saturation warning, so a busy server gets one nudge rather than a stream.
+   */
+  public void warnExplicitSplitUnderLoad(final int partitions) {
+    final int ceiling = executor.getMaximumPoolSize();
+    final int inFlight = inFlightQueries.get();
+    if (inFlight * 2 <= ceiling)
+      // The adaptive gate would have allowed this too, so the explicit setting changed nothing here.
+      return;
+    final long now = System.currentTimeMillis();
+    final long last = lastExplicitSplitWarnMs.get();
+    if (now - last > SATURATION_WARN_INTERVAL_MS && lastExplicitSplitWarnMs.compareAndSet(last, now))
+      LogManager.instance().log(this, Level.WARNING,
+          "Sparse-vector top-K split into %d ranges by an explicit %s=%d while %d queries were already in flight on a %d-thread pool. "
+              + "The adaptive default (0) would have kept this query on its caller thread: splitting costs roughly 1.9x the CPU for an "
+              + "8-way split, which buys latency on an idle machine and takes throughput from other queries on a busy one. "
+              + "Set %s=0 to let the engine decide per query.",
+          partitions, GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey(),
+          GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger(), inFlight, ceiling,
+          GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey());
   }
 
   /** Unconditional claim, for an operator who configured an explicit partition count. */

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -374,10 +374,33 @@ public final class SparseVectorScoringPool {
           GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey());
   }
 
-  /** Unconditional claim, for an operator who configured an explicit partition count. */
-  public void reserveWorkers(final int count) {
-    if (count > 0)
-      reservedWorkers.addAndGet(count);
+  /**
+   * Claim for an operator who configured an explicit partition count: granted whether or not the pool
+   * is busy, but never beyond what the pool can actually hold.
+   * <p>
+   * Saturates at the pool ceiling rather than adding blindly. An explicit setting means "do not
+   * throttle me", and it still does not - the caller splits into the ranges it asked for whatever
+   * this returns, including 0. What it must not do is <i>claim</i> capacity that does not exist: the
+   * count is what every other query's gate reads, and a query recording four times the pool's worth
+   * of workers would stop every concurrent query from splitting for its whole duration, far beyond
+   * the contention it actually causes. Past the ceiling the extra ranges are queued, not running, so
+   * counting them would describe parallelism the machine is not providing.
+   *
+   * @return the number actually recorded, which the caller must hand back with
+   *         {@link #releaseWorkers(int)} - not the number it asked for.
+   */
+  public int reserveWorkers(final int count) {
+    if (count <= 0)
+      return 0;
+    final int ceiling = executor.getMaximumPoolSize();
+    while (true) {
+      final int current = reservedWorkers.get();
+      final int granted = Math.min(count, ceiling - current);
+      if (granted <= 0)
+        return 0;
+      if (reservedWorkers.compareAndSet(current, current + granted))
+        return granted;
+    }
   }
 
   /** Hands back workers claimed through {@link #tryReserveWorkers} / {@link #reserveWorkers}. */

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -55,13 +55,25 @@ import java.util.logging.Level;
  * returns a correct top-K. The fallback count is exposed via {@link #getPoolStats()} so
  * dashboards can surface saturation.
  * <p>
- * <b>Wired since #4085.</b> {@code SQLFunctionVectorSparseNeighbors} fans out per-bucket
- * {@code topK} calls onto this pool when a query targets multiple buckets (partitioned types,
- * or types with multiple physical buckets). Within a single bucket's index the scoring still
- * runs serially - per-segment RID-range partitioning was investigated but deferred because the
- * absolute gain is small relative to network + serialization overhead at the latencies the
- * serial 10M benchmark already lands at. The pool is sized through the
- * {@link GlobalConfiguration#SPARSE_VECTOR_SCORING_POOL_THREADS} / {@code _QUEUE_SIZE} knobs.
+ * <b>Two kinds of work land here (#4085).</b> {@code SQLFunctionVectorSparseNeighbors} fans out
+ * per-bucket {@code topK} calls when a query targets multiple buckets (partitioned types, or types
+ * with multiple physical buckets), and {@link PaginatedSparseVectorEngine#topK} splits a single
+ * index's traversal into RID ranges. The two never nest: a fan-out already running on a worker will
+ * not split again, which {@link #isPoolThread()} enforces, because a nested fan-out on a bounded
+ * queue deadlocks rather than degrading.
+ * <p>
+ * <b>Range splitting is not free, which is why it is adaptive.</b> Each range prunes against its own
+ * top-K watermark instead of the global one, so it does more work than its share - about 1.9x total
+ * CPU for an 8-way split on a learned-sparse corpus. A query claims the workers it wants up front
+ * ({@link #tryReserveWorkers(int)}), and the claim is refused once the queries already in flight can
+ * keep the pool's worth of threads busy by themselves. Measured on an 18-worker box at 500k
+ * documents: one client 13.7 -> 3.1 ms p50 with every query split, four clients 13.6 -> 4.1 ms and
+ * throughput up 61%, sixteen clients within 5% of serial throughput with 2 queries out of 8289
+ * split. So the split shows up when there are cores going spare and steps out of the way when there
+ * are not. The pool is sized
+ * through the {@link GlobalConfiguration#SPARSE_VECTOR_SCORING_POOL_THREADS} / {@code _QUEUE_SIZE}
+ * knobs, and the split through {@code SPARSE_VECTOR_SCORING_MAX_PARTITIONS} /
+ * {@code _MIN_POSTINGS_FOR_PARTITIONING}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -81,7 +93,23 @@ public final class SparseVectorScoringPool {
   /** Floor for the auto-sized thread count when {@code SPARSE_VECTOR_SCORING_POOL_THREADS=0}. */
   private static final int DEFAULT_THREADS_FLOOR = 2;
 
+  /**
+   * Marks a thread as belonging to this pool. Read by {@link #isPoolThread()} to stop a fan-out
+   * from nesting inside another one, which on a pool with a bounded queue is a deadlock rather
+   * than a slowdown: the outer tasks occupy every worker and block waiting on inner tasks that sit
+   * in the queue with nobody left to run them. The caller-runs rejection policy does not save it,
+   * because the queue accepts long before it rejects.
+   * <p>
+   * Set on the worker itself rather than per task so it survives whatever the task does, and so a
+   * task that spawns further work inherits nothing it should not.
+   */
+  private static final ThreadLocal<Boolean> POOL_THREAD = new ThreadLocal<>();
+
   private final ThreadPoolExecutor executor;
+  /** Workers claimed by in-flight range fan-outs; see {@link #tryReserveWorkers(int)}. */
+  private final AtomicInteger      reservedWorkers      = new AtomicInteger();
+  /** Sparse-vector top-K calls in flight JVM-wide, split or not; see {@link #queryStarted()}. */
+  private final AtomicInteger      inFlightQueries      = new AtomicInteger();
   private final AtomicLong         callerRunCount       = new AtomicLong();
   // Throttle for the WARNING log emitted on saturation: at most one entry per minute. Same
   // shape as the QueryEngineManager pool's throttle - operators see one nudge in the console
@@ -122,7 +150,10 @@ public final class SparseVectorScoringPool {
         60L, TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(queueSize),
         r -> {
-          final Thread t = new Thread(r, "ArcadeDB-SparseVectorScorer-" + workerSeq.incrementAndGet());
+          final Thread t = new Thread(() -> {
+            POOL_THREAD.set(Boolean.TRUE);
+            r.run();
+          }, "ArcadeDB-SparseVectorScorer-" + workerSeq.incrementAndGet());
           t.setDaemon(true);
           return t;
         },
@@ -172,6 +203,91 @@ public final class SparseVectorScoringPool {
    */
   public int getMaxParallelism() {
     return executor.getMaximumPoolSize();
+  }
+
+  /**
+   * True when the calling thread is one of this pool's workers, i.e. when it is already executing a
+   * fan-out task. Callers use it to refuse to fan out again - see {@link #POOL_THREAD}. Also true on
+   * a thread that ran a task inline through the caller-runs policy only if that thread is itself a
+   * worker; a plain caller running a rejected task stays a non-pool thread, which is correct: it has
+   * a whole worker's worth of nothing else to do.
+   */
+  public static boolean isPoolThread() {
+    return Boolean.TRUE.equals(POOL_THREAD.get());
+  }
+
+  /**
+   * Claim up to {@code desired} workers for a range fan-out, returning how many were actually granted
+   * (possibly 0). The caller must hand back exactly what it was granted with
+   * {@link #releaseWorkers(int)}.
+   * <p>
+   * <b>Why a reservation instead of just reading how busy the pool is.</b> Splitting a query buys
+   * latency by burning extra CPU - each range prunes against its own weaker watermark - so it is only
+   * worth doing with capacity nobody else wants. Sizing that from {@link ThreadPoolExecutor#getActiveCount()}
+   * looked sufficient and measured otherwise: at 16 concurrent clients on an 18-worker pool it still
+   * split 57% of queries and gave up 14% of throughput, because every client samples an
+   * instantaneously-idle pool at the same moment and they all decide to split. A reservation is a
+   * claim rather than an observation, so the capacity a query is about to use is already gone from
+   * the next query's view of it.
+   */
+  public int tryReserveWorkers(final int desired) {
+    if (desired <= 0)
+      return 0;
+    final int ceiling = executor.getMaximumPoolSize();
+    // Callers are the load the pool cannot see. A query runs on its caller's thread, so N concurrent
+    // queries already occupy N threads before a single task is submitted, and getActiveCount() stays
+    // near zero right up until the machine is full. Measured on an 18-worker box: at 16 concurrent
+    // clients the pool looks idle at every sampling instant, splits a third of the queries anyway,
+    // and gives up throughput for it. Refusing to split once the callers alone can keep the pool's
+    // worth of threads busy is what makes the default safe under load, and it costs nothing when
+    // idle - one caller against 18 workers splits all the way.
+    if (inFlightQueries.get() * 2 > ceiling)
+      return 0;
+    while (true) {
+      final int current = reservedWorkers.get();
+      final int free = ceiling - current;
+      if (free <= 0)
+        return 0;
+      final int grant = Math.min(desired, free);
+      if (reservedWorkers.compareAndSet(current, current + grant))
+        return grant;
+    }
+  }
+
+  /**
+   * Registers a sparse-vector top-K as in flight, whatever shape it ends up taking. Callers must
+   * pair it with {@link #queryFinished()}. Counting queries rather than tasks is the point: the
+   * concurrency that matters for the split decision arrives on caller threads, which never touch
+   * this pool unless a query decides to fan out.
+   */
+  public void queryStarted() {
+    inFlightQueries.incrementAndGet();
+  }
+
+  public void queryFinished() {
+    inFlightQueries.decrementAndGet();
+  }
+
+  /** Sparse-vector top-K calls currently executing across the JVM. Test and diagnostics hook. */
+  public int getInFlightQueries() {
+    return inFlightQueries.get();
+  }
+
+  /** Unconditional claim, for an operator who configured an explicit partition count. */
+  public void reserveWorkers(final int count) {
+    if (count > 0)
+      reservedWorkers.addAndGet(count);
+  }
+
+  /** Hands back workers claimed through {@link #tryReserveWorkers} / {@link #reserveWorkers}. */
+  public void releaseWorkers(final int count) {
+    if (count > 0)
+      reservedWorkers.addAndGet(-count);
+  }
+
+  /** Workers currently claimed by in-flight range fan-outs. Test and diagnostics hook. */
+  public int getReservedWorkers() {
+    return reservedWorkers.get();
   }
 
   public PoolStats getPoolStats() {

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -109,6 +109,20 @@ public final class SparseVectorScoringPool {
   private static final int CALLER_LOAD_GATE_FACTOR = 2;
 
   /**
+   * How far the ranges of concurrently forced splits may oversubscribe the pool before the setting is
+   * assumed to be working against the query that asked for it.
+   * <p>
+   * Mechanistic rather than a client count: {@code inFlight * partitions} ranges competing for
+   * {@code ceiling} workers is when a query's own ranges start queueing behind its neighbours', which
+   * is what turns the split from a latency win into a latency loss. Two independent harnesses put the
+   * crossover at this factor - between 4 and 8 clients forcing 8 ranges on 18 workers, and around 4
+   * clients forcing 8 on 12 - and it is a rough shape rather than a prediction, which is why it drives
+   * only a log line and never a decision. The crossover itself is hardware and workload specific and
+   * is deliberately not quoted in the setting's documentation.
+   */
+  private static final int SELF_DEFEATING_OVERSUBSCRIPTION = 2;
+
+  /**
    * Marks a thread as belonging to this pool. Read by {@link #isPoolThread()} to stop a fan-out
    * from nesting inside another one, which on a pool with a bounded queue is a deadlock rather
    * than a slowdown: the outer tasks occupy every worker and block waiting on inner tasks that sit
@@ -356,22 +370,30 @@ public final class SparseVectorScoringPool {
   public void warnExplicitSplitUnderLoad(final int partitions) {
     final int ceiling = executor.getMaximumPoolSize();
     final int inFlight = inFlightQueries.get();
-    // The same predicate the gate itself uses, not a copy of it. This warning's entire claim is
-    // "the adaptive default would have refused this", so a second expression here would start
-    // lying the moment the gate is tuned - the one thing naming the factor was meant to prevent.
-    if (!callersAloneCanSaturate())
+    // Two independent reasons to speak, and the contention one alone is not enough.
+    //
+    // callersAloneCanSaturate is "the adaptive default would have refused this", asked through the
+    // same predicate the gate uses rather than a copy of it, so tuning the gate cannot make this
+    // warning lie. But it only trips once callers alone could keep the pool busy - half the pool's
+    // worth of queries - and the measured point where a forced split starts making the FORCING
+    // query slower arrives earlier than that. On an 18-thread pool the gate needs 10 queries in
+    // flight; the crossover sat between 4 and 8. So a purely contention-based trigger stays silent
+    // through the region where the setting has already turned against the person who set it.
+    final boolean wouldHaveBeenRefused = callersAloneCanSaturate();
+    final boolean defeatsItself =
+        (long) inFlight * partitions > (long) ceiling * SELF_DEFEATING_OVERSUBSCRIPTION;
+    if (!wouldHaveBeenRefused && !defeatsItself)
       return;
     final long now = System.currentTimeMillis();
     final long last = lastExplicitSplitWarnMs.get();
     if (now - last > SATURATION_WARN_INTERVAL_MS && lastExplicitSplitWarnMs.compareAndSet(last, now))
       LogManager.instance().log(this, Level.WARNING,
           "Sparse-vector top-K split into %d ranges by an explicit %s=%d with %d queries in flight (including this one) on a "
-              + "%d-thread pool. The adaptive default (0) would have kept this query on its caller thread. Splitting costs roughly 2x "
-              + "the CPU for an 8-way split (measured 1.89x here, 1.98x independently), and under load THIS query pays too, not only "
-              + "its neighbours: measured at 16 concurrent clients, a forced 8-way split returned 0.76x the throughput of no split at "
-              + "all and a median 1.75x worse. What it did buy is a lower tail - p99 297 ms against 579 ms - so forcing the split is a "
-              + "reasonable choice for tail-sensitive traffic and the wrong one for median or throughput. Set %s=0 to let the engine "
-              + "decide per query.",
+              + "%d-thread pool. The adaptive default (0) would have kept this query on its caller thread, and past a handful of "
+              + "concurrent queries a forced split stops helping anything at all: measured at 16 concurrent clients on an 18-thread "
+              + "pool, a forced 8-way split returned 0.52x the throughput of no split, a median 1.85x worse AND a p99 2.5x worse, for "
+              + "1.9x the CPU per query. There is no regime above light concurrency where this setting wins - not median, not "
+              + "throughput, not tail. Set %s=0 to let the engine decide per query.",
           partitions, GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey(),
           GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger(), inFlight, ceiling,
           GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey(),

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -237,6 +237,18 @@ public final class SparseVectorScoringPool {
   }
 
   /**
+   * Whether the queries already in flight on caller threads can keep this pool's worth of threads
+   * busy without any help, which is the point at which splitting stops paying for itself.
+   * <p>
+   * Deliberately the only place this comparison is written. Both the gate that refuses a split and
+   * the warning that reports one granted anyway ask this question, and they have to agree by
+   * construction rather than by two authors keeping two expressions in step.
+   */
+  private boolean callersAloneCanSaturate() {
+    return inFlightQueries.get() * CALLER_LOAD_GATE_FACTOR > executor.getMaximumPoolSize();
+  }
+
+  /**
    * Claim up to {@code desired} workers for a range fan-out, returning how many were actually granted
    * (possibly 0). The caller must hand back exactly what it was granted with
    * {@link #releaseWorkers(int)}.
@@ -261,7 +273,7 @@ public final class SparseVectorScoringPool {
     // and gives up throughput for it. Refusing to split once the callers alone can keep the pool's
     // worth of threads busy is what makes the default safe under load, and it costs nothing when
     // idle - one caller against 18 workers splits all the way.
-    if (inFlightQueries.get() * CALLER_LOAD_GATE_FACTOR > ceiling)
+    if (callersAloneCanSaturate())
       return 0;
     // Work on the pool that never went through a reservation - the per-bucket fan-out submits
     // straight to the executor - still occupies workers, so it counts against what is grantable or a
@@ -344,8 +356,10 @@ public final class SparseVectorScoringPool {
   public void warnExplicitSplitUnderLoad(final int partitions) {
     final int ceiling = executor.getMaximumPoolSize();
     final int inFlight = inFlightQueries.get();
-    if (inFlight * 2 <= ceiling)
-      // The adaptive gate would have allowed this too, so the explicit setting changed nothing here.
+    // The same predicate the gate itself uses, not a copy of it. This warning's entire claim is
+    // "the adaptive default would have refused this", so a second expression here would start
+    // lying the moment the gate is tuned - the one thing naming the factor was meant to prevent.
+    if (!callersAloneCanSaturate())
       return;
     final long now = System.currentTimeMillis();
     final long last = lastExplicitSplitWarnMs.get();

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -366,11 +366,15 @@ public final class SparseVectorScoringPool {
     if (now - last > SATURATION_WARN_INTERVAL_MS && lastExplicitSplitWarnMs.compareAndSet(last, now))
       LogManager.instance().log(this, Level.WARNING,
           "Sparse-vector top-K split into %d ranges by an explicit %s=%d while %d queries were already in flight on a %d-thread pool. "
-              + "The adaptive default (0) would have kept this query on its caller thread: splitting costs roughly 1.9x the CPU for an "
-              + "8-way split, which buys latency on an idle machine and takes throughput from other queries on a busy one. "
+              + "The adaptive default (0) would have kept this query on its caller thread. Splitting costs roughly 2x the CPU for an "
+              + "8-way split (measured 1.89x here, 1.98x independently), and under load that is paid by THIS query too, not only by its "
+              + "neighbours: at 16 concurrent clients a forced 8-way split measured 0.76x the throughput of no split at all, with a "
+              + "median 1.75x worse. It does compress the tail - p99/p50 1.5x against 5.2x - so if tail predictability is what you are "
+              + "buying, this is the trade; if it is median or throughput, %s=0 is faster. "
               + "Set %s=0 to let the engine decide per query.",
           partitions, GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey(),
           GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger(), inFlight, ceiling,
+          GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey(),
           GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey());
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -365,13 +365,13 @@ public final class SparseVectorScoringPool {
     final long last = lastExplicitSplitWarnMs.get();
     if (now - last > SATURATION_WARN_INTERVAL_MS && lastExplicitSplitWarnMs.compareAndSet(last, now))
       LogManager.instance().log(this, Level.WARNING,
-          "Sparse-vector top-K split into %d ranges by an explicit %s=%d while %d queries were already in flight on a %d-thread pool. "
-              + "The adaptive default (0) would have kept this query on its caller thread. Splitting costs roughly 2x the CPU for an "
-              + "8-way split (measured 1.89x here, 1.98x independently), and under load that is paid by THIS query too, not only by its "
-              + "neighbours: at 16 concurrent clients a forced 8-way split measured 0.76x the throughput of no split at all, with a "
-              + "median 1.75x worse. It does compress the tail - p99/p50 1.5x against 5.2x - so if tail predictability is what you are "
-              + "buying, this is the trade; if it is median or throughput, %s=0 is faster. "
-              + "Set %s=0 to let the engine decide per query.",
+          "Sparse-vector top-K split into %d ranges by an explicit %s=%d with %d queries in flight (including this one) on a "
+              + "%d-thread pool. The adaptive default (0) would have kept this query on its caller thread. Splitting costs roughly 2x "
+              + "the CPU for an 8-way split (measured 1.89x here, 1.98x independently), and under load THIS query pays too, not only "
+              + "its neighbours: measured at 16 concurrent clients, a forced 8-way split returned 0.76x the throughput of no split at "
+              + "all and a median 1.75x worse. What it did buy is a lower tail - p99 297 ms against 579 ms - so forcing the split is a "
+              + "reasonable choice for tail-sensitive traffic and the wrong one for median or throughput. Set %s=0 to let the engine "
+              + "decide per query.",
           partitions, GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey(),
           GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger(), inFlight, ceiling,
           GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getKey(),

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -108,8 +108,10 @@ public final class SparseVectorScoringPool {
   private final ThreadPoolExecutor executor;
   /** Workers claimed by in-flight range fan-outs; see {@link #tryReserveWorkers(int)}. */
   private final AtomicInteger      reservedWorkers      = new AtomicInteger();
-  /** Sparse-vector top-K calls in flight JVM-wide, split or not; see {@link #queryStarted()}. */
+  /** Caller-thread top-K calls in flight JVM-wide, split or not; see {@link #queryStarted()}. */
   private final AtomicInteger      inFlightQueries      = new AtomicInteger();
+  /** Top-K calls running on a worker, i.e. the per-bucket fan-out. Occupy capacity, never split. */
+  private final AtomicInteger      poolThreadQueries    = new AtomicInteger();
   /** Cumulative queries that were split into RID ranges rather than run on the caller thread. */
   private final AtomicLong         splitQueries         = new AtomicLong();
   private final AtomicLong         callerRunCount       = new AtomicLong();
@@ -245,9 +247,19 @@ public final class SparseVectorScoringPool {
     // idle - one caller against 18 workers splits all the way.
     if (inFlightQueries.get() * 2 > ceiling)
       return 0;
+    // Work on the pool that never went through a reservation - the per-bucket fan-out submits
+    // straight to the executor - still occupies workers, so it counts against what is grantable or a
+    // split would oversubscribe against it.
+    //
+    // Counted rather than read from ThreadPoolExecutor.getActiveCount(), which looks like the
+    // obvious source and is a trap: it takes the pool's main lock and walks the worker set, so every
+    // query serializes on it. Measured at 16 concurrent clients, with splitting almost entirely
+    // gated off, it cost 29% of throughput on its own - a decision path more expensive than the
+    // decision. Two atomic reads do the same job.
+    final int onPool = poolThreadQueries.get();
     while (true) {
       final int current = reservedWorkers.get();
-      final int free = ceiling - current;
+      final int free = ceiling - current - onPool;
       if (free <= 0)
         return 0;
       final int grant = Math.min(desired, free);
@@ -261,13 +273,27 @@ public final class SparseVectorScoringPool {
    * pair it with {@link #queryFinished()}. Counting queries rather than tasks is the point: the
    * concurrency that matters for the split decision arrives on caller threads, which never touch
    * this pool unless a query decides to fan out.
+   * <p>
+   * <b>Queries already running on a worker are counted separately.</b> The per-bucket fan-out submits
+   * one {@code topK} per bucket, so a single user query against an 8-bucket type would otherwise
+   * register as eight and trip the load gate for unrelated queries on an otherwise quiet box. Those
+   * eight are real load, but of a different kind: they occupy workers, which
+   * {@link #tryReserveWorkers(int)} subtracts from what it can grant, whereas the caller-thread count
+   * measures the load nothing else can see. Splitting the two keeps each honest. The pairing stays
+   * symmetric either way, since a thread's pool membership never changes.
    */
   public void queryStarted() {
-    inFlightQueries.incrementAndGet();
+    if (isPoolThread())
+      poolThreadQueries.incrementAndGet();
+    else
+      inFlightQueries.incrementAndGet();
   }
 
   public void queryFinished() {
-    inFlightQueries.decrementAndGet();
+    if (isPoolThread())
+      poolThreadQueries.decrementAndGet();
+    else
+      inFlightQueries.decrementAndGet();
   }
 
   /** Sparse-vector top-K calls currently executing across the JVM. Test and diagnostics hook. */

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -94,6 +94,21 @@ public final class SparseVectorScoringPool {
   private static final int DEFAULT_THREADS_FLOOR = 2;
 
   /**
+   * How much caller-side concurrency is treated as enough to keep the pool busy without help:
+   * splitting stops once {@code inFlightQueries * this > poolSize}, i.e. at half the pool's worth of
+   * concurrent queries.
+   * <p>
+   * A literal rather than a setting, deliberately. It shapes only the middle of the range - an
+   * operator who wants splitting off, or always on, already has
+   * {@link GlobalConfiguration#SPARSE_VECTOR_SCORING_MAX_PARTITIONS} for both - so exposing it would
+   * add a knob that is hard to reason about and easy to set wrongly. Measured at 1, 4 and 16
+   * concurrent clients on an 18-worker pool: full split when idle, still a 61% throughput gain at
+   * four, and within 5% of serial at sixteen. If a machine is found where that shape is wrong, this
+   * is the number to revisit, and it is named so it can be found.
+   */
+  private static final int CALLER_LOAD_GATE_FACTOR = 2;
+
+  /**
    * Marks a thread as belonging to this pool. Read by {@link #isPoolThread()} to stop a fan-out
    * from nesting inside another one, which on a pool with a bounded queue is a deadlock rather
    * than a slowdown: the outer tasks occupy every worker and block waiting on inner tasks that sit
@@ -246,7 +261,7 @@ public final class SparseVectorScoringPool {
     // and gives up throughput for it. Refusing to split once the callers alone can keep the pool's
     // worth of threads busy is what makes the default safe under load, and it costs nothing when
     // idle - one caller against 18 workers splits all the way.
-    if (inFlightQueries.get() * 2 > ceiling)
+    if (inFlightQueries.get() * CALLER_LOAD_GATE_FACTOR > ceiling)
       return 0;
     // Work on the pool that never went through a reservation - the per-bucket fan-out submits
     // straight to the executor - still occupies workers, so it counts against what is grantable or a

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -110,6 +110,8 @@ public final class SparseVectorScoringPool {
   private final AtomicInteger      reservedWorkers      = new AtomicInteger();
   /** Sparse-vector top-K calls in flight JVM-wide, split or not; see {@link #queryStarted()}. */
   private final AtomicInteger      inFlightQueries      = new AtomicInteger();
+  /** Cumulative queries that were split into RID ranges rather than run on the caller thread. */
+  private final AtomicLong         splitQueries         = new AtomicLong();
   private final AtomicLong         callerRunCount       = new AtomicLong();
   // Throttle for the WARNING log emitted on saturation: at most one entry per minute. Same
   // shape as the QueryEngineManager pool's throttle - operators see one nudge in the console
@@ -271,6 +273,20 @@ public final class SparseVectorScoringPool {
   /** Sparse-vector top-K calls currently executing across the JVM. Test and diagnostics hook. */
   public int getInFlightQueries() {
     return inFlightQueries.get();
+  }
+
+  /**
+   * Records that a query was split into RID ranges. Counted here rather than only per index so an
+   * operator can tell "nothing is splitting" apart from "nothing is querying" - the two look
+   * identical on the pool's own gauges, since a query that stays serial never touches this pool.
+   */
+  public void querySplit() {
+    splitQueries.incrementAndGet();
+  }
+
+  /** Cumulative queries split into RID ranges since JVM start. */
+  public long getSplitQueryCount() {
+    return splitQueries.get();
   }
 
   /** Unconditional claim, for an operator who configured an explicit partition count. */

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/MultiBucketSealedSegmentFanoutTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/MultiBucketSealedSegmentFanoutTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.sparsevector.LSMSparseVectorIndex;
+import com.arcadedb.index.sparsevector.SparseVectorScoringPool;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -121,7 +122,7 @@ class MultiBucketSealedSegmentFanoutTest extends TestHelper {
       assertThat(sealed).as("every bucket must have sealed at least one segment").isGreaterThanOrEqualTo(BUCKETS);
     });
 
-    final long completedBefore = com.arcadedb.index.sparsevector.SparseVectorScoringPool.getInstance().getPoolStats()
+    final long completedBefore = SparseVectorScoringPool.getInstance().getPoolStats()
         .completedTasks();
     final int[] queryIdx = docIndices.getFirst();
     final float[] queryVal = docValues.getFirst();
@@ -149,7 +150,7 @@ class MultiBucketSealedSegmentFanoutTest extends TestHelper {
       }
     });
 
-    final long completedAfter = com.arcadedb.index.sparsevector.SparseVectorScoringPool.getInstance().getPoolStats()
+    final long completedAfter = SparseVectorScoringPool.getInstance().getPoolStats()
         .completedTasks();
     assertThat(completedAfter).as("fan-out must have dispatched (before=%d after=%d)", completedBefore, completedAfter)
         .isGreaterThan(completedBefore);

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/MultiBucketSealedSegmentFanoutTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/MultiBucketSealedSegmentFanoutTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.sparsevector.LSMSparseVectorIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A multi-bucket sparse-vector query whose postings have been flushed to sealed segments - the
+ * combination the per-bucket fan-out was never covered against, since every existing fan-out test
+ * queries an index whose postings still sit in the memtable, and an in-memory source reads no pages.
+ * <p>
+ * What makes it worth pinning down: the fan-out runs each bucket's {@code topK} on a scoring-pool
+ * worker, and a worker carries no database context of its own, while the segment read path needs one
+ * to borrow its decode buffer. It works today only because {@code LocalDatabase.checkDatabaseIsOpen}
+ * creates a context as a side effect for any thread that reaches a checked database method, and the
+ * index wrapper happens to call one on the way in. Nothing states that contract, so a future
+ * refactor that skips or reorders that call would break segment-backed multi-bucket queries with
+ * "Transaction context not found on current thread" and no test would notice. This one would.
+ * <p>
+ * Written while wiring intra-query parallelism (issue #4085), which hit exactly that wall from the
+ * other direction: it reaches the decoder without passing a checked method first, and so establishes
+ * its worker context explicitly.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MultiBucketSealedSegmentFanoutTest extends TestHelper {
+
+  private static final int  BUCKETS     = 8;
+  private static final int  DIMS        = 512;
+  private static final int  DOCS        = 400;
+  private static final int  NNZ_PER_DOC = 6;
+  private static final int  K           = 10;
+  private static final long SEED        = 4085L;
+
+  @Test
+  void multiBucketQueryOverSealedSegmentsReturnsResults() {
+    final String typeName = "SealedFanOutDoc";
+    final String idxName = typeName + "[tokens,weights]";
+
+    final List<int[]> docIndices = new ArrayList<>(DOCS);
+    final List<float[]> docValues = new ArrayList<>(DOCS);
+    final List<RID> docRids = new ArrayList<>(DOCS);
+
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(typeName).withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY " + typeName + ".tokens ARRAY_OF_INTEGERS");
+      database.command("sql", "CREATE PROPERTY " + typeName + ".weights ARRAY_OF_FLOATS");
+      database.getSchema()
+          .buildTypeIndex(typeName, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(DIMS)
+          .create();
+
+      final Random rnd = new Random(SEED);
+      for (int i = 0; i < DOCS; i++) {
+        final int[] indices = new int[NNZ_PER_DOC];
+        final float[] values = new float[NNZ_PER_DOC];
+        final HashSet<Integer> picked = new HashSet<>(NNZ_PER_DOC);
+        for (int j = 0; j < NNZ_PER_DOC; j++) {
+          int dim;
+          do {
+            dim = rnd.nextInt(DIMS);
+          } while (!picked.add(dim));
+          indices[j] = dim;
+          values[j] = 0.1f + rnd.nextFloat();
+        }
+        final MutableDocument doc = database.newDocument(typeName);
+        doc.set("tokens", indices);
+        doc.set("weights", values);
+        doc.save();
+        docIndices.add(indices);
+        docValues.add(values);
+        docRids.add(doc.getIdentity());
+      }
+    });
+
+    // Seal every bucket's memtable into a segment: this is what a settled index looks like, and what
+    // the fan-out was never exercised against.
+    database.transaction(() -> {
+      final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName(idxName);
+      int sealed = 0;
+      for (final Index sub : typeIndex.getIndexesOnBuckets()) {
+        final LSMSparseVectorIndex sparse = (LSMSparseVectorIndex) sub;
+        sparse.flush();
+        sealed += sparse.getEngine().segmentCount();
+      }
+      // Without this the test would silently prove nothing: an unsealed index answers from the
+      // in-memory memtable, which reads no pages and so never needs a database context.
+      assertThat(sealed).as("every bucket must have sealed at least one segment").isGreaterThanOrEqualTo(BUCKETS);
+    });
+
+    final long completedBefore = com.arcadedb.index.sparsevector.SparseVectorScoringPool.getInstance().getPoolStats()
+        .completedTasks();
+    final int[] queryIdx = docIndices.getFirst();
+    final float[] queryVal = docValues.getFirst();
+
+    final List<RID> hits = new ArrayList<>();
+    database.transaction(() -> {
+      final StringBuilder idx = new StringBuilder("[");
+      final StringBuilder val = new StringBuilder("[");
+      for (int i = 0; i < queryIdx.length; i++) {
+        if (i > 0) {
+          idx.append(',');
+          val.append(',');
+        }
+        idx.append(queryIdx[i]);
+        val.append(queryVal[i]);
+      }
+      idx.append(']');
+      val.append(']');
+      try (final ResultSet rs = database.query("sql",
+          "SELECT expand(vectorSparseNeighbors('" + idxName + "', " + idx + ", " + val + ", " + K + "))")) {
+        while (rs.hasNext()) {
+          final Result r = rs.next();
+          hits.add(r.getProperty("rid") != null ? r.getProperty("rid") : r.getIdentity().orElse(null));
+        }
+      }
+    });
+
+    final long completedAfter = com.arcadedb.index.sparsevector.SparseVectorScoringPool.getInstance().getPoolStats()
+        .completedTasks();
+    assertThat(completedAfter).as("fan-out must have dispatched (before=%d after=%d)", completedBefore, completedAfter)
+        .isGreaterThan(completedBefore);
+    assertThat(hits).as("a multi-bucket query over sealed segments must return the top-K").hasSize(K);
+    assertThat(hits.getFirst()).as("self-query must return self at rank 0").isEqualTo(docRids.getFirst());
+
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexLargeBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexLargeBenchmark.java
@@ -18,8 +18,10 @@
  */
 package com.arcadedb.index.sparsevector;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
@@ -27,7 +29,9 @@ import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -153,7 +157,7 @@ class LSMSparseVectorIndexLargeBenchmark extends TestHelper {
     }
 
     System.out.printf("%n=== Index-backed `vector.sparseNeighbors` (K=%d) ===%n", K);
-    final long indexNs = benchIndex(queryIdx, queryVal);
+    final long indexNs = benchIndexBothShapes(queryIdx, queryVal);
 
     System.out.printf("%n=== Brute-force `vector.sparseDot` over %,d docs (K=%d, %s) ===%n", docCount, K,
         runFullBruteForce ? "warmup+5 iters" : "1 iter only - too slow at this scale");
@@ -166,30 +170,61 @@ class LSMSparseVectorIndexLargeBenchmark extends TestHelper {
         bfNs / 1_000_000.0 / bfIters);
   }
 
-  private long benchIndex(final int[][] qi, final float[][] qv) {
+  /**
+   * Runs the query sweep twice - once with the traversal pinned to the caller thread, once with the
+   * RID-range split of issue #4085 - and reports both plus the speedup. Also asserts the two shapes
+   * return the same documents, which is the correctness claim of the split at a scale no unit test
+   * reaches (multi-segment, 10M postings, a real index rather than a hand-built segment).
+   *
+   * @return the split arm's total, so the caller keeps reporting the speedup against brute force for
+   *         the shape a user actually gets by default.
+   */
+  private long benchIndexBothShapes(final int[][] qi, final float[][] qv) {
+    final int previous = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(1);
+      final List<List<RID>> serialHits = new ArrayList<>();
+      final long serialNs = benchIndex(qi, qv, "serial (1 range)", serialHits);
+
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(0);
+      final List<List<RID>> splitHits = new ArrayList<>();
+      final long splitNs = benchIndex(qi, qv, "adaptive split", splitHits);
+
+      for (int q = 0; q < serialHits.size(); q++)
+        assertThat(splitHits.get(q)).as("split must return the same documents as the serial scan (query %d)", q)
+            .isEqualTo(serialHits.get(q));
+
+      System.out.printf("Intra-query split: %.2f -> %.2f ms/query (%.2fx)%n",
+          serialNs / 1_000_000.0 / ITERATIONS, splitNs / 1_000_000.0 / ITERATIONS, (double) serialNs / splitNs);
+      return splitNs;
+    } finally {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previous);
+    }
+  }
+
+  private long benchIndex(final int[][] qi, final float[][] qv, final String label, final List<List<RID>> hitsOut) {
     final String sql = "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))";
     for (int q = 0; q < WARMUP; q++)
       runIndexOnce(sql, qi[q], qv[q]);
     long totalNs = 0;
     for (int q = 0; q < ITERATIONS; q++) {
       final long start = System.nanoTime();
-      final int seen = runIndexOnce(sql, qi[WARMUP + q], qv[WARMUP + q]);
+      final List<RID> hits = runIndexOnce(sql, qi[WARMUP + q], qv[WARMUP + q]);
       totalNs += System.nanoTime() - start;
-      assertThat(seen).as("index path must return >= 1 result").isGreaterThan(0);
+      assertThat(hits).as("index path must return >= 1 result").isNotEmpty();
+      hitsOut.add(hits);
     }
-    System.out.printf("vector.sparseNeighbors: avg %.2f ms/query over %d iterations%n",
-        totalNs / 1_000_000.0 / ITERATIONS, ITERATIONS);
+    System.out.printf("vector.sparseNeighbors [%s]: avg %.2f ms/query over %d iterations%n",
+        label, totalNs / 1_000_000.0 / ITERATIONS, ITERATIONS);
     return totalNs;
   }
 
-  private int runIndexOnce(final String sql, final int[] qi, final float[] qv) {
+  private List<RID> runIndexOnce(final String sql, final int[] qi, final float[] qv) {
+    final List<RID> hits = new ArrayList<>(K);
     final ResultSet rs = database.query("sql", sql, IDX_NAME, qi, qv, K);
-    int seen = 0;
-    while (rs.hasNext()) {
-      rs.next();
-      seen++;
-    }
-    return seen;
+    while (rs.hasNext())
+      rs.next().getIdentity().ifPresent(hits::add);
+    return hits;
   }
 
   private long benchBruteForce(final int[][] qi, final float[][] qv, final boolean runFull) {

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -73,6 +73,17 @@ class ParallelRangeTopKTest extends TestHelper {
   /** Enough postings on the widest dim to cut into ranges, without paying to build a big corpus. */
   private static final int SMALL_DOCS = 6_000;
   private static final int K     = 10;
+  /**
+   * Ceiling on how many blocking tasks a saturation loop will submit. Purely a runaway guard: the
+   * loop stops when the queue reports full, and this stops it looping forever if that never happens.
+   */
+  private static final int SATURATION_SUBMIT_LIMIT = 10_000;
+  /**
+   * How long a saturation task waits before giving up. The tests always release the latch in a
+   * finally, so this only matters when something has already gone wrong - and then it turns a hung
+   * CI job into a failed test, which is the difference between a diagnosis and an hour of nothing.
+   */
+  private static final int SATURATION_RELEASE_TIMEOUT_SECONDS = 60;
 
   @Test
   void rangePartitionedScoringReproducesTheSerialResult() throws Exception {
@@ -410,7 +421,10 @@ class ParallelRangeTopKTest extends TestHelper {
         for (int i = 0; i < pool.getMaxParallelism(); i++) {
           hogs.add(executor.submit(() -> {
             occupied.countDown();
-            release.await();
+            // Same guard as the caller-runs test: never block the submitting thread, and never
+            // block unboundedly, so a mis-sized saturation cannot wedge the run.
+            if (SparseVectorScoringPool.isPoolThread())
+              release.await(SATURATION_RELEASE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             return null;
           }));
         }
@@ -469,12 +483,23 @@ class ParallelRangeTopKTest extends TestHelper {
         // task then runs somewhere that already has a database context.
         final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
         final ExecutorService executor = pool.getExecutorService();
-        final int toBlock = pool.getMaxParallelism() + pool.getPoolStats().queueCapacityRemaining();
-        for (int i = 0; i < toBlock; i++)
+        // Submit until the queue reports itself full rather than computing a count up front: the
+        // count is read from a racing snapshot, and overshooting it by even one is not a slow test
+        // but a permanently stuck one. An over-submitted task is rejected and the caller-runs policy
+        // runs it HERE, on this thread, where awaiting a latch released in a finally this thread can
+        // no longer reach hangs the JVM until CI times out. The guard below is what makes the task
+        // safe to run anywhere; this loop is what stops it happening in the first place.
+        int guard = 0;
+        while (pool.getPoolStats().queueCapacityRemaining() > 0 && guard++ < SATURATION_SUBMIT_LIMIT)
           executor.submit(() -> {
-            release.await();
+            // Only block when actually on a worker. A task that finds itself on the submitting
+            // thread was rejected, and blocking there is exactly the deadlock described above.
+            if (SparseVectorScoringPool.isPoolThread())
+              release.await(SATURATION_RELEASE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             return null;
           });
+        assertThat(guard).as("the pool must actually be saturated for this test to mean anything")
+            .isLessThan(SATURATION_SUBMIT_LIMIT);
 
         database.begin();
         try {

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -765,6 +765,80 @@ class ParallelRangeTopKTest extends TestHelper {
     }
   }
 
+  @Test
+  void anExplicitClaimSaturatesAtThePoolCeilingButTheSplitStillHappens() throws Exception {
+    final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+    final int ceiling = pool.getMaxParallelism();
+    final int baseline = pool.getReservedWorkers();
+
+    // The claim is capped: asking for far more than the pool holds records only what it can hold.
+    final int granted = pool.reserveWorkers(ceiling * 10);
+    try {
+      assertThat(granted).as("an explicit claim must saturate at the pool ceiling").isEqualTo(ceiling - baseline);
+      assertThat(pool.getReservedWorkers())
+          .as("reserved workers must never exceed the ceiling, however many ranges were asked for")
+          .isEqualTo(ceiling);
+      // And with the pool fully claimed, a further claim records nothing rather than going negative
+      // or overflowing past the ceiling.
+      assertThat(pool.reserveWorkers(ceiling)).as("a fully claimed pool grants nothing").isZero();
+      assertThat(pool.getReservedWorkers()).isEqualTo(ceiling);
+    } finally {
+      pool.releaseWorkers(granted);
+    }
+    assertThat(pool.getReservedWorkers()).as("the claim must return to baseline").isEqualTo(baseline);
+  }
+
+  @Test
+  void anExplicitSplitDoesNotYieldToAFullyClaimedPool() throws Exception {
+    final int previousPartitions = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+    int hogged = 0;
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(4);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+
+      final Map<RID, Map<Integer, Float>> corpus = buildCorpus(SMALL_DOCS, 91L, false);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085explicit", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        final List<RidScore> expected = engine.topK(queryDims, queryWeights, K);
+        final long splitsBefore = engine.partitionedQueryCount();
+
+        // Claim the entire pool on behalf of someone else. An adaptive query would go serial here;
+        // an explicit one is an operator saying "do not throttle me", so it must still split.
+        hogged = pool.tryReserveWorkers(pool.getMaxParallelism());
+        assertThat(hogged).isPositive();
+        final int reservedWhileHogged = pool.getReservedWorkers();
+
+        assertSameResult(engine.topK(queryDims, queryWeights, K), expected, "explicit split, pool fully claimed");
+        assertThat(engine.partitionedQueryCount())
+            .as("an explicit split must not yield to a busy pool").isEqualTo(splitsBefore + 1);
+        // ...and it must not have inflated the count on the way through, which is what would have
+        // suppressed splitting for every other query on the box.
+        assertThat(pool.getReservedWorkers())
+            .as("an explicit split must not leave the ceiling exceeded").isEqualTo(reservedWhileHogged);
+      }
+    } finally {
+      pool.releaseWorkers(hogged);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previousPartitions);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+    }
+  }
+
   // ---------- helpers ----------
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.IndexException;
 import com.arcadedb.index.sparsevector.SegmentFormat.WeightQuantization;
 import com.arcadedb.schema.LocalSchema;
 
@@ -35,10 +36,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Correctness of the intra-query parallel top-K introduced in issue #4085: a query may be split into
@@ -365,6 +369,69 @@ class ParallelRangeTopKTest extends TestHelper {
     assertThat(pool.getInFlightQueries()).isZero();
     assertThat(pool.tryReserveWorkers(1)).as("capacity must come back once the callers drain").isEqualTo(1);
     pool.releaseWorkers(1);
+  }
+
+  @Test
+  void aRangeThatNeverGetsAWorkerFailsTheQueryOnTheDeadline() throws Exception {
+    final int previousPartitions = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    final int previousTimeout = GlobalConfiguration.SPARSE_VECTOR_SCORING_TIMEOUT_SECONDS.getValueAsInteger();
+    final CountDownLatch release = new CountDownLatch(1);
+    final CountDownLatch occupied = new CountDownLatch(1);
+    final List<Future<?>> hogs = new ArrayList<>();
+    try {
+      // Explicit split, so the load gate does not veto it while the pool is deliberately jammed.
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(2);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_TIMEOUT_SECONDS.setValue(1);
+
+      final Map<RID, Map<Integer, Float>> corpus = buildCorpus(SMALL_DOCS, 8L, false);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085deadline", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        // Jam every worker so the query's range can be submitted but never started. Deterministic:
+        // the deadline is what ends the query, not a race between it and the scoring.
+        final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+        final ExecutorService executor = pool.getExecutorService();
+        for (int i = 0; i < pool.getMaxParallelism(); i++) {
+          hogs.add(executor.submit(() -> {
+            occupied.countDown();
+            release.await();
+            return null;
+          }));
+        }
+        assertThat(occupied.await(10, TimeUnit.SECONDS)).as("a worker must have picked up the block").isTrue();
+
+        assertThatThrownBy(() -> engine.topK(queryDims, queryWeights, K))
+            .isInstanceOf(IndexException.class)
+            .hasMessageContaining("timed out")
+            .hasMessageContaining(GlobalConfiguration.SPARSE_VECTOR_SCORING_TIMEOUT_SECONDS.getKey());
+
+        // A failed fan-out must still hand its claim back, or splitting quietly dies for good.
+        release.countDown();
+        for (final Future<?> f : hogs)
+          f.get(10, TimeUnit.SECONDS);
+        assertThat(pool.getReservedWorkers()).as("a timed-out query must release its claim").isZero();
+      }
+    } finally {
+      release.countDown();
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previousPartitions);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_TIMEOUT_SECONDS.setValue(previousTimeout);
+    }
   }
 
   // ---------- helpers ----------

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -59,6 +59,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * per-range heap and the final merge therefore rank on "score descending, then RID ascending", and
  * the tie test below fails without that.
  * <p>
+ * <b>Where the claim stops.</b> Rounding and the tie-break are not independent, so "identical list"
+ * holds for distinct scores and for ties that survive rounding intact, not universally: two
+ * documents that tie exactly in one shape can sit an ulp apart in the other, and at the k boundary
+ * an ulp decides which is kept. The RID tie-break cannot reach that case, because it only orders
+ * scores that are still equal after rounding. What holds without qualification is that the split
+ * never returns a worse answer - same count, rank-for-rank indistinguishable scores, nothing below
+ * the serial k-th - which is what
+ * {@link #aPlateauOfNearTiesAtTheBoundaryStillReturnsAnEquallyGoodResult} pins.
+ * <p>
  * The other thing asserted here is that a fan-out never nests. A scoring-pool worker that split its
  * own query again would fill the pool with tasks waiting on tasks that nothing is left to run - a
  * deadlock, not a slowdown, and one the caller-runs rejection policy does not catch because the
@@ -84,6 +93,8 @@ class ParallelRangeTopKTest extends TestHelper {
    * CI job into a failed test, which is the difference between a diagnosis and an hour of nothing.
    */
   private static final int SATURATION_RELEASE_TIMEOUT_SECONDS = 60;
+  /** Wide enough to cover float summation-order differences, far below any real score gap. */
+  private static final float TIE_EPSILON = 1e-4f;
 
   @Test
   void rangePartitionedScoringReproducesTheSerialResult() throws Exception {
@@ -150,6 +161,90 @@ class ParallelRangeTopKTest extends TestHelper {
         assertSameResult(BmwScorer.mergeRanges(ranges, K), serial, "tied partitions=" + partitions);
       }
     });
+  }
+
+  /**
+   * The one case where the split may legitimately keep a different document than the serial scan,
+   * and therefore the case that says what the equivalence claim actually is.
+   * <p>
+   * A plateau of documents with mathematically equal scores straddles the k-th place, built from
+   * weights that are not exactly representable so the order MaxScore sums a document's terms in can
+   * move its total by an ulp. That order follows the essential/non-essential split, which a range
+   * reaches at a different watermark than the whole scan, so two documents that tie exactly in one
+   * shape can sit an ulp apart in the other - and at the k boundary an ulp decides which is kept.
+   * The RID tie-break cannot save this: it only breaks ties between scores that are still equal
+   * after rounding.
+   * <p>
+   * So the guarantee is not "identical RIDs in all cases". It is that the split never returns a
+   * <i>worse</i> answer: the same number of documents, rank for rank indistinguishable in score,
+   * and never one that ranks below the serial k-th. That is what is asserted here. The existing
+   * tie test uses exactly-representable weights, which deliberately removes the rounding and pins
+   * the tie-break on its own; this one puts the rounding back.
+   */
+  @Test
+  void aPlateauOfNearTiesAtTheBoundaryStillReturnsAnEquallyGoodResult() throws Exception {
+    final int previousPartitions = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+
+      // Weights chosen so no partial sum is exact in binary floating point.
+      final float[] awkward = { 0.1f, 0.3f, 0.7f, 0.05f, 0.15f, 0.35f, 0.45f, 0.55f, 0.65f, 0.85f, 0.95f, 0.25f };
+      final TreeMap<RID, Map<Integer, Float>> corpus = new TreeMap<>(SparseSegmentBuilder::compareRid);
+      // Background: enough postings for the split to engage, all scoring well below the plateau.
+      for (int i = 0; i < SMALL_DOCS; i++) {
+        final TreeMap<Integer, Float> doc = new TreeMap<>();
+        for (int d = 0; d < 4; d++)
+          doc.put(d, 0.01f);
+        corpus.put(new RID(0, 1L + i), doc);
+      }
+      // The plateau: many more documents than k, every one carrying the identical heavy weights, so
+      // their true scores are equal and only rounding can separate them.
+      for (int i = 0; i < K * 5; i++) {
+        final TreeMap<Integer, Float> doc = new TreeMap<>();
+        for (int d = 0; d < awkward.length; d++)
+          doc.put(d, awkward[d]);
+        corpus.put(new RID(0, 1L + (long) SMALL_DOCS + i * 7L), doc);
+      }
+
+      final int[] queryDims = new int[awkward.length];
+      final float[] queryWeights = new float[awkward.length];
+      for (int d = 0; d < awkward.length; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085plateau", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(1);
+        final List<RidScore> serial = engine.topK(queryDims, queryWeights, K);
+        assertThat(serial).hasSize(K);
+
+        for (final int partitions : new int[] { 2, 4, 8 }) {
+          GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(partitions);
+          final List<RidScore> split = engine.topK(queryDims, queryWeights, K);
+
+          assertThat(split).as("split=%d must return as many documents", partitions).hasSameSizeAs(serial);
+          final float worstSerial = serial.getLast().score();
+          for (int i = 0; i < serial.size(); i++) {
+            assertThat(split.get(i).score()).as("split=%d rank %d must be indistinguishable in score", partitions, i)
+                .isCloseTo(serial.get(i).score(), Offset.offset(TIE_EPSILON));
+            assertThat(split.get(i).score()).as("split=%d rank %d must not rank below the serial k-th", partitions, i)
+                .isGreaterThanOrEqualTo(worstSerial - TIE_EPSILON);
+          }
+        }
+      }
+    } finally {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previousPartitions);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -68,6 +68,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * the serial k-th - which is what
  * {@link #aPlateauOfNearTiesAtTheBoundaryStillReturnsAnEquallyGoodResult} pins.
  * <p>
+ * <b>How often that corner bites in practice: not once, so far.</b> Measured over 1000 real Big-ANN
+ * SPLADE queries at INT8, comparing returned id lists against the serial arm at both the adaptive
+ * default and a forced 8-way split, the sets, the order and the counts came back identical every
+ * time. The summation-order effect is real and visible in the arithmetic - the largest rank-for-rank
+ * score difference was 9.0e-06 on scores of order 20, about 0.45 ppm - but that is some four orders
+ * of magnitude short of flipping a decision at the k boundary on that weight distribution. Which is
+ * why the weakened guarantee is still the one to state and this test is still what pins it: it
+ * constructs the case deliberately instead of waiting to meet it, and nothing should be read into
+ * the field result beyond "do not expect to see this on real data".
+ * <p>
  * The other thing asserted here is that a fan-out never nests. A scoring-pool worker that split its
  * own query again would fill the pool with tasks waiting on tasks that nothing is left to run - a
  * deadlock, not a slowdown, and one the caller-runs rejection policy does not catch because the

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.index.sparsevector;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.ComponentFile;
@@ -431,6 +432,73 @@ class ParallelRangeTopKTest extends TestHelper {
       GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previousPartitions);
       GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
       GlobalConfiguration.SPARSE_VECTOR_SCORING_TIMEOUT_SECONDS.setValue(previousTimeout);
+    }
+  }
+
+  @Test
+  void aRangeForcedOntoTheCallerThreadLeavesTheCallersTransactionAlone() throws Exception {
+    final int previousPartitions = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    final CountDownLatch release = new CountDownLatch(1);
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(2);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+
+      final Map<RID, Map<Integer, Float>> corpus = buildCorpus(SMALL_DOCS, 12L, false);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085callerruns", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        final List<RidScore> expected = engine.topK(queryDims, queryWeights, K);
+
+        // Saturate the pool - every worker busy AND every queue slot taken - so the next submission
+        // is rejected and the pool's caller-runs policy executes it inline on the submitting thread.
+        // That thread is the one inside the transaction below, which is the whole point: the range
+        // task then runs somewhere that already has a database context.
+        final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+        final ExecutorService executor = pool.getExecutorService();
+        final int toBlock = pool.getMaxParallelism() + pool.getPoolStats().queueCapacityRemaining();
+        for (int i = 0; i < toBlock; i++)
+          executor.submit(() -> {
+            release.await();
+            return null;
+          });
+
+        database.begin();
+        try {
+          // No uncommitted changes, so the query is still allowed to split; the range it submits is
+          // rejected by the saturated pool and runs right here.
+          final List<RidScore> got = engine.topK(queryDims, queryWeights, K);
+          assertSameResult(got, expected, "range forced through caller-runs");
+
+          // The real damage an unconditional DatabaseContext.init() does here: it takes the
+          // "ROLLBACK PREVIOUS TXS" branch and silently rolls back the caller's transaction, then the
+          // matching removeContext wipes the context the rest of the query still needs.
+          assertThat(database.isTransactionActive())
+              .as("the caller's transaction must survive a range that ran on its own thread").isTrue();
+          assertThat(DatabaseContext.INSTANCE.getContextIfExists(((DatabaseInternal) database).getDatabasePath()))
+              .as("the caller's database context must not be torn down under it").isNotNull();
+        } finally {
+          if (database.isTransactionActive())
+            database.rollback();
+        }
+      }
+    } finally {
+      release.countDown();
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previousPartitions);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -1,0 +1,490 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.sparsevector.SegmentFormat.WeightQuantization;
+import com.arcadedb.schema.LocalSchema;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Correctness of the intra-query parallel top-K introduced in issue #4085: a query may be split into
+ * RID ranges scored independently and merged, and the merged answer has to be the one the serial
+ * traversal would have produced - <b>the same list, not merely an equally good one</b>.
+ * <p>
+ * That distinction is the whole point of the test. Splitting is exact by construction for distinct
+ * scores: ranges partition the RID space, so a document is scored once and its score does not depend
+ * on which range held it - to within float rounding, since the order a document's terms are summed
+ * in follows the pruning split, which the two shapes reach differently (see
+ * {@link #assertSameResult}). Ties are where a partitioned traversal can legitimately diverge, because
+ * each range keeps its own top-K and the two shapes see candidates in different orders. Both the
+ * per-range heap and the final merge therefore rank on "score descending, then RID ascending", and
+ * the tie test below fails without that.
+ * <p>
+ * The other thing asserted here is that a fan-out never nests. A scoring-pool worker that split its
+ * own query again would fill the pool with tasks waiting on tasks that nothing is left to run - a
+ * deadlock, not a slowdown, and one the caller-runs rejection policy does not catch because the
+ * bounded queue accepts long before it rejects.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ParallelRangeTopKTest extends TestHelper {
+
+  private static final int DIMS  = 24;
+  private static final int DOCS  = 30_000;
+  /** Enough postings on the widest dim to cut into ranges, without paying to build a big corpus. */
+  private static final int SMALL_DOCS = 6_000;
+  private static final int K     = 10;
+
+  @Test
+  void rangePartitionedScoringReproducesTheSerialResult() throws Exception {
+    final Map<RID, Map<Integer, Float>> corpus = buildCorpus(DOCS, 5388L, false);
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = buildSegment("seg-4085-ranges", 1L, corpus);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      final List<RidScore> serial = scoreRange(reader, queryDims, queryWeights, null, null);
+
+      // Every split count, including ones that do not divide the corpus evenly.
+      for (final int partitions : new int[] { 2, 3, 4, 8, 16 }) {
+        final RID[] boundaries = evenBoundaries(reader, partitions);
+        final List<List<RidScore>> ranges = new ArrayList<>();
+        for (int i = 0; i <= boundaries.length; i++) {
+          final RID start = i == 0 ? null : boundaries[i - 1];
+          final RID end = i == boundaries.length ? null : boundaries[i];
+          ranges.add(scoreRange(reader, queryDims, queryWeights, start, end));
+        }
+        assertSameResult(BmwScorer.mergeRanges(ranges, K), serial, "partitions=" + partitions);
+      }
+    });
+  }
+
+  @Test
+  void tiedScoresResolveIdenticallyWhetherOrNotTheQueryIsSplit() throws Exception {
+    // Every document carries the same weight on the same dims, so the whole corpus ties on score and
+    // the top-K is decided purely by the tie-break. A partitioned run that ranked ties differently
+    // would return a different set of RIDs here, not just a different order.
+    final Map<RID, Map<Integer, Float>> corpus = buildCorpus(DOCS, 4085L, true);
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = buildSegment("seg-4085-ties", 1L, corpus);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      final List<RidScore> serial = scoreRange(reader, queryDims, queryWeights, null, null);
+      // Ties must be won by the lowest RIDs, and the result ordered by RID ascending.
+      RID previous = null;
+      for (final RidScore rs : serial) {
+        if (previous != null)
+          assertThat(SparseSegmentBuilder.compareRid(previous, rs.rid())).isNegative();
+        previous = rs.rid();
+      }
+
+      for (final int partitions : new int[] { 2, 4, 8 }) {
+        final RID[] boundaries = evenBoundaries(reader, partitions);
+        final List<List<RidScore>> ranges = new ArrayList<>();
+        for (int i = 0; i <= boundaries.length; i++) {
+          final RID start = i == 0 ? null : boundaries[i - 1];
+          final RID end = i == boundaries.length ? null : boundaries[i];
+          ranges.add(scoreRange(reader, queryDims, queryWeights, start, end));
+        }
+        assertSameResult(BmwScorer.mergeRanges(ranges, K), serial, "tied partitions=" + partitions);
+      }
+    });
+  }
+
+  @Test
+  void emptyAndSingletonRangesAreHandled() throws Exception {
+    final Map<RID, Map<Integer, Float>> corpus = buildCorpus(2_000, 99L, false);
+
+    inTx(() -> {
+      final PaginatedSegmentReader reader = buildSegment("seg-4085-edges", 1L, corpus);
+      final int[] queryDims = { 0, 1, 2 };
+      final float[] queryWeights = { 1.0f, 1.0f, 1.0f };
+
+      // A range entirely past the last posting yields nothing rather than failing.
+      assertThat(scoreRange(reader, queryDims, queryWeights, new RID(0, 9_000_000L), null)).isEmpty();
+      // An empty half-open range [x, x) yields nothing.
+      final RID x = new RID(0, 101L);
+      assertThat(scoreRange(reader, queryDims, queryWeights, x, x)).isEmpty();
+      // A range before the first posting still returns the head of the corpus.
+      assertThat(scoreRange(reader, queryDims, queryWeights, new RID(0, 0L), null)).isNotEmpty();
+    });
+  }
+
+  @Test
+  void theEngineSplitsAQueryAndReturnsWhatTheSerialPathWould() throws Exception {
+    final int previous = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    try {
+      final Map<RID, Map<Integer, Float>> corpus = buildCorpus(DOCS, 777L, false);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(1);
+        final List<RidScore> serial = engine.topK(queryDims, queryWeights, K);
+        assertThat(engine.partitionedQueryCount()).isZero();
+
+        // Below the work threshold the query stays on the caller thread even with splitting enabled.
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(4);
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(Long.MAX_VALUE);
+        assertSameResult(engine.topK(queryDims, queryWeights, K), serial, "below work threshold");
+        assertThat(engine.partitionedQueryCount()).isZero();
+
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+        assertSameResult(engine.topK(queryDims, queryWeights, K), serial, "engine 4-way split");
+        assertThat(engine.partitionedQueryCount()).isEqualTo(1L);
+
+        // Repeated runs must be stable, and a larger k must hold too.
+        assertSameResult(engine.topK(queryDims, queryWeights, K), serial, "engine 4-way split, repeat");
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(1);
+        final List<RidScore> serial50 = engine.topK(queryDims, queryWeights, 50);
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(8);
+        assertSameResult(engine.topK(queryDims, queryWeights, 50), serial50, "engine 8-way split, k=50");
+      }
+    } finally {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previous);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+    }
+  }
+
+  @Test
+  void aQueryAlreadyRunningOnTheScoringPoolDoesNotSplitAgain() throws Exception {
+    final int previous = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(8);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+
+      final Map<RID, Map<Integer, Float>> corpus = buildCorpus(SMALL_DOCS, 31L, false);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085nested", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        final List<RidScore> onCallerThread = engine.topK(queryDims, queryWeights, K);
+        final long splitsAfterCallerRun = engine.partitionedQueryCount();
+        assertThat(splitsAfterCallerRun).isEqualTo(1L);
+
+        // Same query submitted the way the per-bucket fan-out submits it. It must complete - a nested
+        // split would wedge the pool - and it must not have split again.
+        final ExecutorService pool = SparseVectorScoringPool.getInstance().getExecutorService();
+        final Future<List<RidScore>> f = pool.submit(() -> engine.topK(queryDims, queryWeights, K));
+        assertSameResult(f.get(), onCallerThread, "submitted onto the scoring pool");
+        assertThat(engine.partitionedQueryCount()).isEqualTo(splitsAfterCallerRun);
+        assertThat(SparseVectorScoringPool.isPoolThread()).isFalse();
+      }
+    } finally {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previous);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+    }
+  }
+
+  @Test
+  void claimedWorkersAreAlwaysHandedBack() throws Exception {
+    final int previous = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(4);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+
+      final Map<RID, Map<Integer, Float>> corpus = buildCorpus(SMALL_DOCS, 5L, false);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+      final int reservedBefore = pool.getReservedWorkers();
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085reserve", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        for (int i = 0; i < 5; i++)
+          engine.topK(queryDims, queryWeights, K);
+        assertThat(engine.partitionedQueryCount()).isEqualTo(5L);
+      }
+
+      // A leak here would be silent and permanent: every later query would see the pool as busier
+      // than it is and quietly stop splitting, with nothing failing to point at it.
+      assertThat(pool.getReservedWorkers()).as("claimed workers must be released after every query")
+          .isEqualTo(reservedBefore);
+    } finally {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previous);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+    }
+  }
+
+  @Test
+  void aFullyClaimedPoolKeepsTheQueryOnTheCallerThread() throws Exception {
+    final int previous = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+    int hogged = 0;
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(0);  // adaptive
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+
+      final Map<RID, Map<Integer, Float>> corpus = buildCorpus(SMALL_DOCS, 6L, false);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085busy", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        final List<RidScore> whenFree = engine.topK(queryDims, queryWeights, K);
+        final long splitWhenFree = engine.partitionedQueryCount();
+
+        // Stand in for a server already busy with other queries: claim every worker.
+        hogged = pool.tryReserveWorkers(pool.getMaxParallelism());
+        assertThat(hogged).isGreaterThan(0);
+
+        final List<RidScore> whenBusy = engine.topK(queryDims, queryWeights, K);
+        assertThat(engine.partitionedQueryCount())
+            .as("with no capacity left the query must not split").isEqualTo(splitWhenFree);
+        assertSameResult(whenBusy, whenFree, "serial fallback under a fully claimed pool");
+      }
+    } finally {
+      pool.releaseWorkers(hogged);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previous);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+    }
+  }
+
+  @Test
+  void concurrentCallersSuppressTheSplitEvenWhileThePoolLooksIdle() {
+    final SparseVectorScoringPool pool = SparseVectorScoringPool.getInstance();
+    final int ceiling = pool.getMaxParallelism();
+    assertThat(pool.getInFlightQueries()).isZero();
+
+    // Nobody else querying: capacity is grantable.
+    assertThat(pool.tryReserveWorkers(1)).as("an idle pool must grant a worker").isEqualTo(1);
+    pool.releaseWorkers(1);
+
+    // Enough concurrent callers to keep the pool's worth of threads busy on their own. The pool's
+    // own counters still read idle at this instant - the callers are not its threads - which is
+    // exactly the blind spot this gate covers: sizing the split from pool activity alone measured a
+    // third of queries splitting at 16 concurrent clients, and cost throughput to do it.
+    final int callers = ceiling / 2 + 1;
+    for (int i = 0; i < callers; i++)
+      pool.queryStarted();
+    try {
+      assertThat(pool.getInFlightQueries()).isEqualTo(callers);
+      assertThat(pool.tryReserveWorkers(1))
+          .as("with callers alone able to saturate the box, a query must not claim workers").isZero();
+    } finally {
+      for (int i = 0; i < callers; i++)
+        pool.queryFinished();
+    }
+
+    assertThat(pool.getInFlightQueries()).isZero();
+    assertThat(pool.tryReserveWorkers(1)).as("capacity must come back once the callers drain").isEqualTo(1);
+    pool.releaseWorkers(1);
+  }
+
+  // ---------- helpers ----------
+
+  /**
+   * Same documents, in the same order, with the same scores to within float rounding.
+   * <p>
+   * The scores are compared with a tolerance rather than exactly, and that is not slack in the test -
+   * it is the one thing partitioning genuinely changes. MaxScore sums a document's contributions in
+   * an order that depends on where the essential/non-essential split sits, and the split moves with
+   * the top-K watermark, which a range reaches differently from the whole scan. The same document
+   * therefore gets the same terms added in a different order, and float addition is not associative:
+   * the two arms can land one ulp apart. The document set and its ranking are unaffected.
+   */
+  private static void assertSameResult(final List<RidScore> got, final List<RidScore> expected, final String what) {
+    assertThat(got).as("%s: result size", what).hasSameSizeAs(expected);
+    for (int i = 0; i < expected.size(); i++) {
+      assertThat(got.get(i).rid()).as("%s: rid at %d", what, i).isEqualTo(expected.get(i).rid());
+      assertThat(got.get(i).score()).as("%s: score at %d", what, i)
+          .isCloseTo(expected.get(i).score(), Offset.offset(1e-4f));
+    }
+  }
+
+  private static List<RidScore> scoreRange(final PaginatedSegmentReader reader, final int[] queryDims,
+      final float[] queryWeights, final RID start, final RID end) throws IOException {
+    final DimCursor[] cursors = new DimCursor[queryDims.length];
+    try {
+      for (int i = 0; i < queryDims.length; i++) {
+        final PaginatedSegmentDimCursor sc = reader.openCursor(queryDims[i]);
+        cursors[i] = sc == null ? null : new DimCursor(queryDims[i], List.of(sc));
+      }
+      return BmwScorer.topK(queryDims, queryWeights, cursors, K, start, end);
+    } finally {
+      for (final DimCursor c : cursors)
+        if (c != null)
+          c.close();
+    }
+  }
+
+  /** Cuts at evenly spaced block boundaries of dim 0, the same rule the engine's planner uses. */
+  private static RID[] evenBoundaries(final PaginatedSegmentReader reader, final int partitions) throws IOException {
+    final PaginatedDimMetadata md = reader.dimMetadata(0);
+    final int blocks = md.blockCount();
+    final RID[] out = new RID[partitions - 1];
+    for (int i = 1; i < partitions; i++) {
+      final int b = (int) ((long) blocks * i / partitions);
+      out[i - 1] = new RID(md.blockFirstBucketId(b), md.blockFirstPosition(b));
+    }
+    return out;
+  }
+
+  private static Map<RID, Map<Integer, Float>> buildCorpus(final int docs, final long seed, final boolean allTied) {
+    final Random rnd = new Random(seed);
+    final TreeMap<RID, Map<Integer, Float>> out = new TreeMap<>();
+    for (int i = 0; i < docs; i++) {
+      final TreeMap<Integer, Float> doc = new TreeMap<>();
+      if (allTied) {
+        // Identical weight on identical dims: every document scores exactly the same.
+        for (int d = 0; d < 4; d++)
+          doc.put(d, 0.5f);
+      } else {
+        for (int d = 0; d < DIMS; d++)
+          if (rnd.nextFloat() < 0.5f / (d + 1))
+            doc.put(d, 0.90f + rnd.nextFloat() * 0.10f);
+      }
+      if (!doc.isEmpty())
+        out.put(new RID(0, 1L + i), doc);
+    }
+    if (!allTied) {
+      // A handful of genuine answers, so the top-K watermark rises and pruning actually engages -
+      // which is what makes the partitioned arm prune differently from the serial one.
+      for (int r = 0; r < 40; r++) {
+        final Map<Integer, Float> doc = out.computeIfAbsent(new RID(0, 1L + rnd.nextInt(docs)), rid -> new TreeMap<>());
+        for (int m = 0; m < 12; m++)
+          doc.putIfAbsent(rnd.nextInt(DIMS), 0.90f + rnd.nextFloat() * 0.10f);
+      }
+    }
+    return out;
+  }
+
+  @FunctionalInterface
+  private interface CheckedRunnable {
+    void run() throws Exception;
+  }
+
+  private void inTx(final CheckedRunnable r) {
+    database.transaction(() -> {
+      try {
+        r.run();
+      } catch (final RuntimeException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  /** FP32 so scores round-trip exactly and the two arms can be compared with {@code isEqualTo}. */
+  private PaginatedSegmentReader buildSegment(final String name, final long segmentId,
+      final Map<RID, Map<Integer, Float>> docs) throws IOException {
+    final TreeMap<Integer, TreeMap<RID, Float>> byDim = new TreeMap<>();
+    for (final var doc : docs.entrySet())
+      for (final var dw : doc.getValue().entrySet())
+        byDim.computeIfAbsent(dw.getKey(), k -> new TreeMap<>()).put(doc.getKey(), dw.getValue());
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final SparseSegmentComponent c = new SparseSegmentComponent(db, name, db.getDatabasePath() + "/" + name,
+        ComponentFile.MODE.READ_WRITE, SparseSegmentComponent.DEFAULT_PAGE_SIZE);
+    ((LocalSchema) db.getSchema().getEmbedded()).registerFile(c);
+    try (final SparseSegmentBuilder b = new SparseSegmentBuilder(c,
+        SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+      b.setSegmentId(segmentId);
+      for (final var dim : byDim.entrySet()) {
+        b.startDim(dim.getKey());
+        for (final var p : dim.getValue().entrySet())
+          b.appendPosting(p.getKey(), p.getValue());
+        b.endDim();
+      }
+      b.finish();
+    }
+    return new PaginatedSegmentReader(c);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -527,6 +527,68 @@ class ParallelRangeTopKTest extends TestHelper {
     }
   }
 
+  @Test
+  void anOuterTransactionsUncommittedChangesStillBlockTheSplit() throws Exception {
+    final int previousPartitions = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(4);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+
+      final Map<RID, Map<Integer, Float>> corpus = buildCorpus(SMALL_DOCS, 21L, false);
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      database.getSchema().createDocumentType("OuterTxProbe");
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085nestedtx", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : corpus.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+
+        final List<RidScore> expected = engine.topK(queryDims, queryWeights, K);
+        final long splitsWhenClean = engine.partitionedQueryCount();
+        assertThat(splitsWhenClean).as("a clean caller must split, or the rest proves nothing").isPositive();
+
+        database.begin();
+        try {
+          // Dirty the OUTER transaction, then open a nested one that is itself clean. Asking only
+          // the innermost transaction whether it has changes would answer "no" here and let the
+          // query split, and a worker reading committed pages through its own context would not see
+          // what the outer transaction has written.
+          database.newDocument("OuterTxProbe").set("k", 1).save();
+          database.begin();
+          try {
+            engine.topK(queryDims, queryWeights, K);
+            assertThat(engine.partitionedQueryCount())
+                .as("a nested-clean caller over a dirty outer transaction must not split")
+                .isEqualTo(splitsWhenClean);
+          } finally {
+            database.rollback();
+          }
+        } finally {
+          if (database.isTransactionActive())
+            database.rollback();
+        }
+
+        // And once everything is rolled back it splits again, so the guard is not simply stuck on.
+        assertSameResult(engine.topK(queryDims, queryWeights, K), expected, "after the transaction ended");
+        assertThat(engine.partitionedQueryCount()).isGreaterThan(splitsWhenClean);
+      }
+    } finally {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previousPartitions);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+    }
+  }
+
   // ---------- helpers ----------
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/ParallelRangeTopKTest.java
@@ -684,6 +684,87 @@ class ParallelRangeTopKTest extends TestHelper {
     }
   }
 
+  /**
+   * Equivalence with a live memtable under the query.
+   * <p>
+   * Every other engine-level test here flushes before querying, so the memtable leg of the merged
+   * cursor is empty in all of them and the split has only ever been asserted against sealed
+   * segments. It splits over a populated memtable too: the guard only refuses when the <i>caller</i>
+   * holds uncommitted changes, and postings committed by an earlier transaction are not that.
+   * <p>
+   * There is a reason to expect this to hold - the ranges partition the RID space whatever the
+   * postings are stored in, and the memtable's looser per-term ceiling can only prune more
+   * conservatively, never wrongly - but "expected to hold" is what the rest of this class exists to
+   * stop us relying on. The memtable is also the one source that reports no finite block boundary,
+   * so it is the leg where the block-skip machinery behaves differently from a segment.
+   */
+  @Test
+  void aQueryOverALiveMemtableSplitsAndStillMatchesTheSerialResult() throws Exception {
+    final int previousPartitions = GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.getValueAsInteger();
+    final long previousMin = GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.getValueAsLong();
+    try {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(1L);
+
+      final Map<RID, Map<Integer, Float>> sealed = buildCorpus(SMALL_DOCS, 77L, false);
+      // A second, disjoint slice of the RID space that stays in the memtable, interleaved with the
+      // sealed one so ranges straddle both sources rather than each landing in a single leg.
+      final TreeMap<RID, Map<Integer, Float>> live = new TreeMap<>(SparseSegmentBuilder::compareRid);
+      final Random rnd = new Random(78L);
+      for (int i = 0; i < SMALL_DOCS / 4; i++) {
+        final TreeMap<Integer, Float> doc = new TreeMap<>();
+        for (int d = 0; d < DIMS; d++)
+          if (rnd.nextFloat() < 0.5f / (d + 1))
+            doc.put(d, 0.90f + rnd.nextFloat() * 0.10f);
+        if (!doc.isEmpty())
+          live.put(new RID(0, 2L + i * 4L), doc);
+      }
+
+      final int[] queryDims = new int[DIMS];
+      final float[] queryWeights = new float[DIMS];
+      for (int d = 0; d < DIMS; d++) {
+        queryDims[d] = d;
+        queryWeights[d] = 1.0f;
+      }
+
+      try (final PaginatedSparseVectorEngine engine = new PaginatedSparseVectorEngine((DatabaseInternal) database,
+          "idx4085memtable", SegmentParameters.builder().weightQuantization(WeightQuantization.FP32).build())) {
+        database.transaction(() -> {
+          for (final var doc : sealed.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+          engine.flush();
+        });
+        // Committed in its own transaction and deliberately NOT flushed, so by query time these are
+        // committed postings living in the memtable and the caller is clean.
+        database.transaction(() -> {
+          for (final var doc : live.entrySet())
+            for (final var dw : doc.getValue().entrySet())
+              engine.put(dw.getKey(), doc.getKey(), dw.getValue());
+        });
+
+        assertThat(engine.memtablePostings())
+            .as("the memtable must actually be carrying postings, or this test proves nothing").isPositive();
+        assertThat(engine.segmentCount()).as("and there must be a sealed segment to merge them against").isPositive();
+
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(1);
+        final List<RidScore> serial = engine.topK(queryDims, queryWeights, K);
+        assertThat(serial).isNotEmpty();
+        final long splitsBefore = engine.partitionedQueryCount();
+
+        for (final int partitions : new int[] { 2, 4, 8 }) {
+          GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(partitions);
+          assertSameResult(engine.topK(queryDims, queryWeights, K), serial, "live memtable, split=" + partitions);
+        }
+        assertThat(engine.partitionedQueryCount())
+            .as("the query must really have split over the memtable, not quietly stayed serial")
+            .isEqualTo(splitsBefore + 3);
+      }
+    } finally {
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MAX_PARTITIONS.setValue(previousPartitions);
+      GlobalConfiguration.SPARSE_VECTOR_SCORING_MIN_POSTINGS_FOR_PARTITIONING.setValue(previousMin);
+    }
+  }
+
   // ---------- helpers ----------
 
   /**

--- a/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
@@ -134,7 +134,10 @@ public final class PoolMetrics implements MeterBinder {
         .description("Sparse-vector scoring: cumulative top-K queries split into parallel RID ranges since startup. "
             + "Counts the decision, not the outcome: a range submitted to a full queue runs inline on the caller under the "
             + "caller-runs policy, so a query counted here can still have executed serially. Read alongside "
-            + "tasks.caller_run_fallbacks, which is where that shows up.")
+            + "tasks.caller_run_fallbacks, which is where that shows up. It also records only WHETHER a query split, not into "
+            + "how many ranges - and width is what explains the tail-latency band the default shows at moderate concurrency, "
+            + "where some queries claim a wide split and others get none. A distribution of granted partition counts is the "
+            + "gauge that would show it; this one cannot.")
         .tags(tags).register(registry);
   }
 

--- a/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
@@ -78,6 +78,7 @@ public final class PoolMetrics implements MeterBinder {
         () -> svsp.getPoolStats().queueCapacityRemaining(),
         () -> svsp.getPoolStats().completedTasks(),
         () -> svsp.getPoolStats().callerRunFallbacks());
+    bindSparseVectorSplit(registry, svsp);
 
     // Dedicated pool for the BLOCKING parallel-scan producers (issues #4948/#4950): unbounded task queue by
     // design (backpressure comes from each query's bounded result queue), so callerRunFallbacks is always 0
@@ -99,6 +100,36 @@ public final class PoolMetrics implements MeterBinder {
         .description("Cumulative ghost (dangling) edges skipped during graph traversal since startup. "
             + "Sustained growth indicates a data-integrity anomaly, e.g. incomplete HA replication or a partially rolled-back transaction.")
         .register(registry);
+  }
+
+  /**
+   * Three extra gauges on the {@code sparse_vector} row that explain the pool's own numbers
+   * (issue #4085).
+   * <p>
+   * A sparse-vector top-K decides per query whether to split itself into RID ranges, and a query
+   * that stays serial never touches the pool at all. Without these, an idle {@code sparse_vector}
+   * row is ambiguous in a way an operator cannot resolve: nobody is querying, everybody is querying
+   * but the load gate has switched splitting off, the queries are too small to qualify, or something
+   * is broken - all four look the same. {@code queries.in_flight} separates "no queries" from "no
+   * splitting", {@code queries.split} confirms splitting has ever happened, and {@code pool.reserved}
+   * shows the capacity currently claimed, which is what the gate decides against.
+   * <p>
+   * Registered only for this pool. The other pools take work as it is handed to them and have no
+   * equivalent decision to explain, so their rows leave these blank rather than reporting a
+   * meaningless zero.
+   */
+  private static void bindSparseVectorSplit(final MeterRegistry registry, final SparseVectorScoringPool pool) {
+    final Tags tags = Tags.of(Tag.of("pool", "sparse_vector"));
+    Gauge.builder("arcadedb.executor.pool.reserved", () -> pool.getReservedWorkers())
+        .description("Sparse-vector scoring: workers currently claimed by in-flight range splits").tags(tags)
+        .register(registry);
+    Gauge.builder("arcadedb.executor.queries.in_flight", () -> pool.getInFlightQueries())
+        .description("Sparse-vector scoring: top-K queries executing right now, split or serial. "
+            + "Once these can keep the pool busy on their own, queries stop splitting and run on their caller's thread.")
+        .tags(tags).register(registry);
+    Gauge.builder("arcadedb.executor.queries.split", () -> pool.getSplitQueryCount())
+        .description("Sparse-vector scoring: cumulative top-K queries split into parallel RID ranges since startup")
+        .tags(tags).register(registry);
   }
 
   private static void bindPool(final MeterRegistry registry, final String poolTag, final String description,

--- a/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
@@ -124,8 +124,11 @@ public final class PoolMetrics implements MeterBinder {
         .description("Sparse-vector scoring: workers currently claimed by in-flight range splits").tags(tags)
         .register(registry);
     Gauge.builder("arcadedb.executor.queries.in_flight", () -> pool.getInFlightQueries())
-        .description("Sparse-vector scoring: top-K queries executing right now, split or serial. "
-            + "Once these can keep the pool busy on their own, queries stop splitting and run on their caller's thread.")
+        .description("Sparse-vector scoring: top-K queries executing on caller threads right now, split or serial - the "
+            + "number the split gate is compared against. Once these alone can keep the pool busy, queries stop splitting "
+            + "and run on their caller's thread. Deliberately excludes queries already running on a worker (the per-bucket "
+            + "fan-out), which occupy capacity rather than competing for it and show up under pool.active instead; counting "
+            + "them here would let one multi-bucket query read as several and gate unrelated ones.")
         .tags(tags).register(registry);
     Gauge.builder("arcadedb.executor.queries.split", () -> pool.getSplitQueryCount())
         .description("Sparse-vector scoring: cumulative top-K queries split into parallel RID ranges since startup. "

--- a/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
@@ -128,7 +128,10 @@ public final class PoolMetrics implements MeterBinder {
             + "Once these can keep the pool busy on their own, queries stop splitting and run on their caller's thread.")
         .tags(tags).register(registry);
     Gauge.builder("arcadedb.executor.queries.split", () -> pool.getSplitQueryCount())
-        .description("Sparse-vector scoring: cumulative top-K queries split into parallel RID ranges since startup")
+        .description("Sparse-vector scoring: cumulative top-K queries split into parallel RID ranges since startup. "
+            + "Counts the decision, not the outcome: a range submitted to a full queue runs inline on the caller under the "
+            + "caller-runs policy, so a query counted here can still have executed serially. Read alongside "
+            + "tasks.caller_run_fallbacks, which is where that shows up.")
         .tags(tags).register(registry);
   }
 

--- a/server/src/test/java/com/arcadedb/server/monitor/PoolMetricsTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/PoolMetricsTest.java
@@ -48,6 +48,17 @@ class PoolMetricsTest {
       "arcadedb.executor.tasks.completed",
       "arcadedb.executor.tasks.caller_run_fallbacks");
 
+  /**
+   * Gauges only the sparse-vector pool publishes: they explain its per-query decision to split a
+   * top-K into parallel RID ranges (issue #4085). Deliberately absent on the other pools, which take
+   * work as it is handed to them - Studio renders a dash there rather than a zero that would read as
+   * "nothing is splitting" when the concept does not apply.
+   */
+  private static final Set<String> SPARSE_ONLY_GAUGE_NAMES = Set.of(
+      "arcadedb.executor.pool.reserved",
+      "arcadedb.executor.queries.in_flight",
+      "arcadedb.executor.queries.split");
+
   @Test
   void registersGaugesForBothPoolsWithPoolTag() {
     final SimpleMeterRegistry registry = new SimpleMeterRegistry();
@@ -68,6 +79,13 @@ class PoolMetricsTest {
             .as("gauge '%s' tagged pool=%s must be registered", gaugeName, poolTag)
             .isNotNull();
       }
+    }
+
+    for (final String gaugeName : SPARSE_ONLY_GAUGE_NAMES) {
+      assertThat(registry.find(gaugeName).tag("pool", "sparse_vector").meter())
+          .as("split-decision gauge '%s' must be registered for the sparse-vector pool", gaugeName).isNotNull();
+      assertThat(registry.find(gaugeName).tag("pool", "query").meter())
+          .as("split-decision gauge '%s' must NOT be registered for pools that never split", gaugeName).isNull();
     }
   }
 
@@ -122,6 +140,21 @@ class PoolMetricsTest {
         assertThat(pool.getDouble(shortName))
             .as("pool=%s gauge '%s' must be a finite number", poolTag, shortName).isFinite();
       }
+    }
+
+    // The split-decision gauges reach Studio through the same grouping, on the sparse-vector row
+    // only. The JS renders a dash where a key is absent, so "present for sparse_vector, absent
+    // elsewhere" is the contract - a zero on the wrong row would read as "nothing is splitting".
+    final JSONObject sparse = executors.getJSONObject("sparse_vector");
+    final JSONObject query = executors.getJSONObject("query");
+    for (final String gaugeName : SPARSE_ONLY_GAUGE_NAMES) {
+      final String shortName = gaugeName.substring("arcadedb.executor.".length());
+      assertThat(sparse.has(shortName))
+          .as("pool=sparse_vector must expose split gauge '%s' in JSON", shortName).isTrue();
+      assertThat(sparse.getDouble(shortName))
+          .as("split gauge '%s' must be a finite number", shortName).isFinite();
+      assertThat(query.has(shortName))
+          .as("pool=query must NOT expose split gauge '%s'", shortName).isFalse();
     }
   }
 }

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -321,7 +321,9 @@ function displayMetrics() {
     executorsHtml += "<td class='" + fallbackCellClass + "'>" + fallbacks.toLocaleString() + "</td>";
     // Split-decision columns (#4085). Only the sparse-vector pool decides per query whether to
     // parallelise, so a pool that does not report them shows "-" rather than a zero that would read
-    // as "nothing is splitting" when the concept simply does not apply.
+    // as "nothing is splitting" when the concept simply does not apply. "Queries Split" is the
+    // decision, not the outcome: under caller-runs a submitted range executes inline on the caller,
+    // so it pairs with the Caller-Run Fallbacks column to the left.
     executorsHtml += "<td class='text-end'>" + gaugeOrDash(pool, "pool.reserved") + "</td>";
     executorsHtml += "<td class='text-end'>" + gaugeOrDash(pool, "queries.in_flight") + "</td>";
     executorsHtml += "<td class='text-end'>" + gaugeOrDash(pool, "queries.split") + "</td>";

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -299,7 +299,8 @@ function displayMetrics() {
   // tasks.caller_run_fallbacks. The sparse-vector pool adds pool.reserved, queries.in_flight and
   // queries.split, which explain its per-query decision to parallelise or not (#4085).
   var ex = serverData.metrics.executors || {};
-  var executorRowLabels = { "query": "Query Parallelism", "sparse_vector": "Sparse Vector Scoring" };
+  var executorRowLabels = { "query": "Query Parallelism", "sparse_vector": "Sparse Vector Scoring",
+      "parallel_scan": "Parallel Scan Producers" };
   var executorPoolNames = Object.keys(ex).sort();
   var executorsHtml = "";
   for (var i = 0; i < executorPoolNames.length; i++) {

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -285,10 +285,19 @@ function displayMetrics() {
   }
   $("#srvMetricMetersTable").html(metersHtml || "<tr><td colspan='3' class='text-muted text-center'>No HTTP meters available.</td></tr>");
 
+  // Renders a gauge the pool may not publish at all: absent means "not applicable to this pool",
+  // which is different from zero and must not be shown as one.
+  function gaugeOrDash(pool, key) {
+    return pool[key] === undefined || pool[key] === null ? "<span class='text-muted'>-</span>"
+        : Math.round(pool[key]).toLocaleString();
+  }
+
   // Executor Pools table - rendered from metrics.executors. Server-side keys are populated by
-  // PoolMetrics; expected pool names are "query" (QueryEngineManager) and "sparse_vector"
-  // (SparseVectorScoringPool). Each pool's gauges are: pool.size, pool.active, queue.depth,
-  // queue.capacity_remaining, tasks.completed, tasks.caller_run_fallbacks.
+  // PoolMetrics; expected pool names are "query" (QueryEngineManager), "sparse_vector"
+  // (SparseVectorScoringPool) and "parallel_scan" (ParallelScanProducerPool). Each pool's gauges
+  // are: pool.size, pool.active, queue.depth, queue.capacity_remaining, tasks.completed,
+  // tasks.caller_run_fallbacks. The sparse-vector pool adds pool.reserved, queries.in_flight and
+  // queries.split, which explain its per-query decision to parallelise or not (#4085).
   var ex = serverData.metrics.executors || {};
   var executorRowLabels = { "query": "Query Parallelism", "sparse_vector": "Sparse Vector Scoring" };
   var executorPoolNames = Object.keys(ex).sort();
@@ -310,9 +319,15 @@ function displayMetrics() {
     executorsHtml += "<td class='text-end'>" + Math.round(pool["queue.capacity_remaining"] || 0).toLocaleString() + "</td>";
     executorsHtml += "<td class='text-end'>" + Math.round(pool["tasks.completed"] || 0).toLocaleString() + "</td>";
     executorsHtml += "<td class='" + fallbackCellClass + "'>" + fallbacks.toLocaleString() + "</td>";
+    // Split-decision columns (#4085). Only the sparse-vector pool decides per query whether to
+    // parallelise, so a pool that does not report them shows "-" rather than a zero that would read
+    // as "nothing is splitting" when the concept simply does not apply.
+    executorsHtml += "<td class='text-end'>" + gaugeOrDash(pool, "pool.reserved") + "</td>";
+    executorsHtml += "<td class='text-end'>" + gaugeOrDash(pool, "queries.in_flight") + "</td>";
+    executorsHtml += "<td class='text-end'>" + gaugeOrDash(pool, "queries.split") + "</td>";
     executorsHtml += "</tr>";
   }
-  $("#srvMetricExecutorsTable").html(executorsHtml || "<tr><td colspan='6' class='text-muted text-center'>No executor pool metrics available.</td></tr>");
+  $("#srvMetricExecutorsTable").html(executorsHtml || "<tr><td colspan='9' class='text-muted text-center'>No executor pool metrics available.</td></tr>");
 
   // Sparse Vector Indexes table - rendered from metrics.sparseVectorIndexes. Shape:
   //   { dbName: { typeIndexName: { memtablePostings, segmentCount, totalPostings } } }

--- a/studio/src/main/resources/static/server.html
+++ b/studio/src/main/resources/static/server.html
@@ -261,7 +261,7 @@
         <div class="card mb-3">
           <div class="card-header">
             Executor Pools
-            <span class="text-muted small ms-2">live thread / queue / saturation gauges per engine pool</span>
+            <span class="text-muted small ms-2">live thread / queue / saturation gauges per engine pool; the last three columns apply to sparse-vector scoring, which decides per query whether to parallelise</span>
           </div>
           <div class="card-body p-0">
             <div class="table-responsive">
@@ -274,6 +274,9 @@
                     <th class="text-end">Queue Free</th>
                     <th class="text-end">Tasks Completed</th>
                     <th class="text-end">Caller-Run Fallbacks</th>
+                    <th class="text-end">Reserved</th>
+                    <th class="text-end">Queries In Flight</th>
+                    <th class="text-end">Queries Split</th>
                   </tr>
                 </thead>
                 <tbody id="srvMetricExecutorsTable"></tbody>

--- a/studio/src/main/resources/static/server.html
+++ b/studio/src/main/resources/static/server.html
@@ -261,7 +261,7 @@
         <div class="card mb-3">
           <div class="card-header">
             Executor Pools
-            <span class="text-muted small ms-2">live thread / queue / saturation gauges per engine pool; the last three columns apply to sparse-vector scoring, which decides per query whether to parallelise</span>
+            <span class="text-muted small ms-2">live thread / queue / saturation gauges per engine pool; the last three columns apply to sparse-vector scoring, which decides per query whether to parallelise. Queries Split counts the decision, so read it with Caller-Run Fallbacks: a range submitted to a full queue still runs inline on the caller</span>
           </div>
           <div class="card-body p-0">
             <div class="table-responsive">


### PR DESCRIPTION
Closes #4085.

Wires the dispatch `SparseVectorScoringPool` was built for: a top-K over a single `LSM_SPARSE_VECTOR` index is scored as several RID ranges concurrently and merged, instead of one traversal on the caller's thread.

## Measured

SPLADE-shaped corpus, INT8, 18-worker box. Single query, ranges forced:

| corpus | serial | 8 ranges | 16 ranges |
|---|---|---|---|
| 500k | 13.4 ms p50 | 4.0 (3.4x) | 2.4 (5.6x) |
| 1M | 26.2 ms p50 | 7.6 (3.5x) | 4.5 (5.9x) |

`LSMSparseVectorIndexLargeBenchmark`, which now runs both shapes and asserts they return the same documents:

| corpus | serial | adaptive split | |
|---|---|---|---|
| 1M | 5.13 ms/query | 2.83 | 1.82x |
| 10M | 24.18 ms/query | 6.90 | 3.51x |

The 1M gain is smaller there because that benchmark's query is 10 terms over 30 nnz/doc: at 5 ms of work, per-range cursor setup and the merge take a visible share. The split pays in proportion to how much work the query does.

## Why the gating is most of the diff

A range prunes against its own top-K watermark rather than the global one, so it does more work than its share: **1.16x total CPU at 2 ranges, 1.89x at 8**. That is free latency on an idle machine and stolen throughput on a busy one, so the decision has to be adaptive.

Sizing it from pool activity was tried first and measured wrong. A query runs on its caller's thread, so at 16 concurrent clients the pool reads idle at every sampling instant: a third of queries split anyway and throughput fell 14%. The gate that works counts **queries in flight**, not pool activity. At 500k:

| clients | serial QPS | adaptive QPS | p50 | queries split |
|---|---|---|---|---|
| 1 | 72 | 322 | 3.05 vs 13.7 ms | 100% |
| 4 | 290 | 468 (+61%) | 4.13 vs 13.6 ms | 74% |
| 16 | 869 | 829 (-4.6%) | 19.0 vs 17.8 ms | 2 of 8289 |

A query also refuses to split when it is already running on a pool worker (a nested fan-out on a bounded queue deadlocks rather than degrading, since the outer tasks hold every worker while waiting on inner tasks nothing is left to run), and when the caller holds uncommitted page changes, which a worker's own transaction context cannot see.

## Results are the serial ones, ties included

`RidScoreMinHeap` now breaks ties on RID ascending, so which of several equally-scored documents survives no longer depends on heap layout, and the merge ranks the same way. **This is a behaviour change**: a query with tied scores could previously return either document and now deterministically returns the lowest RID.

Scores can differ by one ulp between the two shapes, because MaxScore sums a document's terms in an order that follows the pruning split. Document set and ranking are unaffected; documented on the test that asserts it.

## Also here

- The caller scores one range itself rather than blocking on all of them.
- `topKGrouped` stays serial: merging grouped results needs the per-group worsts, not a flat best-k.
- Studio's Executor Pools card gains three columns on the sparse-vector row (reserved workers, queries in flight, queries split). Without them an idle row is ambiguous between "nobody querying", "load gate switched splitting off", "queries too small" and "broken".
- `MultiBucketSealedSegmentFanoutTest` covers multi-bucket over sealed segments, which had no coverage and passes today only because `LocalDatabase.checkDatabaseIsOpen` creates a thread context as a side effect. Nothing states that contract, so a refactor could have broken segment-backed multi-bucket queries silently.

## New settings

- `arcadedb.sparseVectorScoringMaxPartitions` (0 = adaptive, 1 = off, >1 = explicit and bypasses the load gate)
- `arcadedb.sparseVectorScoringMinPostingsForPartitioning` (default 200,000)

## Testing

Full `engine` module 10,128 tests and full `server` module 763 tests, zero failures. New `ParallelRangeTopKTest` covers range/serial equivalence at 2..16 ranges, tie determinism, empty and out-of-bounds ranges, engine-level equivalence, no nested split, no worker leak, and in-flight suppression.

Not verified: the Studio card rendering in a browser. The gauges and the JSON contract are pinned by `PoolMetricsTest`, but nobody has looked at the page.

## Worth a reviewer's attention

1. The load gate is a heuristic. It measured well at 1/4/16 clients on one machine and is the piece most likely to want tuning on other hardware.
2. The tie-break change is user-visible for tied scores.
3. Whether explicit `maxPartitions > 1` should really bypass the load gate, or whether an operator asking for N ranges should still yield under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF4M78mPjg8VH7GR5pPZEp
