### PR TITLE
test(engine) #5570: tolerate retry exhaustion in EdgeAppendMergeRaceTest, keep failing on corruption

### DIFF
--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
@@ -95,6 +95,16 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     // Readers are the corruption detector, so their give-ups need a floor rather than the writers' ceiling: a
     // run where readers mostly failed to complete a traversal would go green with the BufferUnderflowException
     // guard barely exercised. Assert the detector actually ran, in absolute terms and as a share.
+    //
+    // Neither bound re-couples the test to runner speed, which is the thing #5570 set out to remove:
+    //
+    // - a read-only transaction cannot give up at all. commit1stPhase locks exactly the files that
+    //   lockFilesFromChanges() collects from modifiedPages / newPages / indexChanges, all empty here, so
+    //   tryLockFiles iterates an empty list and no COMMIT_LOCK_TIMEOUT can elapse; with no modified page there
+    //   is likewise nothing for checkPageVersion to reject. So readerGiveUps is structurally 0, which makes the
+    //   share bound vacuous (n > n/2) until readers really do start failing - exactly the degradation it guards.
+    // - the absolute floor is 4 traversals for the whole run, against 18000 write transactions the readers loop
+    //   underneath, and the earliest ones parse a nearly empty chain. No runner is slow enough for that.
     final int readTx = outcome.readTransactions();
     assertThat(outcome.readerCommits())
         .as("full chain traversals completed: %d of %d reader transactions", outcome.readerCommits(), readTx)
@@ -139,7 +149,10 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     final AtomicInteger addedCount = new AtomicInteger();
     final AtomicInteger removedCount = new AtomicInteger();
     final AtomicInteger readerCommits = new AtomicInteger();
-    final GiveUps writerGiveUps = new GiveUps();
+    // Tallied per role, not per writer/reader: an adder losing the append race and a remover losing the
+    // structural race are different symptoms, and a starvation regression is worth attributing to one of them.
+    final GiveUps adderGiveUps = new GiveUps();
+    final GiveUps removerGiveUps = new GiveUps();
     final GiveUps readerGiveUps = new GiveUps();
     final AtomicBoolean addersDone = new AtomicBoolean();
     final CountDownLatch start = new CountDownLatch(1);
@@ -159,7 +172,7 @@ class EdgeAppendMergeRaceTest extends TestHelper {
               src.save();
               src.newEdge("TRANSFERS", hubRID);
               holder[0] = src.getIdentity();
-            }, attempts, writerGiveUps))
+            }, attempts, adderGiveUps))
               // GAVE UP: nothing was committed, so nothing to count and nothing to offer to the removers.
               continue;
 
