### PR TITLE
feat(engine): let the schema dictionary grow past a single page

### DIFF
--- a/docs/5560-dictionary-multipage.md
+++ b/docs/5560-dictionary-multipage.md
@@ -49,6 +49,22 @@ names); a string value is only ever looked up with `create=false`, so user data 
 `CURRENT_VERSION` goes to 1, with a guard refusing a dictionary written by a newer ArcadeDB rather than
 misreading it as this layout.
 
+### Why the version is not bumped when an existing database first rolls over
+
+The version is stamped at creation, so a `v0` database that later grows past page 0 keeps saying `v0` on
+disk. Bumping it on first rollover was considered and rejected:
+
+- The version is part of the **file name** (`dictionary.0.65536.v1.dict`). Changing it at runtime means
+  renaming a live component file. `PaginatedComponent.rename` can only do that behind a full flush barrier
+  (`waitAllPagesOfDatabaseAreFlushed`), and doing it from inside an append transaction would race
+  replication, which ships pages by file id, and leave follower file names diverged from the leader's.
+- It would protect nothing. `ComponentFactory` passes the parsed version straight through without
+  validating it, so a build old enough to be at risk opens a `v1` file just as happily as a `v0` one. The
+  guard added here only helps a *newer* format meeting *this* reader.
+
+So the version records what wrote the file, and the operational signal that a database has left single-page
+territory is the INFO line logged when page 1 is created.
+
 ## Upgrade notes
 
 **Single node.** Nothing to do. An existing database keeps its page size and its `v0` file name, and gains

--- a/docs/5560-dictionary-multipage.md
+++ b/docs/5560-dictionary-multipage.md
@@ -65,6 +65,21 @@ disk. Bumping it on first rollover was considered and rejected:
 So the version records what wrote the file, and the operational signal that a database has left single-page
 territory is the INFO line logged when page 1 is created.
 
+### How to tell whether a database has rolled over
+
+The log line is emitted once, when it happens, so it is no help for a database you are looking at after the
+fact. The durable answer is the file size: the dictionary is one page per `pageSize` bytes, and `pageSize`
+is in the file name.
+
+```
+$ ls -l <database>/dictionary.*.dict
+-rw-r--r--  1 arcadedb  arcadedb  131072  dictionary.0.65536.v1.dict
+```
+
+131072 / 65536 = 2 pages, so this database has rolled over and cannot be read by a build without multi-page
+support. A file of exactly `pageSize` bytes (or less) is still single-page and remains downgradable. This is
+worth checking before rolling a cluster back to an older build.
+
 ## Upgrade notes
 
 **Single node.** Nothing to do. An existing database keeps its page size and its `v0` file name, and gains

