### PR TITLE
fix(server) #5565: dismantle the Micrometer subsystem when the last server stops

### DIFF
--- a/docs/5565-query-metrics-lifecycle.md
+++ b/docs/5565-query-metrics-lifecycle.md
@@ -102,6 +102,36 @@ mvn -pl server -am -Dtest='MicrometerQueryMetricsRecorderTest,DefaultServerMetri
 mvn -pl postgresw -am verify -Pintegration            # the suite from the report, one JVM
 ```
 
+## Pull request
+
+[#5582](https://github.com/ArcadeData/arcadedb/pull/5582).
+
+### Review cycle 1 (f9016702)
+
+Applied:
+
+- The teardown's ownership contract is now stated where the snapshot is taken: while a server is up it owns
+  every meter registered on the global registry, so an embedding application must register its own meters
+  before starting the server, or on a registry of its own added to the composite.
+- The reason the registry and the binders are installed outside `METRICS_INSTALL_MUTEX` is documented:
+  registering an already-registered meter id is a no-op in Micrometer and the counter transitions that
+  decide the snapshot and the teardown are serialised, so concurrent startups interleave safely; holding
+  the mutex across MXBean binding would serialise unrelated startups for nothing.
+- The counter reset on an in-process restart is now in `docs/release-26.8.1.md`, so it is not reported as a
+  regression.
+
+Not applied, with reasons:
+
+- **`@Tag("slow")` on `ServerMetricsLifecycleTest`.** Measured under a second for all five cases together (six server
+  start/stop cycles on a local run). `CLAUDE.md` reserves the tag for tests taking noticeably long, which
+  this does not.
+- **A separate `SERVER_ROOT_PATH` per server in the two-server test.** Sharing the root path and varying
+  only `SERVER_DATABASE_DIRECTORY` is exactly what `BaseGraphServerTest.startServers()` does for its
+  multi-server tests, and `TestServerHelper.deleteDatabaseFolders()` only cleans `./target/databases<i>`.
+  A private root path would leave a `databases/` directory behind that the CI leak check looks for.
+- **Sharing the duplicated `invalidateTimerCache()` Javadoc.** The two caches are private to two unrelated
+  classes; a shared constant would couple an HTTP handler to a monitor class to save two sentences.
+
 ## Impact
 
 - Query and HTTP RED metrics keep recording, and keep reporting the values they recorded, across an

--- a/docs/5565-query-metrics-lifecycle.md
+++ b/docs/5565-query-metrics-lifecycle.md
@@ -169,6 +169,22 @@ Not applied: the reviewer asked whether a permanent per-issue analysis file unde
 It is the established convention in this repository (`docs/5541-*`, `docs/5560-*`, `docs/5459-*`, ...), so
 the file stays and the release note remains the user-facing summary.
 
+### Review cycle 4 (9c2f75ea)
+
+Two hardening points, both applied:
+
+- The pre-install snapshot is now taken *before* the increment. If `currentMeterIds()` ever threw on the
+  first install, the count was already at 1 with `metersBeforeInstall` still null, and the teardown's
+  membership test would NPE (swallowed, then self-healing). Taking the snapshot first leaves nothing
+  half-installed.
+- The ordering that makes the teardown race-free is now stated at the call site: the timer caches are
+  cleared and the meters removed without holding off recording threads, so `stopMetrics()` must stay last
+  in `stopInternal()`, after the plugins, the HTTP service and the databases are down and nothing can
+  repopulate them.
+
+Review cycles stopped here at the configured maximum. The remaining open observation is the ownership
+contract, which every cycle judged deliberate and documented rather than actionable.
+
 ## Impact
 
 - Query and HTTP RED metrics keep recording, and keep reporting the values they recorded, across an

--- a/docs/5565-query-metrics-lifecycle.md
+++ b/docs/5565-query-metrics-lifecycle.md
@@ -92,6 +92,7 @@ reachable through the composite that the Prometheus and OTLP plugins attach to.
 | `queryTimerRecordsIntoTheLiveRegistryAfterARestart` | two registries after one restart |
 | `queryRecorderIsRetiredWhenTheServerStops` | the Holder keeps the recorder of the dead server |
 | `metricsSurviveWhileAnotherServerInTheSameJvmIsRunning` | (guards the reference count) |
+| `aFailedStartDoesNotLeaveTheMetricsSubsystemInstalled` | (guards the failed-start rollback, see cycle 2) |
 
 The recorder is exercised through `QueryMetricsRecorder.Holder.get()`, i.e. the same entry point the
 engine uses, under a `protocol` tag unique to the test so its meters cannot collide with another test's.
@@ -131,6 +132,29 @@ Not applied, with reasons:
   A private root path would leave a `databases/` directory behind that the CI leak check looks for.
 - **Sharing the duplicated `invalidateTimerCache()` Javadoc.** The two caches are private to two unrelated
   classes; a shared constant would couple an HTTP handler to a monitor class to save two sentences.
+
+### Review cycle 2 (f258c355)
+
+One real defect found, in the failure path the first version introduced. `startMetrics()` raises the
+reference count near the top of `start()`, but the failures that matter (a plugin, the HTTP service, the
+databases) happen much later and do **not** all route through `stop()` - `startInternal()` only calls it
+from the final `SERVER_UP` catch. A single leaked increment means the count never returns to zero, so the
+last-one-out teardown is disabled for the life of the JVM: worse than the leak it replaced, and reachable
+by an embedder that catches a start failure and retries in-process.
+
+`start()` now releases the metrics install if `startInternal()` throws, and rethrows unchanged. Only the
+install is undone - the rest of the failure path and the caller's ownership of the `stop()` decision are
+untouched, and a `stop()` that follows finds nothing left to dismantle (`stopMetrics()` is guarded on its
+own registry reference).
+
+`aFailedStartDoesNotLeaveTheMetricsSubsystemInstalled` covers it: SSL requested with no key store fails
+`httpServer.startService()`, well past the metrics install, and the test then asserts a later server can
+still tear the subsystem down. Verified to fail with the rollback removed and pass with it.
+
+The two remaining points were flagged as acknowledged rather than actionable: the aggressive ownership
+contract (documented in cycle 1) and the window in a concurrent stop+start interleave where a stopping
+server has already pulled its child registry - sequential start/stop, which is the real-world and test
+path, is unaffected.
 
 ## Impact
 

--- a/docs/5565-query-metrics-lifecycle.md
+++ b/docs/5565-query-metrics-lifecycle.md
@@ -156,6 +156,19 @@ contract (documented in cycle 1) and the window in a concurrent stop+start inter
 server has already pulled its child registry - sequential start/stop, which is the real-world and test
 path, is unaffected.
 
+### Review cycle 3 (a1cdb09e)
+
+The rollback from cycle 2 was guarded on `metricsRegistry != null`, which is assigned *after* the mutex is
+released, while the count is raised inside it. A throw in between (`currentMeterIds()`, the
+`SimpleMeterRegistry` constructor) would make `stopMetrics()` return early and leak the count for good -
+the very failure mode cycle 2 set out to remove. The install is now tracked by a per-instance
+`metricsInstalled` flag set in the same critical section as the increment, and `stopMetrics()` guards on
+that and releases the count whether or not the registry ever got created.
+
+Not applied: the reviewer asked whether a permanent per-issue analysis file under `docs/` is intended.
+It is the established convention in this repository (`docs/5541-*`, `docs/5560-*`, `docs/5459-*`, ...), so
+the file stays and the release note remains the user-facing summary.
+
 ## Impact
 
 - Query and HTTP RED metrics keep recording, and keep reporting the values they recorded, across an

--- a/docs/5565-query-metrics-lifecycle.md
+++ b/docs/5565-query-metrics-lifecycle.md
@@ -1,0 +1,114 @@
+# #5565 - query metrics die across an in-process server restart (PostgresQueryMetricsIT red on main)
+
+## Symptom
+
+`PostgresQueryMetricsIT.postgresQueriesTaggedWithPostgresProtocol` fails in CI, never in isolation:
+
+```
+Expecting actual: 0L to be greater than or equal to: 1L
+  at PostgresQueryMetricsIT.java:76
+```
+
+The preceding `assertThat(timer).isNotNull()` passes, so the `arcadedb.query.duration` timer tagged
+`protocol=postgres` exists in the registry but reports a count of zero.
+
+## Root cause
+
+Three facts combine.
+
+1. `ArcadeDBServer.start()` called `Metrics.addRegistry(new SimpleMeterRegistry())` on every start and
+   nothing removed it on stop. Micrometer's `Metrics.globalRegistry` is a JVM-wide composite, so a JVM
+   that starts servers in sequence (every IT suite does, `reuseForks=true` and `forkCount=1`) accumulates
+   one child registry per start. The full IT suite reaches double digits.
+
+2. Registering a meter on a composite creates a `CompositeTimer` that holds one child meter **per child
+   registry**, and `CompositeTimer.count()` returns `firstChild().count()` - the children live in an
+   `IdentityHashMap`, so which child answers is arbitrary. When a registry is added *after* a recording,
+   the child meter it gets is brand new and reads zero.
+
+   A timer created and recorded in generation 1 therefore reports either its real count or 0 in
+   generation 2, depending on identity hash order.
+
+3. `Search.timer()` returns an arbitrary match. The postgresw IT suite produces several
+   `protocol=postgres` timers, differing in `db`/`language`/`type`
+   (`PostgresPreparedStatementMetricsIT` alone contributes `db=postgresdb, language=sql`), so the
+   assertion is not necessarily handed the timer its own query recorded.
+
+Put together: the test resolves a `protocol=postgres` timer created by an earlier server generation and
+reads it through a child registry that never recorded into it, hence non-null with count 0.
+
+The product defect this exposes is bigger than the test. Because `MicrometerQueryMetricsRecorder` caches
+the resolved `Timer` in a static map and the meters themselves are never deregistered, after an
+in-process restart `arcadedb.query.duration` is fed into meters whose values are spread across
+abandoned registry generations, and every scrape reads one arbitrary generation. The same shape applies
+to `arcadedb.http.requests` (same static cache in `AbstractServerHttpHandler`) and to the gauges bound
+by `PoolMetrics`/`EngineMetricsBinder`/`HAReplicationMetrics`, whose re-registration on the second start
+is silently ignored by Micrometer because a meter with that id already exists - so they keep reporting
+the *stopped* server. Production runs one server per JVM, but embedded applications and tests restart in
+place.
+
+Two smaller leaks belonged to the same asymmetry: `new JvmGcMetrics()` was never closed (it holds
+notification listeners on the GC MXBeans), and the `MeterFilter` backstop was re-appended to the global
+config on every start, which is also what produced the `A MeterFilter is being configured after a Meter
+has been registered` warnings all over the CI logs.
+
+## Fix
+
+`ArcadeDBServer` now installs and uninstalls the metrics subsystem symmetrically, in `startMetrics()`
+and `stopMetrics()`:
+
+- the server keeps a reference to the `SimpleMeterRegistry` (and the optional `LoggingMeterRegistry`) it
+  added, and on stop removes it from the global composite and closes it;
+- `JvmGcMetrics` is kept and closed on stop;
+- the `MeterFilter` backstop is installed once per JVM, before any meter exists, which is what
+  Micrometer requires;
+- on stop the meters the server generations registered are removed from the global composite. The set of
+  meters present before the *first* install is snapshotted and excluded, so meters an embedding
+  application registered itself are left alone;
+- the two static timer caches (`MicrometerQueryMetricsRecorder`, `AbstractServerHttpHandler`) are
+  invalidated at the same point, because a cached `Timer` whose meter has been deregistered silently
+  discards every sample - that would have converted the reporting bug into a total loss of query metrics
+  after a restart;
+- `QueryMetricsRecorder.Holder` is reset to `NO_OP`, so with no server left the engine stops timing
+  queries instead of feeding a dismantled registry.
+
+The install is **reference counted** (`METRICS_INSTALL_MUTEX`, `metricsInstalls`): HA and embedded
+setups run several servers in one JVM, and each one removes only its own registry. The shared state -
+meters, caches, recorder - is dismantled by the last server out, so a stopping node never strips the
+meters its still-running siblings publish.
+
+Registering the backing registry per server start is left as is: it is what makes each server's meters
+reachable through the composite that the Prometheus and OTLP plugins attach to.
+
+## Verification
+
+`server/src/test/java/com/arcadedb/server/monitor/ServerMetricsLifecycleTest.java` drives real
+`ArcadeDBServer` start/stop cycles. All five tests fail on the pre-fix code:
+
+| test | pre-fix failure |
+|---|---|
+| `meterRegistryIsRemovedWhenTheServerStops` | the stopped server's registry is still in the composite |
+| `queryTimersDoNotOutliveTheServerThatRecordedThem` | the meter survives the shutdown |
+| `queryTimerRecordsIntoTheLiveRegistryAfterARestart` | two registries after one restart |
+| `queryRecorderIsRetiredWhenTheServerStops` | the Holder keeps the recorder of the dead server |
+| `metricsSurviveWhileAnotherServerInTheSameJvmIsRunning` | (guards the reference count) |
+
+The recorder is exercised through `QueryMetricsRecorder.Holder.get()`, i.e. the same entry point the
+engine uses, under a `protocol` tag unique to the test so its meters cannot collide with another test's.
+
+```
+mvn -pl server -am -Dtest=ServerMetricsLifecycleTest test
+mvn -pl server -am -Dtest='MicrometerQueryMetricsRecorderTest,DefaultServerMetricsTest' test
+mvn -pl postgresw -am verify -Pintegration            # the suite from the report, one JVM
+```
+
+## Impact
+
+- Query and HTTP RED metrics keep recording, and keep reporting the values they recorded, across an
+  in-process server restart.
+- The per-start registry, GC-listener and MeterFilter leaks are gone, and with them the
+  `MeterFilter is being configured after a Meter has been registered` warning.
+- The postgresw metrics ITs become independent of suite order, because each server generation starts
+  from a clean set of meters.
+- Reported counters restart from zero when a server restarts in-process, which is the intended reading:
+  the values belong to the server that recorded them.

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -37,6 +37,29 @@ The same goes for the write shapes no merge can replay (a delete, a placeholder 
 record that has to spill out of its page). Nothing changes for single-writer workloads, and no application
 change is needed. The merge can be switched off with `arcadedb.txPageSlotMerge=false`.
 
+#### Query and HTTP metrics survive an in-process server restart
+
+The server added a Micrometer registry to the JVM-wide global registry on every start and removed none on
+stop. Since a meter registered on that composite holds one child per backing registry and reports the value
+of a single, arbitrarily chosen child, a restart in the same JVM left `arcadedb.query.duration` and
+`arcadedb.http.requests` reporting from a child registry that had never recorded them - reading back as 0 -
+while the gauges bound at startup kept reporting the *stopped* server
+([#5565](https://github.com/ArcadeData/arcadedb/issues/5565)).
+
+The metrics subsystem is now dismantled when the server stops: its registry is removed and closed, the
+meters it registered are deregistered, the query and HTTP timer caches are dropped and the engine stops
+timing queries. Several servers sharing one JVM (HA, embedded) are reference counted, so a stopping node
+never strips the meters its siblings publish, and meters registered before the first server started are
+left untouched.
+
+Two consequences for embedded and multi-server setups. A restart in the same process now **resets the
+counters**, because the values belong to the server that recorded them: a scraper that outlives a restart
+sees the series start from zero rather than continue. And while a server is up it owns the meters on the
+global registry, so an application that wants its own meters to survive the server's shutdown should
+register them before starting it, or on its own registry added to the composite.
+
+Only production deployments running a single server per JVM were unaffected.
+
 ### New Features
 
 #### Bloom filters on compacted LSM indexes (enabled by default)

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -39,6 +39,7 @@ import com.arcadedb.server.ai.AiConfiguration;
 import com.arcadedb.server.event.FileServerEventLog;
 import com.arcadedb.server.event.ServerEventLog;
 import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.handler.AbstractServerHttpHandler;
 import com.arcadedb.server.mcp.MCPConfiguration;
 import com.arcadedb.database.QueryMetricsRecorder;
 import com.arcadedb.database.QueryTracer;
@@ -55,6 +56,8 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.CodeUtils;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.ServerPathUtils;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
@@ -73,6 +76,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -143,6 +147,20 @@ public class ArcadeDBServer {
   private volatile    STATUS                                status                               = STATUS.OFFLINE;
   private final       AtomicBoolean snapshotInstallInProgress            = new AtomicBoolean(false);
   private volatile    Function<LocalDatabase, DatabaseInternal> databaseWrapper;
+  // Micrometer's global composite registry, the meter binders and the per-tuple timer caches of
+  // MicrometerQueryMetricsRecorder/AbstractServerHttpHandler are JVM-wide, while a start()/stop() pair is
+  // not: a start that adds a backing registry and a stop that removes none grows the composite by one
+  // child per in-process restart. A composite meter answers count() from a single, arbitrarily chosen
+  // child, and a child added after a recording starts at zero, so meters fed by an earlier generation
+  // still resolve through find() but read back 0 (issue #5565). The install is therefore reference
+  // counted - HA and embedded setups run several servers in one JVM - and the last one out dismantles it.
+  private static final Object       METRICS_INSTALL_MUTEX = new Object();
+  private static       int          metricsInstalls;
+  private static       boolean      metricsFiltersInstalled;
+  private static       Set<Meter.Id> metersBeforeInstall;
+  private              MeterRegistry metricsRegistry;
+  private              MeterRegistry metricsLoggingRegistry;
+  private              JvmGcMetrics  metricsJvmGc;
 //  private             ServerMonitor                         serverMonitor;
 
   static {
@@ -261,39 +279,8 @@ public class ArcadeDBServer {
     }
 
     // START METRICS & CONNECTED JMX REPORTER
-    if (configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS)) {
-      // Backstop against a path-tag cardinality explosion on arcadedb.http.requests. The handler already
-      // collapses unmatched URIs to a constant, but this caps the number of distinct "path" tag values and
-      // denies further ones so a future route or regression can never grow the registry without bound.
-      // Configured before any registry/meter is added, as Micrometer requires MeterFilters to precede the
-      // meters they govern.
-      Metrics.globalRegistry.config().meterFilter(
-          MeterFilter.maximumAllowableTags("arcadedb.http.requests", "path", 100, MeterFilter.deny()));
-
-      Metrics.addRegistry(new SimpleMeterRegistry());
-
-      new ClassLoaderMetrics().bindTo(Metrics.globalRegistry);
-      new JvmMemoryMetrics().bindTo(Metrics.globalRegistry);
-      new JvmGcMetrics().bindTo(Metrics.globalRegistry);
-      new ProcessorMetrics().bindTo(Metrics.globalRegistry);
-      new JvmThreadMetrics().bindTo(Metrics.globalRegistry);
-      // Engine executor pools (query parallelism + sparse-vector scoring) - exposes
-      // arcadedb.executor.pool.{size,active,...} gauges tagged with pool=<name>.
-      new PoolMetrics().bindTo(Metrics.globalRegistry);
-      // Engine-wide Profiler stats (cache hit/miss, pages, WAL, MVCC conflicts, open files, tx,
-      // queries) - exposes arcadedb.engine.* gauges read live from the Profiler on each scrape.
-      new EngineMetricsBinder().bindTo(Metrics.globalRegistry);
-      // HA replication health (heartbeat lag + replication lag) sourced live from the HA plugin -
-      // exposes arcadedb.ha.* gauges; harmless no-op (all -1/0) when HA is disabled.
-      new HAReplicationMetrics(this).bindTo(Metrics.globalRegistry);
-      QueryMetricsRecorder.Holder.register(new MicrometerQueryMetricsRecorder());
-
-      if (configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_LOGGING)) {
-        LogManager.instance().log(this, Level.INFO, "- Logging metrics enabled...");
-        Metrics.addRegistry(new LoggingMeterRegistry());
-      }
-      LogManager.instance().log(this, Level.INFO, "Metrics Collection Started");
-    }
+    if (configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS))
+      startMetrics();
 
     // Register the engine-boundary query tracer regardless of the metrics flag: it opens a span only
     // when the optional tracing plugin has attached a tracer to the ObservationRegistry, and is a
@@ -580,6 +567,103 @@ public class ArcadeDBServer {
     }
   }
 
+  private void startMetrics() {
+    synchronized (METRICS_INSTALL_MUTEX) {
+      if (!metricsFiltersInstalled) {
+        // Backstop against a path-tag cardinality explosion on arcadedb.http.requests. The handler already
+        // collapses unmatched URIs to a constant, but this caps the number of distinct "path" tag values and
+        // denies further ones so a future route or regression can never grow the registry without bound.
+        // A MeterFilter cannot be removed from a registry, so it is installed once per JVM, and before any
+        // meter exists as Micrometer requires MeterFilters to precede the meters they govern.
+        Metrics.globalRegistry.config().meterFilter(
+            MeterFilter.maximumAllowableTags("arcadedb.http.requests", "path", 100, MeterFilter.deny()));
+        metricsFiltersInstalled = true;
+      }
+
+      if (metricsInstalls++ == 0)
+        // Meters already registered belong to somebody else (typically the embedding application), so the
+        // shutdown below removes only what the server generations added on top of them.
+        metersBeforeInstall = currentMeterIds();
+    }
+
+    metricsRegistry = new SimpleMeterRegistry();
+    Metrics.addRegistry(metricsRegistry);
+
+    new ClassLoaderMetrics().bindTo(Metrics.globalRegistry);
+    new JvmMemoryMetrics().bindTo(Metrics.globalRegistry);
+    // Registers notification listeners on the GC MXBeans, so it must be closed on shutdown.
+    metricsJvmGc = new JvmGcMetrics();
+    metricsJvmGc.bindTo(Metrics.globalRegistry);
+    new ProcessorMetrics().bindTo(Metrics.globalRegistry);
+    new JvmThreadMetrics().bindTo(Metrics.globalRegistry);
+    // Engine executor pools (query parallelism + sparse-vector scoring) - exposes
+    // arcadedb.executor.pool.{size,active,...} gauges tagged with pool=<name>.
+    new PoolMetrics().bindTo(Metrics.globalRegistry);
+    // Engine-wide Profiler stats (cache hit/miss, pages, WAL, MVCC conflicts, open files, tx,
+    // queries) - exposes arcadedb.engine.* gauges read live from the Profiler on each scrape.
+    new EngineMetricsBinder().bindTo(Metrics.globalRegistry);
+    // HA replication health (heartbeat lag + replication lag) sourced live from the HA plugin -
+    // exposes arcadedb.ha.* gauges; harmless no-op (all -1/0) when HA is disabled.
+    new HAReplicationMetrics(this).bindTo(Metrics.globalRegistry);
+    QueryMetricsRecorder.Holder.register(new MicrometerQueryMetricsRecorder());
+
+    if (configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_LOGGING)) {
+      LogManager.instance().log(this, Level.INFO, "- Logging metrics enabled...");
+      metricsLoggingRegistry = new LoggingMeterRegistry();
+      Metrics.addRegistry(metricsLoggingRegistry);
+    }
+    LogManager.instance().log(this, Level.INFO, "Metrics Collection Started");
+  }
+
+  private void stopMetrics() {
+    if (metricsRegistry == null)
+      // Metrics were disabled for this server: nothing of ours to dismantle.
+      return;
+
+    LogManager.instance().log(this, Level.INFO, "- Stop metrics collection");
+
+    if (metricsJvmGc != null) {
+      CodeUtils.executeIgnoringExceptions(metricsJvmGc::close, "Error on closing the JVM GC metrics", false);
+      metricsJvmGc = null;
+    }
+    if (metricsLoggingRegistry != null) {
+      removeMeterRegistry(metricsLoggingRegistry);
+      metricsLoggingRegistry = null;
+    }
+    removeMeterRegistry(metricsRegistry);
+    metricsRegistry = null;
+
+    synchronized (METRICS_INSTALL_MUTEX) {
+      if (--metricsInstalls > 0)
+        // A sibling server in this JVM still publishes to the shared registry: leave its meters in place.
+        return;
+
+      // Last one out: the engine must stop timing queries, the cached timers must not outlive the
+      // registries that backed them, and no meter may survive to be read from a later generation that
+      // never recorded into it.
+      QueryMetricsRecorder.Holder.register(QueryMetricsRecorder.NO_OP);
+      MicrometerQueryMetricsRecorder.invalidateTimerCache();
+      AbstractServerHttpHandler.invalidateTimerCache();
+
+      for (final Meter meter : Metrics.globalRegistry.getMeters())
+        if (!metersBeforeInstall.contains(meter.getId()))
+          Metrics.globalRegistry.remove(meter);
+
+      metersBeforeInstall = null;
+    }
+  }
+
+  private static void removeMeterRegistry(final MeterRegistry registry) {
+    Metrics.removeRegistry(registry);
+    CodeUtils.executeIgnoringExceptions(registry::close, "Error on closing the metrics registry", false);
+  }
+
+  private static Set<Meter.Id> currentMeterIds() {
+    final Set<Meter.Id> ids = new HashSet<>();
+    Metrics.globalRegistry.forEachMeter(meter -> ids.add(meter.getId()));
+    return ids;
+  }
+
   private void stopInternal() {
     if (status == STATUS.OFFLINE || status == STATUS.SHUTTING_DOWN)
       return;
@@ -612,8 +696,7 @@ public class ArcadeDBServer {
           false);
     databases.clear();
 
-    CodeUtils.executeIgnoringExceptions(() ->
-      LogManager.instance().log(this, Level.INFO, "- Stop JMX Metrics"), "Error on stopping JMX Metrics", false);
+    CodeUtils.executeIgnoringExceptions(this::stopMetrics, "Error on stopping the metrics collection", false);
 
     LogManager.instance().log(this, Level.INFO, "ArcadeDB Server is down");
 

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -581,10 +581,19 @@ public class ArcadeDBServer {
       }
 
       if (metricsInstalls++ == 0)
-        // Meters already registered belong to somebody else (typically the embedding application), so the
-        // shutdown below removes only what the server generations added on top of them.
+        // Meters already registered belong to somebody else (typically the embedding application) and are
+        // left alone by the shutdown. The flip side is the contract: from here until the last server stops,
+        // the server owns every meter registered on the global registry, so an embedded application that
+        // wants its own meters to outlive the server must register them before starting it, or on a registry
+        // of its own added to the composite (what the Prometheus and OTLP plugins do).
         metersBeforeInstall = currentMeterIds();
     }
+
+    // The registry and the binders below are deliberately installed outside the mutex: it guards only the
+    // shared install state (counter, snapshot, filter). Two servers starting concurrently in one JVM can
+    // interleave here safely, because registering an already-registered meter id is a no-op in Micrometer
+    // and the counter transitions that decide the snapshot and the teardown are serialised above. Holding
+    // the mutex across MXBean binding would serialise unrelated server startups for no benefit.
 
     metricsRegistry = new SimpleMeterRegistry();
     Metrics.addRegistry(metricsRegistry);

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -158,6 +158,7 @@ public class ArcadeDBServer {
   private static       int          metricsInstalls;
   private static       boolean      metricsFiltersInstalled;
   private static       Set<Meter.Id> metersBeforeInstall;
+  private              boolean       metricsInstalled;
   private              MeterRegistry metricsRegistry;
   private              MeterRegistry metricsLoggingRegistry;
   private              JvmGcMetrics  metricsJvmGc;
@@ -589,6 +590,10 @@ public class ArcadeDBServer {
         metricsFiltersInstalled = true;
       }
 
+      // Paired with the decrement in stopMetrics() through this flag, set in the same critical section as the
+      // increment: anything that throws further down must still be able to release the count, or it never
+      // returns to zero and the last-one-out teardown is disabled for the life of the JVM.
+      metricsInstalled = true;
       if (metricsInstalls++ == 0)
         // Meters already registered belong to somebody else (typically the embedding application) and are
         // left alone by the shutdown. The flip side is the contract: from here until the last server stops,
@@ -634,9 +639,10 @@ public class ArcadeDBServer {
   }
 
   private void stopMetrics() {
-    if (metricsRegistry == null)
-      // Metrics were disabled for this server: nothing of ours to dismantle.
+    if (!metricsInstalled)
+      // Metrics were disabled for this server, or already dismantled: nothing of ours to release.
       return;
+    metricsInstalled = false;
 
     LogManager.instance().log(this, Level.INFO, "- Stop metrics collection");
 
@@ -648,8 +654,11 @@ public class ArcadeDBServer {
       removeMeterRegistry(metricsLoggingRegistry);
       metricsLoggingRegistry = null;
     }
-    removeMeterRegistry(metricsRegistry);
-    metricsRegistry = null;
+    // Null when the install threw before getting this far: the count below is released either way.
+    if (metricsRegistry != null) {
+      removeMeterRegistry(metricsRegistry);
+      metricsRegistry = null;
+    }
 
     synchronized (METRICS_INSTALL_MUTEX) {
       if (--metricsInstalls > 0)

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -590,17 +590,20 @@ public class ArcadeDBServer {
         metricsFiltersInstalled = true;
       }
 
-      // Paired with the decrement in stopMetrics() through this flag, set in the same critical section as the
-      // increment: anything that throws further down must still be able to release the count, or it never
-      // returns to zero and the last-one-out teardown is disabled for the life of the JVM.
-      metricsInstalled = true;
-      if (metricsInstalls++ == 0)
+      if (metricsInstalls == 0)
         // Meters already registered belong to somebody else (typically the embedding application) and are
         // left alone by the shutdown. The flip side is the contract: from here until the last server stops,
         // the server owns every meter registered on the global registry, so an embedded application that
         // wants its own meters to outlive the server must register them before starting it, or on a registry
-        // of its own added to the composite (what the Prometheus and OTLP plugins do).
+        // of its own added to the composite (what the Prometheus and OTLP plugins do). Taken before the
+        // increment, so a failure here leaves nothing to release and no half-installed count behind.
         metersBeforeInstall = currentMeterIds();
+
+      // Paired with the decrement in stopMetrics() through this flag, set in the same critical section as the
+      // increment: anything that throws further down must still be able to release the count, or it never
+      // returns to zero and the last-one-out teardown is disabled for the life of the JVM.
+      metricsInstalled = true;
+      metricsInstalls++;
     }
 
     // The registry and the binders below are deliberately installed outside the mutex: it guards only the
@@ -723,6 +726,9 @@ public class ArcadeDBServer {
           false);
     databases.clear();
 
+    // Deliberately last: the timer caches are cleared and the meters removed without holding off recording
+    // threads, so this must run once the plugins, the HTTP service and the databases are down and nothing is
+    // left to repopulate them. Keep it after those shutdowns.
     CodeUtils.executeIgnoringExceptions(this::stopMetrics, "Error on stopping the metrics collection", false);
 
     LogManager.instance().log(this, Level.INFO, "ArcadeDB Server is down");

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -219,6 +219,15 @@ public class ArcadeDBServer {
     lifecycleLock.lock();
     try {
       startInternal();
+    } catch (final RuntimeException | Error e) {
+      // A start that fails after the metrics install (a plugin, the HTTP service, the databases) does not
+      // necessarily reach stop(): callers own that decision. The reference count must be released anyway,
+      // otherwise it never returns to zero and the last-one-out teardown is disabled for the life of the
+      // JVM - the shared meters, timer caches and recorder of a server that never came up would survive
+      // every later stop. Only the metrics install is undone here; the rest of the failure path is
+      // unchanged, and a stop() that follows finds nothing left to dismantle.
+      CodeUtils.executeIgnoringExceptions(this::stopMetrics, "Error on stopping the metrics collection", false);
+      throw e;
     } finally {
       lifecycleLock.unlock();
     }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -644,6 +644,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   }
 
   /**
+   * Drops every cached timer. A cached {@link Timer} is bound to the registries backing
+   * {@code Metrics.globalRegistry} when it was built, so it must not outlive them: recording into a meter
+   * whose backing registry is gone silently discards the sample. Called when the server dismantles the
+   * metrics subsystem, so the next server generation rebuilds its timers from scratch.
+   */
+  public static void invalidateTimerCache() {
+    HTTP_REQUEST_TIMERS.clear();
+  }
+
+  /**
    * Resolves (and caches) the {@code arcadedb.http.requests} RED timer for the given bounded tag tuple.
    * Building the timer once per distinct {@code method|path|status|db} tuple and reusing it removes the
    * per-request {@code Timer.Builder}/{@code Tags}/{@code Meter.Id} allocation and registry hash lookup

--- a/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java
@@ -44,6 +44,16 @@ public final class MicrometerQueryMetricsRecorder implements QueryMetricsRecorde
   }
 
   /**
+   * Drops every cached timer. A cached {@link Timer} is bound to the registries backing
+   * {@code Metrics.globalRegistry} when it was built, so it must not outlive them: recording into a meter
+   * whose backing registry is gone silently discards the sample. Called when the server dismantles the
+   * metrics subsystem, so the next server generation rebuilds its timers from scratch.
+   */
+  public static void invalidateTimerCache() {
+    QUERY_TIMERS.clear();
+  }
+
+  /**
    * Resolves (and caches) the {@code arcadedb.query.duration} timer for the given bounded tag tuple.
    * Package-private for direct unit testing.
    */

--- a/server/src/test/java/com/arcadedb/server/monitor/ServerMetricsLifecycleTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/ServerMetricsLifecycleTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression tests for the lifecycle of the server-side Micrometer subsystem.
@@ -132,7 +133,35 @@ class ServerMetricsLifecycleTest extends StaticBaseServerTest {
     assertThat(queryTimer()).as("the last server out dismantles the subsystem").isNull();
   }
 
+  @Test
+  void aFailedStartDoesNotLeaveTheMetricsSubsystemInstalled() {
+    // SSL requested with no key store: the HTTP service fails to start, which happens well after the
+    // metrics install and does not go through stop().
+    final ContextConfiguration config = serverConfiguration(0);
+    config.setValue(GlobalConfiguration.NETWORK_USE_SSL, true);
+
+    final ArcadeDBServer failing = new ArcadeDBServer(config);
+    servers.add(failing);
+    assertThatThrownBy(failing::start).isInstanceOf(RuntimeException.class);
+
+    // The install of the server that never came up must have been released, or the reference count could
+    // never return to zero and no later server would be able to dismantle the subsystem.
+    final ArcadeDBServer server = startServer(0);
+    recordQuery();
+    server.stop();
+
+    assertThat(queryTimer()).as("a failed start must not pin the metrics subsystem").isNull();
+    assertThat(QueryMetricsRecorder.Holder.get()).isSameAs(QueryMetricsRecorder.NO_OP);
+  }
+
   private ArcadeDBServer startServer(final int index) {
+    final ArcadeDBServer server = new ArcadeDBServer(serverConfiguration(index));
+    servers.add(server);
+    server.start();
+    return server;
+  }
+
+  private static ContextConfiguration serverConfiguration(final int index) {
     final ContextConfiguration config = new ContextConfiguration();
     config.setValue(GlobalConfiguration.SERVER_NAME, "metrics_lifecycle_" + index);
     config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
@@ -140,11 +169,7 @@ class ServerMetricsLifecycleTest extends StaticBaseServerTest {
     config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, DEFAULT_PASSWORD_FOR_TESTS);
     config.setValue(GlobalConfiguration.SERVER_HTTP_IO_THREADS, 2);
     config.setValue(GlobalConfiguration.TYPE_DEFAULT_BUCKETS, 2);
-
-    final ArcadeDBServer server = new ArcadeDBServer(config);
-    servers.add(server);
-    server.start();
-    return server;
+    return config;
   }
 
   private static void recordQuery() {

--- a/server/src/test/java/com/arcadedb/server/monitor/ServerMetricsLifecycleTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/ServerMetricsLifecycleTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.QueryMetricsRecorder;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.StaticBaseServerTest;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the lifecycle of the server-side Micrometer subsystem.
+ * <p>
+ * Micrometer's global composite registry, the meter binders and the per-tuple timer caches are JVM-wide,
+ * while a server start/stop pair is not. A start that adds a backing registry and a stop that removes
+ * none makes the composite grow one child per in-process restart, and a composite meter answers
+ * {@code count()} from a single, arbitrarily chosen child: a child added after a recording starts at
+ * zero, so a meter fed by an earlier generation still resolves through {@code find()} but reads back 0.
+ * The subsystem must therefore be dismantled symmetrically - yet only by the last server out, because
+ * HA and embedded setups run several servers in one JVM.
+ */
+class ServerMetricsLifecycleTest extends StaticBaseServerTest {
+  // Protocol tag used only here, so these meters can never collide with another test's.
+  private static final String PROTOCOL = "metrics-lifecycle";
+
+  private final List<ArcadeDBServer> servers = new ArrayList<>();
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    for (final ArcadeDBServer server : servers)
+      if (server.isStarted())
+        server.stop();
+    servers.clear();
+    super.endTest();
+  }
+
+  @Test
+  void meterRegistryIsRemovedWhenTheServerStops() {
+    final List<MeterRegistry> before = registries();
+
+    final ArcadeDBServer server = startServer(0);
+    assertThat(registries()).as("the server must install its own backing registry").hasSizeGreaterThan(before.size());
+
+    server.stop();
+
+    assertThat(registries()).as("a stopped server must not leave its registry in the global composite")
+        .containsExactlyInAnyOrderElementsOf(before);
+  }
+
+  @Test
+  void queryTimersDoNotOutliveTheServerThatRecordedThem() {
+    final ArcadeDBServer server = startServer(0);
+    recordQuery();
+    assertThat(queryTimer()).as("the running server must record the query").isNotNull();
+
+    server.stop();
+
+    assertThat(queryTimer()).as("a meter whose backing registry is gone must not survive the shutdown").isNull();
+  }
+
+  @Test
+  void queryTimerRecordsIntoTheLiveRegistryAfterARestart() {
+    final List<MeterRegistry> beforeAnyStart = registries();
+
+    startServer(0).stop();
+
+    startServer(0);
+    recordQuery();
+
+    final List<MeterRegistry> installed = registries();
+    installed.removeAll(beforeAnyStart);
+    assertThat(installed).as("a restart must not leave the previous generation's registry behind").hasSize(1);
+
+    // The recording must reach the registry that is actually being scraped now: neither the timer cached
+    // by the previous generation nor its meter may be handed back.
+    final Timer live = installed.get(0).find("arcadedb.query.duration").tag("protocol", PROTOCOL).timer();
+    assertThat(live).as("the restarted server must record into its own registry").isNotNull();
+    assertThat(live.count()).isEqualTo(1L);
+  }
+
+  @Test
+  void queryRecorderIsRetiredWhenTheServerStops() {
+    final ArcadeDBServer server = startServer(0);
+    assertThat(QueryMetricsRecorder.Holder.get()).isNotSameAs(QueryMetricsRecorder.NO_OP);
+
+    server.stop();
+
+    assertThat(QueryMetricsRecorder.Holder.get()).as("with no server left the engine must stop timing queries")
+        .isSameAs(QueryMetricsRecorder.NO_OP);
+  }
+
+  @Test
+  void metricsSurviveWhileAnotherServerInTheSameJvmIsRunning() {
+    final ArcadeDBServer first = startServer(0);
+    final ArcadeDBServer second = startServer(1);
+    recordQuery();
+
+    first.stop();
+
+    assertThat(queryTimer()).as("a still-running server keeps owning the metrics subsystem").isNotNull();
+    assertThat(QueryMetricsRecorder.Holder.get()).isNotSameAs(QueryMetricsRecorder.NO_OP);
+
+    second.stop();
+
+    assertThat(queryTimer()).as("the last server out dismantles the subsystem").isNull();
+  }
+
+  private ArcadeDBServer startServer(final int index) {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_NAME, "metrics_lifecycle_" + index);
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, "./target/databases" + index);
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, DEFAULT_PASSWORD_FOR_TESTS);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_IO_THREADS, 2);
+    config.setValue(GlobalConfiguration.TYPE_DEFAULT_BUCKETS, 2);
+
+    final ArcadeDBServer server = new ArcadeDBServer(config);
+    servers.add(server);
+    server.start();
+    return server;
+  }
+
+  private static void recordQuery() {
+    QueryMetricsRecorder.Holder.get().record(PROTOCOL, "graph", "sql", "query", 1_000_000L);
+  }
+
+  private static Timer queryTimer() {
+    return Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", PROTOCOL).timer();
+  }
+
+  private static List<MeterRegistry> registries() {
+    return new ArrayList<>(Metrics.globalRegistry.getRegistries());
+  }
+}


### PR DESCRIPTION
Closes #5565

`ArcadeDBServer.start()` added a `SimpleMeterRegistry` to Micrometer's JVM-wide global composite on every start and nothing removed it on stop, so a JVM that starts servers in sequence (every IT suite: `reuseForks=true`, `forkCount=1`) accumulates one child registry per start. A composite meter holds one child meter per child registry and `CompositeTimer.count()` returns `firstChild().count()` from an `IdentityHashMap`, so a registry added after a recording contributes a brand-new zero-valued child that may be the one answering. That is how `PostgresQueryMetricsIT` resolves a `protocol=postgres` timer (non-null) whose count reads 0: `Search.timer()` hands it an arbitrary match, and the postgresw suite produces several such timers from earlier server generations. The product-level consequence is that `arcadedb.query.duration` and `arcadedb.http.requests` values fragment across abandoned registry generations after an in-process restart, and gauges bound by `PoolMetrics`/`EngineMetricsBinder`/`HAReplicationMetrics` keep reporting the *stopped* server because re-registering an existing meter id is silently ignored.

The metrics subsystem is now installed and uninstalled symmetrically, reference counted so HA and embedded setups running several servers in one JVM are unaffected: each server removes and closes only the registry it added, and the last one out removes the meters the server generations registered (meters that predate the first install are snapshotted and left alone), invalidates the two static timer caches - a cached `Timer` whose meter has been deregistered silently discards every sample - and resets `QueryMetricsRecorder.Holder` to `NO_OP`. `JvmGcMetrics` is now closed (it holds GC MXBean notification listeners) and the `MeterFilter` backstop is installed once per JVM before any meter exists, which also removes the `A MeterFilter is being configured after a Meter has been registered` warnings from the CI logs.

Full analysis in `docs/5565-query-metrics-lifecycle.md`.

## Test plan

- [x] `mvn -pl server -am -Dtest=ServerMetricsLifecycleTest test` - new regression test, all 5 cases fail on the pre-fix code (registry left behind, meter outliving its registry, two registries after one restart, recorder not retired) and pass after
- [x] `mvn -pl server -am -Dtest='com.arcadedb.server.**.*Test' test` - 776 server unit tests green
- [x] `mvn -pl postgresw -am verify -Pintegration` - the suite from the report, 116 ITs in one JVM, green (including both postgres metrics ITs)
- [x] `mvn -pl server -am verify -Pintegration` - 565 ITs, only the pre-existing `StudioProductionModeIT.studioDisabledInProductionByDefault` failure (reproduced identically on unmodified `main`)
- [x] `mvn -pl bolt,mongodbw,redisw,grpcw -am verify -Pintegration -Dit.test='*MetricsIT'` - every wire protocol's metrics IT green
- [x] `mvn -pl metrics -am verify -Pintegration` - Prometheus and OTLP plugin tests green (they add/remove their own registries around this teardown)