### PR TITLE
fix(#5459): stdev()/stdevP() return NULL for empty input instead of 0.0

### DIFF
--- a/docs/5459-stdev-empty-input-null.md
+++ b/docs/5459-stdev-empty-input-null.md
@@ -1,0 +1,106 @@
+# 5459 - `stdev()` / `stdevP()` return `0.0` for empty input instead of `NULL`
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5459
+
+## Problem
+
+```cypher
+UNWIND [] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp;
+```
+
+returned `{"std": 0.0, "stdp": 0.0}` instead of `NULL`, making an input with no observations
+indistinguishable from a non-empty input whose dispersion is genuinely zero.
+
+Every sibling aggregate that cannot derive a value from an empty input already returned `NULL`:
+`avg()`, `min()`, `max()`, `percentileCont()`, `percentileDisc()`. Neo4j corrected the same
+`stDev()` behavior in `2026.05.0`.
+
+## Root cause
+
+`SQLFunctionStandardDeviation.getResult()` (engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionStandardDeviation.java).
+
+Its base class `SQLFunctionVariance.getResult()` already returns `null` when the observation count
+`n == 0`, which is exactly the empty-input signal. The standard-deviation subclass then discarded it:
+
+```java
+final Object variance = super.getResult();
+if (variance != null)
+  return Math.sqrt((Double) variance);
+return 0.0;      // <-- swallowed the null
+```
+
+The Cypher names route here through `CypherFunctionFactory` (`stdev`/`stdev_samp` -> `stddev`,
+`stdevp`/`stdev_pop` -> `stddevp`), and `SQLFunctionStandardDeviationP` extends
+`SQLFunctionStandardDeviation`, so all four spellings plus the SQL `stddev()`/`stddevp()` shared the
+single defect.
+
+## Fix
+
+Propagate the `null` instead of substituting `0.0`. One-line inversion of the branch; nothing else in
+the aggregation path changed.
+
+The `n == 1` case is untouched and still returns `0.0` - a single observation is a real observation
+with zero dispersion, which matches Neo4j.
+
+## Behavior change beyond the reported case
+
+The issue scoped itself to `UNWIND []`. The fix also changes all-`NULL` input, e.g.
+`UNWIND [null, null] AS x RETURN stdev(x)`, from `0.0` to `NULL`.
+
+This is intentional and is the same defect: `SQLFunctionVariance.addValue()` skips `null` values, so
+an all-`NULL` input also has zero observations. It also makes `stdev` consistent with `avg`, `min`,
+`max`, `percentileCont` and `percentileDisc`, which already return `NULL` for that identical input in
+the very same test class.
+
+### Existing tests modified (deviation from the "never modify existing tests" rule)
+
+Four assertions in `OpenCypherAggregatingFunctionsComprehensiveTest` asserted the buggy `0.0` for
+all-`NULL` input and were changed to assert `NULL`, matching how the neighbouring `avgNull`,
+`minNull`, `maxNull`, `percentileContAliasNull` and `percentileDiscAliasNull` cases in the same file
+are already written:
+
+- `stDevNull`
+- `stDevPNull`
+- `stdevSampNull`
+- `stdevPopNull`
+
+No test was deleted, and no test coverage was lost.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionStandardDeviation.java` | Return `null` for zero observations instead of `0.0` |
+| `engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherStDevEmptyInputTest.java` | New regression test (7 cases) |
+| `engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherAggregatingFunctionsComprehensiveTest.java` | 4 all-`NULL` assertions corrected to `NULL` |
+
+## Verification
+
+Test written first and confirmed failing against unmodified `main`:
+
+```
+Tests run: 7, Failures: 3  -- OpenCypherStDevEmptyInputTest
+```
+
+The three failures were exactly the empty-input and all-`NULL` cases. The four control cases
+(`avg`/`min`/`max`/percentiles over zero rows returning `NULL`, `[5,5]` -> `0.0`, `[5]` -> `0.0`,
+`[1,2,3]` -> `1.0`/`0.8165`) passed before the fix, proving the test isolates the defect.
+
+After the fix:
+
+```
+mvn -pl engine -Dtest='OpenCypherStDevEmptyInputTest,OpenCypherStDevTest,
+  OpenCypherAggregatingFunctionsComprehensiveTest,SQLFunctionVarianceTest,
+  SQLFunctionAdditionalCoverageTest' test
+  -> Tests run: 115, Failures: 0, Errors: 0
+
+mvn -pl engine -Dtest='com.arcadedb.function.**.*Test,com.arcadedb.query.opencypher.**.*Test' test
+  -> Tests run: 4830, Failures: 0, Errors: 0, Skipped: 13
+```
+
+## Impact
+
+- Applications can now distinguish "no observations" (`NULL`) from "observations with no variation" (`0.0`).
+- Callers that treated the old `0.0` as a sentinel for the empty case will now receive `NULL`. This is
+  the intended correction and matches every other ArcadeDB aggregate as well as Neo4j `2026.05.0`+.
+- No other module references `stddev`/`stdev`; the change is contained to the engine.

--- a/docs/5459-stdev-empty-input-null.md
+++ b/docs/5459-stdev-empty-input-null.md
@@ -123,10 +123,22 @@ No code changes were required. No items were deferred.
 
 `clean-approval` on the reviewer that responded, with `gemini-code-assist` timing out.
 
-CI on `d5cb727` at the time of writing: `build-and-package`, `builder-tests`, CodeQL, Codacy and the
-Go, JS, Java, C# and Python e2e suites all green. The long-running `unit-tests`, `slow-unit-tests`,
-`integration-tests`, `ha-integration-tests` and `studio-e2e-tests` jobs were still in flight and must
-be confirmed before merge. The `Meterian client scan` job fails, which is a dependency-vulnerability
-scan unrelated to this change - no dependency was added or changed.
+### CI on `b325309`
+
+Green: `build-and-package`, `builder-tests`, `studio-e2e-tests`, CodeQL (all six languages), Codacy,
+and the Go, JS, Java, C# and Python e2e suites.
+
+Three jobs are red, and **all three fail identically on unrelated PRs**, so none is caused by this
+change. This change touches only `SQLFunctionStandardDeviation.getResult()`; none of the failing
+tests exercises an aggregate function.
+
+| Job | Failing test | Evidence it is pre-existing |
+|---|---|---|
+| `slow-unit-tests` | `EdgeAppendMergeRaceTest.addersRemoversAndReadersOnOneHotVertex` - `ConcurrentModificationException` on a hot-vertex edge append | Same test, same exception on PR #5537. This is the supernode edge-append page conflict documented in `engine/CLAUDE.md`. |
+| `integration-tests` | `Issue4141SessionManagementIT` (2 tests) - HTTP 400 from `/api/v1/command/graph` | Byte-identical failure on PR #5537 and on PR #5536, which is already merged to `main`. |
+| `Meterian client scan` | n/a | Dependency-vulnerability scan; no dependency was added or changed. |
+
+`unit-tests` and `ha-integration-tests` had not reported at the time of writing and should be
+confirmed before merge.
 
 Merge remains the developer's decision.

--- a/docs/5459-stdev-empty-input-null.md
+++ b/docs/5459-stdev-empty-input-null.md
@@ -1,6 +1,7 @@
 # 5459 - `stdev()` / `stdevP()` return `0.0` for empty input instead of `NULL`
 
 Issue: https://github.com/ArcadeData/arcadedb/issues/5459
+PR: https://github.com/ArcadeData/arcadedb/pull/5539
 
 ## Problem
 
@@ -104,3 +105,28 @@ mvn -pl engine -Dtest='com.arcadedb.function.**.*Test,com.arcadedb.query.opencyp
 - Callers that treated the old `0.0` as a sentinel for the empty case will now receive `NULL`. This is
   the intended correction and matches every other ArcadeDB aggregate as well as Neo4j `2026.05.0`+.
 - No other module references `stddev`/`stdev`; the change is contained to the engine.
+
+## Review cycles
+
+### Cycle 1 - head `d5cb727`
+
+Initial push: the fix, the new regression test, the four corrected assertions, and this doc.
+
+| Reviewer | Outcome |
+|---|---|
+| `claude[bot]` | **LGTM.** Verified the inheritance chain covers all four Cypher spellings plus SQL `stddev()`/`stddevp()`, confirmed the `n == 1` path is correctly untouched, and independently confirmed no other test in the tree depends on the old `0.0`. One non-blocking nit about an assertion idiom that is pre-existing local style in the modified file - no action taken, matching the surrounding file was deliberate. |
+| `gemini-code-assist` | No response within the polling window. Consistent with this repository's recent history, where gemini has not responded to any PR head. |
+
+No code changes were required. No items were deferred.
+
+## Final state
+
+`clean-approval` on the reviewer that responded, with `gemini-code-assist` timing out.
+
+CI on `d5cb727` at the time of writing: `build-and-package`, `builder-tests`, CodeQL, Codacy and the
+Go, JS, Java, C# and Python e2e suites all green. The long-running `unit-tests`, `slow-unit-tests`,
+`integration-tests`, `ha-integration-tests` and `studio-e2e-tests` jobs were still in flight and must
+be confirmed before merge. The `Meterian client scan` job fails, which is a dependency-vulnerability
+scan unrelated to this change - no dependency was added or changed.
+
+Merge remains the developer's decision.

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionStandardDeviation.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionStandardDeviation.java
@@ -38,8 +38,9 @@ public class SQLFunctionStandardDeviation extends SQLFunctionVariance {
   @Override
   public Object getResult() {
     final Object variance = super.getResult();
-    if (variance != null)
-      return Math.sqrt((Double) variance);
-    return 0.0;
+    if (variance == null)
+      // no observations: null keeps an empty input distinguishable from a zero-dispersion one
+      return null;
+    return Math.sqrt((Double) variance);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherStDevEmptyInputTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherStDevEmptyInputTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Regression test for GitHub issue #5459: stdev() and stdevP() returned 0.0 for an input with no
+ * observations, making it indistinguishable from a non-empty set whose dispersion is genuinely zero.
+ * The other aggregates that cannot derive a value from an empty input (avg, min, max, percentiles)
+ * already return NULL.
+ */
+class OpenCypherStDevEmptyInputTest extends TestHelper {
+
+  @Test
+  void stDevOverZeroRowsReturnsNull() {
+    final Result result = queryOneRow("UNWIND [] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp");
+
+    assertThat((Object) result.getProperty("std")).isNull();
+    assertThat((Object) result.getProperty("stdp")).isNull();
+  }
+
+  @Test
+  void stDevAliasesOverZeroRowsReturnNull() {
+    final Result result = queryOneRow("UNWIND [] AS x RETURN stdev_samp(x) AS samp, stdev_pop(x) AS pop");
+
+    assertThat((Object) result.getProperty("samp")).isNull();
+    assertThat((Object) result.getProperty("pop")).isNull();
+  }
+
+  @Test
+  void stDevOverAllNullRowsReturnsNull() {
+    final Result result = queryOneRow("UNWIND [null, null] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp");
+
+    assertThat((Object) result.getProperty("std")).isNull();
+    assertThat((Object) result.getProperty("stdp")).isNull();
+  }
+
+  @Test
+  void otherAggregatesOverZeroRowsAlsoReturnNull() {
+    final Result result = queryOneRow(
+        "UNWIND [] AS x RETURN avg(x) AS a, min(x) AS mi, max(x) AS ma, percentileCont(x, 0.5) AS pc, percentileDisc(x, 0.5) AS pd");
+
+    assertThat((Object) result.getProperty("a")).isNull();
+    assertThat((Object) result.getProperty("mi")).isNull();
+    assertThat((Object) result.getProperty("ma")).isNull();
+    assertThat((Object) result.getProperty("pc")).isNull();
+    assertThat((Object) result.getProperty("pd")).isNull();
+  }
+
+  @Test
+  void zeroVarianceInputStillReturnsZero() {
+    final Result result = queryOneRow("UNWIND [5, 5] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp");
+
+    assertThat(((Number) result.getProperty("std")).doubleValue()).isEqualTo(0.0);
+    assertThat(((Number) result.getProperty("stdp")).doubleValue()).isEqualTo(0.0);
+  }
+
+  @Test
+  void singleObservationReturnsZero() {
+    final Result result = queryOneRow("UNWIND [5] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp");
+
+    assertThat(((Number) result.getProperty("std")).doubleValue()).isEqualTo(0.0);
+    assertThat(((Number) result.getProperty("stdp")).doubleValue()).isEqualTo(0.0);
+  }
+
+  @Test
+  void nonZeroVarianceInputIsUnchanged() {
+    final Result result = queryOneRow("UNWIND [1, 2, 3] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp");
+
+    assertThat(((Number) result.getProperty("std")).doubleValue()).isCloseTo(1.0, within(0.0001));
+    assertThat(((Number) result.getProperty("stdp")).doubleValue()).isCloseTo(0.816496580927726, within(0.0001));
+  }
+
+  private Result queryOneRow(final String cypher) {
+    try (final ResultSet resultSet = database.query("opencypher", cypher)) {
+      assertThat(resultSet.hasNext()).isTrue();
+      return resultSet.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherAggregatingFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherAggregatingFunctionsComprehensiveTest.java
@@ -329,7 +329,7 @@ class OpenCypherAggregatingFunctionsComprehensiveTest extends TestHelper {
     final ResultSet result = database.command("opencypher",
         "UNWIND [null, null] AS val RETURN stDev(val) AS result");
     Assertions.assertThat(result.hasNext() != false).isTrue();
-    assertThat(((Number) result.next().getProperty("result")).doubleValue()).isEqualTo(0.0);
+    Assertions.assertThat(result.next().getProperty("result") == null).isTrue();
   }
 
   // ==================== stDevP() Tests ====================
@@ -350,7 +350,7 @@ class OpenCypherAggregatingFunctionsComprehensiveTest extends TestHelper {
     final ResultSet result = database.command("opencypher",
         "UNWIND [null, null] AS val RETURN stDevP(val) AS result");
     Assertions.assertThat(result.hasNext() != false).isTrue();
-    assertThat(((Number) result.next().getProperty("result")).doubleValue()).isEqualTo(0.0);
+    Assertions.assertThat(result.next().getProperty("result") == null).isTrue();
   }
 
   // ==================== sum() Tests ====================
@@ -530,7 +530,7 @@ class OpenCypherAggregatingFunctionsComprehensiveTest extends TestHelper {
     final ResultSet result = database.command("opencypher",
         "UNWIND [null, null] AS val RETURN stdev_samp(val) AS result");
     Assertions.assertThat(result.hasNext() != false).isTrue();
-    assertThat(((Number) result.next().getProperty("result")).doubleValue()).isEqualTo(0.0);
+    Assertions.assertThat(result.next().getProperty("result") == null).isTrue();
   }
 
   // ==================== stdev_pop() Tests (alias of stDevP()) ====================
@@ -551,6 +551,6 @@ class OpenCypherAggregatingFunctionsComprehensiveTest extends TestHelper {
     final ResultSet result = database.command("opencypher",
         "UNWIND [null, null] AS val RETURN stdev_pop(val) AS result");
     Assertions.assertThat(result.hasNext() != false).isTrue();
-    assertThat(((Number) result.next().getProperty("result")).doubleValue()).isEqualTo(0.0);
+    Assertions.assertThat(result.next().getProperty("result") == null).isTrue();
   }
 }


### PR DESCRIPTION
Closes #5459

## Summary

`stdev()` and `stdevP()` returned `0.0` when their input contained no observations, making an empty input indistinguishable from a non-empty input whose dispersion is genuinely zero. Every sibling aggregate that cannot derive a value from an empty input (`avg()`, `min()`, `max()`, `percentileCont()`, `percentileDisc()`) already returned `NULL`, and Neo4j corrected the same `stDev()` behavior in `2026.05.0`.

The root cause is in `SQLFunctionStandardDeviation.getResult()`. Its base class `SQLFunctionVariance.getResult()` already returns `null` when the observation count is zero, which is exactly the empty-input signal, but the standard-deviation subclass discarded it and substituted `0.0`. The fix propagates the `null`. Because the Cypher names route here through `CypherFunctionFactory` (`stdev`/`stdev_samp` -> `stddev`, `stdevp`/`stdev_pop` -> `stddevp`) and `SQLFunctionStandardDeviationP` extends `SQLFunctionStandardDeviation`, one branch inversion covers all four Cypher spellings plus SQL `stddev()`/`stddevp()`. The `n == 1` case is untouched and still returns `0.0`, since a single observation is a real observation with zero dispersion.

## Behavior change beyond the reported case

The issue scoped itself to `UNWIND []`. The fix also changes all-`NULL` input (`UNWIND [null, null] AS x RETURN stdev(x)`) from `0.0` to `NULL`. This is the same defect: `SQLFunctionVariance.addValue()` skips `null` values, so an all-`NULL` input also has zero observations. It brings `stdev` in line with `avg`, `min`, `max`, `percentileCont` and `percentileDisc`, which already return `NULL` for that identical input.

Consequently four assertions in `OpenCypherAggregatingFunctionsComprehensiveTest` (`stDevNull`, `stDevPNull`, `stdevSampNull`, `stdevPopNull`) were asserting the buggy `0.0` and are corrected to assert `NULL`, matching how the neighbouring `avgNull`/`minNull`/`maxNull`/`percentileContAliasNull`/`percentileDiscAliasNull` cases in the same file are already written. No test was deleted and no coverage was lost. Flagging explicitly since it departs from the usual "only add tests" rule.

## Test plan

- [x] New regression test `OpenCypherStDevEmptyInputTest` (7 cases) written first and confirmed failing on unmodified `main`: `Tests run: 7, Failures: 3`. The 3 failures were exactly the empty-input and all-`NULL` cases; the 4 control cases passed before the fix, proving the test isolates the defect.
- [x] Controls covered: `avg`/`min`/`max`/percentiles over zero rows return `NULL`; `[5,5]` -> `0.0`; `[5]` -> `0.0`; `[1,2,3]` -> `1.0` / `0.816496580927726`.
- [x] Directly affected suites green: `OpenCypherStDevEmptyInputTest`, `OpenCypherStDevTest`, `OpenCypherAggregatingFunctionsComprehensiveTest`, `SQLFunctionVarianceTest`, `SQLFunctionAdditionalCoverageTest` -> `Tests run: 115, Failures: 0, Errors: 0`.
- [x] Broad regression sweep over the SQL function and Cypher packages: `mvn -pl engine -Dtest='com.arcadedb.function.**.*Test,com.arcadedb.query.opencypher.**.*Test' test` -> `Tests run: 4830, Failures: 0, Errors: 0, Skipped: 13`.
- [x] Verified no other module references `stddev`/`stdev`; the change is contained to the engine.

To verify manually:

```cypher
UNWIND [] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp;   -- both NULL
UNWIND [5, 5] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp;  -- both 0.0
UNWIND [1, 2, 3] AS x RETURN stdev(x) AS std, stdevP(x) AS stdp;  -- 1.0 / 0.8164965809
```