--- a/docs/5560-dictionary-multipage.md
+++ b/docs/5560-dictionary-multipage.md
@@ -1,0 +1,86 @@
+# PR #5560 - Schema dictionary spans multiple pages
+
+## Symptom
+
+`com.arcadedb.engine.Dictionary` held every type name and property name in page 0 alone, so a database was
+capped at whatever fitted there: `pageSize - 8 (page header) - 4 (legacy counter)` = 327,668 bytes,
+measured at 48,396 short names. Past that, `CREATE PROPERTY` and inserting a document with a new field
+name failed permanently with `DatabaseMetadataException: No space left in dictionary file`, and there was
+no way to grow. Entries are never reclaimed, so a schemaless workload with dynamic field names walked
+steadily toward the wall.
+
+## Fix
+
+Names roll over to a new page. Every page, page 0 included, carries the same 4-byte legacy counter, so a
+dictionary written before this change is exactly a dictionary of one page and loads with no special case:
+no migration, no rewrite, no format flag needed to read an existing database.
+
+The invariant everything follows from: **an id is the ordinal of the name in page order**, and that id is
+written inside records on disk. The layout is therefore strictly append-only across pages. Names go only to
+the last page, and a page left behind is never revisited even when it still has room; filling a gap would
+renumber every name after it and silently repoint every record that referenced them.
+
+Three details carry the correctness:
+
+- `addItemToPage` **reads** the tail page before deciding where to write. Enlisting it as modifiable and
+  then finding it full would bump its version, rewrite it at commit for nothing, and false-conflict with
+  concurrent transactions (the page is the conflict unit, see `engine/CLAUDE.md`).
+- `reload()` walks `Math.max(1, pageCount.get())` pages and reads them through `PageManager`, never through
+  `TransactionContext.getPage()`. Both halves speak durable state: `getTotalPages()` would count pages a
+  rolling-back transaction is discarding, and `TransactionContext.getPage()` resolves `modifiedPages` first,
+  so the rollback reload would rebuild the dictionary from exactly the content being thrown away. That
+  second half was a defect predating this change, since `updateName` always rewrote page 0 inside the
+  caller's transaction.
+- `updateName` re-lays the dictionary out from page 0 in the same order, so no id moves, and empties the
+  pages the new content no longer reaches. `reload()` walks every committed page, so a stale tail page
+  would otherwise re-add its old names.
+
+## Page size and format version
+
+`DEF_PAGE_SIZE` drops from 327,680 to 65,536 for new dictionaries. That size existed only to make the
+single available page hold as many names as possible; now that pages roll over, a new name dirties and
+eventually flushes one page, so a smaller page is 5x less write amplification per name. Existing databases
+keep the page size they were created with, read back from the file name.
+
+One consequence: on a new database a single identifier caps at `pageSize - 12` = ~65Kb, against ~327Kb
+before. Only identifiers ever enter the dictionary (the `create=true` callers: type names and property
+names); a string value is only ever looked up with `create=false`, so user data is never subject to this.
+
+`CURRENT_VERSION` goes to 1, with a guard refusing a dictionary written by a newer ArcadeDB rather than
+misreading it as this layout.
+
+## Upgrade notes
+
+**Single node.** Nothing to do. An existing database keeps its page size and its `v0` file name, and gains
+rollover on the next write that needs it.
+
+**Downgrade.** Once a database has grown past page 0 it can no longer be opened by an older ArcadeDB, which
+reads page 0 only and reports `Dictionary item with id N is not valid`. Loud, not silent. Such a database
+could not have existed before this change, since the write would have been refused. A new database that has
+never rolled over stays readable by an older build, so downgradability is lost exactly when the database
+starts depending on the feature, not before.
+
+**Cluster: upgrade followers before, or together with, the leader.** Dictionary pages replicate as raw
+pages through `TransactionManager.applyChanges`. A new-version leader that rolls the dictionary over ships
+page 1 and beyond to its followers; a follower still running a build without multi-page support writes the
+page but reloads only page 0, so its in-RAM dictionary is missing those names and every record referencing
+them fails with `Dictionary item with id N is not valid`. Upgrading followers first avoids the window
+entirely.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java`
+
+- `namesRollOverToNewPagesInsteadOfBeingRefused` - past one page it keeps working, ids resolve both ways
+- `idsSurviveAReopen` - the mapping is identical after a reopen
+- `pageZeroKeepsTheLegacySinglePageLayout` - page 0 still reads with the pre-multi-page algorithm, which is
+  the backward-compatibility guarantee
+- `aNameTooBigForAnEmptyPageIsRejectedAndLeavesTheDictionaryUsable`
+- `documentsWithPropertyNamesSpanningPagesReadBack` - the serializer round trip across pages
+- `updateNameRewritesEveryPage` / `updateNameGrowingBeyondTheExistingPagesAddsOne` - shrink and grow
+- `aRolledBackTransactionThatGrewTheDictionaryLeavesItIntact` - the case that exposed the dirty-page reload
+- `aDictionaryFromANewerFormatIsRefusedInsteadOfMisread` - the version guard through the real load path
+- `aReplicatedNewDictionaryPageIsVisibleAfterApplyChanges` - the follower apply path
+
+`engine/src/test/java/com/arcadedb/schema/DictionaryLimitsTest.java` - filling well past one page keeps
+working, entries are never reclaimed, both directions survive a reload.

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
@@ -55,8 +54,11 @@ import java.util.logging.Level;
  * revisited even when it still has room, and nothing is ever removed. Writing into an earlier page would renumber every name
  * after it and silently repoint every record that referenced them.
  * <br>
- * A name is never split over two pages, so the tail of a page is left unused when the next name does not fit: at identifier
- * lengths that is well under 1% of the file. The only hard limit left is a single name larger than one page, which caps one
+ * A name is never split over two pages, so the tail of a page is left unused when the next name does not fit: on the append path,
+ * at identifier lengths, that is well under 1% of the file. {@link #updateName} is looser - a rewrite that shrinks the content
+ * leaves the pages it no longer reaches empty, and appends resume on the last of them, so the pages in between stay empty for
+ * good. They cost one zero-entry read each on load and nothing else, and no production code calls that method. The only hard
+ * limit left is a single name larger than one page, which caps one
  * identifier at {@code pageSize - BasePage.PAGE_HEADER_SIZE - DICTIONARY_HEADER_SIZE} bytes: ~65Kb on a dictionary created with
  * the current {@link #DEF_PAGE_SIZE}, against ~327Kb on one created before it was reduced. Existing databases keep their page
  * size, so only new ones see the lower cap, and no realistic identifier comes close to either.
@@ -94,7 +96,7 @@ public class Dictionary extends PaginatedComponent {
    * volatile field is what makes a reader either see both halves of the old snapshot or both halves of the new one, and is
    * what gives the reader a happens-before edge with the rebuild at all.
    * <br>
-   * {@code names} is an array with spare capacity rather than a {@link CopyOnWriteArrayList}, and {@code size} is how much of it
+   * {@code names} is an array with spare capacity rather than a {@code CopyOnWriteArrayList}, and {@code size} is how much of it
    * is live. A COW list copies its whole backing array on every append, so growing a dictionary of N names cost N^2/2 element
    * copies: ~150ms and 4.6Gb of copying at the 48K names that used to be the hard ceiling, and quadratically worse without one.
    * Removing that ceiling is exactly what this class now does, so the append had to stop being O(n).
@@ -169,7 +171,14 @@ public class Dictionary extends PaginatedComponent {
           // THE COMMIT ABOVE CAN HAVE SWAPPED THE SNAPSHOT (RELOAD ON ROLLBACK/RETRY): RE-READ IT
           current = entries;
 
-          if (current.ids().putIfAbsent(name, newPos.get()) == null) {
+          // THE NAMES ARE PUBLISHED BEFORE THE MAP, AND THE ORDER MATTERS. THE TWO CANNOT BE UPDATED ATOMICALLY TOGETHER, SO ONE
+          // OF THEM LEADS BY AN INSTANT AND A CONCURRENT READER CAN LAND IN BETWEEN. LEADING WITH THE MAP MEANS THAT READER
+          // RESOLVES THE NAME TO AN ID THAT getNameById() DOES NOT YET ACCEPT, WHICH THROWS. LEADING WITH THE NAMES MEANS IT
+          // FINDS THE NAME NOT PRESENT YET AND -1 COMES BACK, WHICH EVERY create=false CALLER ALREADY HANDLES (BinarySerializer
+          // JUST SKIPS THE COMPRESSION) AND WHICH A create=true CALLER RESOLVES BY BLOCKING ON THIS MONITOR. NOBODY CAN HOLD THE
+          // NEW ID BEFORE THE MAP PUBLISHES IT, BECAUSE IT ONLY REACHES A RECORD AFTER THIS RETURNS. A MISS COSTS NOTHING, A
+          // THROW COSTS A REQUEST, SO THE MISS IS THE ONE TO PREFER
+          if (!current.ids().containsKey(name)) {
             final int appended = appendName(current, name);
             if (appended != newPos.get() + 1) {
               try {
@@ -179,6 +188,7 @@ public class Dictionary extends PaginatedComponent {
               }
               throw new SchemaException("Error on updating dictionary for key '" + name + "'");
             }
+            current.ids().putIfAbsent(name, newPos.get());
           }
           pos = current.ids().get(name);
         }

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -474,10 +474,22 @@ public class Dictionary extends PaginatedComponent {
       final int totalPages = Math.max(1, pageCount.get());
 
       for (int pageNumber = 0; pageNumber < totalPages; ++pageNumber) {
-        // createIfNotExists IS LOAD BEARING, NOT A DEFAULT: PAIRED WITH THE FLOOR ABOVE IT MATERIALISES PAGE 0 OF A FILE THAT
-        // IS SHORTER THAN ONE PAGE (KILLED MID-WRITE), WHICH IS WHAT THE SINGLE-PAGE READER USED TO DO
-        final BasePage page = database.getPageManager()
-            .getImmutablePage(new PageId(database, file.getFileId(), pageNumber), pageSize, false, true);
+        // createIfNotExists ONLY FOR PAGE 0, WHERE IT IS LOAD BEARING: PAIRED WITH THE FLOOR ABOVE IT MATERIALISES PAGE 0 OF A
+        // FILE SHORTER THAN ONE PAGE (KILLED MID-WRITE), WHICH IS WHAT THE SINGLE-PAGE READER DID.
+        //
+        // FOR EVERY LATER PAGE IT IS OFF, SO A PAGE THAT pageCount CLAIMS BUT THAT IS NOT THERE FAILS INSTEAD OF BEING INVENTED.
+        // AN INVENTED PAGE IS NOT MERELY MASKED CORRUPTION: IT CONTRIBUTES ZERO NAMES, WHICH SHIFTS EVERY NAME AFTER IT DOWN BY
+        // AS MANY IDS AS THE MISSING PAGE HELD, AND IDS ARE EMBEDDED IN RECORDS. SILENTLY RENUMBERING IS THE ONE OUTCOME THIS
+        // CLASS EXISTS TO PREVENT, SO A GAP HAS TO BE LOUD.
+        final BasePage page;
+        try {
+          page = database.getPageManager()
+              .getImmutablePage(new PageId(database, file.getFileId(), pageNumber), pageSize, false, pageNumber == 0);
+        } catch (final IllegalArgumentException e) {
+          throw new DatabaseMetadataException(
+              "Schema dictionary of database '" + database.getName() + "' is truncated: page " + pageNumber + " of " + totalPages
+                  + " is missing. Reading on would silently renumber every name stored after it", e);
+        }
 
         page.setBufferPosition(DICTIONARY_HEADER_SIZE);
         while (page.getBufferPosition() < page.getContentSize())

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -29,6 +29,7 @@ import com.arcadedb.utility.CollectionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -88,15 +89,25 @@ public class Dictionary extends PaginatedComponent {
   private static final int    DICTIONARY_HEADER_SIZE = Binary.INT_SERIALIZED_SIZE;
 
   /**
-   * The name list and the name->id map are replaced together by {@link #reload()}, which runs on threads that do not hold this
+   * The names and the name-&gt;id map are replaced together by {@link #reload()}, which runs on threads that do not hold this
    * component's monitor (transaction rollback and replication apply). Publishing them as one immutable pair through a single
    * volatile field is what makes a reader either see both halves of the old snapshot or both halves of the new one, and is
    * what gives the reader a happens-before edge with the rebuild at all.
+   * <br>
+   * {@code names} is an array with spare capacity rather than a {@link CopyOnWriteArrayList}, and {@code size} is how much of it
+   * is live. A COW list copies its whole backing array on every append, so growing a dictionary of N names cost N^2/2 element
+   * copies: ~150ms and 4.6Gb of copying at the 48K names that used to be the hard ceiling, and quadratically worse without one.
+   * Removing that ceiling is exactly what this class now does, so the append had to stop being O(n).
+   * <br>
+   * An append writes {@code names[size]} and then publishes a new {@code Entries} with {@code size + 1}. Mutating the shared
+   * array before the volatile write is safe both ways round: a reader holding the older snapshot has the smaller size and never
+   * looks at that slot, and a reader that sees the new snapshot sees the slot through the volatile write's happens-before edge.
+   * Growth doubles the array, so appends stay amortised O(1) while reads stay a volatile read plus an array index.
    */
-  private record Entries(List<String> names, ConcurrentMap<String, Integer> ids) {
+  private record Entries(String[] names, int size, ConcurrentMap<String, Integer> ids) {
   }
 
-  private volatile Entries entries = new Entries(new CopyOnWriteArrayList<>(), new ConcurrentHashMap<>(1024));
+  private volatile Entries entries = new Entries(new String[64], 0, new ConcurrentHashMap<>(1024));
 
   public static class PaginatedComponentFactoryHandler implements ComponentFactory.PaginatedComponentFactoryHandler {
     @Override
@@ -151,7 +162,7 @@ public class Dictionary extends PaginatedComponent {
           final AtomicInteger newPos = new AtomicInteger();
 
           database.transaction(() -> {
-            newPos.set(entries.names().size());
+            newPos.set(entries.size());
             addItemToPage(name);
           }, false);
 
@@ -159,8 +170,8 @@ public class Dictionary extends PaginatedComponent {
           current = entries;
 
           if (current.ids().putIfAbsent(name, newPos.get()) == null) {
-            current.names().add(name);
-            if (current.names().size() != newPos.get() + 1) {
+            final int appended = appendName(current, name);
+            if (appended != newPos.get() + 1) {
               try {
                 reload();
               } catch (final IOException e) {
@@ -180,12 +191,30 @@ public class Dictionary extends PaginatedComponent {
     return pos;
   }
 
-  public String getNameById(final int nameId) {
-    final List<String> names = entries.names();
-    if (nameId < 0 || nameId >= names.size())
-      throw new IllegalArgumentException("Dictionary item with id " + nameId + " is not valid (total=" + names.size() + ")");
+  /**
+   * Appends one name to the in-RAM view and publishes it, returning the new total. Amortised O(1): see {@link Entries} for why
+   * the slot is written before the volatile publish and why that is safe for readers holding either snapshot.
+   * <p>
+   * Callers hold this component's monitor.
+   */
+  private int appendName(final Entries current, final String name) {
+    String[] names = current.names();
+    final int size = current.size();
 
-    final String itemName = names.get(nameId);
+    if (size == names.length)
+      names = Arrays.copyOf(names, names.length * 2);
+
+    names[size] = name;
+    entries = new Entries(names, size + 1, current.ids());
+    return size + 1;
+  }
+
+  public String getNameById(final int nameId) {
+    final Entries current = entries;
+    if (nameId < 0 || nameId >= current.size())
+      throw new IllegalArgumentException("Dictionary item with id " + nameId + " is not valid (total=" + current.size() + ")");
+
+    final String itemName = current.names()[nameId];
     if (itemName == null)
       throw new IllegalArgumentException("Dictionary item with id " + nameId + " was not found");
 
@@ -242,15 +271,16 @@ public class Dictionary extends PaginatedComponent {
         throw new IllegalArgumentException(
             "Cannot rename the item '" + oldName + "' in the dictionary because it has been used as a type name");
 
-    final List<String> dictionary = entries.names();
-    final ConcurrentMap<String, Integer> dictionaryMap = entries.ids();
+    final Entries current = entries;
+    final int total = current.size();
+    final ConcurrentMap<String, Integer> dictionaryMap = current.ids();
 
     // READ-ONLY SCAN. ONE PASS: THE OLD indexOf()-UNTIL-GONE LOOP RE-SCANNED THE WHOLE LIST PER OCCURRENCE, AND ONLY TERMINATED
     // BECAUSE THE NAMES DIFFER, SINCE WITH oldName EQUAL TO newName EVERY SCAN FOUND WHAT THE PREVIOUS set() HAD JUST WRITTEN.
     // THE EARLY RETURN ABOVE STILL COVERS THAT CASE, BUT SCANNING BY INDEX MAKES IT IMPOSSIBLE BY CONSTRUCTION
     final List<Integer> oldIndexes = new ArrayList<>();
-    for (int i = 0; i < dictionary.size(); ++i)
-      if (oldName.equals(dictionary.get(i)))
+    for (int i = 0; i < total; ++i)
+      if (oldName.equals(current.names()[i]))
         oldIndexes.add(i);
 
     if (oldIndexes.isEmpty())
@@ -258,9 +288,16 @@ public class Dictionary extends PaginatedComponent {
 
     try {
       // VALIDATION IS OVER: FROM HERE ON THE ONLY WAY OUT IS AN IOException, WHICH THE catch REPAIRS WITH A reload()
-      dictionaryMap.remove(oldName);
+      //
+      // THE RENAME GOES ONTO A COPY RATHER THAN INTO THE LIVE ARRAY. AN APPEND ONLY EVER WRITES A SLOT PAST THE PUBLISHED SIZE,
+      // SO IT CAN SHARE ITS ARRAY WITH OLDER READERS; A RENAME REWRITES A SLOT THEY ARE ALREADY READING, WHICH WOULD NEED A
+      // HAPPENS-BEFORE EDGE THEY DO NOT HAVE. ONE COPY PER RENAME IS NOTHING NEXT TO THE FULL PAGE REWRITE BELOW.
+      final String[] renamed = Arrays.copyOf(current.names(), current.names().length);
       for (final int oldIndex : oldIndexes)
-        dictionary.set(oldIndex, newName);
+        renamed[oldIndex] = newName;
+
+      dictionaryMap.remove(oldName);
+      entries = new Entries(renamed, total, dictionaryMap);
 
       // REWRITE THE WHOLE DICTIONARY FROM PAGE 0 IN THE SAME ORDER, SO NO ID MOVES. THE TOTAL SIZE CAN SHRINK OR GROW, SO PAGES
       // ARE ADDED AS NEEDED AND THE ONES THE NEW CONTENT NO LONGER REACHES ARE EMPTIED: reload() WALKS EVERY COMMITTED PAGE, AND
@@ -268,7 +305,9 @@ public class Dictionary extends PaginatedComponent {
       int pageNumber = 0;
       MutablePage page = resetPageForRewrite(pageNumber);
 
-      for (final String d : dictionary) {
+      // BOUNDED BY total, NOT BY renamed.length: THE ARRAY CARRIES SPARE CAPACITY FOR FUTURE APPENDS AND THOSE SLOTS ARE NULL
+      for (int i = 0; i < total; ++i) {
+        final String d = renamed[i];
         final byte[] property = d.getBytes(DatabaseFactory.getDefaultCharset());
         final int required = spaceRequiredBy(property);
         // newName WAS ALREADY CHECKED ABOVE AND THE OTHERS FIT BY CONSTRUCTION: THIS ONLY CATCHES A CORRUPT PAGE, AND SAYS SO
@@ -358,13 +397,19 @@ public class Dictionary extends PaginatedComponent {
     updateCounters(page);
 
     if (pageNumber == 1)
-      // THE ONE MOMENT IN A DATABASE'S LIFE WHEN IT STOPS BEING READABLE BY A BUILD WITHOUT MULTI-PAGE SUPPORT. LEAVING A
-      // BREADCRUMB HERE IS WHAT LETS AN OPERATOR CORRELATE A FOLLOWER LATER REPORTING "Dictionary item with id N is not valid"
-      // WITH THIS EVENT. INFO, NOT WARNING: NOTHING IS WRONG, AND A WARNING ON HEALTHY GROWTH IS HOW LOGS BECOME UNREADABLE
-      LogManager.instance().log(this, Level.INFO,
-          "Database '%s' schema dictionary grew beyond its first page. Any replica or tool running a build without multi-page "
-              + "dictionary support can no longer read this database: upgrade followers before, or together with, the leader",
-          null, database.getName());
+      // THE ONE MOMENT IN A DATABASE'S LIFE WHEN IT STOPS BEING READABLE BY A BUILD WITHOUT MULTI-PAGE SUPPORT. THE BREADCRUMB
+      // IS WHAT LETS AN OPERATOR CORRELATE A FOLLOWER LATER REPORTING "Dictionary item with id N is not valid" WITH THIS EVENT.
+      //
+      // ON COMMIT, NOT HERE: THIS RUNS INSIDE A TRANSACTION THAT CAN STILL ROLL BACK, AND updateName GROWS INSIDE THE CALLER'S
+      // TRANSACTION, SO LOGGING EAGERLY WOULD ANNOUNCE A ROLLOVER THAT NEVER HAPPENED. A BREADCRUMB THAT LIES IS WORSE THAN NO
+      // BREADCRUMB. THE KEY MAKES IT ONE LINE PER TRANSACTION EVEN IF SEVERAL PAGES ARE ADDED, AND ROLLBACK DISCARDS IT.
+      //
+      // INFO, NOT WARNING: NOTHING IS WRONG, AND WARNINGS ON HEALTHY GROWTH ARE HOW LOGS STOP BEING READ
+      database.getTransaction().addAfterCommitCallbackIfAbsent("dictionaryRolledOver",
+          () -> LogManager.instance().log(this, Level.INFO,
+              "Database '%s' schema dictionary grew beyond its first page. Any replica or tool running a build without "
+                  + "multi-page dictionary support can no longer read this database: upgrade followers before, or together "
+                  + "with, the leader", null, database.getName()));
 
     return page;
   }
@@ -413,9 +458,10 @@ public class Dictionary extends PaginatedComponent {
       return;
 
     } else {
-      // LOAD THE DICTIONARY IN RAM. THE NAMES ARE COLLECTED IN AN ARRAYLIST AND THE COPY-ON-WRITE LIST IS BUILT ONCE FROM IT:
-      // APPENDING TO A CopyOnWriteArrayList COPIES THE WHOLE BACKING ARRAY PER ITEM, MAKING THIS QUADRATIC ON THE ENTRY COUNT
-      // (~150ms FOR 48K ENTRIES, PAID ON EVERY OPEN, EVERY ROLLBACK OF A DICTIONARY TX AND EVERY REPLICATED DICTIONARY CHANGE).
+      // LOAD THE DICTIONARY IN RAM. COLLECTED IN AN ARRAYLIST BECAUSE THE ENTRY COUNT IS NOT KNOWN UNTIL THE LAST PAGE HAS BEEN
+      // READ, THEN COPIED INTO THE PUBLISHED ARRAY ONCE. THIS USED TO APPEND STRAIGHT INTO A CopyOnWriteArrayList, WHICH COPIED
+      // THE WHOLE BACKING ARRAY PER ENTRY AND MADE THE LOAD QUADRATIC: ~150ms FOR 48K ENTRIES, PAID ON EVERY OPEN, EVERY
+      // ROLLBACK OF A DICTIONARY TRANSACTION AND EVERY REPLICATED DICTIONARY CHANGE.
       final List<String> loaded = new ArrayList<>();
 
       // COMMITTED STATE ON BOTH COUNTS, WHICH IS THE WHOLE CONTRACT OF THIS METHOD: EVERY CALLER (LOAD, ROLLBACK, AND THE TWO
@@ -444,7 +490,13 @@ public class Dictionary extends PaginatedComponent {
       for (int i = 0; i < size; ++i)
         newDictionaryMap.putIfAbsent(loaded.get(i), i);
 
-      this.entries = new Entries(new CopyOnWriteArrayList<>(loaded), newDictionaryMap);
+      // SPARE CAPACITY SO THE FIRST APPEND AFTER A RELOAD DOES NOT IMMEDIATELY HAVE TO GROW THE ARRAY. reload() RUNS ON THE
+      // ROLLBACK AND REPLICATION PATHS, SO APPENDS RIGHT AFTER ONE ARE THE NORMAL CASE RATHER THAN THE EXCEPTION
+      final String[] names = new String[Math.max(64, size + (size >> 2))];
+      for (int i = 0; i < size; ++i)
+        names[i] = loaded.get(i);
+
+      this.entries = new Entries(names, size, newDictionaryMap);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -55,7 +55,14 @@ import java.util.logging.Level;
  * after it and silently repoint every record that referenced them.
  * <br>
  * A name is never split over two pages, so the tail of a page is left unused when the next name does not fit: at identifier
- * lengths that is well under 1% of the file. The only hard limit left is a single name larger than one page.
+ * lengths that is well under 1% of the file. The only hard limit left is a single name larger than one page, which caps one
+ * identifier at {@code pageSize - BasePage.PAGE_HEADER_SIZE - DICTIONARY_HEADER_SIZE} bytes: ~65Kb on a dictionary created with
+ * the current {@link #DEF_PAGE_SIZE}, against ~327Kb on one created before it was reduced. Existing databases keep their page
+ * size, so only new ones see the lower cap, and no realistic identifier comes close to either.
+ * <br>
+ * <b>Upgrade order in a cluster:</b> a follower still running a build without multi-page support reads page 0 only, so once a
+ * database has rolled over, replicated pages beyond the first leave that follower reporting "Dictionary item with id N is not
+ * valid". Followers have to be upgraded before, or together with, the leader. See {@code docs/5560-dictionary-multipage.md}.
  * <br>
  */
 public class Dictionary extends PaginatedComponent {
@@ -389,6 +396,8 @@ public class Dictionary extends PaginatedComponent {
       final int totalPages = Math.max(1, pageCount.get());
 
       for (int pageNumber = 0; pageNumber < totalPages; ++pageNumber) {
+        // createIfNotExists IS LOAD BEARING, NOT A DEFAULT: PAIRED WITH THE FLOOR ABOVE IT MATERIALISES PAGE 0 OF A FILE THAT
+        // IS SHORTER THAN ONE PAGE (KILLED MID-WRITE), WHICH IS WHAT THE SINGLE-PAGE READER USED TO DO
         final BasePage page = database.getPageManager()
             .getImmutablePage(new PageId(database, file.getFileId(), pageNumber), pageSize, false, true);
 

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -147,6 +147,15 @@ public class Dictionary extends PaginatedComponent {
           "Dictionary '" + filePath + "' was written with format version " + version + ", which this version of ArcadeDB cannot "
               + "read (latest known is " + CURRENT_VERSION + ")");
     reload();
+
+    if (pageCount.get() > 1)
+      // RESTATED ON EVERY OPEN, NOT ONLY WHEN IT HAPPENS. THE ROLLOVER ITSELF IS LOGGED ONCE, WHICH IS NO USE TO SOMEONE LOOKING
+      // AT A DATABASE AFTERWARDS OR PLANNING A ROLLBACK; THIS IS THE SAME FACT AS CURRENT STATE RATHER THAN AS AN EVENT. IT IS
+      // DERIVED FROM THE PAGE COUNT, SO IT CANNOT DRIFT THE WAY A SEPARATE PERSISTED MARKER COULD
+      LogManager.instance().log(this, Level.INFO,
+          "Database '%s' schema dictionary spans %d pages. It cannot be read by a build without multi-page dictionary support, "
+              + "so replicas and any rollback target have to be on this version or newer", null, database.getName(),
+          pageCount.get());
   }
 
   public int getIdByName(final String name, final boolean create) {

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -180,20 +180,6 @@ public class Dictionary extends PaginatedComponent {
   }
 
   /**
-   * Bytes still available on the page names are currently appended to, length prefix included. Not a capacity: once it runs out
-   * the next name opens a new page. Useful to size a write that should, or should not, cross a page boundary.
-   */
-  public int getAvailableSpaceInLastPage() {
-    try {
-      final BasePage lastPage = database.getTransaction()
-          .getPage(new PageId(database, file.getFileId(), getTotalPages() - 1), pageSize);
-      return freeSpaceIn(lastPage);
-    } catch (final IOException e) {
-      throw new SchemaException("Error on reading the database schema dictionary", e);
-    }
-  }
-
-  /**
    * Updates a name. The update will impact the entire database with both properties and values (if used as ENUM). The update is valid only if the name has not been used as type name.
    *
    * @param oldName The old name to rename. Must be already present in the schema dictionary
@@ -212,6 +198,11 @@ public class Dictionary extends PaginatedComponent {
     if (oldName.equals(newName))
       // NOTHING TO DO. WITHOUT THIS THE LOOP BELOW WOULD NEVER FIND ITS TERMINATION CONDITION
       return;
+
+    // VALIDATED BEFORE ANYTHING IS MUTATED: THE REWRITE BELOW EDITS THE IN-RAM VIEW FIRST, AND A newName TOO BIG FOR A PAGE
+    // WOULD OTHERWISE LEAVE IT RENAMED BUT UNWRITTEN UNTIL THE CALLER'S ROLLBACK HAPPENED TO REPAIR IT. EVERY OTHER NAME IS
+    // ALREADY STORED ON A PAGE OF THIS SIZE, SO newName IS THE ONLY ONE THAT CAN FAIL
+    checkNameFitsAPage(newName, spaceRequiredBy(newName.getBytes(DatabaseFactory.getDefaultCharset())));
 
     final List<String> dictionary = entries.names();
     final ConcurrentMap<String, Integer> dictionaryMap = entries.ids();
@@ -247,6 +238,8 @@ public class Dictionary extends PaginatedComponent {
       for (final String d : dictionary) {
         final byte[] property = d.getBytes(DatabaseFactory.getDefaultCharset());
         final int required = spaceRequiredBy(property);
+        // newName WAS ALREADY CHECKED ABOVE AND THE OTHERS FIT BY CONSTRUCTION: THIS ONLY CATCHES A CORRUPT PAGE, AND SAYS SO
+        // INSTEAD OF LETTING writeString() FAIL WITH A RAW PAGE-BOUNDARY ERROR
         checkNameFitsAPage(d, required);
 
         if (freeSpaceIn(page) < required)
@@ -268,7 +261,7 @@ public class Dictionary extends PaginatedComponent {
       } catch (final IOException ioException) {
         LogManager.instance().log(this, Level.SEVERE, "Error on reloading dictionary", ioException);
       }
-      throw new SchemaException("Error on updating name in dictionary");
+      throw new SchemaException("Error on updating name in dictionary", e);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -76,6 +76,12 @@ public class Dictionary extends PaginatedComponent {
   public static final  int    DEF_PAGE_SIZE          = 65_536;
   /**
    * v0 is single page, v1 rolls over. The reader handles both, the version only marks what wrote the file.
+   * <br>
+   * It is stamped at creation and never changed, so a v0 database that later rolls over keeps saying v0. That is deliberate:
+   * this number lives in the FILE NAME, so bumping it at runtime means renaming a live component file, which
+   * {@link PaginatedComponent#rename} can only do behind a full flush barrier and which would race replication shipping pages
+   * by file id. It would also buy nothing, because a build old enough to be at risk does not validate this field at all - it
+   * would open a v1 file just as happily. The signal that a database has rolled over is the INFO logged when page 1 is created.
    */
   private static final int    CURRENT_VERSION        = 1;
   // THIS IS LEGACY BECAUSE THE NUMBER OF ITEMS WAS STORED IN THE HEADER. NOW THE DICTIONARY IS POPULATED FROM THE ACTUAL CONTENT IN THE PAGES

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -38,18 +38,35 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 /**
- * HEADER = [itemCount(int:4),pageSize(int:4)] CONTENT-PAGES = [propertyName(string)]
+ * Maps every type name, property name and enumerated string value of a database to a small integer id, which is what records
+ * carry instead of the name itself.
  * <br>
- * The whole dictionary lives in page 0: the maximum total size of the names it can hold is
- * {@code pageSize - BasePage.PAGE_HEADER_SIZE - DICTIONARY_HEADER_SIZE} bytes, each name costing its UTF-8 length plus a
- * 1-3 byte varint prefix. With the default page size that is ~327Kb of names, i.e. tens of thousands of entries.
- * Entries are only ever appended and are never reclaimed.
+ * PAGE = [itemCount(int:4)][name(string)]* , where a name is a 1-3 byte varint length followed by its UTF-8 bytes. Every page
+ * has the same shape, page 0 included, so a dictionary written before multi-page support (which is exactly one such page) loads
+ * unchanged.
+ * <br>
+ * <b>An id is the ordinal of the name in page order</b>, and that id is written inside records on disk. The layout is therefore
+ * strictly append-only across pages: names are only ever added to the LAST page, a page that has been left behind is never
+ * revisited even when it still has room, and nothing is ever removed. Writing into an earlier page would renumber every name
+ * after it and silently repoint every record that referenced them.
+ * <br>
+ * A name is never split over two pages, so the tail of a page is left unused when the next name does not fit: at identifier
+ * lengths that is well under 1% of the file. The only hard limit left is a single name larger than one page.
  * <br>
  */
 public class Dictionary extends PaginatedComponent {
-  public static final  String DICT_EXT        = "dict";
-  public static final  int    DEF_PAGE_SIZE   = 65536 * 5;
-  private static final int    CURRENT_VERSION = 0;
+  public static final String DICT_EXT = "dict";
+  /**
+   * Before multi-page support this was 65536 * 5, sized only to make the one available page hold as many names as possible.
+   * Now that pages roll over, the page is sized like the rest of the engine instead: a new name dirties and eventually flushes
+   * one page, so a smaller page is five times less write amplification per name. Existing databases keep the page size they
+   * were created with, which is read back from the file name.
+   */
+  public static final  int    DEF_PAGE_SIZE          = 65_536;
+  /**
+   * v0 is single page, v1 rolls over. The reader handles both, the version only marks what wrote the file.
+   */
+  private static final int    CURRENT_VERSION        = 1;
   // THIS IS LEGACY BECAUSE THE NUMBER OF ITEMS WAS STORED IN THE HEADER. NOW THE DICTIONARY IS POPULATED FROM THE ACTUAL CONTENT IN THE PAGES
   private static final int    DICTIONARY_HEADER_SIZE = Binary.INT_SERIALIZED_SIZE;
 
@@ -94,6 +111,11 @@ public class Dictionary extends PaginatedComponent {
       final ComponentFile.MODE mode, final int pageSize,
       final int version) throws IOException {
     super(database, name, filePath, id, mode, pageSize, version);
+    if (version > CURRENT_VERSION)
+      // A NEWER LAYOUT WOULD BE READ AS IF IT WERE THIS ONE, SILENTLY. REFUSE INSTEAD OF GUESSING
+      throw new DatabaseMetadataException(
+          "Dictionary '" + filePath + "' was written with format version " + version + ", which this version of ArcadeDB cannot "
+              + "read (latest known is " + CURRENT_VERSION + ")");
     reload();
   }
 
@@ -158,12 +180,14 @@ public class Dictionary extends PaginatedComponent {
   }
 
   /**
-   * Returns the bytes still available in the dictionary page for new names, prefix included.
+   * Bytes still available on the page names are currently appended to, length prefix included. Not a capacity: once it runs out
+   * the next name opens a new page. Useful to size a write that should, or should not, cross a page boundary.
    */
-  public int getAvailableSpace() {
+  public int getAvailableSpaceInLastPage() {
     try {
-      final BasePage header = database.getTransaction().getPage(new PageId(database, file.getFileId(), 0), pageSize);
-      return header.getMaxContentSize() - header.getContentSize();
+      final BasePage lastPage = database.getTransaction()
+          .getPage(new PageId(database, file.getFileId(), getTotalPages() - 1), pageSize);
+      return freeSpaceIn(lastPage);
     } catch (final IOException e) {
       throw new SchemaException("Error on reading the database schema dictionary", e);
     }
@@ -214,19 +238,25 @@ public class Dictionary extends PaginatedComponent {
           throw new IllegalArgumentException(
               "Cannot rename the item '" + oldName + "' in the dictionary because it has been used as a type name");
 
-      final MutablePage header = database.getTransaction()
-          .getPageToModify(new PageId(database, file.getFileId(), 0), pageSize, false);
-
-      header.clearContent();
-      updateCounters(header);
+      // REWRITE THE WHOLE DICTIONARY FROM PAGE 0 IN THE SAME ORDER, SO NO ID MOVES. THE TOTAL SIZE CAN SHRINK OR GROW, SO PAGES
+      // ARE ADDED AS NEEDED AND THE ONES THE NEW CONTENT NO LONGER REACHES ARE EMPTIED: reload() WALKS EVERY COMMITTED PAGE, AND
+      // A STALE TAIL PAGE LEFT BEHIND WOULD RE-ADD ITS OLD NAMES ON THE NEXT LOAD.
+      int pageNumber = 0;
+      MutablePage page = resetPageForRewrite(pageNumber);
 
       for (final String d : dictionary) {
         final byte[] property = d.getBytes(DatabaseFactory.getDefaultCharset());
+        final int required = spaceRequiredBy(property);
+        checkNameFitsAPage(d, required);
 
-        checkSpaceLeft(header, property, dictionary.size());
+        if (freeSpaceIn(page) < required)
+          page = resetPageForRewrite(++pageNumber);
 
-        header.writeString(header.getContentSize(), d);
+        page.writeString(page.getContentSize(), d);
       }
+
+      for (int stale = pageNumber + 1; stale < getTotalPages(); ++stale)
+        resetPageForRewrite(stale);
 
       final Integer newIndex = dictionaryMap.get(newName);
       if (newIndex == null)
@@ -242,40 +272,97 @@ public class Dictionary extends PaginatedComponent {
     }
   }
 
+  /**
+   * Empties the given page, creating it when the rewrite needs more pages than the dictionary currently has, and leaves it with
+   * only the legacy counter so it is ready to receive names.
+   */
+  private MutablePage resetPageForRewrite(final int pageNumber) throws IOException {
+    if (pageNumber >= getTotalPages())
+      return addPage(pageNumber);
+
+    final MutablePage page = database.getTransaction()
+        .getPageToModify(new PageId(database, file.getFileId(), pageNumber), pageSize, false);
+    page.clearContent();
+    updateCounters(page);
+    return page;
+  }
+
   private void addItemToPage(final String propertyName) {
     if (!database.isTransactionActive())
       throw new SchemaException("Error on adding new item to the database schema dictionary because no transaction was active");
 
     final byte[] property = propertyName.getBytes(DatabaseFactory.getDefaultCharset());
+    final int required = spaceRequiredBy(property);
+    checkNameFitsAPage(propertyName, required);
 
-    final MutablePage header;
     try {
-      header = database.getTransaction().getPageToModify(new PageId(database, file.getFileId(), 0), pageSize, false);
+      final int totalPages = getTotalPages();
+      final MutablePage target;
 
-      checkSpaceLeft(header, property, entries.names().size());
+      if (totalPages == 0)
+        // NO PAGE AT ALL, WHICH HAPPENS WHEN THE DATABASE WAS KILLED BEFORE THE HEADER PAGE REACHED DISK
+        target = addPage(0);
+      else {
+        // ONLY THE LAST PAGE IS EVER APPENDED TO, EVEN WHEN AN EARLIER ONE STILL HAS ROOM: SEE THE CLASS JAVADOC ON WHY
+        // FILLING A GAP WOULD RENUMBER EVERY NAME AFTER IT.
+        final int lastPageNumber = totalPages - 1;
+        final PageId lastPageId = new PageId(database, file.getFileId(), lastPageNumber);
 
-      header.writeString(header.getContentSize(), propertyName);
+        // READ BEFORE DECIDING: getPageToModify() WOULD ENLIST THE PAGE AS MODIFIED EVEN WHEN THE NAME DOES NOT FIT, BUMPING ITS
+        // VERSION AND REWRITING IT AT COMMIT FOR NOTHING, AND MAKING IT FALSE-CONFLICT WITH CONCURRENT TRANSACTIONS.
+        final BasePage lastPage = database.getTransaction().getPage(lastPageId, pageSize);
+
+        target = freeSpaceIn(lastPage) >= required ?
+            database.getTransaction().getPageToModify(lastPageId, pageSize, false) :
+            addPage(lastPageNumber + 1);
+      }
+
+      target.writeString(target.getContentSize(), propertyName);
 
     } catch (final IOException e) {
-      throw new SchemaException("Error on adding new item to the database schema dictionary");
+      throw new SchemaException("Error on adding new item to the database schema dictionary", e);
     }
   }
 
   /**
-   * The dictionary is a single page, so the free space is what is left of the page content area. Both the varint length prefix
-   * that {@link MutablePage#writeString} emits and the 8 bytes of page header have to be accounted for: overestimating the
-   * space by even one byte turns the actionable "no space left in dictionary" into a raw "cannot write outside the page space".
+   * Appends an empty page to the dictionary, initialised with the legacy counter every page carries.
    */
-  private void checkSpaceLeft(final BasePage header, final byte[] name, final int items) {
-    final int required = Binary.getUnsignedNumberSpace(name.length) + name.length;
-    if (header.getMaxContentSize() - header.getContentSize() < required)
+  private MutablePage addPage(final int pageNumber) {
+    final MutablePage page = database.getTransaction().addPage(new PageId(database, file.getFileId(), pageNumber), pageSize);
+    updateCounters(page);
+    return page;
+  }
+
+  /**
+   * What one name occupies on a page: the varint length prefix that {@link MutablePage#writeString} emits, plus the UTF-8 bytes.
+   */
+  private static int spaceRequiredBy(final byte[] name) {
+    return Binary.getUnsignedNumberSpace(name.length) + name.length;
+  }
+
+  /**
+   * Free bytes left on a page. {@link BasePage#getMaxContentSize()} already excludes the page header, unlike
+   * {@link BasePage#getAvailableContentSize()} which over-reports by exactly that header.
+   */
+  private static int freeSpaceIn(final BasePage page) {
+    return page.getMaxContentSize() - page.getContentSize();
+  }
+
+  /**
+   * Names never span pages, so one that does not fit an empty page can never be stored, no matter how many pages there are.
+   */
+  private void checkNameFitsAPage(final String name, final int required) {
+    final int usable = pageSize - BasePage.PAGE_HEADER_SIZE - DICTIONARY_HEADER_SIZE;
+    if (required > usable)
       throw new DatabaseMetadataException(
-          "No space left in dictionary file (items=" + items + ", pageSize=" + pageSize + "). The dictionary holds every type "
-              + "name, property name and enumerated string value ever used in this database and entries are never reclaimed");
+          "Dictionary item '" + (name.length() > 64 ? name.substring(0, 64) + "..." : name) + "' needs " + required
+              + " bytes and cannot fit in a dictionary page of " + pageSize + " bytes (usable " + usable
+              + "): a name is never split across pages");
   }
 
   private void updateCounters(final MutablePage header) {
-    // THIS IS LEGACY CODE CONTAINING THE NUMBER OF ITEMS. NOW THE ITEMS ARE DIRECTLY READ FORM THE PAGE
+    // THIS IS LEGACY CODE CONTAINING THE NUMBER OF ITEMS. NOW THE ITEMS ARE DIRECTLY READ FORM THE PAGE. IT IS STILL WRITTEN ON
+    // EVERY PAGE, PAGE 0 INCLUDED, SO THAT ALL PAGES HAVE ONE SHAPE AND A PRE-MULTI-PAGE FILE NEEDS NO SPECIAL CASE
     header.writeInt(0, 0);
   }
 
@@ -290,16 +377,23 @@ public class Dictionary extends PaginatedComponent {
       return;
 
     } else {
-      final BasePage header = database.getTransaction().getPage(new PageId(database, file.getFileId(), 0), pageSize);
-
       // LOAD THE DICTIONARY IN RAM. THE NAMES ARE COLLECTED IN AN ARRAYLIST AND THE COPY-ON-WRITE LIST IS BUILT ONCE FROM IT:
       // APPENDING TO A CopyOnWriteArrayList COPIES THE WHOLE BACKING ARRAY PER ITEM, MAKING THIS QUADRATIC ON THE ENTRY COUNT
       // (~150ms FOR 48K ENTRIES, PAID ON EVERY OPEN, EVERY ROLLBACK OF A DICTIONARY TX AND EVERY REPLICATED DICTIONARY CHANGE).
       final List<String> loaded = new ArrayList<>();
 
-      header.setBufferPosition(DICTIONARY_HEADER_SIZE);
-      for (int i = 0; header.getBufferPosition() < header.getContentSize(); ++i)
-        loaded.add(header.readString());
+      // THE COMMITTED PAGE COUNT, NOT getTotalPages(): reload() REBUILDS THE IN-RAM VIEW FROM DURABLE STATE, AND
+      // TransactionContext.rollback() CALLS IT WHILE THE TRANSACTION'S OWN PAGE COUNTER STILL COUNTS PAGES THAT ARE BEING
+      // THROWN AWAY. THE FLOOR OF 1 KEEPS THE PRE-MULTI-PAGE BEHAVIOUR OF ALWAYS READING PAGE 0 OF A NON-EMPTY FILE.
+      final int totalPages = Math.max(1, pageCount.get());
+
+      for (int pageNumber = 0; pageNumber < totalPages; ++pageNumber) {
+        final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageNumber), pageSize);
+
+        page.setBufferPosition(DICTIONARY_HEADER_SIZE);
+        while (page.getBufferPosition() < page.getContentSize())
+          loaded.add(page.readString());
+      }
 
       final int size = loaded.size();
 

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -192,11 +192,22 @@ public class Dictionary extends PaginatedComponent {
 
   /**
    * Updates a name. The update will impact the entire database with both properties and values (if used as ENUM). The update is valid only if the name has not been used as type name.
+   * <br>
+   * <b>Cost:</b> the whole dictionary is re-laid out from page 0, so this dirties every dictionary page and puts them all in the
+   * caller's transaction. The WAL commit therefore grows with the size of the dictionary, not with the one name that changed. It
+   * used to touch page 0 alone, when page 0 was the whole dictionary.
+   * <br>
+   * <b>Concurrency:</b> synchronized on the same monitor as the {@link #getIdByName} create path, because both mutate the shared
+   * {@code entries} snapshot and the same pages. That serialises the in-RAM edit, which is the part that has no other protection:
+   * a concurrent append would otherwise read a half-renamed list. It does NOT make the two atomic against each other on disk -
+   * this method writes inside the CALLER's transaction and does not commit, so an append that commits in between is resolved the
+   * usual way, by the page version check raising {@link com.arcadedb.exception.ConcurrentModificationException} on whichever
+   * commits second. There is no production caller today; anything wiring a live rename should hold a schema-level lock too.
    *
    * @param oldName The old name to rename. Must be already present in the schema dictionary
    * @param newName The new name. Can be already present in the schema dictionary
    */
-  public void updateName(final String oldName, final String newName) {
+  public synchronized void updateName(final String oldName, final String newName) {
     if (!database.isTransactionActive())
       throw new SchemaException("Error on adding new item to the database schema dictionary because no transaction was active");
 
@@ -339,6 +350,16 @@ public class Dictionary extends PaginatedComponent {
   private MutablePage addPage(final int pageNumber) {
     final MutablePage page = database.getTransaction().addPage(new PageId(database, file.getFileId(), pageNumber), pageSize);
     updateCounters(page);
+
+    if (pageNumber == 1)
+      // THE ONE MOMENT IN A DATABASE'S LIFE WHEN IT STOPS BEING READABLE BY A BUILD WITHOUT MULTI-PAGE SUPPORT. LEAVING A
+      // BREADCRUMB HERE IS WHAT LETS AN OPERATOR CORRELATE A FOLLOWER LATER REPORTING "Dictionary item with id N is not valid"
+      // WITH THIS EVENT. INFO, NOT WARNING: NOTHING IS WRONG, AND A WARNING ON HEALTHY GROWTH IS HOW LOGS BECOME UNREADABLE
+      LogManager.instance().log(this, Level.INFO,
+          "Database '%s' schema dictionary grew beyond its first page. Any replica or tool running a build without multi-page "
+              + "dictionary support can no longer read this database: upgrade followers before, or together with, the leader",
+          null, database.getName());
+
     return page;
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -210,34 +210,40 @@ public class Dictionary extends PaginatedComponent {
       // NOTHING TO DO. WITHOUT THIS THE LOOP BELOW WOULD NEVER FIND ITS TERMINATION CONDITION
       return;
 
-    // VALIDATED BEFORE ANYTHING IS MUTATED: THE REWRITE BELOW EDITS THE IN-RAM VIEW FIRST, AND A newName TOO BIG FOR A PAGE
-    // WOULD OTHERWISE LEAVE IT RENAMED BUT UNWRITTEN UNTIL THE CALLER'S ROLLBACK HAPPENED TO REPAIR IT. EVERY OTHER NAME IS
-    // ALREADY STORED ON A PAGE OF THIS SIZE, SO newName IS THE ONLY ONE THAT CAN FAIL
+    // EVERY VALIDATION RUNS BEFORE ANY MUTATION, AND NONE OF THEM NEEDS THE MUTATION TO HAVE HAPPENED. THIS ORDER IS THE WHOLE
+    // POINT: THESE THROW IllegalArgumentException / DatabaseMetadataException, WHICH THE catch BELOW DOES NOT HANDLE (IT ONLY
+    // CATCHES IOException), AND NO DICTIONARY PAGE HAS BEEN TOUCHED YET, SO TransactionContext.rollback() DOES NOT ARM ITS
+    // REPAIRING reload() EITHER. MUTATING FIRST WOULD LEAVE THE IN-RAM VIEW RENAMED IN THE LIST AND MISSING FROM THE MAP UNTIL
+    // SOME UNRELATED RELOAD CAME ALONG.
+
+    // newName IS THE ONLY NAME THAT CAN BE TOO BIG: EVERY OTHER ONE IS ALREADY STORED ON A PAGE OF THIS SIZE
     checkNameFitsAPage(newName, spaceRequiredBy(newName.getBytes(DatabaseFactory.getDefaultCharset())));
+
+    // CHEAPEST FIRST, AND IT DEPENDS ONLY ON oldName, SO IT DOES NOT EVEN NEED THE SCAN BELOW
+    for (final DocumentType t : database.getSchema().getTypes())
+      if (oldName.equals(t.getName()))
+        throw new IllegalArgumentException(
+            "Cannot rename the item '" + oldName + "' in the dictionary because it has been used as a type name");
 
     final List<String> dictionary = entries.names();
     final ConcurrentMap<String, Integer> dictionaryMap = entries.ids();
 
+    // READ-ONLY SCAN. ONE PASS: THE OLD indexOf()-UNTIL-GONE LOOP RE-SCANNED THE WHOLE LIST PER OCCURRENCE, AND ONLY TERMINATED
+    // BECAUSE THE NAMES DIFFER, SINCE WITH oldName EQUAL TO newName EVERY SCAN FOUND WHAT THE PREVIOUS set() HAD JUST WRITTEN.
+    // THE EARLY RETURN ABOVE STILL COVERS THAT CASE, BUT SCANNING BY INDEX MAKES IT IMPOSSIBLE BY CONSTRUCTION
+    final List<Integer> oldIndexes = new ArrayList<>();
+    for (int i = 0; i < dictionary.size(); ++i)
+      if (oldName.equals(dictionary.get(i)))
+        oldIndexes.add(i);
+
+    if (oldIndexes.isEmpty())
+      throw new IllegalArgumentException("Item '" + oldName + "' not found in the dictionary");
+
     try {
+      // VALIDATION IS OVER: FROM HERE ON THE ONLY WAY OUT IS AN IOException, WHICH THE catch REPAIRS WITH A reload()
       dictionaryMap.remove(oldName);
-
-      // ONE PASS. THE OLD indexOf()-UNTIL-GONE LOOP RE-SCANNED THE WHOLE LIST PER OCCURRENCE, AND ONLY TERMINATED BECAUSE THE
-      // NAMES DIFFER: WITH oldName EQUAL TO newName EVERY SCAN FOUND WHAT THE PREVIOUS set() HAD JUST WRITTEN. THE EARLY RETURN
-      // ABOVE STILL COVERS THAT CASE, BUT SCANNING BY INDEX MAKES IT IMPOSSIBLE BY CONSTRUCTION RATHER THAN BY GUARD
-      final List<Integer> oldIndexes = new ArrayList<>();
-      for (int i = 0; i < dictionary.size(); ++i)
-        if (oldName.equals(dictionary.get(i))) {
-          oldIndexes.add(i);
-          dictionary.set(i, newName);
-        }
-
-      if (oldIndexes.isEmpty())
-        throw new IllegalArgumentException("Item '" + oldName + "' not found in the dictionary");
-
-      for (final DocumentType t : database.getSchema().getTypes())
-        if (oldName.equals(t.getName()))
-          throw new IllegalArgumentException(
-              "Cannot rename the item '" + oldName + "' in the dictionary because it has been used as a type name");
+      for (final int oldIndex : oldIndexes)
+        dictionary.set(oldIndex, newName);
 
       // REWRITE THE WHOLE DICTIONARY FROM PAGE 0 IN THE SAME ORDER, SO NO ID MOVES. THE TOTAL SIZE CAN SHRINK OR GROW, SO PAGES
       // ARE ADDED AS NEEDED AND THE ONES THE NEW CONTENT NO LONGER REACHES ARE EMPTIED: reload() WALKS EVERY COMMITTED PAGE, AND

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -221,16 +221,15 @@ public class Dictionary extends PaginatedComponent {
     try {
       dictionaryMap.remove(oldName);
 
+      // ONE PASS. THE OLD indexOf()-UNTIL-GONE LOOP RE-SCANNED THE WHOLE LIST PER OCCURRENCE, AND ONLY TERMINATED BECAUSE THE
+      // NAMES DIFFER: WITH oldName EQUAL TO newName EVERY SCAN FOUND WHAT THE PREVIOUS set() HAD JUST WRITTEN. THE EARLY RETURN
+      // ABOVE STILL COVERS THAT CASE, BUT SCANNING BY INDEX MAKES IT IMPOSSIBLE BY CONSTRUCTION RATHER THAN BY GUARD
       final List<Integer> oldIndexes = new ArrayList<>();
-      while (true) {
-        final int oldIndex = dictionary.indexOf(oldName);
-        if (oldIndex == -1)
-          break;
-
-        oldIndexes.add(oldIndex);
-
-        dictionary.set(oldIndex, newName);
-      }
+      for (int i = 0; i < dictionary.size(); ++i)
+        if (oldName.equals(dictionary.get(i))) {
+          oldIndexes.add(i);
+          dictionary.set(i, newName);
+        }
 
       if (oldIndexes.isEmpty())
         throw new IllegalArgumentException("Item '" + oldName + "' not found in the dictionary");

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -38,8 +38,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 /**
- * Maps every type name, property name and enumerated string value of a database to a small integer id, which is what records
- * carry instead of the name itself.
+ * Maps names to small integer ids, which is what records carry instead of the name itself.
+ * <br>
+ * Only identifiers are ever ADDED here: type names and property names, the callers that pass {@code create=true} to
+ * {@link #getIdByName}. A string VALUE is only ever looked up with {@code create=false}, and is stored as a reference when it
+ * happens to match an entry already present (see {@code BinarySerializer.serializeProperties}). User data therefore never
+ * enters the dictionary, and the per-name size limit below only ever applies to identifiers.
  * <br>
  * PAGE = [itemCount(int:4)][name(string)]* , where a name is a 1-3 byte varint length followed by its UTF-8 bytes. Every page
  * has the same shape, page 0 included, so a dictionary written before multi-page support (which is exactly one such page) loads
@@ -375,13 +379,18 @@ public class Dictionary extends PaginatedComponent {
       // (~150ms FOR 48K ENTRIES, PAID ON EVERY OPEN, EVERY ROLLBACK OF A DICTIONARY TX AND EVERY REPLICATED DICTIONARY CHANGE).
       final List<String> loaded = new ArrayList<>();
 
-      // THE COMMITTED PAGE COUNT, NOT getTotalPages(): reload() REBUILDS THE IN-RAM VIEW FROM DURABLE STATE, AND
-      // TransactionContext.rollback() CALLS IT WHILE THE TRANSACTION'S OWN PAGE COUNTER STILL COUNTS PAGES THAT ARE BEING
-      // THROWN AWAY. THE FLOOR OF 1 KEEPS THE PRE-MULTI-PAGE BEHAVIOUR OF ALWAYS READING PAGE 0 OF A NON-EMPTY FILE.
+      // COMMITTED STATE ON BOTH COUNTS, WHICH IS THE WHOLE CONTRACT OF THIS METHOD: EVERY CALLER (LOAD, ROLLBACK, AND THE TWO
+      // POST-COMMIT REPLICATION PATHS) WANTS WHAT IS DURABLE, NEVER WHAT A TRANSACTION IS CURRENTLY HOLDING.
+      //
+      // getTotalPages() WOULD COUNT PAGES A ROLLING-BACK TRANSACTION IS THROWING AWAY, AND TransactionContext.getPage() WOULD
+      // RETURN THAT TRANSACTION'S OWN DIRTY COPY (IT CHECKS modifiedPages FIRST), SO A ROLLBACK WOULD REBUILD THE DICTIONARY
+      // FROM EXACTLY THE CONTENT BEING DISCARDED. READ THROUGH THE PAGE MANAGER INSTEAD, AND COUNT WITH pageCount, WHICH ONLY
+      // ADVANCES ON COMMIT. THE FLOOR OF 1 KEEPS THE PRE-MULTI-PAGE BEHAVIOUR OF ALWAYS READING PAGE 0 OF A NON-EMPTY FILE.
       final int totalPages = Math.max(1, pageCount.get());
 
       for (int pageNumber = 0; pageNumber < totalPages; ++pageNumber) {
-        final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageNumber), pageSize);
+        final BasePage page = database.getPageManager()
+            .getImmutablePage(new PageId(database, file.getFileId(), pageNumber), pageSize, false, true);
 
         page.setBufferPosition(DICTIONARY_HEADER_SIZE);
         while (page.getBufferPosition() < page.getContentSize())

--- a/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
@@ -30,9 +30,12 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -321,6 +324,88 @@ class DictionaryMultiPageTest extends TestHelper {
     }
 
     assertThat(dictionary().getIdByName("beforeTheDowngrade", false)).isNotEqualTo(-1);
+  }
+
+  /**
+   * updateName validates before it mutates, and this is the case that proves it has to. Renaming a name that is also a type
+   * name is refused with an IllegalArgumentException, which is not an IOException, so updateName's own repairing catch does not
+   * fire; and no dictionary page has been written yet, so the rollback does not arm its reload either. Nothing would repair a
+   * half-applied rename, so the rename must not start.
+   */
+  @Test
+  void aRenameRefusedBecauseTheNameIsATypeLeavesTheDictionaryConsistent() {
+    fillPages(2);
+    database.getSchema().createDocumentType("Shared");
+
+    final Dictionary dictionary = dictionary();
+    final int id = dictionary.getIdByName("Shared", false);
+    assertThat(id).as("the type name is in the dictionary").isNotEqualTo(-1);
+
+    assertThatThrownBy(() -> database.transaction(() -> dictionary.updateName("Shared", "Renamed")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("used as a type name");
+
+    // BOTH DIRECTIONS STILL AGREE, WITHOUT AN UNRELATED RELOAD HAVING TO COME ALONG AND REPAIR THEM
+    assertThat(dictionary.getIdByName("Shared", false)).isEqualTo(id);
+    assertThat(dictionary.getNameById(id)).isEqualTo("Shared");
+    assertThat(dictionary.getIdByName("Renamed", false)).isEqualTo(-1);
+  }
+
+  /**
+   * The class reasons carefully about threads: appends serialise on this component's monitor while reload() runs on threads
+   * that do not hold it. Nothing exercised that under contention, and a rollover is where it would hurt, since two threads
+   * computing the tail page at once is what would renumber entries.
+   */
+  @Test
+  void concurrentAppendsAcrossARolloverKeepEveryIdUnique() throws Exception {
+    final Dictionary dictionary = dictionary();
+    final int threads = 4;
+    final int namesPerThread = 250;
+
+    final CountDownLatch startLine = new CountDownLatch(1);
+    final List<Thread> workers = new ArrayList<>();
+    final Map<String, Integer> assigned = new ConcurrentHashMap<>();
+    final List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+
+    for (int t = 0; t < threads; ++t) {
+      final int worker = t;
+      final Thread thread = new Thread(() -> {
+        try {
+          startLine.await();
+          for (int i = 0; i < namesPerThread; ++i) {
+            final String candidate = name(worker * namesPerThread + i);
+            assigned.put(candidate, dictionary.getIdByName(candidate, true));
+          }
+        } catch (final Throwable e) {
+          failures.add(e);
+        }
+      }, "dictionary-appender-" + t);
+      workers.add(thread);
+      thread.start();
+    }
+
+    startLine.countDown();
+    for (final Thread thread : workers)
+      thread.join();
+
+    assertThat(failures).isEmpty();
+
+    final int total = threads * namesPerThread;
+    assertThat(assigned).hasSize(total);
+    assertThat(dictionary.getTotalPages()).as("the fixture has to actually roll over").isGreaterThan(1);
+    // NO TWO NAMES SHARE AN ID, AND THE IDS COVER EXACTLY 0..total-1 WITH THE ENTRIES THAT WERE ALREADY THERE
+    assertThat(new HashSet<>(assigned.values())).hasSize(total);
+
+    for (final Map.Entry<String, Integer> entry : assigned.entrySet())
+      assertThat(dictionary.getNameById(entry.getValue())).isEqualTo(entry.getKey());
+
+    // AND THE IDS HANDED OUT UNDER CONTENTION MATCH THE ORDER THE NAMES ACTUALLY LANDED IN ON THE PAGES
+    dictionary.reload();
+    for (final Map.Entry<String, Integer> entry : assigned.entrySet()) {
+      assertThat(dictionary.getIdByName(entry.getKey(), false)).as("id of '%s' after reload", entry.getKey())
+          .isEqualTo(entry.getValue());
+      assertThat(dictionary.getNameById(entry.getValue())).isEqualTo(entry.getKey());
+    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
@@ -298,6 +298,47 @@ class DictionaryMultiPageTest extends TestHelper {
   }
 
   /**
+   * The compatibility guarantee in the forward direction, which {@link #pageZeroKeepsTheLegacySinglePageLayout} only covers in
+   * reverse: a single-page dictionary carrying the pre-multi-page format version is opened by this code, read in full, and then
+   * rolled over. The file is relabelled rather than synthesised because the two formats are byte-identical for one page - the
+   * version in the name is the only thing that differs, which is precisely the claim being tested.
+   */
+  @Test
+  void aDictionaryLabelledWithThePreviousFormatVersionLoadsAndThenRollsOver() {
+    final int before = 40;
+    for (int i = 0; i < before; ++i)
+      dictionary().getIdByName(name(i), true);
+    assertThat(dictionary().getTotalPages()).as("the fixture has to still be a single page").isEqualTo(1);
+
+    database.close();
+
+    final File databaseDirectory = new File(getDatabasePath());
+    final File[] dictionaryFiles = databaseDirectory.listFiles((dir, fileName) -> fileName.endsWith("." + Dictionary.DICT_EXT));
+    assertThat(dictionaryFiles).hasSize(1);
+    final File current = dictionaryFiles[0];
+    final File legacy = new File(databaseDirectory, current.getName().replaceFirst("\\.v\\d+\\.", ".v0."));
+    assertThat(current.renameTo(legacy)).isTrue();
+
+    database = factory.open();
+
+    // IT LOADED, IN FULL, WITH NO MIGRATION
+    assertThat(dictionary().getDictionaryMap()).hasSize(before);
+    assertAllNamesResolve(before);
+
+    // AND IT GROWS FROM THERE, KEEPING EVERY ID IT ARRIVED WITH
+    int added = before;
+    while (dictionary().getTotalPages() < 3) {
+      dictionary().getIdByName(name(added), true);
+      ++added;
+    }
+    assertAllNamesResolve(added);
+
+    reopenDatabase();
+    assertThat(dictionary().getDictionaryMap()).hasSize(added);
+    assertAllNamesResolve(added);
+  }
+
+  /**
    * A dictionary written by a future ArcadeDB would be read as if it had this layout, silently. Opening the database has to fail
    * loudly instead. Exercised the way it would really happen, through the load path, by renaming the file to a higher version.
    */

--- a/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
@@ -27,6 +27,7 @@ import com.arcadedb.exception.DatabaseMetadataException;
 import com.arcadedb.schema.DocumentType;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -222,6 +223,68 @@ class DictionaryMultiPageTest extends TestHelper {
     for (int i = 0; i < added; ++i)
       if (i != renamedId)
         assertThat(dictionary().getIdByName(name(i), false)).as("id of entry %d after reopen", i).isEqualTo(i);
+  }
+
+  /**
+   * The other half of the rewrite: renaming to a name that no longer fits the pages the dictionary already has must ADD one.
+   * The shrink branch is covered above; this is the {@code pageNumber >= getTotalPages()} branch of resetPageForRewrite.
+   */
+  @Test
+  void updateNameGrowingBeyondTheExistingPagesAddsOne() {
+    final int added = fillPages(3);
+    final Dictionary dictionary = dictionary();
+    final int pagesBefore = dictionary.getTotalPages();
+    final int renamedId = dictionary.getIdByName(name(1), false);
+
+    // ALMOST A WHOLE PAGE ON ITS OWN, SO THE RE-LAYOUT CANNOT POSSIBLY FIT IN THE PAGES THAT ARE ALREADY THERE
+    final String huge = "z".repeat(dictionary.getPageSize() - BasePage.PAGE_HEADER_SIZE - Binary.INT_SERIALIZED_SIZE - 8);
+
+    database.transaction(() -> dictionary.updateName(name(1), huge));
+
+    assertThat(dictionary.getTotalPages()).as("the rewrite had to grow the file").isGreaterThan(pagesBefore);
+    assertThat(dictionary.getNameById(renamedId)).isEqualTo(huge);
+    assertThat(dictionary.getIdByName(huge, false)).isEqualTo(renamedId);
+
+    for (int i = 0; i < added; ++i)
+      if (i != renamedId)
+        assertThat(dictionary.getIdByName(name(i), false)).as("id of entry %d after the rename", i).isEqualTo(i);
+
+    reopenDatabase();
+
+    assertThat(dictionary().getDictionaryMap()).hasSize(added);
+    assertThat(dictionary().getNameById(renamedId)).isEqualTo(huge);
+    for (int i = 0; i < added; ++i)
+      if (i != renamedId)
+        assertThat(dictionary().getIdByName(name(i), false)).as("id of entry %d after reopen", i).isEqualTo(i);
+  }
+
+  /**
+   * A dictionary written by a future ArcadeDB would be read as if it had this layout, silently. Opening the database has to fail
+   * loudly instead. Exercised the way it would really happen, through the load path, by renaming the file to a higher version.
+   */
+  @Test
+  void aDictionaryFromANewerFormatIsRefusedInsteadOfMisread() {
+    dictionary().getIdByName("beforeTheDowngrade", true);
+    database.close();
+
+    final File databaseDirectory = new File(getDatabasePath());
+    final File[] dictionaryFiles = databaseDirectory.listFiles((dir, fileName) -> fileName.endsWith("." + Dictionary.DICT_EXT));
+    assertThat(dictionaryFiles).hasSize(1);
+
+    final File current = dictionaryFiles[0];
+    final File fromTheFuture = new File(databaseDirectory, current.getName().replaceFirst("\\.v\\d+\\.", ".v99."));
+    assertThat(current.renameTo(fromTheFuture)).isTrue();
+
+    try {
+      assertThatThrownBy(() -> factory.open()).hasStackTraceContaining("format version 99");
+      assertThat(DatabaseFactory.getActiveDatabaseInstance(getDatabasePath())).isNull();
+    } finally {
+      // PUT IT BACK AND REOPEN, SO THE HARNESS CAN DROP THE DATABASE AT THE END OF THE TEST
+      assertThat(fromTheFuture.renameTo(current)).isTrue();
+      database = factory.open();
+    }
+
+    assertThat(dictionary().getIdByName("beforeTheDowngrade", false)).isNotEqualTo(-1);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.engine;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Binary;
+import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
@@ -446,6 +447,34 @@ class DictionaryMultiPageTest extends TestHelper {
       assertThat(dictionary.getIdByName(entry.getKey(), false)).as("id of '%s' after reload", entry.getKey())
           .isEqualTo(entry.getValue());
       assertThat(dictionary.getNameById(entry.getValue())).isEqualTo(entry.getKey());
+    }
+  }
+
+  /**
+   * A page the count claims but that is not on disk must stop the load, not be invented. Inventing it is not merely masked
+   * corruption: an empty page contributes zero names, so every name after it would come back with an id lower by however many
+   * the missing page held, and those ids are embedded in records. A partial replication replay, which writes a high page number
+   * without the ones before it, is how the count gets ahead of the file.
+   * <p>
+   * Runs against its own database, dropped at the end, because it deliberately leaves the page count inconsistent.
+   */
+  @Test
+  void aDictionaryPageThatIsClaimedButMissingFailsLoudly() {
+    final Database other = TestHelper.createDatabase(getDatabasePath() + "_claimedButMissing");
+    try {
+      final Dictionary dictionary = other.getSchema().getDictionary();
+      dictionary.getIdByName("aNameOnPageZero", true);
+      assertThat(dictionary.getTotalPages()).isEqualTo(1);
+
+      // CLAIM TWO PAGES THAT WERE NEVER WRITTEN
+      dictionary.updatePageCount(3);
+
+      assertThatThrownBy(dictionary::reload)
+          .isInstanceOf(DatabaseMetadataException.class)
+          .hasMessageContaining("is truncated")
+          .hasMessageContaining("page 1 of 3");
+    } finally {
+      other.drop();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
@@ -259,6 +259,42 @@ class DictionaryMultiPageTest extends TestHelper {
   }
 
   /**
+   * The reason reload() walks the COMMITTED page count instead of getTotalPages(). A rolled-back transaction still has its own
+   * page counter set when TransactionContext.rollback() reloads the dictionary, so reading that counter would walk a page that
+   * was never committed and rebuild the dictionary from content that is being thrown away.
+   * <p>
+   * updateName is what reaches this: it runs inside the CALLER's transaction and both modifies existing pages and adds new
+   * ones, so a dictionary page lands in modifiedPages (which is what arms the reload on rollback) while the growth is still
+   * uncommitted. An append through getIdByName cannot, because it only ever adds a page and never modifies one.
+   */
+  @Test
+  void aRolledBackTransactionThatGrewTheDictionaryLeavesItIntact() {
+    final int added = fillPages(2);
+    final Dictionary dictionary = dictionary();
+    final int pagesBefore = dictionary.getTotalPages();
+
+    final String huge = "z".repeat(dictionary.getPageSize() - BasePage.PAGE_HEADER_SIZE - Binary.INT_SERIALIZED_SIZE - 8);
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      dictionary.updateName(name(1), huge);
+      assertThat(dictionary.getTotalPages()).as("the rename has to grow the dictionary for this test to mean anything")
+          .isGreaterThan(pagesBefore);
+      throw new IllegalStateException("rolled back on purpose");
+    })).isInstanceOf(IllegalStateException.class);
+
+    // THE GROWTH IS GONE AND THE IN-RAM VIEW, WHICH updateName HAD ALREADY EDITED, WAS REPAIRED BY THE ROLLBACK RELOAD
+    assertThat(dictionary.getTotalPages()).isEqualTo(pagesBefore);
+    assertThat(dictionary.getIdByName(huge, false)).isEqualTo(-1);
+    assertAllNamesResolve(added);
+
+    reopenDatabase();
+
+    assertThat(dictionary().getTotalPages()).isEqualTo(pagesBefore);
+    assertThat(dictionary().getDictionaryMap()).hasSize(added);
+    assertAllNamesResolve(added);
+  }
+
+  /**
    * A dictionary written by a future ArcadeDB would be read as if it had this layout, silently. Opening the database has to fail
    * loudly instead. Exercised the way it would really happen, through the load path, by renaming the file to a higher version.
    */

--- a/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.exception.DatabaseMetadataException;
+import com.arcadedb.schema.DocumentType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The dictionary used to live in page 0 alone, which capped a database at whatever names fitted in one page. These tests pin the
+ * behaviour that replaces that cap: names roll over to a new page, ids stay put across the rollover and across a reopen, and a
+ * database written before multi-page support (which is exactly a dictionary of one page) still reads byte for byte.
+ * <p>
+ * In package {@code com.arcadedb.engine} on purpose: verifying the on-page layout needs the component's file id and page size.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class DictionaryMultiPageTest extends TestHelper {
+  /**
+   * Long enough that a few hundred names cross several pages, short enough to stay a plausible identifier length.
+   */
+  private static final int NAME_LENGTH = 500;
+
+  private static String name(final int i) {
+    final String prefix = "p" + i + "_";
+    return prefix + "x".repeat(NAME_LENGTH - prefix.length());
+  }
+
+  private Dictionary dictionary() {
+    return database.getSchema().getDictionary();
+  }
+
+  /**
+   * Adds names until the dictionary spans at least {@code pages} pages, and returns how many it added.
+   */
+  private int fillPages(final int pages) {
+    final Dictionary dictionary = dictionary();
+    int added = 0;
+    while (dictionary.getTotalPages() < pages) {
+      dictionary.getIdByName(name(added), true);
+      ++added;
+    }
+    return added;
+  }
+
+  private void assertAllNamesResolve(final int total) {
+    final Dictionary dictionary = dictionary();
+    for (int i = 0; i < total; ++i) {
+      assertThat(dictionary.getIdByName(name(i), false)).as("id of entry %d", i).isEqualTo(i);
+      assertThat(dictionary.getNameById(i)).as("name of id %d", i).isEqualTo(name(i));
+    }
+  }
+
+  @Test
+  void namesRollOverToNewPagesInsteadOfBeingRefused() {
+    final Dictionary dictionary = dictionary();
+    assertThat(dictionary.getTotalPages()).isEqualTo(1);
+
+    final int added = fillPages(3);
+
+    assertThat(dictionary.getTotalPages()).isGreaterThanOrEqualTo(3);
+    // MORE NAMES THAN ONE PAGE COULD EVER HOLD, WHICH IS THE WHOLE POINT
+    assertThat((long) added * NAME_LENGTH).isGreaterThan(dictionary.getPageSize());
+    assertThat(dictionary.getDictionaryMap()).hasSize(added);
+    assertAllNamesResolve(added);
+  }
+
+  @Test
+  void idsSurviveAReopen() {
+    final int added = fillPages(3);
+    final Map<String, Integer> before = new LinkedHashMap<>(dictionary().getDictionaryMap());
+
+    reopenDatabase();
+
+    assertThat(dictionary().getDictionaryMap()).isEqualTo(before);
+    assertAllNamesResolve(added);
+    assertThat(dictionary().getTotalPages()).isGreaterThanOrEqualTo(3);
+  }
+
+  /**
+   * The compatibility guarantee: page 0 is written exactly as a pre-multi-page ArcadeDB wrote it, so an existing database (whose
+   * dictionary is one page) loads unchanged. Reads page 0 with the old single-page algorithm and checks it yields the first
+   * names, in order, starting at id 0.
+   */
+  @Test
+  void pageZeroKeepsTheLegacySinglePageLayout() {
+    final int added = fillPages(2);
+    final Dictionary dictionary = dictionary();
+
+    final List<String> onPageZero = new ArrayList<>();
+    database.transaction(() -> {
+      try {
+        final BasePage page = ((DatabaseInternal) database).getTransaction()
+            .getPage(new PageId((DatabaseInternal) database, dictionary.getFileId(), 0), dictionary.getPageSize());
+        // THE PRE-MULTI-PAGE READER: SKIP THE 4 BYTE LEGACY COUNTER, THEN READ STRINGS UP TO THE CONTENT SIZE
+        page.setBufferPosition(Binary.INT_SERIALIZED_SIZE);
+        while (page.getBufferPosition() < page.getContentSize())
+          onPageZero.add(page.readString());
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    assertThat(onPageZero).isNotEmpty();
+    assertThat(onPageZero.size()).isLessThan(added);
+    for (int i = 0; i < onPageZero.size(); ++i)
+      assertThat(onPageZero.get(i)).as("legacy read of id %d", i).isEqualTo(name(i));
+  }
+
+  /**
+   * A name is never split over two pages, so one that cannot fit an empty page can never be stored. That has to be said clearly
+   * rather than surface as a page-boundary error, and it must leave the dictionary usable.
+   */
+  @Test
+  void aNameTooBigForAnEmptyPageIsRejectedAndLeavesTheDictionaryUsable() {
+    final Dictionary dictionary = dictionary();
+    dictionary.getIdByName("before", true);
+
+    final String tooBig = "y".repeat(dictionary.getPageSize());
+
+    assertThatThrownBy(() -> dictionary.getIdByName(tooBig, true))
+        .isInstanceOf(DatabaseMetadataException.class)
+        .hasMessageContaining("cannot fit");
+
+    assertThat(dictionary.getIdByName(tooBig, false)).isEqualTo(-1);
+    assertThat(dictionary.getIdByName("before", false)).isNotEqualTo(-1);
+    dictionary.getIdByName("after", true);
+    assertThat(dictionary.getNameById(dictionary.getIdByName("after", false))).isEqualTo("after");
+  }
+
+  /**
+   * Rollover has to survive the serializer round trip, not just the dictionary API: property names are stored as dictionary ids
+   * inside every record.
+   */
+  @Test
+  void documentsWithPropertyNamesSpanningPagesReadBack() {
+    final int propertiesPerDocument = 20;
+    final int documents = 30;
+
+    final DocumentType type = database.getSchema().createDocumentType("Wide");
+    assertThat(type).isNotNull();
+
+    database.transaction(() -> {
+      for (int d = 0; d < documents; ++d) {
+        final MutableDocument doc = database.newDocument("Wide");
+        doc.set("docId", d);
+        for (int p = 0; p < propertiesPerDocument; ++p)
+          doc.set(name(d * propertiesPerDocument + p), "v" + d + "_" + p);
+        doc.save();
+      }
+    });
+
+    assertThat(dictionary().getTotalPages()).isGreaterThan(1);
+
+    reopenDatabase();
+
+    database.transaction(() -> {
+      database.scanType("Wide", true, record -> {
+        final int d = record.asDocument().getInteger("docId");
+        for (int p = 0; p < propertiesPerDocument; ++p)
+          assertThat(record.asDocument().getString(name(d * propertiesPerDocument + p))).isEqualTo("v" + d + "_" + p);
+        return true;
+      });
+    });
+  }
+
+  /**
+   * updateName rewrites the whole dictionary. Across pages that means re-laying it out from page 0 and emptying whatever pages
+   * the shorter content no longer reaches, otherwise a stale tail page would re-add its old names on the next reload.
+   */
+  @Test
+  void updateNameRewritesEveryPage() {
+    final int added = fillPages(3);
+    final Dictionary dictionary = dictionary();
+    final int renamedId = dictionary.getIdByName(name(1), false);
+
+    database.transaction(() -> dictionary.updateName(name(1), "short"));
+
+    assertThat(dictionary.getNameById(renamedId)).isEqualTo("short");
+    assertThat(dictionary.getIdByName("short", false)).isEqualTo(renamedId);
+    assertThat(dictionary.getIdByName(name(1), false)).isEqualTo(-1);
+
+    // EVERY OTHER ENTRY KEPT ITS ID
+    for (int i = 0; i < added; ++i)
+      if (i != renamedId)
+        assertThat(dictionary.getIdByName(name(i), false)).as("id of entry %d after the rename", i).isEqualTo(i);
+
+    reopenDatabase();
+
+    assertThat(dictionary().getDictionaryMap()).hasSize(added);
+    assertThat(dictionary().getNameById(renamedId)).isEqualTo("short");
+    for (int i = 0; i < added; ++i)
+      if (i != renamedId)
+        assertThat(dictionary().getIdByName(name(i), false)).as("id of entry %d after reopen", i).isEqualTo(i);
+  }
+
+  /**
+   * The follower path: a replicated transaction that carries a brand new dictionary page has to create it and make its names
+   * visible, which only happens if the post-apply reload walks every page rather than page 0.
+   */
+  @Test
+  void aReplicatedNewDictionaryPageIsVisibleAfterApplyChanges() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final Dictionary dictionary = dictionary();
+
+    final int entriesBefore = dictionary.getDictionaryMap().size();
+    final int newPageNumber = dictionary.getTotalPages();
+
+    // BUILD THE PAGE IMAGE THE LEADER WOULD HAVE SHIPPED: THE 4 BYTE LEGACY COUNTER FOLLOWED BY ONE NAME
+    final String replicated = "replicatedName";
+    final Binary image = new Binary();
+    image.putInt(0);
+    image.putBytes(replicated.getBytes(DatabaseFactory.getDefaultCharset()));
+    image.flip();
+    final byte[] content = image.toByteArray();
+
+    final WALFile.WALPage walPage = new WALFile.WALPage();
+    walPage.fileId = dictionary.getFileId();
+    walPage.pageNumber = newPageNumber;
+    walPage.currentPageVersion = 1;
+    walPage.changesFrom = BasePage.PAGE_HEADER_SIZE;
+    walPage.changesTo = BasePage.PAGE_HEADER_SIZE + content.length - 1;
+    walPage.currentPageSize = content.length;
+    walPage.currentContent = new Binary(content);
+
+    final WALFile.WALTransaction walTx = new WALFile.WALTransaction();
+    walTx.txId = 987654;
+    walTx.timestamp = System.currentTimeMillis();
+    walTx.pages = new WALFile.WALPage[] { walPage };
+
+    assertThat(db.getTransactionManager().applyChanges(walTx, Collections.emptyMap(), false)).isTrue();
+
+    assertThat(dictionary.getTotalPages()).isEqualTo(newPageNumber + 1);
+    assertThat(dictionary.getDictionaryMap()).hasSize(entriesBefore + 1);
+    assertThat(dictionary.getIdByName(replicated, false)).isEqualTo(entriesBefore);
+    assertThat(dictionary.getNameById(entriesBefore)).isEqualTo(replicated);
+
+    // AND THE NEXT LOCALLY ADDED NAME CONTINUES AFTER IT INSTEAD OF OVERWRITING IT
+    assertThat(dictionary.getIdByName("afterReplication", true)).isEqualTo(entriesBefore + 1);
+    assertThat(dictionary.getNameById(entriesBefore)).isEqualTo(replicated);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/DictionaryLimitsTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DictionaryLimitsTest.java
@@ -20,49 +20,39 @@ package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.engine.Dictionary;
-import com.arcadedb.exception.DatabaseMetadataException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Pins the boundaries of the schema dictionary: it lives in one page, it never reclaims an entry, and it has to say so when it
- * runs out of room instead of leaking a raw page-boundary error.
+ * Pins the boundaries of the schema dictionary: entries are never reclaimed, and both directions of the mapping survive a
+ * reload. Page rollover has its own test, {@link com.arcadedb.engine.DictionaryMultiPageTest}.
  */
 class DictionaryLimitsTest extends TestHelper {
   /**
-   * Names are padded so a handful of thousands of them, rather than tens of thousands, exhaust the page.
+   * Names are padded so a few thousand of them, rather than tens of thousands, cross a page boundary.
    */
   private static String name(final int i) {
     return ("p" + i).concat("x".repeat(100));
   }
 
+  /**
+   * Filling far past one page used to end in "no space left in dictionary file". It has to just keep working now, with every id
+   * still resolvable in both directions.
+   */
   @Test
-  void runningOutOfPageSpaceIsReportedAsADictionaryError() {
+  void fillingWellPastOnePageKeepsWorking() {
     final Dictionary dictionary = database.getSchema().getDictionary();
 
-    int inserted = 0;
-    DatabaseMetadataException failure = null;
-    try {
-      for (int i = 0; i < 100_000; ++i) {
-        dictionary.getIdByName(name(i), true);
-        ++inserted;
-      }
-    } catch (final DatabaseMetadataException e) {
-      failure = e;
-    }
+    final int total = 20_000;
+    for (int i = 0; i < total; ++i)
+      dictionary.getIdByName(name(i), true);
 
-    assertThat(failure).as("the dictionary is bounded by its single page and must eventually refuse a name").isNotNull();
-    assertThat(failure.getMessage()).contains("No space left in dictionary file");
-    assertThat(failure.getMessage()).contains("items=" + inserted);
+    assertThat((long) total * 100).as("the fixture has to be bigger than a single page").isGreaterThan(dictionary.getPageSize());
+    assertThat(dictionary.getTotalPages()).isGreaterThan(1);
+    assertThat(dictionary.getDictionaryMap()).hasSize(total);
 
-    // THE WHOLE PAGE MINUS THE PAGE HEADER AND THE LEGACY COUNTER IS USABLE, AND THE REFUSAL HAPPENS ONLY AT THE VERY END
-    assertThat(dictionary.getAvailableSpace()).isLessThan(102 + 1);
-
-    // THE FAILED INSERT ROLLED BACK CLEANLY: EVERYTHING ACCEPTED SO FAR IS STILL RESOLVABLE IN BOTH DIRECTIONS
-    assertThat(dictionary.getDictionaryMap()).hasSize(inserted);
-    for (int i = 0; i < inserted; ++i) {
+    for (int i = 0; i < total; ++i) {
       final int id = dictionary.getIdByName(name(i), false);
       assertThat(id).isEqualTo(i);
       assertThat(dictionary.getNameById(id)).isEqualTo(name(i));

--- a/engine/src/test/java/com/arcadedb/schema/DictionaryLimitsTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DictionaryLimitsTest.java
@@ -39,17 +39,21 @@ class DictionaryLimitsTest extends TestHelper {
   /**
    * Filling far past one page used to end in "no space left in dictionary file". It has to just keep working now, with every id
    * still resolvable in both directions.
+   * <p>
+   * Sized by what it has to prove, not by a round number: every name costs its own nested transaction, so 3,000 padded names
+   * cross four pages and keep the test well under a second even on a slow CI runner. Twenty thousand of them proved nothing
+   * more and only bought 20,000 WAL commits.
    */
   @Test
   void fillingWellPastOnePageKeepsWorking() {
     final Dictionary dictionary = database.getSchema().getDictionary();
 
-    final int total = 20_000;
+    final int total = 3_000;
     for (int i = 0; i < total; ++i)
       dictionary.getIdByName(name(i), true);
 
     assertThat((long) total * 100).as("the fixture has to be bigger than a single page").isGreaterThan(dictionary.getPageSize());
-    assertThat(dictionary.getTotalPages()).isGreaterThan(1);
+    assertThat(dictionary.getTotalPages()).as("several pages, not just a rollover").isGreaterThanOrEqualTo(4);
     assertThat(dictionary.getDictionaryMap()).hasSize(total);
 
     for (int i = 0; i < total; ++i) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotCompressionRatioTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotCompressionRatioTest.java
@@ -173,7 +173,8 @@ class SnapshotCompressionRatioTest {
    */
   @Test
   void sparsePageSizedEntry_doesNotExceedRatioLimit() throws Exception {
-    // Dictionary.DEF_PAGE_SIZE = 65536 * 5 = 327 680 bytes, freshly initialised → mostly zeros
+    // 327 680 bytes is the dictionary page size of any database created before multi-page support, and stays the largest
+    // sparse entry a snapshot of one can carry. Kept as a literal: this pins the ratio guard, not the current page size
     final int dictionaryPageSize = 65_536 * 5;
     final byte[] sparseData = new byte[dictionaryPageSize]; // all-zeros: highly compressible
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Release note / upgrade requirement: in a cluster, upgrade followers before, or together with, the leader.**
>
> Dictionary pages replicate as raw pages. Once a leader's dictionary grows past its first page it ships page 1 and
> beyond to its followers, and a follower still running a build without multi-page support writes those pages but
> reloads only page 0. Its in-RAM dictionary is then missing every name past the first page, and each record
> referencing one fails with `Dictionary item with id N is not valid`.
>
> Related: a database that has rolled over can no longer be opened by an older ArcadeDB at all. To check whether a
> given database has rolled over, divide its dictionary file size by the page size in its own file name:
> `ls -l <db>/dictionary.*.dict` - 131072 / 65536 = 2 pages means rolled over. A file at or under one page is still
> single-page and remains downgradable.
>
> Full detail in `docs/5560-dictionary-multipage.md`, section *Upgrade notes*.

## The limit

`com.arcadedb.engine.Dictionary` maps every type name, property name and enumerated string value to a small integer id, and that id is what records carry instead of the name. Despite the class javadoc saying "CONTENT-PAGES", it only ever used **page 0**, so a database was capped at whatever fitted there: `pageSize - 8 - 4` = **327,668 bytes of names**, measured at **48,396** short names before the write was refused.

Past that point `CREATE PROPERTY`, or inserting a document with a new field name, failed permanently. There was no path to grow, and entries are never reclaimed, so a schemaless workload with dynamic field names walked steadily toward it.

## What changed

Names roll over to a new page. Every page, page 0 included, carries the same 4-byte legacy counter, so **a dictionary written before this change is exactly a dictionary of one page and loads unchanged**: no migration, no rewrite, no format flag needed to read an existing database.

The invariant everything follows from: **an id is the ordinal of the name in page order**, and that id sits inside records on disk. So the layout is strictly append-only across pages. Names go only to the LAST page, and a page left behind is never revisited even when it still has room. Filling a gap would renumber every name after it and silently repoint every record referencing them, which is the one way this change could corrupt data rather than throw. A name is never split across pages, so the wasted tail is under 1% at identifier lengths, and the only limit left is a single name larger than one page, which is now refused by name.

Three details worth review attention:

- `addItemToPage` **reads** the tail page before deciding where to write. Asking for it as modifiable and then finding it full would bump its version, rewrite it at commit for nothing, and make it false-conflict with concurrent transactions.
- `reload()` walks the **committed** page count, not `getTotalPages()`. `TransactionContext.rollback()` calls `reload()` while the transaction's own page counter still counts pages being thrown away. The floor of 1 keeps the previous behaviour of always reading page 0 of a non-empty file.
- `updateName()` re-lays the dictionary out from page 0 in the same order, so no id moves, and **empties the pages the new content no longer reaches**. `reload()` walks every committed page, so a stale tail page would otherwise re-add its old names.

## Page size and format version

`DEF_PAGE_SIZE` drops from 327,680 to **65,536** for new dictionaries. That size existed only to make the single available page hold as many names as possible. Now that pages roll over, a new name dirties and eventually flushes one page, so a smaller page is 5x less write amplification per name. Existing databases keep the page size they were created with, which is read back from the file name.

`CURRENT_VERSION` goes to 1, with a guard refusing a dictionary written by a newer ArcadeDB rather than misreading it.

**Downgrade note:** once a database grows past page 0 it can no longer be opened by an older ArcadeDB, which reads page 0 only and reports `Dictionary item with id N is not valid`. Loud, not silent, and such a database could not have existed before this change since the write would have been refused.

## Tests

New `DictionaryMultiPageTest` (in `com.arcadedb.engine`, so it can inspect the on-page layout):

- rollover instead of refusal, with every id resolvable both ways
- ids survive a reopen
- **page 0 still reads with the pre-multi-page algorithm**, which is the compatibility guarantee
- a name too big for an empty page is refused clearly and leaves the dictionary usable
- documents whose property names span pages read back after a reopen (the serializer round trip)
- `updateName` rewrites every page and keeps every other id
- the **follower path**: a replicated WAL transaction carrying a brand new dictionary page creates it, makes its names visible, and the next local name continues after it

`DictionaryLimitsTest` had a test asserting the old "no space left in dictionary file" behaviour; it now asserts that filling well past one page keeps working.

Local run: 920 engine test classes, 0 failures, at the time of pushing (the full run was still going through an unrelated long test).
