### PR TITLE
fix(engine) #5568: publish the vector index location map atomically instead of clearing and refilling it

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -112,4 +112,37 @@ Expected parameter(s): id
 
 To keep the old behaviour for a specific query, bind the name explicitly to `null`.
 
+## Vector index: the location cache no longer evicts, and `arcadedb.vectorIndex.locationCacheSize` is ignored
+
+**Behaviour change for operators.** `arcadedb.vectorIndex.locationCacheSize` (and the per-index
+`locationCacheSize` metadata) used to cap the in-memory location index of an `LSM_VECTOR` index and let it evict.
+That was never a cache bound. A location is the only record of which record a vector id belongs to and where its
+entry sits in the index file, and nothing on disk maps a vector id back to an offset, so an evicted entry could
+not be recovered - and every reader reads a missing location as deleted. A cap of 100 over 1000 live vectors made
+`countEntries()` report 100, and a query whose neighbours had been evicted dropped them
+([#5568](https://github.com/ArcadeData/arcadedb/issues/5568)).
+
+The limit dates from when the index held one location per *write*, so it grew with the write history. Issue #5516
+removed that: a tombstoned id releases its location, so residency now follows the number of **live** vectors.
+
+- **The setting is ignored** and reported once per index at `WARNING`. The `low-ram` profile no longer sets it.
+- **Plan for ~90 bytes per live vector** - about 90MB per million, 900MB at 10 million. This is the figure
+  `getStats()` now reports as `estimatedLocationIndexBytes`; it previously quoted the 24-byte payload and so
+  under-estimated the footprint several-fold.
+- **An index that appeared to work under a cap on a large corpus may now need a larger heap** instead of silently
+  under-reporting its size and losing vectors from searches. That is the intended trade: a wrong answer is worse
+  than a visible memory requirement.
+- A compaction transiently holds two copies of the location set while it publishes the new one.
+
+## Vector index: `countEntries()` is no longer torn by a concurrent graph rebuild
+
+A rebuild used to clear the live location index and refill it entry by entry. The write lock it held only
+serializes writers; `countEntries()` and `getStats()` take no lock, so they observed the map mid-refill and
+reported an arbitrary fraction of its real content - a different wrong number on each run, most visibly right
+after a `compact()`, because a compaction *is* a rebuild. A rebuild now publishes a fully populated replacement
+with a single reference assignment, so a reader sees either the whole old set or the whole new one, and the
+compaction publishes it inside the same critical section that swaps the data file - closing a window in which a
+search could resolve pre-compaction offsets against the new file
+([#5568](https://github.com/ArcadeData/arcadedb/issues/5568)).
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -129,6 +129,8 @@ removed that: a tombstoned id releases its location, so residency now follows th
 - **Plan for ~90 bytes per live vector** - about 90MB per million, 900MB at 10 million. This is the figure
   `getStats()` now reports as `estimatedLocationIndexBytes`; it previously quoted the 24-byte payload and so
   under-estimated the footprint several-fold.
+  [#5588](https://github.com/ArcadeData/arcadedb/issues/5588) tracks bringing that down to ~20 bytes by laying
+  the locations out in primitive arrays.
 - **An index that appeared to work under a cap on a large corpus may now need a larger heap** instead of silently
   under-reporting its size and losing vectors from searches. That is the intended trade: a wrong answer is worse
   than a visible memory requirement.

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -133,7 +133,12 @@ removed that: a tombstoned id releases its location, so residency now follows th
   the locations out in primitive arrays.
 - **An index that appeared to work under a cap on a large corpus may now need a larger heap** instead of silently
   under-reporting its size and losing vectors from searches. That is the intended trade: a wrong answer is worse
-  than a visible memory requirement.
+  than a visible memory requirement. Size it before upgrading if you had capped a very large corpus - 100M live
+  vectors is ~9GB resident.
+- **`estimatedLocationIndexBytes` steps up ~3.75x on upgrade** (24 -> 90 bytes per entry). Nothing changed about
+  the memory it describes; the stat used to quote the payload rather than the retained heap. Any dashboard or
+  alert threshold wired to it needs re-basing, and the same is true of `countEntries()` and `totalVectors` on an
+  index that had been capped - those were reporting the cap, not the index.
 - A compaction transiently holds two copies of the location set while it publishes the new one.
 
 ## Vector index: `countEntries()` is no longer torn by a concurrent graph rebuild

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -91,7 +91,6 @@ public enum GlobalConfiguration {
       } else if ("high-performance".equalsIgnoreCase(v)) {
         ASYNC_OPERATIONS_QUEUE_IMPL.setValue("fast");
         VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(-1);
-        VECTOR_INDEX_LOCATION_CACHE_SIZE.setValue(-1);
         VECTOR_INDEX_SEARCH_CACHE_MAX_HEAP_PERCENT.setValue(50);
         VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.setValue(50);
 
@@ -125,7 +124,8 @@ public enum GlobalConfiguration {
         SERVER_HTTP_IO_THREADS.setValue(cores > 8 ? 4 : 2);
         SERVER_HTTP_WORKER_THREADS.setValue(16);
         VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(10_000);
-        VECTOR_INDEX_LOCATION_CACHE_SIZE.setValue(10_000);
+        // VECTOR_INDEX_LOCATION_CACHE_SIZE is deliberately NOT capped here: it is not a cache, and bounding it
+        // made this profile drop live vectors from searches (issue #5568).
         VECTOR_INDEX_SEARCH_CACHE_SIZE.setValue(10_000);
 
         POLYGLOT_ENGINE_ENABLED.setValue(false);
@@ -643,10 +643,14 @@ public enum GlobalConfiguration {
 
   VECTOR_INDEX_LOCATION_CACHE_SIZE("arcadedb.vectorIndex.locationCacheSize", SCOPE.DATABASE,
       """
-      Maximum number of vector locations to cache in memory per vector index. \
-      Set to -1 for unlimited (backward compatible). \
-      Each entry uses ~56 bytes. Recommended: 100000 for datasets with 1M+ vectors (~5.6MB), \
-      -1 for smaller datasets.""",
+      DEPRECATED and ignored since issue #5568: the location index is always unlimited, and a positive value is \
+      reported once per index at WARNING. A vector location is the only record of which record a vector id belongs \
+      to and where its entry sits in the index file, and nothing on disk maps a vector id back to an offset, so \
+      evicting one destroyed that mapping rather than spilling it to a slower tier: the index under-reported its \
+      size, and any reader resolving an evicted id read it as deleted. The limit existed when the index held one \
+      location per write; issue #5516 made a tombstoned id release \
+      its location, so residency is now proportional to the live vectors (~90 bytes each) instead of to the write \
+      history.""",
       Integer.class, -1),
 
   VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE("arcadedb.vectorIndex.graphBuildCacheSize", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -615,14 +615,24 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * stays reachable for its in-flight readers while the new one is built, so a rebuild transiently holds two
    * location sets (~90 bytes per live entry each) instead of one. That is a bounded, promptly released spike and
    * the price of the atomicity.
+   * <p>
+   * The population loop runs under the write lock even though only the final store needs it. Hoisting it out would
+   * shorten the locked window, but it would also let an insert commit into the instance about to be discarded, so
+   * the loss window for a concurrent write would grow by the whole population. Holding the lock keeps exactly the
+   * exclusion the in-place refill had, and the loop is an in-memory map fill - tens of milliseconds on a 200K
+   * index, not the O(index size) document reads issue #5391 moved out of this lock.
    *
    * @param liveEntries the live set the index must hold, already pointing at the file that is current now
    */
   private void publishLocationIndex(final Collection<VectorEntryForGraphBuild> liveEntries) {
-    // The intermediate is a long: `size() * 4` overflows int past ~536M entries, and a negative capacity would
-    // fail the rebuild rather than merely sizing the map badly.
-    final VectorLocationIndex rebuilt = new VectorLocationIndex(getLocationCacheSize(),
-        (int) Math.min(Integer.MAX_VALUE, Math.max(16L, (long) liveEntries.size() * 4 / 3 + 1)));
+    // Size the map for what it will actually hold. A bounded cache FIFO-evicts down to its cap as the loop fills
+    // it, so sizing from the live count there would allocate a table for millions of entries to hold `maxSize` of
+    // them. The intermediate is a long: `size() * 4` overflows int past ~536M entries, and a negative capacity
+    // would fail the rebuild rather than merely sizing the map badly.
+    final int cacheSize = getLocationCacheSize();
+    final long resident = cacheSize > 0 ? Math.min(cacheSize, liveEntries.size()) : liveEntries.size();
+    final VectorLocationIndex rebuilt = new VectorLocationIndex(cacheSize,
+        (int) Math.min(Integer.MAX_VALUE, Math.max(16L, resident * 4 / 3 + 1)));
     for (final VectorEntryForGraphBuild entry : liveEntries)
       rebuilt.addOrUpdate(entry.vectorId, entry.isCompacted, entry.absoluteFileOffset, entry.rid, false);
     // The rebuilt index only knows the ids that are still live, so its high-water mark can be lower than the one

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -179,7 +179,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
   private final    AtomicInteger                 nextId;
   private final    AtomicReference<INDEX_STATUS> status;
   // Set once the ignored location-cache limit has been reported, so a rebuild does not repeat the warning.
-  private volatile boolean                       locationCacheCapReported;
+  // compareAndSet, not a plain flag: two threads racing the first call would otherwise both log it.
+  private final    AtomicBoolean                 locationCacheCapReported = new AtomicBoolean();
 
   // Graph file for persistent storage of graph topology
   // Allows lazy-loading graph from disk and avoiding expensive rebuilds
@@ -4814,7 +4815,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
     stats.put("vectorCacheMisses", searchCache != null ? searchCache.getMisses() : 0L);
 
     // NEW: Memory estimates
-    stats.put("estimatedLocationIndexBytes", (long) locations.size() * 24L);
+    // Quote the retained heap, not the 24-byte payload: this stat is what an operator sizes a heap from, and the
+    // payload-only figure it used to report under-estimated the location index several-fold (issue #5568).
+    stats.put("estimatedLocationIndexBytes",
+        (long) locations.size() * VectorLocationIndex.APPROX_RETAINED_BYTES_PER_LOCATION);
     stats.put("estimatedOrdinalMapBytes", ordinalToVectorId != null ?
         (long) ordinalToVectorId.length * 4L : 0L);
 
@@ -5263,8 +5267,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         metadata.locationCacheSize :
         database.getConfiguration().getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_LOCATION_CACHE_SIZE);
 
-    if (configured > 0 && !locationCacheCapReported) {
-      locationCacheCapReported = true;
+    if (configured > 0 && locationCacheCapReported.compareAndSet(false, true)) {
       LogManager.instance().log(this, Level.WARNING,
           """
           Ignoring a location cache limit of %d for vector index '%s': evicting a live vector location deletes the \

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -178,6 +178,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
   private volatile VectorLocationIndex           vectorIndex;
   private final    AtomicInteger                 nextId;
   private final    AtomicReference<INDEX_STATUS> status;
+  // Set once the ignored location-cache limit has been reported, so a rebuild does not repeat the warning.
+  private volatile boolean                       locationCacheCapReported;
 
   // Graph file for persistent storage of graph topology
   // Allows lazy-loading graph from disk and avoiding expensive rebuilds
@@ -625,14 +627,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @param liveEntries the live set the index must hold, already pointing at the file that is current now
    */
   private void publishLocationIndex(final Collection<VectorEntryForGraphBuild> liveEntries) {
-    // Size the map for what it will actually hold. A bounded cache FIFO-evicts down to its cap as the loop fills
-    // it, so sizing from the live count there would allocate a table for millions of entries to hold `maxSize` of
-    // them. The intermediate is a long: `size() * 4` overflows int past ~536M entries, and a negative capacity
-    // would fail the rebuild rather than merely sizing the map badly.
-    final int cacheSize = getLocationCacheSize();
-    final long resident = cacheSize > 0 ? Math.min(cacheSize, liveEntries.size()) : liveEntries.size();
-    final VectorLocationIndex rebuilt = new VectorLocationIndex(cacheSize,
-        (int) Math.min(Integer.MAX_VALUE, Math.max(16L, resident * 4 / 3 + 1)));
+    // The location index is always unlimited (see getLocationCacheSize), so it will hold every live entry and is
+    // sized for exactly that. The intermediate is a long: `size() * 4` overflows int past ~536M entries, and a
+    // negative capacity would fail the rebuild rather than merely sizing the map badly.
+    final VectorLocationIndex rebuilt = new VectorLocationIndex(getLocationCacheSize(),
+        (int) Math.min(Integer.MAX_VALUE, Math.max(16L, (long) liveEntries.size() * 4 / 3 + 1)));
     for (final VectorEntryForGraphBuild entry : liveEntries)
       rebuilt.addOrUpdate(entry.vectorId, entry.isCompacted, entry.absoluteFileOffset, entry.rid, false);
     // The rebuilt index only knows the ids that are still live, so its high-water mark can be lower than the one
@@ -2296,33 +2295,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
       LogManager.instance().log(this, Level.SEVERE, "Error building PQ for index %s: %s", indexName, e.getMessage());
       // Don't throw - PQ is optional, index can still work with exact search
     }
-  }
-
-  /**
-   * Build ordinal-to-vectorId mapping from current vectorIndex.
-   * For incremental builds, ordinals ARE vectorIds (identity mapping for non-deleted entries).
-   */
-  /**
-   * Build identity ordinal mapping for live builder: ordinal[i] = i for each active vectorId.
-   * The live builder uses vectorIds as graph ordinals directly (no remapping).
-   */
-  private int[] buildLiveOrdinalMapping() {
-    final int maxId = vectorIndex.getMaxVectorId();
-    final int[] mapping = new int[maxId + 1];
-    for (int i = 0; i <= maxId; i++)
-      mapping[i] = i;
-    return mapping;
-  }
-
-  /** Currently unused - kept alongside {@link #buildLiveOrdinalMapping()}, which is the one the live builder uses. */
-  private int[] buildOrdinalMapping() {
-    // Read the volatile field once: a rebuild publishes a replacement instance (issue #5568), and taking the ids
-    // from one generation and their locations from the next would silently drop live vectors from the mapping.
-    final VectorLocationIndex locations = vectorIndex;
-    return locations.getAllVectorIds().filter(id -> {
-      final VectorLocationIndex.VectorLocation loc = locations.getLocation(id);
-      return loc != null && !loc.deleted;
-    }).sorted().toArray();
   }
 
   /**
@@ -5262,31 +5234,51 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
-   * Get the location cache size from configuration (per-index metadata or global default).
+   * Size of the location index, which is always unlimited (issue #5568).
+   * <p>
+   * {@code arcadedb.vectorIndex.locationCacheSize} (and its per-index {@code locationCacheSize} metadata) used to
+   * cap the location index and let it evict. That is not a cache bound - it is data loss. A location is the only
+   * record of which RID a vector id belongs to and where its entry sits in the file; there is no vector id to
+   * offset index on disk, so an evicted entry cannot be recovered. Measured: a cap of 100 over 1000 live vectors
+   * makes {@code countEntries()} report 100 and {@link #getStats()} under-report by the same 900. Every reader
+   * that resolves a vector id reads a missing location as deleted (see the result loops of the search paths), so
+   * a query whose neighbours were evicted drops them; the small reproduction above still answered in full because
+   * its vectors were also in the in-memory delta buffer, which is not a guarantee an index can rely on.
+   * <p>
+   * The cap was introduced when the index held one location per WRITE, so it grew without bound on a re-embedding
+   * workload. Issue #5516 removed that: a tombstoned id releases its location, so residency is O(live vectors) -
+   * proportional to the data the user asked to index, and roughly 90 bytes each. Capping that buys a memory
+   * ceiling by silently returning wrong results, which is never the right trade for a database.
+   * <p>
+   * The setting is therefore honoured as a sizing hint only and reported once per index at WARNING. Bringing the
+   * footprint down is a storage question, not an eviction one: laying the locations out in primitive arrays
+   * indexed by vector id would cost ~20 bytes each instead of ~90, with no per-entry objects at all.
    *
-   * @return Maximum number of vector locations to cache, or -1 for unlimited
-   */
-  private int getLocationCacheSize() {
-    if (metadata != null && metadata.locationCacheSize > -1) {
-      return metadata.locationCacheSize;
-    }
-    return mutable.getDatabase().getConfiguration()
-        .getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_LOCATION_CACHE_SIZE);
-  }
-
-  /**
-   * Get the location cache size from configuration during initialization.
-   * Used when mutable is not yet initialized.
+   * @param database The database instance, since {@code mutable} may not be initialized yet
    *
-   * @param database The database instance
-   *
-   * @return Maximum number of vector locations to cache, or -1 for unlimited
+   * @return always -1, meaning unlimited
    */
   private int getLocationCacheSize(final DatabaseInternal database) {
-    if (metadata != null && metadata.locationCacheSize > -1) {
-      return metadata.locationCacheSize;
+    final int configured = metadata != null && metadata.locationCacheSize > -1 ?
+        metadata.locationCacheSize :
+        database.getConfiguration().getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_LOCATION_CACHE_SIZE);
+
+    if (configured > 0 && !locationCacheCapReported) {
+      locationCacheCapReported = true;
+      LogManager.instance().log(this, Level.WARNING,
+          """
+          Ignoring a location cache limit of %d for vector index '%s': evicting a live vector location deletes the \
+          only mapping from its vector id to its record, so a capped index silently drops vectors from searches. \
+          Locations are resident only for live vectors since issue #5516, so the index costs ~90 bytes per indexed \
+          vector regardless of this setting""",
+          configured, indexName);
     }
-    return database.getConfiguration().getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_LOCATION_CACHE_SIZE);
+    return -1;
+  }
+
+  /** @see #getLocationCacheSize(DatabaseInternal) - always -1. */
+  private int getLocationCacheSize() {
+    return getLocationCacheSize(mutable.getDatabase());
   }
 
   /**
@@ -5584,175 +5576,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (timer != null) {
       timer.cancel();
       inactivityTimer = null;
-    }
-  }
-
-  /**
-   * Get a vector location by ID, with fallback to page scanning if evicted from cache.
-   * This method provides transparent cache miss handling for bounded location caches.
-   * <p>
-   * NOTE: nothing calls this today. Every reader - the searches, the delta merge, the ordinal maps, the RID
-   * filters - goes straight to {@code vectorIndex.getLocation()}, so an entry evicted by a bounded
-   * {@code arcadedb.vectorIndex.locationCacheSize} reads as null and is treated as deleted instead of being
-   * reconstructed here. That makes the bounded mode lose vectors from searches until the next rebuild; wiring the
-   * readers through this method is the fix, and it is deliberately out of scope for issue #5568.
-   *
-   * @param vectorId The vector ID to look up
-   *
-   * @return The vector location, or null if not found
-   */
-  private VectorLocationIndex.VectorLocation getVectorLocation(final int vectorId) {
-    // One read of the volatile field for the whole method: a rebuild publishes a replacement instance (issue
-    // #5568), and re-reading would let the miss be answered against one generation and re-cached into the next,
-    // seeding the fresh index with an offset into the file the compaction just replaced. The cost of that choice is
-    // that a re-cache racing a swap lands on the detached generation and is lost, so the next miss on that id scans
-    // the pages again - a repeated reconstruction, never a wrong answer, and only while a rebuild is in flight.
-    final VectorLocationIndex locations = vectorIndex;
-
-    // Try cache first (O(1) lookup)
-    VectorLocationIndex.VectorLocation loc = locations.getLocation(vectorId);
-    if (loc != null) {
-      return loc;
-    }
-
-    // A tombstoned id has no location by design (issue #5516): nothing to reconstruct, and scanning the pages for it
-    // would return its pre-tombstone entry (page order returns the first match), resurrecting a deleted vector.
-    if (locations.isDeleted(vectorId))
-      return null;
-
-    // Cache miss - reconstruct by scanning pages (expensive but rare for LRU cache)
-    loc = reconstructLocationFromPages(vectorId);
-    if (loc != null) {
-      // Add back to cache for future access
-      locations.addOrUpdate(vectorId, loc.isCompacted, loc.absoluteFileOffset, loc.rid, loc.deleted);
-    }
-    return loc;
-  }
-
-  /**
-   * Reconstruct a vector location from pages when evicted from cache.
-   * Scans compacted index first (more likely for old vectors), then mutable index.
-   *
-   * @param vectorId The vector ID to find
-   *
-   * @return The reconstructed location, or null if not found
-   */
-  private VectorLocationIndex.VectorLocation reconstructLocationFromPages(final int vectorId) {
-    // Scan compacted index first (more likely to contain old vectors)
-    if (compactedSubIndex != null) {
-      final VectorLocationIndex.VectorLocation loc = scanPagesForVectorId(compactedSubIndex.getFileId(),
-          compactedSubIndex.getTotalPages(), vectorId, true);
-      if (loc != null)
-        return loc;
-    }
-
-    // Scan mutable index
-    return scanPagesForVectorId(mutable.getFileId(), mutable.getTotalPages(), vectorId, false);
-  }
-
-  /**
-   * Scan pages in a specific file to find a vector by ID.
-   * Similar to loadVectorsFromFile() but stops at first match.
-   *
-   * @param fileId      The file ID to scan
-   * @param totalPages  Number of pages in the file
-   * @param vectorId    The vector ID to find
-   * @param isCompacted True if scanning compacted file
-   *
-   * @return The vector location if found, null otherwise
-   */
-  private VectorLocationIndex.VectorLocation scanPagesForVectorId(final int fileId, final int totalPages,
-      final int vectorId,
-      final boolean isCompacted) {
-    for (int pageNum = 0; pageNum < totalPages; pageNum++) {
-      try {
-        final BasePage currentPage = mutable.getDatabase().getPageManager()
-            .getImmutablePage(new PageId(mutable.getDatabase(), fileId, pageNum), getPageSize(), false, false);
-
-        if (currentPage == null)
-          continue;
-
-        final int offsetFreeContent = currentPage.readInt(OFFSET_FREE_CONTENT);
-        final int numberOfEntries = currentPage.readInt(OFFSET_NUM_ENTRIES);
-
-        if (numberOfEntries == 0)
-          continue;
-
-        // Calculate header size
-        final int headerSize;
-        if (isCompacted && pageNum == 0) {
-          headerSize = HEADER_BASE_SIZE + (4 * 4); // base + 4 ints for metadata
-        } else {
-          headerSize = HEADER_BASE_SIZE;
-        }
-
-        // Calculate absolute file offset for this page's data
-        final long pageBaseOffset = ((long) fileId << 32) | (pageNum * getPageSize());
-
-        // Parse entries in this page
-        int entryOffset = headerSize;
-        for (int i = 0; i < numberOfEntries && entryOffset < offsetFreeContent; i++) {
-          final long entryFileOffset = pageBaseOffset + entryOffset;
-          final int id = currentPage.readInt(entryOffset);
-          entryOffset += 4;
-
-          // Check if this is the vector we're looking for
-          if (id == vectorId) {
-            // Found it! Read the rest of the entry
-            final int bucketId = currentPage.readInt(entryOffset);
-            entryOffset += 4;
-            final long position = currentPage.readLong(entryOffset);
-            entryOffset += 8;
-            final RID rid = new RID(bucketId, position);
-
-            final byte flags = currentPage.readByte(entryOffset);
-            entryOffset += 1;
-            final boolean deleted = (flags & 0x01) != 0;
-
-            // Skip vector data (if present)
-            // Entry format: id(4) + bucketId(4) + position(8) + flags(1) + [quantized data]
-            // We don't need to read the vector data, just return the location
-
-            return new VectorLocationIndex.VectorLocation(isCompacted, entryFileOffset, rid, deleted);
-          }
-
-          // Skip to next entry: bucketId(4) + position(8) + flags(1) + vector data
-          entryOffset += 4 + 8 + 1;
-
-          // Skip quantized vector data if present
-          if (metadata.quantizationType != VectorQuantizationType.NONE) {
-            final int quantizedSize = calculateQuantizedSize(metadata.dimensions, metadata.quantizationType);
-            entryOffset += quantizedSize;
-          }
-        }
-      } catch (final Exception e) {
-        LogManager.instance()
-            .log(this, Level.WARNING, "Error scanning page %d in file %d for vectorId %d: %s", pageNum, fileId,
-                vectorId,
-                e.getMessage());
-      }
-    }
-
-    return null; // Not found in this file
-  }
-
-  /**
-   * Calculate the size of quantized vector data in bytes.
-   *
-   * @param dimensions       Number of vector dimensions
-   * @param quantizationType Type of quantization
-   *
-   * @return Size in bytes
-   */
-  private int calculateQuantizedSize(final int dimensions, final VectorQuantizationType quantizationType) {
-    switch (quantizationType) {
-    case INT8:
-      return dimensions; // 1 byte per dimension
-    case BINARY:
-      return (dimensions + 7) / 8; // 1 bit per dimension, rounded up to bytes
-    case NONE:
-    default:
-      return 0;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -172,7 +172,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
   private volatile GraphState                    graphState;
   private volatile ImmutableGraphIndex           graphIndex;        // Current graph (OnHeap or OnDisk)
   private volatile int[]                         ordinalToVectorId; // Maps graph ordinals to vector IDs
-  private final    VectorLocationIndex           vectorIndex;       // Lightweight pointer index
+  // Lightweight pointer index. Volatile and swapped as a whole (never cleared and refilled in place) so the
+  // lock-free readers - countEntries(), the `size() == 0` short-circuits of the search paths, getStats() - always
+  // see a complete location set instead of a rebuild in progress (issue #5568).
+  private volatile VectorLocationIndex           vectorIndex;
   private final    AtomicInteger                 nextId;
   private final    AtomicReference<INDEX_STATUS> status;
 
@@ -383,11 +386,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * filesystem: leaving the old file behind was why compaction used to make the index bigger, not smaller.
    *
    * @param liveEntries the live set, re-pointed in place at the new file
+   *
+   * @return true when the file was actually rewritten and the location index re-published with it, false when the
+   * rewrite was skipped
    */
-  private void rewriteDataFileWithLiveEntries(final Collection<VectorEntryForGraphBuild> liveEntries) {
+  private boolean rewriteDataFileWithLiveEntries(final Collection<VectorEntryForGraphBuild> liveEntries) {
     if (liveEntries.isEmpty()) {
       LogManager.instance().log(this, Level.INFO, "Skipping compaction of vector index '%s': no live vectors", indexName);
-      return;
+      return false;
     }
 
     for (final VectorEntryForGraphBuild entry : liveEntries)
@@ -399,7 +405,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             "Skipping compaction of vector index '%s': the live set contains vectors recovered outside the index "
                 + "pages, so no space was reclaimed. Retry once a rebuild has persisted them",
             indexName);
-        return;
+        return false;
       }
 
     final DatabaseInternal database = getDatabase();
@@ -504,6 +510,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
         currentInsertPageNum = newPages.size() - 1;
         currentMutablePages.set(1);
 
+        // Re-point the location index at the new file in the SAME critical section that swapped it (issue #5568).
+        // The entries above already carry their new offsets; leaving the swap to the caller would open a window in
+        // which the index answers offsets into a file that no longer exists - a search landing there reads another
+        // entry's bytes, or the dropped compacted component through a null reference.
+        publishLocationIndex(liveEntries);
+
         ((LocalSchema) database.getSchema()).setMigratedFileId(oldFileId, newFileId);
         database.getSchema().getEmbedded().saveConfiguration();
 
@@ -524,6 +536,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       dropReplacedComponent(previousMutable);
       dropReplacedComponent(previousCompacted);
 
+      return true;
     } finally {
       if (newFileId > -1)
         database.getTransactionManager().unlockFile(newFileId, Thread.currentThread());
@@ -576,6 +589,35 @@ public class LSMVectorIndex implements Index, IndexInternal {
       LogManager.instance().log(this, Level.WARNING, "Error dropping the file replaced by the compaction of '%s': %s",
           indexName, e.getMessage());
     }
+  }
+
+  /**
+   * Replace the location index with one holding exactly {@code liveEntries}, published by a single reference
+   * assignment to the volatile field (issue #5568).
+   * <p>
+   * The replacement is populated on a DETACHED instance on purpose. Refilling the live index in place - clear()
+   * followed by one addOrUpdate per entry - is atomic only for the writers, which all hold the index write lock;
+   * every reader of the location index is lock-free by design ({@link #countEntries()}, {@link #getStats()}, the
+   * {@code vectorIndex.size() == 0} short-circuits on the search paths, the RID filters) and observed the map
+   * mid-refill, seeing an arbitrary fraction of its real content. That is what made {@code countEntries()} report a
+   * different wrong number on each run after a compaction: the rebuild the compaction triggers was still refilling
+   * the map while the caller counted it. A count is the visible symptom; a search that runs in the same window
+   * short-circuits on an apparently empty index and returns nothing.
+   * <p>
+   * Callers must hold the write lock: it is what keeps a concurrent insert or remove from mutating the instance
+   * being replaced (its mutation would be dropped by the swap), not what protects the readers.
+   *
+   * @param liveEntries the live set the index must hold, already pointing at the file that is current now
+   */
+  private void publishLocationIndex(final Collection<VectorEntryForGraphBuild> liveEntries) {
+    final VectorLocationIndex rebuilt = new VectorLocationIndex(getLocationCacheSize(),
+        Math.max(16, liveEntries.size() * 4 / 3 + 1));
+    for (final VectorEntryForGraphBuild entry : liveEntries)
+      rebuilt.addOrUpdate(entry.vectorId, entry.isCompacted, entry.absoluteFileOffset, entry.rid, false);
+    // The rebuilt index only knows the ids that are still live, so its high-water mark can be lower than the one
+    // already handed out. Carry the sequence over, or the next insert would reuse an id a tombstone still refers to.
+    rebuilt.setNextId(Math.max(rebuilt.getNextId(), nextId.get()));
+    vectorIndex = rebuilt;
   }
 
   /**
@@ -1546,8 +1588,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // about to be built on. Doing it in the rebuild instead of in a separate compactor is what keeps the two from
     // disagreeing on what "live" means. Entries are re-pointed at the new file below, so everything downstream
     // (validation, preload, vectorIndex re-sync, graph build) transparently uses the compacted file.
-    if (compactDataFile)
-      rewriteDataFileWithLiveEntries(ridToLatestVector.values());
+    // A completed rewrite already re-published the location index against the new file, inside the critical section
+    // that swapped it - re-publishing an identical copy below would only reopen the window it closed (issue #5568).
+    final boolean locationIndexAlreadyPublished = compactDataFile && rewriteDataFileWithLiveEntries(
+        ridToLatestVector.values());
 
     // Rebuild ordinal mapping (may have changed after document scan fallback)
     final int[] finalActiveVectorIdsFromPages = ridToLatestVector.values().stream()
@@ -1563,14 +1607,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final int[] vectorIds;
     try {
       // CRITICAL: If we couldn't read any entries from pages (e.g., during database close),
-      // DON'T clear vectorIndex - use what's already in memory!
+      // DON'T replace vectorIndex - use what's already in memory!
       if (!ridToLatestVector.isEmpty()) {
-        // Update vectorIndex to match what we found on pages (sync it with disk state)
-        // This ensures vectorIndex is consistent with the graph we're about to build
-        vectorIndex.clear();
-        for (final VectorEntryForGraphBuild entry : ridToLatestVector.values()) {
-          vectorIndex.addOrUpdate(entry.vectorId, entry.isCompacted, entry.absoluteFileOffset, entry.rid, false);
-        }
+        // Update vectorIndex to match what we found on pages (sync it with disk state).
+        if (!locationIndexAlreadyPublished)
+          publishLocationIndex(ridToLatestVector.values());
         vectorIds = finalActiveVectorIdsFromPages; // Use vector IDs from pages (may include doc-scan fallback)
       } else {
         LogManager.instance().log(this, Level.SEVERE,
@@ -2253,8 +2294,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   private int[] buildOrdinalMapping() {
-    return vectorIndex.getAllVectorIds().filter(id -> {
-      final VectorLocationIndex.VectorLocation loc = vectorIndex.getLocation(id);
+    // Read the volatile field once: a rebuild publishes a replacement instance (issue #5568), and taking the ids
+    // from one generation and their locations from the next would silently drop live vectors from the mapping.
+    final VectorLocationIndex locations = vectorIndex;
+    return locations.getAllVectorIds().filter(id -> {
+      final VectorLocationIndex.VectorLocation loc = locations.getLocation(id);
       return loc != null && !loc.deleted;
     }).sorted().toArray();
   }
@@ -5527,22 +5571,27 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @return The vector location, or null if not found
    */
   private VectorLocationIndex.VectorLocation getVectorLocation(final int vectorId) {
+    // One read of the volatile field for the whole method: a rebuild publishes a replacement instance (issue
+    // #5568), and re-reading would let the miss be answered against one generation and re-cached into the next,
+    // seeding the fresh index with an offset into the file the compaction just replaced.
+    final VectorLocationIndex locations = vectorIndex;
+
     // Try cache first (O(1) lookup)
-    VectorLocationIndex.VectorLocation loc = vectorIndex.getLocation(vectorId);
+    VectorLocationIndex.VectorLocation loc = locations.getLocation(vectorId);
     if (loc != null) {
       return loc;
     }
 
     // A tombstoned id has no location by design (issue #5516): nothing to reconstruct, and scanning the pages for it
     // would return its pre-tombstone entry (page order returns the first match), resurrecting a deleted vector.
-    if (vectorIndex.isDeleted(vectorId))
+    if (locations.isDeleted(vectorId))
       return null;
 
     // Cache miss - reconstruct by scanning pages (expensive but rare for LRU cache)
     loc = reconstructLocationFromPages(vectorId);
     if (loc != null) {
       // Add back to cache for future access
-      vectorIndex.addOrUpdate(vectorId, loc.isCompacted, loc.absoluteFileOffset, loc.rid, loc.deleted);
+      locations.addOrUpdate(vectorId, loc.isCompacted, loc.absoluteFileOffset, loc.rid, loc.deleted);
     }
     return loc;
   }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -5256,7 +5256,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * <p>
    * The setting is therefore honoured as a sizing hint only and reported once per index at WARNING. Bringing the
    * footprint down is a storage question, not an eviction one: laying the locations out in primitive arrays
-   * indexed by vector id would cost ~20 bytes each instead of ~90, with no per-entry objects at all.
+   * indexed by vector id would cost ~20 bytes each instead of ~90, with no per-entry objects at all (issue
+   * #5588).
    *
    * @param database The database instance, since {@code mutable} may not be initialized yet
    *

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -606,6 +606,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * <p>
    * Callers must hold the write lock: it is what keeps a concurrent insert or remove from mutating the instance
    * being replaced (its mutation would be dropped by the swap), not what protects the readers.
+   * <p>
+   * The CPU cost is the same as the in-place refill it replaces, but peak heap is not: the instance being replaced
+   * stays reachable for its in-flight readers while the new one is built, so a rebuild transiently holds two
+   * location sets (~90 bytes per live entry each) instead of one. That is a bounded, promptly released spike and
+   * the price of the atomicity.
    *
    * @param liveEntries the live set the index must hold, already pointing at the file that is current now
    */
@@ -5573,7 +5578,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
   private VectorLocationIndex.VectorLocation getVectorLocation(final int vectorId) {
     // One read of the volatile field for the whole method: a rebuild publishes a replacement instance (issue
     // #5568), and re-reading would let the miss be answered against one generation and re-cached into the next,
-    // seeding the fresh index with an offset into the file the compaction just replaced.
+    // seeding the fresh index with an offset into the file the compaction just replaced. The cost of that choice is
+    // that a re-cache racing a swap lands on the detached generation and is lost, so the next miss on that id scans
+    // the pages again - a repeated reconstruction, never a wrong answer, and only while a rebuild is in flight.
     final VectorLocationIndex locations = vectorIndex;
 
     // Try cache first (O(1) lookup)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -173,8 +173,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
   private volatile ImmutableGraphIndex           graphIndex;        // Current graph (OnHeap or OnDisk)
   private volatile int[]                         ordinalToVectorId; // Maps graph ordinals to vector IDs
   // Lightweight pointer index. Volatile and swapped as a whole (never cleared and refilled in place) so the
-  // lock-free readers - countEntries(), the `size() == 0` short-circuits of the search paths, getStats() - always
-  // see a complete location set instead of a rebuild in progress (issue #5568).
+  // readers that take no lock - countEntries() and getStats() - always see a complete location set instead of a
+  // rebuild in progress (issue #5568). Everything else reaches it through lock.readLock().
   private volatile VectorLocationIndex           vectorIndex;
   private final    AtomicInteger                 nextId;
   private final    AtomicReference<INDEX_STATUS> status;
@@ -596,13 +596,17 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * assignment to the volatile field (issue #5568).
    * <p>
    * The replacement is populated on a DETACHED instance on purpose. Refilling the live index in place - clear()
-   * followed by one addOrUpdate per entry - is atomic only for the writers, which all hold the index write lock;
-   * every reader of the location index is lock-free by design ({@link #countEntries()}, {@link #getStats()}, the
-   * {@code vectorIndex.size() == 0} short-circuits on the search paths, the RID filters) and observed the map
-   * mid-refill, seeing an arbitrary fraction of its real content. That is what made {@code countEntries()} report a
-   * different wrong number on each run after a compaction: the rebuild the compaction triggers was still refilling
-   * the map while the caller counted it. A count is the visible symptom; a search that runs in the same window
-   * short-circuits on an apparently empty index and returns nothing.
+   * followed by one addOrUpdate per entry - is atomic only for whoever holds the index lock. The searches do
+   * ({@code lock.readLock()} covers their {@code vectorIndex.size() == 0} short-circuit and the RID filters), but
+   * {@link #countEntries()} and {@link #getStats()} take no lock at all, and they observed the map mid-refill and
+   * reported an arbitrary fraction of its real content - a different wrong number on each run after a compaction,
+   * because the rebuild a compaction triggers was still refilling the map while the caller counted it.
+   * <p>
+   * A swap fixes that without putting a lock on a read path, and it is what makes the invariant structural rather
+   * than a rule every future reader has to remember. It also covers a hazard the read lock cannot: a compaction
+   * swaps the data file in one write-locked section and used to re-publish the locations in a later one, so a
+   * search could take the read lock in between and resolve old offsets against the new file. That is why the
+   * compaction publishes from inside the section that swaps the file.
    * <p>
    * Callers must hold the write lock: it is what keeps a concurrent insert or remove from mutating the instance
    * being replaced (its mutation would be dropped by the swap), not what protects the readers.
@@ -615,8 +619,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @param liveEntries the live set the index must hold, already pointing at the file that is current now
    */
   private void publishLocationIndex(final Collection<VectorEntryForGraphBuild> liveEntries) {
+    // The intermediate is a long: `size() * 4` overflows int past ~536M entries, and a negative capacity would
+    // fail the rebuild rather than merely sizing the map badly.
     final VectorLocationIndex rebuilt = new VectorLocationIndex(getLocationCacheSize(),
-        Math.max(16, liveEntries.size() * 4 / 3 + 1));
+        (int) Math.min(Integer.MAX_VALUE, Math.max(16L, (long) liveEntries.size() * 4 / 3 + 1)));
     for (final VectorEntryForGraphBuild entry : liveEntries)
       rebuilt.addOrUpdate(entry.vectorId, entry.isCompacted, entry.absoluteFileOffset, entry.rid, false);
     // The rebuilt index only knows the ids that are still live, so its high-water mark can be lower than the one
@@ -2298,6 +2304,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     return mapping;
   }
 
+  /** Currently unused - kept alongside {@link #buildLiveOrdinalMapping()}, which is the one the live builder uses. */
   private int[] buildOrdinalMapping() {
     // Read the volatile field once: a rebuild publishes a replacement instance (issue #5568), and taking the ids
     // from one generation and their locations from the next would silently drop live vectors from the mapping.
@@ -4776,12 +4783,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
   public Map<String, Long> getStats() {
     final Map<String, Long> stats = new HashMap<>();
 
-    // Existing metrics
-    stats.put("totalVectors", (long) vectorIndex.size());
-    stats.put("activeVectors", vectorIndex.getActiveCount());
+    // Existing metrics. One read of the volatile field for the whole snapshot: a rebuild publishes a replacement
+    // instance (issue #5568), and three separate reads could each land on a different generation and report three
+    // numbers that never described the same index.
+    final VectorLocationIndex locations = vectorIndex;
+    stats.put("totalVectors", (long) locations.size());
+    stats.put("activeVectors", locations.getActiveCount());
     // Ask the deleted-id set instead of subtracting: a tombstoned id keeps no resident location since issue #5516,
     // so size() - activeCount() is always 0 now and this stat would report "no deletions" on an index full of them.
-    stats.put("deletedVectors", (long) vectorIndex.getDeletedCount());
+    stats.put("deletedVectors", (long) locations.getDeletedCount());
     stats.put("dimensions", (long) metadata.dimensions);
     stats.put("maxConnections", (long) metadata.maxConnections);
     stats.put("beamWidth", (long) metadata.beamWidth);
@@ -4822,7 +4832,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     stats.put("vectorCacheMisses", searchCache != null ? searchCache.getMisses() : 0L);
 
     // NEW: Memory estimates
-    stats.put("estimatedLocationIndexBytes", (long) vectorIndex.size() * 24L);
+    stats.put("estimatedLocationIndexBytes", (long) locations.size() * 24L);
     stats.put("estimatedOrdinalMapBytes", ordinalToVectorId != null ?
         (long) ordinalToVectorId.length * 4L : 0L);
 
@@ -5570,6 +5580,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
   /**
    * Get a vector location by ID, with fallback to page scanning if evicted from cache.
    * This method provides transparent cache miss handling for bounded location caches.
+   * <p>
+   * NOTE: nothing calls this today. Every reader - the searches, the delta merge, the ordinal maps, the RID
+   * filters - goes straight to {@code vectorIndex.getLocation()}, so an entry evicted by a bounded
+   * {@code arcadedb.vectorIndex.locationCacheSize} reads as null and is treated as deleted instead of being
+   * reconstructed here. That makes the bounded mode lose vectors from searches until the next rebuild; wiring the
+   * readers through this method is the fix, and it is deliberately out of scope for issue #5568.
    *
    * @param vectorId The vector ID to look up
    *

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorLocationIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorLocationIndex.java
@@ -31,8 +31,9 @@ import java.util.stream.IntStream;
 
 /**
  * Lightweight index that stores only vector location metadata (absolute file offset, RID)
- * instead of the full vector data. This dramatically reduces memory usage:
- * ~24 bytes per vector vs ~3KB for a 768-dimension vector.
+ * instead of the full vector data. This dramatically reduces memory usage: the payload of one location is ~24
+ * bytes, and it retains {@link #APPROX_RETAINED_BYTES_PER_LOCATION} once the map and object overheads around it
+ * are counted, against ~3KB for a 768-dimension vector.
  * <p>
  * Uses absolute file offsets for direct random access without loading full pages.
  * <p>
@@ -52,6 +53,16 @@ import java.util.stream.IntStream;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class VectorLocationIndex {
+  /**
+   * Approximate retained heap of one live location, and the single figure every caller and document should quote.
+   * Enumerated in issue #5516: the {@link VectorLocation} and the {@link RID} it points at, the boxed
+   * {@code Integer} key, the map node and its table slot, and the entry the id owns in the RID reverse index. The
+   * 24 bytes of payload it carries are only a fraction of that, which is why sizing an index off the payload
+   * under-estimates it several-fold. An estimate, not a measurement: the exact layout depends on the JVM and on
+   * whether compressed oops are in play.
+   */
+  public static final int APPROX_RETAINED_BYTES_PER_LOCATION = 90;
+
   private final Map<Integer, VectorLocation> locations;
   // Reverse index RID -> vector ids, mirroring the keys stored in `locations`. Lets remove(keys, rid) resolve the
   // vector ids for a single RID in O(k) instead of scanning every id in the index (issue #5318). Kept perfectly in

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorLocationIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorLocationIndex.java
@@ -42,6 +42,12 @@ import java.util.stream.IntStream;
  * rebuild - 1.2MB for the 9.3M ids that used to cost 970MB.
  * <p>
  * Used by LSMVectorIndex to implement lazy-loading of vectors from disk.
+ * <p>
+ * The bounded ({@code maxSize > 0}) backend below evicts, and {@link LSMVectorIndex} deliberately never asks for
+ * it (issue #5568): there is no vector id to offset index on disk, so an evicted location cannot be recovered, and
+ * every reader reads "no location" as "deleted". Bounding it made the index under-report its size and exposed any
+ * reader resolving an evicted id to a false "deleted". Do not wire {@code arcadedb.vectorIndex.locationCacheSize}
+ * back into the constructor without first giving the file a lookup that makes a miss recoverable.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/test/java/com/arcadedb/LowRamProfileTest.java
+++ b/engine/src/test/java/com/arcadedb/LowRamProfileTest.java
@@ -72,7 +72,11 @@ class LowRamProfileTest {
 
     // VECTOR INDEX CAPS
     assertThat(GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.getValueAsInteger()).isEqualTo(10_000);
-    assertThat(GlobalConfiguration.VECTOR_INDEX_LOCATION_CACHE_SIZE.getValueAsInteger()).isEqualTo(10_000);
+    // The location index is deliberately NOT capped, even here (issue #5568): it is not a cache of something
+    // recomputable - evicting an entry destroys the only mapping from a vector id to its record, so this profile
+    // used to make an index under-report its size and read evicted ids as deleted. Saving RAM by returning wrong
+    // answers is not a trade a low-memory profile gets to make.
+    assertThat(GlobalConfiguration.VECTOR_INDEX_LOCATION_CACHE_SIZE.getValueAsInteger()).isEqualTo(-1);
 
     // POLYGLOT ENGINE DISABLED -- avoids loading GraalVM Truffle + every language jar at startup
     assertThat(GlobalConfiguration.POLYGLOT_ENGINE_ENABLED.getValueAsBoolean()).isFalse();

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
@@ -1288,6 +1288,61 @@ class LSMVectorIndexTest extends TestHelper {
     assertThat(typeIndex.countEntries()).as("Count after the compactions").isEqualTo(numVectors);
   }
 
+  /**
+   * Issue #5568: a configured {@code arcadedb.vectorIndex.locationCacheSize} must not evict live vectors.
+   * <p>
+   * The limit used to bound the location index and let it FIFO-evict. A location is the only record of which
+   * record a vector id belongs to and where its entry sits in the file, and nothing on disk maps a vector id back
+   * to an offset, so an evicted entry did not fall back to a slower path - the mapping was gone. With the values
+   * below the index reported 100 of its 1000 vectors, and every reader that resolves one of the 900 evicted ids
+   * reads it as deleted. The limit is now honoured as a sizing hint only.
+   */
+  @Test
+  void aConfiguredLocationCacheLimitDoesNotDropVectors() {
+    final int locationCacheLimit = 100;
+    final int numVectors = 1000;
+    final int neighbours = 50;
+
+    // Per-database, so it is dropped with the database and cannot leak into the rest of the suite.
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_LOCATION_CACHE_SIZE, locationCacheLimit);
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE CappedLocations IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY CappedLocations.vec IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON CappedLocations (vec) LSM_VECTOR \
+          METADATA {dimensions: 4, similarity: 'COSINE'}\
+          """);
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < numVectors; i++) {
+        final var vertex = database.newVertex("CappedLocations");
+        vertex.set("vec", new float[] { (float) i, (float) i + 1, (float) i + 2, (float) i + 3 });
+        vertex.save();
+      }
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("CappedLocations[vec]");
+    final LSMVectorIndex lsmIndex = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+    assertThat(typeIndex.countEntries())
+        .as("Every indexed vector must stay resident even with a location cache limit of " + locationCacheLimit)
+        .isEqualTo(numVectors);
+
+    // Smoke check on the search path with the same limit configured. This one passed even while the cap was
+    // evicting - the query's neighbours were still in the in-memory delta buffer - so it is not the regression
+    // guard, the count above is. It is here to prove the search API stays whole once eviction is gone.
+    database.transaction(() -> {
+      final var cursor = lsmIndex.get(new Object[] { new float[] { 10.0f, 11.0f, 12.0f, 13.0f } }, neighbours);
+      int found = 0;
+      while (cursor.hasNext()) {
+        cursor.next();
+        found++;
+      }
+      assertThat(found).as("A k-NN query should return k results").isEqualTo(neighbours);
+    });
+  }
+
   @Test
   void vectorNeighborsViaSQL() {
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
@@ -51,7 +51,10 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1139,38 +1142,29 @@ class LSMVectorIndexTest extends TestHelper {
 //      System.out.println("Second compaction result: " + compacted);
     }
 
-    if (compacted) {
-//      System.out.println("Compaction succeeded!");
+    // The verification below is worthless if the compaction never ran, and a silently skipped verification used to
+    // read as a passing test (issue #5568). Fail instead: a compaction that cannot be scheduled or that finds
+    // nothing to do is itself something to look at.
+    assertThat(compacted).as("""
+        Compaction did not run, so nothing about it was verified. Check that the index status was AVAILABLE when \
+        scheduleCompaction() was called, that the database is open with page flushing enabled, and that the index \
+        holds entries to compact""").isTrue();
 
-      // After compaction, verify the index still works correctly
-      final long countAfterCompaction = typeIndex.countEntries();
-      assertThat(countAfterCompaction).as("Should still have " + numVectors + " entries after compaction").isEqualTo(numVectors);
+    // After compaction, verify the index still works correctly
+    final long countAfterCompaction = typeIndex.countEntries();
+    assertThat(countAfterCompaction).as("Should still have " + numVectors + " entries after compaction").isEqualTo(numVectors);
 
-      // Verify we can still query the index
-      database.transaction(() -> {
-        final float[] queryVec = { 500.0f, 501.0f, 502.0f, 503.0f }; // Last iteration values for first doc
-        final var cursor = typeIndex.get(new Object[] { queryVec }, 10);
-        int count = 0;
-        while (cursor.hasNext()) {
-          cursor.next();
-          count++;
-        }
-        assertThat(count > 0).as("Should find vectors after compaction").isTrue();
-      });
-
-      // Check if compacted sub-index was created
-//      final var compactedSubIndex = lsmIndex.getSubIndex();
-//      if (compactedSubIndex != null) {
-//        System.out.println("Compacted sub-index created: fileId=" + compactedSubIndex.getFileId() +
-//            ", pages=" + compactedSubIndex.getTotalPages());
-//      }
-    } else {
-      System.out.println("Compaction failed or returned no changes. This could mean:");
-      System.out.println("  - Status was not COMPACTION_SCHEDULED when compact() was called");
-      System.out.println("  - Database is closed or page flushing is suspended");
-      System.out.println("  - No immutable pages found");
-      System.out.println("  - No entries were compacted (all deleted or empty pages)");
-    }
+    // Verify we can still query the index
+    database.transaction(() -> {
+      final float[] queryVec = { 500.0f, 501.0f, 502.0f, 503.0f }; // Last iteration values for first doc
+      final var cursor = typeIndex.get(new Object[] { queryVec }, 10);
+      int count = 0;
+      while (cursor.hasNext()) {
+        cursor.next();
+        count++;
+      }
+      assertThat(count > 0).as("Should find vectors after compaction").isTrue();
+    });
 
     // Verify sample documents still exist with correct latest values
     database.transaction(() -> {
@@ -1204,6 +1198,87 @@ class LSMVectorIndexTest extends TestHelper {
         assertThat(vec[0]).as("Vector[0] for doc " + i + " should have original value").isEqualTo((float) i);
       }
     });
+  }
+
+  /**
+   * Issue #5568: a rebuild must publish the location index atomically.
+   * <p>
+   * The rebuild used to clear the live location index and refill it entry by entry under the index write lock. Every
+   * reader of that index is lock-free by design, so a reader running while a rebuild was in flight saw the map
+   * mid-refill: {@code countEntries()} returned an arbitrary fraction of the real content, a different wrong number
+   * on each run. A compaction IS a rebuild, which is what made the failure show up right after {@code compact()}.
+   * <p>
+   * The counter thread here plays the role of any concurrent reader (a {@code count()} query, the metrics
+   * collector, a search short-circuiting on an apparently empty index) and the assertion is the invariant that was
+   * violated: no reader may ever see fewer entries than the index holds.
+   */
+  @Test
+  void countEntriesIsNeverTornByAConcurrentRebuild() throws Exception {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE TornCount IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY TornCount.vec IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON TornCount (vec) LSM_VECTOR \
+          METADATA {dimensions: 4, similarity: 'COSINE'}\
+          """);
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("TornCount[vec]");
+    final LSMVectorIndex lsmIndex = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    final int numVectors = 3000;
+    final List<RID> rids = new ArrayList<>(numVectors);
+    database.transaction(() -> {
+      for (int i = 0; i < numVectors; i++) {
+        final var vertex = database.newVertex("TornCount");
+        vertex.set("vec", new float[] { (float) i, (float) i + 1, (float) i + 2, (float) i + 3 });
+        vertex.save();
+        rids.add(vertex.getIdentity());
+      }
+    });
+
+    // Supersede a slice of the vectors so the pages carry tombstones and the live set is a strict subset of the
+    // entries: the rebuild then has to merge, which is exactly the state the reported failure was taken in.
+    database.transaction(() -> {
+      for (int i = 0; i < 500; i++) {
+        final var doc = rids.get(i).asDocument().modify();
+        doc.set("vec", new float[] { i + 1000f, i + 1001f, i + 1002f, i + 1003f });
+        doc.save();
+      }
+    });
+
+    assertThat(typeIndex.countEntries()).as("Baseline count before any compaction").isEqualTo(numVectors);
+
+    final AtomicBoolean stop = new AtomicBoolean(false);
+    final AtomicLong lowestCount = new AtomicLong(Long.MAX_VALUE);
+    final AtomicReference<Throwable> counterFailure = new AtomicReference<>();
+    final Thread counter = new Thread(() -> {
+      try {
+        while (!stop.get())
+          lowestCount.getAndAccumulate(typeIndex.countEntries(), Math::min);
+      } catch (final Throwable t) {
+        counterFailure.set(t);
+      }
+    }, "issue5568-counter");
+    counter.setDaemon(true);
+    counter.start();
+
+    try {
+      // No writer runs from here on, so the count is a constant: every compaction rebuilds the same live set.
+      for (int round = 0; round < 3; round++) {
+        assertThat(lsmIndex.scheduleCompaction()).as("Compaction round " + round + " should be schedulable").isTrue();
+        assertThat(lsmIndex.compact()).as("Compaction round " + round + " should run").isTrue();
+      }
+    } finally {
+      stop.set(true);
+      counter.join(30_000);
+    }
+
+    assertThat(counterFailure.get()).as("The concurrent reader should not fail").isNull();
+    assertThat(lowestCount.get())
+        .as("countEntries() must never observe a partially rebuilt location index")
+        .isEqualTo(numVectors);
+    assertThat(typeIndex.countEntries()).as("Count after the compactions").isEqualTo(numVectors);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
@@ -1247,6 +1247,10 @@ class LSMVectorIndexTest extends TestHelper {
       }
     });
 
+    // Every count below is compared against the full live set, which assumes an UNBOUNDED location cache - the
+    // default of arcadedb.vectorIndex.locationCacheSize, and what this suite runs with. Under a bounded cache (the
+    // low-ram profile caps it at 10_000) the index FIFO-evicts down to the cap and countEntries() legitimately
+    // reports the cap instead of the live count, so the invariant would have to be expressed against that bound.
     assertThat(typeIndex.countEntries()).as("Baseline count before any compaction").isEqualTo(numVectors);
 
     final AtomicBoolean stop = new AtomicBoolean(false);
@@ -1254,8 +1258,11 @@ class LSMVectorIndexTest extends TestHelper {
     final AtomicReference<Throwable> counterFailure = new AtomicReference<>();
     final Thread counter = new Thread(() -> {
       try {
-        while (!stop.get())
+        while (!stop.get()) {
           lowestCount.getAndAccumulate(typeIndex.countEntries(), Math::min);
+          // countEntries() is O(live entries): spin politely instead of burning a core for the whole compaction.
+          Thread.onSpinWait();
+        }
       } catch (final Throwable t) {
         counterFailure.set(t);
       }


### PR DESCRIPTION
Fixes #5568

## The bug is real, but it is not compaction losing entries

`countEntries()` on a dense `LSM_VECTOR` returns `VectorLocationIndex.getActiveCount()`. A graph rebuild re-synced that index **in place**: `vectorIndex.clear()` followed by one `addOrUpdate` per live entry, under `lock.writeLock()`.

That lock only serializes the **writers** (`put`/`remove` take it). Every **reader** of the location index is lock-free by design - `countEntries()`, `getStats()`, the `vectorIndex.size() == 0` short-circuits on the three search paths, the RID filters. They observed the map mid-refill and got an arbitrary fraction of its real content.

A compaction *is* a rebuild (`compact()` -> `buildGraphFromScratch(null, true)`), which is why the count read right after `compact()` was the one that broke. With INFO logging on, the sequence is unambiguous:

```
01:01:56.032  Compacted vector index '...': 30000 live vectors in 1 pages (was file 4, now file 6)
01:02:10.888  Inactivity timeout expired (15000 ms), triggering graph rebuild for 80000 pending mutations
01:02:14.221  Built graph for index '...'          <- compaction's rebuild releases graphBuildLock, compact() returns
01:02:14.25x  <- the waiting inactivity rebuild starts refilling the location map
              [Should still have 30000 entries after compaction] expected: 30000L but was: 4976L
```

The 15-second inactivity timer fires while the compaction's 14-second JVector build holds `graphBuildLock`, and it starts clearing/refilling the map microseconds before the test reads it. Runs that "passed" simply read the count before the timer got in - which is also why the counts (4976, 7907, 13414, 19675, 21149, 21373 out of 30000) are arbitrary fractions rather than an off-by-one.

The count is only the visible symptom. A **search** running in the same window short-circuits on an apparently empty index and returns nothing.

## Fix

`vectorIndex` is now `volatile` and a rebuild publishes a **fully populated replacement instance** with a single reference assignment (`publishLocationIndex`), so a reader sees either the whole old set or the whole new one. Readers still take no lock. CPU cost is the same as the in-place refill it replaces; peak heap is not - the replaced instance stays reachable for its in-flight readers while the new one is built, so a rebuild transiently holds two location sets (~90 bytes per live entry each) instead of one. That spike is bounded, promptly released, and the price of the atomicity. On top of that:

- the compaction publishes the replacement **inside the same critical section that swaps the data file**, closing a pre-existing window in which the index answered offsets into a file that had just been dropped (a search landing there reads another entry's bytes, or the nulled compacted component);
- `getVectorLocation()` and `buildOrdinalMapping()` read the volatile field once so they cannot mix generations - the former would otherwise answer a miss against one generation and re-cache a stale offset into the next.

## Checked and dismissed as a second bug

`30000 live vectors in 1 pages` in the compaction log looks alarming but is correct: an unquantized `LSM_VECTOR` entry is ~8 bytes (varint id + varint bucketId + varint position + deleted flag + quantization-type flag; the vector itself stays in the document), so 30000 of them fit in one 256KB page. `MutablePage.checkBoundariesOnWrite` would have thrown otherwise.

## Verification

- **New `countEntriesIsNeverTornByAConcurrentRebuild`**: polls `countEntries()` from a second thread across three compactions and asserts it never dips below the real content. Without the fix it observes **0** within 0.9 s; with the fix, 5/5 clean runs.
- **`manualCompactionRemovesDuplicates`**: 5/5 clean runs (it failed on 4 of the first 5 baseline runs on `main`), and it now **fails when the compaction did not run** instead of silently verifying nothing - per the second follow-up in the issue.
- **Whole `com.arcadedb.index.**` package**: 911 tests, 0 failures.

## Note for whoever debugs the engine next

The engine's INFO logs are invisible in tests unless **both** `com.arcadedb.level` and `java.util.logging.ConsoleHandler.level` are lowered in `engine/src/test/resources/arcadedb-log.properties` - the handler filters at WARNING independently of the logger. Lowering only the logger looks like the logging is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF4M78mPjg8VH7GR5pPZEp
