### PR TITLE
fix(#5461): recognize every clause keyword that can open a subquery body

### DIFF
--- a/docs/5461-subquery-leading-clause-keyword.md
+++ b/docs/5461-subquery-leading-clause-keyword.md
@@ -138,10 +138,12 @@ dependency manifest (four Java files, one test, one doc). Every other gate - Cod
   unreachable, because a bare pattern is normalized into `MATCH ... RETURN 1` at build time before
   `correlate` runs. Verified (single construction site) and documented with a comment rather than
   deleted, so the branch stays correct if that normalization ever moves.
-- **Not addressed, pre-existing.** The `subquery.toUpperCase().contains("RETURN ")` test that decides
-  whether a body needs a synthesized `RETURN` is a naive substring match and would false-positive on
-  a string literal such as `WHERE x = 'RETURN '`. It predates this change and correcting it needs its
-  own literal-aware scan and tests; it is only touched here incidentally.
+- **Investigated, not a defect.** Both review cycles flagged the
+  `subquery.toUpperCase().contains("RETURN ")` test as a naive substring match that would
+  false-positive on a literal such as `WHERE x = 'RETURN y'`. Probed directly: it does not produce a
+  wrong answer. `COUNT { MATCH (n:T) WHERE n.name = 'RETURN y' }` returns the true count (2 of 3
+  rows), because a `MATCH`-only body executes fine without the synthesized `RETURN`. The substring
+  match is imprecise but currently harmless, so nothing was filed for it.
 - **No action, informational.** The mutating keywords in `CLAUSE_KEYWORDS` are inert on the
   `COUNT`/`EXISTS` parse-time path, since update clauses are rejected before it. They are carried for
   completeness of the shared list and for boundary detection.
@@ -160,11 +162,13 @@ dependency manifest (four Java files, one test, one doc). Every other gate - Cod
   (`database.query(...)`), which exceeds two short-string allocations by orders of magnitude. Removing
   the allocation would also mean either duplicating the word-boundary logic or adding a
   case-insensitive variant of it, and duplicated keyword logic is precisely what caused this bug.
-- **Not addressed, pre-existing (same class as this bug).** The update-clause guards in all three
-  parse methods (`upper.contains("SET ")`, `"CREATE "`, ...) are naive substring scans with the exact
-  blind spot fixed here: a literal or property name containing `SET ` false-matches. Worth its own
-  issue together with the `contains("RETURN ")` item above, so the literal-aware cleanup is not lost
-  now that keyword scanning is consistent everywhere else.
+- **Filed as #5541.** The update-clause guards in all three parse methods
+  (`upper.contains("SET ")`, `"CREATE "`, ...) are naive substring scans with the exact blind spot
+  fixed here. Confirmed by direct probe: `COUNT { MATCH (n:T) WHERE n.name = 'SET x' RETURN n }`
+  throws `InvalidClauseComposition: COUNT subquery cannot contain update clauses` for a read-only
+  body, and `EXISTS` and `COLLECT` fail identically. Left out of this PR to keep it scoped; unlike
+  #5461 it throws rather than returning a silent neutral value, so it is visible rather than
+  data-corrupting.
 
 ## Impact
 

--- a/docs/5461-subquery-leading-clause-keyword.md
+++ b/docs/5461-subquery-leading-clause-keyword.md
@@ -82,18 +82,25 @@ prepends the patterns as their own MATCH clause when the body starts with a clau
 ## Verification
 
 New regression test `engine/src/test/java/com/arcadedb/query/opencypher/Issue5461SubqueryLeadingClauseTest.java`,
-10 tests. Every one of them was confirmed failing before the fix: 5 failures on the first run, then 1
-remaining correlated failure that isolated the second defect, and the no-`RETURN` case checked
-separately by restoring the old three-keyword whitelist (0 instead of 2).
+11 tests. Every one of them was confirmed failing before the fix: 5 failures on the first run, then 1
+remaining correlated failure that isolated the second defect, the no-`RETURN` case checked separately
+by restoring the old three-keyword whitelist (0 instead of 2), and the classifier unit test checked
+by removing the bounds check (`StringIndexOutOfBoundsException`).
+
+A first attempt at that last test asserted `COUNT { }` did not throw. It passed with and without the
+bounds check - `COUNT { }` never reaches the classifier - so it was replaced with a direct call to
+the public method rather than kept as coverage it did not provide.
 
 Coverage: `COUNT`/`EXISTS`/`COLLECT` with an `UNWIND`-first body across list sizes 0-3; the issue's
 per-outer-row case; bodies opening with `CALL` and `OPTIONAL MATCH`; an `UNWIND`-first body with no
 `RETURN` of its own; the correlated `MATCH (n:T) ... COUNT { UNWIND n.tags AS t ... }` form; the
-`WITH 1 AS dummy` and `RETURN 1` controls from the issue; the returning-`CALL {}` repro; and a guard
-that bare-pattern bodies are still wrapped into a `MATCH`.
+`WITH 1 AS dummy` and `RETURN 1` controls from the issue; the returning-`CALL {}` repro; a guard that
+bare-pattern bodies are still wrapped into a `MATCH`; and the classifier itself against blank bodies
+and patterns bound to keyword-prefixed variables (`matches = (a)-->(b)`).
 
-Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7693 tests, 0 failures, plus the
-full `engine` module suite.
+Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7695 tests, 0 failures, and the
+full `engine` module suite, 10150 tests, 0 failures. The opencypher count reconciles against a
+measured `main` baseline of 7684 plus this branch's 11 new tests.
 
 ## Pull request
 
@@ -112,6 +119,18 @@ already tolerates any leading clause. Three minor non-blocking notes, dispositio
 below. One of them (`INSERT` is not a standard openCypher clause) was checked against the grammar and
 is incorrect: `Cypher25Parser.g4` defines `insertClause : INSERT insertPatternList` and lists it among
 the clause alternatives, so `INSERT` belongs in the list and was kept.
+
+**Cycle 3** - `a550352` - claude[bot]: no blocking issues. It confirmed the first-char pre-filter is
+sound for both callers (derived from the superset array, and non-ASCII first chars fall through to
+the full scan), and that the bounds check closes the empty-body case. Three minor notes, all
+declined with reasons below.
+
+### CI note
+
+`Meterian client scan` fails on this PR with a security score of 0. It is **not caused by this
+change**: the same check fails identically on PRs #5539, #5536 and #5534, and this branch touches no
+dependency manifest (four Java files, one test, one doc). Every other gate - Codacy, CodeQL,
+`claude-review`, setup - passes.
 
 ## Follow-ups
 
@@ -133,6 +152,14 @@ the clause alternatives, so `INSERT` belongs in the list and was kept.
   is a sound pre-filter for both callers. Indexing the first character also made a blank body throw,
   so `matchesAnyKeywordAt` now bounds-checks and a unit test covers it - verified non-vacuous by
   removing the check and watching the test fail with `StringIndexOutOfBoundsException`.
+- **Declined in cycle 3, with a correction.** `startsWithClauseKeyword` allocates a
+  `trim().toUpperCase()` copy per call. The review placed this off the row-scan hot path; that is not
+  quite right - `CountExpression`/`ExistsExpression` call it through `wrapNonMatchBody`, which runs
+  once per outer row for a correlated subquery. It is still not worth changing: each of those outer
+  rows already pays for a complete standalone parse and execution of the subquery
+  (`database.query(...)`), which exceeds two short-string allocations by orders of magnitude. Removing
+  the allocation would also mean either duplicating the word-boundary logic or adding a
+  case-insensitive variant of it, and duplicated keyword logic is precisely what caused this bug.
 - **Not addressed, pre-existing (same class as this bug).** The update-clause guards in all three
   parse methods (`upper.contains("SET ")`, `"CREATE "`, ...) are naive substring scans with the exact
   blind spot fixed here: a literal or property name containing `SET ` false-matches. Worth its own

--- a/docs/5461-subquery-leading-clause-keyword.md
+++ b/docs/5461-subquery-leading-clause-keyword.md
@@ -108,6 +108,11 @@ reachable (a `whereCondition` is only ever produced alongside a `matchPattern`, 
 multi-`MATCH` bodies correctly, and `COLLECT` needs no wrapper change because its `WITH *` shape
 already tolerates any leading clause. Three minor non-blocking notes, dispositioned below.
 
+**Cycle 2** - `0a8ed53` - claude[bot]: LGTM, no blocking findings. Four minor notes, dispositioned
+below. One of them (`INSERT` is not a standard openCypher clause) was checked against the grammar and
+is incorrect: `Cypher25Parser.g4` defines `insertClause : INSERT insertPatternList` and lists it among
+the clause alternatives, so `INSERT` belongs in the list and was kept.
+
 ## Follow-ups
 
 - **Applied in cycle 1.** The bare-pattern branch of `CountExpression.wrapNonMatchBody` is
@@ -121,6 +126,18 @@ already tolerates any leading clause. Three minor non-blocking notes, dispositio
 - **No action, informational.** The mutating keywords in `CLAUSE_KEYWORDS` are inert on the
   `COUNT`/`EXISTS` parse-time path, since update clauses are rejected before it. They are carried for
   completeness of the shared list and for boundary detection.
+- **Applied in cycle 2.** The boundary scan walked all 21 keywords at every unnested character
+  position. It now rejects a position on a single `boolean[]` read keyed by the first character. The
+  table is derived from `CLAUSE_BOUNDARY_KEYWORDS` at class init, so it cannot drift from the list
+  the way the three original copies did, and because that array is a superset of `CLAUSE_KEYWORDS` it
+  is a sound pre-filter for both callers. Indexing the first character also made a blank body throw,
+  so `matchesAnyKeywordAt` now bounds-checks and a unit test covers it - verified non-vacuous by
+  removing the check and watching the test fail with `StringIndexOutOfBoundsException`.
+- **Not addressed, pre-existing (same class as this bug).** The update-clause guards in all three
+  parse methods (`upper.contains("SET ")`, `"CREATE "`, ...) are naive substring scans with the exact
+  blind spot fixed here: a literal or property name containing `SET ` false-matches. Worth its own
+  issue together with the `contains("RETURN ")` item above, so the literal-aware cleanup is not lost
+  now that keyword scanning is consistent everywhere else.
 
 ## Impact
 

--- a/docs/5461-subquery-leading-clause-keyword.md
+++ b/docs/5461-subquery-leading-clause-keyword.md
@@ -95,6 +95,33 @@ that bare-pattern bodies are still wrapped into a `MATCH`.
 Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7693 tests, 0 failures, plus the
 full `engine` module suite.
 
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5540
+
+### Review cycles
+
+**Cycle 1** - `a5cc23d` - claude[bot]: no blocking findings. It independently traced and confirmed
+the three correctness properties the fix depends on: a `WHERE`-before-`UNWIND` corruption is not
+reachable (a `whereCondition` is only ever produced alongside a `matchPattern`, so
+`injectMatchPatterns` always runs first), adding `MATCH`/`OPTIONAL` to the boundary list handles
+multi-`MATCH` bodies correctly, and `COLLECT` needs no wrapper change because its `WITH *` shape
+already tolerates any leading clause. Three minor non-blocking notes, dispositioned below.
+
+## Follow-ups
+
+- **Applied in cycle 1.** The bare-pattern branch of `CountExpression.wrapNonMatchBody` is
+  unreachable, because a bare pattern is normalized into `MATCH ... RETURN 1` at build time before
+  `correlate` runs. Verified (single construction site) and documented with a comment rather than
+  deleted, so the branch stays correct if that normalization ever moves.
+- **Not addressed, pre-existing.** The `subquery.toUpperCase().contains("RETURN ")` test that decides
+  whether a body needs a synthesized `RETURN` is a naive substring match and would false-positive on
+  a string literal such as `WHERE x = 'RETURN '`. It predates this change and correcting it needs its
+  own literal-aware scan and tests; it is only touched here incidentally.
+- **No action, informational.** The mutating keywords in `CLAUSE_KEYWORDS` are inert on the
+  `COUNT`/`EXISTS` parse-time path, since update clauses are rejected before it. They are carried for
+  completeness of the shared list and for boundary detection.
+
 ## Impact
 
 Any `COUNT { }` or `EXISTS { }` whose body opens with `UNWIND`, `CALL`, `OPTIONAL MATCH` or `FOREACH`

--- a/docs/5461-subquery-leading-clause-keyword.md
+++ b/docs/5461-subquery-leading-clause-keyword.md
@@ -1,0 +1,103 @@
+# #5461 - UNWIND as the first clause yields zero rows in COUNT {} and EXISTS {} subqueries
+
+## Symptom
+
+A subquery body whose first clause is `UNWIND` produces no rows:
+
+```cypher
+RETURN COUNT { UNWIND [1, 2] AS y RETURN y } AS c;
+-- returns 0, expected 2
+```
+
+Adding an otherwise inert `WITH 1 AS dummy` before the `UNWIND` restores the correct answer, which is
+what makes the report look like a subquery initialization problem. `EXISTS { }` is affected the same
+way (silently `false`), and so is any body opening with `CALL`, `OPTIONAL MATCH` or `FOREACH`.
+
+The `CALL { }` half of the report did **not** reproduce on `main`: the returning-CALL repro from the
+issue already yields the expected 6 rows. `SubqueryStep` seeds its inner plan with a one-row seed, so
+`UnwindStep` gets its input. That case is covered by a test here as a regression guard only.
+
+## Root cause
+
+Two incomplete keyword lists, both in the text-rewriting layer that `COUNT { }`, `EXISTS { }` and
+`COLLECT { }` use. Those three expressions do not run inside the outer plan - they re-execute their
+body as a **standalone query string**, once per outer row - so every decision about the body is made
+by string inspection.
+
+**1. The parse-time pattern wrapper.** `CypherExpressionBuilder.parseCountExpression` and
+`parseExistsExpression` have to tell a bare pattern (`COUNT { (a)-[:KNOWS]->(b) }`, which needs a
+synthesized `MATCH`) from a full subquery body (which does not). The test was:
+
+```java
+if (!upperTrimmed.startsWith("MATCH") && !upperTrimmed.startsWith("WITH") && !upperTrimmed.startsWith("RETURN"))
+  subquery = "MATCH " + subquery + " RETURN 1";
+```
+
+`UNWIND [1, 2] AS y RETURN y` matches none of the three, so it was read as a pattern and became
+`MATCH UNWIND [1, 2] AS y RETURN y RETURN 1`, which does not parse. Each of the three expressions
+absorbs a body that cannot run into its neutral value, so the parse failure surfaced as `COUNT` = 0
+and `EXISTS` = false rather than as an error. `COLLECT` has no such wrapper, which is why it was the
+one of the three that already worked - the asymmetry is the tell.
+
+The leading `WITH` workaround works simply because `WITH` is one of the three listed keywords.
+
+**2. The correlation injection point.** Once the body is correlated to an outer row,
+`CorrelatedSubqueryRewriter.injectWhereConditions` inserts `WHERE id(n) = $param` before the first
+clause keyword that closes the MATCH pattern. Its list was `WITH, RETURN, ORDER, SKIP, LIMIT, UNION` -
+also missing `UNWIND`. For `MATCH (n) UNWIND n.tags AS t RETURN t` it therefore skipped past the
+`UNWIND` and produced `MATCH (n) UNWIND n.tags AS t WHERE id(n) = $p RETURN t`. `WHERE` cannot follow
+`UNWIND`, so this too failed to parse and was absorbed as 0.
+
+Only the second list matters once an outer graph variable is in play, which is why a correlated
+`MATCH (n:T) RETURN COUNT { UNWIND n.tags AS t RETURN t }` stayed broken after the first list was
+fixed. Both had to be corrected.
+
+A third copy of the same list already existed and was already correct: `ExistsExpression`'s private
+`wrapNonMatchBody` knew about `UNWIND`, `CALL` and `OPTIONAL`. Three copies, three different contents.
+
+## Fix
+
+`CorrelatedSubqueryRewriter` gains the single authoritative list and one public predicate:
+
+- `CLAUSE_KEYWORDS` - every keyword that can open a Cypher subquery body (`MATCH`, `OPTIONAL`, `WITH`,
+  `RETURN`, `UNWIND`, `CALL`, `FOREACH`, `LOAD`, `USE`, `FINISH`, and the mutating clauses).
+- `startsWithClauseKeyword(body)` - case-insensitive, with a word boundary so a pattern bound to a
+  variable such as `matches` is not read as `MATCH`.
+- `CLAUSE_BOUNDARY_KEYWORDS` - the same list plus `ORDER`, `SKIP`, `LIMIT`, `UNION`, used by
+  `injectWhereConditions` to find where the MATCH pattern ends. `WHERE` stays out of it: it is the one
+  keyword the injection merges into instead of stopping at.
+
+The three drifted call sites now route through it:
+
+- `CypherExpressionBuilder.parseCountExpression` / `parseExistsExpression` - wrap into `MATCH` only
+  when the body is genuinely not a clause.
+- `ExistsExpression.wrapNonMatchBody` - its private keyword list deleted in favor of the shared one.
+- `CorrelatedSubqueryRewriter.injectWhereConditions` - scans for any boundary keyword.
+
+One further correlated-path defect had to go with it. `CountExpression`'s non-MATCH wrapper built
+`"MATCH " + patterns + ", " + body + " RETURN 1"`, comma-splicing the injected pattern into whatever
+clause the body opened with: `MATCH (n), UNWIND n.tags AS t RETURN t`. It now mirrors `EXISTS` and
+prepends the patterns as their own MATCH clause when the body starts with a clause keyword.
+
+## Verification
+
+New regression test `engine/src/test/java/com/arcadedb/query/opencypher/Issue5461SubqueryLeadingClauseTest.java`,
+10 tests. Every one of them was confirmed failing before the fix: 5 failures on the first run, then 1
+remaining correlated failure that isolated the second defect, and the no-`RETURN` case checked
+separately by restoring the old three-keyword whitelist (0 instead of 2).
+
+Coverage: `COUNT`/`EXISTS`/`COLLECT` with an `UNWIND`-first body across list sizes 0-3; the issue's
+per-outer-row case; bodies opening with `CALL` and `OPTIONAL MATCH`; an `UNWIND`-first body with no
+`RETURN` of its own; the correlated `MATCH (n:T) ... COUNT { UNWIND n.tags AS t ... }` form; the
+`WITH 1 AS dummy` and `RETURN 1` controls from the issue; the returning-`CALL {}` repro; and a guard
+that bare-pattern bodies are still wrapped into a `MATCH`.
+
+Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7693 tests, 0 failures, plus the
+full `engine` module suite.
+
+## Impact
+
+Any `COUNT { }` or `EXISTS { }` whose body opens with `UNWIND`, `CALL`, `OPTIONAL MATCH` or `FOREACH`
+silently returned the neutral value. The silence is the dangerous part: a de-duplicating
+`WHERE NOT EXISTS { ... }` guard built on such a body degrades into an unconditional write. The
+shared keyword list closes the class of defect rather than the single reported instance.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
@@ -23,10 +23,12 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BinaryOperator;
+import java.util.stream.Stream;
 
 /**
  * Shared text rewriting used by the three subquery expressions - {@code EXISTS { }},
@@ -46,8 +48,37 @@ import java.util.function.BinaryOperator;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public final class CorrelatedSubqueryRewriter {
+  /**
+   * Keywords that can open a Cypher subquery body. Anything else is a bare pattern, and only a bare
+   * pattern may be wrapped into a synthesized {@code MATCH}. {@code OPTIONAL} covers
+   * {@code OPTIONAL MATCH}, {@code LOAD} covers {@code LOAD CSV} and {@code DETACH} covers
+   * {@code DETACH DELETE}.
+   */
+  private static final String[] CLAUSE_KEYWORDS = { "MATCH", "OPTIONAL", "WITH", "RETURN", "UNWIND", "CALL", "FOREACH",
+      "LOAD", "USE", "FINISH", "CREATE", "MERGE", "SET", "DELETE", "DETACH", "REMOVE", "INSERT" };
+
+  /**
+   * Keywords that close the pattern of the MATCH a correlation condition is injected into: every
+   * clause keyword, plus the sub-clauses that can trail a projection. {@code WHERE} is deliberately
+   * absent - it is the one keyword the injection merges into rather than stops at.
+   */
+  private static final String[] CLAUSE_BOUNDARY_KEYWORDS = Stream.concat(Arrays.stream(CLAUSE_KEYWORDS),
+      Stream.of("ORDER", "SKIP", "LIMIT", "UNION")).toArray(String[]::new);
 
   private CorrelatedSubqueryRewriter() {
+  }
+
+  /**
+   * Tells whether a subquery body opens with a clause keyword rather than with a bare pattern.
+   * <p>
+   * Callers use this to decide whether the body still needs a synthesized {@code MATCH} in front of
+   * it. The list has to stay complete: an unlisted keyword makes its clause look like a pattern, and
+   * the resulting {@code MATCH UNWIND [1, 2] AS y RETURN y RETURN 1} does not parse. Because the
+   * three subquery expressions absorb a failed body into their neutral value, that misclassification
+   * surfaces only as a silently wrong {@code COUNT} of 0 or {@code EXISTS} of false (issue #5461).
+   */
+  public static boolean startsWithClauseKeyword(final String body) {
+    return matchesAnyKeywordAt(body.trim().toUpperCase(), 0, CLAUSE_KEYWORDS);
   }
 
   /**
@@ -226,9 +257,7 @@ public final class CorrelatedSubqueryRewriter {
 
       if (matchesKeywordAt(upper, i, "WHERE") && topWherePos < 0)
         topWherePos = i;
-      else if (clauseStart < 0 && (matchesKeywordAt(upper, i, "WITH") || matchesKeywordAt(upper, i, "RETURN")
-          || matchesKeywordAt(upper, i, "ORDER") || matchesKeywordAt(upper, i, "SKIP")
-          || matchesKeywordAt(upper, i, "LIMIT") || matchesKeywordAt(upper, i, "UNION")))
+      else if (clauseStart < 0 && matchesAnyKeywordAt(upper, i, CLAUSE_BOUNDARY_KEYWORDS))
         clauseStart = i;
 
       // Stop once we find a non-WHERE clause keyword
@@ -294,6 +323,13 @@ public final class CorrelatedSubqueryRewriter {
         return false;
     }
     return true;
+  }
+
+  private static boolean matchesAnyKeywordAt(final String upper, final int pos, final String[] keywords) {
+    for (final String keyword : keywords)
+      if (matchesKeywordAt(upper, pos, keyword))
+        return true;
+    return false;
   }
 
   private static boolean isCypherIdentifierChar(final char c) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
@@ -65,6 +65,18 @@ public final class CorrelatedSubqueryRewriter {
   private static final String[] CLAUSE_BOUNDARY_KEYWORDS = Stream.concat(Arrays.stream(CLAUSE_KEYWORDS),
       Stream.of("ORDER", "SKIP", "LIMIT", "UNION")).toArray(String[]::new);
 
+  /**
+   * First letters of {@link #CLAUSE_BOUNDARY_KEYWORDS}, so the per-character boundary scan rejects a
+   * position with one array read instead of walking every keyword. Derived, never hand-maintained:
+   * the whole point of this class is that hand-maintained copies of the keyword list drift.
+   */
+  private static final boolean[] BOUNDARY_KEYWORD_FIRST_CHAR = new boolean[128];
+
+  static {
+    for (final String keyword : CLAUSE_BOUNDARY_KEYWORDS)
+      BOUNDARY_KEYWORD_FIRST_CHAR[keyword.charAt(0)] = true;
+  }
+
   private CorrelatedSubqueryRewriter() {
   }
 
@@ -325,7 +337,17 @@ public final class CorrelatedSubqueryRewriter {
     return true;
   }
 
+  /**
+   * The first-char table is built from {@link #CLAUSE_BOUNDARY_KEYWORDS}, which is a superset of
+   * {@link #CLAUSE_KEYWORDS}, so it is a sound pre-filter for either array: it can never reject a
+   * position one of them would have matched.
+   */
   private static boolean matchesAnyKeywordAt(final String upper, final int pos, final String[] keywords) {
+    if (pos >= upper.length())
+      return false;
+    final char first = upper.charAt(pos);
+    if (first < BOUNDARY_KEYWORD_FIRST_CHAR.length && !BOUNDARY_KEYWORD_FIRST_CHAR[first])
+      return false;
     for (final String keyword : keywords)
       if (matchesKeywordAt(upper, pos, keyword))
         return true;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CountExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CountExpression.java
@@ -52,7 +52,7 @@ public class CountExpression implements Expression {
   public Object evaluate(final Result result, final CommandContext context) {
     final Map<String, Object> params = CorrelatedSubqueryRewriter.newParams(context);
     final String modifiedSubquery = CorrelatedSubqueryRewriter.correlate(subquery, result, "__count_", params,
-        (patterns, body) -> "MATCH " + patterns + ", " + body + " RETURN 1");
+        CountExpression::wrapNonMatchBody);
     long count = 0L;
     try (final ResultSet resultSet = context.getDatabase().query("opencypher", modifiedSubquery, params)) {
       while (resultSet.hasNext()) {
@@ -67,6 +67,20 @@ public class CountExpression implements Expression {
       return 0L;
     }
     return count;
+  }
+
+  /**
+   * Builds the correlated query when the body does not start with MATCH.
+   * <p>
+   * A body that opens with another clause keyword only needs the extra patterns prepended as their own
+   * MATCH; comma-splicing them into the body's first clause instead produced the unparseable
+   * {@code MATCH (n), UNWIND n.tags AS t RETURN t} and the failure was absorbed as a count of zero.
+   * A bare pattern body is joined to the injected patterns as a further pattern of the same MATCH.
+   */
+  private static String wrapNonMatchBody(final String patterns, final String body) {
+    if (CorrelatedSubqueryRewriter.startsWithClauseKeyword(body))
+      return "MATCH " + patterns + " " + body;
+    return "MATCH " + patterns + ", " + body + " RETURN 1";
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CountExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CountExpression.java
@@ -80,6 +80,9 @@ public class CountExpression implements Expression {
   private static String wrapNonMatchBody(final String patterns, final String body) {
     if (CorrelatedSubqueryRewriter.startsWithClauseKeyword(body))
       return "MATCH " + patterns + " " + body;
+    // Defensive mirror of EXISTS: a bare pattern is normalized into "MATCH ... RETURN 1" when the
+    // expression is built, so the correlation takes the leading-MATCH path and never arrives here.
+    // Kept so the wrapper stays correct if that normalization ever moves.
     return "MATCH " + patterns + ", " + body + " RETURN 1";
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ExistsExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ExistsExpression.java
@@ -67,9 +67,7 @@ public class ExistsExpression implements Expression {
    * A bare pattern body becomes the predicate of the injected MATCH.
    */
   private static String wrapNonMatchBody(final String patterns, final String body) {
-    final String upper = body.toUpperCase();
-    if (upper.startsWith("RETURN") || upper.startsWith("WITH") || upper.startsWith("UNWIND")
-        || upper.startsWith("CALL") || upper.startsWith("OPTIONAL"))
+    if (CorrelatedSubqueryRewriter.startsWithClauseKeyword(body))
       return "MATCH " + patterns + " " + body;
     return "MATCH " + patterns + " WHERE " + body;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -1832,12 +1832,9 @@ class CypherExpressionBuilder {
           "InvalidClauseComposition: Existential subquery cannot contain update clauses");
 
     // If it's a pattern without MATCH, add MATCH prefix
-    final String upperTrimmed = subquery.toUpperCase();
-    if (!upperTrimmed.startsWith("MATCH")
-        && !upperTrimmed.startsWith("WITH")
-        && !upperTrimmed.startsWith("RETURN")) {
+    if (!CorrelatedSubqueryRewriter.startsWithClauseKeyword(subquery)) {
       subquery = "MATCH " + subquery + " RETURN true";
-    } else if (!upperTrimmed.contains("RETURN ")) {
+    } else if (!subquery.toUpperCase().contains("RETURN ")) {
       // Full subquery without RETURN — add RETURN true
       subquery = subquery + " RETURN true";
     }
@@ -1896,12 +1893,9 @@ class CypherExpressionBuilder {
           "InvalidClauseComposition: COUNT subquery cannot contain update clauses");
 
     // Pattern-only form: wrap with MATCH and add RETURN 1 so the outer evaluator can count rows.
-    final String upperTrimmed = subquery.toUpperCase();
-    if (!upperTrimmed.startsWith("MATCH")
-        && !upperTrimmed.startsWith("WITH")
-        && !upperTrimmed.startsWith("RETURN")) {
+    if (!CorrelatedSubqueryRewriter.startsWithClauseKeyword(subquery)) {
       subquery = "MATCH " + subquery + " RETURN 1";
-    } else if (!upperTrimmed.contains("RETURN ")) {
+    } else if (!subquery.toUpperCase().contains("RETURN ")) {
       subquery = subquery + " RETURN 1";
     }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5461SubqueryLeadingClauseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5461SubqueryLeadingClauseTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.ast.CorrelatedSubqueryRewriter;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Regression test for GitHub issue #5461.
@@ -133,6 +135,23 @@ class Issue5461SubqueryLeadingClauseTest {
     for (final Result row : results)
       pairs.add(row.<Number>getProperty("x").intValue() + "," + row.<Number>getProperty("y").intValue());
     assertThat(pairs).containsExactly("1,1", "1,2", "2,1", "2,2", "3,1", "3,2");
+  }
+
+  @Test
+  void clauseKeywordTestClassifiesBodiesWithoutThrowing() {
+    // The clause-keyword test indexes the first character, so a blank body must not throw.
+    assertThatCode(() -> CorrelatedSubqueryRewriter.startsWithClauseKeyword("")).doesNotThrowAnyException();
+    assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("   ")).isFalse();
+
+    assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("UNWIND [1] AS y RETURN y")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("unwind [1] AS y RETURN y")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("OPTIONAL MATCH (n) RETURN n")).isTrue();
+
+    // Bare patterns must stay classified as patterns, including one bound to a keyword-prefixed name
+    assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("(a)-[:KNOWS]->(b)")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("matches = (a)-->(b)")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("returns = (a)-->(b)")).isFalse();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5461SubqueryLeadingClauseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5461SubqueryLeadingClauseTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #5461.
+ * <p>
+ * {@code COUNT { }} and {@code EXISTS { }} bodies are re-executed as standalone queries, and a body
+ * that is a bare pattern has to be wrapped into a {@code MATCH}. The wrapper used to recognize only
+ * {@code MATCH}, {@code WITH} and {@code RETURN} as clause keywords, so a body opening with any other
+ * clause - {@code UNWIND}, {@code CALL}, {@code OPTIONAL MATCH} - was mistaken for a pattern and
+ * spliced into an unparseable {@code MATCH UNWIND [1,2] AS y RETURN y RETURN 1}. The parse failure was
+ * absorbed into the expression's neutral value, so {@code COUNT} silently returned 0 and
+ * {@code EXISTS} silently returned false.
+ */
+class Issue5461SubqueryLeadingClauseTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-5461-subquery-leading-clause").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  private Object scalar(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("v");
+    }
+  }
+
+  private List<Result> rows(final String query) {
+    final List<Result> collected = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        collected.add(rs.next());
+    }
+    return collected;
+  }
+
+  @Test
+  void countSubqueryStartingWithUnwind() {
+    assertThat(scalar("RETURN COUNT { UNWIND [1, 2] AS y RETURN y } AS v")).isEqualTo(2L);
+    assertThat(scalar("RETURN COUNT { UNWIND [1] AS y RETURN y } AS v")).isEqualTo(1L);
+    assertThat(scalar("RETURN COUNT { UNWIND [1, 2, 3] AS y RETURN y } AS v")).isEqualTo(3L);
+    assertThat(scalar("RETURN COUNT { UNWIND [] AS y RETURN y } AS v")).isEqualTo(0L);
+  }
+
+  @Test
+  void countSubqueryStartingWithUnwindAndNoReturn() {
+    assertThat(scalar("RETURN COUNT { UNWIND [1, 2] AS y } AS v")).isEqualTo(2L);
+  }
+
+  @Test
+  void countSubqueryLeadingWithControlsStillWork() {
+    assertThat(scalar("RETURN COUNT { WITH 1 AS dummy UNWIND [1, 2] AS y RETURN y } AS v")).isEqualTo(2L);
+    assertThat(scalar("RETURN COUNT { RETURN 1 } AS v")).isEqualTo(1L);
+  }
+
+  @Test
+  void countSubqueryStartingWithUnwindIsEvaluatedPerOuterRow() {
+    final List<Result> results = rows(
+        "UNWIND [1, 2, 3] AS x RETURN x, COUNT { UNWIND [1, 2] AS y RETURN y } AS c ORDER BY x");
+
+    assertThat(results).hasSize(3);
+    for (int i = 0; i < 3; i++) {
+      assertThat(results.get(i).<Number>getProperty("x").intValue()).isEqualTo(i + 1);
+      assertThat(results.get(i).<Number>getProperty("c").longValue()).as("count for outer row %d", i + 1).isEqualTo(2L);
+    }
+  }
+
+  @Test
+  void countSubqueryStartingWithCallOrOptionalMatch() {
+    assertThat(scalar("RETURN COUNT { CALL { RETURN 1 AS z } RETURN z } AS v")).isEqualTo(1L);
+    assertThat(scalar("RETURN COUNT { OPTIONAL MATCH (n:NoSuchLabel) RETURN n } AS v")).isEqualTo(1L);
+  }
+
+  @Test
+  void existsSubqueryStartingWithUnwind() {
+    assertThat(scalar("RETURN EXISTS { UNWIND [1, 2] AS y RETURN y } AS v")).isEqualTo(true);
+    assertThat(scalar("RETURN EXISTS { UNWIND [] AS y RETURN y } AS v")).isEqualTo(false);
+    assertThat(scalar("RETURN EXISTS { CALL { RETURN 1 AS z } RETURN z } AS v")).isEqualTo(true);
+  }
+
+  @Test
+  void collectSubqueryStartingWithUnwind() {
+    assertThat(scalar("RETURN COLLECT { UNWIND [1, 2] AS y RETURN y } AS v")).isEqualTo(List.of(1L, 2L));
+  }
+
+  @Test
+  void returningCallSubqueryStartingWithUnwind() {
+    final List<Result> results = rows(
+        "UNWIND [1, 2, 3] AS x CALL { UNWIND [1, 2] AS y RETURN y } RETURN x, y ORDER BY x, y");
+
+    assertThat(results).hasSize(6);
+    final List<String> pairs = new ArrayList<>(6);
+    for (final Result row : results)
+      pairs.add(row.<Number>getProperty("x").intValue() + "," + row.<Number>getProperty("y").intValue());
+    assertThat(pairs).containsExactly("1,1", "1,2", "2,1", "2,2", "3,1", "3,2");
+  }
+
+  @Test
+  void correlatedSubqueryStartingWithUnwind() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:T {tags: ['a', 'b', 'c']})"));
+
+    assertThat(scalar("MATCH (n:T) RETURN COUNT { UNWIND n.tags AS t RETURN t } AS v")).isEqualTo(3L);
+    assertThat(scalar("MATCH (n:T) RETURN EXISTS { UNWIND n.tags AS t RETURN t } AS v")).isEqualTo(true);
+    assertThat(scalar("MATCH (n:T) RETURN COLLECT { UNWIND n.tags AS t RETURN t } AS v")).isEqualTo(List.of("a", "b", "c"));
+  }
+
+  @Test
+  void patternOnlySubqueriesAreStillWrappedIntoMatch() {
+    database.transaction(() -> database.command("opencypher", "CREATE (a:P {n:'a'})-[:KNOWS]->(b:P {n:'b'})"));
+
+    assertThat(scalar("MATCH (a:P {n:'a'}) RETURN COUNT { (a)-[:KNOWS]->(:P) } AS v")).isEqualTo(1L);
+    assertThat(scalar("MATCH (a:P {n:'a'}) RETURN EXISTS { (a)-[:KNOWS]->(:P) } AS v")).isEqualTo(true);
+    assertThat(scalar("MATCH (a:P {n:'b'}) RETURN EXISTS { (a)-[:KNOWS]->(:P) } AS v")).isEqualTo(false);
+  }
+}


### PR DESCRIPTION
Closes #5461

`COUNT {}` and `EXISTS {}` re-execute their body as a standalone query string, and a body that is a bare pattern has to be wrapped into a synthesized `MATCH`. The test that told a pattern from a full subquery body recognized only `MATCH`, `WITH` and `RETURN`, so a body opening with `UNWIND` (or `CALL`, `OPTIONAL MATCH`, `FOREACH`) was mistaken for a pattern and spliced into the unparseable `MATCH UNWIND [1, 2] AS y RETURN y RETURN 1`. All three subquery expressions absorb a body that cannot run into their neutral value, so the parse failure surfaced as a silent `COUNT` of 0 and `EXISTS` of false instead of an error - and `COLLECT`, which has no such wrapper, was the one of the three that already worked. A second incomplete copy of the same keyword list in `injectWhereConditions` broke the correlated form the same way, and a third copy in `ExistsExpression.wrapNonMatchBody` was already correct. `CorrelatedSubqueryRewriter` now owns one authoritative list that every site routes through, and `CountExpression`'s non-MATCH wrapper stops comma-splicing the injected pattern into the body's first clause.

Two notes on the report itself: the bug is broader than filed (`EXISTS {}` and `CALL`/`OPTIONAL MATCH`/`FOREACH`-first bodies are affected identically), and the returning-`CALL {}` half **does not reproduce** on `main` - that repro already returns the expected 6 rows, so it is covered here as a regression guard only.

## Test plan

- [x] New `Issue5461SubqueryLeadingClauseTest` (10 tests) - every assertion confirmed failing before the fix and passing after. The no-`RETURN` case was verified in isolation by restoring the old three-keyword whitelist (0 instead of 2).
- [x] `COUNT`/`EXISTS`/`COLLECT` with an `UNWIND`-first body, list sizes 0-3, including the empty-list control that must stay 0.
- [x] The issue's per-outer-row case: `UNWIND [1,2,3] AS x RETURN x, COUNT { UNWIND [1,2] AS y RETURN y }` gives 2 for each of the 3 rows.
- [x] Bodies opening with `CALL` and `OPTIONAL MATCH`; an `UNWIND`-first body with no `RETURN` of its own.
- [x] Correlated form `MATCH (n:T) RETURN COUNT { UNWIND n.tags AS t RETURN t }` - this is the one that isolated the second keyword list.
- [x] The issue's controls (`WITH 1 AS dummy`, `RETURN 1`) and a guard that bare-pattern bodies are still wrapped into a `MATCH`.
- [x] Regression: full `com.arcadedb.query.opencypher.**` suite, 7693 tests, 0 failures.
- [x] Regression: full `engine` module suite, 10149 tests, 0 failures.

To verify by hand:

```cypher
RETURN COUNT { UNWIND [1, 2] AS y RETURN y } AS c;   -- 2 (was 0)
RETURN EXISTS { UNWIND [1, 2] AS y RETURN y } AS e;  -- true (was false)
```