@@ -190,7 +203,7 @@ class EdgeAppendMergeRaceTest extends TestHelper {
             // A remover that gives up leaves its victim un-deleted and does not count it, so the expected edge
             // count stays exact. The victim is deliberately not re-queued: retrying it forever would hide the
             // give-up instead of reporting it.
-            if (commit(() -> victim.asVertex(true).delete(), attempts, writerGiveUps))
+            if (commit(() -> victim.asVertex(true).delete(), attempts, removerGiveUps))
               removedCount.incrementAndGet();
           }
         } catch (final Throwable e) {
@@ -230,8 +243,8 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     for (final Thread thread : threads)
       thread.join();
 
-    final RaceOutcome outcome = new RaceOutcome(addedCount.get(), removedCount.get(), writerGiveUps.count.get(),
-        readerCommits.get(), readerGiveUps.count.get(),
+    final RaceOutcome outcome = new RaceOutcome(addedCount.get(), removedCount.get(), adderGiveUps.count.get(),
+        removerGiveUps.count.get(), readerCommits.get(), readerGiveUps.count.get(),
         ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges);
 
     // The suite pins com.arcadedb to SEVERE, so a run with give-ups is the only one that prints: a genuine
@@ -239,9 +252,10 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     // to trip the assertions below.
     LogManager.instance()
         .log(this, outcome.writerGiveUps() + outcome.readerGiveUps() > 0 ? Level.SEVERE : Level.WARNING,
-            "#5570 race outcome: added=%d removed=%d merges=%d give-ups(write)=%d traversals=%d give-ups(read)=%d%s%s",
-            outcome.added(), outcome.removed(), outcome.merges(), outcome.writerGiveUps(), outcome.readerCommits(),
-            outcome.readerGiveUps(), writerGiveUps.describeFirst("write"), readerGiveUps.describeFirst("read"));
+            "#5570 race outcome: added=%d removed=%d merges=%d traversals=%d give-ups: adder=%d remover=%d reader=%d%s%s%s",
+            outcome.added(), outcome.removed(), outcome.merges(), outcome.readerCommits(), outcome.adderGiveUps(),
+            outcome.removerGiveUps(), outcome.readerGiveUps(), adderGiveUps.describeFirst("adder"),
+            removerGiveUps.describeFirst("remover"), readerGiveUps.describeFirst("reader"));
 
     if (!errors.isEmpty())
       throw new AssertionError(errors.size() + " thread(s) failed with a non-retryable error, first: " + errors.getFirst(),
@@ -301,9 +315,14 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     }
   }
 
