### PR TITLE
docs: record how dependency alerts are triaged

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,4 +67,48 @@ Out of scope:
 - Vulnerabilities in upstream dependencies that are already tracked by their own advisories. (Please still let us know so we can upgrade.)
 - Issues that require physical access to an already-compromised host.
 
+## How we triage dependency alerts
+
+Dependabot alerts and security updates are enabled on this repository. We triage
+them by **where the dependency runs**, not by severity alone.
+
+**Runtime dependencies** - anything reachable from a published artifact (the
+engine, server, HA, wire protocol modules, Studio, the Docker images, the client
+libraries) - are always reviewed and patched. No automatic dismissal applies to
+them at any severity.
+
+**Development-scope dependencies** - build plugins, test frameworks, and the
+`e2e-*` harnesses - never ship in a distribution and execute only in CI, against
+inputs this repository controls. Two auto-triage rules dismiss the classes of
+alert that are not actionable there:
+
+| Rule | Covers |
+| ---- | ------ |
+| GitHub-curated preset, *Dismiss low impact issues for development-scoped dependencies* | Resource-exhaustion advisories: CWE-400, CWE-674, CWE-754, CWE-770, CWE-835 |
+| Custom rule | CWE-407 (inefficient algorithmic complexity), development scope only |
+
+The custom rule exists because the curated preset dismisses an advisory only when
+*every* CWE on it is in the preset's set, so a ReDoS tagged CWE-400 **and**
+CWE-407 stays open while the same class of issue tagged CWE-400 alone is
+dismissed. Both rules are configured in the repository's security settings and
+therefore leave no trace in the source tree, which is why they are recorded here.
+
+**Development scope does not mean ignored.** These rules are deliberately narrow.
+At development scope we still review, and never auto-dismiss, path traversal
+(CWE-22), information disclosure (CWE-200), code injection, and malicious or
+compromised packages - a build tool that can read or exfiltrate files is a real
+supply-chain risk regardless of whether it ships. As a backstop,
+`.github/workflows/e2e-dependency-audit.yml` fails on any runtime-scope finding
+in the E2E harnesses and reports development-scope findings without blocking.
+
+Some advisories have no fixed release on the major line a pinned upstream
+dependency requires. Where we knowingly carry one, the reason is recorded in the
+relevant `pom.xml` or in `.github/dependabot.yml` rather than being silently
+dismissed.
+
+None of this changes what you should report: if you can show that a
+development-scope dependency is reachable from a shipped artifact, or exploitable
+in a way we have not considered, please tell us through the private channels
+above.
+
 Thank you for helping keep ArcadeDB and its users safe.


### PR DESCRIPTION
## What does this PR do?

Adds a **How we triage dependency alerts** section to `SECURITY.md`. One file, 44 added lines, documentation only.

It records the triage principle (by *where the dependency runs*, not by severity alone), what each of the two Dependabot auto-triage rules covers, and - deliberately given equal weight - what is **not** auto-dismissed.

## Motivation

Both auto-triage rules live in the repository's security settings and **leave no trace in the source tree**. Nothing in the repo explained why one development-scope advisory is dismissed automatically while another, of the same severity against the same package, stays open. Anyone auditing the alert history would have found the pattern inexplicable.

This is the same class of gap just closed in #5536 for the frozen Gremlin properties: a constraint that is real, load-bearing, and invisible to the person who needs it.

The asymmetry is genuinely non-obvious. The GitHub-curated preset dismisses an advisory only when *every* CWE on it is in the preset's set, so a ReDoS tagged CWE-400 **and** CWE-407 stays open while the same class of issue tagged CWE-400 alone is dismissed. Without that written down it reads as a bug.

## Related issues

Follows the Dependabot hygiene work in #5523, #5534, and #5536. Context for the frozen upstream pins is #5535.

## Additional Notes

**Reviewer attention is best spent on the "does not mean ignored" paragraph.** The section is careful not to read as a blanket exemption for development-scope dependencies. It states explicitly that path traversal (CWE-22), information disclosure (CWE-200), code injection, and malicious or compromised packages are still reviewed at development scope, on the grounds that a build tool able to read or exfiltrate files is a real supply-chain risk whether or not it ships. It also points at `.github/workflows/e2e-dependency-audit.yml` as the backstop that fails on any runtime-scope finding.

**One dependency on a setting outside this repo.** The section describes a custom auto-triage rule for CWE-407 at development scope. If that rule has not been created in **Settings -> Advanced Security -> Dependabot -> Auto-triage rules**, this PR describes a state that does not exist yet. Either create it before merging, or say so and the custom-rule row plus the paragraph explaining it can be dropped - the rest of the section stands on its own, since the curated preset is demonstrably already active.

**Verification:**

- No em dashes, per the repository's writing convention; the file uses `-` consistently with the surrounding text.
- Every referenced path exists on `main`: `.github/workflows/e2e-dependency-audit.yml`, `.github/dependabot.yml`, `gremlin/pom.xml`.
- Every factual claim cross-checked against the live config: the `org.apache.groovy:*` majors ignore rule is present in `.github/dependabot.yml`, and the audit workflow does block on `npm audit --omit=dev --audit-level=high`.
- The CWE split attributed to the curated preset is derived from this repository's own alert history, not assumed: CVE-2026-33750 (CWE-400 alone) was auto-dismissed, while CVE-2026-13149 (CWE-400 **and** CWE-407) stayed open.
- Heading structure verified; the new section sits after **Scope**, which it elaborates, and before the closing line.

## Checklist

- [ ] ~~I have run the build using `mvn clean package`~~ - **not applicable and not run.** The diff is one Markdown file; no source, no build input.
- [ ] ~~My unit tests cover both failure and success scenarios~~ - **no unit tests added.** Documentation change with no behaviour to test.
