### PR TITLE
chore(deps): let Dependabot update indirect Go modules in /e2e-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -222,3 +222,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # Every file in /e2e-go is a *_test.go, so the module declares only three
+    # direct requirements (neo4j-go-driver, testify, testcontainers-go) and
+    # everything else is marked `// indirect`. Without this, version updates
+    # only ever consider those three, and the transitive tree silently drifts
+    # however far behind the direct deps' own floors allow.
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
## Problem

`/e2e-go` has a large set of outdated dependencies, but Dependabot proposes nothing.

The config is not at fault. The `gomod` entry is present and correctly scoped, and it has demonstrably worked: **PR #4970** (merged 2026-07-04) bumped `neo4j-go-driver` 5.28.1 to 5.28.4 through the `go-modules` group.

It is quiet because of how the module is shaped. Every file in `/e2e-go` is a `*_test.go`, so the module declares only three direct requirements:

```
github.com/neo4j/neo4j-go-driver/v5 v5.28.4
github.com/stretchr/testify         v1.11.1
github.com/testcontainers/testcontainers-go v0.43.0
```

`go list -m -u` reports **zero** available updates for those three. Everything else in `go.mod` carries `// indirect`, and **38** of those have fallen behind. Since version updates only consider direct requirements by default, there is nothing for Dependabot to open. PR #4970 confirms the behavior empirically: it bumped the direct dep and left the entire indirect tree alone.

## Change

Add `allow: dependency-type: "all"` to the `gomod` entry so indirect modules are covered too.

This matches how the `/studio` npm entry is already configured (`.github/dependabot.yml:129-130`), so it introduces no new pattern.

PR volume should stay roughly flat: the existing `go-modules` group already collapses minor and patch into a single weekly PR, and majors continue to open individually.

## What this actually recovers

Verified locally against a scratch copy of the module:

| Measure | Value |
|---|---|
| Outdated modules total | 38 (all `// indirect`) |
| Of those, actually compiled into the build | 19 |
| Upgraded by `go get -u -t ./... && go mod tidy` | **22** |
| `go vet ./...` after upgrade | **clean** |
| Still outdated afterwards | 10 |

Those last 10 are held by minimal version selection at whatever floor `testcontainers-go` and the other direct deps declare. They move only when those upstreams raise their own requirements, so this change does not close the gap entirely, and no Dependabot setting would.

## Worth knowing when refreshing this module by hand

Because the module contains only test files, the obvious command is a no-op:

```
go get -u ./...     # no change at all; go.mod comes back byte-identical
go get -u -t ./...  # 22 modules upgraded
```

Without `-t`, Go finds no non-test imports to walk and reports success while doing nothing. Anyone verifying this module manually could reasonably conclude it was already current. Not addressed in this PR (config-only by request), but worth a `README.md` note as a follow-up.

## Risk

Low, and confined to test scope. `/e2e-go` is a conformance harness that never ships in any distribution. A Meterian audit of all 54 modules returned **0 vulnerable**, and there are no open Dependabot alerts in any ecosystem, so this is drift management rather than a security fix.

The counter-argument worth recording: Go's MVS deliberately holds indirect deps at the minimum the graph allows, and pushing them ahead of what `testcontainers-go` was tested against can surface integration breakage upstream never saw. The `go vet` check above shows the current delta is clean, and any future breakage arrives as a failing CI run on an isolated grouped PR rather than in a shipped artifact.

## Verification

- `.github/dependabot.yml` parses as valid YAML; the `gomod` block resolves to the intended keys
- `allow` blocks are now consistent across the file (`npm /studio` and `gomod /e2e-go`)
- pre-commit `check yaml` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)