### PR TITLE
fix(deps): raise vulnerable numpy and py7zr floors in python bindings

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -46,7 +46,7 @@ managed = false
 test = [
     "pytest>=7.0.0",
     "pytest-cov",
-    "numpy>=1.20.0",
+    "numpy>=1.26.4",
     "requests>=2.0.0",  # HTTP API / docs-example tests
 ]
 dev = [
@@ -55,15 +55,15 @@ dev = [
     "mypy",
     "pytest>=7.0.0",
     "pytest-cov",
-    "numpy>=1.20.0",
+    "numpy>=1.26.4",
     "requests>=2.0.0",  # HTTP API / docs-example tests
     "bandit>=1.9.0",
 ]
 vector = [
-    "numpy>=1.20.0",
+    "numpy>=1.26.4",
 ]
 examples = [
-    "py7zr>=0.20.0",  # Required for Stack Exchange data downloads
+    "py7zr>=1.1.3",  # Required for Stack Exchange data downloads
 ]
 
 [project.urls]


### PR DESCRIPTION
## Problem

A Meterian audit flagged two dependencies in `bindings/python/pyproject.toml`. Both are **floor-too-low** findings rather than installed-vulnerable ones: the bindings ship no lock file, so the declared lower bound is the only constraint on what a resolver may legally select.

| Package | Declared | Advisories admitted | Raised to |
|---|---|---|---|
| `py7zr` | `>=0.20.0` | CVE-2022-44900 (9.1), CVE-2026-23879 (8.0), CVE-2026-55195, CVE-2026-55206 | `>=1.1.3` |
| `numpy` | `>=1.20.0` | CVE-2021-34141 (5.3), CVE-2021-33430 (5.3) | `>=1.26.4` |

The py7zr one deserves attention. [CVE-2022-44900](https://github.com/advisories/GHSA-m8xw-9x5x-6vh3) is a directory traversal in `SevenZipFile.extractall`, and `examples/download_data.py:883-884` calls exactly that:

```python
with py7zr.SevenZipFile(archive_path, mode="r") as archive:
    archive.extractall(path=extract_dir)
```

on archives downloaded from Stack Exchange. The affected code path is the one actually in use, not a dormant corner of the library. 1.1.3 additionally clears CVE-2026-23879 (arbitrary file write via symlink) and two decompression-bomb advisories.

## Change

Raise both floors to the lowest release Meterian reports as clear. Four lines across the `test`, `dev`, `vector`, and `examples` extras.

To be precise about the impact: **this is not an upgrade of what installs today.** With no upper bound, a fresh `pip install` already resolves to the newest release. What the change fixes is the gap where a constrained, pinned, or offline resolve could legally land on a vulnerable version and still satisfy the manifest.

Core runtime dependencies are untouched - `arcadedb-embedded` depends only on `jpype1>=1.5.0`, which is clean. Everything here is in optional extras.

## Verification

- `pyproject.toml` parses via `tomllib`; all four extras carry the new floors, `requires-python` unchanged at `>=3.10`
- Fresh resolve against the new constraints in a clean venv: `numpy 2.5.1`, `py7zr 1.1.3`
- Floor is genuinely enforced - `pip install --dry-run "py7zr==0.20.0" "py7zr>=1.1.3"` now fails with a resolver conflict, confirming the vulnerable version is excluded rather than merely deprioritized
- `py7zr 1.1.3` declares `requires-python >=3.10`, matching the package's own `requires-python`, so no supported interpreter loses access to the extra
- The only py7zr API used (`SevenZipFile`, `extractall`) is unchanged across 0.20 → 1.1.3, so the major bump carries no call-site changes

numpy 1.26.4 is a floor, not a pin: on Python 3.13/3.14 (both in the package classifiers) a resolve lands on numpy 2.x, which the `>=` constraint permits.

No regression test accompanies this change: it adjusts declared version constraints with no change to binding behavior, and the constraint is asserted by resolver behavior rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)