### PR TITLE
fix(#5541): reject only clause-level writes in read-only subqueries

### DIFF
--- a/docs/5541-subquery-update-clause-guard.md
+++ b/docs/5541-subquery-update-clause-guard.md
@@ -44,8 +44,8 @@ visible rather than data-corrupting.
 `CorrelatedSubqueryRewriter` gains the update-clause list and one public predicate, next to the
 clause-keyword list it already owns:
 
-- `UPDATE_CLAUSE_KEYWORDS` - `CREATE`, `MERGE`, `SET`, `DELETE`, `REMOVE`. `DELETE` also covers
-  `DETACH DELETE`.
+- `UPDATE_CLAUSE_KEYWORDS` - `CREATE`, `MERGE`, `SET`, `DELETE`, `REMOVE`, `INSERT`. `DELETE` also
+  covers `DETACH DELETE`; on `INSERT` see the review-cycle note below.
 - `containsUpdateClause(body)` - walks the body once, skipping string literals and backtick-quoted
   identifiers (including backslash escapes), and matches only on a word boundary through the existing
   `matchesKeywordAt`.
@@ -71,7 +71,7 @@ correctly derived table rather than borrowing the boundary one. Still derived, n
 
 New regression test
 `engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java`,
-9 tests.
+11 tests.
 
 Proven to fail before the fix: with the helper added but the three guards still naive, 6 of the 9
 failed, each with the exact reported `InvalidClauseComposition` exception - the `COUNT`, `EXISTS`,
@@ -88,20 +88,55 @@ longer identifiers that merely start with a keyword.
 The openCypher TCK scenario that requires rejection - `ExistentialSubquery2.feature` scenario [3],
 "Full existential subquery with update clause should fail" - continues to pass.
 
-Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7711 tests, 0 failures, and the
-full `engine` module suite, 10166 tests, 0 failures.
+Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7713 tests, 0 failures, and the
+full `engine` module suite, 10168 tests, 0 failures.
 
 Both totals reconcile exactly against the last measured run of the previous branch (7695 openCypher /
 10150 engine): +7 for `OpenCypherStDevEmptyInputTest`, which reached `main` after that branch point,
-and +9 for the new class here. Compared per class, no pre-existing test class changed its count, so
+and +11 for the new class here. Compared per class, no pre-existing test class changed its count, so
 the fix moved nothing it should not have. That puts the current `main` baseline at 7702 openCypher /
 10157 engine.
 
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5542
+
+### Review cycles
+
+**Cycle 1** - `e173e070` - claude[bot], no blocking findings but one substantive challenge: that
+leaving `INSERT` out let a real write execute inside a read-only subquery. The code half of the claim
+checked out - `ClauseDispatcher.handleInsert` routes to `visitInsertClause`, which builds a
+`CreateClause`, so `INSERT` genuinely is `CREATE` in this engine.
+
+The consequence half did not. Probed directly against the branch:
+
+```
+COUNT   { INSERT (m:T {name:'leaked-count'})   RETURN m }  ->  0
+EXISTS  { INSERT (m:T {name:'leaked-exists'})  RETURN m }  ->  false
+COLLECT { INSERT (m:T {name:'leaked-collect'}) RETURN m }  ->  []
+total :T nodes afterwards = 2, unchanged; leaked nodes = 0
+```
+
+No write reaches storage. What happens instead is the #5461 failure mode: the body fails downstream
+and each expression absorbs it into its neutral value, so the query silently answers `0` instead of
+raising. So this was not the data-integrity gap it was reported to be - but `INSERT` was still added,
+for the better reason that it converts a silently wrong answer into a proper error and stops
+`CLAUSE_KEYWORDS` and `UPDATE_CLAUSE_KEYWORDS` disagreeing about whether `INSERT` writes. The earlier
+"it parses on `main` today" objection was weak once it was clear those queries answer `0` today.
+
+Also applied from cycle 1: backslash escaping no longer applies inside backtick-quoted identifiers,
+where Cypher escapes a literal backtick by doubling it rather than with a backslash. The review
+called this cosmetic and suggested only correcting the comment; the one-character fix is strictly
+more correct than the comment, so the behavior was fixed instead. Covered by a test in which the
+backslash form would otherwise swallow the closing backtick and hide a genuine trailing `SET`.
+
+Declined, with the reason recorded in code: comments are not skipped by the scan, so an update
+keyword inside a `//` or `/* */` comment still trips the guard. That blind spot predates this change
+(the old `contains("SET ")` had it too) and is not widened here; fixing it means teaching the scanner
+comment syntax, which is beyond this bug.
+
 ## Follow-ups
 
-- **Out of scope, deliberately.** `INSERT` is a real ArcadeDB clause (`Cypher25Parser.g4` defines
-  `insertClause`) and is a write, but it was not in the original guard. Adding it would reject
-  queries that parse today, which is a behavior change beyond this bug. Noted, not changed.
 - **Investigated under #5461, not a defect.** The neighbouring
   `subquery.toUpperCase().contains("RETURN ")` test in `parseCountExpression` /
   `parseExistsExpression` is also an imprecise substring match, but it does not produce a wrong

--- a/docs/5541-subquery-update-clause-guard.md
+++ b/docs/5541-subquery-update-clause-guard.md
@@ -58,10 +58,18 @@ Two deliberate choices:
 - **Nesting is not tracked.** Unlike `injectWhereConditions`, the scan does not skip bracketed
   constructs. A write nested inside one - `CALL { ... CREATE ... }` - is still a write and must still
   be rejected. Only literals are exempt, which is exactly the reported false positive.
-- **Word boundaries make the guard slightly stronger, not weaker.** The old scan required a trailing
-  space, so `CREATE(n)` slipped through; the boundary check catches it. Conversely `n.createdAt`,
-  `n.set`, `[r:SET_BY]` and `{create: 1}` are correctly *not* clauses, via the existing rejection of
-  `.`, `:` and `$` prefixes and of identifier characters on either side.
+- **A word boundary alone is not enough; the keyword must also open a clause.** None of the six
+  keywords is reserved in this grammar - `RETURN 1 AS set` and `RETURN 1 AS insert` both parse - so
+  matching on a word boundary alone flags an alias as a write. The guard additionally requires the
+  keyword to be followed by whitespace or an immediate `(`, which is what a clause takes. That keeps
+  `SET n.x = 1`, `DELETE n` and the space-less `CREATE(n)` that the original trailing-space scan
+  missed, while leaving an alias at the end of a body or before a comma alone. `n.createdAt`,
+  `n.set`, `[r:SET_BY]`, `{create: 1}` and `{set : 1}` are excluded by the surrounding-character
+  rules.
+
+  What no text scan can separate is an alias that is itself followed by a clause, as in
+  `WITH 1 AS set RETURN set`, which is lexically identical to `SET n.x = 1`. That needs clause
+  position from the parse tree and is recorded on the method rather than guessed at.
 
 The first-character pre-filter table introduced in #5540 is now built by a shared `firstCharTable`
 helper and passed to `matchesAnyKeywordAt` explicitly, so the update-keyword scan gets its own
@@ -71,7 +79,7 @@ correctly derived table rather than borrowing the boundary one. Still derived, n
 
 New regression test
 `engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java`,
-12 tests.
+14 tests.
 
 Proven to fail before the fix: with the helper added but the three guards still naive, 6 of the 9
 failed, each with the exact reported `InvalidClauseComposition` exception - the `COUNT`, `EXISTS`,
@@ -88,13 +96,13 @@ longer identifiers that merely start with a keyword.
 The openCypher TCK scenario that requires rejection - `ExistentialSubquery2.feature` scenario [3],
 "Full existential subquery with update clause should fail" - continues to pass.
 
-Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7714 tests, 0 failures, and the
-full `engine` module suite, 10169 tests, 0 failures. Both suites were re-measured after each review
+Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7717 tests, 0 failures, and the
+full `engine` module suite, 10172 tests, 0 failures. Both suites were re-measured after each review
 cycle changed the predicate, rather than carried forward.
 
 Both totals reconcile exactly against the last measured run of the previous branch (7695 openCypher /
 10150 engine): +7 for `OpenCypherStDevEmptyInputTest`, which reached `main` after that branch point,
-and +12 for the new class here. Compared per class, no pre-existing test class changed its count, so
+and +15 for the new class here. Compared per class, no pre-existing test class changed its count, so
 the fix moved nothing it should not have. That puts the current `main` baseline at 7702 openCypher /
 10157 engine.
 
@@ -158,9 +166,45 @@ is ever followed by one. `matchesAnyKeywordAt` was split so the matched keyword'
 for that lookahead, and tests cover both the false positive and that a genuine clause with extra
 whitespace (`MATCH (n)   SET   n.x = 1`) is still caught.
 
-Noted, no action: `containsUpdateClause` calls `toUpperCase()` without a `Locale`. That matches
-`startsWithClauseKeyword` and `injectWhereConditions` beside it, so the Turkish-locale caveat is
-engine-wide rather than introduced here; changing one of the three would be the inconsistency.
+Noted, no action at the time: `containsUpdateClause` calls `toUpperCase()` without a `Locale`. That
+matched the two sibling methods, so changing one of the three looked like the inconsistency. Cycle 3
+raised it again and pointed at the right answer - change all three - which is what happened; see
+below.
+
+**Cycle 3** - `c2c65869` - claude[bot], LGTM, no blocking findings. Both remaining minor notes were
+probed rather than accepted, and both turned out to be real, one of them a regression this branch had
+introduced.
+
+*Locale.* Confirmed, and it is specifically reachable through this branch's own `INSERT` addition:
+
+```
+"insert".toUpperCase() in tr-TR              -> INSERT with a dotted capital I
+containsUpdateClause("insert (n:T)") in tr-TR -> false      (a lowercase write slips past)
+containsUpdateClause("match (n) set ...")     -> true       (SET has no i, so it is unaffected)
+```
+
+`INSERT` is the one update keyword containing an `i`, so adding it in cycle 1 is what made the
+pre-existing locale sloppiness bite. All three `toUpperCase()` calls in the class now pass
+`Locale.ROOT`, and a test asserts the predicate under a Turkish default locale.
+
+*Keyword as an identifier.* The review flagged this as speculative, worth checking "only if `INSERT`
+turns out to be usable as an identifier". It is - and so are the other five, which the review assumed
+were reserved:
+
+```
+RETURN 1 AS set / create / delete / merge / remove / insert   -> all accepted
+```
+
+That makes the alias case real, and it was a **regression introduced by this branch**. The original
+scan required a trailing space, so a body ending `... RETURN 1 AS set` did not match `"SET "` and was
+allowed; the word-boundary match - praised in cycles 1 and 2 as a strengthening - matches at the end
+of a token and rejected it. Verified before the fix: `set`, `create` and `insert` used as aliases
+inside `COUNT { }` all threw.
+
+`containsUpdateClause` now also requires the keyword to be followed by whitespace or an immediate
+`(`, which is what a clause takes and an alias at the end of a body or before a comma does not. The
+space-less `CREATE(n)` improvement survives. Tested across all six keywords, in both the alias and
+the genuine-clause shape.
 
 ## Follow-ups
 

--- a/docs/5541-subquery-update-clause-guard.md
+++ b/docs/5541-subquery-update-clause-guard.md
@@ -71,7 +71,7 @@ correctly derived table rather than borrowing the boundary one. Still derived, n
 
 New regression test
 `engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java`,
-11 tests.
+12 tests.
 
 Proven to fail before the fix: with the helper added but the three guards still naive, 6 of the 9
 failed, each with the exact reported `InvalidClauseComposition` exception - the `COUNT`, `EXISTS`,
@@ -88,12 +88,13 @@ longer identifiers that merely start with a keyword.
 The openCypher TCK scenario that requires rejection - `ExistentialSubquery2.feature` scenario [3],
 "Full existential subquery with update clause should fail" - continues to pass.
 
-Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7713 tests, 0 failures, and the
-full `engine` module suite, 10168 tests, 0 failures.
+Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7714 tests, 0 failures, and the
+full `engine` module suite, 10169 tests, 0 failures. Both suites were re-measured after each review
+cycle changed the predicate, rather than carried forward.
 
 Both totals reconcile exactly against the last measured run of the previous branch (7695 openCypher /
 10150 engine): +7 for `OpenCypherStDevEmptyInputTest`, which reached `main` after that branch point,
-and +11 for the new class here. Compared per class, no pre-existing test class changed its count, so
+and +12 for the new class here. Compared per class, no pre-existing test class changed its count, so
 the fix moved nothing it should not have. That puts the current `main` baseline at 7702 openCypher /
 10157 engine.
 
@@ -134,6 +135,32 @@ Declined, with the reason recorded in code: comments are not skipped by the scan
 keyword inside a `//` or `/* */` comment still trips the guard. That blind spot predates this change
 (the old `contains("SET ")` had it too) and is not widened here; fixing it means teaching the scanner
 comment syntax, which is beyond this bug.
+
+**Cycle 2** - `de4a9b78` - claude[bot], no blocking findings, two actionable points.
+
+The first was that the PR description still argued for leaving `INSERT` out while the code and the
+doc had it in. Correct, and the description was rewritten to present the rejection as the intentional
+behavior change it is rather than deny it.
+
+The second was a suspected false positive on a map key separated from its colon by whitespace, e.g.
+`{set : 1}`. `matchesKeywordAt` rejects a keyword glued to its colon, but the reviewer noted the
+check looks only at the immediately following character. Probed, and it is real - and it is the same
+class of defect this PR exists to fix:
+
+```
+MATCH (n:T {set : 1}) RETURN n                        -> parses, runs, returns no rows
+RETURN COUNT { MATCH (n:T {set : 1}) RETURN n } AS v  -> InvalidClauseComposition
+```
+
+The grammar accepts that shape; only the guard rejected it. `containsUpdateClause` now looks past any
+whitespace after a matched keyword and treats a following colon as a map key, since no update clause
+is ever followed by one. `matchesAnyKeywordAt` was split so the matched keyword's length is available
+for that lookahead, and tests cover both the false positive and that a genuine clause with extra
+whitespace (`MATCH (n)   SET   n.x = 1`) is still caught.
+
+Noted, no action: `containsUpdateClause` calls `toUpperCase()` without a `Locale`. That matches
+`startsWithClauseKeyword` and `injectWhereConditions` beside it, so the Turkish-locale caveat is
+engine-wide rather than introduced here; changing one of the three would be the inconsistency.
 
 ## Follow-ups
 

--- a/docs/5541-subquery-update-clause-guard.md
+++ b/docs/5541-subquery-update-clause-guard.md
@@ -1,0 +1,114 @@
+# #5541 - COUNT/EXISTS/COLLECT reject a read-only body when a string literal contains an update keyword
+
+## Symptom
+
+A read-only subquery whose body merely *mentions* an update keyword fails to parse:
+
+```cypher
+CREATE (:T {name:'SET x'});
+
+RETURN COUNT { MATCH (n:T) WHERE n.name = 'SET x' RETURN n } AS v;
+-- CommandParsingException: InvalidClauseComposition: COUNT subquery cannot contain update clauses
+```
+
+`EXISTS { }` and `COLLECT { }` fail identically, with their own message. The keyword does not have to
+open the literal: `WHERE n.name = 'a SET b'` is rejected too.
+
+## Root cause
+
+`COUNT { }`, `EXISTS { }` and `COLLECT { }` must be read-only, so each of the three parse methods in
+`CypherExpressionBuilder` guards its body against update clauses. All three did it by substring scan
+over the raw text:
+
+```java
+final String upper = subquery.toUpperCase();
+if (upper.contains("SET ") || upper.contains("CREATE ") || upper.contains("DELETE ")
+    || upper.contains("MERGE ") || upper.contains("REMOVE "))
+  throw new CommandParsingException("InvalidClauseComposition: ...");
+```
+
+`contains` cannot tell a clause from ordinary text. A string literal is ordinary text, so any user
+data containing one of the five keywords made a legal read-only filter unparseable.
+
+This is the same class of defect as #5461 (fixed in #5540): a decision about a subquery body taken by
+naive substring matching. #5540 consolidated the *clause-keyword* lists into
+`CorrelatedSubqueryRewriter`, which already scans with word boundaries and skips string literals;
+these update-clause guards were the remaining naive scans in the same three methods.
+
+The failure mode differs from #5461 in a useful way. #5461 was silent - the parse failure was
+absorbed into the expression's neutral value, so `COUNT` returned 0. This one throws, so it is
+visible rather than data-corrupting.
+
+## Fix
+
+`CorrelatedSubqueryRewriter` gains the update-clause list and one public predicate, next to the
+clause-keyword list it already owns:
+
+- `UPDATE_CLAUSE_KEYWORDS` - `CREATE`, `MERGE`, `SET`, `DELETE`, `REMOVE`. `DELETE` also covers
+  `DETACH DELETE`.
+- `containsUpdateClause(body)` - walks the body once, skipping string literals and backtick-quoted
+  identifiers (including backslash escapes), and matches only on a word boundary through the existing
+  `matchesKeywordAt`.
+
+The three guards in `CypherExpressionBuilder` (`parseExistsExpression`, `parseCollectExpression`,
+`parseCountExpression`) now call it. Their messages are unchanged.
+
+Two deliberate choices:
+
+- **Nesting is not tracked.** Unlike `injectWhereConditions`, the scan does not skip bracketed
+  constructs. A write nested inside one - `CALL { ... CREATE ... }` - is still a write and must still
+  be rejected. Only literals are exempt, which is exactly the reported false positive.
+- **Word boundaries make the guard slightly stronger, not weaker.** The old scan required a trailing
+  space, so `CREATE(n)` slipped through; the boundary check catches it. Conversely `n.createdAt`,
+  `n.set`, `[r:SET_BY]` and `{create: 1}` are correctly *not* clauses, via the existing rejection of
+  `.`, `:` and `$` prefixes and of identifier characters on either side.
+
+The first-character pre-filter table introduced in #5540 is now built by a shared `firstCharTable`
+helper and passed to `matchesAnyKeywordAt` explicitly, so the update-keyword scan gets its own
+correctly derived table rather than borrowing the boundary one. Still derived, never hand-maintained.
+
+## Verification
+
+New regression test
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java`,
+9 tests.
+
+Proven to fail before the fix: with the helper added but the three guards still naive, 6 of the 9
+failed, each with the exact reported `InvalidClauseComposition` exception - the `COUNT`, `EXISTS`,
+`COLLECT`, substring-of-literal, quoted-forms and correlated cases. The remaining 3 are the guard
+that genuine update clauses are *still* rejected, the guard that a rejected body writes nothing, and
+the direct unit test of the new predicate; those must pass in both states.
+
+Coverage: literals in single quotes, double quotes and backticks, and an escaped quote inside a
+literal; a keyword as a mid-literal substring; the correlated form; every one of the five update
+clauses plus `DETACH DELETE` still rejected across all three expressions; a rejected body leaving the
+data untouched; and the predicate itself against property access, labels/types, map keys and
+longer identifiers that merely start with a keyword.
+
+The openCypher TCK scenario that requires rejection - `ExistentialSubquery2.feature` scenario [3],
+"Full existential subquery with update clause should fail" - continues to pass.
+
+Regression run: the full `com.arcadedb.query.opencypher.**` suite, 7711 tests, 0 failures, and the
+full `engine` module suite, 10166 tests, 0 failures.
+
+Both totals reconcile exactly against the last measured run of the previous branch (7695 openCypher /
+10150 engine): +7 for `OpenCypherStDevEmptyInputTest`, which reached `main` after that branch point,
+and +9 for the new class here. Compared per class, no pre-existing test class changed its count, so
+the fix moved nothing it should not have. That puts the current `main` baseline at 7702 openCypher /
+10157 engine.
+
+## Follow-ups
+
+- **Out of scope, deliberately.** `INSERT` is a real ArcadeDB clause (`Cypher25Parser.g4` defines
+  `insertClause`) and is a write, but it was not in the original guard. Adding it would reject
+  queries that parse today, which is a behavior change beyond this bug. Noted, not changed.
+- **Investigated under #5461, not a defect.** The neighbouring
+  `subquery.toUpperCase().contains("RETURN ")` test in `parseCountExpression` /
+  `parseExistsExpression` is also an imprecise substring match, but it does not produce a wrong
+  answer: a `MATCH`-only body executes fine without the synthesized `RETURN`. Left alone.
+
+## Impact
+
+Any read-only `COUNT { }`, `EXISTS { }` or `COLLECT { }` filtering on user data that happens to
+contain `SET`, `CREATE`, `DELETE`, `MERGE` or `REMOVE` failed to parse. The guard keeps its full
+strength against real update clauses, and gains the `CREATE(` case the trailing-space form missed.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
@@ -67,9 +67,12 @@ public final class CorrelatedSubqueryRewriter {
 
   /**
    * Clauses that write, and so may not appear in the read-only subquery expressions. {@code DELETE}
-   * also covers {@code DETACH DELETE}.
+   * also covers {@code DETACH DELETE}. {@code INSERT} is here because this engine treats it as a
+   * synonym of {@code CREATE} - {@code ClauseDispatcher.handleInsert} builds a {@code CreateClause} -
+   * so leaving it out let a body that is plainly a write reach the executor, where it produced the
+   * expression's neutral value instead of an error.
    */
-  private static final String[] UPDATE_CLAUSE_KEYWORDS = { "CREATE", "MERGE", "SET", "DELETE", "REMOVE" };
+  private static final String[] UPDATE_CLAUSE_KEYWORDS = { "CREATE", "MERGE", "SET", "DELETE", "REMOVE", "INSERT" };
 
   /**
    * First letters of each keyword array, so a per-character scan rejects a position with one array
@@ -114,6 +117,9 @@ public final class CorrelatedSubqueryRewriter {
    * <p>
    * Nesting is deliberately not tracked: a write nested inside a bracketed construct - {@code CALL {
    * ... CREATE ... }} - is still a write, and must still be rejected.
+   * <p>
+   * Comments are not skipped, so an update keyword inside one is still read as a clause. That blind
+   * spot predates this scan and is not widened by it.
    */
   public static boolean containsUpdateClause(final String body) {
     final String upper = body.toUpperCase();
@@ -123,8 +129,10 @@ public final class CorrelatedSubqueryRewriter {
       final char c = upper.charAt(i);
 
       if (quote != 0) {
-        // Inside a string literal or quoted identifier: only its (non-escaped) closing quote matters
-        if (c == '\\')
+        // Inside a string literal or quoted identifier: only its closing quote matters. Backslash
+        // escapes apply to string literals only - a backtick-quoted identifier escapes a literal
+        // backtick by doubling it, which this toggle handles on its own (close then reopen).
+        if (c == '\\' && quote != '`')
           i++;
         else if (c == quote)
           quote = 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BinaryOperator;
 import java.util.stream.Stream;
@@ -103,7 +104,7 @@ public final class CorrelatedSubqueryRewriter {
    * surfaces only as a silently wrong {@code COUNT} of 0 or {@code EXISTS} of false (issue #5461).
    */
   public static boolean startsWithClauseKeyword(final String body) {
-    return matchesAnyKeywordAt(body.trim().toUpperCase(), 0, CLAUSE_KEYWORDS, BOUNDARY_KEYWORD_FIRST_CHAR);
+    return matchesAnyKeywordAt(body.trim().toUpperCase(Locale.ROOT), 0, CLAUSE_KEYWORDS, BOUNDARY_KEYWORD_FIRST_CHAR);
   }
 
   /**
@@ -122,7 +123,7 @@ public final class CorrelatedSubqueryRewriter {
    * spot predates this scan and is not widened by it.
    */
   public static boolean containsUpdateClause(final String body) {
-    final String upper = body.toUpperCase();
+    final String upper = body.toUpperCase(Locale.ROOT);
     char quote = 0;
 
     for (int i = 0; i < upper.length(); i++) {
@@ -143,23 +144,41 @@ public final class CorrelatedSubqueryRewriter {
         continue;
       }
       final int keywordLength = matchedKeywordLengthAt(upper, i, UPDATE_CLAUSE_KEYWORDS, UPDATE_KEYWORD_FIRST_CHAR);
-      if (keywordLength > 0 && !isMapKeyAt(upper, i + keywordLength))
+      if (keywordLength > 0 && opensAClauseAt(upper, i + keywordLength))
         return true;
     }
     return false;
   }
 
   /**
-   * Tells whether the keyword just matched is really a map key such as {@code {set : 1}}.
+   * Tells whether the keyword just matched is followed by something a write clause can actually take,
+   * rather than being an identifier that happens to be spelled like one.
    * <p>
-   * {@link #matchesKeywordAt} already rejects a keyword glued to its colon ({@code {set: 1}}), but
-   * the key may be separated from it by whitespace, and no update clause is ever followed by a colon.
+   * None of these keywords is reserved in this grammar - {@code RETURN 1 AS set} and
+   * {@code RETURN 1 AS insert} both parse - so a scan that accepts any word boundary flags an alias
+   * as a write. A clause is followed by its pattern or target, so only whitespace or an immediately
+   * following {@code (} qualifies: that keeps {@code SET n.x = 1}, {@code DELETE n} and the
+   * space-less {@code CREATE(n)}, while rejecting an alias at the end of the body or before a comma.
+   * <p>
+   * A colon disqualifies it again, because the keyword is then a map key: {@link #matchesKeywordAt}
+   * already rejects the glued {@code {set: 1}}, and this catches {@code {set : 1}}.
+   * <p>
+   * What this cannot separate is an alias that is itself followed by a clause, as in
+   * {@code WITH 1 AS set RETURN set} - lexically identical to {@code SET n.x = 1}. Telling those
+   * apart needs clause position from the parse tree rather than a text scan.
    */
-  private static boolean isMapKeyAt(final String upper, final int afterKeyword) {
+  private static boolean opensAClauseAt(final String upper, final int afterKeyword) {
+    if (afterKeyword >= upper.length())
+      return false;
+    if (upper.charAt(afterKeyword) == '(')
+      return true;
+    if (!Character.isWhitespace(upper.charAt(afterKeyword)))
+      return false;
+
     int pos = afterKeyword;
     while (pos < upper.length() && Character.isWhitespace(upper.charAt(pos)))
       pos++;
-    return pos < upper.length() && upper.charAt(pos) == ':';
+    return pos < upper.length() && upper.charAt(pos) != ':';
   }
 
   /**
@@ -298,7 +317,7 @@ public final class CorrelatedSubqueryRewriter {
    */
   public static String injectWhereConditions(final String query, final String conditions) {
     // NOTE: upper must not be trimmed - every index below addresses both strings interchangeably
-    final String upper = query.toUpperCase();
+    final String upper = query.toUpperCase(Locale.ROOT);
     int scanStart = 0;
     while (scanStart < upper.length() && Character.isWhitespace(upper.charAt(scanStart)))
       scanStart++;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
@@ -66,18 +66,28 @@ public final class CorrelatedSubqueryRewriter {
       Stream.of("ORDER", "SKIP", "LIMIT", "UNION")).toArray(String[]::new);
 
   /**
-   * First letters of {@link #CLAUSE_BOUNDARY_KEYWORDS}, so the per-character boundary scan rejects a
-   * position with one array read instead of walking every keyword. Derived, never hand-maintained:
-   * the whole point of this class is that hand-maintained copies of the keyword list drift.
+   * Clauses that write, and so may not appear in the read-only subquery expressions. {@code DELETE}
+   * also covers {@code DETACH DELETE}.
    */
-  private static final boolean[] BOUNDARY_KEYWORD_FIRST_CHAR = new boolean[128];
+  private static final String[] UPDATE_CLAUSE_KEYWORDS = { "CREATE", "MERGE", "SET", "DELETE", "REMOVE" };
 
-  static {
-    for (final String keyword : CLAUSE_BOUNDARY_KEYWORDS)
-      BOUNDARY_KEYWORD_FIRST_CHAR[keyword.charAt(0)] = true;
-  }
+  /**
+   * First letters of each keyword array, so a per-character scan rejects a position with one array
+   * read instead of walking every keyword. Derived, never hand-maintained: the whole point of this
+   * class is that hand-maintained copies of the keyword list drift.
+   */
+  private static final boolean[] BOUNDARY_KEYWORD_FIRST_CHAR = firstCharTable(CLAUSE_BOUNDARY_KEYWORDS);
+
+  private static final boolean[] UPDATE_KEYWORD_FIRST_CHAR = firstCharTable(UPDATE_CLAUSE_KEYWORDS);
 
   private CorrelatedSubqueryRewriter() {
+  }
+
+  private static boolean[] firstCharTable(final String[] keywords) {
+    final boolean[] table = new boolean[128];
+    for (final String keyword : keywords)
+      table[keyword.charAt(0)] = true;
+    return table;
   }
 
   /**
@@ -90,7 +100,44 @@ public final class CorrelatedSubqueryRewriter {
    * surfaces only as a silently wrong {@code COUNT} of 0 or {@code EXISTS} of false (issue #5461).
    */
   public static boolean startsWithClauseKeyword(final String body) {
-    return matchesAnyKeywordAt(body.trim().toUpperCase(), 0, CLAUSE_KEYWORDS);
+    return matchesAnyKeywordAt(body.trim().toUpperCase(), 0, CLAUSE_KEYWORDS, BOUNDARY_KEYWORD_FIRST_CHAR);
+  }
+
+  /**
+   * Tells whether a subquery body contains a write clause, which the three read-only subquery
+   * expressions must reject.
+   * <p>
+   * Only a keyword written as a clause counts: the scan skips string literals and backtick-quoted
+   * identifiers, and requires a word boundary. The guard used to be a bare
+   * {@code toUpperCase().contains("SET ")}, which could not tell a clause from ordinary user data, so
+   * a read-only {@code WHERE n.name = 'SET x'} was rejected as an update (issue #5541).
+   * <p>
+   * Nesting is deliberately not tracked: a write nested inside a bracketed construct - {@code CALL {
+   * ... CREATE ... }} - is still a write, and must still be rejected.
+   */
+  public static boolean containsUpdateClause(final String body) {
+    final String upper = body.toUpperCase();
+    char quote = 0;
+
+    for (int i = 0; i < upper.length(); i++) {
+      final char c = upper.charAt(i);
+
+      if (quote != 0) {
+        // Inside a string literal or quoted identifier: only its (non-escaped) closing quote matters
+        if (c == '\\')
+          i++;
+        else if (c == quote)
+          quote = 0;
+        continue;
+      }
+      if (c == '\'' || c == '"' || c == '`') {
+        quote = c;
+        continue;
+      }
+      if (matchesAnyKeywordAt(upper, i, UPDATE_CLAUSE_KEYWORDS, UPDATE_KEYWORD_FIRST_CHAR))
+        return true;
+    }
+    return false;
   }
 
   /**
@@ -269,7 +316,7 @@ public final class CorrelatedSubqueryRewriter {
 
       if (matchesKeywordAt(upper, i, "WHERE") && topWherePos < 0)
         topWherePos = i;
-      else if (clauseStart < 0 && matchesAnyKeywordAt(upper, i, CLAUSE_BOUNDARY_KEYWORDS))
+      else if (clauseStart < 0 && matchesAnyKeywordAt(upper, i, CLAUSE_BOUNDARY_KEYWORDS, BOUNDARY_KEYWORD_FIRST_CHAR))
         clauseStart = i;
 
       // Stop once we find a non-WHERE clause keyword
@@ -338,15 +385,16 @@ public final class CorrelatedSubqueryRewriter {
   }
 
   /**
-   * The first-char table is built from {@link #CLAUSE_BOUNDARY_KEYWORDS}, which is a superset of
-   * {@link #CLAUSE_KEYWORDS}, so it is a sound pre-filter for either array: it can never reject a
-   * position one of them would have matched.
+   * {@code firstChars} must be a table built from a superset of {@code keywords} - see
+   * {@link #firstCharTable} - so that it can never reject a position one of them would have matched.
+   * {@link #CLAUSE_BOUNDARY_KEYWORDS} is such a superset of {@link #CLAUSE_KEYWORDS}.
    */
-  private static boolean matchesAnyKeywordAt(final String upper, final int pos, final String[] keywords) {
+  private static boolean matchesAnyKeywordAt(final String upper, final int pos, final String[] keywords,
+      final boolean[] firstChars) {
     if (pos >= upper.length())
       return false;
     final char first = upper.charAt(pos);
-    if (first < BOUNDARY_KEYWORD_FIRST_CHAR.length && !BOUNDARY_KEYWORD_FIRST_CHAR[first])
+    if (first < firstChars.length && !firstChars[first])
       return false;
     for (final String keyword : keywords)
       if (matchesKeywordAt(upper, pos, keyword))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
@@ -142,10 +142,24 @@ public final class CorrelatedSubqueryRewriter {
         quote = c;
         continue;
       }
-      if (matchesAnyKeywordAt(upper, i, UPDATE_CLAUSE_KEYWORDS, UPDATE_KEYWORD_FIRST_CHAR))
+      final int keywordLength = matchedKeywordLengthAt(upper, i, UPDATE_CLAUSE_KEYWORDS, UPDATE_KEYWORD_FIRST_CHAR);
+      if (keywordLength > 0 && !isMapKeyAt(upper, i + keywordLength))
         return true;
     }
     return false;
+  }
+
+  /**
+   * Tells whether the keyword just matched is really a map key such as {@code {set : 1}}.
+   * <p>
+   * {@link #matchesKeywordAt} already rejects a keyword glued to its colon ({@code {set: 1}}), but
+   * the key may be separated from it by whitespace, and no update clause is ever followed by a colon.
+   */
+  private static boolean isMapKeyAt(final String upper, final int afterKeyword) {
+    int pos = afterKeyword;
+    while (pos < upper.length() && Character.isWhitespace(upper.charAt(pos)))
+      pos++;
+    return pos < upper.length() && upper.charAt(pos) == ':';
   }
 
   /**
@@ -399,15 +413,25 @@ public final class CorrelatedSubqueryRewriter {
    */
   private static boolean matchesAnyKeywordAt(final String upper, final int pos, final String[] keywords,
       final boolean[] firstChars) {
+    return matchedKeywordLengthAt(upper, pos, keywords, firstChars) > 0;
+  }
+
+  /**
+   * Length of the keyword matching at {@code pos}, or -1 when none does. Callers that only need a
+   * yes/no answer use {@link #matchesAnyKeywordAt}; the length is for those that have to look at what
+   * follows the keyword.
+   */
+  private static int matchedKeywordLengthAt(final String upper, final int pos, final String[] keywords,
+      final boolean[] firstChars) {
     if (pos >= upper.length())
-      return false;
+      return -1;
     final char first = upper.charAt(pos);
     if (first < firstChars.length && !firstChars[first])
-      return false;
+      return -1;
     for (final String keyword : keywords)
       if (matchesKeywordAt(upper, pos, keyword))
-        return true;
-    return false;
+        return keyword.length();
+    return -1;
   }
 
   private static boolean isCypherIdentifierChar(final char c) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -1825,9 +1825,7 @@ class CypherExpressionBuilder {
       subquery = originalText.substring(7, originalText.length() - 1).trim(); // fallback
 
     // Check for update clauses inside EXISTS (not allowed)
-    final String upper = subquery.toUpperCase();
-    if (upper.contains("SET ") || upper.contains("CREATE ") || upper.contains("DELETE ") ||
-        upper.contains("MERGE ") || upper.contains("REMOVE "))
+    if (CorrelatedSubqueryRewriter.containsUpdateClause(subquery))
       throw new CommandParsingException(
           "InvalidClauseComposition: Existential subquery cannot contain update clauses");
 
@@ -1859,9 +1857,7 @@ class CypherExpressionBuilder {
       subquery = originalText.substring(8, originalText.length() - 1).trim(); // fallback "COLLECT{" prefix
 
     // Update clauses are not allowed inside a COLLECT subquery
-    final String upper = subquery.toUpperCase();
-    if (upper.contains("SET ") || upper.contains("CREATE ") || upper.contains("DELETE ")
-        || upper.contains("MERGE ") || upper.contains("REMOVE "))
+    if (CorrelatedSubqueryRewriter.containsUpdateClause(subquery))
       throw new CommandParsingException(
           "InvalidClauseComposition: COLLECT subquery cannot contain update clauses");
 
@@ -1886,9 +1882,7 @@ class CypherExpressionBuilder {
     else
       subquery = originalText.substring(6, originalText.length() - 1).trim(); // fallback "COUNT{" prefix
 
-    final String upper = subquery.toUpperCase();
-    if (upper.contains("SET ") || upper.contains("CREATE ") || upper.contains("DELETE ")
-        || upper.contains("MERGE ") || upper.contains("REMOVE "))
+    if (CorrelatedSubqueryRewriter.containsUpdateClause(subquery))
       throw new CommandParsingException(
           "InvalidClauseComposition: COUNT subquery cannot contain update clauses");
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java
@@ -115,6 +115,34 @@ class Issue5541SubqueryUpdateClauseGuardTest {
         .hasMessageContaining("InvalidClauseComposition");
   }
 
+  /**
+   * INSERT is a synonym of CREATE in this engine, so a body opening with it is a write. It used to
+   * slip past the guard and reach the executor, which absorbed it into the expression's neutral
+   * value - a silent 0 rather than an error. No row was ever written, but the answer was wrong.
+   */
+  @Test
+  void insertIsRejectedAsAnUpdateClause() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN COUNT { INSERT (m:T {name:'x'}) RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN EXISTS { INSERT (m:T {name:'x'}) RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN COLLECT { INSERT (m:T {name:'x'}) RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("INSERT (m:T)")).isTrue();
+
+    // ... but INSERT inside a literal is still just data
+    assertThat(scalar("RETURN COUNT { MATCH (n:T) WHERE n.name = 'INSERT here' RETURN n } AS v")).isEqualTo(0L);
+    assertThat(scalar("MATCH (n:T) RETURN count(n) AS v")).isEqualTo(4L);
+  }
+
+  @Test
+  void backtickIdentifiersEscapeByDoublingNotByBackslash() {
+    // A doubled backtick closes and reopens the quote, so the SET after it is still inside data
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) WHERE n.`a``b SET c` = 1 RETURN n")).isFalse();
+    // A backslash is not an escape inside a backtick identifier, so it must not swallow the closer
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) WHERE n.`a\\` = 1 SET n.x = 2")).isTrue();
+  }
+
   @Test
   void rejectedUpdateSubqueryLeavesTheDataUntouched() {
     assertThatThrownBy(() -> database.query("opencypher", "RETURN COUNT { CREATE (m:T {name:'leaked'}) RETURN m } AS v"))

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -148,6 +149,45 @@ class Issue5541SubqueryUpdateClauseGuardTest {
     // The lookahead must not swallow a genuine clause that merely has extra whitespace
     assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n)   SET   n.x = 1")).isTrue();
     assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) REMOVE n:T")).isTrue();
+  }
+
+  /**
+   * None of the update keywords is reserved in this grammar - {@code RETURN 1 AS set} parses - so an
+   * alias spelled like one must not be read as a clause. A scan that accepts any word boundary flags
+   * it; the guard requires the keyword to be followed by whitespace or {@code (}, as a clause is.
+   */
+  @Test
+  void anAliasSpelledLikeAnUpdateClauseIsNotAClause() {
+    for (final String keyword : new String[] { "set", "create", "delete", "merge", "remove", "insert" }) {
+      assertThat(scalar("RETURN COUNT { MATCH (n:T) RETURN 1 AS " + keyword + " } AS v"))
+          .as("alias named %s", keyword).isEqualTo(4L);
+      assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) RETURN 1 AS " + keyword))
+          .as("alias named %s", keyword).isFalse();
+      assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) RETURN 1 AS " + keyword + ", 2 AS b"))
+          .as("alias named %s before a comma", keyword).isFalse();
+    }
+
+    // A space-less write is still a write, which the original trailing-space scan missed
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("CREATE(n:T)")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) DELETE n")).isTrue();
+  }
+
+  /**
+   * The scan uppercases the body to compare against ASCII keywords, so it must not depend on the
+   * default locale. In a Turkish locale {@code "insert".toUpperCase()} yields a dotted capital I,
+   * which does not match {@code INSERT} and let a lowercase write through.
+   */
+  @Test
+  void keywordMatchingIsIndependentOfTheDefaultLocale() {
+    final Locale original = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("insert (n:T)")).isTrue();
+      assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("match (n) set n.x = 1")).isTrue();
+      assertThat(CorrelatedSubqueryRewriter.startsWithClauseKeyword("unwind [1] AS y RETURN y")).isTrue();
+    } finally {
+      Locale.setDefault(original);
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.ast.CorrelatedSubqueryRewriter;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for GitHub issue #5541.
+ * <p>
+ * {@code COUNT { }}, {@code EXISTS { }} and {@code COLLECT { }} must reject a body that contains an
+ * update clause. The guard used to be a plain {@code toUpperCase().contains("SET ")} scan, so any
+ * body whose <em>text</em> mentioned an update keyword was rejected - including a keyword sitting
+ * inside a string literal, where it is ordinary user data rather than a clause. A read-only filter
+ * such as {@code WHERE n.name = 'SET x'} therefore failed to parse.
+ */
+class Issue5541SubqueryUpdateClauseGuardTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-5541-subquery-update-clause-guard").create();
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (:T {name:'SET x'}), (:T {name:'CREATE z'}), (:T {name:'DELETE me'}), (:T {name:'plain'})"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  private Object scalar(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("v");
+    }
+  }
+
+  @Test
+  void countSubqueryWithUpdateKeywordInsideStringLiteral() {
+    assertThat(scalar("RETURN COUNT { MATCH (n:T) WHERE n.name = 'SET x' RETURN n } AS v")).isEqualTo(1L);
+    assertThat(scalar("RETURN COUNT { MATCH (n:T) WHERE n.name = 'CREATE z' RETURN n } AS v")).isEqualTo(1L);
+    assertThat(scalar("RETURN COUNT { MATCH (n:T) WHERE n.name = 'DELETE me' RETURN n } AS v")).isEqualTo(1L);
+  }
+
+  @Test
+  void countSubqueryWithUpdateKeywordAsSubstringOfLiteral() {
+    // The literal need not start with the keyword for the naive scan to trip
+    assertThat(scalar("RETURN COUNT { MATCH (n:T) WHERE n.name = 'a SET b' RETURN n } AS v")).isEqualTo(0L);
+  }
+
+  @Test
+  void existsSubqueryWithUpdateKeywordInsideStringLiteral() {
+    assertThat(scalar("RETURN EXISTS { MATCH (n:T) WHERE n.name = 'SET x' RETURN n } AS v")).isEqualTo(true);
+    assertThat(scalar("RETURN EXISTS { MATCH (n:T) WHERE n.name = 'MERGE nothing' RETURN n } AS v")).isEqualTo(false);
+  }
+
+  @Test
+  void collectSubqueryWithUpdateKeywordInsideStringLiteral() {
+    assertThat(scalar("RETURN COLLECT { MATCH (n:T) WHERE n.name = 'SET x' RETURN n.name } AS v"))
+        .isEqualTo(List.of("SET x"));
+  }
+
+  @Test
+  void doubleQuotedAndBacktickQuotedTextIsAlsoData() {
+    assertThat(scalar("RETURN COUNT { MATCH (n:T) WHERE n.name = \"REMOVE this\" RETURN n } AS v")).isEqualTo(0L);
+    assertThat(scalar("RETURN COUNT { MATCH (n:T) WHERE n.`name` = 'SET x' RETURN n } AS v")).isEqualTo(1L);
+  }
+
+  @Test
+  void genuineUpdateClausesAreStillRejected() {
+    assertThatThrownBy(() -> database.query("opencypher", "MATCH (n:T) RETURN COUNT { MATCH (m:T) SET m.x = 1 RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThatThrownBy(() -> database.query("opencypher", "MATCH (n:T) RETURN EXISTS { MATCH (m:T) SET m.x = 1 } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThatThrownBy(
+        () -> database.query("opencypher", "MATCH (n:T) RETURN COLLECT { MATCH (m:T) SET m.x = 1 RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN COUNT { MATCH (m:T) DETACH DELETE m RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN COUNT { CREATE (m:T) RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN COUNT { MERGE (m:T {name:'q'}) RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN COUNT { MATCH (m:T) REMOVE m:T RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+  }
+
+  @Test
+  void rejectedUpdateSubqueryLeavesTheDataUntouched() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN COUNT { CREATE (m:T {name:'leaked'}) RETURN m } AS v"))
+        .hasMessageContaining("InvalidClauseComposition");
+    assertThat(scalar("MATCH (n:T) RETURN count(n) AS v")).isEqualTo(4L);
+  }
+
+  @Test
+  void updateClauseTestSkipsLiteralsAndRespectsWordBoundaries() {
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) WHERE n.name = 'SET x' RETURN n")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) WHERE n.name = \"CREATE z\" RETURN n")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) WHERE n.`DELETE` = 1 RETURN n")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) WHERE n.name = 'it\\'s SET' RETURN n")).isFalse();
+
+    // Not clause keywords: property access, labels/types, and longer identifiers
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) RETURN n.createdAt")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) RETURN n.set")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n)-[r:SET_BY]->(m) RETURN r")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n {create: 1}) RETURN n")).isFalse();
+
+    // Genuine update clauses
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) SET n.x = 1")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) WHERE n.name = 'SET x' SET n.x = 1")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("CREATE (n:T)")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) DETACH DELETE n")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MERGE (n:T {x: 1})")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) REMOVE n:T")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("")).isFalse();
+  }
+
+  @Test
+  void correlatedSubqueryWithUpdateKeywordInsideStringLiteral() {
+    assertThat(scalar("MATCH (n:T {name:'plain'}) RETURN COUNT { MATCH (m:T) WHERE m.name = 'SET x' RETURN m } AS v"))
+        .isEqualTo(1L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5541SubqueryUpdateClauseGuardTest.java
@@ -135,6 +135,21 @@ class Issue5541SubqueryUpdateClauseGuardTest {
     assertThat(scalar("MATCH (n:T) RETURN count(n) AS v")).isEqualTo(4L);
   }
 
+  /**
+   * A map key spelled like an update clause is data, not a clause. The grammar accepts
+   * {@code MATCH (n:T {set : 1}) RETURN n} standalone, so the guard must accept it too.
+   */
+  @Test
+  void mapKeyNamedLikeAnUpdateClauseIsNotAClause() {
+    assertThat(scalar("RETURN COUNT { MATCH (n:T {set : 1}) RETURN n } AS v")).isEqualTo(0L);
+    assertThat(scalar("RETURN COUNT { MATCH (n:T {create : 1}) RETURN n } AS v")).isEqualTo(0L);
+    assertThat(scalar("RETURN EXISTS { MATCH (n:T {set : 1}) RETURN n } AS v")).isEqualTo(false);
+
+    // The lookahead must not swallow a genuine clause that merely has extra whitespace
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n)   SET   n.x = 1")).isTrue();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) REMOVE n:T")).isTrue();
+  }
+
   @Test
   void backtickIdentifiersEscapeByDoublingNotByBackslash() {
     // A doubled backtick closes and reopens the quote, so the SET after it is still inside data
@@ -162,6 +177,9 @@ class Issue5541SubqueryUpdateClauseGuardTest {
     assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) RETURN n.set")).isFalse();
     assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n)-[r:SET_BY]->(m) RETURN r")).isFalse();
     assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n {create: 1}) RETURN n")).isFalse();