-  private record RaceOutcome(int added, int removed, int writerGiveUps, int readerCommits, int readerGiveUps, long merges) {
+  private record RaceOutcome(int added, int removed, int adderGiveUps, int removerGiveUps, int readerCommits,
+                            int readerGiveUps, long merges) {
+    int writerGiveUps() {
+      return adderGiveUps + removerGiveUps;
+    }
+
     int writeTransactions() {
-      return added + removed + writerGiveUps;
+      return added + removed + writerGiveUps();
     }
 
     int readTransactions() {

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
@@ -20,8 +20,11 @@ package com.arcadedb.graph;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.BasicDatabase;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +38,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,9 +51,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  * If a structural write ever failed to poison its page, a concurrent rebase would re-derive that page from
  * committed-state + appends and drop the relink, leaving a chain whose bytes no longer parse - the truncated
  * read surfaces as java.nio.BufferUnderflowException on the next traversal (the shape reported in #565).
+ * <p>
+ * #5570: what this test does NOT prove is that every transaction eventually commits. Under this much contention
+ * on one page a transaction can lose the race for all of its attempts and give up with a
+ * {@link com.arcadedb.exception.ConcurrentModificationException}, which extends {@link NeedRetryException} and is
+ * a documented outcome applications must handle. Those are counted and bounded, not fatal; anything that is not
+ * retryable - a reader whose traversal stopped parsing above all - still fails the test immediately.
  */
 @Tag("slow")
 class EdgeAppendMergeRaceTest extends TestHelper {
+  private static final int ADDERS = 8, REMOVERS = 4, READERS = 4;
+
   private int     savedThreshold;
   private boolean savedMerge;
 
@@ -66,6 +79,34 @@ class EdgeAppendMergeRaceTest extends TestHelper {
 
   @Test
   void addersRemoversAndReadersOnOneHotVertex() throws Exception {
+    final RaceOutcome outcome = runRace(1500, 100);
+
+    assertThat(outcome.merges()).as("edge-append rebase must actually have fired").isGreaterThan(0);
+
+    // #5570: a handful of give-ups is the expected outcome of a fair race once the runner is slow enough, and
+    // the version gaps observed in CI were 2 to 4, i.e. the loser was never stale. What would NOT be expected
+    // is a large share of the workload never getting through: that is starvation or a livelock, and it shows up
+    // here as this count jumping rather than as an intermittent red build.
+    final int writeTx = outcome.writeTransactions();
+    assertThat(outcome.writerGiveUps())
+        .as("write transactions that exhausted their retries: %d of %d", outcome.writerGiveUps(), writeTx)
+        .isLessThan(Math.max(16, writeTx / 20));
+  }
+
+  /**
+   * Same race with a single attempt per transaction, so retry exhaustion is the norm instead of the exception.
+   * Proves the two halves of the contract in one shot: give-ups are tolerated and counted, and the final
+   * consistency checks stay exact regardless of how many transactions gave up.
+   */
+  @Test
+  void retryExhaustionIsToleratedAndCounted() throws Exception {
+    final RaceOutcome outcome = runRace(200, 1);
+
+    assertThat(outcome.writerGiveUps()).as("one attempt per transaction must produce give-ups on this workload")
+        .isGreaterThan(0);
+  }
+
+  private RaceOutcome runRace(final int perAdder, final int attempts) throws Exception {
     // 26.7.2 SHAPE: no striped layout, so every writer contends on the hot vertex's single head chunk.
     GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(0);
     GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(true);
@@ -84,12 +125,13 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     });
     final RID hubRID = hubHolder[0];
 
-    final int ADDERS = 8, REMOVERS = 4, READERS = 4, PER_ADDER = 1500;
-
     final List<Throwable> errors = new CopyOnWriteArrayList<>();
     final ConcurrentLinkedQueue<RID> live = new ConcurrentLinkedQueue<>();
     final AtomicInteger addedCount = new AtomicInteger();
     final AtomicInteger removedCount = new AtomicInteger();
+    final AtomicInteger writerGiveUps = new AtomicInteger();
+    final AtomicInteger readerGiveUps = new AtomicInteger();
+    final AtomicReference<Throwable> firstGiveUp = new AtomicReference<>();
     final AtomicBoolean addersDone = new AtomicBoolean();
     final CountDownLatch start = new CountDownLatch(1);
     final List<Thread> threads = new ArrayList<>();
@@ -99,16 +141,19 @@ class EdgeAppendMergeRaceTest extends TestHelper {
       threads.add(new Thread(() -> {
         try {
           start.await();
-          for (int i = 0; i < PER_ADDER; i++) {
-            final int n = id * PER_ADDER + i;
+          for (int i = 0; i < perAdder; i++) {
+            final int n = id * perAdder + i;
             final RID[] holder = new RID[1];
-            database.transaction(() -> {
+            if (!commit(() -> {
               final MutableVertex src = database.newVertex("Account");
               src.set("number", n + 1);
               src.save();
               src.newEdge("TRANSFERS", hubRID);
               holder[0] = src.getIdentity();
-            }, true, 100);
+            }, attempts, writerGiveUps, firstGiveUp))
+              // GAVE UP: nothing was committed, so nothing to count and nothing to offer to the removers.
+              continue;
+
             // Only half are ever eligible for removal: the chain must stay long (many chunks) while the
             // removers churn it, instead of draining to empty.
             if ((n & 1) == 0)
@@ -133,8 +178,11 @@ class EdgeAppendMergeRaceTest extends TestHelper {
               Thread.yield();
               continue;
             }
-            database.transaction(() -> victim.asVertex(true).delete(), true, 100);
-            removedCount.incrementAndGet();
+            // A remover that gives up leaves its victim un-deleted and does not count it, so the expected edge
+            // count stays exact. The victim is deliberately not re-queued: retrying it forever would hide the
+            // give-up instead of reporting it.
+            if (commit(() -> victim.asVertex(true).delete(), attempts, writerGiveUps, firstGiveUp))
+              removedCount.incrementAndGet();
           }
         } catch (final Throwable e) {
           errors.add(e);
@@ -148,13 +196,13 @@ class EdgeAppendMergeRaceTest extends TestHelper {
         try {
           start.await();
           while (!addersDone.get()) {
-            database.transaction(() -> {
+            commit(() -> {
               final Vertex hub = hubRID.asVertex(true);
               hub.countEdges(Vertex.DIRECTION.IN, "TRANSFERS");
               for (final Vertex ignored : hub.getVertices(Vertex.DIRECTION.IN, "TRANSFERS")) {
                 // full traversal: forces every chunk in the chain to be parsed
               }
-            }, true, 100);
+            }, attempts, readerGiveUps, firstGiveUp);
           }
         } catch (final Throwable e) {
           errors.add(e);
@@ -170,15 +218,25 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     for (final Thread thread : threads)
       thread.join();
 
-    final long merges = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges;
+    final RaceOutcome outcome = new RaceOutcome(addedCount.get(), removedCount.get(), writerGiveUps.get(),
+        readerGiveUps.get(), ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges);
 
-    if (!errors.isEmpty()) {
-      errors.getFirst().printStackTrace();
-      throw new AssertionError(errors.size() + " thread(s) failed, first: " + errors.getFirst(), errors.getFirst());
-    }
-    assertThat(merges).as("edge-append rebase must actually have fired").isGreaterThan(0);
+    // The suite pins com.arcadedb to SEVERE, so a run with give-ups is the only one that prints: a genuine
+    // starvation regression then shows up as this count jumping in the build log, well before it grows enough
+    // to trip the assertion below.
+    LogManager.instance()
+        .log(this, outcome.writerGiveUps() + outcome.readerGiveUps() > 0 ? Level.SEVERE : Level.WARNING,
+            "#5570 race outcome: added=%d removed=%d merges=%d give-ups(write)=%d give-ups(read)=%d%s", outcome.added(),
+            outcome.removed(), outcome.merges(), outcome.writerGiveUps(), outcome.readerGiveUps(),
+            firstGiveUp.get() != null ? " first=" + firstGiveUp.get() : "");
 
-    final int expected = addedCount.get() - removedCount.get();
+    if (!errors.isEmpty())
+      throw new AssertionError(errors.size() + " thread(s) failed with a non-retryable error, first: " + errors.getFirst(),
+          errors.getFirst());
+
+    // addedCount / removedCount only move after a successful commit, so this stays exact no matter how many
+    // transactions gave up.
+    final int expected = outcome.added() - outcome.removed();
     database.transaction(() -> {
       assertThat(hubRID.asVertex(true).countEdges(Vertex.DIRECTION.IN, "TRANSFERS")).isEqualTo(expected);
       int seen = 0;
@@ -186,5 +244,30 @@ class EdgeAppendMergeRaceTest extends TestHelper {
         seen++;
       assertThat(seen).as("every surviving edge still reachable").isEqualTo(expected);
     });
+
+    return outcome;
+  }
+
+  /**
+   * Runs a transaction and reports whether it committed. A transaction that exhausted its attempts raises a
+   * {@link NeedRetryException}: that is contention, not corruption, so it is counted and swallowed. Everything
+   * else - a {@code BufferUnderflowException} from a reader above all - propagates and fails the test.
+   */
+  private boolean commit(final BasicDatabase.TransactionScope block, final int attempts, final AtomicInteger giveUps,
+      final AtomicReference<Throwable> firstGiveUp) {
+    try {
+      database.transaction(block, true, attempts);
+      return true;
+    } catch (final NeedRetryException e) {
+      giveUps.incrementAndGet();
+      firstGiveUp.compareAndSet(null, e);
+      return false;
+    }
+  }
+
+  private record RaceOutcome(int added, int removed, int writerGiveUps, int readerGiveUps, long merges) {
+    int writeTransactions() {
+      return added + removed + writerGiveUps;
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
@@ -265,6 +265,12 @@ class EdgeAppendMergeRaceTest extends TestHelper {
    * Runs a transaction and reports whether it committed. A transaction that exhausted its attempts raises a
    * {@link NeedRetryException}: that is contention, not corruption, so it is counted and swallowed. Everything
    * else - a {@code BufferUnderflowException} from a reader above all - propagates and fails the test.
+   * <p>
+   * Contention give-ups are the ONLY tolerated outcome, deliberately. {@code transaction()} also retries
+   * {@link com.arcadedb.exception.DuplicatedKeyException}, which does not extend {@link NeedRetryException} and
+   * so would still fail this test on exhaustion - correct here, since this workload has no unique index and a
+   * duplicate would mean the engine handed out a colliding RID. Anyone reusing this wrapper on a unique-key
+   * workload has to decide that case explicitly rather than inherit this one.
    */
   private boolean commit(final BasicDatabase.TransactionScope block, final int attempts, final GiveUps giveUps) {
     try {

--- a/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeAppendMergeRaceTest.java
@@ -91,6 +91,15 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     assertThat(outcome.writerGiveUps())
         .as("write transactions that exhausted their retries: %d of %d", outcome.writerGiveUps(), writeTx)
         .isLessThan(Math.max(16, writeTx / 20));
+
+    // Readers are the corruption detector, so their give-ups need a floor rather than the writers' ceiling: a
+    // run where readers mostly failed to complete a traversal would go green with the BufferUnderflowException
+    // guard barely exercised. Assert the detector actually ran, in absolute terms and as a share.
+    final int readTx = outcome.readTransactions();
+    assertThat(outcome.readerCommits())
+        .as("full chain traversals completed: %d of %d reader transactions", outcome.readerCommits(), readTx)
+        .isGreaterThanOrEqualTo(READERS)
+        .isGreaterThan(readTx / 2);
   }
 
   /**
@@ -129,9 +138,9 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     final ConcurrentLinkedQueue<RID> live = new ConcurrentLinkedQueue<>();
     final AtomicInteger addedCount = new AtomicInteger();
     final AtomicInteger removedCount = new AtomicInteger();
-    final AtomicInteger writerGiveUps = new AtomicInteger();
-    final AtomicInteger readerGiveUps = new AtomicInteger();
-    final AtomicReference<Throwable> firstGiveUp = new AtomicReference<>();
+    final AtomicInteger readerCommits = new AtomicInteger();
+    final GiveUps writerGiveUps = new GiveUps();
+    final GiveUps readerGiveUps = new GiveUps();
     final AtomicBoolean addersDone = new AtomicBoolean();
     final CountDownLatch start = new CountDownLatch(1);
     final List<Thread> threads = new ArrayList<>();
@@ -150,7 +159,7 @@ class EdgeAppendMergeRaceTest extends TestHelper {
               src.save();
               src.newEdge("TRANSFERS", hubRID);
               holder[0] = src.getIdentity();
-            }, attempts, writerGiveUps, firstGiveUp))
+            }, attempts, writerGiveUps))
               // GAVE UP: nothing was committed, so nothing to count and nothing to offer to the removers.
               continue;
 
@@ -181,7 +190,7 @@ class EdgeAppendMergeRaceTest extends TestHelper {
             // A remover that gives up leaves its victim un-deleted and does not count it, so the expected edge
             // count stays exact. The victim is deliberately not re-queued: retrying it forever would hide the
             // give-up instead of reporting it.
-            if (commit(() -> victim.asVertex(true).delete(), attempts, writerGiveUps, firstGiveUp))
+            if (commit(() -> victim.asVertex(true).delete(), attempts, writerGiveUps))
               removedCount.incrementAndGet();
           }
         } catch (final Throwable e) {
@@ -196,13 +205,16 @@ class EdgeAppendMergeRaceTest extends TestHelper {
         try {
           start.await();
           while (!addersDone.get()) {
-            commit(() -> {
+            if (commit(() -> {
               final Vertex hub = hubRID.asVertex(true);
               hub.countEdges(Vertex.DIRECTION.IN, "TRANSFERS");
               for (final Vertex ignored : hub.getVertices(Vertex.DIRECTION.IN, "TRANSFERS")) {
                 // full traversal: forces every chunk in the chain to be parsed
               }
-            }, attempts, readerGiveUps, firstGiveUp);
+            }, attempts, readerGiveUps))
+              // A completed traversal is one full parse of the chain, i.e. one actual exercise of the
+              // corruption detector. Counted so the test can prove the detector really ran.
+              readerCommits.incrementAndGet();
           }
         } catch (final Throwable e) {
           errors.add(e);
@@ -218,17 +230,18 @@ class EdgeAppendMergeRaceTest extends TestHelper {
     for (final Thread thread : threads)
       thread.join();
 
-    final RaceOutcome outcome = new RaceOutcome(addedCount.get(), removedCount.get(), writerGiveUps.get(),
-        readerGiveUps.get(), ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges);
+    final RaceOutcome outcome = new RaceOutcome(addedCount.get(), removedCount.get(), writerGiveUps.count.get(),
+        readerCommits.get(), readerGiveUps.count.get(),
+        ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges);
 
     // The suite pins com.arcadedb to SEVERE, so a run with give-ups is the only one that prints: a genuine
     // starvation regression then shows up as this count jumping in the build log, well before it grows enough
-    // to trip the assertion below.
+    // to trip the assertions below.
     LogManager.instance()
         .log(this, outcome.writerGiveUps() + outcome.readerGiveUps() > 0 ? Level.SEVERE : Level.WARNING,
-            "#5570 race outcome: added=%d removed=%d merges=%d give-ups(write)=%d give-ups(read)=%d%s", outcome.added(),
-            outcome.removed(), outcome.merges(), outcome.writerGiveUps(), outcome.readerGiveUps(),
-            firstGiveUp.get() != null ? " first=" + firstGiveUp.get() : "");
+            "#5570 race outcome: added=%d removed=%d merges=%d give-ups(write)=%d traversals=%d give-ups(read)=%d%s%s",
+            outcome.added(), outcome.removed(), outcome.merges(), outcome.writerGiveUps(), outcome.readerCommits(),
+            outcome.readerGiveUps(), writerGiveUps.describeFirst("write"), readerGiveUps.describeFirst("read"));
 
     if (!errors.isEmpty())
       throw new AssertionError(errors.size() + " thread(s) failed with a non-retryable error, first: " + errors.getFirst(),
@@ -253,21 +266,42 @@ class EdgeAppendMergeRaceTest extends TestHelper {
    * {@link NeedRetryException}: that is contention, not corruption, so it is counted and swallowed. Everything
    * else - a {@code BufferUnderflowException} from a reader above all - propagates and fails the test.
    */
-  private boolean commit(final BasicDatabase.TransactionScope block, final int attempts, final AtomicInteger giveUps,
-      final AtomicReference<Throwable> firstGiveUp) {
+  private boolean commit(final BasicDatabase.TransactionScope block, final int attempts, final GiveUps giveUps) {
     try {
       database.transaction(block, true, attempts);
       return true;
     } catch (final NeedRetryException e) {
-      giveUps.incrementAndGet();
-      firstGiveUp.compareAndSet(null, e);
+      giveUps.record(e);
       return false;
     }
   }
 
-  private record RaceOutcome(int added, int removed, int writerGiveUps, int readerGiveUps, long merges) {
+  /**
+   * Per-role tally of transactions that ran out of attempts. Kept per role so the logged sample cannot be a
+   * reader exception in a writer-dominated run.
+   */
+  private static final class GiveUps {
+    final AtomicInteger              count = new AtomicInteger();
+    final AtomicReference<Throwable> first = new AtomicReference<>();
+
+    void record(final NeedRetryException e) {
+      count.incrementAndGet();
+      first.compareAndSet(null, e);
+    }
+
+    String describeFirst(final String role) {
+      final Throwable e = first.get();
+      return e != null ? " first(" + role + ")=" + e : "";
+    }
+  }
+
+  private record RaceOutcome(int added, int removed, int writerGiveUps, int readerCommits, int readerGiveUps, long merges) {
     int writeTransactions() {
       return added + removed + writerGiveUps;
+    }
+
+    int readTransactions() {
+      return readerCommits + readerGiveUps;
     }
   }
 }


### PR DESCRIPTION
Closes #5570.

## Why the test was red

`EdgeAppendMergeRaceTest.addersRemoversAndReadersOnOneHotVertex` failed in 4 of the last 8 `Java CI - test` runs on `main`, always with the same signature: a `ConcurrentModificationException` escaping a transaction that had used up all 100 of its attempts.

`LocalDatabase.transaction(block, join, attempts)` rethrows the last `NeedRetryException` once attempts run out, so a transaction that keeps losing a fair race lands in the test's `catch (Throwable)` and becomes a hard failure. The version gaps observed in CI were 2 to 4 - the loser was never stale. With 16 threads (8 adders, 4 removers, 4 readers) committing against one hot vertex's chain, some transaction losing 100 times in a row is the expected outcome on a slow runner, not a livelock and not a lost poison bit.

## What changed (test-only, no engine change)

The race body moved into `runRace(perAdder, attempts)`, and every transaction now goes through a `commit()` wrapper that separates the two things the test was conflating:

- a `NeedRetryException` from an exhausted transaction is **counted**, not fatal. This also covers `LockTimeoutException`, the other load-sensitive failure mode `engine/CLAUDE.md` warns about on slow runners, which would have been the next intermittent red;
- anything non-retryable still fails immediately - above all a reader whose traversal stopped parsing, the `BufferUnderflowException` shape from #565 that this test exists to hunt.

Consistency assertions are unchanged and needed no adjustment: `addedCount` / `removedCount` only move after a successful commit, and a remover that gives up leaves its victim un-deleted, so `expected = added - removed` stays exact. A victim whose delete gave up is deliberately not re-queued - retrying it forever would hide the give-up instead of reporting it.

## Three additions beyond what the issue proposed

The issue proposed "count and report". Reporting alone means a genuine starvation regression scrolls past in a log nobody reads, so:

1. **The count is bounded, not just logged**: give-ups must stay under 5% of write transactions. Occasional losses pass; a livelock or real starvation trips the assertion.
2. **Escalating log level**: the suite pins `com.arcadedb` to `SEVERE`, so the outcome line logs at `SEVERE` only when there was at least one give-up (`WARNING` otherwise). A clean run prints nothing; a degrading run becomes visible in the build log well before it grows enough to fail.
3. **A fast deterministic companion test**, `retryExhaustionIsToleratedAndCounted`: the same race with `attempts=1`, so exhaustion is the norm instead of the exception. It pins the tolerance path down locally rather than leaving it exercised only by an unlucky CI runner, and proves the final consistency check stays exact when hundreds of transactions give up. ~0.5s.

## Verification

```
EdgeAppendMergeRaceTest                              2/2 pass
  addersRemoversAndReadersOnOneHotVertex   3.2s   added=12000 removed=6000 merges=10547 give-ups=0
  retryExhaustionIsToleratedAndCounted     0.4s   added=1517  removed=9    merges=26878 give-ups=830
com.arcadedb.graph.*Test (incl. @Tag("slow"))       26/26 pass
```

Fast variant run 5x standalone: 5/5 green, give-ups robustly in the 820-832 range, so `isGreaterThan(0)` is not a new flake.

## Follow-up worth considering separately

`LocalDatabase.delayBetweenRetries` sleeps a flat `1 + random(0..100)` ms on every attempt, with no backoff. Under 16-way contention that is a thundering herd where a transaction's odds of winning do not improve with each loss, which is why exhaustion after 100 attempts is reachable at all. Exponential backoff with jitter would make give-ups far rarer for real applications, not just for this test. That changes engine retry semantics on a hot path, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBKzpXuVgoDPbrBwNsGCaz