### PR TITLE
fix(deps): pin Jackson family to 2.22.1 via jackson-bom

### DIFF
--- a/grpc-client/pom.xml
+++ b/grpc-client/pom.xml
@@ -33,10 +33,6 @@
     <packaging>jar</packaging>
     <name>ArcadeDB gRPC Client</name>
 
-    <properties>
-        <jackson-databind.version>2.22.1</jackson-databind.version>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -156,7 +152,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <micrometer-tracing.version>1.7.0</micrometer-tracing.version>
         <opentelemetry.version>1.64.0</opentelemetry.version>
         <postgres.version>42.7.13</postgres.version>
+        <jackson.version>2.22.1</jackson.version>
 
         <assertj-core.version>3.27.7</assertj-core.version>
         <junit.jupiter.version>6.1.2</junit.jupiter.version>
@@ -496,6 +497,17 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-bom</artifactId>
                 <version>${assertj-core.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Pin the whole Jackson family through the BOM. Transitive deps (swagger-core in the
+                 server module, gremlin in the graph modules) drag in split Jackson versions, which
+                 both reopens fixed deserialization CVEs and risks mixing databind against an older
+                 jackson-core than it was compiled for. One managed version keeps the family aligned. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Problem

A Meterian dependency audit of the full reactor flagged `jackson-databind` and `jackson-core` **2.21.1** as HIGH severity. Both arrive transitively via `io.swagger.core.v3:swagger-core:2.2.52` at **compile** scope in the server module.

Top advisories on the 2.21.1 pair:

| ID | CVSS | Issue |
|---|---|---|
| [GHSA-j3rv-43j4-c7qm](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-j3rv-43j4-c7qm) (CVE-2026-54512) | 8.1 | `PolymorphicTypeValidator` bypass |
| [GHSA-rmj7-2vxq-3g9f](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-rmj7-2vxq-3g9f) (CVE-2026-54513) | 8.1 | Array component type not validated against the allowlist |
| [GHSA-r7wm-3cxj-wff9](https://github.com/FasterXML/jackson-core/security/advisories/GHSA-r7wm-3cxj-wff9) | 8.0 | Incomplete fix for async-parser number length constraint bypass |

Plus seven further MEDIUM advisories on databind (view-filter and property-exclusion bypasses, SSRF via eager DNS resolution).

Separately, the reactor was resolving **four different Jackson versions simultaneously**:

```
jackson-annotations      2.21
jackson-core             2.21.1
jackson-databind         2.21.1
jackson-dataformat-yaml  2.22.0
jackson-datatype-jsr310  2.22.0
```

Running `databind` against an older `jackson-core` than it was compiled against is its own latent hazard, independent of the CVEs.

## Change

Import `jackson-bom` in the root `dependencyManagement` so every module resolves one aligned Jackson version, instead of pinning artifacts individually.

`grpc-client` had its own local `jackson-databind.version` property (already 2.22.1); that is now redundant and removed, so the module inherits from the parent.

## Why 2.22.1 and not 2.21.5

Meterian offers both `2.21.5` and `2.22.1` as safe. 2.21.5 looks like the smaller bump, but [GHSA-5jmj-h7xm-6q6v](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-5jmj-h7xm-6q6v) names `2.22.0` explicitly in its affected range, and two artifacts in the tree were already on 2.22.0. Pinning the 2.21.5 line would have **downgraded** those two and left the advisory open. 2.22.1 is the lowest release that clears every advisory in the set without regressing anything.

## Verification

- `mvn -T1C -DskipTests install` — BUILD SUCCESS, all 26 modules
- `dependency:tree` after the change resolves a single aligned family: `core`/`databind`/`dataformat-yaml`/`datatype-jsr310` all `2.22.1`, `annotations` `2.22`
- Re-ran the Meterian check against the resolved set: `0 vulnerable / 5 clean`
- Tests in the Jackson-consuming modules:

| Module | Tests | Result |
|---|---|---|
| server | 771 | pass |
| integration | — | pass |
| graphql | 26 | pass |
| mongodbw | 21 | pass |
| postgresw | 248 | pass |
| grpc-client | 132 | pass |

`console` shows 2 errors in `ConsoleAsyncInsertTest` (`Security User/Password not valid`). These reproduce identically on `main` with this change stashed, so they are pre-existing and unrelated.

No regression test accompanies this change: it is a dependency-resolution pin with no ArcadeDB behavior change, and the resolved-version assertion lives in `dependency:tree` rather than in a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)