### PR TITLE
docs: name both auto-triage rules as they appear in the settings UI

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,8 +84,8 @@ alert that are not actionable there:
 
 | Rule | Covers |
 | ---- | ------ |
-| GitHub-curated preset, *Dismiss low impact issues for development-scoped dependencies* | Resource-exhaustion advisories: CWE-400, CWE-674, CWE-754, CWE-770, CWE-835 |
-| Custom rule | CWE-407 (inefficient algorithmic complexity), development scope only |
+| GitHub-curated preset, *Dismiss low-impact alerts for development-scoped dependencies* | Resource-exhaustion advisories: CWE-400, CWE-674, CWE-754, CWE-770, CWE-835 |
+| Custom rule, *Dismiss dev-scope algorithmic complexity* (`cwe:407 scope:development`) | CWE-407 (inefficient algorithmic complexity), development scope only |
 
 The custom rule exists because the curated preset dismisses an advisory only when
 *every* CWE on it is in the preset's set, so a ReDoS tagged CWE-400 **and**


### PR DESCRIPTION
## What does this PR do?

Corrects two rule names in the **How we triage dependency alerts** table added by #5538, so they match the labels on the Dependabot rules settings page. Two lines, documentation only.

```diff
-| GitHub-curated preset, *Dismiss low impact issues for development-scoped dependencies* | ...
+| GitHub-curated preset, *Dismiss low-impact alerts for development-scoped dependencies* | ...

-| Custom rule | CWE-407 (inefficient algorithmic complexity), development scope only |
+| Custom rule, *Dismiss dev-scope algorithmic complexity* (`cwe:407 scope:development`) | ... |
```

## Motivation

The surrounding prose presents the preset in italics as its name, so it reads as a verbatim label. It was not one: the actual label is *"Dismiss low-impact alerts for development-scoped dependencies"* ("low-impact alerts", not "low impact issues"). Anyone comparing the document against the settings page would fail to find a match and reasonably conclude the doc described a different rule.

The second line is a **deliberate scope addition beyond the naming fix**, flagged here for review. It records the custom rule's filter query verbatim because that query is genuinely hard to rediscover:

- The **Target alerts** field is a GitHub-search-style query box, not a plain value input, so entering `CWE-407` is rejected as an invalid value. The working form is `cwe:407` - key, colon, bare number, no `CWE-` prefix.
- GitHub's own documentation states the dependency scope values are `devDependency` or `runtime`. **The UI requires `development`.** The docs are wrong.

Both cost real time to establish against the live UI. If you would rather keep this PR to the naming correction alone, say so and the second line comes out.

## Related issues

Follows #5538, which added the section. Part of the Dependabot hygiene work in #5523, #5534, #5536.

## Additional Notes

Nothing else in the section changes. The CWE list attributed to the preset, the "does not mean ignored" paragraph, and the backstop reference are all untouched and remain accurate.

Verified: the corrected preset label and the custom rule name and query were read directly off `/settings/dependabot_rules`, where both rules are listed as Enabled. No em dashes, per the repository's writing convention.

## Checklist

- [ ] ~~I have run the build using `mvn clean package`~~ - **not applicable and not run.** Two lines of Markdown; no source, no build input.
- [ ] ~~My unit tests cover both failure and success scenarios~~ - **no unit tests added.** No behaviour to test.
