### PR TITLE
fix: escape backslashes inside back-tick quoted SQL names

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -170,8 +170,8 @@ A single backslash immediately before the closing back-tick escapes it, so the n
 the statement is rejected rather than silently absorbing what follows. Only names that actually contain a
 backslash are affected; every other quoted name, including one containing an escaped back-tick, is unchanged.
 
-This is also the encoding the Postgres wire protocol already applied when it rewrote quoted identifiers, so the
-two agree now.
+The Postgres wire protocol already read back-tick identifiers this way; it now also writes them this way, so a
+double-quoted Postgres name carrying a backslash survives the translation instead of losing it.
 
 #### Cypher: an unbound `$parameter` is now an error, not null
 

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -5,6 +5,22 @@ they land during the 26.8.1 development cycle, so the release notes are ready at
 
 ### Fixes
 
+#### MongoDB protocol: field names and filter values can no longer inject SQL
+
+A MongoDB command is translated into a SQL statement, and the field names and values taken off the wire were
+embedded in it without escaping. Both could close their own quoting and append clauses of their own, so any
+client able to send an `update` or `delete` could rewrite the statement it was translated into:
+
+- A filter **value** containing a single quote closed the string literal, so
+  `updateMany({name: "v1' OR 'x' = 'x"}, ...)` produced `WHERE name = 'v1' OR 'x' = 'x'` and updated **every**
+  document instead of the intended one.
+- A `$unset` or `$inc` **field name** containing a back-tick closed the identifier and named further properties,
+  so a single crafted key removed a property the client never asked for.
+- A filter **field name** was appended unquoted and could introduce a predicate of its own.
+
+Values are now escaped for the literal they sit in and every field name is back-tick quoted, one dot-separated
+segment at a time so that navigation into an embedded document keeps working.
+
 #### Back-tick quoted names containing a backslash are no longer mis-parsed
 
 A schema object name may contain a back-tick or a backslash, and the SQL spelling of such a name escapes it with

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -5,6 +5,34 @@ they land during the 26.8.1 development cycle, so the release notes are ready at
 
 ### Fixes
 
+#### Back-tick quoted names containing a backslash are no longer mis-parsed
+
+A schema object name may contain a back-tick or a backslash, and the SQL spelling of such a name escapes it with
+a leading backslash. Escaping the back-tick but not the backslash left that encoding ambiguous, with two
+consequences.
+
+A name that arrived already escaped was escaped a second time, so the spelling grew one backslash on every
+parse and re-emission and the name no longer resolved:
+
+```sql
+-- the type named a`b
+SELECT FROM `a\`b`
+-- re-emitted as `a\\`b`, and addressing the type reported: Type with name 'a\`b' was not found
+```
+
+A name ending in a backslash left the closing back-tick indistinguishable from an escaped one, so the quoted
+token ran past the end of the name and absorbed the SQL that followed it:
+
+```sql
+-- SET ` is consumed into the type name instead of parsing as a clause
+UPDATE `T\` SET `v` = 1
+```
+
+The same applied to a bucket or index addressed through a `schema:<kind>:<name>` target.
+
+Both are fixed: a backslash now escapes the character that follows it, in the lexer and in the quoting applied
+by the engine and by the Studio, so the encoding is unambiguous in both directions.
+
 #### Concurrent writes to unrelated records of the same page no longer conflict
 
 ArcadeDB detects write conflicts per *page*, so two transactions that touched the same bucket page raised a
@@ -124,6 +152,26 @@ $ ls -l <database>/dictionary.*.dict
 remains downgradable.
 
 ### Breaking Changes
+
+#### SQL: inside a back-tick quoted name a backslash escapes the next character
+
+A backslash used to stand for itself unless it preceded a back-tick, so a name carrying one could be written
+bare. It now always escapes the character that follows it, which is what makes the closing back-tick
+unambiguous, and a literal backslash has to be doubled:
+
+```sql
+-- before
+SELECT FROM `C:\data`
+-- now
+SELECT FROM `C:\\data`
+```
+
+A single backslash immediately before the closing back-tick escapes it, so the name is left unterminated and
+the statement is rejected rather than silently absorbing what follows. Only names that actually contain a
+backslash are affected; every other quoted name, including one containing an escaped back-tick, is unchanged.
+
+This is also the encoding the Postgres wire protocol already applied when it rewrote quoted identifiers, so the
+two agree now.
 
 #### Cypher: an unbound `$parameter` is now an error, not null
 

--- a/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLLexer.g4
+++ b/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLLexer.g4
@@ -404,7 +404,7 @@ BUCKET_NUMBER_IDENTIFIER: B U C K E T COLON INTEGER_LITERAL;
 // user-supplied name may carry (spaces, colons, ...).
 SCHEMA_IDENTIFIER: S C H E M A COLON IDENTIFIER (COLON (SCHEMA_QUOTED_NAME_PART | SCHEMA_NAME_PART))?;
 fragment SCHEMA_NAME_PART: (LETTER | [0-9] | '_' | '[' | ']' | '.' | '-' | ',')+;
-fragment SCHEMA_QUOTED_NAME_PART: BACKTICK ( ~[`] | '\\`' )+ BACKTICK;
+fragment SCHEMA_QUOTED_NAME_PART: BACKTICK ( ~[`\\] | '\\' . )+ BACKTICK;
 
 // URL Identifiers
 HTTP_URL: 'http://' URL_CHAR+;
@@ -493,8 +493,11 @@ IDENTIFIER
     : (DOLLAR | LETTER) PART_LETTER*
     ;
 
+// A backslash always escapes the character that follows it, so `\\` is a literal backslash and '\\`' a literal back-tick. Letting
+// a bare backslash stand for itself would make the closing back-tick ambiguous: `T\` could read as an unterminated name whose
+// back-tick was escaped, and the lexer would run past the intended end of the token and absorb the SQL that follows it.
 QUOTED_IDENTIFIER
-    : BACKTICK ( ~[`] | '\\`' )+ BACKTICK
+    : BACKTICK ( ~[`\\] | '\\' . )+ BACKTICK
     ;
 
 fragment LETTER: [A-Z_a-z];

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -3854,12 +3854,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     if (ctx.IDENTIFIER() != null) {
       return new Identifier(ctx.IDENTIFIER().getText());
     } else if (ctx.QUOTED_IDENTIFIER() != null) {
-      final String quoted = ctx.QUOTED_IDENTIFIER().getText();
-      // Remove backticks
-      final String unquoted = quoted.substring(1, quoted.length() - 1);
-      final Identifier id = new Identifier(unquoted);
-      id.setQuotedStringValue(quoted);
-      return id;
+      return Identifier.quoted(ctx.QUOTED_IDENTIFIER().getText());
     } else {
       // Handle keywords used as identifiers (NAME, VALUE, TYPE, etc.)
       // Note: Record attributes (@rid, @type, @in, @out) are handled in visitIdentifierChain
@@ -5556,11 +5551,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     if (bodyCtx.QUOTED_IDENTIFIER() != null) {
       // Legacy syntax: CREATE INDEX `name` [IF NOT EXISTS] indexType [ENGINE engine] [METADATA json]
-      final String quoted = bodyCtx.QUOTED_IDENTIFIER().getText();
-      final String unquoted = quoted.substring(1, quoted.length() - 1);
-      final Identifier nameId = new Identifier(unquoted);
-      nameId.setQuotedStringValue(quoted);
-      stmt.name = nameId;
+      stmt.name = Identifier.quoted(bodyCtx.QUOTED_IDENTIFIER().getText());
       // No typeName — legacy indexes are not bound to a type via ON clause
 
       if (bodyCtx.indexType() != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Identifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Identifier.java
@@ -56,7 +56,8 @@ public class Identifier extends SimpleNode {
   }
 
   /**
-   * returns the value as is, with back-ticks quoted with backslash
+   * returns the value in escaped form, ready to be emitted between back-ticks: both back-ticks and backslashes carry a leading
+   * backslash. Use {@link #getStringValue()} for the plain name, which is what schema lookups take.
    *
    * @return
    */
@@ -65,16 +66,12 @@ public class Identifier extends SimpleNode {
   }
 
   /**
-   * returns the plain string representation of this identifier, with quoting removed from back-ticks
+   * returns the plain string representation of this identifier, with the escaping removed
    *
    * @return
    */
   public String getStringValue() {
-    if (value == null)
-      return null;
-    // reverse the escaping applied by setStringValue(): turn `\`` back into a plain back-tick, leaving
-    // any other backslash untouched so names that legitimately contain a backslash are preserved
-    return value.replace("\\`", "`");
+    return unescape(value);
   }
 
   /**
@@ -84,17 +81,70 @@ public class Identifier extends SimpleNode {
    * @param s
    */
   public void setStringValue(final String s) {
-    if (s == null)
-      value = null;
-    else if (s.contains("`"))
-      value = s.replace("`", "\\`");
-    else
-      value = s;
+    value = escape(s);
   }
 
+  /**
+   * sets the value from the SQL spelling of a back-tick quoted identifier, outer back-ticks included. The inner text is already in
+   * escaped form, so it is stored verbatim: escaping it again would turn every {@code \`} into {@code \\`} and grow one backslash
+   * per parse -> re-emit cycle.
+   */
   public void setQuotedStringValue(final String s) {
     quoted = true;
-    setStringValue(s.substring(1, s.length() - 1));
+    value = s.substring(1, s.length() - 1);
+  }
+
+  /**
+   * escapes the two characters that carry meaning inside a back-tick quoted identifier, each with a leading backslash. A backslash
+   * has to be escaped as well, otherwise a name ending with one would swallow the closing back-tick.
+   */
+  static String escape(final String s) {
+    if (s == null)
+      return null;
+
+    int escapes = 0;
+    for (int i = 0; i < s.length(); i++) {
+      final char c = s.charAt(i);
+      if (c == '`' || c == '\\')
+        ++escapes;
+    }
+
+    if (escapes == 0)
+      // by far the common case: nothing to escape, so keep the original instance
+      return s;
+
+    final StringBuilder buffer = new StringBuilder(s.length() + escapes);
+    for (int i = 0; i < s.length(); i++) {
+      final char c = s.charAt(i);
+      if (c == '`' || c == '\\')
+        buffer.append('\\');
+      buffer.append(c);
+    }
+    return buffer.toString();
+  }
+
+  /**
+   * reverses {@link #escape(String)}: a backslash consumes the character that follows it.
+   */
+  static String unescape(final String s) {
+    if (s == null)
+      return null;
+
+    final int firstEscape = s.indexOf('\\');
+    if (firstEscape < 0)
+      // by far the common case: nothing was escaped, so keep the original instance
+      return s;
+
+    final StringBuilder buffer = new StringBuilder(s.length());
+    buffer.append(s, 0, firstEscape);
+    for (int i = firstEscape; i < s.length(); i++) {
+      final char c = s.charAt(i);
+      if (c == '\\' && i + 1 < s.length())
+        buffer.append(s.charAt(++i));
+      else
+        buffer.append(c);
+    }
+    return buffer.toString();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Identifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Identifier.java
@@ -56,6 +56,17 @@ public class Identifier extends SimpleNode {
   }
 
   /**
+   * builds an identifier from the SQL spelling of a back-tick quoted name, outer back-ticks included. Going through the
+   * {@link #Identifier(String)} constructor first would run the inner text through {@link #escape(String)} only to discard the
+   * result on the following {@link #setQuotedStringValue(String)}.
+   */
+  public static Identifier quoted(final String spelling) {
+    final Identifier identifier = new Identifier(-1);
+    identifier.setQuotedStringValue(spelling);
+    return identifier;
+  }
+
+  /**
    * returns the value in escaped form, ready to be emitted between back-ticks: both back-ticks and backslashes carry a leading
    * backslash. Use {@link #getStringValue()} for the plain name, which is what schema lookups take.
    *

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Identifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Identifier.java
@@ -106,6 +106,14 @@ public class Identifier extends SimpleNode {
   }
 
   /**
+   * returns the SQL spelling of a name: the name escaped and wrapped in back-ticks, safe to embed in a statement whatever
+   * characters it carries. Callers that build SQL text by hand should route every schema object name through this.
+   */
+  public static String quote(final String name) {
+    return "`" + escape(name) + "`";
+  }
+
+  /**
    * escapes the two characters that carry meaning inside a back-tick quoted identifier, each with a leading backslash. A backslash
    * has to be escaped as well, otherwise a name ending with one would swallow the closing back-tick.
    */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SchemaIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SchemaIdentifier.java
@@ -49,7 +49,7 @@ public class SchemaIdentifier extends SimpleNode {
    */
   public static String unquoteName(final String namePart) {
     if (namePart.length() > 1 && namePart.charAt(0) == '`' && namePart.charAt(namePart.length() - 1) == '`')
-      return namePart.substring(1, namePart.length() - 1).replace("\\`", "`");
+      return Identifier.unescape(namePart.substring(1, namePart.length() - 1));
     return namePart;
   }
 
@@ -65,7 +65,7 @@ public class SchemaIdentifier extends SimpleNode {
           && c != ',';
     }
 
-    return needsQuoting ? "`" + namePart.replace("`", "\\`") + "`" : namePart;
+    return needsQuoting ? "`" + Identifier.escape(namePart) + "`" : namePart;
   }
 
   public String getName() {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QuotedSchemaNameInjectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QuotedSchemaNameInjectionTest.java
@@ -78,6 +78,20 @@ class QuotedSchemaNameInjectionTest extends TestHelper {
     assertNameAddressableAndIsolated("Mixed\\`Name");
   }
 
+  /**
+   * A DDL statement names the object it creates, so the name has to survive the round-trip through the statement rather than being
+   * silently altered on the way in: an unescaped backslash would make {@code CREATE DOCUMENT TYPE `My\Type`} create MyType.
+   */
+  @Test
+  void createdTypeKeepsTheNameItWasGiven() {
+    final String typeName = "My\\Type";
+
+    database.command("sql", "CREATE DOCUMENT TYPE " + quoteSqlName(typeName));
+
+    assertThat(database.getSchema().existsType(typeName)).isTrue();
+    assertThat(database.getSchema().existsType("MyType")).isFalse();
+  }
+
   @Test
   void injectionAttemptInNameIsTreatedAsPlainName() {
     // a name crafted to close the identifier early and append a command must survive as a single, literal type name

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QuotedSchemaNameInjectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QuotedSchemaNameInjectionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A schema object name may contain a back-tick or a backslash. Any caller that embeds such a name into a SQL command has to escape
+ * both characters, so that the quoted identifier ends where it is meant to end and cannot absorb the rest of the command. This
+ * covers the escaping that the Studio applies before it addresses a type, bucket or index by name.
+ */
+class QuotedSchemaNameInjectionTest extends TestHelper {
+
+  /**
+   * The reference implementation of the escaping, mirroring {@code quoteSqlName()} in studio-utils.js.
+   */
+  private static String quoteSqlName(final String name) {
+    final StringBuilder buffer = new StringBuilder(name.length() + 2).append('`');
+    for (int i = 0; i < name.length(); i++) {
+      final char c = name.charAt(i);
+      if (c == '`' || c == '\\')
+        buffer.append('\\');
+      buffer.append(c);
+    }
+    return buffer.append('`').toString();
+  }
+
+  private void assertNameAddressableAndIsolated(final String typeName) {
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.newDocument(typeName).set("tag", "kept").save());
+
+    final String quoted = quoteSqlName(typeName);
+
+    final ResultSet result = database.query("sql", "SELECT FROM " + quoted);
+    assertThat(result.stream().count()).isEqualTo(1);
+
+    // the identifier must not swallow the clause that follows it: the WHERE has to be applied, not absorbed into the name
+    final ResultSet filtered = database.query("sql", "SELECT FROM " + quoted + " WHERE `tag` = 'absent'");
+    assertThat(filtered.stream().count()).isZero();
+  }
+
+  @Test
+  void nameWithBackTickIsAddressable() {
+    assertNameAddressableAndIsolated("Back`Tick");
+  }
+
+  @Test
+  void nameEndingWithBackslashIsAddressable() {
+    assertNameAddressableAndIsolated("Trailing\\");
+  }
+
+  @Test
+  void nameWithInnerBackslashIsAddressable() {
+    assertNameAddressableAndIsolated("Inner\\Slash");
+  }
+
+  @Test
+  void nameWithBackslashBeforeBackTickIsAddressable() {
+    assertNameAddressableAndIsolated("Mixed\\`Name");
+  }
+
+  @Test
+  void injectionAttemptInNameIsTreatedAsPlainName() {
+    // a name crafted to close the identifier early and append a command must survive as a single, literal type name
+    final String hostile = "Evil` ; DROP TYPE Victim; --";
+    database.getSchema().createDocumentType("Victim");
+    database.getSchema().createDocumentType(hostile);
+
+    final ResultSet result = database.query("sql", "SELECT FROM " + quoteSqlName(hostile));
+
+    assertThat(result.stream().count()).isZero();
+    assertThat(database.getSchema().existsType("Victim")).isTrue();
+    assertThat(database.getSchema().existsType(hostile)).isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/IdentifierTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/IdentifierTest.java
@@ -55,11 +55,13 @@ class IdentifierTest {
 
   @Test
   void backslashWithoutBackTickPreserved() {
-    // A literal backslash not followed by a back-tick must be left untouched by getStringValue()
+    // A literal backslash in a name survives the round-trip through getStringValue()
     final Identifier identifier = new Identifier("na\\me");
 
     assertThat(identifier.getStringValue()).isEqualTo("na\\me");
-    assertThat(identifier.getValue()).isEqualTo("na\\me");
+    // getValue() is the escaped form, so the backslash is itself escaped: leaving it bare would make the closing back-tick of
+    // `na\me` ambiguous once the value is emitted back into SQL
+    assertThat(identifier.getValue()).isEqualTo("na\\\\me");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/QuotedIdentifierEscapingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/QuotedIdentifierEscapingTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.query.sql.antlr.SQLAntlrParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the escaping contract of back-tick quoted identifiers. A schema object name may contain a back-tick or a backslash, so the
+ * escaping has to survive the parse -> re-emit -> re-parse cycle without altering the name and without letting the quoted token
+ * absorb the SQL that follows it.
+ */
+class QuotedIdentifierEscapingTest {
+
+  private static String reemit(final String sql) {
+    final Statement statement = new SQLAntlrParser(null).parse(sql);
+    final StringBuilder builder = new StringBuilder();
+    statement.toString(null, builder);
+    return builder.toString();
+  }
+
+  @Test
+  void quotedInputIsNotEscapedTwice() {
+    // `a\`b` is the SQL spelling of the name a`b - the inner text arrives already escaped and must not be escaped again
+    final Identifier identifier = new Identifier(-1);
+    identifier.setQuotedStringValue("`a\\`b`");
+
+    assertThat(identifier.getStringValue()).isEqualTo("a`b");
+    assertThat(identifier.getValue()).isEqualTo("a\\`b");
+    assertThat(identifier.toString()).isEqualTo("`a\\`b`");
+  }
+
+  @Test
+  void escapedBackTickNameSurvivesReEmission() {
+    assertThat(reemit("SELECT FROM `a\\`b`")).isEqualTo("SELECT FROM `a\\`b`");
+  }
+
+  @Test
+  void nameEndingWithBackslashSurvivesReEmission() {
+    assertThat(reemit("SELECT FROM `T\\\\`")).isEqualTo("SELECT FROM `T\\\\`");
+  }
+
+  @Test
+  void backslashTerminatedNameDoesNotAbsorbFollowingSql() {
+    // the closing back-tick of `T\\` must terminate the identifier instead of pairing with the backslash, otherwise the
+    // lexer runs on and swallows " SET `" into the type name
+    assertThat(reemit("UPDATE `T\\\\` SET `v` = 1")).isEqualTo("UPDATE `T\\\\` SET `v` = 1");
+  }
+
+  @Test
+  void backslashOnlyNameRoundTripsThroughIdentifier() {
+    final Identifier identifier = new Identifier("T\\");
+
+    assertThat(identifier.getStringValue()).isEqualTo("T\\");
+  }
+
+  @Test
+  void backTickAndBackslashCombinedRoundTripsThroughIdentifier() {
+    final Identifier identifier = new Identifier("a\\`b");
+
+    assertThat(identifier.getStringValue()).isEqualTo("a\\`b");
+  }
+
+  /**
+   * The trailing name part of a {@code schema:<kind>:<name>} target carries its own quoting, used whenever a bucket or index is
+   * addressed by name, so it has to follow the same escaping rule as a plain quoted identifier.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { "plain", "Back`Tick", "Trailing\\", "Inner\\Slash", "Mixed\\`Name", "Type[propA,propB]",
+      "Evil` ; DROP TYPE Victim; --" })
+  void schemaNamePartSurvivesQuoteUnquoteRoundTrip(final String namePart) {
+    assertThat(SchemaIdentifier.unquoteName(SchemaIdentifier.quoteName(namePart))).isEqualTo(namePart);
+  }
+
+  @Test
+  void schemaNamePartEndingWithBackslashDoesNotAbsorbFollowingSql() {
+    assertThat(reemit("SELECT FROM schema:bucket:" + SchemaIdentifier.quoteName("Trailing\\") + " WHERE `v` = 1"))
+        .isEqualTo("SELECT FROM schema:bucket:" + SchemaIdentifier.quoteName("Trailing\\") + " WHERE `v` = 1");
+  }
+}

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -19,6 +19,7 @@
 package com.arcadedb.gremlin;
 
 import com.arcadedb.database.*;
+import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.database.Record;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.RecordNotFoundException;
@@ -303,9 +304,7 @@ public class ArcadeGraph implements Graph, Closeable {
       for (final Bucket b : buckets) {
         if (i > 0)
           query.append(", ");
-        query.append("`");
-        query.append(b.getName());
-        query.append("`");
+        query.append(Identifier.quote(b.getName()));
         ++i;
       }
       query.append("]");
@@ -371,9 +370,7 @@ public class ArcadeGraph implements Graph, Closeable {
       for (final Bucket b : buckets) {
         if (i > 0)
           query.append(", ");
-        query.append("`");
-        query.append(b.getName());
-        query.append("`");
+        query.append(Identifier.quote(b.getName()));
         ++i;
       }
       query.append("]");

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.grpc;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.database.DatabaseContext;
@@ -3086,7 +3087,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private static String quoteName(final String name) {
     if (name == null || name.isEmpty())
       throw new IllegalArgumentException("SQL identifier must not be empty");
-    return "`" + name.replace("`", "\\`") + "`";
+    return Identifier.quote(name);
   }
 
   // Match an existing row by key and merge onto it; false when none matched (caller then inserts).

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -26,6 +26,7 @@ import com.arcadedb.query.sql.executor.IteratorResultSet;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.TypeIndexBuilder;
@@ -479,7 +480,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
           final Number limit = (Number) del.get("limit");
           final boolean single = limit != null && limit.intValue() == 1;
 
-          final StringBuilder sql = new StringBuilder("DELETE FROM `").append(collectionName).append('`');
+          final StringBuilder sql = new StringBuilder("DELETE FROM ").append(Identifier.quote(collectionName));
           appendWhere(sql, q);
           if (single)
             sql.append(" LIMIT 1");
@@ -556,7 +557,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     if (!database.getSchema().existsType(collectionName) || u == null)
       return 0;
 
-    final StringBuilder sql = new StringBuilder("UPDATE `").append(collectionName).append('`');
+    final StringBuilder sql = new StringBuilder("UPDATE ").append(Identifier.quote(collectionName));
     appendUpdateOperations(sql, u);
     appendWhere(sql, q);
     if (!multi)
@@ -637,12 +638,12 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
         for (final String field : operand.keySet()) {
           if (i++ > 0)
             sql.append(", ");
-          sql.append('`').append(field).append('`');
+          sql.append(MongoDBToSqlTranslator.quoteFieldPath(field));
         }
       }
       case "$inc" -> {
         for (final Map.Entry<String, Object> f : operand.entrySet())
-          sql.append(" SET `").append(f.getKey()).append("` += ").append((Number) f.getValue());
+          sql.append(" SET ").append(MongoDBToSqlTranslator.quoteFieldPath(f.getKey())).append(" += ").append((Number) f.getValue());
       }
       default -> throw new UnsupportedOperationException("Unsupported update operator '" + op + "'");
       }

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
@@ -19,6 +19,8 @@
 package com.arcadedb.mongo;
 
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.parser.Expression;
+import com.arcadedb.query.sql.parser.Identifier;
 import de.bwaldvogel.mongo.backend.Utils;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.bson.ObjectId;
@@ -45,7 +47,7 @@ public class MongoDBToSqlTranslator {
         } else
           throw new IllegalArgumentException("Invalid operator " + key);
       } else {
-        buffer.append(entry.getKey());
+        buffer.append(quoteFieldPath(entry.getKey()));
         buffer.append(" = ");
         buildValue(buffer, value);
       }
@@ -73,7 +75,7 @@ public class MongoDBToSqlTranslator {
           sql.append(" AND ");
 
         if (key != null)
-          sql.append(key);
+          sql.append(quoteFieldPath(key.toString()));
 
         buildExpression(sql, subKey, subValue);
 
@@ -159,12 +161,34 @@ public class MongoDBToSqlTranslator {
   }
 
   protected static void buildValue(final StringBuilder buffer, final Object value) {
-    if (value instanceof String) {
+    if (value instanceof String string) {
+      // the value is embedded in the statement, so it has to be escaped for a single-quoted literal: inlining it raw lets a
+      // quote in the value close the literal and append arbitrary SQL to the WHERE clause
       buffer.append('\'');
-      buffer.append(value);
+      buffer.append(Expression.encodeSingle(string));
       buffer.append('\'');
     } else
       buffer.append(value);
+  }
+
+  /**
+   * Quotes a field reference for embedding in a statement. A MongoDB field name is a dot-separated path, so each segment is quoted
+   * on its own: quoting the whole path would turn navigation into a single property whose name contains a dot.
+   */
+  protected static String quoteFieldPath(final String field) {
+    final int dot = field.indexOf('.');
+    if (dot < 0)
+      return Identifier.quote(field);
+
+    final StringBuilder buffer = new StringBuilder(field.length() + 8);
+    int start = 0;
+    for (int i = dot; i >= 0; i = field.indexOf('.', start)) {
+      if (start > 0)
+        buffer.append('.');
+      buffer.append(Identifier.quote(field.substring(start, i)));
+      start = i + 1;
+    }
+    return buffer.append('.').append(Identifier.quote(field.substring(start))).toString();
   }
 
   protected static void fillResultSet(final int numberToSkip, final int numberToReturn, final List<Document> result, final Iterator it) {

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBSqlInjectionTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBSqlInjectionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.result.UpdateResult;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.client.model.Filters.eq;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A MongoDB command is translated into a SQL statement, so every field name and every value taken off the wire is attacker
+ * controlled text that ends up inside that statement. Names are back-tick quoted and values single quoted; neither may be able to
+ * close its quoting and append clauses of its own.
+ */
+public class MongoDBSqlInjectionTest extends BaseGraphServerTest {
+
+  private static final int                       DEF_PORT = 27017;
+  private              MongoClient               client;
+  private              MongoCollection<Document> collection;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin");
+  }
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+    getDatabase(0);
+    client = new MongoClient(new ServerAddress("localhost", DEF_PORT));
+    client.getDatabase(getDatabaseName()).createCollection("doc");
+    collection = client.getDatabase(getDatabaseName()).getCollection("doc");
+    for (int i = 0; i < 5; i++)
+      collection.insertOne(new Document("name", "v" + i).append("victim", "present"));
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    if (client != null)
+      client.close();
+    super.endTest();
+  }
+
+  @Test
+  void aQuoteInAFilterValueCannotExtendTheWhereClause() {
+    // the crafted value closes the literal and adds an always-true disjunction, which would widen the update to every document
+    final UpdateResult result = collection.updateMany(new Document("name", "v1' OR 'x' = 'x"),
+        new Document("$set", new Document("pwned", "yes")));
+
+    assertThat(result.getModifiedCount()).isZero();
+    assertThat(collection.countDocuments(new Document("pwned", "yes"))).isZero();
+  }
+
+  @Test
+  void aBackTickInAnUnsetFieldNameCannotNameASecondProperty() {
+    // the crafted name closes the identifier and names a property the client never asked to remove
+    collection.updateOne(eq("name", "v1"), new Document("$unset", new Document("harmless`, `victim", "")));
+
+    final Document after = collection.find(eq("name", "v1")).first();
+    assertThat(after).isNotNull();
+    assertThat(after.containsKey("victim")).isTrue();
+  }
+
+  @Test
+  void aCraftedFilterFieldNameCannotBecomeAPredicate() {
+    // the field name is appended as an identifier, so it cannot introduce an always-true condition of its own
+    final UpdateResult result = collection.updateMany(new Document("1 = 1 OR name", "nomatch"),
+        new Document("$set", new Document("pwned", "yes")));
+
+    assertThat(result.getModifiedCount()).isZero();
+    assertThat(collection.countDocuments(new Document("pwned", "yes"))).isZero();
+  }
+
+  @Test
+  void ordinaryFiltersAndUpdatesStillWork() {
+    assertThat(collection.countDocuments(new Document("name", "v1"))).isEqualTo(1);
+
+    final UpdateResult result = collection.updateMany(new Document("name", "v2"),
+        new Document("$set", new Document("touched", "yes")));
+    assertThat(result.getModifiedCount()).isEqualTo(1);
+
+    collection.updateOne(eq("name", "v3"), new Document("$unset", new Document("victim", "")));
+    final Document after = collection.find(eq("name", "v3")).first();
+    assertThat(after).isNotNull();
+    assertThat(after.containsKey("victim")).isFalse();
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresQuotedIdentifierRewriter.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresQuotedIdentifierRewriter.java
@@ -252,7 +252,10 @@ public class PostgresQuotedIdentifierRewriter {
     out.append('`');
     for (int k = 0; k < identifier.length(); k++) {
       final char c = identifier.charAt(k);
-      if (c == '`')
+      // inside a back-tick identifier a backslash escapes the character that follows it, so both characters have to be escaped:
+      // leaving a backslash bare would make the engine read `My\Type` as MyType, and one before the closing back-tick would
+      // consume it
+      if (c == '`' || c == '\\')
         out.append('\\');
       out.append(c);
     }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresQuotedIdentifierRewriterTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresQuotedIdentifierRewriterTest.java
@@ -43,6 +43,18 @@ public class PostgresQuotedIdentifierRewriterTest {
   }
 
   @Test
+  void backslashInAQuotedNameIsEscapedOnTheWayOut() {
+    // inside a back-tick identifier a backslash escapes the character that follows it, so a backslash carried over from a
+    // Postgres double-quoted name has to be doubled or the engine reads `My\\Type` as MyType
+    assertThat(PostgresQuotedIdentifierRewriter.rewrite("SELECT FROM \"My\\Type\"")).isEqualTo("SELECT FROM `My\\\\Type`");
+  }
+
+  @Test
+  void backTickInAQuotedNameIsEscapedOnTheWayOut() {
+    assertThat(PostgresQuotedIdentifierRewriter.rewrite("SELECT FROM \"Back`Tick\"")).isEqualTo("SELECT FROM `Back\\`Tick`");
+  }
+
+  @Test
   void qualifiedIdentifiersAreTranslated() {
     assertThat(PostgresQuotedIdentifierRewriter.rewrite("SELECT \"c\".\"name\" FROM Character AS \"c\"")).isEqualTo(
         "SELECT `c`.`name` FROM Character AS `c`");

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -1479,7 +1479,7 @@ function createIndex(typeName) {
     let command = "CREATE INDEX";
     if (ifNotExists) command += " IF NOT EXISTS";
     command += " ON `" + typeName + "` (";
-    command += selectedProps.map(function (p) { return "`" + p + "`"; }).join(", ");
+    command += selectedProps.map(function (p) { return quoteSqlName(p); }).join(", ");
     command += ") " + indexTypeSql;
     if ((algorithm == "LSM_TREE" || algorithm == "HASH") && nullStrategy != "") command += " NULL_STRATEGY " + nullStrategy;
     if (metadataJson != null) command += " METADATA " + metadataJson;
@@ -1627,7 +1627,7 @@ function createType(category) {
     // Multiple parents
     let parents = $("#inputCreateTypeParents").val();
     if (parents && parents.length > 0)
-      command += " EXTENDS " + parents.map(function (p) { return "`" + p + "`"; }).join(", ");
+      command += " EXTENDS " + parents.map(function (p) { return quoteSqlName(p); }).join(", ");
 
     let buckets = $("#inputCreateTypeBuckets").val();
     if (buckets && parseInt(buckets) > 0)
@@ -4546,24 +4546,24 @@ function createGraphAnalyticalView() {
     if (vt)
       vt = vt.filter(function (v) { return v !== "__ALL__"; });
     if (vt && vt.length > 0)
-      command += " VERTEX TYPES (" + vt.map(function (v) { return "`" + v + "`"; }).join(", ") + ")";
+      command += " VERTEX TYPES (" + vt.map(function (v) { return quoteSqlName(v); }).join(", ") + ")";
 
     let et = $("#inputGavEdgeTypes").val();
     if (et)
       et = et.filter(function (e) { return e !== "__ALL__"; });
     if (et && et.length > 0)
-      command += " EDGE TYPES (" + et.map(function (e) { return "`" + e + "`"; }).join(", ") + ")";
+      command += " EDGE TYPES (" + et.map(function (e) { return quoteSqlName(e); }).join(", ") + ")";
 
     let props = $("#inputGavProperties").val().trim();
     if (props) {
-      let propList = props.split(",").map(function (p) { return "`" + p.trim() + "`"; }).filter(function (p) { return p !== "``"; });
+      let propList = props.split(",").filter(function (p) { return p.trim() !== ""; }).map(function (p) { return quoteSqlName(p.trim()); });
       if (propList.length > 0)
         command += " PROPERTIES (" + propList.join(", ") + ")";
     }
 
     let edgeProps = $("#inputGavEdgeProperties").val().trim();
     if (edgeProps) {
-      let edgePropList = edgeProps.split(",").map(function (p) { return "`" + p.trim() + "`"; }).filter(function (p) { return p !== "``"; });
+      let edgePropList = edgeProps.split(",").filter(function (p) { return p.trim() !== ""; }).map(function (p) { return quoteSqlName(p.trim()); });
       if (edgePropList.length > 0)
         command += " EDGE PROPERTIES (" + edgePropList.join(", ") + ")";
     }

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -2965,6 +2965,21 @@ function browseType(typeName) {
   });
 }
 
+// Quick-action helpers for the type and view detail panes. The SQL is built here, where quoteSqlName() applies, instead of
+// being spelled out inside an inline onclick attribute: a name embedded there would have to survive HTML decoding, JS string
+// parsing and SQL quoting at once, and only the first of those was handled.
+function browseRecords(typeName) {
+  executeCommand("sql", "select from " + quoteSqlName(typeName));
+}
+
+function browseRecordsWithConnections(typeName) {
+  executeCommand("sql", "select *, bothE() as `@edges` from " + quoteSqlName(typeName));
+}
+
+function countRecords(typeName) {
+  executeCommand("sql", "select count(*) from " + quoteSqlName(typeName));
+}
+
 function executeCommand(language, query) {
   globalResultset = null;
 
@@ -3531,10 +3546,10 @@ function showTypeDetail(typeName) {
   html += "<div class='db-detail-section'>";
   html += "<h6><i class='fa fa-play-circle'></i> Quick Actions</h6>";
   html += "<div class='d-flex flex-wrap gap-2'>";
-  html += "<button class='btn btn-sm db-action-btn' onclick='executeCommand(\"sql\", \"select from \\`" + row.name + "\\`\")'><i class='fa fa-table'></i> Browse records</button>";
+  html += "<button class='btn btn-sm db-action-btn' onclick='browseRecords(\"" + escapeHtml(row.name) + "\")'><i class='fa fa-table'></i> Browse records</button>";
   if (row.type == "vertex")
-    html += "<button class='btn btn-sm db-action-btn' onclick='executeCommand(\"sql\", \"select *, bothE() as \\`@edges\\` from \\`" + row.name + "\\`\")'><i class='fa fa-project-diagram'></i> With connections</button>";
-  html += "<button class='btn btn-sm db-action-btn' onclick='executeCommand(\"sql\", \"select count(*) from \\`" + row.name + "\\`\")'><i class='fa fa-calculator'></i> Count records</button>";
+    html += "<button class='btn btn-sm db-action-btn' onclick='browseRecordsWithConnections(\"" + escapeHtml(row.name) + "\")'><i class='fa fa-project-diagram'></i> With connections</button>";
+  html += "<button class='btn btn-sm db-action-btn' onclick='countRecords(\"" + escapeHtml(row.name) + "\")'><i class='fa fa-calculator'></i> Count records</button>";
   html += "<button class='btn btn-sm db-action-btn db-action-btn-danger' onclick='dropType(\"" + escapeHtml(row.name) + "\")'><i class='fa fa-trash'></i> Drop Type</button>";
   html += "</div>";
   html += "</div>";
@@ -4219,7 +4234,7 @@ function renderMaterializedViewsSidebarSection(views, isQuerySidebar) {
 
     if (isQuerySidebar) {
       html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
-      html += "onclick='executeCommand(\"sql\", \"select from \\`" + view.name + "\\`\"); return false;' ";
+      html += "onclick='browseRecords(\"" + escapeHtml(view.name) + "\"); return false;' ";
       html += "title='" + name + " (Materialized View)'>";
       html += "<span class='mv-status-dot " + statusClass + "'></span>";
       html += "<span class='sidebar-badge-name'>" + name + "</span>";
@@ -4263,7 +4278,7 @@ function renderMaterializedViewsSidebarBadges(views, isQuerySidebar) {
 
     if (isQuerySidebar) {
       html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
-      html += "onclick='executeCommand(\"sql\", \"select from \\`" + view.name + "\\`\"); return false;' ";
+      html += "onclick='browseRecords(\"" + escapeHtml(view.name) + "\"); return false;' ";
       html += "title='" + name + " (Materialized View)'>";
       html += "<span class='mv-status-dot " + statusClass + "'></span>";
       html += "<span class='sidebar-badge-name'>" + name + "</span>";
@@ -5052,7 +5067,7 @@ function showMaterializedViewDetail(viewName) {
   html += "<h6><i class='fa fa-play-circle'></i> Quick Actions</h6>";
   html += "<div class='d-flex flex-wrap gap-2'>";
   html += "<button class='btn btn-sm db-action-btn' onclick='refreshMaterializedView(\"" + escapeHtml(view.name) + "\")'><i class='fa fa-sync'></i> Refresh Now</button>";
-  html += "<button class='btn btn-sm db-action-btn' onclick='executeCommand(\"sql\", \"select from \\`" + view.name + "\\`\")'><i class='fa fa-table'></i> Browse Records</button>";
+  html += "<button class='btn btn-sm db-action-btn' onclick='browseRecords(\"" + escapeHtml(view.name) + "\")'><i class='fa fa-table'></i> Browse Records</button>";
   html += "<button class='btn btn-sm db-action-btn' onclick='alterMaterializedView(\"" + escapeHtml(view.name) + "\")'><i class='fa fa-pen'></i> Alter Refresh Mode</button>";
   html += "<button class='btn btn-sm db-action-btn db-action-btn-danger' onclick='dropMaterializedView(\"" + escapeHtml(view.name) + "\")'><i class='fa fa-trash'></i> Drop View</button>";
   html += "</div></div>";

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -909,7 +909,7 @@ function dropProperty(type, property) {
           url: "api/v1/command/" + database,
           data: JSON.stringify({
             language: "sql",
-            command: "drop property `" + type + "`.`" + property + "`",
+            command: "drop property " + quoteSqlName(type) + "." + quoteSqlName(property),
             serializer: "record",
           }),
           beforeSend: function (xhr) {
@@ -946,7 +946,7 @@ function dropIndex(indexName, type) {
           url: "api/v1/command/" + database,
           data: JSON.stringify({
             language: "sql",
-            command: "drop index `" + indexName + "`",
+            command: "drop index " + quoteSqlName(indexName),
             serializer: "record",
           }),
           beforeSend: function (xhr) {
@@ -1002,7 +1002,7 @@ function runRepartition(typeName) {
           url: "api/v1/command/" + database,
           data: JSON.stringify({
             language: "sql",
-            command: "REBUILD TYPE `" + typeName + "` WITH repartition = true",
+            command: "REBUILD TYPE " + quoteSqlName(typeName) + " WITH repartition = true",
             serializer: "record",
           }),
           beforeSend: function (xhr) {
@@ -1059,7 +1059,7 @@ function dropType(typeName) {
               url: "api/v1/command/" + database,
               data: JSON.stringify({
                 language: "sql",
-                command: "drop type `" + typeName + "` unsafe",
+                command: "drop type " + quoteSqlName(typeName) + " unsafe",
                 serializer: "record",
               }),
               beforeSend: function (xhr) {
@@ -1233,7 +1233,7 @@ function createProperty(typeName) {
     let compression = $("#inputCreatePropCompression").val();
     let ifNotExists = $("#inputCreatePropIfNotExists").prop("checked");
 
-    let command = "CREATE PROPERTY `" + typeName + "`.`" + name + "`";
+    let command = "CREATE PROPERTY " + quoteSqlName(typeName) + "." + quoteSqlName(name);
     if (ifNotExists) command += " IF NOT EXISTS";
     command += " " + type;
     if (ofType != "") command += " OF " + ofType;
@@ -1478,7 +1478,7 @@ function createIndex(typeName) {
 
     let command = "CREATE INDEX";
     if (ifNotExists) command += " IF NOT EXISTS";
-    command += " ON `" + typeName + "` (";
+    command += " ON " + quoteSqlName(typeName) + " (";
     command += selectedProps.map(function (p) { return quoteSqlName(p); }).join(", ");
     command += ") " + indexTypeSql;
     if ((algorithm == "LSM_TREE" || algorithm == "HASH") && nullStrategy != "") command += " NULL_STRATEGY " + nullStrategy;
@@ -1619,7 +1619,7 @@ function createType(category) {
       return;
     }
 
-    let command = "CREATE " + sqlKeyword + " TYPE `" + name + "`";
+    let command = "CREATE " + sqlKeyword + " TYPE " + quoteSqlName(name);
 
     if ($("#inputCreateTypeIfNotExists").prop("checked"))
       command += " IF NOT EXISTS";
@@ -1788,7 +1788,7 @@ function createTimeSeriesType() {
       return;
     }
 
-    let command = "CREATE TIMESERIES TYPE `" + name + "`";
+    let command = "CREATE TIMESERIES TYPE " + quoteSqlName(name);
 
     if ($("#tsCreateIfNotExists").prop("checked"))
       command += " IF NOT EXISTS";
@@ -2921,7 +2921,7 @@ function browseType(typeName) {
   if (!database) return;
 
   let limit = parseInt($("#inputLimit").val()) || 100;
-  let query = "select from `" + typeName + "`";
+  let query = "select from " + quoteSqlName(typeName);
 
   $("#inputLanguage").val("sql");
   editor.setValue(query);
@@ -4539,7 +4539,7 @@ function createGraphAnalyticalView() {
     let command = "CREATE GRAPH ANALYTICAL VIEW";
     if ($("#inputGavIfNotExists").prop("checked"))
       command += " IF NOT EXISTS";
-    command += " `" + name + "`";
+    command += " " + quoteSqlName(name);
 
     let vt = $("#inputGavVertexTypes").val();
     // Filter out the "All types" sentinel — no VERTEX TYPES clause means all
@@ -4804,7 +4804,7 @@ function dropGav(gavName) {
         url: "api/v1/command/" + database,
         data: JSON.stringify({
           language: "sql",
-          command: "DROP GRAPH ANALYTICAL VIEW `" + gavName + "`"
+          command: "DROP GRAPH ANALYTICAL VIEW " + quoteSqlName(gavName)
         }),
         beforeSend: function (xhr) {
           xhr.setRequestHeader("Authorization", globalCredentials);
@@ -4829,7 +4829,7 @@ function alterGavUpdateMode(gavName, newMode) {
     url: "api/v1/command/" + database,
     data: JSON.stringify({
       language: "sql",
-      command: "ALTER GRAPH ANALYTICAL VIEW `" + gavName + "` UPDATE MODE " + newMode
+      command: "ALTER GRAPH ANALYTICAL VIEW " + quoteSqlName(gavName) + " UPDATE MODE " + newMode
     }),
     beforeSend: function (xhr) {
       xhr.setRequestHeader("Authorization", globalCredentials);
@@ -4851,7 +4851,7 @@ function rebuildGav(gavName) {
     url: "api/v1/command/" + database,
     data: JSON.stringify({
       language: "sql",
-      command: "REBUILD GRAPH ANALYTICAL VIEW `" + gavName + "`"
+      command: "REBUILD GRAPH ANALYTICAL VIEW " + quoteSqlName(gavName)
     }),
     beforeSend: function (xhr) {
       xhr.setRequestHeader("Authorization", globalCredentials);
@@ -5139,7 +5139,7 @@ function createMaterializedView() {
       return;
     }
     let mode = $("input[name='mvRefreshMode']:checked").val();
-    let command = "CREATE MATERIALIZED VIEW `" + name + "` AS " + query;
+    let command = "CREATE MATERIALIZED VIEW " + quoteSqlName(name) + " AS " + query;
     if (mode != "MANUAL") {
       command += " REFRESH";
       if (mode == "PERIODIC") {
@@ -5215,7 +5215,7 @@ function refreshMaterializedView(name) {
           url: "api/v1/command/" + database,
           data: JSON.stringify({
             language: "sql",
-            command: "REFRESH MATERIALIZED VIEW `" + name + "`",
+            command: "REFRESH MATERIALIZED VIEW " + quoteSqlName(name),
             serializer: "record",
           }),
           beforeSend: function (xhr) {
@@ -5249,7 +5249,7 @@ function alterMaterializedView(name) {
 
   globalPrompt("Alter Materialized View: " + escapeHtml(name), html, "Alter", function () {
     let mode = $("input[name='mvAlterMode']:checked").val();
-    let command = "ALTER MATERIALIZED VIEW `" + name + "` REFRESH " + mode;
+    let command = "ALTER MATERIALIZED VIEW " + quoteSqlName(name) + " REFRESH " + mode;
     if (mode == "PERIODIC") {
       let interval = parseInt($("#mvAlterInterval").val()) || 5;
       let unit = $("#mvAlterIntervalUnit").val() || "MINUTE";
@@ -5303,7 +5303,7 @@ function dropMaterializedView(name) {
           url: "api/v1/command/" + database,
           data: JSON.stringify({
             language: "sql",
-            command: "DROP MATERIALIZED VIEW `" + name + "`",
+            command: "DROP MATERIALIZED VIEW " + quoteSqlName(name),
             serializer: "record",
           }),
           beforeSend: function (xhr) {
@@ -5650,7 +5650,7 @@ function refreshMvFromMetrics(name) {
   jQuery.ajax({
     type: "POST",
     url: "api/v1/command/" + database,
-    data: JSON.stringify({ language: "sql", command: "REFRESH MATERIALIZED VIEW `" + name + "`" }),
+    data: JSON.stringify({ language: "sql", command: "REFRESH MATERIALIZED VIEW " + quoteSqlName(name) }),
     beforeSend: function (xhr) { xhr.setRequestHeader("Authorization", globalCredentials); },
   }).done(function () {
     globalNotify("Success", "Materialized view '" + escapeHtml(name) + "' refreshed", "success");

--- a/studio/src/main/resources/static/js/studio-record-editor.js
+++ b/studio/src/main/resources/static/js/studio-record-editor.js
@@ -369,7 +369,7 @@ function saveRecordEditor() {
     } else
       sqlValue = "'" + current.replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "'";
 
-    setParts.push("`" + prop + "` = " + sqlValue);
+    setParts.push(quoteSqlName(prop) + " = " + sqlValue);
   });
 
   // Collect deleted properties (REMOVE)
@@ -377,7 +377,7 @@ function saveRecordEditor() {
   var curr = globalRecordEditorState.properties;
   for (var p in orig) {
     if (!curr.hasOwnProperty(p))
-      removeParts.push("`" + p + "`");
+      removeParts.push(quoteSqlName(p));
   }
 
   if (setParts.length === 0 && removeParts.length === 0) {

--- a/studio/src/main/resources/static/js/studio-timeseries.js
+++ b/studio/src/main/resources/static/js/studio-timeseries.js
@@ -659,7 +659,7 @@ function tsDropType() {
       jQuery.ajax({
         type: "POST",
         url: "api/v1/command/" + db,
-        data: JSON.stringify({ language: "sql", command: "DROP TYPE `" + typeName + "` IF EXISTS" }),
+        data: JSON.stringify({ language: "sql", command: "DROP TYPE " + quoteSqlName(typeName) + " IF EXISTS" }),
         contentType: "application/json",
         beforeSend: function (xhr) {
           xhr.setRequestHeader("Authorization", globalCredentials);
@@ -702,7 +702,7 @@ function tsAddDownsamplingPolicy(typeName) {
       return;
     }
 
-    var command = "ALTER TIMESERIES TYPE `" + typeName + "` ADD DOWNSAMPLING POLICY";
+    var command = "ALTER TIMESERIES TYPE " + quoteSqlName(typeName) + " ADD DOWNSAMPLING POLICY";
     for (var i = 0; i < tiers.length; i++)
       command += " AFTER " + tiers[i].after + " " + tiers[i].afterUnit + " GRANULARITY " + tiers[i].gran + " " + tiers[i].granUnit;
 
@@ -751,7 +751,7 @@ function tsDropDownsamplingPolicy(typeName) {
       jQuery.ajax({
         type: "POST",
         url: "api/v1/command/" + db,
-        data: JSON.stringify({ language: "sql", command: "ALTER TIMESERIES TYPE `" + typeName + "` DROP DOWNSAMPLING POLICY" }),
+        data: JSON.stringify({ language: "sql", command: "ALTER TIMESERIES TYPE " + quoteSqlName(typeName) + " DROP DOWNSAMPLING POLICY" }),
         contentType: "application/json",
         beforeSend: function (xhr) {
           xhr.setRequestHeader("Authorization", globalCredentials);

--- a/studio/src/main/resources/static/js/studio-utils.js
+++ b/studio/src/main/resources/static/js/studio-utils.js
@@ -168,9 +168,13 @@ function escapeHtml(unsafe) {
 /**
  * Wraps a schema object name (bucket, index, type) in back-ticks so it can be embedded in a SQL command even when it carries
  * characters that are not valid in a bare identifier - e.g. the comma in the auto-derived compound-index name `Type[propA,propB]`.
+ *
+ * Inside a back-tick quoted identifier a backslash escapes the character that follows it, so both metacharacters have to be
+ * escaped. Escaping only the back-tick would leave a name ending in a backslash able to consume the closing back-tick, and the
+ * SQL that followed the identifier would be absorbed into the name.
  */
 function quoteSqlName(name) {
-  return "`" + String(name).replace(/`/g, "\\`") + "`";
+  return "`" + String(name).replace(/[\\`]/g, "\\$&") + "`";
 }
 
 function arrayRemove(array, predicate) {


### PR DESCRIPTION
Fixes the CodeQL `js/incomplete-sanitization` alert
[#2311](https://github.com/ArcadeData/arcadedb/security/code-scanning/2311), the same defect at its source in the
engine, and every other place that builds a SQL statement by hand from a name or value it does not control.

> **Security note.** Tracing the alert surfaced a pre-existing SQL injection in the MongoDB wire protocol,
> unrelated to the grammar change and more serious than the alert itself. It is described below and fixed here.

## The defect

A schema object name may contain a back-tick or a backslash - all of `` Back`Tick ``, `Trail\` and `Mid\Slash`
are accepted by `createDocumentType`. The SQL spelling of such a name escapes it with a leading backslash, but
only the back-tick was ever escaped, which left the encoding ambiguous in both directions.

**Double escaping.** `setQuotedStringValue()` handed the already-escaped inner text to `setStringValue()`, which
escaped it a second time. The spelling grew one backslash per parse -> re-emit cycle, and the plain name came
back wrong, so addressing the type by name failed:

```
SELECT FROM `a\`b`     -- the type named a`b
  re-emitted as        SELECT FROM `a\\`b`
  resolved as          a\`b   ->  "Type with name 'a\`b' was not found"
```

**Token absorbing.** The lexer rule matched a backslash as an ordinary character and had no `\\` escape, so it
could not tell a closing back-tick from an escaped one. It ran past the end of the name and swallowed the SQL
after it:

```
UPDATE `T\` SET `v` = 1     -- " SET `" is consumed into the type name
```

The same applied to a bucket or index addressed through a `schema:<kind>:<name>` target, which is the path the
Studio uses.

## MongoDB protocol: SQL injection through field names and values

A MongoDB command is translated into SQL, and the field names and values taken off the wire were embedded with no
escaping. Any client able to send an `update` or `delete` could rewrite the statement. Verified against a running
server:

| Vector | Payload | Result |
| --- | --- | --- |
| Filter **value** | `updateMany({name: "v1' OR 'x' = 'x"}, {$set:{pwned:"yes"}})` | modified **all 5** documents, not 0 |
| `$unset` **field name** | key `` harmless`, `victim `` | destroyed the `victim` property, never named by the client |
| Filter **field name** | key `1 = 1 OR name` | emitted `1 = 1 OR name = 'nomatch'` - unquoted predicate |

The value vector is the reachable one: it applies to every update and delete filter, with no precondition. The
`find`/`count` path does not use this translator, which is why it is unaffected.

Fixed by escaping values for the literal they sit in (`Expression.encodeSingle`) and back-tick quoting every field
name one dot-separated segment at a time, so `a.b` stays navigation instead of becoming a single property named
`a.b`.

Escaping closes this. **Binding the values as parameters is the better shape** for the translator and is left as
follow-up work.

## The fix

A backslash now escapes the character that follows it, consistently across the lexer and every place that
applies or reverses the quoting:

- `SQLLexer.g4` - `QUOTED_IDENTIFIER` and `SCHEMA_QUOTED_NAME_PART` now read:

  ```antlr
  BACKTICK ( ~[`\\] | '\\' . )+ BACKTICK
  ```

- `Identifier` - a single-pass `escape`/`unescape` pair; `setQuotedStringValue()` stores the inner text verbatim
  instead of re-escaping it. Both keep a no-allocation fast path for the common unescaped name.
- `SchemaIdentifier.quoteName`/`unquoteName` - reuse those helpers rather than carrying their own partial copy.
- `studio-utils.js` `quoteSqlName()` - escapes both metacharacters.
- Every remaining schema-name interpolation in the Studio - 31 call sites across `studio-database.js`,
  `studio-record-editor.js` and `studio-timeseries.js` - now routes through `quoteSqlName()`. Most had **no**
  escaping at all, including the enclosing type name in `CREATE INDEX ... ON` and `CREATE TYPE`, which the
  grammar change would otherwise have silently altered (`validateTypeName()` rejects a back-tick but not a
  backslash).
- `PostgresQuotedIdentifierRewriter.translateQuotedIdentifier` escaped only the back-tick when writing a
  back-tick identifier, so a Postgres double-quoted name carrying a backslash lost it. It now escapes both,
  matching the read path in the same class, which already had these semantics.
- `Identifier.quoted(spelling)` builds a node from a quoted spelling without running the inner text through
  `escape()` only to discard the result, as the two AST builder call sites were doing.
- `Identifier.quote(name)` is the single place that spells a name for embedding in SQL. The remaining hand-built
  statements now use it: `grpcw/ArcadeDbGrpcService.java` quoted only the back-tick, and
  `gremlin/ArcadeGraph.java` did not quote bucket names at all (2 sites).
- The six Studio inline `onclick` handlers that built SQL inside an HTML attribute now call
  `browseRecords`/`browseRecordsWithConnections`/`countRecords`, so the statement is assembled in JS where
  `quoteSqlName()` applies and the name reaches the attribute through a single HTML escape - the same shape as the
  sibling buttons beside them.

## Breaking change

A literal backslash inside a quoted name has to be doubled - `` `C:\data` `` becomes `` `C:\\data` ``. A single
backslash directly before the closing back-tick now escapes it, leaving the name unterminated, so the statement
is rejected instead of silently absorbing what follows. Names without a backslash, including those with an
escaped back-tick, are unaffected. Recorded under Breaking Changes in `docs/release-26.8.1.md`.

## Verification

Both fixes were confirmed load-bearing by reverting them and watching the new tests fail:

- With the production change reverted, every new assertion fails, with the bug in the message
  (`Type with name 'Back\`Tick' was not found`).
- With **only** the grammar reverted, `backslashTerminatedNameDoesNotAbsorbFollowingSql` fails again - the
  `Identifier` fix alone is not sufficient.
- `IdentifierTest.backslashWithoutBackTickPreserved` pinned the old internal encoding and was updated; its
  behavioural assertion (a backslash in a name round-trips) is unchanged.

New tests:

- `QuotedIdentifierEscapingTest` (14) - escaping contract, re-emission idempotency, `schema:` name parts.
- `QuotedSchemaNameInjectionTest` (6) - end-to-end against a database: hostile names stay addressable, a
  following `WHERE` is not absorbed, a name crafted to close the identifier and append `DROP TYPE` is treated as
  a plain name, and a created type keeps the name it was given.
- `PostgresQuotedIdentifierRewriterTest` (+2) - back-tick and backslash escaped on the write path.

The Studio regression was confirmed by executing the unescaped spelling the Studio used to emit:

```
CREATE DOCUMENT TYPE `My\Type`   ->  existsType("My\Type") = false
                                     existsType("MyType")  = true
```

`MongoDBSqlInjectionTest` (4) - end-to-end through the Mongo wire protocol: a quoted value cannot extend the
`WHERE` clause, a back-tick in a `$unset` name cannot name a second property, a crafted filter field name cannot
become a predicate, and ordinary filters/updates still work. The three injection cases **fail without the fix**;
the fourth passes either way, so it is a real control.

Suites run green: full engine module (10288), OpenCypher (3820), postgresw (250), grpcw (172), mongodbw (27),
gremlin (BUILD SUCCESS).

## Left out of scope

- **Parameter binding for the MongoDB translator.** Escaping is correct, but binding values would remove the
  class of bug rather than the instance. Worth a follow-up issue.
- **The Studio's HTML-attribute escaping.** The inline-handler pattern - `onclick='dropType("<escaped>")'` - is
  used by roughly ten buttons and carries a documented double-escape hazard for names with embedded quotes
  (`studio-database.js:3345-3354`, where the remedy is a `data-*` attribute read via `dataset`). This PR removes
  the *SQL* layer from those attributes; converting the handlers themselves should be done uniformly across all
  of them, not for six in isolation.

`server/mcp/tools/MCPToolUtils.java:133` was reviewed and is safe: it rejects any identifier containing a
back-tick, and Cypher quotes by doubling rather than with a backslash.
