### PR TITLE
perf(engine) #5519: dictionary-encode TimeSeries TAG columns to remove the 258-byte stride per column

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -231,6 +231,45 @@ Two related corrections:
 A batch that fails still connects the incoming edges of what it already committed before it answers, because
 skipping that would leave persisted edges without back-pointers. On a large load that pass takes a while, so
 it now says so in the log rather than looking like a fresh hang.
+#### TimeSeries TAG columns are dictionary-encoded: 36x less page traffic on a tag-heavy schema
+
+A TimeSeries mutable row is fixed-stride, so a `STRING` TAG column reserved the widest value it could ever
+hold - `2 + MAX_STRING_BYTES`, 258 bytes - whether the tag was `us-east-1` or empty. Tags are low-cardinality
+by definition, which is what makes them tags, so nearly all of that was padding that still had to be written,
+flushed and shipped through the WAL ([#5519](https://github.com/ArcadeData/arcadedb/issues/5519)).
+
+A TAG column now holds a 4-byte id into a per-**type** append-only dictionary component (`.tstd`, one file per
+TimeSeries type, shared by every shard):
+
+| arm | tags | fields | stride | rows per 64K page |
+|---|---|---|---|---|
+| 1 tag, 3 fields | 1 | 3 | 290 B → **36 B** | 225 → **1819** |
+| 10 tags, 3 fields | 10 | 3 | 2612 B → **72 B** | 25 → **909** |
+| 10 tags, 10 fields | 10 | 10 | 2668 B → **128 B** | 24 → **511** |
+
+On `TimeSeriesTagStrideBenchmark`, the ten-tag arm went from writing 50.0 MB of pages for 2.1 MB of payload
+(23x amplification) to 1.4 MB (0.7x), and from 29.9 ms to 6.0 ms. The single-tag arm improves too - it was
+paying the same reservation for its one column - so a tag-heavy schema does not converge on a narrow one: the
+stride ratio between them goes from 9.0x to 2.0x, which is the honest cost of nine more columns rather than
+nine more paddings. Corroborated independently on real TSBS data (2,592,000 points through the primitive batch
+API) by @tae898 in the issue.
+
+- **Ids are 4 bytes, not the 2 the sealed `DictionaryCodec` uses.** That trades ~900 rows per page for ~1250
+  in exchange for removing the overflow-past-65535 question entirely. Id 0 is reserved for null/empty, so the
+  old round trip is unchanged.
+- **STRING *fields* stay inline.** A field is where high-cardinality text belongs; interning it would grow the
+  dictionary without bound.
+- **`arcadedb.timeSeriesTagDictionaryMaxSize`** caps distinct values per type, default 1M (roughly 100MB). The
+  dictionary is held in RAM, so this turns a mis-declared high-cardinality TAG into a clear error instead of
+  unbounded growth.
+- **Existing types keep the inline layout.** The mutable row format is versioned per type, so a database
+  written by an earlier build opens and reads unchanged, and there is no in-place migration. A new TimeSeries
+  type gets the encoding; an existing one has to be recreated to gain it. If you are benchmarking, point the
+  harness at a fresh database or you will measure the old layout and see no change.
+- **A probe that computes the stride itself has the mirror problem.** A harness carrying the old
+  `8 + 258 * tags + 8 * fields` formula reports the layout this replaced and turns a real improvement into what
+  looks like a measurement error. The encoded formula is `8 + 4 * tags + 8 * fields`. Both failure modes produce
+  a confident null result from a harness that looks correct in isolation.
 
 ### Breaking Changes
 

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -234,6 +234,10 @@ public enum GlobalConfiguration {
       "Filesystem directory where new paired external-property buckets are created. If empty (default), external buckets sit alongside primary buckets in the database directory. Set to a path on cheaper/slower storage (HDD, network mount) to tier the heavy payloads away from the topology files. The directory must exist and be writable. Existing external buckets are not relocated when this changes.",
       String.class, ""),
 
+  TIMESERIES_TAG_DICTIONARY_MAX_SIZE("arcadedb.timeSeriesTagDictionaryMaxSize", SCOPE.DATABASE,
+      "Maximum number of distinct values one TimeSeries type's tag dictionary may hold. TAG columns are dictionary-encoded in the mutable row so each occupies a 4-byte id instead of a reserved 258-byte slot; the dictionary is kept in RAM, so this caps its footprint and turns a mis-declared high-cardinality TAG into a clear error instead of unbounded growth. Default is 1M distinct values, roughly 100MB",
+      Integer.class, 1_000_000),
+
   BUCKET_REUSE_SPACE_MODE("arcadedb.bucketReuseSpaceMode", SCOPE.DATABASE,
       "How to reuse space in pages. 'high' = more space saved, but slower opening and update/delete time. 'medium' to still reuse space without the initial scan at opening time. 'low' for faster performance, but less space reused. Default is 'high'",
       String.class, "high", Set.of("low", "medium", "high")),

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -37,6 +37,7 @@ import com.arcadedb.engine.WALFile;
 import com.arcadedb.engine.WALFileFactory;
 import com.arcadedb.engine.WALFileFactoryEmbedded;
 import com.arcadedb.engine.timeseries.TimeSeriesBucket;
+import com.arcadedb.engine.timeseries.TimeSeriesTagDictionary;
 import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.ConcurrentModificationException;
@@ -155,6 +156,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       LSMVectorIndexGraphFile.FILE_EXT,
       SparseSegmentComponent.FILE_EXT,
       TimeSeriesBucket.BUCKET_EXT,
+      TimeSeriesTagDictionary.DICT_EXT,
       HashIndexBucket.UNIQUE_INDEX_EXT,
       HashIndexBucket.NOTUNIQUE_INDEX_EXT);
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
@@ -33,6 +33,7 @@ import com.arcadedb.schema.Type;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -60,7 +61,16 @@ import java.util.Set;
  * - [2..9]   min timestamp in page (long)
  * - [10..17] max timestamp in page (long)
  * - [18..]   row data: fixed-size rows [timestamp(8)|col1|col2|...]
- *            For STRING columns: 2-byte length prefix + up to MAX_STRING_BYTES payload
+ *            TAG STRING columns: a 4-byte {@link TimeSeriesTagDictionary} id (format version 1)
+ *            other STRING columns: 2-byte length prefix + up to MAX_STRING_BYTES payload
+ * <p>
+ * <b>Format versions.</b> Version 0 stored every STRING column inline and reserved
+ * {@code 2 + MAX_STRING_BYTES} for it in the stride, so a ten-tag row cost 2612 bytes of stride to
+ * carry ~110 bytes of payload: 25 rows per 64 KB page and 24x page and WAL amplification (issue
+ * #5519). Version 1 dictionary-encodes TAG STRING columns into a fixed 4-byte id, taking the same
+ * schema to a 72-byte stride and ~900 rows per page. Both layouts are readable; which one a bucket
+ * uses is decided by whether a dictionary was handed to it, which the schema's
+ * {@code mutableFormatVersion} determines, so a database written by an older build keeps working.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -68,8 +78,23 @@ public class TimeSeriesBucket extends PaginatedComponent {
 
   public static final  String BUCKET_EXT       = "tstb";
   public static final  int    MAX_STRING_BYTES = 256;
-  public static final  int    CURRENT_VERSION  = 0;
-  private static final int    MAGIC_VALUE      = 0x54534243; // "TSBC"
+
+  /**
+   * Mutable row format that stores TAG STRING columns inline, reserving the maximum width per row.
+   */
+  public static final int VERSION_INLINE_TAGS = 0;
+
+  /**
+   * Mutable row format that stores TAG STRING columns as a 4-byte tag-dictionary id (issue #5519).
+   */
+  public static final int VERSION_DICTIONARY_TAGS = 1;
+
+  public static final  int CURRENT_VERSION = VERSION_DICTIONARY_TAGS;
+  /**
+   * Width of a dictionary-encoded TAG column in the row stride.
+   */
+  private static final int DICT_ID_SIZE    = 4;
+  private static final int MAGIC_VALUE     = 0x54534243; // "TSBC"
 
   // Header page offsets (from PAGE_HEADER_SIZE)
   private static final int HEADER_MAGIC_OFFSET            = 0;
@@ -95,6 +120,14 @@ public class TimeSeriesBucket extends PaginatedComponent {
   private int                    rowSize; // fixed row size in bytes
   // Value-column kinds, resolved with rowSize so the boxed append path does not rebuild them per call.
   private byte[]                 columnKinds;
+  // Per-type tag dictionary, or null for a format-version-0 bucket that stores tags inline. Not final:
+  // a cold open builds a column-less stub through the component factory, and the shard supplies both
+  // the columns and the dictionary once the type is known.
+  private TimeSeriesTagDictionary tagDictionary;
+  // Indexed by the ordinal among non-timestamp columns: whether that column is a 4-byte dictionary id.
+  private boolean[]                     dictEncoded;
+  // The ordinals of the dictionary-encoded columns, so the ingest path can walk only those.
+  private int[]                         dictColumns;
 
   /**
    * Factory handler for loading existing .tstb files during schema load.
@@ -104,20 +137,30 @@ public class TimeSeriesBucket extends PaginatedComponent {
     @Override
     public PaginatedComponent createOnLoad(final DatabaseInternal database, final String name, final String filePath,
         final int id, final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
-      return new TimeSeriesBucket(database, name, filePath, id, new ArrayList<>());
+      return new TimeSeriesBucket(database, name, filePath, id, new ArrayList<>(), null);
     }
   }
 
   /**
-   * Creates a new TimeSeries bucket.
+   * Creates a new TimeSeries bucket storing tags inline (format version 0).
    */
   public TimeSeriesBucket(final DatabaseInternal database, final String name, final String filePath,
       final List<ColumnDefinition> columns) throws IOException {
+    this(database, name, filePath, columns, null);
+  }
+
+  /**
+   * Creates a new TimeSeries bucket.
+   *
+   * @param tagDictionary per-type tag dictionary, or {@code null} to store TAG STRING columns inline
+   *                      as format version 0 did
+   */
+  public TimeSeriesBucket(final DatabaseInternal database, final String name, final String filePath,
+      final List<ColumnDefinition> columns, final TimeSeriesTagDictionary tagDictionary) throws IOException {
     super(database, name, filePath, BUCKET_EXT, ComponentFile.MODE.READ_WRITE,
         database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE), CURRENT_VERSION);
-    this.columns = columns;
-    this.rowSize = calculateRowSize(columns);
-    this.columnKinds = ObjectColumnsRowSource.kindsOf(columns);
+    this.tagDictionary = tagDictionary;
+    resolveLayout(columns);
     // Note: initHeaderPage() is NOT called here.
     // TimeSeriesShard calls it in a self-contained nested transaction after registering the
     // bucket with the schema, so the nested TX commit can resolve the file by its ID.
@@ -127,21 +170,69 @@ public class TimeSeriesBucket extends PaginatedComponent {
    * Opens an existing TimeSeries bucket.
    */
   public TimeSeriesBucket(final DatabaseInternal database, final String name, final String filePath, final int id,
-      final List<ColumnDefinition> columns) throws IOException {
+      final List<ColumnDefinition> columns, final TimeSeriesTagDictionary tagDictionary) throws IOException {
     super(database, name, filePath, id, ComponentFile.MODE.READ_WRITE,
         database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE), CURRENT_VERSION);
-    this.columns = columns;
-    this.rowSize = calculateRowSize(columns);
-    this.columnKinds = ObjectColumnsRowSource.kindsOf(columns);
+    this.tagDictionary = tagDictionary;
+    resolveLayout(columns);
   }
 
   /**
-   * Sets column definitions (called during cold open after the factory handler creates a stub bucket).
+   * Sets column definitions and the tag dictionary together, which is what a cold open needs: the
+   * factory handler builds a stub with neither, and both have to be in place before the row layout is
+   * resolved or the stride would be computed for the wrong format version. Passing them separately is
+   * deliberately not possible - the stride and the dictionary have to agree.
    */
-  public void setColumns(final List<ColumnDefinition> columns) {
+  public void setColumns(final List<ColumnDefinition> columns, final TimeSeriesTagDictionary tagDictionary) {
+    this.tagDictionary = tagDictionary;
+    resolveLayout(columns);
+  }
+
+  /**
+   * Resolves everything the row format derives from the columns: the stride, the boxed-append kind
+   * table, and which columns are dictionary-encoded. Doing it once here is what lets the read and
+   * write loops decide a column's width with an array lookup instead of re-deriving it per value.
+   */
+  private void resolveLayout(final List<ColumnDefinition> columns) {
     this.columns = columns;
-    this.rowSize = calculateRowSize(columns);
     this.columnKinds = ObjectColumnsRowSource.kindsOf(columns);
+
+    int valueColumnCount = 0;
+    for (final ColumnDefinition col : columns)
+      if (col.getRole() != ColumnDefinition.ColumnRole.TIMESTAMP)
+        valueColumnCount++;
+
+    this.dictEncoded = new boolean[valueColumnCount];
+    int dictCount = 0;
+    int colIdx = 0;
+    for (final ColumnDefinition col : columns) {
+      if (col.getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
+        continue;
+      if (isDictionaryEncoded(col)) {
+        dictEncoded[colIdx] = true;
+        dictCount++;
+      }
+      colIdx++;
+    }
+
+    this.dictColumns = new int[dictCount];
+    int d = 0;
+    for (int i = 0; i < valueColumnCount; i++)
+      if (dictEncoded[i])
+        dictColumns[d++] = i;
+
+    this.rowSize = calculateRowSize(columns);
+  }
+
+  /**
+   * A column is dictionary-encoded when a dictionary exists and the column is a STRING TAG. FIELD
+   * strings stay inline: a field is where high-cardinality text belongs, and interning it would grow
+   * the dictionary without bound.
+   */
+  private boolean isDictionaryEncoded(final ColumnDefinition col) {
+    return tagDictionary != null
+        && col.getRole() == ColumnDefinition.ColumnRole.TAG
+        && col.getDataType() == Type.STRING;
   }
 
   /**
@@ -176,6 +267,11 @@ public class TimeSeriesBucket extends PaginatedComponent {
     final int sampleCount = source.size();
     if (sampleCount == 0)
       return;
+
+    // Resolve tag ids first, before a single data page is touched. Interning commits its own nested
+    // transaction, so running it up front keeps the dictionary pages out of this transaction's page
+    // set and, with it, out of any MVCC conflict with the rows we are about to write.
+    internTagValues(source, sampleCount);
 
     final TransactionContext tx = database.getTransaction();
     final MutablePage headerPage = tx.getPageToModify(new PageId(database, fileId, 0), pageSize, false);
@@ -217,7 +313,11 @@ public class TimeSeriesBucket extends PaginatedComponent {
         // The width table decides, not the type name: a column with no fixed width is stored
         // length-prefixed, which is the only encoding the reader can walk past (issue #5475).
         final int fixedSize = col.getFixedSize();
-        if (fixedSize > 0)
+        if (dictEncoded[colIdx]) {
+          // Every value was interned above, so this lookup always resolves.
+          dataPage.writeInt(colOffset, tagDictionary.getId(source.getStringValue(i, colIdx)));
+          colOffset += DICT_ID_SIZE;
+        } else if (fixedSize > 0)
           colOffset += writeRawValue(dataPage, colOffset, fixedSize, source.getRawValue(i, colIdx));
         else
           colOffset += writeStringValue(dataPage, colOffset, col, source.getStringValue(i, colIdx));
@@ -242,6 +342,37 @@ public class TimeSeriesBucket extends PaginatedComponent {
     headerPage.writeLong(HEADER_SAMPLE_COUNT_OFFSET, totalSamples);
     headerPage.writeLong(HEADER_MIN_TS_OFFSET, minTs);
     headerPage.writeLong(HEADER_MAX_TS_OFFSET, maxTs);
+  }
+
+  /**
+   * Assigns a dictionary id to every tag value in the batch that does not already have one.
+   * <p>
+   * Steady state costs one lookup per distinct run of values and no transaction at all: a tag repeats
+   * heavily within a batch, so the per-column {@code lastSeen} reference check absorbs runs before the
+   * map is consulted, and after warm-up nothing is ever missing.
+   */
+  private void internTagValues(final TimeSeriesRowSource source, final int sampleCount) throws IOException {
+    if (dictColumns.length == 0)
+      return;
+
+    List<String> missing = null;
+    for (final int colIdx : dictColumns) {
+      String lastSeen = null;
+      for (int i = 0; i < sampleCount; i++) {
+        final String value = source.getStringValue(i, colIdx);
+        if (value == null || value.isEmpty() || value == lastSeen)
+          continue;
+        lastSeen = value;
+        if (tagDictionary.getId(value) == TimeSeriesTagDictionary.NO_ID) {
+          if (missing == null)
+            missing = new ArrayList<>();
+          missing.add(value);
+        }
+      }
+    }
+
+    if (missing != null)
+      tagDictionary.internAll(missing);
   }
 
   private static void flushDataPageHeader(final MutablePage page, final int samplesInPage, final long minTs, final long maxTs) {
@@ -408,11 +539,15 @@ public class TimeSeriesBucket extends PaginatedComponent {
     private final int      columnIndex;
     private final Set<?>   values;
     private final byte[][] utf8Values;
+    // Non-null only for a dictionary-encoded column: the candidates resolved to ids once, so the
+    // per-row test is an int compare against a tiny array.
+    private final int[]    dictIds;
 
-    private TagMatcher(final int columnIndex, final Set<?> values, final byte[][] utf8Values) {
+    private TagMatcher(final int columnIndex, final Set<?> values, final byte[][] utf8Values, final int[] dictIds) {
       this.columnIndex = columnIndex;
       this.values = values;
       this.utf8Values = utf8Values;
+      this.dictIds = dictIds;
     }
   }
 
@@ -431,6 +566,23 @@ public class TimeSeriesBucket extends PaginatedComponent {
       if (columnIndices != null && !isInArray(cond.columnIndex(), columnIndices))
         return null;
 
+      if (cond.columnIndex() >= 0 && cond.columnIndex() < dictEncoded.length && dictEncoded[cond.columnIndex()]) {
+        // Resolve the candidates to ids once. A candidate the dictionary has never seen cannot appear
+        // in any row, so it is dropped; if that leaves nothing, the condition is unsatisfiable and the
+        // whole filter can be answered without touching a page.
+        final int[] resolved = new int[cond.matchValues().size()];
+        int found = 0;
+        for (final Object value : cond.matchValues()) {
+          final int id = tagDictionary.getId(value == null ? null : value.toString());
+          if (id != TimeSeriesTagDictionary.NO_ID)
+            resolved[found++] = id;
+        }
+        if (found == 0)
+          return null;
+        matchers[i] = new TagMatcher(cond.columnIndex(), cond.matchValues(), null, Arrays.copyOf(resolved, found));
+        continue;
+      }
+
       boolean allStrings = !cond.matchValues().isEmpty();
       for (final Object value : cond.matchValues())
         if (!(value instanceof String)) {
@@ -446,7 +598,7 @@ public class TimeSeriesBucket extends PaginatedComponent {
           utf8Values[v++] = ((String) value).getBytes(StandardCharsets.UTF_8);
       }
 
-      matchers[i] = new TagMatcher(cond.columnIndex(), cond.matchValues(), utf8Values);
+      matchers[i] = new TagMatcher(cond.columnIndex(), cond.matchValues(), utf8Values, null);
     }
     return matchers;
   }
@@ -467,22 +619,34 @@ public class TimeSeriesBucket extends PaginatedComponent {
           target = col;
           break;
         }
-        colOffset += getColumnStorageSize(page, colOffset, col);
+        colOffset += getColumnStorageSize(page, colOffset, col, colIdx);
         colIdx++;
       }
 
       if (target == null)
         return false;
 
+      if (matcher.dictIds != null) {
+        // Dictionary-encoded: an int compare, no decode and no allocation.
+        if (!matchesDictId(page.readInt(colOffset), matcher.dictIds))
+          return false;
+      }
       // The byte comparison only applies to a STRING column: on any other type the leading bytes are
       // not a length prefix and the value has to be decoded.
-      if (matcher.utf8Values != null && target.getDataType() == Type.STRING) {
+      else if (matcher.utf8Values != null && target.getDataType() == Type.STRING) {
         if (!matchesUtf8(page, colOffset, matcher.utf8Values))
           return false;
-      } else if (!matcher.values.contains(readColumnValue(page, colOffset, target)))
+      } else if (!matcher.values.contains(readColumnValue(page, colOffset, target, colIdx)))
         return false;
     }
     return true;
+  }
+
+  private static boolean matchesDictId(final int id, final int[] candidates) {
+    for (final int candidate : candidates)
+      if (candidate == id)
+        return true;
+    return false;
   }
 
   /**
@@ -777,13 +941,23 @@ public class TimeSeriesBucket extends PaginatedComponent {
   }
 
   /**
-   * Returns the fixed stride, in bytes, that one sample occupies in a data page. Note that a row is
-   * <em>written</em> packed: a STRING column stores its actual bytes but reserves
-   * {@code 2 + MAX_STRING_BYTES} in the stride, so on a tag-heavy schema the stride is much wider than
-   * the row content (issue #5519).
+   * Returns the fixed stride, in bytes, that one sample occupies in a data page.
+   * <p>
+   * A dictionary-encoded TAG column contributes exactly {@code DICT_ID_SIZE}, so the stride matches
+   * what the row actually costs. An inline STRING column - any STRING FIELD, and every STRING column
+   * of a format-version-0 bucket - still reserves {@code 2 + MAX_STRING_BYTES} while writing itself
+   * packed, which is the amplification issue #5519 reported.
    */
   public int getRowSize() {
     return rowSize;
+  }
+
+  /**
+   * Returns the tag dictionary backing this bucket's TAG columns, or {@code null} for a
+   * format-version-0 bucket that stores them inline.
+   */
+  public TimeSeriesTagDictionary getTagDictionary() {
+    return tagDictionary;
   }
 
   /**
@@ -903,8 +1077,8 @@ public class TimeSeriesBucket extends PaginatedComponent {
       for (int c = 0; c < columns.size(); c++) {
         if (columns.get(c).getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
           continue;
-        result[colIdx + 1] = readColumnValue(page, colOffset, columns.get(c));
-        colOffset += getColumnStorageSize(page, colOffset, columns.get(c));
+        result[colIdx + 1] = readColumnValue(page, colOffset, columns.get(c), colIdx);
+        colOffset += getColumnStorageSize(page, colOffset, columns.get(c), colIdx);
         colIdx++;
       }
     } else {
@@ -916,9 +1090,9 @@ public class TimeSeriesBucket extends PaginatedComponent {
         if (columns.get(c).getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
           continue;
         if (isInArray(colIdx, columnIndices)) {
-          result[resultIdx++] = readColumnValue(page, colOffset, columns.get(c));
+          result[resultIdx++] = readColumnValue(page, colOffset, columns.get(c), colIdx);
         }
-        colOffset += getColumnStorageSize(page, colOffset, columns.get(c));
+        colOffset += getColumnStorageSize(page, colOffset, columns.get(c), colIdx);
         colIdx++;
       }
     }
@@ -931,7 +1105,11 @@ public class TimeSeriesBucket extends PaginatedComponent {
    * {@link ColumnDefinition#boxRaw(long)} so the mutable and sealed layers cannot return different
    * Java types for the same declared column (issue #5475).
    */
-  private Object readColumnValue(final BasePage page, final int offset, final ColumnDefinition col) {
+  private Object readColumnValue(final BasePage page, final int offset, final ColumnDefinition col, final int colIdx) {
+    if (dictEncoded[colIdx])
+      // The shared String instance, so a scan of millions of rows no longer allocates one per tag.
+      return tagDictionary.getById(page.readInt(offset));
+
     final int fixedSize = col.getFixedSize();
     if (fixedSize > 0)
       return col.boxRaw(readRawValue(page, offset, fixedSize));
@@ -945,7 +1123,9 @@ public class TimeSeriesBucket extends PaginatedComponent {
     return new String(bytes, StandardCharsets.UTF_8);
   }
 
-  private int getColumnStorageSize(final BasePage page, final int offset, final ColumnDefinition col) {
+  private int getColumnStorageSize(final BasePage page, final int offset, final ColumnDefinition col, final int colIdx) {
+    if (dictEncoded[colIdx])
+      return DICT_ID_SIZE;
     final int fixed = col.getFixedSize();
     if (fixed > 0)
       return fixed;
@@ -953,16 +1133,25 @@ public class TimeSeriesBucket extends PaginatedComponent {
     return 2 + (page.readShort(offset) & 0xFFFF);
   }
 
-  private static int calculateRowSize(final List<ColumnDefinition> columns) {
+  /**
+   * Sums the per-column widths the read and write loops walk. Must be called after {@link #dictEncoded}
+   * is resolved: the stride and the cursor advance have to agree column for column, or a row overruns
+   * its neighbours (the defect behind issue #5475).
+   */
+  private int calculateRowSize(final List<ColumnDefinition> columns) {
     int size = 8; // timestamp (always 8 bytes)
+    int colIdx = 0;
     for (final ColumnDefinition col : columns) {
       if (col.getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
         continue;
       final int fixed = col.getFixedSize();
-      if (fixed > 0)
+      if (dictEncoded[colIdx])
+        size += DICT_ID_SIZE;
+      else if (fixed > 0)
         size += fixed;
       else
         size += 2 + MAX_STRING_BYTES; // max STRING: 2-byte length prefix + max payload
+      colIdx++;
     }
     return size;
   }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -19,6 +19,7 @@
 package com.arcadedb.engine.timeseries;
 
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.LocalSchema;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -60,6 +61,8 @@ public class TimeSeriesEngine implements AutoCloseable {
   private final byte[]                 columnKinds;
   private final ExecutorService        shardExecutor;
   private final AtomicLong             appendCounter = new AtomicLong();
+  // Shared by every shard of this type, or null when no column is dictionary-encoded (issue #5519).
+  private       TimeSeriesTagDictionary tagDictionary;
 
   public TimeSeriesEngine(final DatabaseInternal database, final String typeName,
       final List<ColumnDefinition> columns, final int shardCount) throws IOException {
@@ -69,6 +72,18 @@ public class TimeSeriesEngine implements AutoCloseable {
   public TimeSeriesEngine(final DatabaseInternal database, final String typeName,
       final List<ColumnDefinition> columns, final int shardCount,
       final long compactionBucketIntervalMs) throws IOException {
+    this(database, typeName, columns, shardCount, compactionBucketIntervalMs, TimeSeriesBucket.CURRENT_VERSION);
+  }
+
+  /**
+   * @param mutableFormatVersion the type's stored mutable row format version. Version 0 keeps TAG
+   *                             STRING columns inline; version 1 and above dictionary-encode them
+   *                             into a 4-byte id (issue #5519). It comes from the schema so a
+   *                             database written by an older build keeps its layout.
+   */
+  public TimeSeriesEngine(final DatabaseInternal database, final String typeName,
+      final List<ColumnDefinition> columns, final int shardCount,
+      final long compactionBucketIntervalMs, final int mutableFormatVersion) throws IOException {
     this.database = database;
     this.typeName = typeName;
     this.columns = columns;
@@ -84,8 +99,10 @@ public class TimeSeriesEngine implements AutoCloseable {
     });
 
     try {
+      // One dictionary per type, resolved before the shards so every shard shares the same id space.
+      this.tagDictionary = TimeSeriesTagDictionary.openOrCreate(database, typeName, columns, mutableFormatVersion);
       for (int i = 0; i < shardCount; i++)
-        shards[i] = new TimeSeriesShard(database, typeName, i, columns, compactionBucketIntervalMs);
+        shards[i] = new TimeSeriesShard(database, typeName, i, columns, compactionBucketIntervalMs, tagDictionary);
     } catch (final Exception e) {
       shardExecutor.shutdownNow();
       // Close any shards that were successfully created
@@ -718,6 +735,16 @@ public class TimeSeriesEngine implements AutoCloseable {
     }
     for (final TimeSeriesShard shard : shards)
       shard.close();
+    if (tagDictionary != null)
+      tagDictionary.close();
+  }
+
+  /**
+   * Returns the tag dictionary shared by this type's shards, or {@code null} when no column is
+   * dictionary-encoded.
+   */
+  public TimeSeriesTagDictionary getTagDictionary() {
+    return tagDictionary;
   }
 
   /**
@@ -735,6 +762,16 @@ public class TimeSeriesEngine implements AutoCloseable {
     }
     for (final TimeSeriesShard shard : shards)
       shard.drop();
+
+    // The dictionary is one file shared by every shard, so it is dropped once, after them. This is
+    // the whole reclamation story for interned tag values: they live exactly as long as the type.
+    if (tagDictionary != null) {
+      final int dictionaryFileId = tagDictionary.getFileId();
+      database.getPageManager().deleteFile(database, dictionaryFileId);
+      database.getFileManager().dropFile(dictionaryFileId);
+      ((LocalSchema) database.getSchema()).removeFile(dictionaryFileId);
+      tagDictionary = null;
+    }
   }
 
   // --- Private helpers ---

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -94,6 +94,11 @@ public class TimeSeriesShard implements AutoCloseable {
     this(database, baseName, shardIndex, columns, 0);
   }
 
+  /**
+   * Assumes the current mutable row format, so it must not be used to open a type whose stored
+   * {@code mutableFormatVersion} says otherwise: that would read inline tag bytes as dictionary ids.
+   * Test-only for that reason - the engine threads the type's own version through the constructor below.
+   */
   public TimeSeriesShard(final DatabaseInternal database, final String baseName, final int shardIndex,
                          final List<ColumnDefinition> columns, final long compactionBucketIntervalMs) throws IOException {
     this(database, baseName, shardIndex, columns, compactionBucketIntervalMs,

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -96,6 +96,17 @@ public class TimeSeriesShard implements AutoCloseable {
 
   public TimeSeriesShard(final DatabaseInternal database, final String baseName, final int shardIndex,
                          final List<ColumnDefinition> columns, final long compactionBucketIntervalMs) throws IOException {
+    this(database, baseName, shardIndex, columns, compactionBucketIntervalMs,
+        TimeSeriesTagDictionary.openOrCreate(database, baseName, columns, TimeSeriesBucket.CURRENT_VERSION));
+  }
+
+  /**
+   * @param tagDictionary the type's shared tag dictionary, or {@code null} to store TAG STRING columns
+   *                      inline as mutable format version 0 did
+   */
+  public TimeSeriesShard(final DatabaseInternal database, final String baseName, final int shardIndex,
+                         final List<ColumnDefinition> columns, final long compactionBucketIntervalMs,
+                         final TimeSeriesTagDictionary tagDictionary) throws IOException {
     this.shardIndex = shardIndex;
     this.typeName = baseName;
     this.database = database;
@@ -110,11 +121,11 @@ public class TimeSeriesShard implements AutoCloseable {
     final Component existing = schema.getFileByName(shardName);
     if (existing instanceof TimeSeriesBucket tsb) {
       this.mutableBucket = tsb;
-      this.mutableBucket.setColumns(columns);
+      this.mutableBucket.setColumns(columns, tagDictionary);
     } else {
       // First-time creation: register the file with the schema BEFORE initialising the header
       // page, so that the nested-TX commit in initHeaderPage() can resolve the file by its ID.
-      this.mutableBucket = new TimeSeriesBucket(database, shardName, shardPath, columns);
+      this.mutableBucket = new TimeSeriesBucket(database, shardName, shardPath, columns, tagDictionary);
       schema.registerFile(mutableBucket);
       // Initialise the header page in a self-contained nested transaction.  Using a nested TX
       // here ensures that page 0 is committed immediately and is NOT placed in any enclosing

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -1,0 +1,568 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.Component;
+import com.arcadedb.engine.ComponentFactory;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponent;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Type;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+
+/**
+ * Append-only string dictionary shared by every shard of one TimeSeries type, so a TAG column
+ * occupies a fixed 4-byte id in the mutable row instead of a reserved
+ * {@code 2 + MAX_STRING_BYTES} slot (issue #5519).
+ * <p>
+ * The reservation was the whole defect: the writer stored a tag packed but the stride assumed the
+ * maximum, so a ten-tag row cost 2612 bytes of stride to carry ~110 bytes of payload, fitting 25
+ * rows in a 64 KB page and amplifying page and WAL traffic 24x. A tag is low-cardinality by
+ * definition, which is exactly what a dictionary exploits.
+ * <p>
+ * <b>Scope is the type, not the shard nor the database.</b> Per type is what makes the id space
+ * meaningful: every shard sees the same declared tag set, dropping the type drops the dictionary
+ * (which is the whole reclamation story), and cardinality is bounded per type rather than shared
+ * with every other type in the database. The database-wide {@code com.arcadedb.engine.Dictionary}
+ * cannot serve this role: it is a single 320 KB page holding every property and type name, it grows
+ * a {@code CopyOnWriteArrayList} one O(n) copy at a time, and it commits a nested transaction per
+ * new value under a global monitor.
+ * <p>
+ * <b>Ids.</b> Id 0 is reserved and virtual: it denotes {@code null}/{@code ""}, consumes no stored
+ * entry, and preserves the pre-existing round-trip where a null tag reads back as {@code ""}. Stored
+ * entries take ids 1..N in insertion order. Ids are 4 bytes, so there is no overflow case to handle
+ * and no fallback path; the 2-byte id a per-block sealed dictionary uses would have bought ~1250
+ * rows per page instead of ~900, which is not worth an overflow story.
+ * <p>
+ * <b>Transactions.</b> New values are interned in one nested transaction per append batch, taken
+ * before the data transaction begins and serialized across shards by {@link #internLock}. Committing
+ * separately means the data pages never conflict with the dictionary tail page, and the in-RAM
+ * mapping is published only after that commit succeeds, so a failed commit leaves RAM and disk
+ * agreeing. The converse - a committed id whose data transaction then rolls back - leaves an unused
+ * entry, which is harmless because the dictionary is append-only and ids are never reused.
+ * <p>
+ * <b>Steady state is free.</b> After warm-up every value is already known, so an append does a
+ * lookup pass and no transaction at all.
+ * <p>
+ * Header page (page 0) layout (offsets from PAGE_HEADER_SIZE) - 13 bytes:
+ * - [0..3]   magic "TSTD" (4 bytes)
+ * - [4]      formatVersion (1 byte)
+ * - [5..8]   stored entry count (int)
+ * - [9..12]  data page count (int)
+ * <p>
+ * Data page layout (offsets from PAGE_HEADER_SIZE):
+ * - [0..3]   entry count in page (int)
+ * - [4..7]   bytes used after the page header (int)
+ * - [8..]    entries: 2-byte length prefix + UTF-8 payload, never straddling a page boundary
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class TimeSeriesTagDictionary extends PaginatedComponent {
+
+  public static final String DICT_EXT        = "tstd";
+  public static final int    CURRENT_VERSION = 0;
+
+  /**
+   * Id of {@code null} and of the empty string. Virtual: it is never stored.
+   */
+  public static final int EMPTY_ID = 0;
+
+  /**
+   * Returned by {@link #getId(String)} for a value this dictionary has never interned.
+   */
+  public static final int NO_ID = -1;
+
+  /**
+   * Suffix appended to the TimeSeries type name to name its dictionary component.
+   */
+  public static final String NAME_SUFFIX = "_tags";
+
+  private static final int MAGIC_VALUE = 0x54535444; // "TSTD"
+
+  // Header page offsets (from PAGE_HEADER_SIZE)
+  private static final int HEADER_MAGIC_OFFSET          = 0;
+  private static final int HEADER_FORMAT_VERSION_OFFSET = 4;
+  private static final int HEADER_ENTRY_COUNT_OFFSET    = 5;
+  private static final int HEADER_DATA_PAGE_COUNT       = 9;
+
+  // Data page offsets (from PAGE_HEADER_SIZE)
+  private static final int DATA_ENTRY_COUNT_OFFSET = 0;
+  private static final int DATA_USED_BYTES_OFFSET  = 4;
+  private static final int DATA_ENTRIES_OFFSET     = 8;
+
+  // Id -> value. Replaced wholesale on growth and volatile-published after the entries are written,
+  // so a reader that resolves an id read off a committed data page always sees the value for it.
+  private volatile String[] byId = { "" };
+  // Value -> id. Concurrent because lookups run on every ingest thread while interning holds the lock.
+  private final ConcurrentHashMap<String, Integer> idByValue = new ConcurrentHashMap<>();
+
+  private volatile int     entryCount;
+  private volatile int     dataPageCount;
+  private          int     maxSize;
+  // Whether the in-RAM mapping has been rebuilt from the pages. A dictionary created in this session
+  // starts loaded; one the component factory rebuilt at cold open does not.
+  private volatile boolean loaded;
+  // Entry count at the last reload triggered by an unresolvable id, so a corrupt id cannot make every
+  // row of a scan re-read the pages. Guarded by this instance's monitor.
+  private          int     reloadedAtEntryCount = -1;
+
+  // Serializes id assignment across the shards of this type. Contended only while a batch carries
+  // values never seen before, which is the warm-up phase and nothing after it.
+  private final Lock internLock = new ReentrantLock();
+
+  /**
+   * Factory handler for loading an existing .tstd file during schema load. The in-RAM mapping is
+   * rebuilt later by {@link #load()}, once the component is registered and the file id resolves.
+   */
+  public static class PaginatedComponentFactoryHandler implements ComponentFactory.PaginatedComponentFactoryHandler {
+    @Override
+    public PaginatedComponent createOnLoad(final DatabaseInternal database, final String name, final String filePath,
+        final int id, final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
+      return new TimeSeriesTagDictionary(database, name, filePath, id);
+    }
+  }
+
+  /**
+   * Creates a new tag dictionary. As with {@link TimeSeriesBucket}, the header page is NOT written
+   * here: {@link #initHeaderPage()} must be called after the component is registered with the
+   * schema, so the commit can resolve the file by its id.
+   */
+  public TimeSeriesTagDictionary(final DatabaseInternal database, final String name, final String filePath)
+      throws IOException {
+    super(database, name, filePath, DICT_EXT, ComponentFile.MODE.READ_WRITE,
+        database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE), CURRENT_VERSION);
+    this.maxSize = database.getConfiguration().getValueAsInteger(GlobalConfiguration.TIMESERIES_TAG_DICTIONARY_MAX_SIZE);
+  }
+
+  /**
+   * Opens an existing tag dictionary.
+   */
+  public TimeSeriesTagDictionary(final DatabaseInternal database, final String name, final String filePath, final int id)
+      throws IOException {
+    super(database, name, filePath, id, ComponentFile.MODE.READ_WRITE,
+        database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE), CURRENT_VERSION);
+    this.maxSize = database.getConfiguration().getValueAsInteger(GlobalConfiguration.TIMESERIES_TAG_DICTIONARY_MAX_SIZE);
+  }
+
+  /**
+   * Returns the dictionary shared by every shard of a TimeSeries type, creating and registering it on
+   * first use. The single instance comes from the schema, which is what makes it per-type rather than
+   * per-shard: the first shard creates it, the rest find it, and a cold open finds the one the
+   * component factory rebuilt.
+   *
+   * @param mutableFormatVersion the type's stored mutable row format version
+   *
+   * @return the dictionary, or {@code null} when the type has no STRING TAG column to encode or was
+   * written by a build that stored tags inline
+   */
+  public static TimeSeriesTagDictionary openOrCreate(final DatabaseInternal database, final String typeName,
+      final List<ColumnDefinition> columns, final int mutableFormatVersion) throws IOException {
+    if (mutableFormatVersion < TimeSeriesBucket.VERSION_DICTIONARY_TAGS || !hasDictionaryColumns(columns))
+      return null;
+
+    final String name = typeName + NAME_SUFFIX;
+    final LocalSchema schema = (LocalSchema) database.getSchema();
+
+    final Component existing = schema.getFileByName(name);
+    if (existing instanceof TimeSeriesTagDictionary dictionary) {
+      dictionary.ensureLoaded();
+      return dictionary;
+    }
+
+    final TimeSeriesTagDictionary dictionary =
+        new TimeSeriesTagDictionary(database, name, database.getDatabasePath() + "/" + name);
+    schema.registerFile(dictionary);
+
+    if (dictionary.getTotalPages() > 0)
+      // The component was absent from the schema but its file is on disk. Adopt what is there:
+      // writing a fresh header would silently reset the id space and orphan every id already stored
+      // in a data page.
+      dictionary.load();
+    else {
+      dictionary.initHeaderPage();
+      dictionary.loaded = true;
+    }
+    return dictionary;
+  }
+
+  /**
+   * Whether any column of the type would be dictionary-encoded. A type with no STRING TAG has nothing
+   * to intern, so it gets no dictionary file at all.
+   */
+  public static boolean hasDictionaryColumns(final List<ColumnDefinition> columns) {
+    for (final ColumnDefinition col : columns)
+      if (col.getRole() == ColumnDefinition.ColumnRole.TAG && col.getDataType() == Type.STRING)
+        return true;
+    return false;
+  }
+
+  /**
+   * Writes the header page in a self-contained nested transaction, mirroring
+   * {@link TimeSeriesBucket#initHeaderPage()}. Routed through the wrapped database so that, under
+   * HA, the page is shipped to followers together with the file-creation entry of the enclosing DDL.
+   */
+  public void initHeaderPage() throws IOException {
+    final DatabaseInternal db = database.getWrappedDatabaseInstance();
+    db.begin();
+    // Only this method's own nested transaction may be rolled back below: if begin() had failed there
+    // would be no nested transaction, and rolling back "the active one" would discard the caller's.
+    boolean ownTransaction = true;
+    try {
+      final MutablePage headerPage = db.getTransaction().addPage(new PageId(database, fileId, 0), pageSize);
+      headerPage.writeInt(HEADER_MAGIC_OFFSET, MAGIC_VALUE);
+      headerPage.writeByte(HEADER_FORMAT_VERSION_OFFSET, (byte) CURRENT_VERSION);
+      headerPage.writeInt(HEADER_ENTRY_COUNT_OFFSET, 0);
+      headerPage.writeInt(HEADER_DATA_PAGE_COUNT, 0);
+      pageCount.set(1);
+      db.commit();
+      ownTransaction = false;
+    } catch (final Exception e) {
+      throw e instanceof IOException io ? io : new IOException("Failed to initialise TimeSeries tag dictionary header", e);
+    } finally {
+      if (ownTransaction && db.isTransactionActive())
+        db.rollback();
+    }
+  }
+
+  /**
+   * Rebuilds the in-RAM mapping from the pages, in a self-contained read transaction. Called once
+   * per open, after the component is registered with the schema.
+   */
+  public synchronized void ensureLoaded() throws IOException {
+    if (loaded)
+      return;
+    load();
+  }
+
+  public synchronized void load() throws IOException {
+    loaded = true;
+    if (getTotalPages() == 0)
+      return;
+
+    // A read transaction of our own, so this can be called from inside a scan. It must be the only one
+    // rolled back at the end: load() is reachable from resolveMiss() mid-query, and discarding the
+    // caller's transaction there would abort the very scan that asked for the value.
+    database.begin();
+    try {
+      final TransactionContext tx = database.getTransaction();
+      final BasePage headerPage = tx.getPage(new PageId(database, fileId, 0), pageSize);
+      final int storedEntries = headerPage.readInt(HEADER_ENTRY_COUNT_OFFSET);
+      final int pages = headerPage.readInt(HEADER_DATA_PAGE_COUNT);
+
+      final String[] values = new String[storedEntries + 1];
+      values[EMPTY_ID] = "";
+
+      idByValue.clear();
+      int id = 1;
+      for (int pageNum = 1; pageNum <= pages; pageNum++) {
+        final BasePage page = tx.getPage(new PageId(database, fileId, pageNum), pageSize);
+        final int pageEntries = page.readInt(DATA_ENTRY_COUNT_OFFSET);
+        int offset = DATA_ENTRIES_OFFSET;
+        for (int i = 0; i < pageEntries; i++) {
+          final int len = page.readShort(offset) & 0xFFFF;
+          final byte[] bytes = new byte[len];
+          if (len > 0)
+            page.readByteArray(offset + 2, bytes);
+          final String value = new String(bytes, StandardCharsets.UTF_8);
+          values[id] = value;
+          idByValue.putIfAbsent(value, id);
+          id++;
+          offset += 2 + len;
+        }
+      }
+
+      this.byId = values;
+      this.entryCount = storedEntries;
+      this.dataPageCount = pages;
+    } finally {
+      if (database.isTransactionActive())
+        database.rollback();
+    }
+  }
+
+  /**
+   * Returns the id of an already-interned value, {@link #EMPTY_ID} for {@code null} or {@code ""},
+   * or {@link #NO_ID} when the value has never been interned. Allocation-free and lock-free.
+   */
+  public int getId(final String value) {
+    if (value == null || value.isEmpty())
+      return EMPTY_ID;
+    final Integer id = idByValue.get(value);
+    return id != null ? id : NO_ID;
+  }
+
+  /**
+   * Resolves an id back to its value. Returns the shared {@link String} instance, so a scan over
+   * millions of rows no longer allocates one string per tag per row as the inline encoding did.
+   */
+  public String getById(final int id) {
+    final String[] values = byId;
+    if (id >= 0 && id < values.length && values[id] != null)
+      return values[id];
+    return resolveMiss(id);
+  }
+
+  /**
+   * Rebuilds from the pages when an id is read that this instance has not interned itself.
+   * <p>
+   * The case that matters is an HA follower: it receives the dictionary pages through the Raft WAL and
+   * applies them to storage, but {@link #internAll} - the only thing that populates the in-RAM mapping
+   * - runs on the leader. Without this the follower would hand back {@code null} for every tag written
+   * since it opened. Reloading on the miss makes the map self-healing wherever pages can arrive from
+   * outside this instance.
+   */
+  private synchronized String resolveMiss(final int id) {
+    // Another thread may have reloaded while this one waited on the monitor.
+    String[] values = byId;
+    if (id >= 0 && id < values.length && values[id] != null)
+      return values[id];
+
+    // An id inside what is already loaded is not a staleness miss, and reloading cannot conjure it.
+    // The same holds once a reload has already been attempted at this entry count: repeating it would
+    // re-read every page on every row of a scan carrying a corrupt id.
+    if (id < 0 || id <= entryCount || entryCount == reloadedAtEntryCount)
+      return null;
+
+    try {
+      load();
+    } catch (final IOException e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Error reloading TimeSeries tag dictionary '%s' while resolving id %d: %s", e, getName(), id, e.getMessage());
+      return null;
+    }
+    reloadedAtEntryCount = entryCount;
+
+    values = byId;
+    return id < values.length ? values[id] : null;
+  }
+
+  /**
+   * Interns a single value and returns its id, committing if the value is new.
+   */
+  public int intern(final String value) throws IOException {
+    final int existing = getId(value);
+    if (existing != NO_ID)
+      return existing;
+    internAll(Collections.singletonList(value));
+    return getId(value);
+  }
+
+  /**
+   * Assigns an id to every value in {@code values} that does not already have one, in a single
+   * nested transaction. Values already known, {@code null} and {@code ""} are skipped, so calling
+   * this on an entire batch costs nothing once the dictionary is warm.
+   */
+  public void internAll(final Collection<String> values) throws IOException {
+    if (values.isEmpty())
+      return;
+
+    internLock.lock();
+    try {
+      // Re-check under the lock: another shard may have interned these while we were queued.
+      final List<String> toAdd = new ArrayList<>();
+      final Set<String> pending = new HashSet<>();
+      for (final String value : values) {
+        if (value == null || value.isEmpty() || idByValue.containsKey(value))
+          continue;
+        if (pending.add(value))
+          toAdd.add(value);
+      }
+      if (toAdd.isEmpty())
+        return;
+
+      if (entryCount + toAdd.size() > maxSize)
+        throw new IllegalStateException(
+            "TimeSeries tag dictionary '" + getName() + "' would exceed the maximum of " + maxSize
+                + " distinct values (current=" + entryCount + ", adding=" + toAdd.size()
+                + "). A TAG column is meant to be low-cardinality; move a high-cardinality value to a FIELD, or raise "
+                + GlobalConfiguration.TIMESERIES_TAG_DICTIONARY_MAX_SIZE.getKey());
+
+      for (final String value : toAdd)
+        if (value.getBytes(StandardCharsets.UTF_8).length > TimeSeriesBucket.MAX_STRING_BYTES)
+          throw new IllegalArgumentException(
+              "Tag value exceeds max length of " + TimeSeriesBucket.MAX_STRING_BYTES + " bytes for dictionary '"
+                  + getName() + "'");
+
+      // Route through the wrapped database so the pages are shipped to followers under HA.
+      final DatabaseInternal db = database.getWrappedDatabaseInstance();
+      db.begin();
+      // See initHeaderPage(): roll back only our own nested transaction, never a caller's. This one
+      // usually IS nested - the ingest path calls it from inside the append transaction.
+      boolean ownTransaction = true;
+      final int[] appended;
+      try {
+        appended = appendEntries(db.getTransaction(), toAdd);
+        db.commit();
+        ownTransaction = false;
+      } catch (final Exception e) {
+        throw e instanceof IOException io ? io :
+            new IOException("Failed to append to TimeSeries tag dictionary '" + getName() + "'", e);
+      } finally {
+        if (ownTransaction && db.isTransactionActive())
+          db.rollback();
+      }
+
+      // Publish to RAM only now: before the commit, disk is the single source of truth, so a failed
+      // commit leaves nothing to undo.
+      publish(appended[0], appended[1], toAdd);
+    } finally {
+      internLock.unlock();
+    }
+  }
+
+  /**
+   * Number of stored entries, excluding the virtual empty-string id.
+   */
+  public int size() {
+    return entryCount;
+  }
+
+  /**
+   * Number of allocated data pages, excluding the header page.
+   */
+  public int getDataPageCount() {
+    return dataPageCount;
+  }
+
+  /**
+   * Overrides the configured cardinality cap for this dictionary.
+   */
+  public void setMaxSize(final int maxSize) {
+    this.maxSize = maxSize;
+  }
+
+  // --- Private helpers ---
+
+  /**
+   * Appends the values to the tail data page, spilling onto new pages so an entry is never split.
+   * Returns {@code { id assigned to the first value, resulting data page count }}.
+   */
+  private int[] appendEntries(final TransactionContext tx, final List<String> toAdd) throws IOException {
+    final MutablePage headerPage = tx.getPageToModify(new PageId(database, fileId, 0), pageSize, false);
+    int storedEntries = headerPage.readInt(HEADER_ENTRY_COUNT_OFFSET);
+    int pages = headerPage.readInt(HEADER_DATA_PAGE_COUNT);
+    final int firstId = storedEntries + 1;
+
+    final int capacity = pageSize - BasePage.PAGE_HEADER_SIZE - DATA_ENTRIES_OFFSET;
+
+    MutablePage page = null;
+    int pageEntries = 0;
+    int pageUsed = 0;
+    if (pages > 0) {
+      page = tx.getPageToModify(new PageId(database, fileId, pages), pageSize, false);
+      pageEntries = page.readInt(DATA_ENTRY_COUNT_OFFSET);
+      pageUsed = page.readInt(DATA_USED_BYTES_OFFSET);
+    }
+
+    for (final String value : toAdd) {
+      final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+      final int needed = 2 + bytes.length;
+
+      if (page == null || pageUsed + needed > capacity) {
+        if (page != null)
+          flushDataPageHeader(page, pageEntries, pageUsed);
+        page = allocateDataPage(tx, ++pages);
+        pageEntries = 0;
+        pageUsed = 0;
+      }
+
+      page.writeShort(DATA_ENTRIES_OFFSET + pageUsed, (short) bytes.length);
+      if (bytes.length > 0)
+        page.writeByteArray(DATA_ENTRIES_OFFSET + pageUsed + 2, bytes);
+      pageUsed += needed;
+      pageEntries++;
+      storedEntries++;
+    }
+
+    flushDataPageHeader(page, pageEntries, pageUsed);
+    headerPage.writeInt(HEADER_ENTRY_COUNT_OFFSET, storedEntries);
+    headerPage.writeInt(HEADER_DATA_PAGE_COUNT, pages);
+    return new int[] { firstId, pages };
+  }
+
+  private MutablePage allocateDataPage(final TransactionContext tx, final int pageNum) throws IOException {
+    final MutablePage page;
+    if (pageNum < getTotalPages())
+      page = tx.getPageToModify(new PageId(database, fileId, pageNum), pageSize, false);
+    else {
+      page = tx.addPage(new PageId(database, fileId, pageNum), pageSize);
+      pageCount.incrementAndGet();
+    }
+    page.writeInt(DATA_ENTRY_COUNT_OFFSET, 0);
+    page.writeInt(DATA_USED_BYTES_OFFSET, 0);
+    return page;
+  }
+
+  private static void flushDataPageHeader(final MutablePage page, final int entries, final int used) {
+    page.writeInt(DATA_ENTRY_COUNT_OFFSET, entries);
+    page.writeInt(DATA_USED_BYTES_OFFSET, used);
+  }
+
+  /**
+   * Publishes the committed entries to the in-RAM mapping.
+   * <p>
+   * The reverse array is grown by doubling and the new reference is volatile-published <em>before</em>
+   * the forward map is populated, so a thread that finds a value in the map can always resolve the id
+   * it got back.
+   */
+  private void publish(final int firstId, final int pages, final List<String> toAdd) {
+    final int required = firstId + toAdd.size();
+    String[] values = byId;
+    if (required > values.length) {
+      int newLength = Math.max(values.length * 2, 16);
+      while (newLength < required)
+        newLength *= 2;
+      final String[] grown = new String[newLength];
+      System.arraycopy(values, 0, grown, 0, values.length);
+      values = grown;
+    }
+
+    int id = firstId;
+    for (final String value : toAdd)
+      values[id++] = value;
+
+    this.byId = values;
+    this.entryCount = firstId - 1 + toAdd.size();
+
+    id = firstId;
+    for (final String value : toAdd)
+      idByValue.putIfAbsent(value, id++);
+
+    this.dataPageCount = pages;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -137,9 +137,6 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   // Whether the in-RAM mapping has been rebuilt from the pages. A dictionary created in this session
   // starts loaded; one the component factory rebuilt at cold open does not.
   private volatile boolean loaded;
-  // Entry count at the last reload triggered by an unresolvable id, so a corrupt id cannot make every
-  // row of a scan re-read the pages. Guarded by this instance's monitor.
-  private          int     reloadedAtEntryCount = -1;
 
   // Serializes id assignment across the shards of this type. Contended only while a batch carries
   // values never seen before, which is the warm-up phase and nothing after it.
@@ -353,9 +350,15 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       return values[id];
 
     // An id inside what is already loaded is not a staleness miss, and reloading cannot conjure it.
-    // The same holds once a reload has already been attempted at this entry count: repeating it would
-    // re-read every page on every row of a scan carrying a corrupt id.
-    if (id < 0 || id <= entryCount || entryCount == reloadedAtEntryCount)
+    if (id < 0 || id <= entryCount)
+      return null;
+
+    // Reload only when the pages really do hold the id, which is what tells a stale map apart from a
+    // corrupt id: without this a scan carrying a corrupt id would re-read every page on every row.
+    // The test is against the count stored in the header - one already-cached page read - and not
+    // against the last reload, because a leader interns for as long as it ingests: keying on the
+    // reload would self-heal for the first wave of ids and then never again.
+    if (id > peekStoredEntryCount())
       return null;
 
     try {
@@ -365,10 +368,33 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
           "Error reloading TimeSeries tag dictionary '%s' while resolving id %d: %s", e, getName(), id, e.getMessage());
       return null;
     }
-    reloadedAtEntryCount = entryCount;
 
     values = byId;
     return id < values.length ? values[id] : null;
+  }
+
+  /**
+   * Entry count as stored in the header page, which is what an id arriving from outside this instance
+   * has to be measured against. Read in a transaction of its own, like {@link #load()}, since this is
+   * reachable from inside a scan. A header that cannot be read degrades to the in-RAM count, so the
+   * caller declines to reload rather than reloading once per row.
+   */
+  private int peekStoredEntryCount() {
+    if (getTotalPages() == 0)
+      return entryCount;
+
+    database.begin();
+    try {
+      return database.getTransaction().getPage(new PageId(database, fileId, 0), pageSize)
+          .readInt(HEADER_ENTRY_COUNT_OFFSET);
+    } catch (final IOException e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Error reading the header of TimeSeries tag dictionary '%s': %s", e, getName(), e.getMessage());
+      return entryCount;
+    } finally {
+      if (database.isTransactionActive())
+        database.rollback();
+    }
   }
 
   /**
@@ -412,11 +438,16 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
                 + "). A TAG column is meant to be low-cardinality; move a high-cardinality value to a FIELD, or raise "
                 + GlobalConfiguration.TIMESERIES_TAG_DICTIONARY_MAX_SIZE.getKey());
 
-      for (final String value : toAdd)
-        if (value.getBytes(StandardCharsets.UTF_8).length > TimeSeriesBucket.MAX_STRING_BYTES)
+      // Encoded once here and carried to the pages: a value is validated and written in the same bytes.
+      final List<byte[]> encoded = new ArrayList<>(toAdd.size());
+      for (final String value : toAdd) {
+        final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > TimeSeriesBucket.MAX_STRING_BYTES)
           throw new IllegalArgumentException(
               "Tag value exceeds max length of " + TimeSeriesBucket.MAX_STRING_BYTES + " bytes for dictionary '"
                   + getName() + "'");
+        encoded.add(bytes);
+      }
 
       // Route through the wrapped database so the pages are shipped to followers under HA.
       final DatabaseInternal db = database.getWrappedDatabaseInstance();
@@ -426,7 +457,7 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       boolean ownTransaction = true;
       final int[] appended;
       try {
-        appended = appendEntries(db.getTransaction(), toAdd);
+        appended = appendEntries(db.getTransaction(), encoded);
         db.commit();
         ownTransaction = false;
       } catch (final Exception e) {
@@ -469,10 +500,10 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   // --- Private helpers ---
 
   /**
-   * Appends the values to the tail data page, spilling onto new pages so an entry is never split.
-   * Returns {@code { id assigned to the first value, resulting data page count }}.
+   * Appends the already UTF-8 encoded values to the tail data page, spilling onto new pages so an
+   * entry is never split. Returns {@code { id assigned to the first value, resulting data page count }}.
    */
-  private int[] appendEntries(final TransactionContext tx, final List<String> toAdd) throws IOException {
+  private int[] appendEntries(final TransactionContext tx, final List<byte[]> toAdd) throws IOException {
     final MutablePage headerPage = tx.getPageToModify(new PageId(database, fileId, 0), pageSize, false);
     int storedEntries = headerPage.readInt(HEADER_ENTRY_COUNT_OFFSET);
     int pages = headerPage.readInt(HEADER_DATA_PAGE_COUNT);
@@ -489,9 +520,17 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       pageUsed = page.readInt(DATA_USED_BYTES_OFFSET);
     }
 
-    for (final String value : toAdd) {
-      final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    for (final byte[] bytes : toAdd) {
       final int needed = 2 + bytes.length;
+
+      // MAX_STRING_BYTES caps an entry at 258 bytes, so this can only fire on a configured page size
+      // far too small to host one. Checked rather than assumed: without it the write below would run
+      // off the end of a freshly allocated page.
+      if (needed > capacity)
+        throw new IllegalArgumentException(
+            "A tag value of " + bytes.length + " bytes does not fit a dictionary page of " + pageSize
+                + " bytes (capacity " + capacity + ") for '" + getName() + "'. Raise "
+                + GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getKey());
 
       if (page == null || pageUsed + needed > capacity) {
         if (page != null)

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -128,8 +128,9 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   // Id -> value. Replaced wholesale on growth and volatile-published after the entries are written,
   // so a reader that resolves an id read off a committed data page always sees the value for it.
   private volatile String[] byId = { "" };
-  // Value -> id. Concurrent because lookups run on every ingest thread while interning holds the lock.
-  private final ConcurrentHashMap<String, Integer> idByValue = new ConcurrentHashMap<>();
+  // Value -> id. Concurrent because lookups run on every ingest thread while interning holds the lock,
+  // and volatile because a reload replaces it wholesale instead of clearing it under those lookups.
+  private volatile ConcurrentHashMap<String, Integer> idByValue = new ConcurrentHashMap<>();
 
   private volatile int     entryCount;
   private volatile int     dataPageCount;
@@ -267,9 +268,10 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   }
 
   public synchronized void load() throws IOException {
-    loaded = true;
-    if (getTotalPages() == 0)
+    if (getTotalPages() == 0) {
+      loaded = true;
       return;
+    }
 
     // A read transaction of our own, so this can be called from inside a scan. It must be the only one
     // rolled back at the end: load() is reachable from resolveMiss() mid-query, and discarding the
@@ -284,7 +286,10 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       final String[] values = new String[storedEntries + 1];
       values[EMPTY_ID] = "";
 
-      idByValue.clear();
+      // Built aside and swapped in below rather than rebuilt in place: a lookup runs lock-free and
+      // concurrently with this, and clearing the live map would make it report a stored value as
+      // absent - which on the ingest path means interning a second id for a value that already has one.
+      final ConcurrentHashMap<String, Integer> rebuilt = new ConcurrentHashMap<>();
       int id = 1;
       for (int pageNum = 1; pageNum <= pages; pageNum++) {
         final BasePage page = tx.getPage(new PageId(database, fileId, pageNum), pageSize);
@@ -297,15 +302,20 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
             page.readByteArray(offset + 2, bytes);
           final String value = new String(bytes, StandardCharsets.UTF_8);
           values[id] = value;
-          idByValue.putIfAbsent(value, id);
+          rebuilt.putIfAbsent(value, id);
           id++;
           offset += 2 + len;
         }
       }
 
+      // Published only now, complete: same order as publish(), reverse array before forward map, so a
+      // thread that finds a value in the map can always resolve the id it got back. A load that throws
+      // before this point leaves the previous mapping untouched, and `loaded` false so it is retried.
       this.byId = values;
+      this.idByValue = rebuilt;
       this.entryCount = storedEntries;
       this.dataPageCount = pages;
+      this.loaded = true;
     } finally {
       if (database.isTransactionActive())
         database.rollback();
@@ -578,8 +588,14 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
    * The reverse array is grown by doubling and the new reference is volatile-published <em>before</em>
    * the forward map is populated, so a thread that finds a value in the map can always resolve the id
    * it got back.
+   * <p>
+   * Synchronized on the same monitor as {@link #load()} so a reload cannot swap in a mapping rebuilt
+   * from the pages while this is publishing into the one it replaces, which would drop these entries
+   * from RAM and let the next batch intern a second id for a value that already has one. Reached only
+   * when a batch carries a value never seen before, so the extra ordering costs nothing in steady state.
+   * Callers hold {@code internLock} first, and nothing takes that lock while holding this monitor.
    */
-  private void publish(final int firstId, final int pages, final List<String> toAdd) {
+  private synchronized void publish(final int firstId, final int pages, final List<String> toAdd) {
     final int required = firstId + toAdd.size();
     String[] values = byId;
     if (required > values.length) {

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -37,6 +37,7 @@ import com.arcadedb.engine.Dictionary;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.timeseries.TimeSeriesBucket;
 import com.arcadedb.engine.timeseries.TimeSeriesMaintenanceScheduler;
+import com.arcadedb.engine.timeseries.TimeSeriesTagDictionary;
 import com.arcadedb.event.*;
 import com.arcadedb.exception.ConfigurationException;
 import com.arcadedb.exception.DatabaseMetadataException;
@@ -150,6 +151,8 @@ public class LocalSchema implements Schema {
     componentFactory.registerComponent(SparseSegmentComponent.FILE_EXT,
         new SparseSegmentComponent.PaginatedComponentFactoryHandler());
     componentFactory.registerComponent(TimeSeriesBucket.BUCKET_EXT, new TimeSeriesBucket.PaginatedComponentFactoryHandler());
+    componentFactory.registerComponent(TimeSeriesTagDictionary.DICT_EXT,
+        new TimeSeriesTagDictionary.PaginatedComponentFactoryHandler());
     componentFactory.registerComponent(HashIndexBucket.UNIQUE_INDEX_EXT,
         new HashIndex.PaginatedComponentFactoryHandlerUnique());
     componentFactory.registerComponent(HashIndexBucket.NOTUNIQUE_INDEX_EXT,

--- a/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
@@ -49,8 +49,10 @@ public class LocalTimeSeriesType extends LocalDocumentType {
   private int                          shardCount;
   private long                         retentionMs;
   private long                         compactionBucketIntervalMs;
-  private int                          sealedFormatVersion;
-  private int                          mutableFormatVersion;
+  private int                          sealedFormatVersion  = TimeSeriesSealedStore.CURRENT_VERSION;
+  // A type created by this build writes the current mutable row format; one restored from JSON keeps
+  // whatever version wrote its pages, which is what lets a pre-#5519 database open unchanged.
+  private int                          mutableFormatVersion = TimeSeriesBucket.CURRENT_VERSION;
   private final List<ColumnDefinition>  tsColumns         = new ArrayList<>();
   private       List<DownsamplingTier> downsamplingTiers = new ArrayList<>();
   private volatile TimeSeriesEngine    engine;
@@ -67,7 +69,7 @@ public class LocalTimeSeriesType extends LocalDocumentType {
     if (engine != null)
       return;
     engine = new TimeSeriesEngine((DatabaseInternal) schema.getDatabase(), name, tsColumns, shardCount > 0 ? shardCount : 1,
-        compactionBucketIntervalMs);
+        compactionBucketIntervalMs, mutableFormatVersion);
   }
 
   public TimeSeriesEngine getEngine() {
@@ -171,8 +173,10 @@ public class LocalTimeSeriesType extends LocalDocumentType {
     json.put("retentionMs", retentionMs);
     if (compactionBucketIntervalMs > 0)
       json.put("compactionBucketIntervalMs", compactionBucketIntervalMs);
-    json.put("sealedFormatVersion", TimeSeriesSealedStore.CURRENT_VERSION);
-    json.put("mutableFormatVersion", TimeSeriesBucket.CURRENT_VERSION);
+    json.put("sealedFormatVersion", sealedFormatVersion);
+    // The version that wrote this type's pages, NOT the current constant: rewriting an existing v0
+    // type as v1 would tell the next open to read inline tag bytes as dictionary ids.
+    json.put("mutableFormatVersion", mutableFormatVersion);
 
     final JSONArray colArray = new JSONArray();
     for (final ColumnDefinition col : tsColumns) {
@@ -216,10 +220,13 @@ public class LocalTimeSeriesType extends LocalDocumentType {
       throw new IllegalStateException(
           "Unsupported sealed store format version " + sealedFormatVersion + " (expected " +
               TimeSeriesSealedStore.CURRENT_VERSION + ") for TimeSeries type '" + name + "'");
+    // Older mutable formats stay readable: the version selects the row layout rather than gating the
+    // open, so a type written before the tag dictionary (issue #5519) keeps its inline tag columns.
+    // Only a version this build does not know about is refused.
     mutableFormatVersion = json.getInt("mutableFormatVersion", 0);
-    if (mutableFormatVersion != TimeSeriesBucket.CURRENT_VERSION)
+    if (mutableFormatVersion > TimeSeriesBucket.CURRENT_VERSION)
       throw new IllegalStateException(
-          "Unsupported mutable bucket format version " + mutableFormatVersion + " (expected " +
+          "Unsupported mutable bucket format version " + mutableFormatVersion + " (this build supports up to " +
               TimeSeriesBucket.CURRENT_VERSION + ") for TimeSeries type '" + name + "'");
 
     tsColumns.clear();

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue5416DescendingTailTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue5416DescendingTailTest.java
@@ -124,7 +124,14 @@ class Issue5416DescendingTailTest extends TestHelper {
     // page is examined, and every older page is dropped on its header alone.
     assertThat(metrics.getMaterializedRows()).isLessThanOrEqualTo(4);
     assertThat(metrics.getScannedPages()).isLessThanOrEqualTo(2);
-    assertThat(metrics.getSkippedPages()).isGreaterThan(100);
+
+    // Every page the walk reached was either scanned or skipped: nothing was left unaccounted for,
+    // which is what "dropped on its header alone" means. Derived from the stride rather than
+    // hard-coded, because how many pages 80k rows occupy is a property of the row format - dictionary
+    // -encoding the host tag took this schema from a 274-byte stride to 20 (issue #5519).
+    final int rowsPerPage = engine.getShard(0).getMutableBucket().getMaxSamplesPerPage();
+    final int dataPages = (20_000 * TAGS + rowsPerPage - 1) / rowsPerPage;
+    assertThat(metrics.getScannedPages() + metrics.getSkippedPages()).isEqualTo(dataPages);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue5519TagStrideTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue5519TagStrideTest.java
@@ -23,9 +23,13 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -379,5 +383,59 @@ class Issue5519TagStrideTest extends TestHelper {
     // A null tag reads back as "" in both formats
     assertThat(rows.get(1)[1]).isEqualTo("");
     database.commit();
+  }
+
+  /**
+   * The compatibility claim end to end, through a real open rather than through a null dictionary: a
+   * database whose stored schema says mutable format 0 keeps the inline layout when this build opens
+   * it, and never adopts the dictionary. Simulated by relabelling the type on disk before the pages
+   * hold anything, since a v1 type whose rows already carry 4-byte ids could not honestly be called v0.
+   */
+  @Test
+  void aTypeStoredAsVersion0OpensWithTheInlineFormat() throws Exception {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE Legacy TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS 1");
+
+    final String databasePath = database.getDatabasePath();
+    database.close();
+
+    // Rewrite the stored schema as a pre-#5519 one: mutable format 0, and no dictionary component
+    final File schemaFile = new File(databasePath + "/schema.json");
+    final JSONObject schema = new JSONObject(Files.readString(schemaFile.toPath(), StandardCharsets.UTF_8));
+    final JSONObject legacy = schema.getJSONObject("types").getJSONObject("Legacy");
+    assertThat(legacy.getInt("mutableFormatVersion", -1)).isEqualTo(TimeSeriesBucket.CURRENT_VERSION);
+    legacy.put("mutableFormatVersion", 0);
+    Files.writeString(schemaFile.toPath(), schema.toString(), StandardCharsets.UTF_8);
+
+    final File[] dictFiles = new File(databasePath).listFiles((dir, fileName) -> fileName.startsWith("Legacy_tags."));
+    if (dictFiles != null)
+      for (final File dictFile : dictFiles)
+        assertThat(dictFile.delete()).isTrue();
+
+    database = factory.open();
+
+    final LocalTimeSeriesType reopened = (LocalTimeSeriesType) database.getSchema().getType("Legacy");
+    final TimeSeriesEngine engine = reopened.getEngine();
+
+    // No dictionary, and the row is back to the reserved inline slot
+    assertThat(engine.getTagDictionary()).isNull();
+    assertThat(engine.getShard(0).getMutableBucket().getRowSize())
+        .isEqualTo(8 + (2 + TimeSeriesBucket.MAX_STRING_BYTES) + 8);
+
+    // ...and it still reads and writes tags correctly through the normal path
+    database.begin();
+    engine.appendSamples(new long[] { 1_000L, 2_000L }, new Object[] { "web01", "web02" }, new Object[] { 1.5, 2.5 });
+    database.commit();
+
+    database.begin();
+    final List<Object[]> rows = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0)[1]).isEqualTo("web01");
+    assertThat(rows.get(1)[1]).isEqualTo("web02");
+    assertThat(engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, TagFilter.eq(0, "web02"))).hasSize(1);
+    database.commit();
+
+    // Writing it back out must not relabel it as current, or the next open would misread these rows
+    assertThat(reopened.toJSON().getInt("mutableFormatVersion", -1)).isZero();
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue5519TagStrideTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue5519TagStrideTest.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5519: {@code TimeSeriesBucket.calculateRowSize()} reserved {@code 2 + MAX_STRING_BYTES} for
+ * every STRING column, so the TSBS cpu-only schema - ten tags and three fields - paid a 2612-byte
+ * stride to store ~110 bytes of payload. That fits 25 rows in a 64 KB page, a 4% fill, and since
+ * {@code MutablePage.MAX_MODIFIED_RANGES} is 8, the scattered writes collapsed to the page hull and
+ * the WAL shipped whole pages: 131 MB written to store 5.5 MB.
+ * <p>
+ * TAG STRING columns are now dictionary-encoded into a 4-byte id, which is what the sealed layer
+ * already did for the same columns. The tests below pin the new stride and, more importantly, that
+ * nothing observable changed: the same values come back, through the same readers, before and after
+ * compaction and across a reopen.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5519TagStrideTest extends TestHelper {
+
+  /**
+   * The schema {@code cpu_influx.lp} actually ships: ten tags, plus fields.
+   */
+  private static final String[] TSBS_TAGS = { "hostname", "region", "datacenter", "rack", "os", "arch", "team", "service",
+      "service_version", "service_environment" };
+
+  private TimeSeriesEngine createTsbsType(final String typeName, final int shards) {
+    final StringBuilder tags = new StringBuilder();
+    for (final String tag : TSBS_TAGS) {
+      if (!tags.isEmpty())
+        tags.append(", ");
+      tags.append(tag).append(" STRING");
+    }
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts TAGS (" + tags
+        + ") FIELDS (usage_user DOUBLE, usage_system DOUBLE, usage_idle DOUBLE) SHARDS " + shards);
+    return ((LocalTimeSeriesType) database.getSchema().getType(typeName)).getEngine();
+  }
+
+  /**
+   * Appends {@code rows} samples whose tag values cycle over {@code hosts} distinct hostnames.
+   */
+  private void appendRows(final TimeSeriesEngine engine, final int rows, final int hosts) throws IOException {
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[TSBS_TAGS.length + 3][rows];
+
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + i * 1_000L;
+      columns[0][i] = "host_" + (i % hosts);
+      columns[1][i] = "eu-west-1";
+      columns[2][i] = "dc_" + (i % 4);
+      columns[3][i] = "rack_" + (i % 8);
+      columns[4][i] = "Ubuntu16";
+      columns[5][i] = "x86";
+      columns[6][i] = "SF";
+      columns[7][i] = "7";
+      columns[8][i] = "1";
+      columns[9][i] = "production";
+      columns[10][i] = (double) i;
+      columns[11][i] = i * 2.0;
+      columns[12][i] = i * 3.0;
+    }
+    engine.appendBatch(timestamps, columns);
+  }
+
+  /**
+   * The defect, stated as a number. Before: {@code 8 + 10 * 258 + 3 * 8 = 2612} bytes and 25 rows per
+   * 64 KB page. After: {@code 8 + 10 * 4 + 3 * 8 = 72}.
+   */
+  @Test
+  void tenTagStrideCollapsesToFourBytesPerTag() {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 1);
+    final TimeSeriesBucket bucket = engine.getShard(0).getMutableBucket();
+
+    assertThat(bucket.getRowSize()).isEqualTo(8 + TSBS_TAGS.length * 4 + 3 * 8);
+    assertThat(bucket.getRowSize()).isEqualTo(72);
+
+    // 25 rows per page was the reported symptom; the page now carries an order of magnitude more.
+    assertThat(bucket.getMaxSamplesPerPage()).isGreaterThan(900);
+  }
+
+  /**
+   * The shape {@code cpu_influx.lp} actually ships - ten tags and ten fields, not the ten-and-three
+   * the issue's own table used. Reported on #5519 by @tae898, whose measurement put it at a 2,668-byte
+   * stride and 24 rows per page, the worst of the three arms they ran.
+   */
+  @Test
+  void theShippingTsbsShapeOfTenTagsAndTenFields() {
+    final StringBuilder tags = new StringBuilder();
+    for (final String tag : TSBS_TAGS) {
+      if (!tags.isEmpty())
+        tags.append(", ");
+      tags.append(tag).append(" STRING");
+    }
+    final StringBuilder fields = new StringBuilder();
+    for (int i = 0; i < 10; i++) {
+      if (!fields.isEmpty())
+        fields.append(", ");
+      fields.append("f").append(i).append(" DOUBLE");
+    }
+    database.command("sql",
+        "CREATE TIMESERIES TYPE CpuFull TIMESTAMP ts TAGS (" + tags + ") FIELDS (" + fields + ") SHARDS 1");
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType("CpuFull")).getEngine();
+    final TimeSeriesBucket bucket = engine.getShard(0).getMutableBucket();
+
+    // Was 8 + 10 * 258 + 10 * 8 = 2668 bytes and 24 rows per 64KB page
+    assertThat(bucket.getRowSize()).isEqualTo(8 + 10 * 4 + 10 * 8);
+    assertThat(bucket.getRowSize()).isEqualTo(128);
+    assertThat(bucket.getMaxSamplesPerPage()).isEqualTo(511);
+  }
+
+  @Test
+  void tagValuesRoundTripThroughTheDictionary() throws Exception {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 1);
+    appendRows(engine, 2_000, 7);
+
+    final List<Object[]> rows = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+    assertThat(rows).hasSize(2_000);
+
+    rows.sort((a, b) -> Long.compare((long) a[0], (long) b[0]));
+    for (int i = 0; i < 2_000; i++) {
+      final Object[] row = rows.get(i);
+      assertThat(row[0]).isEqualTo(1_700_000_000_000L + i * 1_000L);
+      assertThat(row[1]).isEqualTo("host_" + (i % 7));
+      assertThat(row[2]).isEqualTo("eu-west-1");
+      assertThat(row[3]).isEqualTo("dc_" + (i % 4));
+      assertThat(row[4]).isEqualTo("rack_" + (i % 8));
+      assertThat(row[10]).isEqualTo("production");
+      assertThat(row[11]).isEqualTo((double) i);
+      assertThat(row[13]).isEqualTo(i * 3.0);
+    }
+  }
+
+  /**
+   * Id 0 is reserved so a null tag still reads back as {@code ""}, which is what the inline encoding
+   * did with its zero-length payload.
+   */
+  @Test
+  void nullTagStillReadsBackAsEmptyString() throws Exception {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 1);
+
+    final Object[][] columns = new Object[TSBS_TAGS.length + 3][1];
+    for (int c = 0; c < TSBS_TAGS.length; c++)
+      columns[c][0] = null;
+    columns[10][0] = 1.0;
+    columns[11][0] = 2.0;
+    columns[12][0] = 3.0;
+    engine.appendBatch(new long[] { 1_700_000_000_000L }, columns);
+
+    final List<Object[]> rows = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+    assertThat(rows).hasSize(1);
+    for (int c = 1; c <= TSBS_TAGS.length; c++)
+      assertThat(rows.getFirst()[c]).isEqualTo("");
+  }
+
+  @Test
+  void tagFilterMatchesThroughTheDictionary() throws Exception {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 1);
+    appendRows(engine, 1_000, 5);
+
+    final List<Object[]> matching = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, TagFilter.eq(0, "host_3"));
+    assertThat(matching).hasSize(200);
+    for (final Object[] row : matching)
+      assertThat(row[1]).isEqualTo("host_3");
+
+    // Newest-first path evaluates the filter straight off the page, now as an int compare.
+    final List<Object[]> newest = engine.queryDescending(Long.MIN_VALUE, Long.MAX_VALUE, null,
+        TagFilter.eq(0, "host_3"), 3, null);
+    assertThat(newest).hasSize(3);
+    for (final Object[] row : newest)
+      assertThat(row[1]).isEqualTo("host_3");
+    assertThat((long) newest.getFirst()[0]).isGreaterThan((long) newest.get(1)[0]);
+  }
+
+  /**
+   * A filter value the dictionary has never seen cannot appear in any row, so the condition is
+   * unsatisfiable and the scan short-circuits without decoding a page.
+   */
+  @Test
+  void filterOnANeverStoredTagValueMatchesNothing() throws Exception {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 1);
+    appendRows(engine, 500, 3);
+
+    assertThat(engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, TagFilter.eq(0, "host_does_not_exist"))).isEmpty();
+    assertThat(engine.queryDescending(Long.MIN_VALUE, Long.MAX_VALUE, null, TagFilter.eq(0, "host_does_not_exist"), 10,
+        null)).isEmpty();
+  }
+
+  /**
+   * A STRING FIELD is where high-cardinality text belongs, so it is not interned: it keeps the inline
+   * encoding and the wide reservation that goes with it.
+   */
+  @Test
+  void stringFieldsAreNotDictionaryEncoded() {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE Logs TIMESTAMP ts TAGS (host STRING) FIELDS (message STRING, level INTEGER) SHARDS 1");
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType("Logs")).getEngine();
+
+    // 8 (ts) + 4 (dictionary-encoded host) + 258 (inline message) + 4 (level)
+    assertThat(engine.getShard(0).getMutableBucket().getRowSize())
+        .isEqualTo(8 + 4 + (2 + TimeSeriesBucket.MAX_STRING_BYTES) + 4);
+  }
+
+  @Test
+  void stringFieldValuesStillRoundTrip() throws Exception {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE Logs TIMESTAMP ts TAGS (host STRING) FIELDS (message STRING, level INTEGER) SHARDS 1");
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType("Logs")).getEngine();
+
+    engine.appendBatch(new long[] { 1_000L, 2_000L },
+        new Object[][] { { "web01", "web02" }, { "started", "stopped" }, { 1, 2 } });
+
+    final List<Object[]> rows = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+    rows.sort((a, b) -> Long.compare((long) a[0], (long) b[0]));
+    assertThat(rows.get(0)[1]).isEqualTo("web01");
+    assertThat(rows.get(0)[2]).isEqualTo("started");
+    assertThat(rows.get(1)[1]).isEqualTo("web02");
+    assertThat(rows.get(1)[2]).isEqualTo("stopped");
+  }
+
+  /**
+   * The dictionary is per type: every shard resolves a value to the same id, and one file backs them
+   * all.
+   */
+  @Test
+  void allShardsShareOneDictionary() throws Exception {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 4);
+    appendRows(engine, 2_000, 11);
+
+    final TimeSeriesTagDictionary dictionary = engine.getTagDictionary();
+    assertThat(dictionary).isNotNull();
+    for (int i = 0; i < 4; i++)
+      assertThat(engine.getShard(i).getMutableBucket().getTagDictionary()).isSameAs(dictionary);
+
+    // 11 hostnames + 1 region + 4 datacenters + 8 racks + 6 single-valued tags
+    assertThat(dictionary.size()).isEqualTo(11 + 1 + 4 + 8 + 6);
+
+    final List<Object[]> rows = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, TagFilter.eq(0, "host_9"));
+    assertThat(rows).hasSize(2_000 / 11 + (2_000 % 11 > 9 ? 1 : 0));
+  }
+
+  @Test
+  void tagValuesSurviveCompaction() throws Exception {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 1);
+    appendRows(engine, 3_000, 6);
+
+    engine.getShard(0).compact();
+    assertThat(engine.getShard(0).getSealedStore().getBlockCount()).isPositive();
+
+    final List<Object[]> rows = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, TagFilter.eq(0, "host_4"));
+    assertThat(rows).hasSize(500);
+    for (final Object[] row : rows) {
+      assertThat(row[1]).isEqualTo("host_4");
+      assertThat(row[10]).isEqualTo("production");
+    }
+  }
+
+  @Test
+  void tagValuesSurviveAReopen() throws Exception {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 2);
+    appendRows(engine, 1_500, 9);
+
+    reopenDatabase();
+
+    final LocalTimeSeriesType type = (LocalTimeSeriesType) database.getSchema().getType("Cpu");
+    final TimeSeriesEngine reopened = type.getEngine();
+    assertThat(reopened.getTagDictionary()).isNotNull();
+    assertThat(reopened.getTagDictionary().size()).isEqualTo(9 + 1 + 4 + 8 + 6);
+
+    final List<Object[]> rows = reopened.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+    assertThat(rows).hasSize(1_500);
+
+    rows.sort((a, b) -> Long.compare((long) a[0], (long) b[0]));
+    for (int i = 0; i < 1_500; i++) {
+      assertThat(rows.get(i)[1]).isEqualTo("host_" + (i % 9));
+      assertThat(rows.get(i)[4]).isEqualTo("rack_" + (i % 8));
+    }
+
+    // And an append after the reopen keeps assigning ids from where the reload left off
+    appendRows(reopened, 100, 20);
+    assertThat(reopened.getTagDictionary().size()).isEqualTo(20 + 1 + 4 + 8 + 6);
+    assertThat(reopened.query(Long.MIN_VALUE, Long.MAX_VALUE, null, TagFilter.eq(0, "host_15"))).isNotEmpty();
+  }
+
+  /**
+   * The dictionary file is now discovered on open like any other component, so dropping the type has
+   * to take it with it. A leftover would be re-adopted by a type recreated under the same name and
+   * hand back tag values that belong to the dropped one.
+   */
+  @Test
+  void droppingTheTypeRemovesTheDictionaryFile() throws Exception {
+    final TimeSeriesEngine engine = createTsbsType("Cpu", 1);
+    appendRows(engine, 200, 5);
+    assertThat(listTagDictionaryFiles()).hasSize(1);
+
+    database.command("sql", "DROP TYPE Cpu");
+    assertThat(listTagDictionaryFiles()).isEmpty();
+
+    // Recreating under the same name starts from an empty id space, and survives a reopen
+    final TimeSeriesEngine recreated = createTsbsType("Cpu", 1);
+    assertThat(recreated.getTagDictionary().size()).isZero();
+    appendRows(recreated, 100, 3);
+
+    reopenDatabase();
+    final TimeSeriesEngine reopened = ((LocalTimeSeriesType) database.getSchema().getType("Cpu")).getEngine();
+    assertThat(reopened.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null)).hasSize(100);
+    assertThat(reopened.query(Long.MIN_VALUE, Long.MAX_VALUE, null, TagFilter.eq(0, "host_2"))).isNotEmpty();
+  }
+
+  private List<String> listTagDictionaryFiles() {
+    final List<String> found = new ArrayList<>();
+    final java.io.File[] files = new java.io.File(database.getDatabasePath()).listFiles();
+    if (files != null)
+      for (final java.io.File file : files)
+        if (file.getName().endsWith("." + TimeSeriesTagDictionary.DICT_EXT))
+          found.add(file.getName());
+    return found;
+  }
+
+  /**
+   * Backward compatibility: a bucket built without a dictionary is a format-version-0 bucket. It
+   * keeps the inline tag encoding, the wide stride that comes with it, and reads back the same
+   * values, which is what lets a database written before this change open unchanged.
+   */
+  @Test
+  void aBucketWithoutADictionaryKeepsTheInlineFormat() throws Exception {
+    final List<ColumnDefinition> columns = new ArrayList<>();
+    columns.add(new ColumnDefinition("ts", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP));
+    columns.add(new ColumnDefinition("host", Type.STRING, ColumnDefinition.ColumnRole.TAG));
+    columns.add(new ColumnDefinition("value", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD));
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    database.begin();
+    final TimeSeriesBucket bucket =
+        new TimeSeriesBucket(db, "legacy_inline", db.getDatabasePath() + "/legacy_inline", columns);
+    ((LocalSchema) db.getSchema()).registerFile(bucket);
+    bucket.initHeaderPage();
+
+    assertThat(bucket.getTagDictionary()).isNull();
+    assertThat(bucket.getRowSize()).isEqualTo(8 + (2 + TimeSeriesBucket.MAX_STRING_BYTES) + 8);
+
+    bucket.appendSamples(new long[] { 1_000L, 2_000L }, new Object[] { "web01", null },
+        new Object[] { 1.5, 2.5 });
+    database.commit();
+
+    database.begin();
+    final List<Object[]> rows = bucket.scanRange(Long.MIN_VALUE, Long.MAX_VALUE, null);
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0)[1]).isEqualTo("web01");
+    assertThat(rows.get(0)[2]).isEqualTo(1.5);
+    // A null tag reads back as "" in both formats
+    assertThat(rows.get(1)[1]).isEqualTo("");
+    database.commit();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.LocalSchema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the contract of the per-type tag dictionary that backs the fixed-width tag slot in the
+ * mutable row format (issue #5519).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TimeSeriesTagDictionaryTest extends TestHelper {
+
+  private TimeSeriesTagDictionary createDictionary(final String name) throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final TimeSeriesTagDictionary dict = new TimeSeriesTagDictionary(db, name, db.getDatabasePath() + "/" + name);
+    ((LocalSchema) db.getSchema()).registerFile(dict);
+    dict.initHeaderPage();
+    return dict;
+  }
+
+  @Test
+  void internAssignsDenseIdsFromOne() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_dense");
+
+    assertThat(dict.intern("host_a")).isEqualTo(1);
+    assertThat(dict.intern("host_b")).isEqualTo(2);
+    assertThat(dict.intern("host_c")).isEqualTo(3);
+
+    assertThat(dict.getById(1)).isEqualTo("host_a");
+    assertThat(dict.getById(2)).isEqualTo("host_b");
+    assertThat(dict.getById(3)).isEqualTo("host_c");
+    assertThat(dict.size()).isEqualTo(3);
+  }
+
+  @Test
+  void internIsIdempotent() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_idempotent");
+
+    final int first = dict.intern("eu-west-1");
+    assertThat(dict.intern("eu-west-1")).isEqualTo(first);
+    assertThat(dict.intern("eu-west-1")).isEqualTo(first);
+    assertThat(dict.size()).isEqualTo(1);
+  }
+
+  /**
+   * The mutable row format used to store a null tag as a zero-length string and hand it back as
+   * {@code ""}. Reserving id 0 keeps that round-trip byte-for-byte identical, and costs no entry.
+   */
+  @Test
+  void nullAndEmptyShareTheReservedId() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_reserved");
+
+    assertThat(dict.intern(null)).isEqualTo(TimeSeriesTagDictionary.EMPTY_ID);
+    assertThat(dict.intern("")).isEqualTo(TimeSeriesTagDictionary.EMPTY_ID);
+    assertThat(TimeSeriesTagDictionary.EMPTY_ID).isEqualTo(0);
+    assertThat(dict.getById(0)).isEqualTo("");
+    // Neither consumed a stored entry
+    assertThat(dict.size()).isZero();
+  }
+
+  @Test
+  void unknownValueResolvesToNoId() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_unknown");
+    dict.intern("known");
+
+    assertThat(dict.getId("never-seen")).isEqualTo(TimeSeriesTagDictionary.NO_ID);
+    assertThat(dict.getId("known")).isEqualTo(1);
+  }
+
+  @Test
+  void internAllAssignsOneIdPerDistinctValue() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_batch");
+
+    dict.internAll(List.of("a", "b", "a", "c", "b", "a"));
+
+    assertThat(dict.size()).isEqualTo(3);
+    assertThat(dict.getId("a")).isEqualTo(1);
+    assertThat(dict.getId("b")).isEqualTo(2);
+    assertThat(dict.getId("c")).isEqualTo(3);
+  }
+
+  /**
+   * An entry never straddles a page boundary, so the reload walk can read a page's entries from its
+   * own counter without a continuation marker.
+   */
+  @Test
+  void entriesSpillOntoFurtherPages() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_spill");
+
+    // 250-byte values: at 252 bytes of stored width each, a 64K page holds ~260 of them.
+    final String filler = "x".repeat(250);
+    final List<String> values = new ArrayList<>();
+    for (int i = 0; i < 1000; i++)
+      values.add(filler + "_" + i);
+    dict.internAll(values);
+
+    assertThat(dict.size()).isEqualTo(1000);
+    assertThat(dict.getDataPageCount()).isGreaterThan(1);
+    for (int i = 0; i < 1000; i++)
+      assertThat(dict.getById(dict.getId(values.get(i)))).isEqualTo(values.get(i));
+  }
+
+  @Test
+  void reloadRebuildsTheIdenticalMapping() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_reload");
+    final List<String> values = new ArrayList<>();
+    for (int i = 0; i < 500; i++)
+      values.add("host_" + i);
+    dict.internAll(values);
+
+    final int[] idsBefore = new int[values.size()];
+    for (int i = 0; i < values.size(); i++)
+      idsBefore[i] = dict.getId(values.get(i));
+
+    // Drop the in-RAM state and rebuild it from the pages alone
+    database.transaction(() -> {
+      try {
+        dict.load();
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    assertThat(dict.size()).isEqualTo(500);
+    for (int i = 0; i < values.size(); i++) {
+      assertThat(dict.getId(values.get(i))).isEqualTo(idsBefore[i]);
+      assertThat(dict.getById(idsBefore[i])).isEqualTo(values.get(i));
+    }
+  }
+
+  /**
+   * An HA follower receives the dictionary pages through the Raft WAL but never runs the interning
+   * that populates the in-RAM mapping, so an id can be readable from a data page while the map has
+   * never seen it. Simulated here by a second instance over the same file that was never loaded: the
+   * lookup must self-heal rather than hand back {@code null}.
+   */
+  @Test
+  void anIdWrittenByAnotherInstanceIsResolvedByReloading() throws Exception {
+    final TimeSeriesTagDictionary writer = createDictionary("tags_follower");
+    writer.internAll(List.of("host_a", "host_b", "host_c"));
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final TimeSeriesTagDictionary follower = new TimeSeriesTagDictionary(db, "tags_follower",
+        db.getDatabasePath() + "/tags_follower", writer.getFileId());
+
+    // Nothing loaded yet: the map is empty but the pages are on disk
+    assertThat(follower.size()).isZero();
+
+    assertThat(follower.getById(2)).isEqualTo("host_b");
+    assertThat(follower.size()).isEqualTo(3);
+    assertThat(follower.getById(1)).isEqualTo("host_a");
+    assertThat(follower.getById(3)).isEqualTo("host_c");
+  }
+
+  /**
+   * An id beyond anything ever stored stays unresolvable, and does not send every subsequent lookup
+   * back to the pages.
+   */
+  @Test
+  void anIdBeyondTheDictionaryStaysUnresolved() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_bogus");
+    dict.internAll(List.of("a", "b"));
+
+    assertThat(dict.getById(99)).isNull();
+    assertThat(dict.getById(99)).isNull();
+    assertThat(dict.size()).isEqualTo(2);
+    assertThat(dict.getById(1)).isEqualTo("a");
+  }
+
+  @Test
+  void valueLongerThanTheRowLimitIsRejected() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_toolong");
+
+    assertThatThrownBy(() -> dict.intern("y".repeat(TimeSeriesBucket.MAX_STRING_BYTES + 1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("exceeds max length");
+  }
+
+  @Test
+  void exceedingTheConfiguredCapIsRejected() throws Exception {
+    final TimeSeriesTagDictionary dict = createDictionary("tags_cap");
+    dict.setMaxSize(4);
+
+    dict.internAll(List.of("a", "b", "c", "d"));
+    assertThat(dict.size()).isEqualTo(4);
+
+    assertThatThrownBy(() -> dict.intern("e"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tag dictionary");
+
+    // The rejection left the committed state untouched
+    assertThat(dict.size()).isEqualTo(4);
+    assertThat(dict.getId("e")).isEqualTo(TimeSeriesTagDictionary.NO_ID);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
@@ -181,6 +181,36 @@ class TimeSeriesTagDictionaryTest extends TestHelper {
   }
 
   /**
+   * The follower keeps self-healing across successive waves of interning, not just the first one. A
+   * leader interns for as long as it ingests, so a follower that reloaded once and then stopped would
+   * read {@code null} for every tag value first seen after that reload.
+   */
+  @Test
+  void aSecondWaveOfIdsIsAlsoResolvedByReloading() throws Exception {
+    final TimeSeriesTagDictionary writer = createDictionary("tags_follower_waves");
+    writer.internAll(List.of("host_a", "host_b"));
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final TimeSeriesTagDictionary follower = new TimeSeriesTagDictionary(db, "tags_follower_waves",
+        db.getDatabasePath() + "/tags_follower_waves", writer.getFileId());
+
+    // Wave 1: the reload that the single-wave test already covers
+    assertThat(follower.getById(2)).isEqualTo("host_b");
+    assertThat(follower.size()).isEqualTo(2);
+
+    // Wave 2: more values interned by the writer after the follower has already reloaded once
+    writer.internAll(List.of("host_c", "host_d"));
+
+    assertThat(follower.getById(4)).isEqualTo("host_d");
+    assertThat(follower.getById(3)).isEqualTo("host_c");
+    assertThat(follower.size()).isEqualTo(4);
+
+    // ...and a third wave, to prove the trigger is the growth and not the reload count
+    writer.internAll(List.of("host_e"));
+    assertThat(follower.getById(5)).isEqualTo("host_e");
+  }
+
+  /**
    * An id beyond anything ever stored stays unresolvable, and does not send every subsequent lookup
    * back to the pages.
    */

--- a/engine/src/test/java/performance/TimeSeriesTagStrideBenchmark.java
+++ b/engine/src/test/java/performance/TimeSeriesTagStrideBenchmark.java
@@ -33,31 +33,38 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Isolates what a tag-heavy TimeSeries schema actually pays on ingest (issue #5519).
+ * Isolates what a tag-heavy TimeSeries schema pays on ingest, and now guards the fix (issue #5519).
  * <p>
- * {@code TimeSeriesBucket.calculateRowSize()} reserves {@code 2 + MAX_STRING_BYTES} = 258 bytes of row
- * stride for every STRING column, while {@code writeStringValue()} stores the row packed. Only the
- * stride assumes the maximum, and the stride is what positions the row inside the page, so short tag
- * values are spread across a page that is almost entirely unwritten padding.
+ * <b>What this measured before the fix.</b> {@code TimeSeriesBucket.calculateRowSize()} reserved
+ * {@code 2 + MAX_STRING_BYTES} = 258 bytes of row stride for every STRING column while
+ * {@code writeStringValue()} stored the row packed. Only the stride assumed the maximum, and the
+ * stride is what positions the row inside the page, so short tag values were spread across a page
+ * that was almost entirely unwritten padding: a 2612-byte stride, 25 rows per 64 KB page, and 24x
+ * page and WAL amplification.
  * <p>
- * Three arms, each appending the same number of rows, differing in exactly one thing:
+ * <b>What it measures now.</b> TAG STRING columns are dictionary-encoded into a 4-byte id, so the
+ * same schema has a 72-byte stride and ~900 rows per page. The arms are unchanged, which is the
+ * point - the same three measurements now tell the opposite story:
  * <ol>
  *   <li>{@code WideStride} - the TSBS cpu-only shape: 10 STRING tags of ~8 chars plus 3 DOUBLE fields.</li>
- *   <li>{@code WideStrideBigValues} - the same schema with 200-char tag values. Twenty times more string
- *       bytes are encoded and copied per row, and the stride is unchanged. Isolates encoding cost.</li>
- *   <li>{@code NarrowStride} - the same tag text joined into one STRING column. Identical content, one
- *       ninth the stride. Isolates page traffic.</li>
+ *   <li>{@code WideStrideBigValues} - the same schema with 200-char tag values. Before, this proved the
+ *       encode loop was not the cost, because twenty times more string bytes at the same stride was
+ *       free. Now it is free for a second reason: each distinct value is interned once and the row
+ *       stores an id, so the tag length has stopped mattering at all.</li>
+ *   <li>{@code NarrowStride} - the same tag text joined into one STRING column. It used to have one
+ *       ninth the stride of arm 1; it now has half (36 bytes against 72), because what separates them
+ *       is nine extra 4-byte ids rather than nine 258-byte reservations.</li>
  * </ol>
- * Arm 2 costs about the same as arm 1 and arm 3 is several times faster, which is the finding: on a
- * tag-heavy schema the ingest is paying for pages, not for encoding. Backs the numbers quoted on #5519
- * and on issue #5474; when the tag dictionary of #5519 lands, arm 1 should converge towards arm 3.
+ * Arm 1 has converged towards arm 3, which is what the fix promised on #5519. The remaining gap is
+ * the real cost of nine more columns - nine more dictionary lookups and 36 more bytes per row - not
+ * padding. The assertions below are the regression guard: they now pin the absence of amplification
+ * rather than its presence, so a change that reintroduces a padded stride fails here.
  * <p>
  * Run explicitly with
  * {@code ./mvnw -pl engine -Dtest=TimeSeriesTagStrideBenchmark -Dgroups=benchmark test}.
  * Override the batch size with {@code -Darcadedb.tagStrideBenchmark.rows=50000} to reproduce the batch
- * size quoted on those issues. The default is deliberately smaller: at the default 64 KB page size a
- * wide-stride arm writes {@code rows / 25} pages per batch, so 50k rows costs roughly 1 GB under
- * {@code target/} across the three arms.
+ * size quoted on those issues. That used to cost roughly 1 GB under {@code target/} across the three
+ * arms; with the padding gone it costs about 40x less.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -100,19 +107,31 @@ class TimeSeriesTagStrideBenchmark extends TestHelper {
       arm.report();
     System.out.println();
 
-    // The finding, stated as the two orderings that survive re-running on other hardware.
+    // Timing orderings that survive re-running on other hardware.
 
-    // Twenty times more string bytes per row, same stride: encoding is not what ingest is paying for.
+    // Twenty times more string bytes per row: a value is interned once and the row carries an id, so
+    // the length of a tag no longer reaches the write path at all.
     assertThat(wideBig.medianNanos()).isLessThan(wide.medianNanos() * 2);
 
-    // Same tag content, one ninth of the stride: page traffic is.
-    assertThat(narrow.medianNanos() * 2).isLessThan(wide.medianNanos());
+    // Nine fewer tag columns is still nine fewer lookups and 36 fewer bytes per row, so the one-tag
+    // arm stays ahead - but by a factor, not by the order of magnitude the padding used to cost.
+    assertThat(narrow.medianNanos()).isLessThan(wide.medianNanos());
 
-    // Structural rather than timing-based, so these hold on any host: a page holds an order of
-    // magnitude fewer rows once ten tag columns each reserve 258 bytes they do not use.
+    // Structural rather than timing-based, so these hold on any host.
+
+    // Tag length does not move the stride in either direction.
     assertThat(wide.rowsPerPage()).isEqualTo(wideBig.rowsPerPage());
-    assertThat(wide.rowsPerPage() * 8).isLessThan(narrow.rowsPerPage());
-    assertThat(wide.pageTrafficAmplification()).isGreaterThan(10);
+
+    // The fix, stated as a number: a 64 KB page holds hundreds of ten-tag rows. It held 25.
+    assertThat(wide.rowsPerPage()).isGreaterThan(500);
+
+    // And the two arms have converged. Before the dictionary the one-tag arm fitted nine times more
+    // rows per page; the gap is now the four bytes per extra tag and nothing else.
+    assertThat(narrow.rowsPerPage()).isLessThan(wide.rowsPerPage() * 3);
+
+    // No amplification left: a page carries less than the naive inline encoding of the rows in it,
+    // where it used to carry more than ten times as much.
+    assertThat(wide.pageTrafficAmplification()).isLessThan(1.5);
   }
 
   private static String tenTagColumns() {
@@ -226,15 +245,19 @@ class TimeSeriesTagStrideBenchmark extends TestHelper {
      * How many bytes of page are moved, through the buffer pool and through the WAL, for every byte of
      * sample data actually stored. The WAL ships the whole used region of each page because
      * {@code MutablePage.MAX_MODIFIED_RANGES} is 8 and the row writes are scattered at stride distance.
+     * <p>
+     * A ratio, not an integer count: dictionary-encoded tags take the wide arm below 1.0, and rounding
+     * that to zero would read as "no page traffic" rather than "less page traffic than payload".
      */
-    private long pageTrafficAmplification() {
-      return pageTrafficBytesPerBatch() / payloadBytesPerBatch;
+    private double pageTrafficAmplification() {
+      return (double) pageTrafficBytesPerBatch() / payloadBytesPerBatch;
     }
 
     private void report() {
       System.out.printf(Locale.ROOT, "%-22s %8d %11d %10d %12s %18s %8.1f%n", name, bucket.getRowSize(), rowsPerPage(),
           pagesPerBatch(), format(payloadBytesPerBatch),
-          format(pageTrafficBytesPerBatch()) + " (" + pageTrafficAmplification() + "x)", medianNanos() / 1_000_000.0);
+          format(pageTrafficBytesPerBatch()) + String.format(Locale.ROOT, " (%.1fx)", pageTrafficAmplification()),
+          medianNanos() / 1_000_000.0);
     }
 
     private String format(final long bytes) {

--- a/server/src/test/java/com/arcadedb/server/TimeSeriesIngestBatchAppendIT.java
+++ b/server/src/test/java/com/arcadedb/server/TimeSeriesIngestBatchAppendIT.java
@@ -68,13 +68,24 @@ class TimeSeriesIngestBatchAppendIT extends BaseGraphServerTest {
     assertThat(postLineProtocol(0, body.toString())).isEqualTo(204);
     final long delta = writeTxCount() - before;
 
-    // One shard, one measurement: a single batched append transaction. Allow one extra commit of slack
-    // for incidental bookkeeping; the pre-fix per-sample shape produced SAMPLES transactions, so the
-    // bound separates the two shapes unambiguously.
+    // One shard, one measurement: a single batched append transaction, plus one commit for the tag
+    // dictionary the first time it sees "h1" (issue #5519), plus one of slack for incidental
+    // bookkeeping. The pre-fix per-sample shape produced SAMPLES transactions, so the bound still
+    // separates the two shapes unambiguously.
     assertThat(delta).as("append transactions for %d samples in one measurement", SAMPLES)
-        .isLessThanOrEqualTo(2);
+        .isLessThanOrEqualTo(3);
 
     assertThat(rowCount("batched")).isEqualTo(SAMPLES);
+
+    // The dictionary commit is a warm-up cost and nothing more: posting the same tag again interns
+    // nothing, so the second request cannot cost more transactions than the first.
+    final long beforeSecond = writeTxCount();
+    assertThat(postLineProtocol(0, body.toString())).isEqualTo(204);
+    final long secondDelta = writeTxCount() - beforeSecond;
+
+    assertThat(secondDelta).as("append transactions for a repeat post, dictionary already warm")
+        .isLessThanOrEqualTo(2);
+    assertThat(rowCount("batched")).isEqualTo(SAMPLES * 2);
   }
 
   @Test
@@ -93,8 +104,11 @@ class TimeSeriesIngestBatchAppendIT extends BaseGraphServerTest {
     assertThat(postLineProtocol(0, body.toString())).isEqualTo(204);
     final long delta = writeTxCount() - before;
 
+    // Two measurements: one append transaction each, plus one tag-dictionary commit each for the first
+    // sighting of "h1" (the dictionary is per type, so the two do not share one), plus a commit of
+    // slack. Still far below the SAMPLES transactions the per-sample shape produced.
     assertThat(delta).as("append transactions for %d samples across 2 measurements", SAMPLES)
-        .isLessThanOrEqualTo(3);
+        .isLessThanOrEqualTo(5);
 
     assertThat(rowCount("batched_a")).isEqualTo(SAMPLES / 2);
     assertThat(rowCount("batched_b")).isEqualTo(SAMPLES / 2);


### PR DESCRIPTION
Closes #5519.

## The problem

A TimeSeries mutable row is fixed-stride, so every column has to reserve the widest value it could ever hold. For
a `STRING` TAG column that is `2 + MAX_STRING_BYTES` = **258 bytes**, whether the tag is `us-east-1` or empty.

Tags are low-cardinality by definition - that is what makes them tags rather than fields - so almost all of that
reservation was padding, and padding in a fixed-stride row is not free: it is written, flushed, and shipped
through the WAL like real data. The shipping TSBS `cpu_influx.lp` schema has ten tags, which is a 2,612-byte
stride, **25 rows per 64K page**, and 23x page+WAL amplification against payload.

`TimeSeriesTagStrideBenchmark` (added in #5520) isolated it, and @tae898 corroborated it end to end from Python
on real TSBS data - 2,592,000 points, N=3 - measuring 4.74x slower ingest for ten tags than for one, with strides
and rows-per-page matching the formula exactly.

## The fix

A TAG column now holds a **4-byte id** into a per-**type** append-only dictionary component (`.tstd`, one file
per TimeSeries type, shared by every shard) instead of an inline reserved slot.

| arm | tags | fields | stride | rows per 64K page |
|---|---|---|---|---|
| 1 tag, 3 fields | 1 | 3 | 290 B → **36 B** | 225 → **1819** |
| 10 tags, 3 fields | 10 | 3 | 2612 B → **72 B** | 25 → **909** |
| 10 tags, 10 fields | 10 | 10 | 2668 B → **128 B** | 24 → **511** |

`TimeSeriesTagStrideBenchmark`, same host, same 20k batches:

```
before
arm                      stride   rows/page      pages      payload       page traffic       ms
WideStride                 2612          25        800       2.1 MB      50.0 MB (23x)     29.9
WideStrideBigValues        2612          25        800      39.1 MB      50.0 MB (1x)      25.5
NarrowStride                290         225         89       1.9 MB       5.6 MB (2x)       4.3

after
WideStride                   72         909         23       2.1 MB       1.4 MB (0.7x)      6.0
WideStrideBigValues          72         909         23      39.1 MB       1.4 MB (0.0x)      5.5
NarrowStride                 36        1819         11       1.9 MB       0.7 MB (0.4x)      2.0
```

A tag-heavy schema does **not** converge on a narrow one, and should not: the single-tag arm was paying the same
reservation for its one column, so it improves too. The stride ratio between the two goes from 9.0x to 2.0x -
what remains is the real cost of nine more columns (nine more dictionary lookups, 36 more bytes per row), with no
padding left to remove.

## Design decisions worth reviewing

- **Ids are 4 bytes, not the 2 the sealed `DictionaryCodec` uses.** That costs ~900 rows per page instead of
  ~1250 and buys away the overflow-past-65535 question entirely, rather than deferring it to a per-type limit
  someone eventually hits. `DictionaryCodecOverflowTest` covers the sealed side, which is unchanged.
- **Id 0 is reserved for null/empty**, so the existing null round trip is byte-identical.
- **Per type, not per shard.** Tag values repeat across shards by construction, so a per-shard dictionary would
  hold N copies of the same low-cardinality set and lose most of the win on a sharded type.
- **STRING *fields* stay inline.** A field is where high-cardinality text belongs; interning it would grow the
  dictionary without bound for no reuse. This is the one asymmetry in the change and it is deliberate.
- **`arcadedb.timeSeriesTagDictionaryMaxSize`**, default 1M distinct values (~100MB). The dictionary is held in
  RAM, so the cap turns a mis-declared high-cardinality TAG into a clear error rather than unbounded growth.

## Compatibility

**Existing databases open and read unchanged, and there is no in-place migration.** The mutable row format is
versioned per type: a type created by an earlier build keeps the inline layout, a new type gets the encoding.
An existing type has to be recreated to gain it. Worth stating plainly in the release note (included here)
because a benchmark pointed at an existing database will measure v0 and see no change at all.

The `.tstd` component is registered in both `LocalSchema` and `LocalDatabase`'s supported extensions, so it
survives a reopen rather than being silently discarded.

## Tests

- `TimeSeriesTagDictionaryTest` (11) - the component itself: append, lookup, id stability, null/empty handling,
  persistence across reopen, the max-size cap.
- `Issue5519TagStrideTest` (13) - the row layout end to end: stride per schema shape, rows per page, tag values
  surviving a round trip, mixed TAG/field schemas, existing-type version pinning.
- `TimeSeriesTagStrideBenchmark` - the two structural assertions were **inverted rather than deleted**, so the
  benchmark now guards the fix instead of documenting the defect: a 64K page holds more than 500 ten-tag rows,
  the two arms are within 3x of each other, and page-traffic amplification is below 1.5x where it used to assert
  above 10x. Of the timing assertions, `WideStrideBigValues < WideStride * 2` holds unchanged and
  `NarrowStride * 2 < WideStride` was relaxed to `NarrowStride < WideStride` for the convergence reason above.

## Verification

Rebased onto current `main` (`9a9358ec5`) and re-run there:

- **484 tests, 0 failures** in `com.arcadedb.engine.timeseries.**`, including `TimeSeriesCrashRecoveryTest`,
  `TimeSeriesConcurrentAppendCompactTest`, `Issue5475ColumnTypesTest` and `Issue5474PrimitiveIngestTest`.
- **948 tests, 0 failures** across `com.arcadedb.schema.**` + `com.arcadedb.engine.**`, covering the
  `LocalSchema` / `LocalDatabase` component registration.