+    // ... including when whitespace separates the key from its colon
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n {set : 1}) RETURN n")).isFalse();
+    assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n {create  :  1}) RETURN n")).isFalse();
 
     // Genuine update clauses
     assertThat(CorrelatedSubqueryRewriter.containsUpdateClause("MATCH (n) SET n.x = 1")).isTrue();


### PR DESCRIPTION
Closes #5541

`COUNT { }`, `EXISTS { }` and `COLLECT { }` must be read-only, so each of the three parse methods in `CypherExpressionBuilder` guards its body against update clauses. All three did it with a substring scan (`upper.contains("SET ")` and friends), which cannot tell a clause from ordinary text. A string literal is ordinary text, so a perfectly legal read-only filter such as `WHERE n.name = 'SET x'` was rejected as an update and failed to parse. The three guards now share a single predicate, `CorrelatedSubqueryRewriter.containsUpdateClause`, placed next to the clause-keyword list that class already owns from #5540.

This is the same class of defect as #5461/#5540 - a decision about a subquery body taken by naive substring matching - and these were the remaining naive scans in those same three methods.

## How the predicate decides

A keyword counts as a write clause only when all of the following hold. Each rule exists because a probe showed the previous version getting a real query wrong:

1. **Outside string literals and backtick-quoted identifiers.** The reported bug: `WHERE n.name = 'SET x'`. Backslash escapes apply to string literals only; a backtick identifier escapes a backtick by doubling it, which the toggle handles.
2. **On a word boundary**, via the existing `matchesKeywordAt`, so `n.createdAt`, `n.set` and `[r:SET_BY]` are excluded.
3. **Followed by whitespace or an immediate `(`.** None of these keywords is reserved in this grammar - `RETURN 1 AS set` and `RETURN 1 AS insert` both parse - so a word boundary alone flags an alias as a write. This keeps `SET n.x = 1`, `DELETE n` and the space-less `CREATE(n)` that the original trailing-space scan missed.
4. **Not followed by a colon**, since the keyword is then a map key: `{create: 1}` and `{set : 1}`.

Nesting is deliberately not tracked, unlike `injectWhereConditions`: a write inside `CALL { ... CREATE ... }` is still a write.

**Known limit, documented on the method:** an alias that is itself followed by a clause (`WITH 1 AS set RETURN set`) is lexically identical to `SET n.x = 1`. Separating those needs clause position from the parse tree rather than a text scan.

## Intentional behavior change: `INSERT` is now rejected

`INSERT` is a synonym of `CREATE` here (`ClauseDispatcher.handleInsert` builds a `CreateClause`), so a body opening with it is a write. `COUNT { INSERT ... }` now throws `InvalidClauseComposition` where it previously returned a silent `0`.

This was raised in review as a possible data-integrity gap. It is not - probing confirmed no write ever reached storage:

```
COUNT   { INSERT (m:T {name:'leaked-count'})   RETURN m }  ->  0
EXISTS  { INSERT (m:T {name:'leaked-exists'})  RETURN m }  ->  false
COLLECT { INSERT (m:T {name:'leaked-collect'}) RETURN m }  ->  []
total :T nodes afterwards = 2, unchanged; leaked nodes = 0
```

That is the #5461 failure mode - the body fails downstream and each expression absorbs it into its neutral value. `INSERT` was added because it converts that silently wrong answer into a proper error and stops `CLAUSE_KEYWORDS` and `UPDATE_CLAUSE_KEYWORDS` disagreeing about whether `INSERT` writes.

## Other notes

- **Locale.** All three `toUpperCase()` calls in the class now pass `Locale.ROOT`. This was reachable through the `INSERT` addition: `INSERT` is the one update keyword containing an `i`, and in a Turkish locale `"insert".toUpperCase()` yields a dotted capital I that does not match, letting a lowercase write past the guard.
- **Comments are not skipped**, so an update keyword inside `//` or `/* */` still trips the guard. That blind spot predates this change and is not widened by it; documented on the method.

## Test plan

- [x] New `Issue5541SubqueryUpdateClauseGuardTest`, 14 tests, all passing
- [x] **Proven to fail before the fix**: with the helper added but the three guards still naive, 6 of the original 9 failed with the exact reported `InvalidClauseComposition`. The alias and locale regressions found in review were likewise reproduced before being fixed
- [x] Genuine update clauses still rejected across all three expressions: `SET`, `CREATE`, `MERGE`, `REMOVE`, `DELETE`, `DETACH DELETE` and `INSERT`
- [x] Aliases named after all six keywords accepted, in both trailing and pre-comma position
- [x] Predicate asserted under a Turkish default locale
- [x] A rejected body leaves the data untouched
- [x] openCypher TCK scenario `ExistentialSubquery2.feature` [3] "Full existential subquery with update clause should fail" still passes
- [x] Literals in all three quote styles, escaped quote inside a literal, backtick doubling, backslash correctly *not* escaping inside backticks, mid-literal substrings, map keys with and without whitespace before the colon, the correlated form
- [x] Full `com.arcadedb.query.opencypher.**` and full `engine` module suites green, re-measured after every review cycle and reconciled per class against the previous branch with no pre-existing class changing count
- [x] Verified no other naive scan for *update* keywords remains anywhere in the engine. The neighbouring `contains("RETURN ")` scans in the same two methods are a different naive scan and do remain; probed against `COUNT { MATCH (n:T) WHERE n.name = 'please RETURN it' }`, which answers correctly (1, matching ground truth), because a MATCH-only body executes fine without the synthesized projection. Pinned by a test rather than changed
