### PR TITLE
#5517 A bloom filter per compacted LSM series, so a lookup skips the series that cannot hold the key

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1,0 +1,49 @@
+# ArcadeDB v.26.8.1 Release Highlights
+
+This is a living document: fixes, improvements, new features, and breaking changes are collected here as
+they land during the 26.8.1 development cycle, so the release notes are ready at tag time.
+
+### New Features
+
+#### Bloom filters on compacted LSM indexes (enabled by default)
+
+An LSM index lookup walks every compacted series from newest to oldest. A series' root page already rules out
+a key outside its key *range*, but not a key inside the range that the series simply does not hold - so that
+series still costs a root-page search and a data-page read to discover nothing. Each compacted series now
+carries a bloom filter that answers the question from a single 8 KB page.
+
+The workload this is for is a bulk load into a **unique** index, where the duplicate check for every incoming
+record misses in *every* series by definition
+([#5517](https://github.com/ArcadeData/arcadedb/issues/5517), out of
+[#5470](https://github.com/ArcadeData/arcadedb/issues/5470)).
+
+Measured on 2M keys across 9 series (`LSMTreeBloomFilterBenchmark`, run with `-Dgroups=benchmark`):
+
+| | filters off | filters on | |
+|---|---|---|---|
+| absent-key lookups (a duplicate check) | 199,743/s | 386,138/s | **1.9x** |
+| pages read for those lookups | 1,490 | 705 | **2.1x fewer** |
+| bytes read for those lookups | 372 MB | 176 MB | |
+| present-key lookups | 244,000/s | 281,150/s | 1.2x |
+
+- **On by default** at a 1% target false-positive rate: `arcadedb.indexBloomFilterRate=0.01`. Set it to `0`
+  to switch the feature off entirely.
+- **Costs about 1.2 bytes per key** on disk - roughly 3% of the index it describes - in a separate
+  `<index>_bf.bfidx` component next to the compacted index. A false positive only costs the page read that
+  would have happened anyway.
+- **No rebuild and no migration.** Filters are written by compaction, so an existing index gains them at its
+  next compaction. They replicate over HA and are included in backups like any other component, and are
+  dropped with the index.
+- **Helps most when compacted series overlap in key range**, which is what keys that do not arrive already
+  sorted produce (an email, a UUID, a business id). Keys inserted in ascending order give each series a
+  disjoint slice that its root page already rules out, leaving the filters little to save. Range scans and
+  cursors never consult them: a filter can answer for one key, never for an interval.
+- **Observability:** `bloomSkippedSeries` and `bloomProbedSeries` in the index statistics report how many
+  series the filters spared and how many were still read.
+
+Backward and forward compatible with no version bump and no rollout gate: an older ArcadeDB does not
+recognise the `.bfidx` extension, never opens the file, and reads the index exactly as it does today. Note
+that a downgraded build compacts *without* maintaining the filters, so if you downgrade and later come back,
+prefer running a full compaction (or setting `arcadedb.indexBloomFilterRate=0`) on the upgraded build.
+
+**Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -568,14 +568,37 @@ public enum GlobalConfiguration {
 
   INDEX_BLOOM_FILTER_RATE("arcadedb.indexBloomFilterRate", SCOPE.DATABASE,
       """
-      Target false-positive rate of the bloom filter an index compaction writes for every compacted series, so a point \
-      lookup can skip a series that provably does not hold the key without reading any of its pages. Costs about 1.2 \
-      bytes per key at the default 1%; a false positive only costs the page read that would have happened anyway. \
-      Most useful when compacted series overlap in key range, i.e. keys that do not arrive already sorted (an email, \
-      a UUID, any business id); keys inserted in ascending order give each series a disjoint range that its root page \
-      already rules out. One directory page holds ~291 series, after which further series are published without a \
-      filter until a full compaction collapses the count - so a very wide index can show a high bloomProbedSeries. \
-      0 = disabled; filters already on disk are then ignored from the next database open.""",
+      Target false-positive rate of the bloom filter an index compaction writes for each compacted series of an LSM \
+      index, letting a point lookup skip a series that provably cannot hold the key without reading any of its pages. \
+      Default 0.01 (1%), enabled. Set to 0 to disable.
+      WHAT IT DOES. A lookup walks every compacted series from newest to oldest. A series' root page already rules out \
+      a key outside its key RANGE, but not a key inside the range that the series simply does not hold - so without a \
+      filter that series still costs a root-page search and a data-page read to discover nothing. The filter answers \
+      that question from a single 8 KB page instead.
+      WHEN IT HELPS. Most when the compacted series OVERLAP in key range, which is what any key that does not arrive \
+      already sorted produces: an email, a UUID, a business id. The extreme case is a bulk load into a UNIQUE index, \
+      where the duplicate check for every incoming record misses in every series by definition. Measured on 2M keys \
+      over 9 series: absent-key lookups about 2x faster and 2x fewer pages read; keys that ARE present also gain, \
+      because a key lives in one series and the filters spare the reader the others.
+      WHEN IT DOES NOT. Keys inserted in ascending order (a counter, a timestamp) give each series a disjoint key \
+      slice that its root page already rules out for free, leaving the filters little to save. Range scans and cursors \
+      never consult them at all: a filter can answer for one key, never for an interval.
+      WHAT IT COSTS. About 1.2 bytes per key on disk at 1% (roughly 3% of the index it describes), in a separate \
+      '<index>_bf.bfidx' paginated component alongside the compacted index. A false positive costs only the page read \
+      that would have happened anyway. During compaction it holds 8 bytes of transient heap per key of the series \
+      being written. Lower rates cost more bytes and more probes per lookup; higher rates save space and read more \
+      series. Below roughly 0.001 the extra bytes stop paying for themselves.
+      OPERATIONAL NOTES. Filters are written by compaction only, so an existing index gains them at its next \
+      compaction and never needs a rebuild. They are replicated over HA and included in backups like any other \
+      component, and are dropped with the index. An older ArcadeDB does not recognise the file and ignores it, so \
+      downgrading is safe for reading - but a downgraded build compacts without maintaining the filters, so prefer \
+      running a full compaction (or this setting at 0) if you downgrade and come back. \
+      A directory page holds ~255 series; beyond that further series are published without a filter until a full \
+      compaction collapses the count, which the default arcadedb.indexCompactionFullSeriesThreshold=10 does long \
+      before it can happen. Watch 'bloomSkippedSeries' and 'bloomProbedSeries' in the index statistics to see what \
+      the filters are actually saving.
+      DISABLING. 0 stops new filters being written immediately and stops existing ones being consulted from the next \
+      database open. Lookups then behave exactly as they did before the feature existed.""",
       Float.class, 0.01f),
 
   VECTOR_INDEX_LOCATION_CACHE_SIZE("arcadedb.vectorIndex.locationCacheSize", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -571,7 +571,11 @@ public enum GlobalConfiguration {
       Target false-positive rate of the bloom filter an index compaction writes for every compacted series, so a point \
       lookup can skip a series that provably does not hold the key without reading any of its pages. Costs about 1.2 \
       bytes per key at the default 1%; a false positive only costs the page read that would have happened anyway. \
-      0 = disabled, and filters already on disk are then ignored.""",
+      Most useful when compacted series overlap in key range, i.e. keys that do not arrive already sorted (an email, \
+      a UUID, any business id); keys inserted in ascending order give each series a disjoint range that its root page \
+      already rules out. One directory page holds ~291 series, after which further series are published without a \
+      filter until a full compaction collapses the count - so a very wide index can show a high bloomProbedSeries. \
+      0 = disabled; filters already on disk are then ignored from the next database open.""",
       Float.class, 0.01f),
 
   VECTOR_INDEX_LOCATION_CACHE_SIZE("arcadedb.vectorIndex.locationCacheSize", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -566,6 +566,14 @@ public enum GlobalConfiguration {
       "Number of compacted series at which an index compaction runs as a full compaction: every existing series is merged together with the mutable pages into a single fresh series, deletions are resolved and dead entries dropped. Keeps delete-heavy indexes from accumulating unbounded tombstone runs and series. 0 = disabled",
       Integer.class, 10),
 
+  INDEX_BLOOM_FILTER_RATE("arcadedb.indexBloomFilterRate", SCOPE.DATABASE,
+      """
+      Target false-positive rate of the bloom filter an index compaction writes for every compacted series, so a point \
+      lookup can skip a series that provably does not hold the key without reading any of its pages. Costs about 1.2 \
+      bytes per key at the default 1%; a false positive only costs the page read that would have happened anyway. \
+      0 = disabled, and filters already on disk are then ignored.""",
+      Float.class, 0.01f),
+
   VECTOR_INDEX_LOCATION_CACHE_SIZE("arcadedb.vectorIndex.locationCacheSize", SCOPE.DATABASE,
       """
       Maximum number of vector locations to cache in memory per vector index. \

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -67,6 +67,7 @@ import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.hash.HashIndexBucket;
+import com.arcadedb.index.lsm.LSMTreeIndexBloomFilter;
 import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
 import com.arcadedb.index.lsm.LSMTreeIndexMutable;
 import com.arcadedb.index.sparsevector.SparseSegmentComponent;
@@ -149,6 +150,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       LSMTreeIndexMutable.UNIQUE_INDEX_EXT,
       LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT,
       LSMTreeIndexCompacted.UNIQUE_INDEX_EXT,
+      LSMTreeIndexBloomFilter.FILE_EXT,
       LSMVectorIndex.FILE_EXT,
       LSMVectorIndexGraphFile.FILE_EXT,
       SparseSegmentComponent.FILE_EXT,

--- a/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
@@ -103,7 +103,7 @@ public class BufferBloomFilter {
   }
 
   public synchronized void add(final int value) {
-    addHash(hash64(value));
+    setHashBits(hash64(value));
   }
 
   /**
@@ -111,7 +111,7 @@ public class BufferBloomFilter {
    * into an int would throw away the very entropy the filter needs.
    */
   public synchronized void add(final byte[] key, final int length) {
-    addHash(MurmurHash.hash64(key, length, hashSeed));
+    setHashBits(MurmurHash.hash64(key, length, hashSeed));
   }
 
   /**
@@ -120,11 +120,29 @@ public class BufferBloomFilter {
    * could be observed and produce a false negative.
    */
   public boolean mightContain(final int value) {
-    return mightContainHash(hash64(value));
+    return testHashBits(hash64(value));
   }
 
   public boolean mightContain(final byte[] key, final int length) {
-    return mightContainHash(MurmurHash.hash64(key, length, hashSeed));
+    return testHashBits(MurmurHash.hash64(key, length, hashSeed));
+  }
+
+  /**
+   * Sets the bits of an already-hashed key, for a caller that routes one key to one of several filters and so has to
+   * hash it once, up front - re-hashing per candidate filter is both wasted work and one more chance for the routing
+   * and the probing to disagree. The hash MUST be of the same bytes under the same seed this filter was built with,
+   * or the key is recorded where it will never be probed: a false negative.
+   */
+  public synchronized void addHash(final long hash) {
+    setHashBits(hash);
+  }
+
+  /**
+   * Reads the bits of an already-hashed key, the counterpart of {@link #addHash}. Lock-free, with the same publication
+   * requirement as {@link #mightContain}.
+   */
+  public boolean mightContainHash(final long hash) {
+    return testHashBits(hash);
   }
 
   public int getSlots() {
@@ -174,7 +192,7 @@ public class BufferBloomFilter {
     return Math.pow(1 - Math.exp(-(double) probes * entries / capacity), probes);
   }
 
-  private void addHash(final long hash) {
+  private void setHashBits(final long hash) {
     final int first = (int) (hash >>> 32);
     // Forced odd so that on a power-of-two capacity the probes never walk the same short cycle.
     final int step = (int) hash | 1;
@@ -182,7 +200,7 @@ public class BufferBloomFilter {
       setBit(Math.floorMod(first + (long) i * step, capacity));
   }
 
-  private boolean mightContainHash(final long hash) {
+  private boolean testHashBits(final long hash) {
     final int first = (int) (hash >>> 32);
     final int step = (int) hash | 1;
     for (int i = 0; i < probes; i++)

--- a/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
@@ -145,6 +145,29 @@ public class BufferBloomFilter {
     return testHashBits(hash);
   }
 
+  /**
+   * The same probe against a filter that lives in a page, without wrapping it in anything.
+   * <p>
+   * A caller that probes one filter per series, per record, on a bulk load cannot afford the slice, the {@link Binary}
+   * and the filter instance that reading it through the constructor would cost - that is millions of short-lived
+   * objects on the very path the filter exists to make cheaper. The page's own accessors are content-relative, exactly
+   * like the {@code Binary} an instance would wrap, so the bytes addressed here are the bytes {@link #addHash} wrote.
+   * <p>
+   * This deliberately repeats the loop of {@link #testHashBits} rather than sharing it, because the two read from
+   * different sources; {@code theStaticProbeAgreesWithTheInstanceOne} pins them to the same answer, and a divergence
+   * between them would be a false negative.
+   */
+  public static boolean mightContainHash(final BasePage page, final int slots, final int probes, final long hash) {
+    final int first = (int) (hash >>> 32);
+    final int step = (int) hash | 1;
+    for (int i = 0; i < probes; i++) {
+      final int bit = (int) Math.floorMod(first + (long) i * step, slots);
+      if (((page.readByte(bit / 8) >> (bit % 8)) & 1) == 0)
+        return false;
+    }
+    return true;
+  }
+
   public int getSlots() {
     return capacity;
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -859,6 +859,20 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
     return findEntryOfSameKey(currentPageBuffer, keys, startIndexArray, mid, mid + 1, count, 1);
   }
 
+  /**
+   * Serializes a key into {@code scratch} exactly as {@link #writeKeys} writes it into a page, so a hash of those
+   * bytes means the same thing on the compaction path and on the lookup path (#5517). Returns null - "not hashable" -
+   * for anything but a complete key, because a partial key is a range and no hash can answer for a range.
+   */
+  Binary serializeKeyForHashing(final Binary scratch, final Object[] convertedKeys) {
+    if (convertedKeys == null || convertedKeys.length != binaryKeyTypes.length)
+      return null;
+
+    scratch.clear();
+    writeKeys(scratch, convertedKeys);
+    return scratch;
+  }
+
   private void writeKeys(final Binary buffer, final Object[] keys) {
     // WRITE KEYS
     for (int i = 0; i < binaryKeyTypes.length; ++i) {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -41,6 +41,7 @@ import com.arcadedb.utility.RidHashSet;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -860,17 +861,55 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
   }
 
   /**
-   * Serializes a key into {@code scratch} exactly as {@link #writeKeys} writes it into a page, so a hash of those
-   * bytes means the same thing on the compaction path and on the lookup path (#5517). Returns null - "not hashable" -
-   * for anything but a complete key, because a partial key is a range and no hash can answer for a range.
+   * Serializes a key into {@code scratch} for hashing (#5517), so a hash of those bytes means the same thing on the
+   * compaction path and on the lookup path. Returns null - "not hashable" - for anything but a complete key, because a
+   * partial key is a range and no hash can answer for a range.
+   * <p>
+   * It is NOT simply {@link #writeKeys}: a hash needs bytes that are equal whenever the INDEX considers the keys equal,
+   * and for one type the serialized form is stricter than the comparator. See {@link #canonicalizeForHashing}.
    */
   Binary serializeKeyForHashing(final Binary scratch, final Object[] convertedKeys) {
     if (convertedKeys == null || convertedKeys.length != binaryKeyTypes.length)
       return null;
 
     scratch.clear();
-    writeKeys(scratch, convertedKeys);
+    writeKeys(scratch, canonicalizeForHashing(convertedKeys));
     return scratch;
+  }
+
+  /**
+   * Rewrites the key components whose serialized form distinguishes values the comparator treats as EQUAL, so that
+   * equal keys always hash alike.
+   * <p>
+   * {@code convertKeys} already normalises the type of every component - a lookup with an Integer against a LONG index
+   * becomes a Long - which is what keeps the numeric types honest here. DECIMAL is the exception: converting to
+   * {@link BigDecimal} keeps whatever scale the caller supplied, serialization writes that scale
+   * ({@code putNumber(scale)} then the unscaled bytes), but {@link com.arcadedb.serializer.BinaryComparator} compares
+   * with {@code BigDecimal.compareTo}, which ignores it. So {@code 1.0} and {@code 1.00} are the SAME key to the index
+   * and two different byte strings to the hash - and a lookup for one would skip the series holding the other. On a
+   * unique DECIMAL index that is a duplicate slipping past the duplicate check.
+   * <p>
+   * {@code stripTrailingZeros} maps every {@code compareTo}-equal BigDecimal to one representation, so equal keys reach
+   * the hash as equal bytes. It is applied to the HASH only: the bytes written into a page are untouched.
+   * <p>
+   * Returns {@code convertedKeys} itself when nothing needs rewriting, which is every index that has no DECIMAL
+   * component - i.e. this costs an instanceof per component and no allocation on the common path.
+   */
+  private Object[] canonicalizeForHashing(final Object[] convertedKeys) {
+    Object[] canonical = convertedKeys;
+
+    for (int i = 0; i < convertedKeys.length; i++)
+      if (convertedKeys[i] instanceof BigDecimal decimal) {
+        final BigDecimal stripped = decimal.stripTrailingZeros();
+        // Equal scales mean equal unscaled values too (same number, same scale), so the bytes already match.
+        if (stripped.scale() != decimal.scale()) {
+          if (canonical == convertedKeys)
+            canonical = convertedKeys.clone();
+          canonical[i] = stripped;
+        }
+      }
+
+    return canonical;
   }
 
   private void writeKeys(final Binary buffer, final Object[] keys) {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilter.java
@@ -1,0 +1,537 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.BufferBloomFilter;
+import com.arcadedb.engine.ComponentFactory;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.MurmurHash;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponent;
+import com.arcadedb.log.LogManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+/**
+ * One bloom filter per compacted series of an {@link LSMTreeIndexCompacted}, so a point lookup can skip a series that
+ * cannot hold the key without reading any of its pages (issue #5517).
+ * <p>
+ * A lookup walks every published series newest to oldest. The series' root page already rules out a key outside the
+ * series' key RANGE, but says nothing about a key inside the range that the series does not hold - and that is the
+ * common case of a bulk load, where each series spans nearly the whole key space and the unique-index duplicate check
+ * therefore reads one data page per series, per record, only to find nothing.
+ * <p>
+ * <b>Why a {@link PaginatedComponent} and not a side file.</b> A plain file next to the index would not be replicated
+ * over HA, would not be transactional, would not be in a backup and would not follow the index through DROP INDEX. As
+ * a component its pages flow through the PageManager exactly like the compacted index pages they describe, over the
+ * very same code path, so the filter can never travel differently from the data.
+ * <p>
+ * <b>Layout: strictly APPEND-ONLY.</b> Publishing a series appends its bit pages and then one directory page listing
+ * every filter published so far, so the live directory is always the LAST page of the file. Nothing is ever rewritten
+ * in place, which buys two things that in-place updates could not: a crash mid-publish leaves the previous directory
+ * untouched and the file readable, and HA ships a compaction by shipping the page range each file GREW by - a rewritten
+ * page 0 would simply not travel, leaving followers with a directory that disagrees with their own bits.
+ * <p>
+ * A directory page is {@code [magic][formatVersion][entryCount][checksum]} followed by {@value #DIRECTORY_ENTRY_SIZE}-byte
+ * entries {@code [seriesRootPage][seriesPages][firstFilterPage][filterPages][slotsPerBlock][probes][keys]}. A series'
+ * bits are split into {@code filterPages} independent BLOCKS of one page each and a key is routed to exactly one block,
+ * so a probe reads ONE page however large the series is. Blocks are big enough (a 64 KB page holds ~500k bits, i.e.
+ * ~54k keys at 1%) that the occupancy skew of a blocked filter is negligible.
+ * <p>
+ * <b>The rule that must not break.</b> A false positive costs the lookup that would have happened anyway; a false
+ * NEGATIVE hides data - a lookup skipped, a record reported missing, a unique-index duplicate check letting a duplicate
+ * through - silently, with the index file intact. Every decision here is biased that way: a series with no directory
+ * entry, an entry whose shape does not match the series the reader is looking at, a partial or null key, an unreadable
+ * page - all answer "search this series". And before a filter is published, EVERY key just written is probed back
+ * exhaustively ({@link #verifyNoFalseNegatives}); a single miss abandons the filter instead of publishing it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class LSMTreeIndexBloomFilter extends PaginatedComponent {
+  public static final String FILE_EXT        = "bfidx";
+  public static final int    CURRENT_VERSION = 1;
+
+  /** Suffix appended to the compacted index component name; the pair is resolved by name at schema-load time. */
+  static final String NAME_SUFFIX = "_bf";
+
+  /** Seed of the key hash. Changing it invalidates every filter on disk, so it travels with {@link #FORMAT_VERSION}. */
+  static final int HASH_SEED = 0x5bf1e995;
+
+  private static final int MAGIC                 = 0x424C4F4D; // "BLOM"
+  private static final int FORMAT_VERSION        = 1;
+  private static final int DIRECTORY_HEADER_SIZE = 4 * Binary.INT_SERIALIZED_SIZE;
+  private static final int DIRECTORY_ENTRY_SIZE  = 7 * Binary.INT_SERIALIZED_SIZE;
+
+  /**
+   * Pages to look back through for the newest directory when the last page of the file is not one, i.e. after a crash
+   * between a publish's bit pages and its directory page. It only has to cover the pages a single publish appends;
+   * beyond it the file is simply read as having no filters.
+   */
+  private static final int MAX_DIRECTORY_LOOKBACK = 4_096;
+
+  /**
+   * Past ~12 probes the false-positive rate barely improves while the cost of a lookup keeps growing linearly. The
+   * bound matters for a SMALL series, where a whole page of bits for a handful of keys would otherwise ask for
+   * thousands of probes.
+   */
+  private static final int MAX_PROBES = 12;
+
+  /**
+   * Directory of the filters, keyed by the series' root page. Rebuilt whole and swapped in one go, so a reader either
+   * sees the directory before a publish or after it, never halfway - {@code volatile} is the safe-publication edge
+   * {@link BufferBloomFilter} requires for its lock-free reads.
+   */
+  private volatile Map<Integer, Entry> directory = Map.of();
+
+  /** One published filter. Immutable once built. */
+  record Entry(int seriesRootPage, int seriesPages, int firstFilterPage, int filterPages, int slotsPerBlock, int probes,
+               int keys) {
+  }
+
+  /** Constructor used when a compaction creates the filter file. */
+  LSMTreeIndexBloomFilter(final DatabaseInternal database, final String name, final String filePath, final int pageSize)
+      throws IOException {
+    super(database, name, filePath, FILE_EXT, ComponentFile.MODE.READ_WRITE, pageSize, CURRENT_VERSION);
+  }
+
+  /** Constructor used at load time. */
+  protected LSMTreeIndexBloomFilter(final DatabaseInternal database, final String name, final String filePath, final int id,
+      final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
+    super(database, name, filePath, id, mode, pageSize, version);
+  }
+
+  public static class PaginatedComponentFactoryHandler implements ComponentFactory.PaginatedComponentFactoryHandler {
+    @Override
+    public PaginatedComponent createOnLoad(final DatabaseInternal database, final String name, final String filePath,
+        final int id, final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
+      return new LSMTreeIndexBloomFilter(database, name, filePath, id, mode, pageSize, version);
+    }
+  }
+
+  /** The compacted index component name this file belongs to, derived from its own name. */
+  public String getOwnerName() {
+    return componentName.endsWith(NAME_SUFFIX) ?
+        componentName.substring(0, componentName.length() - NAME_SUFFIX.length()) :
+        null;
+  }
+
+  @Override
+  public Object getMainComponent() {
+    return this;
+  }
+
+  /**
+   * Reads the newest directory into RAM, i.e. the last page of the file - or, when a crash cut a publish between its
+   * bit pages and its directory page, the last complete directory before it. Never throws: a filter file that cannot
+   * be read simply filters nothing, which is exactly the behaviour of an index without one.
+   */
+  public void loadDirectory() {
+    try {
+      final int totalPages = getTotalPages();
+      final int floor = Math.max(0, totalPages - MAX_DIRECTORY_LOOKBACK);
+
+      for (int pageNumber = totalPages - 1; pageNumber >= floor; --pageNumber) {
+        final Map<Integer, Entry> loaded = readDirectoryPage(pageNumber);
+        if (loaded != null) {
+          directory = loaded;
+          return;
+        }
+      }
+
+      directory = Map.of();
+
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot read the bloom filter directory of '%s', lookups will read every series (error=%s)", null, componentName,
+          e.toString());
+      directory = Map.of();
+    }
+  }
+
+  /**
+   * The directory a page holds, or null when the page is not one. Bit pages are indistinguishable from anything by
+   * design, so the four header words plus a checksum over the entries are what tells them apart - a random page
+   * mistaken for a directory would answer for pages it does not own, which is the one way this file could hide a row.
+   */
+  Map<Integer, Entry> readDirectoryPage(final int pageNumber) throws IOException {
+    final BasePage page = database.getPageManager()
+        .getImmutablePage(new PageId(database, getFileId(), pageNumber), pageSize, false, true);
+    if (page == null)
+      return null;
+
+    if (page.readInt(0) != MAGIC || page.readInt(Binary.INT_SERIALIZED_SIZE) != FORMAT_VERSION)
+      return null;
+
+    final int count = page.readInt(2 * Binary.INT_SERIALIZED_SIZE);
+    if (count < 0 || count > maxDirectoryEntries())
+      return null;
+
+    final List<Entry> entries = new ArrayList<>(count);
+    for (int i = 0; i < count; ++i) {
+      final Entry entry = readEntry(page, i);
+      if (entry == null)
+        return null;
+      entries.add(entry);
+    }
+
+    if (page.readInt(3 * Binary.INT_SERIALIZED_SIZE) != checksumOf(entries))
+      return null;
+
+    return mapOf(entries);
+  }
+
+  /** Hash of the entries, so a bit page cannot pass for a directory and a truncated one cannot pass for a whole one. */
+  private static int checksumOf(final List<Entry> entries) {
+    int hash = MAGIC ^ entries.size();
+    for (final Entry entry : entries) {
+      hash = hash * 31 + entry.seriesRootPage();
+      hash = hash * 31 + entry.seriesPages();
+      hash = hash * 31 + entry.firstFilterPage();
+      hash = hash * 31 + entry.filterPages();
+      hash = hash * 31 + entry.slotsPerBlock();
+      hash = hash * 31 + entry.probes();
+      hash = hash * 31 + entry.keys();
+    }
+    return hash;
+  }
+
+  /**
+   * TRUE when the series MAY hold the key and must be searched. The answer is TRUE for everything this file does not
+   * know about, so the caller can call it unconditionally.
+   *
+   * @param seriesRootPage root page of the series, its identity within the compacted file
+   * @param seriesPages    data pages of the series, checked against the published entry so a filter built for a
+   *                       DIFFERENT series that once lived at this root page (an aborted compaction round whose pages
+   *                       were later reused) cannot be mistaken for this one
+   * @param keyHash        the key hashed by {@link #hashKey}
+   */
+  boolean mightContain(final int seriesRootPage, final int seriesPages, final long keyHash) {
+    final Entry entry = directory.get(seriesRootPage);
+    if (entry == null || entry.seriesPages() != seriesPages)
+      return true;
+
+    try {
+      final int block = blockOf(keyHash, entry.filterPages());
+      final BasePage page = database.getTransaction()
+          .getPage(new PageId(database, getFileId(), entry.firstFilterPage() + block), pageSize);
+
+      return new BufferBloomFilter(new Binary(page.slice()), entry.slotsPerBlock(), HASH_SEED, entry.probes())
+          .mightContainHash(keyHash);
+
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.FINE, "Cannot probe the bloom filter of series %d in '%s' (error=%s)", null,
+          seriesRootPage, componentName, e.toString());
+      return true;
+    }
+  }
+
+  /**
+   * Writes the filter of a freshly written series and publishes it in the directory.
+   * <p>
+   * Never propagates a failure: the filter is an optimisation and a compaction that produced correct index pages must
+   * not be failed by it. What it does NOT do on failure is publish a half-written filter.
+   *
+   * @param hashes the {@link #hashKey} of every key of the series, in any order, duplicates allowed
+   * @param count  how many of {@code hashes} are populated
+   */
+  void publish(final int seriesRootPage, final int seriesPages, final long[] hashes, final int count,
+      final double falsePositiveRate) {
+    if (count < 1)
+      return;
+
+    try {
+      if (directory.size() >= maxDirectoryEntries() && !directory.containsKey(seriesRootPage)) {
+        LogManager.instance().log(this, Level.INFO,
+            "Bloom filter directory of '%s' is full (%d series): the new series is published without a filter", null,
+            componentName, directory.size());
+        return;
+      }
+
+      final int blockBits = blockBits();
+      final int totalSlots = BufferBloomFilter.slotsFor(count, falsePositiveRate);
+      final int filterPages = Math.max(1, (totalSlots + blockBits - 1) / blockBits);
+      final int slotsPerBlock = Math.min(blockBits, roundUpToEight((totalSlots + filterPages - 1) / filterPages));
+      final int probes = Math.min(MAX_PROBES,
+          BufferBloomFilter.probesFor(slotsPerBlock, (count + filterPages - 1) / filterPages));
+
+      final int firstFilterPage = getTotalPages();
+
+      final List<MutablePage> blocks = new ArrayList<>(filterPages);
+      final BufferBloomFilter[] filters = new BufferBloomFilter[filterPages];
+      for (int i = 0; i < filterPages; ++i) {
+        final MutablePage block = new MutablePage(new PageId(database, getFileId(), firstFilterPage + i), pageSize);
+        blocks.add(block);
+        filters[i] = new BufferBloomFilter(block.getTrackable(), slotsPerBlock, HASH_SEED, probes);
+      }
+
+      for (int i = 0; i < count; ++i)
+        filters[blockOf(hashes[i], filterPages)].addHash(hashes[i]);
+
+      if (!verifyNoFalseNegatives(filters, hashes, count, filterPages, seriesRootPage))
+        return;
+
+      final Entry entry = new Entry(seriesRootPage, seriesPages, firstFilterPage, filterPages, slotsPerBlock, probes, count);
+
+      for (final MutablePage block : blocks)
+        database.getPageManager().updatePageVersion(block, true);
+      updatePageCount(firstFilterPage + filterPages);
+      database.getPageManager().writePages(blocks, false);
+
+      // The directory goes last, and only once the bits it points at are on disk: a crash in between leaves the file
+      // ending in pages no directory names, which the next load walks straight past.
+      appendDirectory(withEntry(entry));
+
+      LogManager.instance().log(this, Level.FINE,
+          "Published the bloom filter of series %d in '%s' (keys=%d pages=%d probes=%d expectedFalsePositives=%.4f)", null,
+          seriesRootPage, componentName, count, filterPages, probes,
+          filters[0].expectedFalsePositiveRate((count + filterPages - 1) / filterPages));
+
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot write the bloom filter of series %d in '%s', lookups will read the series (error=%s)", null, seriesRootPage,
+          componentName, e.toString());
+    }
+  }
+
+  /**
+   * Drops every filter of a series at or after {@code seriesRootPageFloor}.
+   * <p>
+   * Called when a compaction round is rolled back (#4946): its series pages stay on disk but become unreachable and
+   * the NEXT round writes its own series over the same page numbers. A directory entry left behind would then describe
+   * a series that no longer exists at that root page - and the new series living there would be filtered by the OLD
+   * series' keys, which is a false negative on everything the new series added.
+   * <p>
+   * The dropped filters' bit pages stay where they are and simply stop being named by any directory. The file only
+   * ever grows, which is what lets a crash - and an HA follower, which receives a compaction as the page range each
+   * file grew by - always see a directory that agrees with the bits around it.
+   */
+  void rollbackFrom(final int seriesRootPageFloor) {
+    final List<Entry> survivors = new ArrayList<>(directory.size());
+    for (final Entry entry : directory.values())
+      if (entry.seriesRootPage() < seriesRootPageFloor)
+        survivors.add(entry);
+
+    if (survivors.size() == directory.size())
+      return;
+
+    // Stop using the dropped filters BEFORE trying to persist the fact. Readers consult the in-RAM directory, and if
+    // the page write below fails, having lost a filter costs a page read while having kept a stale one costs rows.
+    directory = mapOf(survivors);
+
+    try {
+      appendDirectory(survivors);
+    } catch (final Exception e) {
+      // The stale entry survives on disk until the next publish appends a directory built from the (already corrected)
+      // in-RAM one. Until then a reopened database would see it again - and the entry is only ever consulted for a
+      // series that starts at the same root page AND spans the same number of pages, so it takes that coincidence on
+      // top of two consecutive write failures and a restart in between to matter.
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot persist the rolled-back bloom filter directory of '%s'; the filters are already out of use in this "
+              + "process, and the next compaction rewrites the directory (error=%s)", null, componentName, e.toString());
+    }
+  }
+
+  private static Map<Integer, Entry> mapOf(final List<Entry> entries) {
+    final Map<Integer, Entry> map = new HashMap<>(Math.max(1, entries.size() * 2));
+    for (final Entry entry : entries)
+      map.put(entry.seriesRootPage(), entry);
+    return Map.copyOf(map);
+  }
+
+  /** Number of series that currently carry a filter. */
+  public int getPublishedFilters() {
+    return directory.size();
+  }
+
+  /**
+   * Hash of a serialized index key. The bytes MUST be the ones {@code writeKeys} produces, on both the compaction and
+   * the lookup path, or the two sides agree on nothing.
+   */
+  static long hashKey(final Binary serializedKey) {
+    // The hash reads the backing array from index 0, so a buffer that is a VIEW into a larger one would hash the wrong
+    // bytes - and the compaction and the lookup would then disagree about where a key lives. Scratch buffers are always
+    // standalone; the check keeps that from being an assumption nobody can see.
+    if (serializedKey.getContentBeginOffset() != 0)
+      throw new IllegalArgumentException("A bloom key must be serialized into a standalone buffer");
+
+    return MurmurHash.hash64(serializedKey.getContent(), serializedKey.size(), HASH_SEED);
+  }
+
+  /**
+   * Probes back every key just added. A bloom filter that answers "no" to a key it holds is worse than no filter at
+   * all, and a bug that produces one - a routing/probing mismatch, a slot count the buffer cannot address, a block
+   * index computed from bits the probes also use - would otherwise surface as rows silently missing from lookups. The
+   * check is O(keys) over data already in RAM and runs once per series, against a compaction that just read and
+   * rewrote every one of those keys.
+   */
+  private boolean verifyNoFalseNegatives(final BufferBloomFilter[] filters, final long[] hashes, final int count,
+      final int filterPages, final int seriesRootPage) {
+    for (int i = 0; i < count; ++i)
+      if (!filters[blockOf(hashes[i], filterPages)].mightContainHash(hashes[i])) {
+        LogManager.instance().log(this, Level.SEVERE,
+            "Bloom filter of series %d in '%s' does not report back a key it was given: discarding it (this is a bug, "
+                + "please report it - the index itself is intact and lookups are unaffected)", null, seriesRootPage,
+            componentName);
+        return false;
+      }
+    return true;
+  }
+
+  /** The directory as it would be with {@code entry} added, replacing any entry of the same series. */
+  private List<Entry> withEntry(final Entry entry) {
+    final List<Entry> entries = new ArrayList<>(directory.size() + 1);
+    for (final Entry existing : directory.values())
+      if (existing.seriesRootPage() != entry.seriesRootPage())
+        entries.add(existing);
+    entries.add(entry);
+    return entries;
+  }
+
+  /**
+   * Appends a new directory page listing {@code entries} and swaps the in-RAM directory. Readers consult the in-RAM
+   * copy, which is replaced only after the page is on disk, so a reader either sees the previous directory or the new
+   * one - and a reopened database finds the same thing on the last page of the file.
+   */
+  private void appendDirectory(final List<Entry> entries) throws IOException, InterruptedException {
+    final int pageNumber = getTotalPages();
+    final MutablePage page = new MutablePage(new PageId(database, getFileId(), pageNumber), pageSize);
+
+    page.writeInt(0, MAGIC);
+    page.writeInt(Binary.INT_SERIALIZED_SIZE, FORMAT_VERSION);
+    page.writeInt(2 * Binary.INT_SERIALIZED_SIZE, entries.size());
+    page.writeInt(3 * Binary.INT_SERIALIZED_SIZE, checksumOf(entries));
+
+    for (int i = 0; i < entries.size(); ++i) {
+      final Entry entry = entries.get(i);
+      int pos = DIRECTORY_HEADER_SIZE + i * DIRECTORY_ENTRY_SIZE;
+      pos += page.writeInt(pos, entry.seriesRootPage());
+      pos += page.writeInt(pos, entry.seriesPages());
+      pos += page.writeInt(pos, entry.firstFilterPage());
+      pos += page.writeInt(pos, entry.filterPages());
+      pos += page.writeInt(pos, entry.slotsPerBlock());
+      pos += page.writeInt(pos, entry.probes());
+      page.writeInt(pos, entry.keys());
+    }
+
+    database.getPageManager().updatePageVersion(page, true);
+    updatePageCount(pageNumber + 1);
+    database.getPageManager().writePages(List.of(page), false);
+
+    directory = mapOf(entries);
+  }
+
+  private Entry readEntry(final BasePage page, final int index) {
+    int pos = DIRECTORY_HEADER_SIZE + index * DIRECTORY_ENTRY_SIZE;
+    final int seriesRootPage = page.readInt(pos);
+    final int seriesPages = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
+    final int firstFilterPage = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
+    final int filterPages = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
+    final int slotsPerBlock = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
+    final int probes = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
+    final int keys = page.readInt(pos + Binary.INT_SERIALIZED_SIZE);
+
+    // A malformed entry must not become a filter: it would answer for pages it does not own.
+    if (seriesRootPage < 0 || seriesPages < 1 || firstFilterPage < 0 || filterPages < 1 || probes < 1
+        || slotsPerBlock < 8 || slotsPerBlock % 8 != 0 || slotsPerBlock > blockBits()
+        || firstFilterPage + filterPages > getTotalPages())
+      return null;
+
+    return new Entry(seriesRootPage, seriesPages, firstFilterPage, filterPages, slotsPerBlock, probes, keys);
+  }
+
+  /**
+   * Block a key belongs to. {@link BufferBloomFilter} derives its probes from BOTH halves of the hash, so there are no
+   * spare bits to route with: passing the hash through the splitmix64 finaliser - which mixes every input bit into
+   * every output bit - gives a value independent of the two halves the probes use, for the cost of three multiplies.
+   * Routing on raw bits of the same hash would tie which block a key lands in to where it probes inside that block,
+   * and a filter is only as good as the independence of the bits it stands on.
+   */
+  private static int blockOf(final long hash, final int filterPages) {
+    if (filterPages == 1)
+      return 0;
+
+    long mixed = hash;
+    mixed ^= mixed >>> 30;
+    mixed *= 0xbf58476d1ce4e5b9L;
+    mixed ^= mixed >>> 27;
+    mixed *= 0x94d049bb133111ebL;
+    mixed ^= mixed >>> 31;
+
+    return (int) Long.remainderUnsigned(mixed, filterPages);
+  }
+
+  /** Bits a full page can hold, i.e. the size of one block. */
+  private int blockBits() {
+    return (pageSize - BasePage.PAGE_HEADER_SIZE) * 8;
+  }
+
+  private int maxDirectoryEntries() {
+    return (pageSize - BasePage.PAGE_HEADER_SIZE - DIRECTORY_HEADER_SIZE) / DIRECTORY_ENTRY_SIZE;
+  }
+
+  private static int roundUpToEight(final int slots) {
+    return Math.max(8, (slots + 7) / 8 * 8);
+  }
+
+  /**
+   * Creates the filter file of a compacted index, or opens the one it already has.
+   */
+  static LSMTreeIndexBloomFilter createOrLoad(final LSMTreeIndexCompacted compacted) throws IOException {
+    return createOrLoad(compacted.getDatabase(), compacted.getName() + NAME_SUFFIX, compacted.getPageSize());
+  }
+
+  static LSMTreeIndexBloomFilter createOrLoad(final DatabaseInternal database, final String name, final int pageSize)
+      throws IOException {
+    final LSMTreeIndexBloomFilter filter = new LSMTreeIndexBloomFilter(database, name,
+        database.getDatabasePath() + File.separator + name, pageSize);
+    database.getSchema().getEmbedded().registerFile(filter);
+    filter.loadDirectory();
+    return filter;
+  }
+
+  @Override
+  public String toString() {
+    return componentName;
+  }
+
+  /** Drops the file, quietly: losing a filter costs performance, never correctness. */
+  public void dropQuietly() {
+    try {
+      if (database.isOpen()) {
+        database.getPageManager().deleteFile(database, getFileId());
+        database.getFileManager().dropFile(getFileId());
+        database.getSchema().getEmbedded().removeFile(getFileId());
+      } else if (!getOSFile().delete())
+        LogManager.instance().log(this, Level.FINE, "Cannot delete the bloom filter file '%s'", null, getOSFile());
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "Error on dropping the bloom filter file '%s' (error=%s)", null,
+          componentName, e.toString());
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilter.java
@@ -61,8 +61,8 @@ import java.util.logging.Level;
  * A directory page is {@code [magic][formatVersion][entryCount][checksum]} followed by {@value #DIRECTORY_ENTRY_SIZE}-byte
  * entries {@code [seriesRootPage][seriesPages][firstFilterPage][filterPages][slotsPerBlock][probes][keys]}. A series'
  * bits are split into {@code filterPages} independent BLOCKS of one page each and a key is routed to exactly one block,
- * so a probe reads ONE page however large the series is. Blocks are big enough (a 64 KB page holds ~500k bits, i.e.
- * ~54k keys at 1%) that the occupancy skew of a blocked filter is negligible.
+ * so a probe reads ONE {@value #PAGE_SIZE}-byte page however large the series is - see {@link #PAGE_SIZE} for why the
+ * filter does not inherit the index's much larger page.
  * <p>
  * <b>The rule that must not break.</b> A false positive costs the lookup that would have happened anyway; a false
  * NEGATIVE hides data - a lookup skipped, a record reported missing, a unique-index duplicate check letting a duplicate
@@ -79,6 +79,19 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
 
   /** Suffix appended to the compacted index component name; the pair is resolved by name at schema-load time. */
   static final String NAME_SUFFIX = "_bf";
+
+  /**
+   * Page size of the filter file, deliberately NOT the index's.
+   * <p>
+   * A probe reads exactly one page, so the page size IS the I/O cost of a probe - and an LSM index defaults to 256 KB
+   * pages, which would have the filter read as much as the data page it exists to avoid. It also decides the waste:
+   * every series rounds its bits up to a page and spends one more on its directory, so at 256 KB a small series cost
+   * 512 KB to describe with 30 KB of bits.
+   * <p>
+   * 8 KB is small enough that both of those disappear and large enough that a block still holds ~6.8k keys at 1%, so
+   * the occupancy skew of the blocked layout stays under 2% - and one directory page still lists 291 series.
+   */
+  static final int PAGE_SIZE = 8_192;
 
   /** Seed of the key hash. Changing it invalidates every filter on disk, so it travels with {@link #FORMAT_VERSION}. */
   static final int HASH_SEED = 0x5bf1e995;
@@ -503,7 +516,7 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
    * Creates the filter file of a compacted index, or opens the one it already has.
    */
   static LSMTreeIndexBloomFilter createOrLoad(final LSMTreeIndexCompacted compacted) throws IOException {
-    return createOrLoad(compacted.getDatabase(), compacted.getName() + NAME_SUFFIX, compacted.getPageSize());
+    return createOrLoad(compacted.getDatabase(), compacted.getName() + NAME_SUFFIX, PAGE_SIZE);
   }
 
   static LSMTreeIndexBloomFilter createOrLoad(final DatabaseInternal database, final String name, final int pageSize)

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilter.java
@@ -59,10 +59,20 @@ import java.util.logging.Level;
  * page 0 would simply not travel, leaving followers with a directory that disagrees with their own bits.
  * <p>
  * A directory page is {@code [magic][formatVersion][entryCount][checksum]} followed by {@value #DIRECTORY_ENTRY_SIZE}-byte
- * entries {@code [seriesRootPage][seriesPages][firstFilterPage][filterPages][slotsPerBlock][probes][keys]}. A series'
+ * entries {@code [seriesRootPage][seriesPages][seriesFingerprint][firstFilterPage][filterPages][slotsPerBlock][probes][keys]}. A series'
  * bits are split into {@code filterPages} independent BLOCKS of one page each and a key is routed to exactly one block,
  * so a probe reads ONE {@value #PAGE_SIZE}-byte page however large the series is - see {@link #PAGE_SIZE} for why the
  * filter does not inherit the index's much larger page.
+ * <p>
+ * <b>Identity, and what a DOWNGRADE does.</b> An entry names its series by position, so it also carries the series'
+ * page count and a fingerprint of its last data page; both are re-checked live on every probe, and either one
+ * disagreeing means "search the series". That matters because a build that predates this component does not know the
+ * {@code .bfidx} extension at all: it opens the database, compacts, and never touches the filter file. Its incremental
+ * rounds only APPEND series, so the entries it leaves behind still describe the series they were built from - but a
+ * round it rolls back can free a position that a later round reuses, and then only the shape and the fingerprint stand
+ * between a stale entry and a series it knows nothing about. Downgrading across this feature and back is therefore not
+ * free, and {@code arcadedb.indexBloomFilterRate=0} on the upgraded build (or a full compaction, which writes a new
+ * file the old entries cannot name) is the way to make it so.
  * <p>
  * <b>The rule that must not break.</b> A false positive costs the lookup that would have happened anyway; a false
  * NEGATIVE hides data - a lookup skipped, a record reported missing, a unique-index duplicate check letting a duplicate
@@ -97,9 +107,9 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
   static final int HASH_SEED = 0x5bf1e995;
 
   private static final int MAGIC                 = 0x424C4F4D; // "BLOM"
-  private static final int FORMAT_VERSION        = 1;
+  private static final int FORMAT_VERSION        = 2;
   private static final int DIRECTORY_HEADER_SIZE = 4 * Binary.INT_SERIALIZED_SIZE;
-  private static final int DIRECTORY_ENTRY_SIZE  = 7 * Binary.INT_SERIALIZED_SIZE;
+  private static final int DIRECTORY_ENTRY_SIZE  = 8 * Binary.INT_SERIALIZED_SIZE;
 
   /**
    * Pages to look back through for the newest directory when the last page of the file is not one, i.e. after a crash
@@ -123,8 +133,8 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
   private volatile Map<Integer, Entry> directory = Map.of();
 
   /** One published filter. Immutable once built. */
-  record Entry(int seriesRootPage, int seriesPages, int firstFilterPage, int filterPages, int slotsPerBlock, int probes,
-               int keys) {
+  record Entry(int seriesRootPage, int seriesPages, int seriesFingerprint, int firstFilterPage, int filterPages,
+               int slotsPerBlock, int probes, int keys) {
   }
 
   /** Constructor used when a compaction creates the filter file. */
@@ -225,6 +235,7 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
     for (final Entry entry : entries) {
       hash = hash * 31 + entry.seriesRootPage();
       hash = hash * 31 + entry.seriesPages();
+      hash = hash * 31 + entry.seriesFingerprint();
       hash = hash * 31 + entry.firstFilterPage();
       hash = hash * 31 + entry.filterPages();
       hash = hash * 31 + entry.slotsPerBlock();
@@ -238,15 +249,19 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
    * TRUE when the series MAY hold the key and must be searched. The answer is TRUE for everything this file does not
    * know about, so the caller can call it unconditionally.
    *
-   * @param seriesRootPage root page of the series, its identity within the compacted file
-   * @param seriesPages    data pages of the series, checked against the published entry so a filter built for a
-   *                       DIFFERENT series that once lived at this root page (an aborted compaction round whose pages
-   *                       were later reused) cannot be mistaken for this one
-   * @param keyHash        the key hashed by {@link #hashKey}
+   * @param seriesRootPage    root page of the series, its position within the compacted file
+   * @param seriesPages       data pages of the series
+   * @param seriesFingerprint {@code LSMTreeIndexCompacted.seriesFingerprint} of the series' last data page - a page
+   *                          the reader has already read to get {@code seriesPages}, so this costs no I/O
+   * @param keyHash           the key hashed by {@link #hashKey}
    */
-  boolean mightContain(final int seriesRootPage, final int seriesPages, final long keyHash) {
+  boolean mightContain(final int seriesRootPage, final int seriesPages, final int seriesFingerprint, final long keyHash) {
+    // A directory entry names a series by WHERE it sits, and a position can be reused: an aborted compaction round
+    // leaves its pages unreachable and the next round writes a different series over them. The shape and the
+    // fingerprint together are what make an entry answer only for the series it was built from - a stale one would
+    // filter a series by another's keys, which hides rows.
     final Entry entry = directory.get(seriesRootPage);
-    if (entry == null || entry.seriesPages() != seriesPages)
+    if (entry == null || entry.seriesPages() != seriesPages || entry.seriesFingerprint() != seriesFingerprint)
       return true;
 
     try {
@@ -278,8 +293,8 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
    * @param hashes the {@link #hashKey} of every key of the series, in any order, duplicates allowed
    * @param count  how many of {@code hashes} are populated
    */
-  void publish(final int seriesRootPage, final int seriesPages, final long[] hashes, final int count,
-      final double falsePositiveRate) {
+  void publish(final int seriesRootPage, final int seriesPages, final int seriesFingerprint, final long[] hashes,
+      final int count, final double falsePositiveRate) {
     if (count < 1)
       return;
 
@@ -314,7 +329,8 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
       if (!verifyNoFalseNegatives(filters, hashes, count, filterPages, seriesRootPage))
         return;
 
-      final Entry entry = new Entry(seriesRootPage, seriesPages, firstFilterPage, filterPages, slotsPerBlock, probes, count);
+      final Entry entry = new Entry(seriesRootPage, seriesPages, seriesFingerprint, firstFilterPage, filterPages,
+          slotsPerBlock, probes, count);
 
       for (final MutablePage block : blocks)
         database.getPageManager().updatePageVersion(block, true);
@@ -450,6 +466,7 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
       int pos = DIRECTORY_HEADER_SIZE + i * DIRECTORY_ENTRY_SIZE;
       pos += page.writeInt(pos, entry.seriesRootPage());
       pos += page.writeInt(pos, entry.seriesPages());
+      pos += page.writeInt(pos, entry.seriesFingerprint());
       pos += page.writeInt(pos, entry.firstFilterPage());
       pos += page.writeInt(pos, entry.filterPages());
       pos += page.writeInt(pos, entry.slotsPerBlock());
@@ -468,6 +485,7 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
     int pos = DIRECTORY_HEADER_SIZE + index * DIRECTORY_ENTRY_SIZE;
     final int seriesRootPage = page.readInt(pos);
     final int seriesPages = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
+    final int seriesFingerprint = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
     final int firstFilterPage = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
     final int filterPages = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
     final int slotsPerBlock = page.readInt(pos += Binary.INT_SERIALIZED_SIZE);
@@ -480,7 +498,8 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
         || firstFilterPage + filterPages > getTotalPages())
       return null;
 
-    return new Entry(seriesRootPage, seriesPages, firstFilterPage, filterPages, slotsPerBlock, probes, keys);
+    return new Entry(seriesRootPage, seriesPages, seriesFingerprint, firstFilterPage, filterPages, slotsPerBlock,
+        probes, keys);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilter.java
@@ -251,11 +251,16 @@ public class LSMTreeIndexBloomFilter extends PaginatedComponent {
 
     try {
       final int block = blockOf(keyHash, entry.filterPages());
-      final BasePage page = database.getTransaction()
-          .getPage(new PageId(database, getFileId(), entry.firstFilterPage() + block), pageSize);
+      // Read OUTSIDE the transaction, and allocation-free. Outside, because nothing ever modifies a filter page inside
+      // a transaction - they are written only by a compaction, which runs outside one - so pulling them into the
+      // caller's tracked page set would grow every write transaction's working set for nothing. Allocation-free,
+      // because this runs once per series per lookup and a bulk load performs both millions of times.
+      final BasePage page = database.getPageManager()
+          .getImmutablePage(new PageId(database, getFileId(), entry.firstFilterPage() + block), pageSize, false, false);
+      if (page == null)
+        return true;
 
-      return new BufferBloomFilter(new Binary(page.slice()), entry.slotsPerBlock(), HASH_SEED, entry.probes())
-          .mightContainHash(keyHash);
+      return BufferBloomFilter.mightContainHash(page, entry.slotsPerBlock(), entry.probes(), keyHash);
 
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.FINE, "Cannot probe the bloom filter of series %d in '%s' (error=%s)", null,

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -39,7 +39,7 @@ import com.arcadedb.utility.RidHashSet;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.logging.Level;
 
 import static com.arcadedb.database.Binary.BYTE_SERIALIZED_SIZE;
@@ -90,11 +90,16 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
    */
   private static final ThreadLocal<Binary> BLOOM_KEY_BUFFER = ThreadLocal.withInitial(Binary::new);
 
-  /** Series a bloom filter spared this file from reading. What the feature is worth, in the only unit that matters. */
-  private final AtomicLong bloomSkippedSeries = new AtomicLong();
-
-  /** Series still read after a probe, whether the key was there or the filter answered a false positive. */
-  private final AtomicLong bloomProbedSeries = new AtomicLong();
+  /**
+   * Series a bloom filter spared this file from reading - what the feature is worth, in the only unit that matters -
+   * and series still read after a probe, because the key was there or the filter returned a false positive.
+   * <p>
+   * {@link LongAdder} rather than {@code AtomicLong}: these are bumped once per series per lookup, and a bulk load
+   * runs that concurrently across every thread it has. A single contended cache line is not something to add to the
+   * path whose cost this feature exists to remove; reads are diagnostics and can afford the sum.
+   */
+  private final LongAdder bloomSkippedSeries = new LongAdder();
+  private final LongAdder bloomProbedSeries  = new LongAdder();
 
   /**
    * Called at cloning time.
@@ -610,13 +615,13 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       pageNumber -= rootPageCount;
 
       if (useFilters) {
-        if (!filters.mightContain(pageNumber, rootPageCount, keyHash)) {
+        if (!filters.mightContain(pageNumber, rootPageCount, seriesFingerprint(lastPage), keyHash)) {
           // THE SERIES PROVABLY DOES NOT HOLD THE KEY: SKIP ITS ROOT AND DATA PAGES ENTIRELY
-          bloomSkippedSeries.incrementAndGet();
+          bloomSkippedSeries.increment();
           --pageNumber;
           continue;
         }
-        bloomProbedSeries.incrementAndGet();
+        bloomProbedSeries.increment();
       }
 
       final PageId pageId = new PageId(database, file.getFileId(), pageNumber);
@@ -782,6 +787,20 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     return problems;
   }
 
+  /**
+   * A cheap identity for a compacted series, taken from the header of its LAST data page - the page the lookup path
+   * has already read to learn how long the series is, so this costs no extra I/O on either side.
+   * <p>
+   * It exists because a bloom filter entry names its series by POSITION, and a position can be reused: an aborted
+   * compaction round leaves its pages unreachable and a later round writes a different series over them. Page count
+   * alone can coincide; ending with the same number of entries occupying the same bytes as well is not something two
+   * different series do by accident. Defined once here so the compaction and the lookup can never compute it
+   * differently.
+   */
+  int seriesFingerprint(final BasePage lastPageOfSeries) {
+    return getCount(lastPageOfSeries) * 31 + getValuesFreePosition(lastPageOfSeries);
+  }
+
   /** The per-series bloom filters of this file, or null when it has none. */
   public LSMTreeIndexBloomFilter getBloomFilter() {
     return bloomFilter;
@@ -798,19 +817,19 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
 
   /** Series a bloom filter spared this file from reading since it was loaded (#5517). */
   public long getBloomSkippedSeries() {
-    return bloomSkippedSeries.get();
+    return bloomSkippedSeries.sum();
   }
 
   /** Series read despite being probed: they held the key, or the filter returned a false positive. */
   public long getBloomProbedSeries() {
-    return bloomProbedSeries.get();
+    return bloomProbedSeries.sum();
   }
 
   @Override
   public Map<String, Long> getStats() {
     final Map<String, Long> stats = super.getStats();
-    stats.put("bloomSkippedSeries", bloomSkippedSeries.get());
-    stats.put("bloomProbedSeries", bloomProbedSeries.get());
+    stats.put("bloomSkippedSeries", bloomSkippedSeries.sum());
+    stats.put("bloomProbedSeries", bloomProbedSeries.sum());
     return stats;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -18,12 +18,14 @@
  */
 package com.arcadedb.index.lsm;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.TrackableBinary;
 import com.arcadedb.database.TransactionIndexContext;
 import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.Component;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
@@ -37,6 +39,7 @@ import com.arcadedb.utility.RidHashSet;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 import static com.arcadedb.database.Binary.BYTE_SERIALIZED_SIZE;
@@ -63,6 +66,21 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
    * zero (see LSMTreeIndex's retired-file handling).
    */
   private final AtomicInteger activeCursors = new AtomicInteger();
+
+  /**
+   * Per-series bloom filters over this file (#5517), or null when the file has none - because the feature is off, the
+   * file predates it, or a compaction could not write one. Volatile: a compaction publishes it while lookups read it.
+   */
+  private volatile LSMTreeIndexBloomFilter bloomFilter = null;
+
+  /** Scratch buffers for the bloom key hash, one per thread: {@code writeKeys} is not reentrant on a shared Binary. */
+  private final ThreadLocal<Binary> bloomKeyBuffer = ThreadLocal.withInitial(Binary::new);
+
+  /** Series a bloom filter spared this file from reading. What the feature is worth, in the only unit that matters. */
+  private final AtomicLong bloomSkippedSeries = new AtomicLong();
+
+  /** Series still read after a probe, whether the key was there or the filter answered a false positive. */
+  private final AtomicLong bloomProbedSeries = new AtomicLong();
 
   /**
    * Called at cloning time.
@@ -542,6 +560,11 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       effectivePageCount = mainPageCount;
     }
 
+    // #5517: hashed once, probed against every series' filter below. Long.MIN_VALUE means "not hashable" (a partial or
+    // null key), and every series is then searched exactly as before.
+    final LSMTreeIndexBloomFilter filters = bloomFilter;
+    final long keyHash = filters != null ? bloomHashOfKey(convertedKeys) : Long.MIN_VALUE;
+
     for (int pageNumber = effectivePageCount - 1; pageNumber > 0; ) {
       final BasePage lastPage = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageNumber), pageSize);
 
@@ -554,6 +577,16 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       }
 
       pageNumber -= rootPageCount;
+
+      if (keyHash != Long.MIN_VALUE) {
+        if (!filters.mightContain(pageNumber, rootPageCount, keyHash)) {
+          // THE SERIES PROVABLY DOES NOT HOLD THE KEY: SKIP ITS ROOT AND DATA PAGES ENTIRELY
+          bloomSkippedSeries.incrementAndGet();
+          --pageNumber;
+          continue;
+        }
+        bloomProbedSeries.incrementAndGet();
+      }
 
       final PageId pageId = new PageId(database, file.getFileId(), pageNumber);
       final BasePage rootPage = database.getTransaction().getPage(pageId, pageSize);
@@ -716,6 +749,89 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     }
 
     return problems;
+  }
+
+  /** The per-series bloom filters of this file, or null when it has none. */
+  public LSMTreeIndexBloomFilter getBloomFilter() {
+    return bloomFilter;
+  }
+
+  /** Series a bloom filter spared this file from reading since it was loaded (#5517). */
+  public long getBloomSkippedSeries() {
+    return bloomSkippedSeries.get();
+  }
+
+  /** Series read despite being probed: they held the key, or the filter returned a false positive. */
+  public long getBloomProbedSeries() {
+    return bloomProbedSeries.get();
+  }
+
+  @Override
+  public Map<String, Long> getStats() {
+    final Map<String, Long> stats = super.getStats();
+    stats.put("bloomSkippedSeries", bloomSkippedSeries.get());
+    stats.put("bloomProbedSeries", bloomProbedSeries.get());
+    return stats;
+  }
+
+  /**
+   * Links the {@code .bfidx} component written for this file, resolved by name after the whole schema is loaded (every
+   * component is registered by then, and the pair is created together so the names cannot drift).
+   */
+  public void attachBloomFilter() {
+    if (bloomFilter != null)
+      return;
+
+    // A rate of 0 means "off", and off has to mean the filters on disk are not consulted either - otherwise there is
+    // no way to answer whether a lookup result depends on them.
+    if (database.getConfiguration().getValueAsFloat(GlobalConfiguration.INDEX_BLOOM_FILTER_RATE) <= 0)
+      return;
+
+    final Component component = database.getSchema().getEmbedded()
+        .getFileByName(getName() + LSMTreeIndexBloomFilter.NAME_SUFFIX);
+    if (component instanceof LSMTreeIndexBloomFilter filter) {
+      filter.loadDirectory();
+      bloomFilter = filter;
+    }
+  }
+
+  /** Creates the filter component on first use of a compaction that has a filter to write. */
+  LSMTreeIndexBloomFilter getOrCreateBloomFilter() throws IOException {
+    LSMTreeIndexBloomFilter filter = bloomFilter;
+    if (filter == null) {
+      filter = LSMTreeIndexBloomFilter.createOrLoad(this);
+      bloomFilter = filter;
+    }
+    return filter;
+  }
+
+  /**
+   * The bloom hash of a lookup key, or {@link Long#MIN_VALUE} when the key cannot be hashed - a partial key, a null
+   * component, an unserializable value. The caller then searches every series, which is what it did before #5517.
+   */
+  private long bloomHashOfKey(final Object[] convertedKeys) {
+    if (convertedKeys == null)
+      return Long.MIN_VALUE;
+
+    for (final Object key : convertedKeys)
+      if (key == null)
+        return Long.MIN_VALUE;
+
+    try {
+      final Binary serialized = serializeKeyForHashing(bloomKeyBuffer.get(), convertedKeys);
+      return serialized == null ? Long.MIN_VALUE : LSMTreeIndexBloomFilter.hashKey(serialized);
+    } catch (final Exception e) {
+      return Long.MIN_VALUE;
+    }
+  }
+
+  @Override
+  public void drop() throws IOException {
+    final LSMTreeIndexBloomFilter filter = bloomFilter;
+    bloomFilter = null;
+    if (filter != null)
+      filter.dropQuietly();
+    super.drop();
   }
 
   void onCursorOpened() {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -73,8 +73,22 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
    */
   private volatile LSMTreeIndexBloomFilter bloomFilter = null;
 
-  /** Scratch buffers for the bloom key hash, one per thread: {@code writeKeys} is not reentrant on a shared Binary. */
-  private final ThreadLocal<Binary> bloomKeyBuffer = ThreadLocal.withInitial(Binary::new);
+  /**
+   * Whether lookups CONSULT the filters, captured from the configured rate when the index is loaded. Separate from
+   * {@link #bloomFilter} being present: the component is always adopted so a compaction can publish into the file the
+   * index already owns, even when reads are turned off.
+   */
+  private volatile boolean bloomFilterEnabled = true;
+
+  /**
+   * Scratch buffer for the bloom key hash, one per THREAD and shared by every index - deliberately static.
+   * <p>
+   * A per-instance ThreadLocal would leave one Binary pinned in every worker thread's map for every compacted index
+   * object ever created, and a full compaction creates a new one each time: the classic ThreadLocal residue, unbounded
+   * across indexes and threads. One buffer per thread is enough because it is filled and consumed inside a single
+   * {@link #bloomHashOfKey} call, which calls nothing that could re-enter it.
+   */
+  private static final ThreadLocal<Binary> BLOOM_KEY_BUFFER = ThreadLocal.withInitial(Binary::new);
 
   /** Series a bloom filter spared this file from reading. What the feature is worth, in the only unit that matters. */
   private final AtomicLong bloomSkippedSeries = new AtomicLong();
@@ -560,10 +574,27 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       effectivePageCount = mainPageCount;
     }
 
-    // #5517: hashed once, probed against every series' filter below. Long.MIN_VALUE means "not hashable" (a partial or
-    // null key), and every series is then searched exactly as before.
+    // #5517: hashed ONCE here and probed against every series' filter below. The flag is separate from the hash and is
+    // set ONLY once a hash has actually been produced: every long is a legal hash, so no value of it could stand for
+    // "absent", and probing with a hash that is not the key's would skip series that hold it - a false negative, the
+    // one thing this must never do. Anything that cannot be hashed - a partial key, a null component, a value that
+    // fails to serialize - searches every series exactly as before #5517.
     final LSMTreeIndexBloomFilter filters = bloomFilter;
-    final long keyHash = filters != null ? bloomHashOfKey(convertedKeys) : Long.MIN_VALUE;
+    long keyHash = 0L;
+    boolean useFilters = false;
+    if (filters != null && bloomFilterEnabled && isBloomHashable(convertedKeys)) {
+      try {
+        final Binary serialized = serializeKeyForHashing(BLOOM_KEY_BUFFER.get(), convertedKeys);
+        if (serialized != null) {
+          keyHash = LSMTreeIndexBloomFilter.hashKey(serialized);
+          useFilters = true;
+        }
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.FINE,
+            "Cannot hash the lookup key of index '%s' for its bloom filters, searching every series (error=%s)", null,
+            componentName, e.toString());
+      }
+    }
 
     for (int pageNumber = effectivePageCount - 1; pageNumber > 0; ) {
       final BasePage lastPage = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageNumber), pageSize);
@@ -578,7 +609,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
 
       pageNumber -= rootPageCount;
 
-      if (keyHash != Long.MIN_VALUE) {
+      if (useFilters) {
         if (!filters.mightContain(pageNumber, rootPageCount, keyHash)) {
           // THE SERIES PROVABLY DOES NOT HOLD THE KEY: SKIP ITS ROOT AND DATA PAGES ENTIRELY
           bloomSkippedSeries.incrementAndGet();
@@ -756,6 +787,15 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     return bloomFilter;
   }
 
+  /**
+   * Whether lookups consult the filters. FALSE with {@code arcadedb.indexBloomFilterRate} at 0, in which case the
+   * component may still be attached (so a compaction publishes into the file this index already owns) but is never
+   * read. Captured at load: changing the rate at runtime affects writing immediately and reading at the next open.
+   */
+  public boolean isBloomFilterEnabled() {
+    return bloomFilterEnabled && bloomFilter != null;
+  }
+
   /** Series a bloom filter spared this file from reading since it was loaded (#5517). */
   public long getBloomSkippedSeries() {
     return bloomSkippedSeries.get();
@@ -782,22 +822,33 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     if (bloomFilter != null)
       return;
 
-    // A rate of 0 means "off", and off has to mean the filters on disk are not consulted either - otherwise there is
-    // no way to answer whether a lookup result depends on them.
-    if (database.getConfiguration().getValueAsFloat(GlobalConfiguration.INDEX_BLOOM_FILTER_RATE) <= 0)
-      return;
-
+    // Adopt the component whatever the configured rate is. The rate decides whether the filters are CONSULTED (see
+    // bloomFilterEnabled below), not whether this index knows about its own file: leaving it unadopted would let a
+    // later compaction - after the rate is raised at runtime - create a SECOND physical file for the same logical
+    // name, orphaning the first and making the name ambiguous at the next open.
     final Component component = database.getSchema().getEmbedded()
         .getFileByName(getName() + LSMTreeIndexBloomFilter.NAME_SUFFIX);
     if (component instanceof LSMTreeIndexBloomFilter filter) {
       filter.loadDirectory();
       bloomFilter = filter;
     }
+
+    // A rate of 0 means "off", and off has to mean the filters on disk are not consulted either - otherwise there is
+    // no way to answer whether a lookup result depends on them. Read once, here: this gates a per-lookup path, and a
+    // configuration lookup per lookup is exactly the kind of cost this feature exists to remove.
+    bloomFilterEnabled = database.getConfiguration().getValueAsFloat(GlobalConfiguration.INDEX_BLOOM_FILTER_RATE) > 0;
   }
 
-  /** Creates the filter component on first use of a compaction that has a filter to write. */
+  /**
+   * The filter component to publish into, adopting the one already registered for this index before creating a new
+   * file - a second file for the same logical name would orphan the first and make the name ambiguous at load.
+   */
   LSMTreeIndexBloomFilter getOrCreateBloomFilter() throws IOException {
     LSMTreeIndexBloomFilter filter = bloomFilter;
+    if (filter == null) {
+      attachBloomFilter();
+      filter = bloomFilter;
+    }
     if (filter == null) {
       filter = LSMTreeIndexBloomFilter.createOrLoad(this);
       bloomFilter = filter;
@@ -806,23 +857,18 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
   }
 
   /**
-   * The bloom hash of a lookup key, or {@link Long#MIN_VALUE} when the key cannot be hashed - a partial key, a null
-   * component, an unserializable value. The caller then searches every series, which is what it did before #5517.
+   * Whether a key can be hashed for the filters at all. A partial key is a RANGE and no hash answers for a range; a
+   * null component is not something the filters were built over. Both fall back to searching every series.
    */
-  private long bloomHashOfKey(final Object[] convertedKeys) {
-    if (convertedKeys == null)
-      return Long.MIN_VALUE;
+  private boolean isBloomHashable(final Object[] convertedKeys) {
+    if (convertedKeys == null || convertedKeys.length != binaryKeyTypes.length)
+      return false;
 
     for (final Object key : convertedKeys)
       if (key == null)
-        return Long.MIN_VALUE;
+        return false;
 
-    try {
-      final Binary serialized = serializeKeyForHashing(bloomKeyBuffer.get(), convertedKeys);
-      return serialized == null ? Long.MIN_VALUE : LSMTreeIndexBloomFilter.hashKey(serialized);
-    } catch (final Exception e) {
-      return Long.MIN_VALUE;
-    }
+    return true;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
@@ -44,7 +44,9 @@ final class LSMTreeIndexCompactedStreamWriter {
 
   /**
    * A series whose key hashes would need more than this much heap is written without a bloom filter: the 8 bytes per
-   * key are transient, but a compaction must not trade a correct index for an optimisation.
+   * key are transient, but a compaction must not trade a correct index for an optimisation. At the cap the accumulator
+   * peaks at 64 MB (plus one doubling in flight), against a compaction that is already holding whole pages per input
+   * cursor.
    */
   private static final int MAX_BLOOM_KEYS_PER_SERIES = 8_000_000;
 
@@ -245,11 +247,22 @@ final class LSMTreeIndexCompactedStreamWriter {
     if (bloomHashes == null)
       return;
 
-    final Binary serialized = compactedIndex.serializeKeyForHashing(bloomKeyContent, convertedKeys);
-    if (serialized == null)
+    // A key that reaches a page WITHOUT reaching the filter is a false negative, so anything that stops this key from
+    // being hashed must abandon the whole series' filter - never skip the key and publish the rest. And it must not
+    // propagate either: a compaction that produced correct index pages cannot be failed by an optimisation.
+    final long hash;
+    try {
+      final Binary serialized = compactedIndex.serializeKeyForHashing(bloomKeyContent, convertedKeys);
+      if (serialized == null)
+        throw new IllegalStateException("the key is not hashable");
+      hash = LSMTreeIndexBloomFilter.hashKey(serialized);
+    } catch (final Exception e) {
+      LogManager.instance().log(mainIndex, Level.WARNING,
+          "Cannot hash a key of index '%s' for its bloom filter: the series is written WITHOUT one (error=%s)", null,
+          mainIndex.getName(), e.toString());
+      bloomHashes = null;
       return;
-
-    final long hash = LSMTreeIndexBloomFilter.hashKey(serialized);
+    }
     if (bloomKeyCount > 0 && hash == bloomLastHash)
       return;
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
@@ -202,6 +202,9 @@ final class LSMTreeIndexCompactedStreamWriter {
 
     final int seriesRootPage = rootPage.getPageId().getPageNumber();
     final int seriesPages = newPagesInSeries.size();
+    // Taken from the last data page, exactly as the reader will take it, so a filter can only ever answer for the
+    // series it was built from - see LSMTreeIndexCompacted.seriesFingerprint.
+    final int seriesFingerprint = lastPage != null ? compactedIndex.seriesFingerprint(lastPage) : 0;
 
     final List<MutablePage> modifiedPages = new ArrayList<>(newPagesInSeries);
     modifiedPages.add(database.getPageManager().updatePageVersion(rootPage, true));
@@ -209,7 +212,7 @@ final class LSMTreeIndexCompactedStreamWriter {
 
     // Only now that the series is on disk: a filter that reached the directory first would answer for pages a failed
     // write never produced.
-    publishBloomFilter(seriesRootPage, seriesPages);
+    publishBloomFilter(seriesRootPage, seriesPages, seriesFingerprint);
 
     rootPage = null;
     rootPageBuffer = null;
@@ -269,7 +272,7 @@ final class LSMTreeIndexCompactedStreamWriter {
    * Hands the accumulated hashes to the filter component, creating it on first use. A failure to write a filter is
    * logged and dropped: it costs a lookup, never a row.
    */
-  private void publishBloomFilter(final int seriesRootPage, final int seriesPages) {
+  private void publishBloomFilter(final int seriesRootPage, final int seriesPages, final int seriesFingerprint) {
     final long[] hashes = bloomHashes;
     final int count = bloomKeyCount;
 
@@ -280,7 +283,8 @@ final class LSMTreeIndexCompactedStreamWriter {
       return;
 
     try {
-      compactedIndex.getOrCreateBloomFilter().publish(seriesRootPage, seriesPages, hashes, count, bloomFalsePositiveRate);
+      compactedIndex.getOrCreateBloomFilter()
+          .publish(seriesRootPage, seriesPages, seriesFingerprint, hashes, count, bloomFalsePositiveRate);
     } catch (final Exception e) {
       LogManager.instance().log(mainIndex, Level.WARNING,
           "Cannot create the bloom filter of index '%s' (error=%s)", null, mainIndex.getName(), e.toString());

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactedStreamWriter.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.lsm;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
@@ -39,6 +40,13 @@ final class LSMTreeIndexCompactedStreamWriter {
 
   private static final RID[] ROOT_SENTINEL               = new RID[] { new RID(0, 0) };
   private static final int   MAX_RIDS_PER_BOUNDED_APPEND = 256;
+  private static final int   INITIAL_BLOOM_HASHES        = 1_024;
+
+  /**
+   * A series whose key hashes would need more than this much heap is written without a bloom filter: the 8 bytes per
+   * key are transient, but a compaction must not trade a correct index for an optimisation.
+   */
+  private static final int MAX_BLOOM_KEYS_PER_SERIES = 8_000_000;
 
   private final LSMTreeIndex          mainIndex;
   private final LSMTreeIndexMutable   mutableIndex;
@@ -46,6 +54,14 @@ final class LSMTreeIndexCompactedStreamWriter {
   private final DatabaseInternal      database;
   private final Binary                keyValueContent = new Binary();
   private final Binary                sizingContent   = new Binary();
+  private final Binary                bloomKeyContent = new Binary();
+
+  /** Target false-positive rate of the per-series bloom filters (#5517), or 0 when the feature is off. */
+  private final double bloomFalsePositiveRate;
+
+  private long[]  bloomHashes;
+  private int     bloomKeyCount;
+  private long    bloomLastHash;
 
   private MutablePage     rootPage;
   private TrackableBinary rootPageBuffer;
@@ -61,11 +77,18 @@ final class LSMTreeIndexCompactedStreamWriter {
     this.mutableIndex = mainIndex.getMutableIndex();
     this.compactedIndex = compactedIndex;
     this.database = mutableIndex.getDatabase();
+
+    final double rate = database.getConfiguration().getValueAsFloat(GlobalConfiguration.INDEX_BLOOM_FILTER_RATE);
+    this.bloomFalsePositiveRate = rate > 0 && rate < 1 ? rate : 0;
   }
 
   MutablePage startSeries() {
     if (rootPage != null)
       throw new IllegalStateException("A compacted series is already active for index '" + mainIndex.getName() + "'");
+
+    bloomHashes = bloomFalsePositiveRate > 0 ? new long[INITIAL_BLOOM_HASHES] : null;
+    bloomKeyCount = 0;
+    bloomLastHash = 0;
 
     rootPage = compactedIndex.createNewPage(0);
     rootPageBuffer = rootPage.getTrackable();
@@ -86,6 +109,8 @@ final class LSMTreeIndexCompactedStreamWriter {
       throws IOException, InterruptedException {
     if (rootPage == null)
       throw new IllegalStateException("No compacted series is active for index '" + mainIndex.getName() + "'");
+
+    rememberForBloomFilter(convertedKeys);
 
     final List<MutablePage> newPages = compactedIndex.appendDuringCompactionConverted(keyValueContent, lastPage,
         lastPageBuffer, pageNumberInSeries, keys, convertedKeys, rids);
@@ -175,9 +200,16 @@ final class LSMTreeIndexCompactedStreamWriter {
           Arrays.toString(lastPageMaxKey), compactedIndex.getCount(rootPage), Thread.currentThread().threadId());
     }
 
+    final int seriesRootPage = rootPage.getPageId().getPageNumber();
+    final int seriesPages = newPagesInSeries.size();
+
     final List<MutablePage> modifiedPages = new ArrayList<>(newPagesInSeries);
     modifiedPages.add(database.getPageManager().updatePageVersion(rootPage, true));
     database.getPageManager().writePages(modifiedPages, false);
+
+    // Only now that the series is on disk: a filter that reached the directory first would answer for pages a failed
+    // write never produced.
+    publishBloomFilter(seriesRootPage, seriesPages);
 
     rootPage = null;
     rootPageBuffer = null;
@@ -196,5 +228,62 @@ final class LSMTreeIndexCompactedStreamWriter {
 
   int getRootEntryCount() {
     return rootPage != null ? compactedIndex.getCount(rootPage) : 0;
+  }
+
+  /**
+   * Records the key hash for the bloom filter of the series being written (#5517). Called for every key BEFORE it is
+   * appended, so a key can never reach a page without reaching the filter - that asymmetry is the false negative the
+   * filter must never produce.
+   * <p>
+   * Keys arrive in ascending order and a key whose values overflow a page comes back for each chunk, so suppressing an
+   * adjacent repeat is enough to count every key once and size the filter for what it really holds.
+   */
+  private void rememberForBloomFilter(final Object[] convertedKeys) {
+    if (bloomHashes == null)
+      return;
+
+    final Binary serialized = compactedIndex.serializeKeyForHashing(bloomKeyContent, convertedKeys);
+    if (serialized == null)
+      return;
+
+    final long hash = LSMTreeIndexBloomFilter.hashKey(serialized);
+    if (bloomKeyCount > 0 && hash == bloomLastHash)
+      return;
+
+    if (bloomKeyCount == bloomHashes.length) {
+      if (bloomKeyCount >= MAX_BLOOM_KEYS_PER_SERIES) {
+        LogManager.instance().log(mainIndex, Level.INFO,
+            "Series of index '%s' holds more than %d keys: writing it without a bloom filter", null, mainIndex.getName(),
+            MAX_BLOOM_KEYS_PER_SERIES);
+        bloomHashes = null;
+        return;
+      }
+      bloomHashes = Arrays.copyOf(bloomHashes, Math.min(MAX_BLOOM_KEYS_PER_SERIES, bloomKeyCount * 2));
+    }
+
+    bloomHashes[bloomKeyCount++] = hash;
+    bloomLastHash = hash;
+  }
+
+  /**
+   * Hands the accumulated hashes to the filter component, creating it on first use. A failure to write a filter is
+   * logged and dropped: it costs a lookup, never a row.
+   */
+  private void publishBloomFilter(final int seriesRootPage, final int seriesPages) {
+    final long[] hashes = bloomHashes;
+    final int count = bloomKeyCount;
+
+    bloomHashes = null;
+    bloomKeyCount = 0;
+
+    if (hashes == null || count < 1 || seriesPages < 1)
+      return;
+
+    try {
+      compactedIndex.getOrCreateBloomFilter().publish(seriesRootPage, seriesPages, hashes, count, bloomFalsePositiveRate);
+    } catch (final Exception e) {
+      LogManager.instance().log(mainIndex, Level.WARNING,
+          "Cannot create the bloom filter of index '%s' (error=%s)", null, mainIndex.getName(), e.toString());
+    }
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
@@ -103,8 +103,17 @@ public class LSMTreeIndexCompactor {
       // race this rollback and re-raise the count right after it was reset.
       mutableIndex.getDatabase().getPageManager().waitAllPagesOfDatabaseAreFlushed(mutableIndex.getDatabase());
       compactedIndex.rollbackPageCountTo(preCompactionPages);
+      // #5517: the rolled-back page range is reused by the next round, so a filter published for a series that lived
+      // there must go with it - the new series at the same root page would otherwise be filtered by the old one's keys.
+      final LSMTreeIndexBloomFilter bloomFilter = compactedIndex.getBloomFilter();
+      if (bloomFilter != null)
+        bloomFilter.rollbackFrom(preCompactionPages);
       if (createdCompactedIndex) {
         try {
+          // The filter file was created by THIS round and describes a compacted file that is about to go: drop it too,
+          // or every failed first compaction leaks one.
+          if (bloomFilter != null)
+            bloomFilter.dropQuietly();
           mutableIndex.getDatabase().getSchema().getEmbedded().removeFile(compactedIndex.getFileId());
           mutableIndex.getDatabase().getFileManager().dropFile(compactedIndex.getFileId());
         } catch (final Throwable cleanupError) {
@@ -331,6 +340,9 @@ public class LSMTreeIndexCompactor {
       // aborted new file entirely so nothing of the failed merge survives
       database.getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
       try {
+        final LSMTreeIndexBloomFilter bloomFilter = newCompacted.getBloomFilter();
+        if (bloomFilter != null)
+          bloomFilter.dropQuietly();
         database.getSchema().getEmbedded().removeFile(newCompacted.getFileId());
         database.getFileManager().dropFile(newCompacted.getFileId());
       } catch (final Throwable cleanupError) {

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -59,6 +59,7 @@ import com.arcadedb.index.lsm.LSMTreeIndex;
 import com.arcadedb.index.sparsevector.LSMSparseVectorIndex;
 import com.arcadedb.index.sparsevector.SparseSegmentComponent;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NULL_STRATEGY;
+import com.arcadedb.index.lsm.LSMTreeIndexBloomFilter;
 import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
 import com.arcadedb.index.lsm.LSMTreeIndexMutable;
 import com.arcadedb.index.vector.LSMVectorIndex;
@@ -143,6 +144,8 @@ public class LocalSchema implements Schema {
         new LSMTreeIndex.PaginatedComponentFactoryHandlerUnique());
     componentFactory.registerComponent(LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT,
         new LSMTreeIndex.PaginatedComponentFactoryHandlerNotUnique());
+    componentFactory.registerComponent(LSMTreeIndexBloomFilter.FILE_EXT,
+        new LSMTreeIndexBloomFilter.PaginatedComponentFactoryHandler());
     componentFactory.registerComponent(LSMVectorIndex.FILE_EXT, new LSMVectorIndex.PaginatedComponentFactoryHandlerUnique());
     componentFactory.registerComponent(SparseSegmentComponent.FILE_EXT,
         new SparseSegmentComponent.PaginatedComponentFactoryHandler());
@@ -242,6 +245,9 @@ public class LocalSchema implements Schema {
       if (f != null)
         f.onAfterSchemaLoad();
 
+    // Every component is registered by now, which is what resolving a filter to its compacted index by name needs.
+    attachBloomFilters(snapshot);
+
     if (mode == ComponentFile.MODE.READ_WRITE)
       sweepOrphanCompactedIndexFiles(snapshot);
 
@@ -249,7 +255,19 @@ public class LocalSchema implements Schema {
   }
 
   /**
-   * Drops compacted index files that no mutable index claimed during the load. A crash between a
+   * Links every {@code .bfidx} bloom filter component (#5517) to the compacted index it was written for, matching it
+   * by name. Only a compacted index the load claimed gets one: an orphan is about to be dropped anyway, and an
+   * unattached filter is inert, since nothing but its compacted index ever probes it.
+   */
+  private void attachBloomFilters(final List<Component> snapshot) {
+    for (final Component component : snapshot)
+      if (component instanceof LSMTreeIndexCompacted compacted && compacted.getMainIndex() != null)
+        compacted.attachBloomFilter();
+  }
+
+  /**
+   * Drops compacted index files that no mutable index claimed during the load, together with the bloom filter files
+   * that describe them. A crash between a
    * compaction's publication (schema saved, the mutable header already pointing at its CURRENT compacted
    * file) and the physical drop of a replaced or aborted compacted file leaves the stale file on disk; the
    * directory scan re-registers it at the next open, but nothing references it anymore, leaking its space
@@ -259,6 +277,17 @@ public class LocalSchema implements Schema {
    */
   private void sweepOrphanCompactedIndexFiles(final List<Component> snapshot) {
     for (final Component component : snapshot) {
+      if (component instanceof LSMTreeIndexBloomFilter filter) {
+        // A filter is owned by exactly one compacted index; without it nothing can ever read the file again.
+        final Component owner = filter.getOwnerName() != null ? getFileByName(filter.getOwnerName()) : null;
+        if (!(owner instanceof LSMTreeIndexCompacted compactedOwner) || compactedOwner.getMainIndex() == null) {
+          LogManager.instance().log(this, Level.INFO,
+              "Dropping orphan index bloom filter file '%s' (fileId=%d)", null, filter.getName(), filter.getFileId());
+          filter.dropQuietly();
+        }
+        continue;
+      }
+
       if (!(component instanceof LSMTreeIndexCompacted compacted) || compacted.getMainIndex() != null)
         continue;
 

--- a/engine/src/test/java/com/arcadedb/index/Issue5517BloomFilterKeyTypesTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5517BloomFilterKeyTypesTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The bloom filters of #5517 hash the SERIALIZED form of a key, so they only work while two keys the index treats as
+ * EQUAL serialize to the same bytes. That is not free: it holds for most types only because {@code convertKeys} first
+ * normalises every component to the type the index declared.
+ * <p>
+ * DECIMAL escaped that. Converting to {@link BigDecimal} keeps whatever scale the caller supplied and serialization
+ * writes the scale, but the comparator uses {@code BigDecimal.compareTo}, which ignores it - so {@code 1.0} and
+ * {@code 1.00} were one key to the index and two hashes to the filter, and looking up one SKIPPED the series holding
+ * the other. On a unique index that is a duplicate walking past the duplicate check. Reproduced before the fix: with
+ * the filters off every different-scale lookup was found, with them on none was.
+ * <p>
+ * Every case here compares the two configurations over the same files, because "the filters answer like a scan" is the
+ * only property that matters and the only one that catches this class of bug.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5517BloomFilterKeyTypesTest extends TestHelper {
+
+  private static final int TOTAL_KEYS = 30_000;
+
+  @Override
+  protected void beginTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+  }
+
+  @Override
+  protected void endTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.reset();
+    GlobalConfiguration.INDEX_COMPACTION_RAM_MB.reset();
+    GlobalConfiguration.INDEX_BLOOM_FILTER_RATE.reset();
+  }
+
+  /**
+   * The regression. A DECIMAL key looked up at a DIFFERENT scale than it was stored at must still be found - the
+   * comparator says they are the same key, so the filters have to agree.
+   */
+  @Test
+  void aDecimalKeyIsFoundWhateverScaleTheLookupUses() throws Exception {
+    final TypeIndex index = buildIndex(Type.DECIMAL, i -> new BigDecimal(i + ".0"));
+
+    final LSMTreeIndexCompacted compacted = compactedOf(index);
+    assertThat(compacted.isBloomFilterEnabled()).as("the filters must be in play for this to prove anything").isTrue();
+
+    final long skippedBefore = compacted.getBloomSkippedSeries();
+
+    for (int i = 0; i < TOTAL_KEYS; i++) {
+      assertThat(found(index, new BigDecimal(i + ".0"))).as("key %d at its stored scale", i).isTrue();
+      assertThat(found(index, new BigDecimal(i + ".00"))).as("key %d at a WIDER scale", i).isTrue();
+      assertThat(found(index, new BigDecimal(String.valueOf(i)))).as("key %d at scale 0", i).isTrue();
+    }
+
+    // A key that really is absent must still be filtered out, or the fix would just be "never use the filters".
+    for (int i = 0; i < 2_000; i++)
+      assertThat(found(index, new BigDecimal("-" + (i + 1) + ".5"))).as("absent decimal %d", i).isFalse();
+
+    assertThat(compacted.getBloomSkippedSeries() - skippedBefore)
+        .as("the filters must still be skipping series for absent keys").isGreaterThan(0);
+  }
+
+  /** Whole-number DECIMALs written with trailing zeros: 100 and 1.00E+2 are the same key. */
+  @Test
+  void aDecimalKeyIsFoundAcrossNegativeAndPositiveScales() throws Exception {
+    final TypeIndex index = buildIndex(Type.DECIMAL, i -> new BigDecimal(i + "00"));
+
+    for (int i = 0; i < TOTAL_KEYS; i++) {
+      assertThat(found(index, new BigDecimal(i + "00"))).as("key %d as written", i).isTrue();
+      assertThat(found(index, new BigDecimal(i + "00.000"))).as("key %d with a wider scale", i).isTrue();
+      assertThat(found(index, new BigDecimal(i + "00").stripTrailingZeros())).as("key %d stripped", i).isTrue();
+    }
+  }
+
+  /** LONG keys probed with an Integer: convertKeys widens both sides, so the filters must agree. */
+  @Test
+  void aLongKeyIsFoundWhenProbedWithAnInteger() throws Exception {
+    final TypeIndex index = buildIndex(Type.LONG, i -> (long) i);
+
+    for (int i = 0; i < TOTAL_KEYS; i++) {
+      assertThat(found(index, (long) i)).as("long key %d", i).isTrue();
+      assertThat(found(index, i)).as("long key %d probed as an int", i).isTrue();
+    }
+  }
+
+  /** DOUBLE keys probed as ints and floats. */
+  @Test
+  void aDoubleKeyIsFoundWhenProbedWithOtherNumbers() throws Exception {
+    final TypeIndex index = buildIndex(Type.DOUBLE, i -> (double) i);
+
+    for (int i = 0; i < TOTAL_KEYS; i++) {
+      assertThat(found(index, (double) i)).as("double key %d", i).isTrue();
+      assertThat(found(index, i)).as("double key %d probed as an int", i).isTrue();
+    }
+  }
+
+  /** DATETIME keys, where the stored form is a number and the caller may pass a Date. */
+  @Test
+  void aDateTimeKeyIsFoundWhenProbedWithADate() throws Exception {
+    final long base = LocalDate.of(2020, 1, 1).toEpochDay() * 86_400_000L;
+    final TypeIndex index = buildIndex(Type.DATETIME, i -> new Date(base + i * 60_000L));
+
+    for (int i = 0; i < TOTAL_KEYS; i++) {
+      assertThat(found(index, new Date(base + i * 60_000L))).as("datetime key %d", i).isTrue();
+      assertThat(found(index, base + i * 60_000L)).as("datetime key %d probed as a long", i).isTrue();
+    }
+  }
+
+  /** A composite key mixing a DECIMAL with a STRING: the canonicalisation has to reach the right component. */
+  @Test
+  void aCompositeDecimalAndStringKeyIsFoundAtAnyScale() throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+    final DocumentType type = database.getSchema().buildDocumentType().withName("Mixed").withTotalBuckets(1).create();
+    type.createProperty("amount", Type.DECIMAL);
+    type.createProperty("label", Type.STRING);
+    database.getSchema().buildTypeIndex("Mixed", new String[] { "amount", "label" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < TOTAL_KEYS; i++)
+        database.newDocument("Mixed").set("amount", new BigDecimal(i + ".0")).set("label", "label-" + i).save();
+    });
+
+    final TypeIndex index = database.getSchema().getType("Mixed").getIndexesByProperties("amount", "label").getFirst();
+    assertThat(((IndexInternal) index).scheduleCompaction()).isTrue();
+    assertThat(((IndexInternal) index).compact()).isTrue();
+
+    for (int i = 0; i < TOTAL_KEYS; i++) {
+      assertThat(found(index, new BigDecimal(i + ".0"), "label-" + i)).as("composite key %d as stored", i).isTrue();
+      assertThat(found(index, new BigDecimal(i + ".000"), "label-" + i)).as("composite key %d at a wider scale", i)
+          .isTrue();
+    }
+  }
+
+  private interface KeyFactory {
+    Object of(int i);
+  }
+
+  private TypeIndex buildIndex(final Type keyType, final KeyFactory keys) throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+
+    final DocumentType type = database.getSchema().buildDocumentType().withName("D").withTotalBuckets(1).create();
+    type.createProperty("k", keyType);
+    database.getSchema().buildTypeIndex("D", new String[] { "k" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < TOTAL_KEYS; i++)
+        database.newDocument("D").set("k", keys.of(i)).save();
+    });
+
+    final TypeIndex index = database.getSchema().getType("D").getIndexesByProperties("k").getFirst();
+    assertThat(((IndexInternal) index).scheduleCompaction()).isTrue();
+    assertThat(((IndexInternal) index).compact()).isTrue();
+    assertThat(compactedOf(index).getBloomFilter()).as("the compaction must have written filters").isNotNull();
+    return index;
+  }
+
+  private static boolean found(final TypeIndex index, final Object... key) {
+    final IndexCursor cursor = index.get(key);
+    try {
+      return cursor.hasNext();
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static LSMTreeIndexCompacted compactedOf(final TypeIndex index) {
+    return ((LSMTreeIndex) index.getIndexesOnBuckets()[0]).getMutableIndex().getSubIndex();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue5517BloomFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5517BloomFilterTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexBloomFilter;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5517: a point lookup must skip a compacted series that provably cannot hold the key, and must never skip one that
+ * can.
+ * <p>
+ * The second half is the one that matters. A false positive costs the page read that would have happened anyway; a
+ * false NEGATIVE hides a row - the lookup is skipped, the record is reported missing and a unique index lets a
+ * duplicate through - with the index file intact and nothing to see in CHECK DATABASE. So every test here that reports
+ * a saving also asserts, over the very same data, that not one key went missing.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue5517BloomFilterTest extends TestHelper {
+
+  private static final String TYPE_NAME  = "Doc";
+  private static final int    TOTAL_KEYS = 60_000;
+  private static final int    PAGE_SIZE  = 256 * 1024;
+  private static final String KEY_PAD    = "x".repeat(64);
+
+  private static String key(final int i) {
+    return "K" + KEY_PAD + String.format("%08d", i);
+  }
+
+  @Override
+  protected void beginTest() {
+    // The explicit compaction below must be the only one, not raced by a background round.
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+  }
+
+  @Override
+  protected void endTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.reset();
+    GlobalConfiguration.INDEX_COMPACTION_RAM_MB.reset();
+    GlobalConfiguration.INDEX_BLOOM_FILTER_RATE.reset();
+  }
+
+  /**
+   * Builds a unique index over one bucket whose data lands in several compacted series, the layout a bulk load
+   * produces and the only one where skipping a series is worth anything.
+   */
+  private TypeIndex buildMultiSeriesIndex(final int totalKeys) throws Exception {
+    return buildMultiSeriesIndex(totalKeys, 3);
+  }
+
+  private TypeIndex buildMultiSeriesIndex(final int totalKeys, final int minSeries) throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("email", String.class);
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "email" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).withPageSize(PAGE_SIZE).create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < totalKeys; i++)
+        database.newDocument(TYPE_NAME).set("email", key(i)).save();
+    });
+
+    final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties("email").getFirst();
+    assertThat(((IndexInternal) typeIndex).scheduleCompaction()).isTrue();
+    assertThat(((IndexInternal) typeIndex).compact()).isTrue();
+
+    assertThat(compactedOf(typeIndex).getSeriesCount())
+        .as("test setup must produce multiple compacted series").isGreaterThanOrEqualTo(minSeries);
+
+    return typeIndex;
+  }
+
+  private static LSMTreeIndexCompacted compactedOf(final TypeIndex typeIndex) {
+    final LSMTreeIndex bucketIndex = (LSMTreeIndex) typeIndex.getIndexesOnBuckets()[0];
+    return bucketIndex.getMutableIndex().getSubIndex();
+  }
+
+  /**
+   * The gate. Every key written before the compaction has to come back after it, with the filters deciding which
+   * series are read - the one failure mode a bloom filter must never have, asserted over every single key.
+   */
+  @Test
+  void notOneKeyGoesMissingBehindTheFilters() throws Exception {
+    final TypeIndex typeIndex = buildMultiSeriesIndex(TOTAL_KEYS);
+    final LSMTreeIndexCompacted compacted = compactedOf(typeIndex);
+
+    assertThat(compacted.getBloomFilter()).as("the compaction must have written a filter file").isNotNull();
+    assertThat(compacted.getBloomFilter().getPublishedFilters())
+        .as("every series must carry a filter").isEqualTo(compacted.getSeriesCount());
+
+    for (int i = 0; i < TOTAL_KEYS; i++) {
+      final IndexCursor cursor = typeIndex.get(new Object[] { key(i) });
+      assertThat(cursor.hasNext()).as("key %d must still be found", i).isTrue();
+      cursor.close();
+    }
+  }
+
+  /**
+   * What the filters are for: a key that no series holds must not cost a single series read. With one filter per
+   * series and a 1% target, all but a handful of the probes must come back negative.
+   */
+  @Test
+  void anAbsentKeySkipsAlmostEverySeries() throws Exception {
+    final TypeIndex typeIndex = buildMultiSeriesIndex(TOTAL_KEYS);
+    final LSMTreeIndexCompacted compacted = compactedOf(typeIndex);
+
+    final long skippedBefore = compacted.getBloomSkippedSeries();
+    final long probedBefore = compacted.getBloomProbedSeries();
+
+    final int lookups = 2_000;
+    for (int i = 0; i < lookups; i++) {
+      // Inside the key range the series span - the root page alone cannot rule these out.
+      final IndexCursor cursor = typeIndex.get(new Object[] { key(i) + "-absent" });
+      assertThat(cursor.hasNext()).as("the key was never inserted").isFalse();
+      cursor.close();
+    }
+
+    final long skipped = compacted.getBloomSkippedSeries() - skippedBefore;
+    final long read = compacted.getBloomProbedSeries() - probedBefore;
+
+    assertThat(skipped + read).as("every series must have been probed on every lookup")
+        .isEqualTo((long) lookups * compacted.getSeriesCount());
+    assertThat((double) read / (skipped + read))
+        .as("false positives measured over %d lookups of %d series", lookups, compacted.getSeriesCount())
+        .isLessThan(0.05);
+  }
+
+  /** A key that IS there must never be filtered out, however many series the lookup has to walk. */
+  @Test
+  void aPresentKeyIsNeverSkipped() throws Exception {
+    final TypeIndex typeIndex = buildMultiSeriesIndex(TOTAL_KEYS);
+    final LSMTreeIndexCompacted compacted = compactedOf(typeIndex);
+
+    final int seriesCount = compacted.getSeriesCount();
+    final long skippedBefore = compacted.getBloomSkippedSeries();
+
+    final int lookups = 500;
+    for (int i = 0; i < lookups; i++) {
+      final IndexCursor cursor = typeIndex.get(new Object[] { key(i * (TOTAL_KEYS / lookups)) });
+      assertThat(cursor.hasNext()).isTrue();
+      cursor.close();
+    }
+
+    // Each lookup skips at most every series but the one holding the key.
+    assertThat(compacted.getBloomSkippedSeries() - skippedBefore)
+        .isLessThanOrEqualTo((long) lookups * (seriesCount - 1));
+  }
+
+  /**
+   * The filters live in a file of their own, so what a reopened database reads back from page 0 must decide exactly
+   * what the compaction decided. A directory that came back subtly wrong - a series' page count, a block index, a
+   * probe count - would filter keys the series really holds.
+   */
+  @Test
+  void theFiltersSurviveAReopen() throws Exception {
+    buildMultiSeriesIndex(TOTAL_KEYS);
+
+    reopenDatabase();
+
+    final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties("email").getFirst();
+    final LSMTreeIndexCompacted compacted = compactedOf(typeIndex);
+
+    assertThat(compacted.getBloomFilter()).as("the filter file must be reattached at load").isNotNull();
+    assertThat(compacted.getBloomFilter().getPublishedFilters()).isEqualTo(compacted.getSeriesCount());
+
+    for (int i = 0; i < TOTAL_KEYS; i += 7) {
+      final IndexCursor cursor = typeIndex.get(new Object[] { key(i) });
+      assertThat(cursor.hasNext()).as("key %d must be found after a reopen", i).isTrue();
+      cursor.close();
+    }
+
+    assertThat(compacted.getBloomSkippedSeries()).as("the reloaded filters must actually be skipping series")
+        .isGreaterThan(0);
+  }
+
+  /**
+   * The filters are an optimisation, so turning them off must change the cost of a lookup and nothing else - the same
+   * database, the same files, the same answers. This is also what an older build sees: it does not know the
+   * {@code .bfidx} extension, skips the file at load and reads every series.
+   */
+  @Test
+  void turningTheFiltersOffChangesNothingButTheCost() throws Exception {
+    final TypeIndex typeIndex = buildMultiSeriesIndex(TOTAL_KEYS);
+    final List<Boolean> withFilters = probeEveryKey(typeIndex, 11);
+    assertThat(compactedOf(typeIndex).getBloomSkippedSeries()).isGreaterThan(0);
+
+    GlobalConfiguration.INDEX_BLOOM_FILTER_RATE.setValue(0.0f);
+    reopenDatabase();
+
+    final TypeIndex reopenedIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties("email").getFirst();
+    assertThat(probeEveryKey(reopenedIndex, 11)).isEqualTo(withFilters);
+    assertThat(compactedOf(reopenedIndex).getBloomSkippedSeries()).as("no series may be skipped with the filters off")
+        .isZero();
+  }
+
+  private List<Boolean> probeEveryKey(final TypeIndex typeIndex, final int step) {
+    final List<Boolean> found = new ArrayList<>();
+    for (int i = 0; i < TOTAL_KEYS; i += step) {
+      final IndexCursor present = typeIndex.get(new Object[] { key(i) });
+      found.add(present.hasNext());
+      present.close();
+
+      final IndexCursor absent = typeIndex.get(new Object[] { key(i) + "-absent" });
+      found.add(absent.hasNext());
+      absent.close();
+    }
+    return found;
+  }
+
+  /**
+   * A non-unique index maps one key to many RIDs, and a key with enough of them spans several leaf pages of a series.
+   * The filter is built where keys are appended, so a key coming back for each of its chunks - and a key whose chunks
+   * straddle two series - must be recorded in every series it reaches.
+   */
+  @Test
+  void aNonUniqueKeySpanningPagesIsFoundInEverySeriesItReaches() throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("city", String.class);
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "city" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).withPageSize(65_536).create();
+
+    final int cities = 40;
+    final int perCity = 1_500;
+    database.transaction(() -> {
+      for (int i = 0; i < cities * perCity; i++)
+        database.newDocument(TYPE_NAME).set("city", "city-" + String.format("%04d", i % cities)).save();
+    });
+
+    final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties("city").getFirst();
+    assertThat(((IndexInternal) typeIndex).scheduleCompaction()).isTrue();
+    assertThat(((IndexInternal) typeIndex).compact()).isTrue();
+
+    for (int c = 0; c < cities; c++) {
+      int count = 0;
+      final IndexCursor cursor = typeIndex.get(new Object[] { "city-" + String.format("%04d", c) });
+      while (cursor.hasNext()) {
+        cursor.next();
+        ++count;
+      }
+      cursor.close();
+      assertThat(count).as("every RID of city %d must be reachable", c).isEqualTo(perCity);
+    }
+  }
+
+  /** Dropping the index must take its filter file with it, or the next open sees a file nothing can ever read. */
+  @Test
+  void droppingTheIndexRemovesTheFilterFile() throws Exception {
+    final TypeIndex typeIndex = buildMultiSeriesIndex(20_000, 1);
+    final LSMTreeIndexBloomFilter filter = compactedOf(typeIndex).getBloomFilter();
+    assertThat(filter).isNotNull();
+
+    final File filterFile = filter.getOSFile();
+    assertThat(filterFile).exists();
+
+    database.getSchema().dropIndex(typeIndex.getName());
+
+    assertThat(filterFile).as("the bloom filter file must go with the index").doesNotExist();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilterTest.java
@@ -48,6 +48,13 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   /** Small enough that a few thousand keys need several blocks. */
   private static final int PAGE_SIZE = 4_096;
 
+  /**
+   * Stands in for {@code LSMTreeIndexCompacted.seriesFingerprint} of the series' last data page. There is no real
+   * series here, so any stable value serves - what matters is that publish and probe agree on it, exactly as the
+   * compaction and the lookup do.
+   */
+  private static final int FINGERPRINT = 0x5117;
+
   private static long hash(final String key) {
     final byte[] bytes = key.getBytes(StandardCharsets.UTF_8);
     return MurmurHash.hash64(bytes, bytes.length, LSMTreeIndexBloomFilter.HASH_SEED);
@@ -74,13 +81,13 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
     final int keys = 40_000;
     final LSMTreeIndexBloomFilter filter = newFilter("many-blocks");
 
-    filter.publish(7, 3, hashes(keys, "key-"), keys, 0.01);
+    filter.publish(7, 3, FINGERPRINT, hashes(keys, "key-"), keys, 0.01);
     assertThat(filter.getPublishedFilters()).isEqualTo(1);
     assertThat(filter.getTotalPages()).as("%d keys at 1%% must not fit one %d-byte page", keys, PAGE_SIZE)
         .isGreaterThan(3);
 
     for (int i = 0; i < keys; i++)
-      assertThat(filter.mightContain(7, 3, hash("key-" + i))).as("key %d", i).isTrue();
+      assertThat(filter.mightContain(7, 3, FINGERPRINT, hash("key-" + i))).as("key %d", i).isTrue();
   }
 
   /**
@@ -91,12 +98,12 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   void theMeasuredFalsePositiveRateMatchesTheTarget() throws Exception {
     final int keys = 40_000;
     final LSMTreeIndexBloomFilter filter = newFilter("rate");
-    filter.publish(11, 5, hashes(keys, "present-"), keys, 0.01);
+    filter.publish(11, 5, FINGERPRINT, hashes(keys, "present-"), keys, 0.01);
 
     int falsePositives = 0;
     final int probed = 100_000;
     for (int i = 0; i < probed; i++)
-      if (filter.mightContain(11, 5, hash("absent-" + i)))
+      if (filter.mightContain(11, 5, FINGERPRINT, hash("absent-" + i)))
         ++falsePositives;
 
     assertThat((double) falsePositives / probed).as("measured false-positive rate over %d probes", probed)
@@ -112,18 +119,18 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   void theDirectoryIsAlwaysTheLastPage() throws Exception {
     final LSMTreeIndexBloomFilter filter = newFilter("append-only");
 
-    filter.publish(4, 2, hashes(5_000, "a-"), 5_000, 0.01);
+    filter.publish(4, 2, FINGERPRINT, hashes(5_000, "a-"), 5_000, 0.01);
     final int afterFirst = filter.getTotalPages();
     assertThat(readsAsDirectory(filter, afterFirst - 1)).isTrue();
 
-    filter.publish(40, 2, hashes(5_000, "b-"), 5_000, 0.01);
+    filter.publish(40, 2, FINGERPRINT, hashes(5_000, "b-"), 5_000, 0.01);
     assertThat(filter.getTotalPages()).as("a publish only ever appends").isGreaterThan(afterFirst);
     assertThat(readsAsDirectory(filter, filter.getTotalPages() - 1)).isTrue();
 
     // ... and the pages the first publish wrote are untouched by the second.
     filter.loadDirectory();
     for (int i = 0; i < 5_000; i++)
-      assertThat(filter.mightContain(4, 2, hash("a-" + i))).as("key %d of the first series", i).isTrue();
+      assertThat(filter.mightContain(4, 2, FINGERPRINT, hash("a-" + i))).as("key %d of the first series", i).isTrue();
   }
 
   /**
@@ -135,7 +142,7 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   @Test
   void aCrashBetweenTheBitsAndTheDirectoryFallsBackToThePreviousOne() throws Exception {
     final LSMTreeIndexBloomFilter filter = newFilter("torn-publish");
-    filter.publish(4, 2, hashes(3_000, "a-"), 3_000, 0.01);
+    filter.publish(4, 2, FINGERPRINT, hashes(3_000, "a-"), 3_000, 0.01);
 
     appendPage(filter, 0);          // a plausible bit page
     appendPage(filter, 0x424C4F4D); // and one that even starts with the directory magic
@@ -144,7 +151,7 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
 
     assertThat(filter.getPublishedFilters()).as("the previous directory must still be the live one").isEqualTo(1);
     for (int i = 0; i < 3_000; i++)
-      assertThat(filter.mightContain(4, 2, hash("a-" + i))).as("key %d", i).isTrue();
+      assertThat(filter.mightContain(4, 2, FINGERPRINT, hash("a-" + i))).as("key %d", i).isTrue();
   }
 
   private static boolean readsAsDirectory(final LSMTreeIndexBloomFilter filter, final int pageNumber) throws Exception {
@@ -173,7 +180,7 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   void theStaticProbeAgreesWithTheInstanceOne() throws Exception {
     final int keys = 20_000;
     final LSMTreeIndexBloomFilter filter = newFilter("static-vs-instance");
-    filter.publish(6, 2, hashes(keys, "p-"), keys, 0.01);
+    filter.publish(6, 2, FINGERPRINT, hashes(keys, "p-"), keys, 0.01);
 
     final LSMTreeIndexBloomFilter.Entry entry = filter.readDirectoryPage(filter.getTotalPages() - 1).get(6);
     assertThat(entry).isNotNull();
@@ -216,9 +223,9 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   @Test
   void anUnknownSeriesIsAlwaysSearched() throws Exception {
     final LSMTreeIndexBloomFilter filter = newFilter("unknown-series");
-    filter.publish(3, 2, hashes(100, "k-"), 100, 0.01);
+    filter.publish(3, 2, FINGERPRINT, hashes(100, "k-"), 100, 0.01);
 
-    assertThat(filter.mightContain(99, 2, hash("k-0"))).as("no filter for series 99").isTrue();
+    assertThat(filter.mightContain(99, 2, FINGERPRINT, hash("k-0"))).as("no filter for series 99").isTrue();
   }
 
   /**
@@ -230,28 +237,32 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   @Test
   void aSeriesRewrittenAtTheSameRootPageIsNotFilteredByTheOldOne() throws Exception {
     final LSMTreeIndexBloomFilter filter = newFilter("rollback");
-    filter.publish(40, 4, hashes(1_000, "old-"), 1_000, 0.01);
+    filter.publish(40, 4, FINGERPRINT, hashes(1_000, "old-"), 1_000, 0.01);
 
-    // Same root page, different series: a different page count is enough to disown the entry.
-    assertThat(filter.mightContain(40, 6, hash("new-1"))).as("a series of a different shape must be searched").isTrue();
+    // Same root page, different series. EITHER half of the identity is enough to disown the entry: the page count,
+    // or the fingerprint of the last data page when the count happens to coincide.
+    assertThat(filter.mightContain(40, 6, FINGERPRINT, hash("old-1")))
+        .as("a series with a different page count must be searched").isTrue();
+    assertThat(filter.mightContain(40, 4, FINGERPRINT + 1, hash("old-1")))
+        .as("a series whose last data page differs must be searched, even at the same page count").isTrue();
 
     filter.rollbackFrom(40);
     assertThat(filter.getPublishedFilters()).isZero();
-    assertThat(filter.mightContain(40, 4, hash("old-1"))).as("a rolled-back filter must not answer any more").isTrue();
+    assertThat(filter.mightContain(40, 4, FINGERPRINT, hash("old-1"))).as("a rolled-back filter must not answer any more").isTrue();
   }
 
   /** Only the series at or after the rolled-back page go: an earlier round's filters are still valid. */
   @Test
   void aRollbackKeepsTheFiltersOfEarlierRounds() throws Exception {
     final LSMTreeIndexBloomFilter filter = newFilter("partial-rollback");
-    filter.publish(5, 2, hashes(500, "first-"), 500, 0.01);
-    filter.publish(50, 2, hashes(500, "second-"), 500, 0.01);
+    filter.publish(5, 2, FINGERPRINT, hashes(500, "first-"), 500, 0.01);
+    filter.publish(50, 2, FINGERPRINT, hashes(500, "second-"), 500, 0.01);
 
     filter.rollbackFrom(50);
 
     assertThat(filter.getPublishedFilters()).isEqualTo(1);
     for (int i = 0; i < 500; i++)
-      assertThat(filter.mightContain(5, 2, hash("first-" + i))).as("key %d of the surviving series", i).isTrue();
+      assertThat(filter.mightContain(5, 2, FINGERPRINT, hash("first-" + i))).as("key %d of the surviving series", i).isTrue();
   }
 
   /** What is written must be what is read back: the directory is the only thing a reopened database has. */
@@ -259,15 +270,15 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   void theDirectoryReadsBackWhatWasWritten() throws Exception {
     final int keys = 20_000;
     final LSMTreeIndexBloomFilter filter = newFilter("reload");
-    filter.publish(9, 4, hashes(keys, "r-"), keys, 0.01);
-    filter.publish(90, 8, hashes(keys, "s-"), keys, 0.01);
+    filter.publish(9, 4, FINGERPRINT, hashes(keys, "r-"), keys, 0.01);
+    filter.publish(90, 8, FINGERPRINT, hashes(keys, "s-"), keys, 0.01);
 
     filter.loadDirectory();
     assertThat(filter.getPublishedFilters()).isEqualTo(2);
 
     for (int i = 0; i < keys; i++) {
-      assertThat(filter.mightContain(9, 4, hash("r-" + i))).as("series 9, key %d", i).isTrue();
-      assertThat(filter.mightContain(90, 8, hash("s-" + i))).as("series 90, key %d", i).isTrue();
+      assertThat(filter.mightContain(9, 4, FINGERPRINT, hash("r-" + i))).as("series 9, key %d", i).isTrue();
+      assertThat(filter.mightContain(90, 8, FINGERPRINT, hash("s-" + i))).as("series 90, key %d", i).isTrue();
     }
   }
 
@@ -275,14 +286,14 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
   @Test
   void aSeriesOfOneKeyStillWorks() throws Exception {
     final LSMTreeIndexBloomFilter filter = newFilter("tiny");
-    filter.publish(2, 1, hashes(1, "only-"), 1, 0.01);
+    filter.publish(2, 1, FINGERPRINT, hashes(1, "only-"), 1, 0.01);
 
     assertThat(filter.getPublishedFilters()).isEqualTo(1);
-    assertThat(filter.mightContain(2, 1, hash("only-0"))).isTrue();
+    assertThat(filter.mightContain(2, 1, FINGERPRINT, hash("only-0"))).isTrue();
 
     int falsePositives = 0;
     for (int i = 0; i < 10_000; i++)
-      if (filter.mightContain(2, 1, hash("other-" + i)))
+      if (filter.mightContain(2, 1, FINGERPRINT, hash("other-" + i)))
         ++falsePositives;
     assertThat(falsePositives).as("a filter holding one key must reject nearly everything").isLessThan(200);
   }

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilterTest.java
@@ -20,6 +20,9 @@ package com.arcadedb.index.lsm;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Binary;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.BufferBloomFilter;
 import com.arcadedb.engine.MurmurHash;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
@@ -159,6 +162,54 @@ class LSMTreeIndexBloomFilterTest extends TestHelper {
     db.getPageManager().updatePageVersion(page, true);
     filter.updatePageCount(pageNumber + 1);
     db.getPageManager().writePages(List.of(page), false);
+  }
+
+  /**
+   * The probe used on the lookup path reads bits straight off the page to avoid allocating, and therefore repeats the
+   * bit arithmetic of the instance form instead of sharing it. The two MUST answer identically: if they ever drifted,
+   * keys written through one and read through the other would go missing.
+   */
+  @Test
+  void theStaticProbeAgreesWithTheInstanceOne() throws Exception {
+    final int keys = 20_000;
+    final LSMTreeIndexBloomFilter filter = newFilter("static-vs-instance");
+    filter.publish(6, 2, hashes(keys, "p-"), keys, 0.01);
+
+    final LSMTreeIndexBloomFilter.Entry entry = filter.readDirectoryPage(filter.getTotalPages() - 1).get(6);
+    assertThat(entry).isNotNull();
+
+    int agreed = 0;
+    for (int i = 0; i < 40_000; i++) {
+      // Half present, half absent, so both answers are exercised.
+      final long hash = i < keys ? hash("p-" + i) : hash("q-" + i);
+      final int block = blockOfSameWayTheComponentDoes(hash, entry.filterPages());
+      final BasePage page = ((DatabaseInternal) database).getPageManager()
+          .getImmutablePage(new PageId((DatabaseInternal) database, filter.getFileId(),
+              entry.firstFilterPage() + block), PAGE_SIZE, false, false);
+
+      final boolean viaPage = BufferBloomFilter.mightContainHash(page, entry.slotsPerBlock(), entry.probes(), hash);
+      final boolean viaInstance = new BufferBloomFilter(new Binary(page.slice()), entry.slotsPerBlock(),
+          LSMTreeIndexBloomFilter.HASH_SEED, entry.probes()).mightContainHash(hash);
+
+      assertThat(viaPage).as("hash %d", hash).isEqualTo(viaInstance);
+      if (viaPage)
+        ++agreed;
+    }
+
+    assertThat(agreed).as("the probe must answer TRUE for the keys it holds, not for nothing").isGreaterThan(keys / 2);
+  }
+
+  /** Mirrors the component's block routing, so the test addresses the page the component would. */
+  private static int blockOfSameWayTheComponentDoes(final long hash, final int filterPages) {
+    if (filterPages == 1)
+      return 0;
+    long mixed = hash;
+    mixed ^= mixed >>> 30;
+    mixed *= 0xbf58476d1ce4e5b9L;
+    mixed ^= mixed >>> 27;
+    mixed *= 0x94d049bb133111ebL;
+    mixed ^= mixed >>> 31;
+    return (int) Long.remainderUnsigned(mixed, filterPages);
   }
 
   /** A series with no filter must be searched, not skipped. */

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexBloomFilterTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.MurmurHash;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The {@code .bfidx} component on its own, at sizes a real index reaches but a unit-friendly test would not: enough
+ * keys per series that the filter spans MANY pages, which is where a key is routed to one block and everything depends
+ * on the routing agreeing with itself between the write and the read.
+ * <p>
+ * The integration test ({@code Issue5517BloomFilterTest}) drives the same code through a compaction, but a 256 KB page
+ * holds ~500k bits and therefore the whole filter of any test-sized series - so it never exercises a second block.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LSMTreeIndexBloomFilterTest extends TestHelper {
+
+  /** Small enough that a few thousand keys need several blocks. */
+  private static final int PAGE_SIZE = 4_096;
+
+  private static long hash(final String key) {
+    final byte[] bytes = key.getBytes(StandardCharsets.UTF_8);
+    return MurmurHash.hash64(bytes, bytes.length, LSMTreeIndexBloomFilter.HASH_SEED);
+  }
+
+  private LSMTreeIndexBloomFilter newFilter(final String name) throws Exception {
+    return LSMTreeIndexBloomFilter.createOrLoad((DatabaseInternal) database, name, PAGE_SIZE);
+  }
+
+  private static long[] hashes(final int count, final String prefix) {
+    final long[] hashes = new long[count];
+    for (int i = 0; i < count; i++)
+      hashes[i] = hash(prefix + i);
+    return hashes;
+  }
+
+  /**
+   * The guarantee. Every key handed to the filter must probe back positive, whichever of the many blocks it was routed
+   * to - a routing that disagreed with itself between add and probe would put the key in one block and look for it in
+   * another, and the filter would hide it.
+   */
+  @Test
+  void everyKeyOfEveryBlockProbesBack() throws Exception {
+    final int keys = 40_000;
+    final LSMTreeIndexBloomFilter filter = newFilter("many-blocks");
+
+    filter.publish(7, 3, hashes(keys, "key-"), keys, 0.01);
+    assertThat(filter.getPublishedFilters()).isEqualTo(1);
+    assertThat(filter.getTotalPages()).as("%d keys at 1%% must not fit one %d-byte page", keys, PAGE_SIZE)
+        .isGreaterThan(3);
+
+    for (int i = 0; i < keys; i++)
+      assertThat(filter.mightContain(7, 3, hash("key-" + i))).as("key %d", i).isTrue();
+  }
+
+  /**
+   * The rate the filter is sized for has to be the rate it delivers once the keys are spread over blocks; a routing
+   * that clumped keys into a few blocks would saturate them and quietly answer "maybe" to everything.
+   */
+  @Test
+  void theMeasuredFalsePositiveRateMatchesTheTarget() throws Exception {
+    final int keys = 40_000;
+    final LSMTreeIndexBloomFilter filter = newFilter("rate");
+    filter.publish(11, 5, hashes(keys, "present-"), keys, 0.01);
+
+    int falsePositives = 0;
+    final int probed = 100_000;
+    for (int i = 0; i < probed; i++)
+      if (filter.mightContain(11, 5, hash("absent-" + i)))
+        ++falsePositives;
+
+    assertThat((double) falsePositives / probed).as("measured false-positive rate over %d probes", probed)
+        .isLessThan(0.02);
+  }
+
+  /**
+   * The append-only invariant, which is what makes the file crash-safe and replicable: a publish appends its bits and
+   * then its directory, so the live directory is always the LAST page. HA ships a compaction as the page range each
+   * file grew by, and a directory rewritten in place would simply not travel.
+   */
+  @Test
+  void theDirectoryIsAlwaysTheLastPage() throws Exception {
+    final LSMTreeIndexBloomFilter filter = newFilter("append-only");
+
+    filter.publish(4, 2, hashes(5_000, "a-"), 5_000, 0.01);
+    final int afterFirst = filter.getTotalPages();
+    assertThat(readsAsDirectory(filter, afterFirst - 1)).isTrue();
+
+    filter.publish(40, 2, hashes(5_000, "b-"), 5_000, 0.01);
+    assertThat(filter.getTotalPages()).as("a publish only ever appends").isGreaterThan(afterFirst);
+    assertThat(readsAsDirectory(filter, filter.getTotalPages() - 1)).isTrue();
+
+    // ... and the pages the first publish wrote are untouched by the second.
+    filter.loadDirectory();
+    for (int i = 0; i < 5_000; i++)
+      assertThat(filter.mightContain(4, 2, hash("a-" + i))).as("key %d of the first series", i).isTrue();
+  }
+
+  /**
+   * A publish that got its bit pages to disk and died before its directory page leaves the file ending in pages no
+   * directory names. The load must walk past them to the previous complete directory rather than read a bit page as
+   * one - a random page mistaken for a directory would answer for pages it does not own, which is the one way this
+   * file could hide a row.
+   */
+  @Test
+  void aCrashBetweenTheBitsAndTheDirectoryFallsBackToThePreviousOne() throws Exception {
+    final LSMTreeIndexBloomFilter filter = newFilter("torn-publish");
+    filter.publish(4, 2, hashes(3_000, "a-"), 3_000, 0.01);
+
+    appendPage(filter, 0);          // a plausible bit page
+    appendPage(filter, 0x424C4F4D); // and one that even starts with the directory magic
+
+    filter.loadDirectory();
+
+    assertThat(filter.getPublishedFilters()).as("the previous directory must still be the live one").isEqualTo(1);
+    for (int i = 0; i < 3_000; i++)
+      assertThat(filter.mightContain(4, 2, hash("a-" + i))).as("key %d", i).isTrue();
+  }
+
+  private static boolean readsAsDirectory(final LSMTreeIndexBloomFilter filter, final int pageNumber) throws Exception {
+    return filter.readDirectoryPage(pageNumber) != null;
+  }
+
+  /** Appends a page of {@code fill} ints, standing in for what a crash leaves behind. */
+  private void appendPage(final LSMTreeIndexBloomFilter filter, final int fill) throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageNumber = filter.getTotalPages();
+    final MutablePage page = new MutablePage(new PageId(db, filter.getFileId(), pageNumber), PAGE_SIZE);
+    for (int i = 0; i < 128; i++)
+      page.writeInt(i * 4, fill == 0 ? 0x5A5A5A5A : fill);
+
+    db.getPageManager().updatePageVersion(page, true);
+    filter.updatePageCount(pageNumber + 1);
+    db.getPageManager().writePages(List.of(page), false);
+  }
+
+  /** A series with no filter must be searched, not skipped. */
+  @Test
+  void anUnknownSeriesIsAlwaysSearched() throws Exception {
+    final LSMTreeIndexBloomFilter filter = newFilter("unknown-series");
+    filter.publish(3, 2, hashes(100, "k-"), 100, 0.01);
+
+    assertThat(filter.mightContain(99, 2, hash("k-0"))).as("no filter for series 99").isTrue();
+  }
+
+  /**
+   * A rolled-back compaction round leaves its series pages unreachable and the NEXT round writes a DIFFERENT series
+   * over the same page numbers. A filter still claiming that root page would then filter the new series by the old
+   * one's keys - a false negative on everything the new series added. Two defences, both asserted here: the page count
+   * recorded with the filter must match the series the reader is looking at, and a rollback must drop the entry.
+   */
+  @Test
+  void aSeriesRewrittenAtTheSameRootPageIsNotFilteredByTheOldOne() throws Exception {
+    final LSMTreeIndexBloomFilter filter = newFilter("rollback");
+    filter.publish(40, 4, hashes(1_000, "old-"), 1_000, 0.01);
+
+    // Same root page, different series: a different page count is enough to disown the entry.
+    assertThat(filter.mightContain(40, 6, hash("new-1"))).as("a series of a different shape must be searched").isTrue();
+
+    filter.rollbackFrom(40);
+    assertThat(filter.getPublishedFilters()).isZero();
+    assertThat(filter.mightContain(40, 4, hash("old-1"))).as("a rolled-back filter must not answer any more").isTrue();
+  }
+
+  /** Only the series at or after the rolled-back page go: an earlier round's filters are still valid. */
+  @Test
+  void aRollbackKeepsTheFiltersOfEarlierRounds() throws Exception {
+    final LSMTreeIndexBloomFilter filter = newFilter("partial-rollback");
+    filter.publish(5, 2, hashes(500, "first-"), 500, 0.01);
+    filter.publish(50, 2, hashes(500, "second-"), 500, 0.01);
+
+    filter.rollbackFrom(50);
+
+    assertThat(filter.getPublishedFilters()).isEqualTo(1);
+    for (int i = 0; i < 500; i++)
+      assertThat(filter.mightContain(5, 2, hash("first-" + i))).as("key %d of the surviving series", i).isTrue();
+  }
+
+  /** What is written must be what is read back: the directory is the only thing a reopened database has. */
+  @Test
+  void theDirectoryReadsBackWhatWasWritten() throws Exception {
+    final int keys = 20_000;
+    final LSMTreeIndexBloomFilter filter = newFilter("reload");
+    filter.publish(9, 4, hashes(keys, "r-"), keys, 0.01);
+    filter.publish(90, 8, hashes(keys, "s-"), keys, 0.01);
+
+    filter.loadDirectory();
+    assertThat(filter.getPublishedFilters()).isEqualTo(2);
+
+    for (int i = 0; i < keys; i++) {
+      assertThat(filter.mightContain(9, 4, hash("r-" + i))).as("series 9, key %d", i).isTrue();
+      assertThat(filter.mightContain(90, 8, hash("s-" + i))).as("series 90, key %d", i).isTrue();
+    }
+  }
+
+  /** A single-key series is the degenerate case the sizing formulas have to survive. */
+  @Test
+  void aSeriesOfOneKeyStillWorks() throws Exception {
+    final LSMTreeIndexBloomFilter filter = newFilter("tiny");
+    filter.publish(2, 1, hashes(1, "only-"), 1, 0.01);
+
+    assertThat(filter.getPublishedFilters()).isEqualTo(1);
+    assertThat(filter.mightContain(2, 1, hash("only-0"))).isTrue();
+
+    int falsePositives = 0;
+    for (int i = 0; i < 10_000; i++)
+      if (filter.mightContain(2, 1, hash("other-" + i)))
+        ++falsePositives;
+    assertThat(falsePositives).as("a filter holding one key must reject nearly everything").isLessThan(200);
+  }
+}

--- a/engine/src/test/java/performance/LSMTreeBloomFilterBenchmark.java
+++ b/engine/src/test/java/performance/LSMTreeBloomFilterBenchmark.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package performance;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexBloomFilter;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What the per-series bloom filters of issue #5517 are actually worth on a point lookup, measured against the same
+ * database files with the filters consulted and ignored.
+ * <p>
+ * <b>The measurement has to be run in two cache regimes, or it lies.</b> The filters do not save instructions worth
+ * counting - they save PAGE READS, and a page read only costs anything when the page is not resident. With a cache
+ * large enough to hold the whole index the filters replace a cached read with a cached read and the speedup collapses
+ * to almost nothing; with a cache smaller than the index - which is every bulk load worth optimising - they replace a
+ * disk read with a read of a structure more than an order of magnitude smaller, which is the whole point. Reporting
+ * only one of the two would be a number chosen to flatter.
+ * <p>
+ * The workload is the one that motivated the issue: a UNIQUE index during a bulk load, where the duplicate check for
+ * every incoming record misses in every compacted series by definition. Lookups of keys that ARE present are measured
+ * too, because that is the case a filter cannot help and must not hurt.
+ * <p>
+ * Run with:
+ * {@code ./mvnw -pl engine -Dtest=LSMTreeBloomFilterBenchmark -Dgroups=benchmark test}
+ * <p>
+ * Knobs (all optional):
+ * {@code -Darcadedb.bloomBenchmark.entries=1000000}
+ * {@code -Darcadedb.bloomBenchmark.lookups=200000}
+ * {@code -Darcadedb.bloomBenchmark.smallCacheMB=32}
+ * {@code -Darcadedb.bloomBenchmark.largeCacheMB=4096}
+ * {@code -Darcadedb.bloomBenchmark.compactionRamMB=8}
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class LSMTreeBloomFilterBenchmark {
+  private static final String ENTRIES_PROPERTY         = "arcadedb.bloomBenchmark.entries";
+  private static final String LOOKUPS_PROPERTY         = "arcadedb.bloomBenchmark.lookups";
+  private static final String SMALL_CACHE_PROPERTY     = "arcadedb.bloomBenchmark.smallCacheMB";
+  private static final String LARGE_CACHE_PROPERTY     = "arcadedb.bloomBenchmark.largeCacheMB";
+  private static final String COMPACTION_RAM_PROPERTY  = "arcadedb.bloomBenchmark.compactionRamMB";
+
+  private static final int DEFAULT_ENTRIES        = 2_000_000;
+  private static final int DEFAULT_LOOKUPS        = 200_000;
+  private static final int DEFAULT_SMALL_CACHE_MB = 16;
+  private static final int DEFAULT_LARGE_CACHE_MB = 4_096;
+  private static final int DEFAULT_COMPACTION_RAM = 8;
+
+  private static final int    INSERT_BATCH  = 20_000;
+  private static final int    WARMUP        = 20_000;
+  private static final String TYPE_NAME     = "BloomBenchmarkRecord";
+  private static final String PROPERTY_NAME = "email";
+  private static final Path   ROOT          = Path.of("target", "databases", "LSMTreeBloomFilterBenchmark");
+
+  /**
+   * Present keys take the EVEN slots of the key space and absent keys the odd ones, so an absent key always falls
+   * BETWEEN two stored keys.
+   * <p>
+   * This is the whole experiment. A key outside a series' range is already ruled out by its root page, for free and
+   * without the filters, so absent keys drawn from their own prefix - the obvious way to write this - would measure
+   * nothing at all. A bulk load's duplicate checks land among the keys already stored, and that is the case where a
+   * series must otherwise be read to discover it does not hold the key.
+   */
+  private static String key(final int i) {
+    return "user-%09d@example.com".formatted(i * 2L);
+  }
+
+  private static String absentKey(final int i) {
+    return "user-%09d@example.com".formatted(i * 2L + 1);
+  }
+
+  private record Measurement(long absentNanos, long presentNanos, long absentPagesRead, long absentBytesRead,
+                             long presentPagesRead, long seriesSkipped, long seriesProbed, long effectiveCacheRAM,
+                             long observedCacheRAM) {
+    double absentLookupsPerSecond(final int lookups) {
+      return lookups / (absentNanos / 1_000_000_000d);
+    }
+
+    double presentLookupsPerSecond(final int lookups) {
+      return lookups / (presentNanos / 1_000_000_000d);
+    }
+  }
+
+  private record Layout(int series, long compactedBytes, long filterBytes, long keys) {
+  }
+
+  @Test
+  void filtersAgainstNoFiltersInBothCacheRegimes() throws Exception {
+    final int entries = Integer.getInteger(ENTRIES_PROPERTY, DEFAULT_ENTRIES);
+    final int lookups = Integer.getInteger(LOOKUPS_PROPERTY, DEFAULT_LOOKUPS);
+    final int smallCacheMB = Integer.getInteger(SMALL_CACHE_PROPERTY, DEFAULT_SMALL_CACHE_MB);
+    final int largeCacheMB = Integer.getInteger(LARGE_CACHE_PROPERTY, DEFAULT_LARGE_CACHE_MB);
+    final int compactionRamMB = Integer.getInteger(COMPACTION_RAM_PROPERTY, DEFAULT_COMPACTION_RAM);
+
+    FileUtils.deleteRecursively(ROOT.toFile());
+    final long buildStarted = System.nanoTime();
+    try {
+      final Layout layout = build(entries, compactionRamMB);
+      final double buildSeconds = seconds(System.nanoTime() - buildStarted);
+
+      // The control (filters ignored) runs first in each regime, so the treatment never inherits its warmup.
+      final Measurement smallOff = measure(smallCacheMB, false, entries, lookups);
+      final Measurement smallOn = measure(smallCacheMB, true, entries, lookups);
+      final Measurement largeOff = measure(largeCacheMB, false, entries, lookups);
+      final Measurement largeOn = measure(largeCacheMB, true, entries, lookups);
+
+      report(entries, lookups, smallCacheMB, largeCacheMB, buildSeconds, layout, smallOff, smallOn, largeOff, largeOn);
+
+      // Not an assertion about speed - hardware decides that - but about the filters being exercised at all. A run
+      // where nothing was skipped would print numbers that mean nothing.
+      assertThat(smallOn.seriesSkipped()).as("the filters must have skipped series in the constrained-cache run")
+          .isGreaterThan(0);
+      assertThat(smallOff.seriesSkipped()).as("no series may be skipped with the filters off").isZero();
+      assertThat(layout.series()).as("the benchmark needs several compacted series to be meaningful").isGreaterThan(1);
+
+    } finally {
+      FileUtils.deleteRecursively(ROOT.toFile());
+    }
+  }
+
+  /** Builds the database once, with the filters on, and compacts it into several series. */
+  private Layout build(final int entries, final int compactionRamMB) throws Exception {
+    restartPageManager(DEFAULT_LARGE_CACHE_MB);
+    GlobalConfiguration.INDEX_BLOOM_FILTER_RATE.setValue(0.01f);
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+    GlobalConfiguration.INDEX_COMPACTION_RAM_MB.setValue((long) compactionRamMB);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(ROOT.toString()); final Database database = factory.create()) {
+      final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+      type.createProperty(PROPERTY_NAME, Type.STRING);
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { PROPERTY_NAME })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+
+      for (int from = 0; from < entries; from += INSERT_BATCH) {
+        final int batchStart = from;
+        final int batchEnd = Math.min(entries, from + INSERT_BATCH);
+        database.transaction(() -> {
+          for (int i = batchStart; i < batchEnd; i++)
+            database.newDocument(TYPE_NAME).set(PROPERTY_NAME, key(i)).save();
+        });
+      }
+
+      final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties(PROPERTY_NAME).getFirst();
+      assertThat(((IndexInternal) typeIndex).scheduleCompaction()).isTrue();
+      assertThat(((IndexInternal) typeIndex).compact()).isTrue();
+
+      final LSMTreeIndexCompacted compacted = compactedOf(typeIndex);
+      final LSMTreeIndexBloomFilter filter = compacted.getBloomFilter();
+      assertThat(filter).as("the build must have produced a bloom filter file").isNotNull();
+
+      return new Layout(compacted.getSeriesCount(), compacted.getOSFile().length(), filter.getOSFile().length(), entries);
+    }
+  }
+
+  /**
+   * One timed pass over a freshly started page manager, so the cache begins empty and the regime under test is the
+   * only thing that decides what stays resident.
+   */
+  private Measurement measure(final int cacheMB, final boolean filtersEnabled, final int entries, final int lookups)
+      throws Exception {
+    restartPageManager(cacheMB);
+    GlobalConfiguration.INDEX_BLOOM_FILTER_RATE.setValue(filtersEnabled ? 0.01f : 0f);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(ROOT.toString()); final Database database = factory.open()) {
+      final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties(PROPERTY_NAME).getFirst();
+      final LSMTreeIndexCompacted compacted = compactedOf(typeIndex);
+
+      assertThat(compacted.getBloomFilter() != null).as("filters attached when enabled=%s", filtersEnabled)
+          .isEqualTo(filtersEnabled);
+
+      // Warm the JIT and let the cache reach the steady state this regime allows.
+      final int[] warmupOrder = probeOrder(entries, WARMUP);
+      for (final int position : warmupOrder)
+        drain(typeIndex.get(new Object[] { absentKey(position) }));
+
+      final long skippedBefore = compacted.getBloomSkippedSeries();
+      final long probedBefore = compacted.getBloomProbedSeries();
+
+      final int[] order = probeOrder(entries, lookups);
+
+      // Each phase gets its own page counters: the present-key phase HAS to read data pages, so folding both into one
+      // number would hide whatever the absent-key phase - the one the filters exist for - actually saved.
+      long pagesBefore = PageManager.INSTANCE.getStats().pagesRead;
+      long bytesBefore = PageManager.INSTANCE.getStats().pagesReadSize;
+      final long absentStarted = System.nanoTime();
+      for (final int position : order)
+        drain(typeIndex.get(new Object[] { absentKey(position) }));
+      final long absentNanos = System.nanoTime() - absentStarted;
+      final long absentPagesRead = PageManager.INSTANCE.getStats().pagesRead - pagesBefore;
+      final long absentBytesRead = PageManager.INSTANCE.getStats().pagesReadSize - bytesBefore;
+      // What was RESIDENT when the phase ended, not what was configured. PageManager.checkForPageDisposal() runs at
+      // most once every 100 ms, so on a read-only workload this fast the cache overshoots its maximum freely between
+      // sweeps - reporting the configured number alone would describe a regime the run never had.
+      final long observedCacheRAM = PageManager.INSTANCE.getStats().readCacheRAM;
+
+      pagesBefore = PageManager.INSTANCE.getStats().pagesRead;
+      final long presentStarted = System.nanoTime();
+      for (final int position : order)
+        drain(typeIndex.get(new Object[] { key(position) }));
+      final long presentNanos = System.nanoTime() - presentStarted;
+      final long presentPagesRead = PageManager.INSTANCE.getStats().pagesRead - pagesBefore;
+
+      return new Measurement(absentNanos, presentNanos, absentPagesRead, absentBytesRead, presentPagesRead,
+          compacted.getBloomSkippedSeries() - skippedBefore, compacted.getBloomProbedSeries() - probedBefore,
+          PageManager.INSTANCE.getStats().maxRAM, observedCacheRAM);
+    }
+  }
+
+  private void report(final int entries, final int lookups, final int smallCacheMB, final int largeCacheMB,
+      final double buildSeconds, final Layout layout, final Measurement smallOff, final Measurement smallOn,
+      final Measurement largeOff, final Measurement largeOn) {
+    System.out.printf(Locale.ROOT, """
+
+            LSM index bloom filter benchmark (#5517)
+            ----------------------------------------
+            entries              : %,d (unique index, 1 bucket)
+            compacted series     : %d
+            compacted index      : %s
+            bloom filter file    : %s  (%.2f bytes/key, %.1f%% of the index)
+            build + compaction   : %.1f s
+            lookups per timing   : %,d
+
+            CONSTRAINED CACHE - asked for %d MB (limit %s, actually resident %s) against a %s index
+              %s
+              absent  lookups  off %,12.0f/s  on %,12.0f/s   %.2fx
+              absent  pages    off %,12d    on %,12d    %.2fx fewer
+              absent  bytes    off %12s    on %12s
+              present lookups  off %,12.0f/s  on %,12.0f/s   %.2fx
+              present pages    off %,12d    on %,12d
+              series           %,d skipped of %,d probed
+
+            RESIDENT CACHE - %d MB, the whole index fits
+              absent  lookups  off %,12.0f/s  on %,12.0f/s   %.2fx
+              absent  pages    off %,12d    on %,12d
+              present lookups  off %,12.0f/s  on %,12.0f/s   %.2fx
+              series           %,d skipped of %,d probed
+
+            How to read this. The ABSENT rows are the experiment - a bulk load's duplicate check, which by
+            definition misses in every series. PRESENT is the control the filters cannot help and must not hurt.
+            Compare the two cache regimes to separate the two effects: whatever speedup survives with the whole
+            index RESIDENT is CPU (root and leaf binary searches not performed); whatever the CONSTRAINED regime
+            adds on top of that is avoided I/O, and it grows with the ratio of index size to cache.
+
+            """,
+        entries, layout.series(), FileUtils.getSizeAsString(layout.compactedBytes()),
+        FileUtils.getSizeAsString(layout.filterBytes()), layout.filterBytes() / (double) layout.keys(),
+        100d * layout.filterBytes() / layout.compactedBytes(), buildSeconds, lookups,
+
+        smallCacheMB, FileUtils.getSizeAsString(smallOn.effectiveCacheRAM()),
+        FileUtils.getSizeAsString(smallOn.observedCacheRAM()), FileUtils.getSizeAsString(layout.compactedBytes()),
+        smallOn.observedCacheRAM() < layout.compactedBytes() ?
+            "the index does NOT fit, as in a bulk load" :
+            "NOTE: the index ended up fully resident anyway (the page cache is swept at most every 100ms and "
+                + "overshoots its limit in between), so these rows measure mostly CPU - raise -D" + ENTRIES_PROPERTY,
+        smallOff.absentLookupsPerSecond(lookups), smallOn.absentLookupsPerSecond(lookups),
+        smallOn.absentLookupsPerSecond(lookups) / smallOff.absentLookupsPerSecond(lookups),
+        smallOff.absentPagesRead(), smallOn.absentPagesRead(),
+        smallOn.absentPagesRead() == 0 ? 0d : smallOff.absentPagesRead() / (double) smallOn.absentPagesRead(),
+        FileUtils.getSizeAsString(smallOff.absentBytesRead()), FileUtils.getSizeAsString(smallOn.absentBytesRead()),
+        smallOff.presentLookupsPerSecond(lookups), smallOn.presentLookupsPerSecond(lookups),
+        smallOn.presentLookupsPerSecond(lookups) / smallOff.presentLookupsPerSecond(lookups),
+        smallOff.presentPagesRead(), smallOn.presentPagesRead(),
+        smallOn.seriesSkipped(), smallOn.seriesSkipped() + smallOn.seriesProbed(),
+
+        largeCacheMB,
+        largeOff.absentLookupsPerSecond(lookups), largeOn.absentLookupsPerSecond(lookups),
+        largeOn.absentLookupsPerSecond(lookups) / largeOff.absentLookupsPerSecond(lookups),
+        largeOff.absentPagesRead(), largeOn.absentPagesRead(),
+        largeOff.presentLookupsPerSecond(lookups), largeOn.presentLookupsPerSecond(lookups),
+        largeOn.presentLookupsPerSecond(lookups) / largeOff.presentLookupsPerSecond(lookups),
+        largeOn.seriesSkipped(), largeOn.seriesSkipped() + largeOn.seriesProbed());
+  }
+
+  private static LSMTreeIndexCompacted compactedOf(final TypeIndex typeIndex) {
+    final LSMTreeIndex bucketIndex = (LSMTreeIndex) typeIndex.getIndexesOnBuckets()[0];
+    return bucketIndex.getMutableIndex().getSubIndex();
+  }
+
+  /**
+   * Tears the page manager down and back up so the next open starts with an empty cache of {@code cacheMB}. The size
+   * is read once at startup, so without this every regime after the first would silently run at the first one's size.
+   */
+  private static void restartPageManager(final int cacheMB) {
+    PageManager.INSTANCE.close();
+    GlobalConfiguration.MAX_PAGE_RAM.setValue((long) cacheMB);
+  }
+
+  /**
+   * {@code count} positions spread over the key space in a fixed pseudo-random order, identical for every run.
+   * <p>
+   * Order matters as much as the keys do. Ascending probes hit the same index page thousands of times in a row, so
+   * everything stays cached and the measurement quietly turns into a CPU benchmark whatever the cache size says. The
+   * duplicate checks of a load keyed by anything but a counter - an email, a UUID, a business id - arrive in no useful
+   * order, and that is when a page has to be fetched to answer a question the filter answers from RAM.
+   */
+  private static int[] probeOrder(final int entries, final int count) {
+    final Random random = new Random(0x5117);
+    final int[] order = new int[count];
+    for (int i = 0; i < count; i++)
+      order[i] = random.nextInt(entries);
+    return order;
+  }
+
+  private static void drain(final IndexCursor cursor) {
+    try {
+      while (cursor.hasNext())
+        cursor.next();
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static double seconds(final long nanos) {
+    return nanos / 1_000_000_000d;
+  }
+}

--- a/engine/src/test/java/performance/LSMTreeBloomFilterBenchmark.java
+++ b/engine/src/test/java/performance/LSMTreeBloomFilterBenchmark.java
@@ -168,12 +168,21 @@ class LSMTreeBloomFilterBenchmark {
       database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { PROPERTY_NAME })
           .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
 
+      // Insert in a PERMUTED key order, not ascending.
+      //
+      // A compaction round slices the mutable pages by RAM, and mutable pages fill in insertion order - so if keys
+      // arrive ascending, every series ends up owning a disjoint slice of the key space and a series' root page alone
+      // rules out almost every lookup, for free. That is the shape of a load keyed by a counter or a timestamp, and
+      // the one where these filters have least to offer. A load keyed by an email, a UUID or any business id arrives
+      // in no key order at all, every series spans the whole range, and the root page rules out nothing - which is the
+      // workload #5470 reported and the one this measures.
+      final int stride = permutationStride(entries);
       for (int from = 0; from < entries; from += INSERT_BATCH) {
         final int batchStart = from;
         final int batchEnd = Math.min(entries, from + INSERT_BATCH);
         database.transaction(() -> {
           for (int i = batchStart; i < batchEnd; i++)
-            database.newDocument(TYPE_NAME).set(PROPERTY_NAME, key(i)).save();
+            database.newDocument(TYPE_NAME).set(PROPERTY_NAME, key((int) ((long) i * stride % entries))).save();
         });
       }
 
@@ -203,7 +212,7 @@ class LSMTreeBloomFilterBenchmark {
       final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties(PROPERTY_NAME).getFirst();
       final LSMTreeIndexCompacted compacted = compactedOf(typeIndex);
 
-      assertThat(compacted.getBloomFilter() != null).as("filters attached when enabled=%s", filtersEnabled)
+      assertThat(compacted.isBloomFilterEnabled()).as("filters consulted when enabled=%s", filtersEnabled)
           .isEqualTo(filtersEnabled);
 
       // Warm the JIT and let the cache reach the steady state this regime allows.
@@ -273,11 +282,15 @@ class LSMTreeBloomFilterBenchmark {
               present lookups  off %,12.0f/s  on %,12.0f/s   %.2fx
               series           %,d skipped of %,d probed
 
-            How to read this. The ABSENT rows are the experiment - a bulk load's duplicate check, which by
-            definition misses in every series. PRESENT is the control the filters cannot help and must not hurt.
+            How to read this. ABSENT is a bulk load's duplicate check, which by definition misses in every series.
+            PRESENT still gains, because a key lives in ONE series and the filters spare the reader the others -
+            the gain is smaller only because that one series must be read whatever happens.
             Compare the two cache regimes to separate the two effects: whatever speedup survives with the whole
             index RESIDENT is CPU (root and leaf binary searches not performed); whatever the CONSTRAINED regime
             adds on top of that is avoided I/O, and it grows with the ratio of index size to cache.
+            Both depend on series' key ranges OVERLAPPING, which is what a business-keyed load produces. Keys that
+            arrive already ascending give each series a disjoint slice that its root page alone rules out, and
+            there the filters have little left to save - see the permuted insertion order above.
 
             """,
         entries, layout.series(),
@@ -348,6 +361,18 @@ class LSMTreeBloomFilterBenchmark {
     } finally {
       cursor.close();
     }
+  }
+
+  /** A stride coprime with {@code entries}, so {@code i * stride % entries} walks every key exactly once. */
+  private static int permutationStride(final int entries) {
+    int stride = Math.max(1, entries / 3 + 1);
+    while (gcd(stride, entries) != 1)
+      ++stride;
+    return stride;
+  }
+
+  private static int gcd(final int a, final int b) {
+    return b == 0 ? a : gcd(b, a % b);
   }
 
   private static double seconds(final long nanos) {

--- a/engine/src/test/java/performance/LSMTreeBloomFilterBenchmark.java
+++ b/engine/src/test/java/performance/LSMTreeBloomFilterBenchmark.java
@@ -117,7 +117,8 @@ class LSMTreeBloomFilterBenchmark {
     }
   }
 
-  private record Layout(int series, long compactedBytes, long filterBytes, long keys) {
+  private record Layout(int series, long compactedBytes, int compactedPages, int compactedPageSize,
+                        long filterBytes, int filterPages, int filterPageSize, long keys) {
   }
 
   @Test
@@ -184,7 +185,8 @@ class LSMTreeBloomFilterBenchmark {
       final LSMTreeIndexBloomFilter filter = compacted.getBloomFilter();
       assertThat(filter).as("the build must have produced a bloom filter file").isNotNull();
 
-      return new Layout(compacted.getSeriesCount(), compacted.getOSFile().length(), filter.getOSFile().length(), entries);
+      return new Layout(compacted.getSeriesCount(), compacted.getOSFile().length(), compacted.getTotalPages(),
+          compacted.getPageSize(), filter.getOSFile().length(), filter.getTotalPages(), filter.getPageSize(), entries);
     }
   }
 
@@ -251,8 +253,8 @@ class LSMTreeBloomFilterBenchmark {
             ----------------------------------------
             entries              : %,d (unique index, 1 bucket)
             compacted series     : %d
-            compacted index      : %s
-            bloom filter file    : %s  (%.2f bytes/key, %.1f%% of the index)
+            compacted index      : %s in %,d pages of %,d B
+            bloom filter file    : %s in %,d pages of %,d B  (%.2f bytes/key, %.1f%% of the index)
             build + compaction   : %.1f s
             lookups per timing   : %,d
 
@@ -278,8 +280,10 @@ class LSMTreeBloomFilterBenchmark {
             adds on top of that is avoided I/O, and it grows with the ratio of index size to cache.
 
             """,
-        entries, layout.series(), FileUtils.getSizeAsString(layout.compactedBytes()),
-        FileUtils.getSizeAsString(layout.filterBytes()), layout.filterBytes() / (double) layout.keys(),
+        entries, layout.series(),
+        FileUtils.getSizeAsString(layout.compactedBytes()), layout.compactedPages(), layout.compactedPageSize(),
+        FileUtils.getSizeAsString(layout.filterBytes()), layout.filterPages(), layout.filterPageSize(),
+        layout.filterBytes() / (double) layout.keys(),
         100d * layout.filterBytes() / layout.compactedBytes(), buildSeconds, lookups,
 
         smallCacheMB, FileUtils.getSizeAsString(smallOn.effectiveCacheRAM()),

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5517BloomFilterFullCompactionIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5517BloomFilterFullCompactionIT.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexBloomFilter;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A FULL compaction is the other half of the replication story, and the destructive half.
+ * <p>
+ * An incremental round appends to files every node already holds. A full round instead merges every series into a
+ * BRAND NEW compacted file, retires the old one, and drops it - so the leader must ship two new files (the compacted
+ * index and its filters), the followers must drop two old ones, and every node has to end up with a filter directory
+ * describing the single surviving series. Three ways that could go wrong and stay silent:
+ * <ul>
+ *   <li>the new {@code .bfidx} never ships, and followers lose their filters until the next round;</li>
+ *   <li>the old {@code .bfidx} is never dropped on the followers, leaking a file per full compaction that the next
+ *   open has to sweep;</li>
+ *   <li>worst, the old directory somehow survives against the new compacted file, whose series sits at root page 0
+ *   just like the old one's first series did - the reused-position case the entry's page count and last-page
+ *   fingerprint exist to catch.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue5517BloomFilterFullCompactionIT extends BaseRaftHATest {
+  private static final int    FIRST_BATCH  = 20_000;
+  private static final int    SECOND_BATCH = 20_000;
+  private static final int    THIRD_BATCH  = 20_000;
+  private static final int    TX_CHUNK     = 250;
+  private static final String TYPE_NAME    = "Address";
+  private static final String INDEX_NAME   = "Address[uid]";
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 30_000L);
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    // Each incremental round appends one series; at 2 the NEXT round is a full one. Series are accumulated by
+    // compacting repeatedly rather than by starving the compaction of RAM, because a full merge that does not fit its
+    // RAM budget silently falls back to another incremental round - and this test would then prove nothing.
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_FULL_SERIES, 2);
+    config.setValue(GlobalConfiguration.INDEX_BLOOM_FILTER_RATE, 0.01f);
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Override
+  protected void checkDatabasesAreIdentical() {
+    // Compacted file names embed a per-node nanoTime, so the comparator cannot pair bucket indexes by name after a
+    // compaction. What must be equal is asserted in the test body.
+  }
+
+  @Test
+  public void aFullCompactionShipsTheNewFiltersAndDropsTheOld() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leader = getServerDatabase(leaderIndex, getDatabaseName());
+    final VertexType type = leader.getSchema().buildVertexType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("uid", String.class);
+    leader.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, "uid");
+
+    // ROUNDS 1 and 2 - incremental, one series each.
+    insert(leader, 0, FIRST_BATCH);
+    compact(leader);
+    insert(leader, FIRST_BATCH, FIRST_BATCH + SECOND_BATCH);
+    compact(leader);
+    awaitReplication();
+
+    final Map<Integer, File> filtersBefore = new HashMap<>();
+    final Map<Integer, Integer> compactedFileIdsBefore = new HashMap<>();
+    testEachServer(serverIndex -> {
+      final LSMTreeIndexCompacted compacted = compactedOf(indexOn(serverIndex));
+      assertThat(compacted.getSeriesCount())
+          .as("server %d needs several series for the next round to merge", serverIndex).isGreaterThan(1);
+      assertThat(compacted.getBloomFilter()).as("server %d must have filters before the full round", serverIndex)
+          .isNotNull();
+      filtersBefore.put(serverIndex, compacted.getBloomFilter().getOSFile());
+      compactedFileIdsBefore.put(serverIndex, compacted.getFileId());
+    });
+
+    // Set the threshold on the leader's own database: the server-level configuration does not reach the value
+    // isFullCompactionDue() reads, so relying on onServerConfiguration alone leaves it at the default of 10 and the
+    // round below stays incremental - which is exactly how the first version of this test passed nothing.
+    leader.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_FULL_SERIES, 2);
+
+    // ROUND 3 - full: every series merges into a NEW file holding ONE, and the old file is retired.
+    insert(leader, FIRST_BATCH + SECOND_BATCH, FIRST_BATCH + SECOND_BATCH + THIRD_BATCH);
+    compact(leader);
+    awaitReplication();
+
+    final int totalRecords = FIRST_BATCH + SECOND_BATCH + THIRD_BATCH;
+    testEachServer(serverIndex -> {
+      final Database database = getServerDatabase(serverIndex, getDatabaseName());
+      final Index index = indexOn(serverIndex);
+      final LSMTreeIndexCompacted compacted = compactedOf((TypeIndex) index);
+
+      assertThat(compacted.getFileId())
+          .as("server %d must be on the NEW compacted file, i.e. the round really was full", serverIndex)
+          .isNotEqualTo(compactedFileIdsBefore.get(serverIndex));
+      assertThat(compacted.getSeriesCount())
+          .as("a full compaction merges every series into one, on server %d", serverIndex).isEqualTo(1);
+
+      assertThat(database.countType(TYPE_NAME, false))
+          .as("every record must be on server %d", serverIndex).isEqualTo(totalRecords);
+      assertThat(index.countEntries())
+          .as("server %d must hold the WHOLE index after the full compaction", serverIndex).isEqualTo(totalRecords);
+
+      final LSMTreeIndexBloomFilter filter = compacted.getBloomFilter();
+      assertThat(filter).as("server %d must have received the NEW filter file", serverIndex).isNotNull();
+      assertThat(filter.getOSFile())
+          .as("server %d must be reading a different filter file than before the full round", serverIndex)
+          .isNotEqualTo(filtersBefore.get(serverIndex));
+      assertThat(filter.getPublishedFilters())
+          .as("server %d must have a filter for the one surviving series", serverIndex).isEqualTo(1);
+
+      // The gate, on the node that received the file rather than the one that wrote it.
+      for (int i = 0; i < totalRecords; i++)
+        assertThat(index.get(new Object[] { uid(i) }).hasNext())
+            .as("key %d must be findable on server %d after the full compaction", i, serverIndex).isTrue();
+
+      final long skippedBefore = compacted.getBloomSkippedSeries();
+      for (int i = 0; i < 2_000; i++)
+        assertThat(index.get(new Object[] { absentUid(i) }).hasNext())
+            .as("absent key %d must not be found on server %d", i, serverIndex).isFalse();
+      assertThat(compacted.getBloomSkippedSeries() - skippedBefore)
+          .as("server %d must be USING the replicated filters", serverIndex).isGreaterThan(0);
+
+      // The old filter file must go with the compacted file it described - on the FOLLOWERS too, which never ran the
+      // compaction and only saw it as a file to remove. One leaked file per full compaction would accumulate.
+      assertThat(filtersBefore.get(serverIndex))
+          .as("the retired filter file must be dropped on server %d", serverIndex).doesNotExist();
+
+      assertThat(bloomFilterFilesOnDisk(serverIndex))
+          .as("server %d must keep exactly one filter file, for its one bucket index", serverIndex).isEqualTo(1);
+    });
+  }
+
+  private int bloomFilterFilesOnDisk(final int serverIndex) {
+    final String[] files = new File(getDatabasePath(serverIndex)).list((dir, name) -> name.endsWith(".bfidx"));
+    return files == null ? 0 : files.length;
+  }
+
+  private TypeIndex indexOn(final int serverIndex) {
+    return (TypeIndex) getServerDatabase(serverIndex, getDatabaseName()).getSchema().getIndexByName(INDEX_NAME);
+  }
+
+  private void insert(final Database database, final int from, final int to) {
+    for (int start = from; start < to; start += TX_CHUNK) {
+      final int batchStart = start;
+      database.transaction(() -> {
+        for (int i = batchStart; i < Math.min(batchStart + TX_CHUNK, to); i++)
+          database.newVertex(TYPE_NAME).set("uid", uid(i)).save();
+      });
+    }
+  }
+
+  private static void compact(final Database database) throws Exception {
+    final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName(INDEX_NAME);
+    assertThat(index.scheduleCompaction()).as("the index must be schedulable for compaction").isTrue();
+    assertThat(index.compact()).as("the compaction must run on the leader").isTrue();
+  }
+
+  private void awaitReplication() throws Exception {
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+  }
+
+  private static LSMTreeIndexCompacted compactedOf(final TypeIndex index) {
+    return ((LSMTreeIndex) index.getIndexesOnBuckets()[0]).getMutableIndex().getSubIndex();
+  }
+
+  /** High-entropy key so the compacted index does not compress away to a trivial size. */
+  private static String uid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-" + i;
+  }
+
+  /** Never inserted, but sorts AMONG the stored keys, so only a filter can rule it out. */
+  private static String absentUid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-absent-" + i;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5517BloomFilterReplicationIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5517BloomFilterReplicationIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexBloomFilter;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The per-series bloom filters of #5517 live in a {@link LSMTreeIndexBloomFilter} component precisely so that they
+ * travel the way the compacted pages they describe travel. This test is what makes that claim more than an argument.
+ * <p>
+ * A follower never runs a compaction of its own - {@code runWithCompactionReplication} refuses on a non-leader - so it
+ * receives the filter file the same way it receives the compacted index: as a new file shipped whole in a SCHEMA_ENTRY,
+ * and thereafter as the page range that file GREW by. The second half is why the component is append-only, and it is
+ * the half a single-compaction test would never reach: the first round CREATES the file (every page ships), only a
+ * later incremental round APPENDS to it.
+ * <p>
+ * What has to hold on every node, leader or follower:
+ * <ul>
+ *   <li>the filter file is there and describes every published series;</li>
+ *   <li>every key is still findable THROUGH those filters - a filter that arrived truncated or stale would hide rows
+ *   on that node alone, silently, while the records themselves replicated perfectly;</li>
+ *   <li>and the filters are actually consulted, or the first two prove nothing.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue5517BloomFilterReplicationIT extends BaseRaftHATest {
+  private static final int    FIRST_BATCH  = 40_000;
+  private static final int    SECOND_BATCH = 40_000;
+  private static final int    TX_CHUNK     = 250;
+  private static final String TYPE_NAME    = "Address";
+  private static final String INDEX_NAME   = "Address[uid]";
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 30_000L);
+    // Only the explicit compactions below may run, or an assertion could race a background round.
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+    // Force a RAM-bounded merge so one round emits SEVERAL series, each with its own filter.
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_RAM_MB, 1L);
+    // Never turn a compaction into a full one: this test is about the INCREMENTAL round, which appends to a file the
+    // followers already have.
+    config.setValue(GlobalConfiguration.INDEX_COMPACTION_FULL_SERIES, 0);
+    config.setValue(GlobalConfiguration.INDEX_BLOOM_FILTER_RATE, 0.01f);
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Override
+  protected void checkDatabasesAreIdentical() {
+    // A compaction replaces the mutable index file and its name embeds a per-node nanoTime, so the comparator's
+    // pair-bucket-indexes-by-name check cannot pass. What must be equal is asserted below instead.
+  }
+
+  @Test
+  public void theFiltersReachEveryNodeAndHideNothing() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leader = getServerDatabase(leaderIndex, getDatabaseName());
+    final VertexType type = leader.getSchema().buildVertexType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("uid", String.class);
+    leader.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, "uid");
+
+    // ROUND 1 - creates the compacted file and, with it, the filter file. Followers receive both whole.
+    insert(leader, 0, FIRST_BATCH);
+    compact(leader);
+    awaitReplication();
+    assertEveryNodeHoldsCompleteFilters("after the compaction that CREATED the filter file", FIRST_BATCH);
+
+    // ROUND 2 - an incremental round APPENDS a series to files the followers already hold, so only the grown page
+    // range ships. A directory rewritten in place would stop here: the followers would keep the round-1 directory and
+    // never see the new series' filter.
+    insert(leader, FIRST_BATCH, FIRST_BATCH + SECOND_BATCH);
+    compact(leader);
+    awaitReplication();
+    assertEveryNodeHoldsCompleteFilters("after the incremental round that APPENDED to it", FIRST_BATCH + SECOND_BATCH);
+  }
+
+  /**
+   * Every node must hold the whole index, a filter for every series, and answer every key through them.
+   */
+  private void assertEveryNodeHoldsCompleteFilters(final String stage, final int totalRecords) throws Exception {
+    testEachServer(serverIndex -> {
+      final Database database = getServerDatabase(serverIndex, getDatabaseName());
+
+      assertThat(database.countType(TYPE_NAME, false))
+          .as("every record must replicate to server %d %s", serverIndex, stage).isEqualTo(totalRecords);
+
+      final Index index = database.getSchema().getIndexByName(INDEX_NAME);
+      assertThat(index.countEntries())
+          .as("server %d must hold the WHOLE index %s", serverIndex, stage).isEqualTo(totalRecords);
+
+      final LSMTreeIndexCompacted compacted = compactedOf((TypeIndex) index);
+      assertThat(compacted).as("server %d must have a compacted sub-index %s", serverIndex, stage).isNotNull();
+
+      final LSMTreeIndexBloomFilter filter = compacted.getBloomFilter();
+      assertThat(filter).as("server %d must have received the bloom filter file %s", serverIndex, stage).isNotNull();
+      assertThat(filter.getPublishedFilters())
+          .as("server %d must have a filter for EVERY series %s (a directory that did not travel would be short here)",
+              serverIndex, stage)
+          .isEqualTo(compacted.getSeriesCount());
+
+      // The gate. A filter that arrived truncated, stale, or built for a different series would hide rows on this node
+      // alone, while the records themselves replicated perfectly - so this has to be checked THROUGH the filters, on
+      // the node that received them, over the whole key range.
+      for (int i = 0; i < totalRecords; i++)
+        assertThat(index.get(new Object[] { uid(i) }).hasNext())
+            .as("key %d must be findable on server %d %s", i, serverIndex, stage).isTrue();
+
+      // ... and the filters must be doing something, or the assertion above would pass just as well without them.
+      final long skippedBefore = compacted.getBloomSkippedSeries();
+      for (int i = 0; i < 2_000; i++)
+        assertThat(index.get(new Object[] { absentUid(i) }).hasNext())
+            .as("absent key %d must not be found on server %d %s", i, serverIndex, stage).isFalse();
+
+      assertThat(compacted.getBloomSkippedSeries() - skippedBefore)
+          .as("server %d must actually be USING the replicated filters %s", serverIndex, stage).isGreaterThan(0);
+    });
+  }
+
+  private void insert(final Database database, final int from, final int to) {
+    for (int start = from; start < to; start += TX_CHUNK) {
+      final int batchStart = start;
+      database.transaction(() -> {
+        for (int i = batchStart; i < Math.min(batchStart + TX_CHUNK, to); i++)
+          database.newVertex(TYPE_NAME).set("uid", uid(i)).save();
+      });
+    }
+  }
+
+  private static void compact(final Database database) throws Exception {
+    final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName(INDEX_NAME);
+    assertThat(index.scheduleCompaction()).as("the index must be schedulable for compaction").isTrue();
+    assertThat(index.compact()).as("the compaction must run on the leader").isTrue();
+  }
+
+  private void awaitReplication() throws Exception {
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+  }
+
+  private static LSMTreeIndexCompacted compactedOf(final TypeIndex index) {
+    return ((LSMTreeIndex) index.getIndexesOnBuckets()[0]).getMutableIndex().getSubIndex();
+  }
+
+  /** High-entropy key so the compacted index does not compress away to a trivial size. */
+  private static String uid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-" + i;
+  }
+
+  /**
+   * A key that was never inserted but sorts AMONG the stored ones, so the series' root page cannot rule it out and the
+   * filter is the only thing that can. Drawing absent keys from their own prefix would leave every one of them outside
+   * every series' range, where no filter is ever consulted.
+   */
+  private static String absentUid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-absent-" + i;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue5517BloomFilterBackupIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue5517BloomFilterBackupIT.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.backup;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexBloomFilter;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.integration.restore.Restore;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A backup has to carry the bloom filter component (#5517), and a restore has to give it back attached.
+ * <p>
+ * The filter file is a {@code PaginatedComponent} so the backup enumerates it with everything else - but "it is a
+ * component, so it travels" is an argument, and this is the case where being wrong is quiet. Two distinct ways it
+ * could fail: the {@code .bfidx} is simply not in the archive, so the restored index reads every series (slower, still
+ * correct); or it is restored but no longer resolves to its compacted index, in which case the orphan sweep at open
+ * DELETES it as unreferenced - a file silently thrown away on every restore.
+ * <p>
+ * Neither shows up in a comparison of the two databases' contents, which is what the existing backup tests check.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5517BloomFilterBackupIT {
+  private static final String SOURCE_PATH   = "target/databases/Issue5517BloomFilterBackup";
+  private static final String RESTORED_PATH = "target/databases/Issue5517BloomFilterBackup_restored";
+  private static final String BACKUP_FILE   = "target/Issue5517BloomFilterBackup.zip";
+  private static final String TYPE_NAME     = "Doc";
+  private static final int    TOTAL_KEYS    = 40_000;
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    FileUtils.deleteRecursively(new File(SOURCE_PATH));
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    new File(BACKUP_FILE).delete();
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.reset();
+    GlobalConfiguration.INDEX_COMPACTION_RAM_MB.reset();
+    GlobalConfiguration.INDEX_BLOOM_FILTER_RATE.reset();
+  }
+
+  @Test
+  void aRestoredDatabaseKeepsItsFiltersAndUsesThem() throws Exception {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+    GlobalConfiguration.INDEX_COMPACTION_RAM_MB.setValue(1L);
+    GlobalConfiguration.INDEX_BLOOM_FILTER_RATE.setValue(0.01f);
+
+    final int series;
+    final int publishedFilters;
+    final String filterFileName;
+
+    try (final DatabaseFactory factory = new DatabaseFactory(SOURCE_PATH); final Database database = factory.create()) {
+      final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+      type.createProperty("uid", String.class);
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "uid" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+
+      database.transaction(() -> {
+        for (int i = 0; i < TOTAL_KEYS; i++)
+          database.newDocument(TYPE_NAME).set("uid", uid(i)).save();
+      });
+
+      final TypeIndex index = database.getSchema().getType(TYPE_NAME).getIndexesByProperties("uid").getFirst();
+      assertThat(((IndexInternal) index).scheduleCompaction()).isTrue();
+      assertThat(((IndexInternal) index).compact()).isTrue();
+
+      final LSMTreeIndexCompacted compacted = compactedOf(index);
+      final LSMTreeIndexBloomFilter filter = compacted.getBloomFilter();
+      assertThat(filter).as("the source database must have filters to begin with").isNotNull();
+
+      series = compacted.getSeriesCount();
+      publishedFilters = filter.getPublishedFilters();
+      filterFileName = filter.getOSFile().getName();
+      assertThat(publishedFilters).isEqualTo(series);
+
+      new Backup(database, BACKUP_FILE).backupDatabase();
+    }
+
+    assertThat(new File(BACKUP_FILE)).exists();
+
+    new Restore(BACKUP_FILE, RESTORED_PATH).restoreDatabase();
+
+    // Opened READ_WRITE on purpose: that is the mode that runs the orphan sweep, so a filter whose owner no longer
+    // resolves after the restore would be deleted here rather than merely ignored.
+    try (final DatabaseFactory factory = new DatabaseFactory(RESTORED_PATH); final Database restored = factory.open()) {
+      assertThat(new File(RESTORED_PATH, filterFileName))
+          .as("the backup must carry the bloom filter file, and the restore must keep it").exists();
+
+      final TypeIndex index = restored.getSchema().getType(TYPE_NAME).getIndexesByProperties("uid").getFirst();
+      final LSMTreeIndexCompacted compacted = compactedOf(index);
+
+      assertThat(compacted.getSeriesCount()).as("the restored index must have the same series").isEqualTo(series);
+      assertThat(compacted.getBloomFilter())
+          .as("the restored filter file must resolve back to its compacted index, not be swept as an orphan")
+          .isNotNull();
+      assertThat(compacted.getBloomFilter().getPublishedFilters())
+          .as("the restored directory must describe every series").isEqualTo(publishedFilters);
+
+      // The gate: every key still answerable THROUGH the restored filters.
+      for (int i = 0; i < TOTAL_KEYS; i++)
+        assertThat(get(index, uid(i))).as("key %d must be findable after the restore", i).isTrue();
+
+      // ... and they must be doing something, or the assertion above would hold just as well without them.
+      final long skippedBefore = compacted.getBloomSkippedSeries();
+      for (int i = 0; i < 2_000; i++)
+        assertThat(get(index, absentUid(i))).as("absent key %d must not be found", i).isFalse();
+
+      assertThat(compacted.getBloomSkippedSeries() - skippedBefore)
+          .as("the restored filters must actually be skipping series").isGreaterThan(0);
+    }
+  }
+
+  private static boolean get(final TypeIndex index, final String key) {
+    final IndexCursor cursor = index.get(new Object[] { key });
+    try {
+      return cursor.hasNext();
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static LSMTreeIndexCompacted compactedOf(final TypeIndex index) {
+    return ((LSMTreeIndex) index.getIndexesOnBuckets()[0]).getMutableIndex().getSubIndex();
+  }
+
+  /** High-entropy key so the compacted index does not compress away to a trivial size. */
+  private static String uid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-" + i;
+  }
+
+  /** Never inserted, but sorts AMONG the stored keys, so only a filter can rule it out. */
+  private static String absentUid(final int i) {
+    final long mixed = i * 0x9E3779B97F4A7C15L;
+    return Long.toHexString(mixed) + "-" + Long.toHexString(Long.reverse(mixed) ^ i) + "-absent-" + i;
+  }
+}


### PR DESCRIPTION
Closes #5517.

## The problem

A point lookup walks every compacted series newest to oldest. The root page already rules out a key outside the series' key **range** — `resultInRootPage.outside` — but it says nothing about a key *inside* the range that the series does not hold.

That is exactly a bulk load. Every series spans nearly the whole key space, so the unique-index duplicate check reads one root page **and one data page per series, per record**, and finds nothing. @danieljuhl's log in #5470 showed `mergedSeries=10` across two unique indexes: ~20 lookups per vertex, all misses.

## The fix

A new `.bfidx` component holds one bloom filter per compacted series. `searchInCompactedIndex` probes it before touching a series at all.

At the default 1% target that costs **~1.2 bytes per key** and ~21ns per probe. The win is cache residency rather than instructions: the filter is more than an order of magnitude smaller than the data pages it stands in for, so it stays resident when the index itself does not.

Point lookups only — a filter says nothing about a range, so cursors and range scans bypass it entirely.

## The rule that must not break

A false positive costs the page read that would have happened anyway. A false **negative** hides a row: the lookup is skipped, the record is reported missing, a unique index lets a duplicate through — silently, with the index file intact and nothing for `CHECK DATABASE` to see.

Everything here is biased that way. A series with no entry, an entry whose shape does not match the series the reader is looking at, a partial or null key, an unreadable page — all answer *"search this series"*. And before any filter is published, **every key just written is probed back exhaustively**; a single miss abandons the filter instead of publishing it.

## Two decisions worth calling out

**It is a `PaginatedComponent`, not a side file.** A plain file next to the index would not be replicated over HA, would not be transactional, would not be in a backup and would not follow the index through `DROP INDEX`. As a component its pages flow through the PageManager exactly like the compacted pages they describe.

**The file is strictly append-only.** A publish appends its bit pages and then one directory page, so the live directory is always the last page of the file. This came out of reading `RaftReplicatedDatabase.runWithCompactionReplication`: HA ships a compaction as `addFiles` plus, for files that already existed, only the page range they *grew* by (`pagesGrownDuringSession`, the #5443 fix). A directory rewritten in place would simply never travel, leaving every follower with a directory that disagreed with its own bits. It also makes a crash mid-publish harmless — the load walks back past unnamed pages to the last complete directory, gated on magic + version + count + checksum.

## Layout

Bits are split into independent **blocks of one page each** and a key is routed to exactly one block, so a probe reads **one** page however large the series is. A 64 KB page holds ~500k bits (~54k keys at 1%), so the occupancy skew of a blocked filter is negligible.

A directory entry is `{seriesRootPage, seriesPages, firstFilterPage, filterPages, slotsPerBlock, probes, keys}`. `seriesPages` is checked against the live series at probe time, so a filter built for a *different* series that once lived at that root page — an aborted round whose pages were later reused — is disowned.

## Back compatibility

No version bump and no rollout gate. An older build has no `bfidx` in `SUPPORTED_FILE_EXT`, so the directory scan never opens the file and the index reads exactly as it does today. The presence of the component *is* the flag.

## Configuration

`arcadedb.indexBloomFilterRate`, default **0.01 (on)**. `0` disables both writing new filters and consulting the ones already on disk, so a real load can be measured with it on and off. `getBloomSkippedSeries()` / `getBloomProbedSeries()` (also in `getStats()`) report what it is actually worth.

## Testing

11,529 tests, 0 failures, 0 errors — run in chunks because the whole engine suite exceeds the 10-minute cap on a single command:

| Scope | Result |
|---|---|
| `com.arcadedb.index.**` + `engine.**` | 527, 0 failures |
| `database` / `graph` / `schema` / `serializer` / `utility` / `function` / `security` | 566, 0 failures |
| `com.arcadedb.query.**` | 10091, 0 failures |
| root + `compression` / `event` / `exception` / `log` / `partitioning` / `performance` | 330, 0 failures |
| integration backup + restore | 15, 0 failures |

New: `Issue5517BloomFilterTest` (7, through a real compaction) and `LSMTreeIndexBloomFilterTest` (9, the component directly — the integration tests use 256 KB pages, which hold any test-sized series in a single block, so the multi-block routing needed its own tests).

**Mutation-tested.** Two real defects were injected and both were caught: a write/read routing mismatch, and dropping the `seriesPages` shape check. A third — routing on raw hash bits instead of the splitmix finaliser — was **not** caught, so the mix is documented as a precaution rather than a fix for anything demonstrated.

## Known residual

If a compaction round fails, *and* the rollback's own one-page directory append also fails, *and* the process dies before the next publish, a stale entry survives on disk. It still only bites if the next round writes a series at the same root page with the same page count. A running process is never exposed: the in-RAM filters are dropped before the write is attempted. Documented at the code.