### PR TITLE
fix(deps): raise Ivy to 2.6.0 to clear CVE-2026-26032

### DIFF
--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -41,6 +41,7 @@
         <commons-configuration2.version>2.15.1</commons-configuration2.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
+        <ivy.version>2.6.0</ivy.version>
         <!-- Both properties below are dictated by TinkerPop, not chosen by ArcadeDB.
              Do not raise either one without upgrading gremlin.version first; see #5535. -->
 
@@ -187,6 +188,16 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>${snakeyaml.version}</version>
+        </dependency>
+
+        <!-- ARCADEDB DOES NOT USE THIS LIBRARY BUT GREMLIN DOES: gremlin-groovy pulls Ivy in to
+             back Groovy's Grape dependency loader. TinkerPop 3.8.1 resolves 2.5.3, which is
+             affected by the PackagerResolver path traversal
+             https://nvd.nist.gov/vuln/detail/CVE-2026-26032 -->
+        <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <version>${ivy.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Problem

A Meterian dependency audit of the full reactor flagged `org.apache.ivy:ivy:2.5.3` (MEDIUM, CVSS 5.4).

It reaches the build transitively at **compile** scope:

```
org.apache.tinkerpop:gremlin-groovy:3.8.1
  └─ org.apache.ivy:ivy:2.5.3
```

[CVE-2026-26032](https://nvd.nist.gov/vuln/detail/CVE-2026-26032) (CWE-22, affected range `[2.0.0,2.6.0)`): Ivy's `PackagerResolver` downloads online artifacts and repackages them through a packager-defined build file. A crafted descriptor can write outside the intended directory.

## Change

Raise Ivy to **2.6.0**, the version Meterian reports as safe.

Ivy is present only because `gremlin-groovy` uses it to back Groovy's Grape dependency loader. ArcadeDB does not use Grape, so this is a supply-chain hygiene fix rather than a reachable exploit path in our code.

The upgrade is declared the way this module already handles the same situation for `snakeyaml` (CVE-2022-1471) and `commons-lang3` (CVE-2025-48924): an explicit direct dependency in `gremlin/pom.xml` that overrides the TinkerPop-resolved version, with the rationale in a comment next to it.

Note this deliberately does **not** touch `gremlin.version`. Per the existing warning in `gremlin/pom.xml`, `groovy.version` and `antlr4.version` are dictated by TinkerPop and must not be raised without upgrading TinkerPop first. Ivy carries no such constraint - it is a Grape runtime dependency, not part of the compiled Gremlin grammar or Groovy toolchain.

## Verification

- `mvn -T1C -DskipTests install` — BUILD SUCCESS, all 26 modules
- `dependency:tree` after the change: all 3 occurrences of Ivy resolve to `2.6.0` (was `2.5.3`)
- Re-ran the Meterian check on `org.apache.ivy:ivy:2.6.0`: `0 vulnerable / 1 clean`
- `mvn -pl gremlin-it test` — **253 tests, 0 failures, 0 errors** (42 skipped)

Tests were run in `gremlin-it`, not `gremlin`: the `gremlin` module sets `skipTests` for both surefire and failsafe because its tests cannot run on the unshaded classpath (engine ANTLR 4.13.2 vs TinkerPop ANTLR 4.9.1), and execute against the shaded jar in `gremlin-it` instead.

No regression test accompanies this change: it is a dependency-resolution override with no ArcadeDB behavior change, and the resolved version is asserted by `dependency:tree` rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)