### PR TITLE
fix(engine) #5595: normalise a partition lookup key to the declared type before hashing it

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -407,4 +407,30 @@ partition keys, and the SQL and Cypher planner pruning rules are unaffected.
   boolean)` are deprecated. They still compile, and they never prune, since the keys alone cannot be verified
   against the partition properties.
 
+## Partitioned types: a lookup key boxed differently than the stored value now finds its record
+
+Follow-up to the above. `partitioned(...)` derives the bucket from `Object.hashCode()` on both sides, but the two
+sides saw differently boxed objects: placement hashes the value **after** the schema coerced it to the declared
+property type, while a lookup hashed whatever the caller passed. `Long.hashCode(v)` is `(int) (v ^ (v >>> 32))`
+and `Integer.hashCode(v)` is `v`, so the two agree only for positive values below 2^31. On a `LONG` partition key
+every negative value, and every value outside the `int` range, pruned to a bucket the record had never been placed
+in ([#5595](https://github.com/ArcadeData/arcadedb/issues/5595)).
+
+This was not limited to the Java index API: a plain `SELECT FROM T WHERE id = -5` hits it, because a SQL integer
+literal that fits an `int` arrives as an `Integer` and the planner prunes buckets through the same strategy.
+
+The lookup key is now converted to the declared property type - the very coercion the write path applies - before
+being hashed. Placement is untouched, so **no existing database needs a repartition**. Where the stored form cannot
+be reproduced the strategy declines to prune and the search fans out across every bucket, which is correct and only
+slower:
+
+- the partition property is not declared in the schema, so the record kept whatever Java type the writer used and
+  there is no conversion target;
+- the key does not coerce to the declared type at all;
+- the partition index declares `COLLATE CI`. Case folding is an index-level normalisation that placement never
+  applied, so `'Hello'` and `'hello'` are a single index key living in two different buckets. Only a change to
+  placement could reconcile that, and that would force a repartition, so such a partition is no longer pruned.
+  (Bucket counts that are a power of two up to 32 hid this by arithmetic accident: flipping the case of an ASCII
+  letter shifts the Java string hash by a multiple of 32.)
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/database/MutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/MutableDocument.java
@@ -467,36 +467,31 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
       try {
         final Type propType = property.getType();
 
-        final Class javaImplementation;
-        if (propType == Type.DATE)
-          javaImplementation = database.getSerializer().getDateImplementation();
-        else if (propType == Type.DATETIME)
-          javaImplementation = database.getSerializer().getDateTimeImplementation();
-        else {
-          javaImplementation = propType.getDefaultJavaType();
+        // The same mapping the partitioned bucket strategy replays to hash a lookup key the way this write path
+        // hashed the stored one (issue #5595), hence the shared helper rather than an inline switch.
+        final Class javaImplementation = propType.getJavaImplementation(database);
 
-          if (javaImplementation.equals(Document.class)) {
-            // EMBEDDED DOCUMENT
-            if (value instanceof Map) {
-              final Map<String, Object> map = (Map<String, Object>) value;
-              final String embType = (String) map.get("@type");
+        if (javaImplementation.equals(Document.class)) {
+          // EMBEDDED DOCUMENT
+          if (value instanceof Map) {
+            final Map<String, Object> map = (Map<String, Object>) value;
+            final String embType = (String) map.get("@type");
 
-              final String ofType = property.getOfType();
-              if (ofType != null) {
-                // VALIDATE CONSTRAINT
-                if (!ofType.equals(embType)) {
-                  // CHECK INHERITANCE
-                  final DocumentType schemaType = database.getSchema().getType(embType);
-                  if (!schemaType.instanceOf(ofType))
-                    throw new ValidationException(
-                        "Embedded type '" + embType + "' is not compatible with the type defined in the schema " +
-                            "constraint '"
-                            + ofType + "'");
-                }
+            final String ofType = property.getOfType();
+            if (ofType != null) {
+              // VALIDATE CONSTRAINT
+              if (!ofType.equals(embType)) {
+                // CHECK INHERITANCE
+                final DocumentType schemaType = database.getSchema().getType(embType);
+                if (!schemaType.instanceOf(ofType))
+                  throw new ValidationException(
+                      "Embedded type '" + embType + "' is not compatible with the type defined in the schema " +
+                          "constraint '"
+                          + ofType + "'");
               }
-
-              return newEmbeddedDocument(embType, name);
             }
+
+            return newEmbeddedDocument(embType, name);
           }
         }
 

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
@@ -127,6 +127,9 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
     if (partitionKeyIsCaseInsensitive())
       return -1;
 
+    // RESOLVED ONCE: THE SAME DATABASE BACKS EVERY KEY OF THE LOOKUP
+    final Database database = type.getSchema().getEmbedded().getDatabase();
+
     int hash = 0;
     for (int i = 0; i < keyValues.length; i++) {
       final Object value = keyValues[i];
@@ -138,7 +141,7 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
       // hashCode is type-dependent - Long.hashCode(v) is (int) (v ^ (v >>> 32)) while Integer.hashCode(v) is v -
       // the numerically identical key boxed differently used to hash to a different bucket and miss the record
       // (issue #5595). Replay the write-path coercion here so both sides hash the same object.
-      final Object storedForm = toStoredForm(lookupProperties.get(i), value);
+      final Object storedForm = toStoredForm(database, lookupProperties.get(i), value);
       if (storedForm == UNKNOWN_STORED_FORM)
         return -1;
 
@@ -177,12 +180,11 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
    * An undeclared property has no conversion target - the record kept whatever Java type the writer used - so the
    * two sides cannot be reconciled and this declines. That costs a fan-out, which is correct, only slower.
    */
-  private Object toStoredForm(final String propertyName, final Object value) {
+  private Object toStoredForm(final Database database, final String propertyName, final Object value) {
     final Property property = type.getPolymorphicPropertyIfExists(propertyName);
     if (property == null)
       return UNKNOWN_STORED_FORM;
 
-    final Database database = type.getSchema().getEmbedded().getDatabase();
     try {
       final Object converted = Type.convert(database, value, property.getType().getJavaImplementation(database), property);
       return converted != null ? converted : UNKNOWN_STORED_FORM;

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
@@ -18,10 +18,14 @@
  */
 package com.arcadedb.database.bucketselectionstrategy;
 
+import com.arcadedb.database.Database;
 import com.arcadedb.database.Document;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.LocalDocumentType;
+import com.arcadedb.schema.Property;
+import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
@@ -34,10 +38,24 @@ import java.util.List;
  * a key(s) and therefore a document. There are some limitations on using this implementation: (1) field identified as partition key cannot be modified. (This
  * could be solved in the future by removing and recreating the document in a different bucket. If the record is part of a graph, then the edges will be updated
  * accordingly.)
+ * <p>
+ * <b>The two sides must hash the same object.</b> Placement ({@link #getBucketIdByRecord}) hashes the value the schema
+ * coerced and stored; a lookup ({@link #getBucketIdByKeys}) is handed the caller's raw key. Since {@code hashCode()} is
+ * type-dependent, the lookup side normalises its key to the declared property type before hashing (issue #5595), and
+ * declines to prune - answering -1, which callers read as "search every bucket" - whenever it cannot reproduce the
+ * stored form: an undeclared property, a value that will not coerce, or a case-insensitive partition index, whose two
+ * spellings are one index key but were placed in two different buckets. Placement itself is never altered, so no
+ * existing database needs a repartition.
  *
  * @author Luca Garulli
  */
 public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectionStrategy {
+  /**
+   * Sentinel for "this value's stored form cannot be reproduced", which forces the lookup to fan out. A distinct
+   * object rather than {@code null}, which is a legitimate conversion result.
+   */
+  private static final Object UNKNOWN_STORED_FORM = new Object();
+
   private       LocalDocumentType type;
   private final List<String>      propertyNames;
 
@@ -100,13 +118,77 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
     if (!coversPartitionProperties(lookupProperties, keyValues))
       return -1;
 
+    // A COLLATE CI partition index folds two spellings into one key, but placement hashed the spelling the writer
+    // used, so 'Hello' and 'hello' are one index entry living in two different buckets. Unlike the boxed-type case
+    // below there is no lookup-side normalisation that repairs this - only placement itself could, and changing
+    // placement would force every existing partitioned database through a repartition. Never prune instead.
+    if (partitionKeyIsCaseInsensitive())
+      return -1;
+
     int hash = 0;
     for (int i = 0; i < keyValues.length; i++) {
       final Object value = keyValues[i];
-      if (value != null)
-        hash += value.hashCode();
+      if (value == null)
+        continue;
+
+      // Placement hashed the value AFTER the schema coerced it to the declared type; the caller's key has had no
+      // such treatment (TypeIndex hands the raw keys over, and the index's own convertKeys runs much later). Since
+      // hashCode is type-dependent - Long.hashCode(v) is (int) (v ^ (v >>> 32)) while Integer.hashCode(v) is v -
+      // the numerically identical key boxed differently used to hash to a different bucket and miss the record
+      // (issue #5595). Replay the write-path coercion here so both sides hash the same object.
+      final Object storedForm = toStoredForm(lookupProperties.get(i), value);
+      if (storedForm == UNKNOWN_STORED_FORM)
+        return -1;
+
+      hash += storedForm.hashCode();
     }
     return (hash & 0x7fffffff) % total;
+  }
+
+  /**
+   * Whether the index backing this partition folds case on any of its properties, in which case the bucket a record
+   * was placed in is not derivable from a lookup key at all.
+   * <p>
+   * Resolved on every call rather than remembered: an index can be dropped and recreated with a different collation
+   * without the strategy being re-bound, so a cached answer could outlive the schema it was read from. The cost is a
+   * map lookup keyed on the property-name list, whose hash the JDK caches per String, which is the same order of
+   * magnitude as the per-key property lookup the hashing loop already does.
+   * <p>
+   * No index, or no metadata on it, means nothing declares a collation and therefore nothing folds case - answer
+   * "case-sensitive" and let the normal hashing proceed. A partitioned type can legitimately outlive its index: the
+   * unique index is mandated when the strategy is assigned but never re-checked afterwards.
+   */
+  private boolean partitionKeyIsCaseInsensitive() {
+    final TypeIndex index = type.getPolymorphicIndexByProperties(propertyNames);
+    final IndexMetadata metadata = index != null ? index.getMetadata() : null;
+    return metadata != null && metadata.hasAnyCaseInsensitive();
+  }
+
+  /**
+   * Returns {@code value} in the form {@link #getBucketIdByRecord} would have hashed it, or
+   * {@link #UNKNOWN_STORED_FORM} when that form is not derivable.
+   * <p>
+   * The stored form is the one {@code MutableDocument.convertValueToSchemaType} produces, so the conversion target
+   * comes from the SCHEMA property and not from the index key types: a case-insensitive index lowercases its keys
+   * and a string index stores them as {@code byte[]}, neither of which placement ever applied.
+   * <p>
+   * An undeclared property has no conversion target - the record kept whatever Java type the writer used - so the
+   * two sides cannot be reconciled and this declines. That costs a fan-out, which is correct, only slower.
+   */
+  private Object toStoredForm(final String propertyName, final Object value) {
+    final Property property = type.getPolymorphicPropertyIfExists(propertyName);
+    if (property == null)
+      return UNKNOWN_STORED_FORM;
+
+    final Database database = type.getSchema().getEmbedded().getDatabase();
+    try {
+      final Object converted = Type.convert(database, value, property.getType().getJavaImplementation(database), property);
+      return converted != null ? converted : UNKNOWN_STORED_FORM;
+    } catch (final Exception e) {
+      // A key that cannot be coerced to the declared type cannot match any stored value either, but answering
+      // "bucket N" on a guess would be wrong: let the caller fan out and have the index itself reject the key.
+      return UNKNOWN_STORED_FORM;
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
@@ -21,6 +21,7 @@ package com.arcadedb.database.bucketselectionstrategy;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.Document;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.LocalDocumentType;
@@ -32,6 +33,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 
 /**
  * Select the bucket using a partition algorithm computed as the hashed value of the properties values. This allows to predetermine in which bucket is contained
@@ -187,6 +189,11 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
     } catch (final Exception e) {
       // A key that cannot be coerced to the declared type cannot match any stored value either, but answering
       // "bucket N" on a guess would be wrong: let the caller fan out and have the index itself reject the key.
+      // The catch stays broad so no conversion failure can ever turn a lookup into a wrong answer, but it is logged
+      // so an unrelated bug surfacing here degrades visibly instead of silently costing every query a fan-out.
+      LogManager.instance().log(this, Level.FINE,
+          "Cannot reproduce the stored form of the partition key '%s' on type '%s': searching every bucket", e,
+          propertyName, type.getName());
       return UNKNOWN_STORED_FORM;
     }
   }

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -20,6 +20,7 @@ package com.arcadedb.schema;
 
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.database.Identifiable;
@@ -1324,6 +1325,28 @@ public enum Type {
   }
 
   public Class<?> getDefaultJavaType() {
+    return javaDefaultType;
+  }
+
+  /**
+   * Returns the Java class a value of this type is materialised as once the schema has coerced it, i.e. the target
+   * {@link #convert(Database, Object, Class, Property)} uses when a property declares this type.
+   * <p>
+   * This is {@link #getDefaultJavaType()} for every type except {@code DATE} and {@code DATETIME}, whose runtime
+   * representation is configurable per database. Callers that need to reproduce the stored form of a value - the
+   * write path in {@code MutableDocument}, and the partitioned bucket strategy that has to hash a lookup key the way
+   * placement hashed the stored one (issue #5595) - must agree on this mapping, so it lives in one place.
+   *
+   * @param database database whose {@code DATE}/{@code DATETIME} settings apply, or {@code null} to fall back to the
+   *                 default Java type
+   */
+  public Class<?> getJavaImplementation(final Database database) {
+    if (database instanceof DatabaseInternal internal) {
+      if (this == DATE)
+        return internal.getSerializer().getDateImplementation();
+      if (this == DATETIME)
+        return internal.getSerializer().getDateTimeImplementation();
+    }
     return javaDefaultType;
   }
 

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedBoxedKeyLookupTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedBoxedKeyLookupTest.java
@@ -19,11 +19,15 @@
 package com.arcadedb.partitioning;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LocalDocumentType;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -78,27 +82,62 @@ class PartitionedBoxedKeyLookupTest extends TestHelper {
 
     final TypeIndex index = database.getSchema().getType(typeName).getPolymorphicIndexByProperties("id");
 
-    int foundAsLong = 0;
-    int foundAsInteger = 0;
     database.begin();
     try {
       for (final long value : LONG_VALUES) {
-        if (index.get(new Object[] { value }).hasNext())
-          foundAsLong++;
+        assertThat(index.get(new Object[] { value }).hasNext())
+            .as("record %d found with the natively typed Long key", value).isTrue();
 
-        if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
-          if (index.get(new Object[] { (int) value }).hasNext())
-            foundAsInteger++;
-        } else
-          // OUT OF THE INT RANGE: NOTHING TO COMPARE, COUNT IT AS FOUND SO THE TWO TALLIES STAY COMPARABLE
-          foundAsInteger++;
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE)
+          // OUT OF THE INT RANGE: THERE IS NO NUMERICALLY EQUAL INTEGER TO LOOK IT UP WITH
+          continue;
+
+        assertThat(index.get(new Object[] { (int) value }).hasNext())
+            .as("record %d found with the numerically equal Integer key", value).isTrue();
       }
     } finally {
       database.rollback();
     }
+  }
 
-    assertThat(foundAsLong).as("records found with the natively typed Long key").isEqualTo(LONG_VALUES.length);
-    assertThat(foundAsInteger).as("records found with the numerically equal Integer key").isEqualTo(LONG_VALUES.length);
+  /**
+   * What the fix actually delivers, which "the record was found" cannot prove: fanning out over every bucket also
+   * finds every record, so the tests above would still pass if the strategy regressed to answering -1 unconditionally
+   * and never pruned again - a silent performance cliff. This pins the real invariant instead: a lookup key of a
+   * different boxed type resolves the SAME bucket placement chose, and still narrows the search to one sub-index.
+   */
+  @Test
+  void anIntegerLookupKeyResolvesTheBucketPlacementChose() {
+    final String typeName = "PartitionedBoxedBucketAgreement";
+    createLongType(typeName, true);
+    populateLongType(typeName);
+
+    final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType(typeName);
+    final PartitionedBucketSelectionStrategy strategy =
+        (PartitionedBucketSelectionStrategy) type.getBucketSelectionStrategy();
+    final TypeIndex index = type.getPolymorphicIndexByProperties("id");
+
+    database.begin();
+    try {
+      for (final long value : LONG_VALUES) {
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE)
+          continue;
+
+        final Document record = index.get(new Object[] { value }).next().asDocument();
+        final int placementBucket = strategy.getBucketIdByRecord(record, false);
+        final int lookupBucket = strategy.getBucketIdByKeys(List.of("id"), new Object[] { (int) value }, false);
+
+        assertThat(lookupBucket).as("an Integer lookup key for %d must still prune, not decline", value)
+            .isNotEqualTo(-1);
+        assertThat(lookupBucket).as("Integer lookup for %d must resolve the bucket placement chose", value)
+            .isEqualTo(placementBucket);
+
+        assertThat(index.getIndexesByKeys(new Object[] { (int) value }))
+            .as("an Integer lookup for %d must still narrow to a single bucket's sub-index", value).hasSize(1);
+      }
+    } finally {
+      database.rollback();
+    }
   }
 
   /**
@@ -214,7 +253,15 @@ class PartitionedBoxedKeyLookupTest extends TestHelper {
         database.newDocument(typeName).set("name", value).save();
     });
 
-    final TypeIndex index = database.getSchema().getType(typeName).getPolymorphicIndexByProperties("name");
+    final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType(typeName);
+    final TypeIndex index = type.getPolymorphicIndexByProperties("name");
+
+    // Asserted directly, not just through "the record was found": fanning out is the only correct answer here, and
+    // a decline is the only way to get it.
+    final PartitionedBucketSelectionStrategy strategy =
+        (PartitionedBucketSelectionStrategy) type.getBucketSelectionStrategy();
+    assertThat(strategy.getBucketIdByKeys(List.of("name"), new Object[] { values[0] }, false))
+        .as("a case-insensitive partition index must decline to prune").isEqualTo(-1);
 
     int found = 0;
     database.begin();

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedBoxedKeyLookupTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedBoxedKeyLookupTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.partitioning;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5595. {@code PartitionedBucketSelectionStrategy} derives the bucket from {@code Object.hashCode()} on both
+ * sides, but the two sides used to see differently boxed objects: placement hashes the value AFTER the schema coerced
+ * it to the declared property type, while a lookup hashed whatever the caller passed. {@code Long.hashCode(v)} is
+ * {@code (int) (v ^ (v >>> 32))} and {@code Integer.hashCode(v)} is {@code v}, so the two agree only for positive
+ * values below 2^31: every negative value, and every value above the int range, pruned to a bucket the record was
+ * never placed in and the lookup silently found nothing.
+ * <p>
+ * The lookup key is now converted to the declared property type before hashing, which is what placement hashes.
+ * Placement itself is untouched, so no existing database needs a repartition.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PartitionedBoxedKeyLookupTest extends TestHelper {
+
+  private static final int BUCKETS = 8;
+
+  /** Values chosen so Long and Integer hash codes diverge: only 5 collides by luck. */
+  private static final long[] LONG_VALUES = { -5L, -1L, -12345L, 5L, 123L, -2147483648L, 8589934592L };
+
+  private void createLongType(final String typeName, final boolean partitioned) {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(typeName).withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY " + typeName + ".id LONG");
+      database.command("sql", "CREATE INDEX ON " + typeName + "(id) UNIQUE");
+      if (partitioned)
+        database.command("sql", "ALTER TYPE " + typeName + " BucketSelectionStrategy `partitioned('id')`");
+    });
+  }
+
+  private void populateLongType(final String typeName) {
+    database.transaction(() -> {
+      for (final long value : LONG_VALUES)
+        database.newDocument(typeName).set("id", value).save();
+    });
+  }
+
+  /**
+   * The core of the issue: the very same numeric key, handed to the index as an {@code Integer} instead of the
+   * {@code Long} the schema stores, must resolve the same record.
+   */
+  @Test
+  void aLongKeyLookedUpAsAnIntegerFindsTheRecord() {
+    final String typeName = "PartitionedBoxedLong";
+    createLongType(typeName, true);
+    populateLongType(typeName);
+
+    final TypeIndex index = database.getSchema().getType(typeName).getPolymorphicIndexByProperties("id");
+
+    int foundAsLong = 0;
+    int foundAsInteger = 0;
+    database.begin();
+    try {
+      for (final long value : LONG_VALUES) {
+        if (index.get(new Object[] { value }).hasNext())
+          foundAsLong++;
+
+        if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
+          if (index.get(new Object[] { (int) value }).hasNext())
+            foundAsInteger++;
+        } else
+          // OUT OF THE INT RANGE: NOTHING TO COMPARE, COUNT IT AS FOUND SO THE TWO TALLIES STAY COMPARABLE
+          foundAsInteger++;
+      }
+    } finally {
+      database.rollback();
+    }
+
+    assertThat(foundAsLong).as("records found with the natively typed Long key").isEqualTo(LONG_VALUES.length);
+    assertThat(foundAsInteger).as("records found with the numerically equal Integer key").isEqualTo(LONG_VALUES.length);
+  }
+
+  /**
+   * The SQL planner prunes buckets through the same strategy ({@code SelectExecutionPlanner}), and a SQL integer
+   * literal small enough to fit an int arrives as an {@code Integer}. This is how the bug surfaces in a plain query.
+   */
+  @Test
+  void aSqlEqualityOnALongPartitionKeyFindsTheRecord() {
+    final String typeName = "PartitionedBoxedLongSql";
+    createLongType(typeName, true);
+    populateLongType(typeName);
+
+    for (final long value : LONG_VALUES) {
+      final ResultSet rs = database.query("sql", "SELECT FROM " + typeName + " WHERE id = " + value);
+      assertThat(rs.hasNext()).as("SQL equality on id = " + value).isTrue();
+    }
+  }
+
+  /**
+   * Same query through a bound parameter, which the planner cannot early-calculate: it reaches the strategy through
+   * the index path instead. The parameter is deliberately an {@code Integer}.
+   */
+  @Test
+  void aSqlParameterOfADifferentBoxedTypeFindsTheRecord() {
+    final String typeName = "PartitionedBoxedLongParam";
+    createLongType(typeName, true);
+    populateLongType(typeName);
+
+    for (final long value : LONG_VALUES) {
+      if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE)
+        continue;
+      final ResultSet rs = database.query("sql", "SELECT FROM " + typeName + " WHERE id = :id",
+          Map.of("id", (int) value));
+      assertThat(rs.hasNext()).as("SQL parameter lookup on id = " + value).isTrue();
+    }
+  }
+
+  /** The mirror case: an INTEGER property looked up with a Long key. */
+  @Test
+  void anIntegerKeyLookedUpAsALongFindsTheRecord() {
+    final String typeName = "PartitionedBoxedInteger";
+    final int[] values = { -5, -1, -12345, 5, 123, Integer.MIN_VALUE };
+
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(typeName).withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY " + typeName + ".id INTEGER");
+      database.command("sql", "CREATE INDEX ON " + typeName + "(id) UNIQUE");
+      database.command("sql", "ALTER TYPE " + typeName + " BucketSelectionStrategy `partitioned('id')`");
+      for (final int value : values)
+        database.newDocument(typeName).set("id", value).save();
+    });
+
+    final TypeIndex index = database.getSchema().getType(typeName).getPolymorphicIndexByProperties("id");
+
+    int found = 0;
+    database.begin();
+    try {
+      for (final int value : values)
+        if (index.get(new Object[] { (long) value }).hasNext())
+          found++;
+    } finally {
+      database.rollback();
+    }
+
+    assertThat(found).as("records found with a Long key against an INTEGER property").isEqualTo(values.length);
+  }
+
+  /**
+   * A UNIQUE partition index must keep rejecting a duplicate whose key arrives boxed differently: the commit-time
+   * duplicate check reads through the same pruned path.
+   */
+  @Test
+  void aUniquePartitionIndexRejectsADuplicateBoxedDifferently() {
+    final String typeName = "PartitionedBoxedUnique";
+    createLongType(typeName, true);
+    populateLongType(typeName);
+
+    int accepted = 0;
+    for (final long value : LONG_VALUES) {
+      if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE)
+        continue;
+      try {
+        database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET id = ?", (int) value));
+        accepted++;
+      } catch (final Exception e) {
+        // THE CONSTRAINT HELD
+      }
+    }
+
+    assertThat(accepted).as("duplicates accepted through a differently boxed key").isZero();
+  }
+
+  /**
+   * Sibling of the boxed-type mismatch: a {@code COLLATE CI} index treats two spellings as one key, but placement
+   * hashed the value in the case the writer used, so the two spellings landed in different buckets. There is no
+   * lookup-side normalisation that can reconcile that - the fix is to stop pruning such a partition altogether.
+   * <p>
+   * The bucket count is deliberately NOT a power of two. Flipping the case of an ASCII letter shifts the Java string
+   * hash by a multiple of 32, so with 8 or 16 buckets the two spellings land on the same bucket by arithmetic
+   * accident and the defect stays invisible; with 3 they diverge for every value below.
+   */
+  @Test
+  void aCaseInsensitivePartitionIndexStillFindsEverySpelling() {
+    final String typeName = "PartitionedCaseInsensitive";
+    final String[] values = { "ArcadeDB", "MiXeD CaSe", "Tenant", "Alpha", "Beta", "Gamma" };
+
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(typeName).withTotalBuckets(3).create();
+      database.command("sql", "CREATE PROPERTY " + typeName + ".name STRING");
+      database.command("sql", "CREATE INDEX ON " + typeName + " (name COLLATE CI) UNIQUE");
+      database.command("sql", "ALTER TYPE " + typeName + " BucketSelectionStrategy `partitioned('name')`");
+      for (final String value : values)
+        database.newDocument(typeName).set("name", value).save();
+    });
+
+    final TypeIndex index = database.getSchema().getType(typeName).getPolymorphicIndexByProperties("name");
+
+    int found = 0;
+    database.begin();
+    try {
+      for (final String value : values)
+        if (index.get(new Object[] { value.toLowerCase(Locale.ROOT) }).hasNext())
+          found++;
+    } finally {
+      database.rollback();
+    }
+
+    assertThat(found).as("records found through the case-insensitive spelling of the partition key")
+        .isEqualTo(values.length);
+  }
+
+  /** Control: the same schema on the default round-robin strategy, which never prunes. */
+  @Test
+  void aRoundRobinTypeIsUnaffected() {
+    final String typeName = "RoundRobinBoxedLong";
+    createLongType(typeName, false);
+    populateLongType(typeName);
+
+    final TypeIndex index = database.getSchema().getType(typeName).getPolymorphicIndexByProperties("id");
+
+    int found = 0;
+    database.begin();
+    try {
+      for (final long value : LONG_VALUES) {
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE)
+          continue;
+        if (index.get(new Object[] { (int) value }).hasNext())
+          found++;
+      }
+    } finally {
+      database.rollback();
+    }
+
+    assertThat(found).as("round-robin never prunes, so every Integer lookup already worked").isEqualTo(6);
+  }
+}


### PR DESCRIPTION
Closes #5595.

## The defect

`PartitionedBucketSelectionStrategy` derives the bucket from `Object.hashCode()` on both sides, but the two sides saw differently boxed objects:

- **Placement** (`getBucketIdByRecord`) hashes the value **after** the schema coerced it to the declared property type. Every write path funnels through `MutableDocument.convertValueToSchemaType`, so a `LONG` property always holds a `Long`.
- **Lookup** (`getBucketIdByKeys`) hashed whatever the caller passed. `TypeIndex` hands over the raw keys, and the index's own `convertKeys` runs much later inside `LSMTreeIndex.get`.

`Long.hashCode(v)` is `(int) (v ^ (v >>> 32))` while `Integer.hashCode(v)` is `v`, so the two agree only for positive values below 2^31. On a `LONG` partition key every negative value, and every value outside the `int` range, pruned to a bucket the record had never been placed in and the lookup silently found nothing.

**This is not confined to the Java index API.** A plain `SELECT FROM T WHERE id = -5` hits it too: a SQL integer literal that fits an `int` arrives as an `Integer`, and `SelectExecutionPlanner` prunes buckets through the same strategy. That is the more visible symptom, and the issue did not mention it.

## The fix

The lookup key is converted to the declared property type - the very coercion the write path applies - before being hashed, so both sides hash the same object. **Placement is untouched, so no existing database needs a repartition.**

Rather than inlining the coercion into the strategy, the mapping from a declared type to the Java class it is stored as now lives in one place, `Type.getJavaImplementation(Database)`, and `MutableDocument` routes through it as well. The failure mode here was precisely two places independently deciding what a value is stored as; duplicating the `DATE`/`DATETIME` special-casing into the strategy would have recreated it.

I did **not** take the issue's stronger alternative (hashing `serializeKeyForHashing` bytes), for the reason the issue itself gives: it changes the placement function, so every existing partitioned database would need a repartition that `REBUILD TYPE ... WITH repartition = true` refuses on graph types.

### Where it declines to prune

Returning -1 makes the caller fan out over every bucket: correct, only slower.

- the partition property is not declared in the schema, so the record kept whatever Java type the writer used and there is no conversion target;
- the key does not coerce to the declared type at all;
- **the partition index declares `COLLATE CI`** - a sibling defect found while fixing this one, see below.

### The `COLLATE CI` case

Case folding is an index-level normalisation that placement never applied, so `'Hello'` and `'hello'` are a single index key living in two different buckets. No lookup-side normalisation repairs that - only a change to placement could, which would force a repartition - so such a partition is no longer pruned.

Measured red/green with a 3-bucket type. Bucket counts that are a power of two up to 32 hide it by arithmetic accident: flipping the case of an ASCII letter shifts the Java string hash by a multiple of 32, so the low 5 bits survive.

## Testing

New `engine/src/test/java/com/arcadedb/partitioning/PartitionedBoxedKeyLookupTest.java`, 7 tests. **3 were red on `main`** (which already carries #5591); the round-robin control was green throughout. Each of the three declining paths above was verified red with the guard disabled and green with it.

Full `engine` module suite: **10351 tests, 0 failures, 23 skipped**.

## Two honest notes

- **The duplicate-admission half of the issue does not reproduce** for a declared property. Both sides of the commit-time check (`TransactionIndexContext.checkUniqueIndexKeys` -> `TypeIndex.get`) read schema-coerced values, so they agree. The issue said it was inferred from the shared code path and not reproduced directly; that inference does not hold here. `aUniquePartitionIndexRejectsADuplicateBoxedDifferently` is kept as a regression guard, but it passed before the fix as well.
- `MutableDocument.convertValueToSchemaType` is a very hot write path. The refactor is behaviour-preserving - for `DATE`/`DATETIME` the helper returns the same configured implementation class, which is never `Document.class`, so hoisting the embedded-document check out of the `else` is equivalent - and the full suite was run rather than just the partitioning tests because of it.