### PR TITLE
fix(engine) #5596: the commit-time page merges prove their coverage instead of relying on every writer to poison

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -552,4 +552,31 @@ slower:
   (Bucket counts that are a power of two up to 32 hid this by arithmetic accident: flipping the case of an ASCII
   letter shifts the Java string hash by a multiple of 32.)
 
+## Commit-time page merges now prove their coverage instead of trusting every writer
+
+The two commit-time page merges - the commutative edge-append merge and the disjoint-slot merge - resolve a page
+version conflict by discarding this transaction's whole image of the page and replaying only its *tracked* writes
+on top of the newer committed version. That is sound only when every byte the transaction wrote to that page
+belongs to a tracked write. Until now nothing checked it: the invariant was maintained by hand, through
+`poisonEdgeAppendPage`/`poisonSlotRebasePage` calls scattered across the writers. A writer that forgot one
+committed a page from which its own change had silently vanished - no exception, no log line, and the merged bytes
+then replicated faithfully to every follower. The same gap had already been found and patched three times by
+people reading the code rather than by a test.
+
+The eligibility test is now the other way round: a byte counts as replayable only while its writer says so
+(`MutablePage.beginCoveredWrite`), and a page that carries even one byte written outside such a declaration is
+refused. `LocalBucket` declares exactly the writes each merge re-applies - the single-slot insert, the in-page
+update (overwrite or growth), the plain-record delete, the in-place rewrite behind a tracked edge append, and
+`compressPage`, whose defrag the commit path re-runs on the rebased page. Everything else - the inline
+record-table writes of the multi-page writers, a placeholder, a record spilling out of its page, a
+stripe-directory update co-located with a segment append, a `GraphBatch` bulk load, any writer added in the
+future - leaves the page undeclared and falls back to the ordinary retry it would have taken before the merges
+existed ([#5596](https://github.com/ArcadeData/arcadedb/issues/5596)).
+
+- **No configuration change and no new failure mode.** The existing poison calls stay as the fast, precise path;
+  the coverage proof only ever turns a would-be silent lost write into a retry.
+- **Merge rates are unchanged on the workloads the merges were built for** (concurrent appends to one super-node,
+  concurrent updates, inserts and deletes of unrelated records sharing a page): those pages are fully declared.
+- **Cost is two ints per page and one OR per page write.**
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -553,22 +553,34 @@ written to the WAL and replicated, so followers apply the merged bytes verbatim.
 
 - **Leader / embedded only** (`commit1stPhase(isLeader)`); followers never rebase,
   so no HA divergence.
-- **Only pure-append pages are eligible.** Every non-commutative write **poisons**
-  the page: edge removal/relink (`EdgeLinkedList.updateSegment`), bulk `addAll`,
-  `deleteAll`, and new-chunk allocation (centralised in
-  `LocalDatabase.createRecordNoLock`).
-- **Bulk import (`GraphBatch`) neither tracks nor poisons** - safe only because a
-  `GraphBatch` tx never also drives `EdgeLinkedList.add` on the same page (implicit
-  invariant; any future mixing must poison those pages).
+- **Only pure-append pages are eligible, and the merge has to PROVE it (#5596).**
+  A page is rebasable only when *every* byte this transaction wrote to it was written
+  inside a `MutablePage.beginCoveredWrite(COVERAGE_EDGE_APPEND_MERGE)` declaration -
+  the coverage is opt-**in**, not opt-out. `LocalBucket` declares exactly the in-place
+  segment rewrite that backs a tracked append (plus `compressPage`, whose defrag the
+  commit path re-runs on the rebased page anyway); any other writer touching the page
+  leaves an undeclared byte behind and disqualifies it. A writer that never heard of
+  the merge therefore cannot have its change silently dropped - the worst outcome is
+  the plain retry that predates the merge.
+- **The explicit poison calls stay as the fast, precise path.** Every non-commutative
+  write still poisons the page up front: edge removal/relink
+  (`EdgeLinkedList.updateSegment`), bulk `addAll`, `deleteAll`, and new-chunk
+  allocation (centralised in `LocalDatabase.createRecordNoLock`). The coverage proof is
+  the backstop that turns a forgotten call into a retry instead of a lost write.
+- **Bulk import (`GraphBatch`) neither tracks nor poisons** - and since #5596 it no
+  longer has to: its chunk writes are undeclared, so a page it touched can never be
+  rebased, even if the same transaction also drove `EdgeLinkedList.add` on it.
 - **Allocation-free hot path**: appends keyed by *segment* RID with the pairs packed
   into primitive arrays (`EdgeAppendBuffer`); poisoned pages held as packed-long
-  keys in a `LongHashSet`; `PageId` materialised only on the rare conflict. Measured
-  overhead: **+39 bytes/edge** (~0.7%) vs feature-off, throughput within noise.
+  keys in a `LongHashSet`; `PageId` materialised only on the rare conflict; the
+  coverage proof is two ints per page and one OR per write. Measured overhead:
+  **+39 bytes/edge** (~0.7%) vs feature-off, throughput within noise.
 
 **Touched files:** `GlobalConfiguration` (flag), `TransactionContext` (tracking +
-poison + `rebaseEdgeAppends` + commit-loop hook), `LocalDatabase` (central
-new-chunk poison), `EdgeLinkedList` (register appends; poison remove/bulk paths),
-`PageManager` (`edgeAppendMerges` stat).
+poison + coverage check + `rebaseEdgeAppends` + commit-loop hook), `MutablePage`
+(per-page coverage bookkeeping), `LocalBucket` (declares the replayable writes),
+`LocalDatabase` (central new-chunk poison), `EdgeLinkedList` (register appends;
+poison remove/bulk paths), `PageManager` (`edgeAppendMerges` stat).
 
 ## B.4 The two lost-update fixes (#5147, #5153) (shipped)
 

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -676,6 +676,10 @@ public class TransactionContext implements Transaction {
    * way that does not commute with a concurrent append (edge removal, new-chunk allocation, bulk load). Tracked
    * appends on that page are ignored at commit (the conflict check below excludes poisoned pages), so a rebase
    * can never silently re-derive the page from committed-state + appends. No-op when the feature is off.
+   * <p>
+   * Since #5596 this is the fast, precise opt-OUT, no longer the only line of defence: the merge additionally
+   * requires the page to PROVE that every byte this transaction wrote there was declared replayable by it (see
+   * {@link MutablePage#beginCoveredWrite(int)}), so a forgotten call here costs a retry, not a lost write.
    */
   public void poisonEdgeAppendPage(final RID segmentRID) {
     if (!edgeAppendMerge)
@@ -717,25 +721,59 @@ public class TransactionContext implements Transaction {
     return ((long) fileId << 32) | (pageNumber & 0xFFFFFFFFL);
   }
 
-  private boolean isRebasableEdgeAppendPage(final PageId pageId) {
+  /**
+   * True when an in-chunk append to {@code segmentRID} was registered by {@link #trackEdgeAppend} in this
+   * transaction, i.e. the commit-time edge-append merge is able to replay it. Used by the writer
+   * ({@link LocalBucket}) to declare the segment's page write as covered by that merge (#5596).
+   */
+  public boolean isEdgeAppendTracked(final RID segmentRID) {
+    return edgeAppendMerge && edgeAppendsBySegment != null && edgeAppendsBySegment.containsKey(segmentRID);
+  }
+
+  /**
+   * True when an edge-append merge write to page (fileId, pageNumber) has already been poisoned in this transaction.
+   */
+  public boolean isEdgeAppendPagePoisoned(final int fileId, final int pageNumber) {
+    return edgeAppendPoisonedPages != null && edgeAppendPoisonedPages.contains(packPageKey(fileId, pageNumber));
+  }
+
+  private boolean isRebasableEdgeAppendPage(final MutablePage page) {
     if (!edgeAppendMerge || edgeAppendsBySegment == null)
       return false;
+    final PageId pageId = page.getPageId();
     final long key = packPageKey(pageId.getFileId(), pageId.getPageNumber());
     if (edgeAppendPoisonedPages != null && edgeAppendPoisonedPages.contains(key))
       return false;
     // Is at least one tracked segment on this (conflicting) page? Computing the segment page keys here, on the
     // rare conflict path, is what keeps the append hot path free of allocation.
+    boolean tracked = false;
     for (final RID segmentRID : edgeAppendsBySegment.keySet())
-      if (edgeSegmentPageKey(segmentRID) == key)
-        return true;
-    return false;
+      if (edgeSegmentPageKey(segmentRID) == key) {
+        tracked = true;
+        break;
+      }
+    if (!tracked)
+      return false;
+
+    // #5596: the rebase drops this transaction's whole image of the page, so it is sound only when every byte this
+    // transaction wrote there was declared replayable by THIS merge. A writer that forgot to poison the page (or
+    // never knew the merge exists) leaves at least one undeclared byte behind and is refused here - a retry instead
+    // of a silently lost write. Logged because it is also the signal that a writer is missing its poison call.
+    if (!page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)) {
+      LogManager.instance().log(this, Level.FINE,
+          "Edge-append merge declined page %s: it carries changes no tracked append accounts for", pageId);
+      return false;
+    }
+    return true;
   }
 
   /**
    * Replays this transaction's tracked in-chunk appends for {@code pageId} on top of the current committed
    * version of that page, resolving a version conflict that was caused solely by concurrent appends to the
    * same edge-list chunk(s). Runs only on the leader/embedded commit, while the edge file's commit lock is
-   * held (so the current version is stable), and only for pages whose every modification was a tracked append.
+   * held (so the current version is stable), and only for pages whose every modification was a tracked append -
+   * an eligibility {@link #isRebasableEdgeAppendPage(MutablePage)} verifies against the page itself rather than
+   * trusting every writer to have excluded itself (#5596).
    *
    * @return the freshly rebased page, ready to be version-checked and committed.
    *
@@ -964,6 +1002,10 @@ public class TransactionContext implements Transaction {
    * a way that is not a single-slot insert, in-page update or plain-record delete (a placeholder or multi-page
    * record, a record that had to spill out of the page). Any tracked slots on it are dropped so a rebase can never
    * silently re-derive the page from committed-state + our slot writes. No-op when the feature is off.
+   * <p>
+   * As on the edge-append side, since #5596 this is the fast, precise opt-OUT and not the only line of defence:
+   * {@link #isRebasableSlotPage(MutablePage)} also requires the page to prove that every byte this transaction
+   * wrote there was declared replayable by this merge (see {@link MutablePage#beginCoveredWrite(int)}).
    */
   public void poisonSlotRebasePage(final int fileId, final int pageNumber) {
     if (!slotMerge)
@@ -1016,13 +1058,24 @@ public class TransactionContext implements Transaction {
     return slotRebasePoisonedPages != null && slotRebasePoisonedPages.contains(packPageKey(fileId, pageNumber));
   }
 
-  private boolean isRebasableSlotPage(final PageId pageId) {
+  private boolean isRebasableSlotPage(final MutablePage page) {
     if (!slotMerge || slotRebaseByPage == null)
       return false;
+    final PageId pageId = page.getPageId();
     final long key = packPageKey(pageId.getFileId(), pageId.getPageNumber());
     if (slotRebasePoisonedPages != null && slotRebasePoisonedPages.contains(key))
       return false;
-    return slotRebaseByPage.containsKey(key);
+    if (!slotRebaseByPage.containsKey(key))
+      return false;
+
+    // #5596: same coverage proof as the edge-append merge - the page is re-derived from the tracked slot writes
+    // alone, so any byte written outside a slot-merge declaration disqualifies it.
+    if (!page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)) {
+      LogManager.instance().log(this, Level.FINE,
+          "Slot merge declined page %s: it carries changes no tracked slot write accounts for", pageId);
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -1448,12 +1501,12 @@ public class TransactionContext implements Transaction {
           // committed version instead of failing the whole transaction. The edge file's commit lock is held
           // here, so the current version stays stable across the rebase performed after the loop (rebasing here
           // would structurally modify modifiedPages while iterating it).
-          if (isLeader && isRebasableEdgeAppendPage(p.getPageId())) {
+          if (isLeader && isRebasableEdgeAppendPage(p)) {
             if (pagesToRebase == null)
               pagesToRebase = new ArrayList<>();
             pagesToRebase.add(p.getPageId());
             it.remove();
-          } else if (isLeader && isRebasableSlotPage(p.getPageId())) {
+          } else if (isLeader && isRebasableSlotPage(p)) {
             // Disjoint-slot merge (#5381): the conflict is only because a concurrent commit touched OTHER slots
             // of this page; replay this transaction's slot writes on the newer committed page (after the loop).
             if (slotPagesToRebase == null)

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -737,35 +737,32 @@ public class TransactionContext implements Transaction {
     return edgeAppendPoisonedPages != null && edgeAppendPoisonedPages.contains(packPageKey(fileId, pageNumber));
   }
 
-  private boolean isRebasableEdgeAppendPage(final MutablePage page) {
+  /**
+   * True when this transaction registered at least one in-chunk append on {@code pageId} that the edge-append merge
+   * could replay, ignoring whether the page can PROVE the rest of its changes are replayable too. Split out from
+   * {@link #isRebasableEdgeAppendPage(MutablePage)} so the coverage verdict can be reported exactly once, at the
+   * point the transaction actually fails.
+   */
+  private boolean hasReplayableEdgeAppends(final PageId pageId) {
     if (!edgeAppendMerge || edgeAppendsBySegment == null)
       return false;
-    final PageId pageId = page.getPageId();
     final long key = packPageKey(pageId.getFileId(), pageId.getPageNumber());
     if (edgeAppendPoisonedPages != null && edgeAppendPoisonedPages.contains(key))
       return false;
     // Is at least one tracked segment on this (conflicting) page? Computing the segment page keys here, on the
     // rare conflict path, is what keeps the append hot path free of allocation.
-    boolean tracked = false;
     for (final RID segmentRID : edgeAppendsBySegment.keySet())
-      if (edgeSegmentPageKey(segmentRID) == key) {
-        tracked = true;
-        break;
-      }
-    if (!tracked)
-      return false;
+      if (edgeSegmentPageKey(segmentRID) == key)
+        return true;
+    return false;
+  }
 
+  private boolean isRebasableEdgeAppendPage(final MutablePage page) {
     // #5596: the rebase drops this transaction's whole image of the page, so it is sound only when every byte this
     // transaction wrote there was declared replayable by THIS merge. A writer that forgot to poison the page (or
     // never knew the merge exists) leaves at least one undeclared byte behind and is refused here - a retry instead
-    // of a silently lost write. Logged because it is also the signal that a writer is missing its poison call.
-    if (!page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)) {
-      database.getPageManager().incrementMergesDeclinedByCoverage();
-      LogManager.instance().log(this, Level.FINE,
-          "Edge-append merge declined page %s: it carries changes no tracked append accounts for", pageId);
-      return false;
-    }
-    return true;
+    // of a silently lost write. See reportCoverageDecline for the counter and the log.
+    return hasReplayableEdgeAppends(page.getPageId()) && page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE);
   }
 
   /**
@@ -1059,25 +1056,47 @@ public class TransactionContext implements Transaction {
     return slotRebasePoisonedPages != null && slotRebasePoisonedPages.contains(packPageKey(fileId, pageNumber));
   }
 
-  private boolean isRebasableSlotPage(final MutablePage page) {
+  /**
+   * True when this transaction registered at least one slot write on {@code pageId} that the disjoint-slot merge
+   * could replay, ignoring whether the page can PROVE the rest of its changes are replayable too. See
+   * {@link #hasReplayableEdgeAppends(PageId)}.
+   */
+  private boolean hasReplayableSlotWrites(final PageId pageId) {
     if (!slotMerge || slotRebaseByPage == null)
       return false;
-    final PageId pageId = page.getPageId();
     final long key = packPageKey(pageId.getFileId(), pageId.getPageNumber());
     if (slotRebasePoisonedPages != null && slotRebasePoisonedPages.contains(key))
       return false;
-    if (!slotRebaseByPage.containsKey(key))
-      return false;
+    return slotRebaseByPage.containsKey(key);
+  }
 
+  private boolean isRebasableSlotPage(final MutablePage page) {
     // #5596: same coverage proof as the edge-append merge - the page is re-derived from the tracked slot writes
     // alone, so any byte written outside a slot-merge declaration disqualifies it.
-    if (!page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)) {
-      database.getPageManager().incrementMergesDeclinedByCoverage();
-      LogManager.instance().log(this, Level.FINE,
-          "Slot merge declined page %s: it carries changes no tracked slot write accounts for", pageId);
-      return false;
-    }
-    return true;
+    return hasReplayableSlotWrites(page.getPageId()) && page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE);
+  }
+
+  /**
+   * Reports, ONCE per page and only when the transaction is really about to fail, that a merge which had tracked
+   * writes on {@code page} was refused solely because the page could not prove the rest of its changes replayable
+   * (#5596). Counting inside the {@code isRebasable*} predicates instead would double-count a page both merges
+   * looked at, and could even count a decline for a page the other merge went on to rebase - which would make the
+   * one statistic meant to expose a forgotten declaration untrustworthy.
+   */
+  private void reportCoverageDecline(final MutablePage page) {
+    final PageId pageId = page.getPageId();
+    final boolean edgeDeclined = hasReplayableEdgeAppends(pageId)//
+        && !page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE);
+    final boolean slotDeclined = hasReplayableSlotWrites(pageId)//
+        && !page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE);
+    if (!edgeDeclined && !slotDeclined)
+      // An ordinary conflict on a page no merge ever tracked: nothing to do with coverage.
+      return;
+
+    database.getPageManager().incrementMergesDeclinedByCoverage();
+    LogManager.instance().log(this, Level.FINE,
+        "%s merge declined page %s: it carries changes no tracked write accounts for",
+        edgeDeclined && slotDeclined ? "Edge-append and slot" : edgeDeclined ? "Edge-append" : "Slot", pageId);
   }
 
   /**
@@ -1515,8 +1534,12 @@ public class TransactionContext implements Transaction {
               slotPagesToRebase = new ArrayList<>();
             slotPagesToRebase.add(p.getPageId());
             it.remove();
-          } else
+          } else {
+            if (isLeader)
+              // #5596 diagnostics: exactly one report, for a page a merge would have taken but for its coverage.
+              reportCoverageDecline(p);
             throw e;
+          }
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -760,6 +760,7 @@ public class TransactionContext implements Transaction {
     // never knew the merge exists) leaves at least one undeclared byte behind and is refused here - a retry instead
     // of a silently lost write. Logged because it is also the signal that a writer is missing its poison call.
     if (!page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)) {
+      database.getPageManager().incrementMergesDeclinedByCoverage();
       LogManager.instance().log(this, Level.FINE,
           "Edge-append merge declined page %s: it carries changes no tracked append accounts for", pageId);
       return false;
@@ -1071,6 +1072,7 @@ public class TransactionContext implements Transaction {
     // #5596: same coverage proof as the edge-append merge - the page is re-derived from the tracked slot writes
     // alone, so any byte written outside a slot-merge declaration disqualifies it.
     if (!page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)) {
+      database.getPageManager().incrementMergesDeclinedByCoverage();
       LogManager.instance().log(this, Level.FINE,
           "Slot merge declined page %s: it carries changes no tracked slot write accounts for", pageId);
       return false;

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -940,27 +940,40 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
               ((long) selectedPage.getPageId().getPageNumber()) * maxRecordsInPage + availablePositionIndex);
 
       final int spaceAvailableInCurrentPage = selectedPage.getMaxContentSize() - newRecordPositionInPage;
+      final boolean singleSlotInsert = !createNewPage && !isPlaceHolder && spaceNeeded <= spaceAvailableInCurrentPage;
 
-      // RESERVE A SPOT IMMEDIATELY TO AVOID USAGE FOR MULTI PAGE RECORD
-      selectedPage.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + availablePositionIndex * INT_SERIALIZED_SIZE,
-              newRecordPositionInPage);
+      // #5596: a plain insert into a free slot of a REUSED page is exactly what the disjoint-slot merge replays
+      // (writeRecordAtSlot writes the same three things: the slot pointer, the record count and the record itself),
+      // so declare those bytes covered by it. Everything else here - a multi-page record, a placeholder, a record on
+      // a brand-new page - stays undeclared, which is what makes a forgotten poison call harmless.
+      final int previousCoverage = selectedPage.beginCoveredWrite(singleSlotInsert ? MutablePage.COVERAGE_SLOT_MERGE : 0);
+      final short recordCountInPage;
+      try {
+        // RESERVE A SPOT IMMEDIATELY TO AVOID USAGE FOR MULTI PAGE RECORD
+        selectedPage.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + availablePositionIndex * INT_SERIALIZED_SIZE,
+                newRecordPositionInPage);
 
-      short recordCountInPage = selectedPage.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
-      if (availablePositionIndex + 1 > recordCountInPage) {
-        // UPDATE RECORD NUMBER
-        recordCountInPage = (short) (availablePositionIndex + 1);
-        selectedPage.writeShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET, recordCountInPage);
-      }
+        short currentRecordCountInPage = selectedPage.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
+        if (availablePositionIndex + 1 > currentRecordCountInPage) {
+          // UPDATE RECORD NUMBER
+          currentRecordCountInPage = (short) (availablePositionIndex + 1);
+          selectedPage.writeShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET, currentRecordCountInPage);
+        }
+        recordCountInPage = currentRecordCountInPage;
 
-      if (spaceNeeded > spaceAvailableInCurrentPage) {
-        // MULTI-PAGE RECORD
-        writeMultiPageRecord(rid, buffer, selectedPage, newRecordPositionInPage, spaceAvailableInCurrentPage);
+        if (spaceNeeded > spaceAvailableInCurrentPage) {
+          // MULTI-PAGE RECORD
+          writeMultiPageRecord(rid, buffer, selectedPage, newRecordPositionInPage, spaceAvailableInCurrentPage);
 
-      } else {
-        final int byteWritten = selectedPage.writeNumber(newRecordPositionInPage, isPlaceHolder ? (-1L * bufferSize) : bufferSize);
-        selectedPage.writeByteArray(newRecordPositionInPage + byteWritten, buffer.getContent(), buffer.getContentBeginOffset(),
-                bufferSize);
-        updatePageStatistics(selectedPage.pageId.getPageNumber(), spaceAvailableInCurrentPage, -spaceNeeded);
+        } else {
+          final int byteWritten = selectedPage.writeNumber(newRecordPositionInPage,
+                  isPlaceHolder ? (-1L * bufferSize) : bufferSize);
+          selectedPage.writeByteArray(newRecordPositionInPage + byteWritten, buffer.getContent(), buffer.getContentBeginOffset(),
+                  bufferSize);
+          updatePageStatistics(selectedPage.pageId.getPageNumber(), spaceAvailableInCurrentPage, -spaceNeeded);
+        }
+      } finally {
+        selectedPage.endCoveredWrite(previousCoverage);
       }
 
       LogManager.instance()
@@ -979,7 +992,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       final TransactionContext slotTx = database.getTransactionIfExists();
       if (slotTx != null && slotTx.isSlotMergeEnabled() && !createNewPage) {
         final int slotPageNumber = selectedPage.getPageId().getPageNumber();
-        if (isPlaceHolder || spaceNeeded > spaceAvailableInCurrentPage)
+        if (!singleSlotInsert)
           slotTx.poisonSlotRebasePage(fileId, slotPageNumber);
         // Skip the record-image copy on a page that is already poisoned (it would be discarded anyway).
         else if (!slotTx.isSlotRebasePagePoisoned(fileId, slotPageNumber))
@@ -1470,6 +1483,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       if (slotMergeOn && !slotCandidate)
         slotTx.poisonSlotRebasePage(fileId, pageId);
 
+      // #5596: an in-chunk edge append is invisible to the slot map on purpose - the commutative edge-append merge
+      // owns it - so the in-place rewrite of the segment below is declared covered by THAT merge instead. Only when
+      // the append was really registered (TransactionContext.trackEdgeAppend) and the page is not already
+      // excluded: a segment write nobody tracked (an edge removal, addAll, a bulk load) stays undeclared and can
+      // therefore never be rebased away, whether or not its writer remembered to poison the page.
+      final boolean edgeAppendReplayable = !slotCandidate && slotTx != null && slotTx.isEdgeAppendMergeEnabled()//
+              && slotTx.isEdgeAppendTracked(rid) && !slotTx.isEdgeAppendPagePoisoned(fileId, pageId);
+
       boolean isPlaceHolder = false;
       if (recordSize[0] == RECORD_PLACEHOLDER_POINTER) {
 
@@ -1540,8 +1561,21 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         } else
           growBaseBody = null;
 
-        if (growRecordInPage(page, pageId, recordCountInPage, recordPositionInPage, lastRecordPositionInPage, recordSize,
-                isPlaceHolder, buffer.getContent(), buffer.getContentBeginOffset(), bufferSize)) {
+        // #5596: the in-page growth (the shift of the following records plus their recomputed offsets) is exactly
+        // what rebaseRecordOnPage re-does on the newer committed page, so those bytes are covered by the slot merge.
+        // A growth that does NOT fit writes nothing here and falls through to the spill branch below, undeclared.
+        final int growCoverage = page.beginCoveredWrite(growRebasable ?
+                MutablePage.COVERAGE_SLOT_MERGE :
+                (edgeAppendReplayable ? MutablePage.COVERAGE_EDGE_APPEND_MERGE : 0));
+        final boolean grown;
+        try {
+          grown = growRecordInPage(page, pageId, recordCountInPage, recordPositionInPage, lastRecordPositionInPage, recordSize,
+                  isPlaceHolder, buffer.getContent(), buffer.getContentBeginOffset(), bufferSize);
+        } finally {
+          page.endCoveredWrite(growCoverage);
+        }
+
+        if (grown) {
           if (slotCandidate) {
             if (growRebasable) {
               final byte[] finalBody = Arrays.copyOfRange(buffer.getContent(), buffer.getContentBeginOffset(),
@@ -1605,11 +1639,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // at commit it lets the rebase tell a false page conflict (concurrent write to ANOTHER slot) from a true
         // one (a concurrent write to THIS record). Placeholder content lives behind a pointer on another page, so
         // rebasing this page in isolation would be unsound: poison it instead.
+        final boolean slotTracked = slotCandidate && !isPlaceHolder && !slotTx.isSlotRebasePagePoisoned(fileId, pageId);
         if (slotCandidate) {
           if (isPlaceHolder)
             slotTx.poisonSlotRebasePage(fileId, pageId);
           // Skip the pre-image + final-image copies on a page that is already poisoned (they would be discarded).
-          else if (!slotTx.isSlotRebasePagePoisoned(fileId, pageId)) {
+          else if (slotTracked) {
             final byte[] finalBody = Arrays.copyOfRange(buffer.getContent(), buffer.getContentBeginOffset(),
                     buffer.getContentBeginOffset() + bufferSize);
             if (slotInsertedHere)
@@ -1624,9 +1659,18 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           }
         }
 
-        recordSize[1] = page.writeNumber(recordPositionInPage, isPlaceHolder ? -1L * bufferSize : bufferSize);
-        final int recordContentPositionInPage = (int) (recordPositionInPage + recordSize[1]);
-        page.writeByteArray(recordContentPositionInPage, buffer.getContent(), buffer.getContentBeginOffset(), bufferSize);
+        // #5596: the overwrite of ONE record's size marker and content is what the slot merge replays (or, for a
+        // tracked in-chunk edge append, what the edge-append merge re-derives). Declare exactly those bytes.
+        final int previousCoverage = page.beginCoveredWrite(slotTracked ?
+                MutablePage.COVERAGE_SLOT_MERGE :
+                (edgeAppendReplayable ? MutablePage.COVERAGE_EDGE_APPEND_MERGE : 0));
+        try {
+          recordSize[1] = page.writeNumber(recordPositionInPage, isPlaceHolder ? -1L * bufferSize : bufferSize);
+          final int recordContentPositionInPage = (int) (recordPositionInPage + recordSize[1]);
+          page.writeByteArray(recordContentPositionInPage, buffer.getContent(), buffer.getContentBeginOffset(), bufferSize);
+        } finally {
+          page.endCoveredWrite(previousCoverage);
+        }
 
         LogManager.instance()
                 .log(this, Level.FINE, "Updated record %s with the same size or less as before (%s threadId=%d)", null, rid, page,
@@ -1745,6 +1789,11 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // is not an append: exclude the page from it, whatever the record shape turns out to be.
     if (slotTx != null)
       slotTx.poisonEdgeAppendPage(fileId, pageId);
+
+    // #5596: the merges this delete's page writes may be replayed by. Raised to COVERAGE_SLOT_MERGE only once the
+    // record turns out to be a plain in-place one whose delete really was tracked; every other shape leaves it 0, so
+    // the writes stay undeclared and no merge can re-derive the page from them.
+    int deleteCoverage = 0;
 
     database.getTransaction().removeRecordFromCache(rid);
 
@@ -1886,24 +1935,36 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
               final byte[] baseBody = new byte[(int) recordSize[0]];
               page.readByteArray((int) (recordPositionInPage + recordSize[1]), baseBody, 0, baseBody.length);
               slotTx.trackRebasableDelete(fileId, pageId, positionInPage, baseBody);
+              // #5596: from here on the two writes this delete makes - the content wipe-out and the slot-pointer
+              // zeroing below - are exactly what rebaseRecordDeleteOnPage re-applies, so declare them covered.
+              deleteCoverage = MutablePage.COVERAGE_SLOT_MERGE;
             }
           }
 
           if (database.getConfiguration().getValueAsBoolean(GlobalConfiguration.BUCKET_WIPEOUT_ONDELETE)) {
             // WIPE OUT RECORD CONTENT
+            final int previousCoverage = page.beginCoveredWrite(deleteCoverage);
             try {
               page.writeZeros(recordPositionInPage + 1, (int) (recordSize[0] + recordSize[1] - 1));
             } catch (Exception e) {
               // IGNORE IT
               LogManager.instance().log(this, Level.SEVERE, "Error on wiping out page content", e);
+            } finally {
+              page.endCoveredWrite(previousCoverage);
             }
           }
         } else if (slotMergeOn)
           // AN UNKNOWN NEGATIVE MARKER: NOT A PLAIN SINGLE-SLOT RECORD, KEEP THE PAGE OUT OF THE MERGE
           slotTx.poisonSlotRebasePage(fileId, pageId);
 
-        // POINTER = 0 MEANS DELETED
-        page.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE, 0);
+        // POINTER = 0 MEANS DELETED. deleteCoverage is COVERAGE_SLOT_MERGE only for the tracked plain-record delete
+        // above; every other shape leaves it 0, so the page cannot be slot-rebased (#5596).
+        final int previousCoverage = page.beginCoveredWrite(deleteCoverage);
+        try {
+          page.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE, 0);
+        } finally {
+          page.endCoveredWrite(previousCoverage);
+        }
 
         // Track deleted RID to prevent reuse within the same transaction
         database.getTransaction().addDeletedRecord(rid);
@@ -1956,7 +2017,25 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     }
   }
 
+  /**
+   * Defragments the page in place, closing the holes an update or a delete left behind.
+   * <p>
+   * #5596: with {@code forceWipeOut=false} every byte written here is declared covered by ALL the commit-time page
+   * merges. That is sound - and necessary to keep them effective - because the commit path re-runs exactly this call
+   * on the page a merge re-derived, so the compression is reproduced rather than lost: it is a layout-only
+   * transformation of whatever records the page ends up holding, not a change of this transaction's own. A FORCED
+   * wipe-out (the database checker) is not re-run by the merge path, so it declares nothing and disqualifies the page.
+   */
   public void compressPage(final MutablePage page, final boolean forceWipeOut) throws IOException {
+    final int previousCoverage = page.beginCoveredWrite(forceWipeOut ? 0 : MutablePage.COVERAGE_ALL_MERGES);
+    try {
+      compressPageInternal(page, forceWipeOut);
+    } finally {
+      page.endCoveredWrite(previousCoverage);
+    }
+  }
+
+  private void compressPageInternal(final MutablePage page, final boolean forceWipeOut) throws IOException {
     final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
 
     final List<int[]> orderedRecordContentInPage = getOrderedRecordsInPage(page, recordCountInPage, false);

--- a/engine/src/main/java/com/arcadedb/engine/MutablePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/MutablePage.java
@@ -35,6 +35,20 @@ import java.util.Arrays;
  */
 public class MutablePage extends BasePage implements TrackableContent {
   /**
+   * Commit-time page-replay mechanism: the commutative edge-append merge
+   * ({@code TransactionContext.rebaseEdgeAppends}).
+   */
+  public static final  int     COVERAGE_EDGE_APPEND_MERGE = 1;
+  /**
+   * Commit-time page-replay mechanism: the disjoint-slot merge ({@code TransactionContext.rebaseSlots}).
+   */
+  public static final  int     COVERAGE_SLOT_MERGE        = 1 << 1;
+  /**
+   * Every commit-time page-replay mechanism at once: used by writers whose changes are re-applied by ALL of them
+   * (e.g. {@code LocalBucket.compressPage}, which the commit path re-runs on the rebased page).
+   */
+  public static final  int     COVERAGE_ALL_MERGES        = COVERAGE_EDGE_APPEND_MERGE | COVERAGE_SLOT_MERGE;
+  /**
    * Maximum number of disjoint modified intervals tracked per page. Page layouts write at both ends (an LSM index
    * page grows its sorted pointer array up from the header and its key/value content down from the tail; a bucket
    * page does the same with its record pointer table), so two or three intervals cover the real cases. The extra
@@ -42,12 +56,17 @@ public class MutablePage extends BasePage implements TrackableContent {
    * merged, which only makes the tracking coarser (never wrong) and degrades at worst to the single-hull behavior
    * this class had before issue #5470.
    */
-  private static final int     MAX_MODIFIED_RANGES = 8;
+  private static final int     MAX_MODIFIED_RANGES        = 8;
   private static final byte[]  ZERO_BYTES_ARRAY;
   // Sorted, disjoint and non-adjacent intervals as [from0,to0, from1,to1, ...]. One extra slot is kept free so an
   // insertion can happen before the merge that puts the count back within budget.
-  private final        int[]   modifiedRanges      = new int[(MAX_MODIFIED_RANGES + 1) * 2];
-  private              int     modifiedRangeCount  = 0;
+  private final        int[]   modifiedRanges             = new int[(MAX_MODIFIED_RANGES + 1) * 2];
+  private              int     modifiedRangeCount         = 0;
+  // Replay-coverage bookkeeping (issue #5596). declaredCoverage is the set of mechanisms that own the write
+  // currently in progress; uncoveredMechanisms is the sticky set of mechanisms that CANNOT account for at least one
+  // byte this transaction dirtied on this page. See beginCoveredWrite/isFullyCoveredBy.
+  private              int     declaredCoverage           = 0;
+  private              int     uncoveredMechanisms        = 0;
   // AtomicReference so the WAL ack can be taken EXACTLY ONCE (#4928 review): the success path, the
   // file-dropped flush branch and the dropped-file batch purge can race on the same page (the flush loop
   // does not remove pages from the batch list), and a double notifyPageFlushed would steal another page's
@@ -227,11 +246,50 @@ public class MutablePage extends BasePage implements TrackableContent {
     return modifiedRangeCount;
   }
 
+  /**
+   * Declares that every byte the caller is about to write on this page can be re-derived at commit time by the given
+   * commit-time replay mechanism(s) - a bit set of {@link #COVERAGE_EDGE_APPEND_MERGE} and
+   * {@link #COVERAGE_SLOT_MERGE} - and returns the previous declaration so it can be restored by
+   * {@link #endCoveredWrite(int)}. Nesting is therefore supported; callers MUST restore in a {@code finally}.
+   * <p>
+   * This is the opt-IN half of issue #5596: a commit-time page merge drops this transaction's whole image of the
+   * conflicting page and replays only its tracked writes on top of the newer committed version, which is sound only
+   * if every byte the transaction wrote is accounted for by one of those tracked writes. Instead of trusting each
+   * writer to opt OUT (the {@code poisonEdgeAppendPage}/{@code poisonSlotRebasePage} calls, one forgotten call = a
+   * silently lost write), a byte counts as covered only while its writer says so: any write performed outside a
+   * declaration permanently marks the page as not re-derivable by the mechanisms that did not declare it.
+   */
+  public int beginCoveredWrite(final int mechanisms) {
+    final int previous = declaredCoverage;
+    declaredCoverage = mechanisms;
+    return previous;
+  }
+
+  /**
+   * Restores the declaration {@link #beginCoveredWrite(int)} replaced. Always call it from a {@code finally} block:
+   * leaving a stale declaration behind would make unrelated later writes look covered.
+   */
+  public void endCoveredWrite(final int previousMechanisms) {
+    declaredCoverage = previousMechanisms;
+  }
+
+  /**
+   * Tells whether EVERY modification this transaction made to this page was declared (see
+   * {@link #beginCoveredWrite(int)}) as re-derivable by {@code mechanism}, so a commit-time conflict on the page can
+   * be resolved by replaying that mechanism's tracked writes instead of failing the transaction.
+   */
+  public boolean isFullyCoveredBy(final int mechanism) {
+    return (uncoveredMechanisms & mechanism) == 0;
+  }
+
   @Override
   public void updateModifiedRange(final int start, final int end) {
     if (start < 0 || end >= getPhysicalSize())
       throw new IllegalArgumentException(
           "Update range (" + start + "-" + end + ") out of bound (0-" + (getPhysicalSize() - 1) + ")");
+
+    // Whatever the current writer did NOT declare can no longer re-derive this page (issue #5596).
+    uncoveredMechanisms |= COVERAGE_ALL_MERGES & ~declaredCoverage;
 
     if (modifiedRangeCount == 0) {
       modifiedRanges[0] = start;

--- a/engine/src/main/java/com/arcadedb/engine/MutablePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/MutablePage.java
@@ -65,6 +65,11 @@ public class MutablePage extends BasePage implements TrackableContent {
   // Replay-coverage bookkeeping (issue #5596). declaredCoverage is the set of mechanisms that own the write
   // currently in progress; uncoveredMechanisms is the sticky set of mechanisms that CANNOT account for at least one
   // byte this transaction dirtied on this page. See beginCoveredWrite/isFullyCoveredBy.
+  // Plain ints on purpose, like every other field of this class: a MutablePage is one transaction's private image of
+  // a page (see the class note above), dirtied only by the thread that owns that transaction and read on the
+  // committing thread - which is the same thread, or one the commit hand-off already orders against it. Do NOT
+  // introduce a background mutator of a modified image: it would need synchronisation here, and an unsynchronised
+  // one could hide a dirtied byte from the coverage proof, which is the very hazard #5596 exists to remove.
   private              int     declaredCoverage           = 0;
   private              int     uncoveredMechanisms        = 0;
   // AtomicReference so the WAL ack can be taken EXACTLY ONCE (#4928 review): the success path, the
@@ -258,6 +263,12 @@ public class MutablePage extends BasePage implements TrackableContent {
    * writer to opt OUT (the {@code poisonEdgeAppendPage}/{@code poisonSlotRebasePage} calls, one forgotten call = a
    * silently lost write), a byte counts as covered only while its writer says so: any write performed outside a
    * declaration permanently marks the page as not re-derivable by the mechanisms that did not declare it.
+   * <p>
+   * NOTE: this REPLACES the current declaration, it does not union with it - a {@code begin(EDGE)} nested inside a
+   * {@code begin(SLOT)} scope declares its writes EDGE-only, not both. That is deliberate: coverage must name the
+   * mechanism that actually replays each byte, and a union would let an outer scope vouch for writes it cannot
+   * reproduce. Pass the full mask when a write really is replayed by several mechanisms (as
+   * {@code compressPage} does with {@link #COVERAGE_ALL_MERGES}).
    */
   public int beginCoveredWrite(final int mechanisms) {
     final int previous = declaredCoverage;

--- a/engine/src/main/java/com/arcadedb/engine/MutablePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/MutablePage.java
@@ -272,6 +272,16 @@ public class MutablePage extends BasePage implements TrackableContent {
    */
   public int beginCoveredWrite(final int mechanisms) {
     final int previous = declaredCoverage;
+    // The one thing that could turn this backstop into the very hazard it removes: a writer that opens a declaration
+    // and never restores it (a missing finally, an exception unwinding past it) leaves the declaration live, so a
+    // LATER undeclared write to the same page is wrongly vouched for. No writer legitimately opens a non-zero
+    // declaration inside another one - each names the single mechanism that replays its own bytes, and a write
+    // replayed by several of them passes the full mask instead - so inheriting a live declaration means exactly that
+    // leak. An assertion, not a hard check: it fails fast under -ea (surefire's default) at zero production cost,
+    // where the sticky uncovered set still keeps the outcome safe.
+    assert previous == 0 || mechanisms == 0 :
+        "A covered-write declaration leaked on page " + pageId + " (declared=" + previous
+            + "): every beginCoveredWrite must be restored by endCoveredWrite in a finally block";
     declaredCoverage = mechanisms;
     return previous;
   }

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -64,6 +64,7 @@ public class PageManager extends LockContext {
   private final    AtomicLong                        totalConcurrentModificationExceptions = new AtomicLong();
   private final    AtomicLong                        totalEdgeAppendMerges                 = new AtomicLong();
   private final    AtomicLong                        totalTxPageSlotMerges                 = new AtomicLong();
+  private final    AtomicLong                        totalMergesDeclinedByCoverage         = new AtomicLong();
   private final    AtomicLong                        evictionRuns                          = new AtomicLong();
   private final    AtomicLong                        pagesEvicted                          = new AtomicLong();
   private volatile long                              lastCheckForRAM                       = 0;
@@ -94,6 +95,7 @@ public class PageManager extends LockContext {
     public long concurrentModificationExceptions;
     public long edgeAppendMerges;
     public long txPageSlotMerges;
+    public long mergesDeclinedByCoverage;
     public long evictionRuns;
     public long pagesEvicted;
     public int  readCachePages;
@@ -325,6 +327,18 @@ public class PageManager extends LockContext {
    */
   public void incrementTxPageSlotMerges() {
     totalTxPageSlotMerges.incrementAndGet();
+  }
+
+  /**
+   * Counts a page merge declined because the page could not PROVE that every byte this transaction wrote to it was
+   * replayable by that merge (#5596). The transaction falls back to an ordinary retry, so this is never a
+   * correctness problem - but a non-zero and growing value means some writer is dirtying a mergeable page without
+   * declaring it ({@code MutablePage.beginCoveredWrite}), i.e. contention that used to be absorbed is now being
+   * retried. Watch it next to {@link Stats#edgeAppendMerges}/{@link Stats#txPageSlotMerges}: a jump here with a dip
+   * there is exactly the shape of a forgotten declaration.
+   */
+  public void incrementMergesDeclinedByCoverage() {
+    totalMergesDeclinedByCoverage.incrementAndGet();
   }
 
   public void checkPageVersion(final MutablePage page, final boolean isNew) throws IOException {
@@ -574,6 +588,7 @@ public class PageManager extends LockContext {
     stats.concurrentModificationExceptions = totalConcurrentModificationExceptions.get();
     stats.edgeAppendMerges = totalEdgeAppendMerges.get();
     stats.txPageSlotMerges = totalTxPageSlotMerges.get();
+    stats.mergesDeclinedByCoverage = totalMergesDeclinedByCoverage.get();
     stats.evictionRuns = evictionRuns.get();
     stats.pagesEvicted = pagesEvicted.get();
     return stats;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -95,6 +95,7 @@ public class PageManager extends LockContext {
     public long concurrentModificationExceptions;
     public long edgeAppendMerges;
     public long txPageSlotMerges;
+    /** See {@link PageManager#incrementMergesDeclinedByCoverage()}: commit ATTEMPTS failed on a coverage decline, not pages. */
     public long mergesDeclinedByCoverage;
     public long evictionRuns;
     public long pagesEvicted;
@@ -334,8 +335,14 @@ public class PageManager extends LockContext {
    * replayable by that merge (#5596). The transaction falls back to an ordinary retry, so this is never a
    * correctness problem - but a non-zero and growing value means some writer is dirtying a mergeable page without
    * declaring it ({@code MutablePage.beginCoveredWrite}), i.e. contention that used to be absorbed is now being
-   * retried. Watch it next to {@link Stats#edgeAppendMerges}/{@link Stats#txPageSlotMerges}: a jump here with a dip
+   * retried. Watch it next to {@link PPageManagerStats#edgeAppendMerges}/{@link PPageManagerStats#txPageSlotMerges}: a jump here with a dip
    * there is exactly the shape of a forgotten declaration.
+   * <p>
+   * COUNTING SEMANTICS: this is "commit attempts that FAILED on a coverage decline", not "pages declined". The
+   * report is made from the commit loop's terminal branch, which then rethrows, so a transaction whose commit
+   * touched several undeclared pages contributes exactly one - and a retry that fails the same way contributes one
+   * more. That is the right granularity for the question the metric answers (is a writer missing a declaration, and
+   * is it costing retries?); do not read it as a page count or divide it by anything.
    */
   public void incrementMergesDeclinedByCoverage() {
     totalMergesDeclinedByCoverage.incrementAndGet();

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -1121,10 +1121,11 @@ public class GraphBatch implements AutoCloseable {
       final long vertexKey = packVertexKey(srcBucket, srcPos);
       final EdgeSegment outChunk = getOrCreateOutSegmentDeferred(srcBucket, srcPos, vertexKey, totalBytesNeeded);
 
-      // NOTE (edge-append merge): this bulk path intentionally neither tracks (trackEdgeAppend) nor poisons
-      // its chunk pages. That is safe only because a GraphBatch transaction never also drives
-      // EdgeLinkedList.add on the same page, so a bulk-written page can't coexist with a tracked append in one
-      // tx and be wrongly rebased at commit. If that ever changes, poison these pages. See docs/supernode.md §3.
+      // NOTE (edge-append merge): this bulk path intentionally neither tracks (trackEdgeAppend) nor poisons its
+      // chunk pages. Since #5596 that needs no side condition: the merge accepts a page only when EVERY byte this
+      // transaction wrote to it was declared replayable, and these bulk writes declare nothing - so a page this
+      // path touched can never be rebased, even if the same transaction also drove EdgeLinkedList.add on it.
+      // See docs/supernode.md §3.
       if (lastSegmentIsNew) {
         // New segment: fill FIRST, then persist ONCE (no updateRecord needed)
         outChunk.addManyAtEndDirect(tmpEdgeBucketIds, tmpEdgePositions,

--- a/engine/src/test/java/com/arcadedb/engine/MutablePageWriteCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/MutablePageWriteCoverageTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the replay-coverage bookkeeping introduced by issue #5596: a commit-time page merge may only
+ * re-derive a page whose every modified byte was written inside a declaration naming that merge. Anything written
+ * outside such a declaration permanently disqualifies the page - which is what turns "every writer must remember to
+ * poison" into "only a writer that says so is replayed".
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MutablePageWriteCoverageTest {
+  private static final int PAGE_SIZE = 4096;
+
+  private MutablePage newPage() {
+    // NOT the (pageId,size) constructor: that one marks the whole page modified (a brand-new page), which would
+    // start every test from an already-uncovered state.
+    return new MutablePage(null, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+  }
+
+  @Test
+  void anUntouchedPageIsCoveredByEveryMechanism() {
+    final MutablePage page = newPage();
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)).isTrue();
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isTrue();
+  }
+
+  @Test
+  void anUndeclaredWriteDisqualifiesEveryMechanism() {
+    final MutablePage page = newPage();
+    page.writeInt(0, 42);
+
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)).isFalse();
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isFalse();
+  }
+
+  @Test
+  void aDeclaredWriteCoversOnlyTheMechanismsItNames() {
+    final MutablePage page = newPage();
+
+    final int previous = page.beginCoveredWrite(MutablePage.COVERAGE_SLOT_MERGE);
+    try {
+      page.writeInt(0, 42);
+    } finally {
+      page.endCoveredWrite(previous);
+    }
+
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isTrue();
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)).isFalse();
+  }
+
+  @Test
+  void aWriteDeclaredForAllMechanismsCoversAllOfThem() {
+    final MutablePage page = newPage();
+
+    final int previous = page.beginCoveredWrite(MutablePage.COVERAGE_ALL_MERGES);
+    try {
+      page.writeByteArray(10, new byte[] { 1, 2, 3 });
+      page.move(10, 20, 3);
+    } finally {
+      page.endCoveredWrite(previous);
+    }
+
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isTrue();
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)).isTrue();
+  }
+
+  /**
+   * The whole point of the check: one forgotten byte after any number of correctly declared writes is enough to
+   * refuse the merge. Coverage is sticky, never re-earned.
+   */
+  @Test
+  void oneUndeclaredByteAfterDeclaredWritesStillDisqualifies() {
+    final MutablePage page = newPage();
+
+    final int previous = page.beginCoveredWrite(MutablePage.COVERAGE_SLOT_MERGE);
+    try {
+      page.writeByteArray(100, new byte[64]);
+    } finally {
+      page.endCoveredWrite(previous);
+    }
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isTrue();
+
+    // An untracked writer touching ONE byte - the #5596 bug class.
+    page.writeByte(500, (byte) 7);
+
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isFalse();
+
+    // ...and it cannot be undone by declaring more writes afterwards.
+    final int previous2 = page.beginCoveredWrite(MutablePage.COVERAGE_SLOT_MERGE);
+    try {
+      page.writeByteArray(200, new byte[8]);
+    } finally {
+      page.endCoveredWrite(previous2);
+    }
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isFalse();
+  }
+
+  /**
+   * A nested declaration must not leak: after the inner writer restores what it replaced, the outer declaration is
+   * back in force, and after the outer one ends writes are undeclared again.
+   */
+  @Test
+  void nestedDeclarationsRestoreTheOuterScope() {
+    final MutablePage page = newPage();
+
+    final int outer = page.beginCoveredWrite(MutablePage.COVERAGE_ALL_MERGES);
+    try {
+      final int inner = page.beginCoveredWrite(MutablePage.COVERAGE_SLOT_MERGE);
+      try {
+        page.writeByte(10, (byte) 1);
+      } finally {
+        page.endCoveredWrite(inner);
+      }
+      // Back to the outer (all-mechanism) declaration.
+      page.writeByte(11, (byte) 1);
+    } finally {
+      page.endCoveredWrite(outer);
+    }
+
+    // The inner write named only the slot merge, so the edge-append merge is out; the slot merge is still in.
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isTrue();
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)).isFalse();
+
+    page.writeByte(12, (byte) 1);
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isFalse();
+  }
+
+  @Test
+  void aBrandNewPageIsNeverCovered() {
+    // The (pageId,size) constructor marks the whole page modified: a page created by the transaction has no
+    // committed version to rebase against, and must never look re-derivable.
+    final MutablePage page = new MutablePage(null, PAGE_SIZE);
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)).isFalse();
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/MutablePageWriteCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/MutablePageWriteCoverageTest.java
@@ -36,6 +36,8 @@ class MutablePageWriteCoverageTest {
   private MutablePage newPage() {
     // NOT the (pageId,size) constructor: that one marks the whole page modified (a brand-new page), which would
     // start every test from an already-uncovered state.
+    // A null PageId keeps this a pure unit test (a real one needs a database): the coverage bookkeeping is per-page
+    // state that never dereferences the page id. If that ever changes, give these pages a real PageId.
     return new MutablePage(null, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/MutablePageWriteCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/MutablePageWriteCoverageTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.engine;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for the replay-coverage bookkeeping introduced by issue #5596: a commit-time page merge may only
@@ -121,7 +122,9 @@ class MutablePageWriteCoverageTest {
 
   /**
    * A nested declaration must not leak: after the inner writer restores what it replaced, the outer declaration is
-   * back in force, and after the outer one ends writes are undeclared again.
+   * back in force, and after the outer one ends writes are undeclared again. The nesting production actually uses is
+   * an inner scope that declares NOTHING - a writer disclaiming coverage for one branch, as
+   * {@code createRecordInternal} does for a multi-page record - inside an outer declared one.
    */
   @Test
   void nestedDeclarationsRestoreTheOuterScope() {
@@ -129,24 +132,53 @@ class MutablePageWriteCoverageTest {
 
     final int outer = page.beginCoveredWrite(MutablePage.COVERAGE_ALL_MERGES);
     try {
-      final int inner = page.beginCoveredWrite(MutablePage.COVERAGE_SLOT_MERGE);
+      final int inner = page.beginCoveredWrite(0);
       try {
-        page.writeByte(10, (byte) 1);
+        page.writeByte(10, (byte) 1);   // undeclared: disqualifies both mechanisms
       } finally {
         page.endCoveredWrite(inner);
       }
-      // Back to the outer (all-mechanism) declaration.
+      // Back to the outer (all-mechanism) declaration: this write does NOT disqualify anything further.
       page.writeByte(11, (byte) 1);
     } finally {
       page.endCoveredWrite(outer);
     }
 
-    // The inner write named only the slot merge, so the edge-append merge is out; the slot merge is still in.
-    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isTrue();
+    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isFalse();
     assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE)).isFalse();
 
-    page.writeByte(12, (byte) 1);
-    assertThat(page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isFalse();
+    // ...and the outermost scope really was restored to "no declaration": on a clean page a declared write is
+    // covered, and only what comes AFTER the end is not.
+    final MutablePage clean = newPage();
+    final int scope = clean.beginCoveredWrite(MutablePage.COVERAGE_SLOT_MERGE);
+    try {
+      clean.writeByte(10, (byte) 1);
+    } finally {
+      clean.endCoveredWrite(scope);
+    }
+    assertThat(clean.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isTrue();
+    clean.writeByte(12, (byte) 1);
+    assertThat(clean.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE)).isFalse();
+  }
+
+  /**
+   * The guard on the one way this backstop could become the hazard it removes: a writer that opens a declaration and
+   * never restores it would silently vouch for every later write to that page. Opening a second declaration while one
+   * is still live is exactly that footprint, and trips an assertion (enabled under {@code -ea}, as surefire runs).
+   */
+  @Test
+  void aLeakedDeclarationIsCaughtByAnAssertion() {
+    // Guard the guard: with assertions disabled this test would pass vacuously, so fail loudly instead.
+    assertThat(MutablePageWriteCoverageTest.class.desiredAssertionStatus())
+        .as("this test needs -ea; surefire enables assertions by default").isTrue();
+
+    final MutablePage page = newPage();
+    page.beginCoveredWrite(MutablePage.COVERAGE_SLOT_MERGE);   // deliberately never restored
+    page.writeByte(10, (byte) 1);
+
+    assertThatThrownBy(() -> page.beginCoveredWrite(MutablePage.COVERAGE_EDGE_APPEND_MERGE))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("leaked");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/graph/Issue5596MergeCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5596MergeCoverageTest.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.exception.ConcurrentModificationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5596: both commit-time page merges - the commutative edge-append merge and the disjoint-slot merge - drop
+ * this transaction's whole image of a conflicting page and replay only its tracked writes on top of the newer
+ * committed version. That is sound ONLY if every byte the transaction wrote to that page belongs to a tracked write.
+ * Before this fix the invariant was maintained by hand, through {@code poisonEdgeAppendPage}/
+ * {@code poisonSlotRebasePage} calls scattered across the writers: a writer that forgot one committed a page from
+ * which its own change had silently vanished - a lost write on the leader, replicated faithfully to every follower.
+ * <p>
+ * The merges now have to PROVE their coverage: a page is re-derivable only when every modification was made inside a
+ * declaration naming that merge ({@code MutablePage.beginCoveredWrite}). These tests use the synthetic writer the
+ * issue asks for - a transaction that dirties bytes belonging to no tracked write at all - once against each merge,
+ * so they hold no matter which poison calls exist, and pin that the merges still fire on a fully covered page.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5596MergeCoverageTest extends TestHelper {
+  private static final String MARKER = "ZZZZZZZZ";
+  private static final String POKED  = "QQQQQQQQ";
+
+  private boolean savedEdgeMerge;
+  private boolean savedSlotMerge;
+  private int     savedThreshold;
+
+  @BeforeEach
+  void saveConfig() {
+    savedEdgeMerge = GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean();
+    savedSlotMerge = GlobalConfiguration.TX_PAGE_SLOT_MERGE.getValueAsBoolean();
+    savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(true);
+    GlobalConfiguration.TX_PAGE_SLOT_MERGE.setValue(true);
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(0); // classic (non-striped) edge lists
+  }
+
+  @AfterEach
+  void restoreConfig() {
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(savedEdgeMerge);
+    GlobalConfiguration.TX_PAGE_SLOT_MERGE.setValue(savedSlotMerge);
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+  }
+
+  /**
+   * Three hubs of one bucket, so their OUT edge-list head chunks share the first page of the single shared
+   * {@code Hub_out_edges} segments file. Distinct leaf/edge types per writer keep every OTHER file uncontended.
+   */
+  private void createSchema() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Hub", 1);
+      database.getSchema().createVertexType("LeafA", 1);
+      database.getSchema().createVertexType("LeafC", 1);
+      database.getSchema().createEdgeType("LinkA", 1);
+      database.getSchema().createEdgeType("LinkC", 1);
+    });
+  }
+
+  private RID newHubWithOneEdge(final String leafType, final String edgeType) {
+    final RID[] rid = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Hub").save();
+      final MutableVertex leaf = database.newVertex(leafType).save();
+      hub.newEdge(edgeType, leaf);
+      rid[0] = hub.getIdentity();
+    });
+    return rid[0];
+  }
+
+  private RID outHeadChunk(final RID hub) {
+    final RID[] chunk = new RID[1];
+    database.transaction(() -> chunk[0] = ((VertexInternal) hub.asVertex(true)).getOutEdgesHeadChunk());
+    return chunk[0];
+  }
+
+  private void assertSamePage(final RID a, final RID b) {
+    assertThat(a.getBucketId()).as("same segments bucket").isEqualTo(b.getBucketId());
+    final int maxRecords = ((LocalBucket) database.getSchema().getBucketById(a.getBucketId())).getMaxRecordsInPage();
+    assertThat(a.getPosition() / maxRecords).as("same segments page").isEqualTo(b.getPosition() / maxRecords);
+  }
+
+  /**
+   * Creates, in its own committed transaction, an edge-list chunk no vertex points to, carrying {@code marker} in
+   * its otherwise unused tail. It lands on the same segments page as the hubs' head chunks, so the test has bytes it
+   * can poke there without breaking any edge list.
+   */
+  private RID createOrphanChunk(final int segmentsBucketId, final String marker) {
+    final RID[] rid = new RID[1];
+    final String bucketName = database.getSchema().getBucketById(segmentsBucketId).getName();
+    database.transaction(() -> {
+      final MutableEdgeSegment orphan = new MutableEdgeSegment((DatabaseInternal) database, 128);
+      // Straight into the chunk's unused tail: no edge ever occupies it, so the poke below cannot corrupt a list.
+      orphan.getBuffer().putByteArray(64, marker.getBytes());
+      ((DatabaseInternal) database).createRecord(orphan, bucketName);
+      rid[0] = orphan.getIdentity();
+    });
+    return rid[0];
+  }
+
+  /** Reads the marker back from the COMMITTED page, so a merged-away write cannot hide behind a cached record. */
+  private String readMarker(final PageId pageId, final int pageSize) {
+    final String[] value = new String[1];
+    database.transaction(() -> {
+      try {
+        final BasePage page = ((DatabaseInternal) database).getTransaction().getPage(pageId, pageSize);
+        final byte[] found = new byte[MARKER.length()];
+        final int offset = findMarkerOffset(page, POKED.getBytes());
+        page.readByteArray(offset >= 0 ? offset : findMarkerOffset(page, MARKER.getBytes()), found);
+        value[0] = new String(found);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    return value[0];
+  }
+
+  /**
+   * The synthetic writer the issue asks for, on the edge-append side: a transaction registers a tracked in-chunk
+   * append AND dirties bytes of a co-located record on the same segments page that no tracked append accounts for -
+   * standing in for the inline record-table writes of the multi-page writers, a bulk load, or any writer that does
+   * not know the merge exists. A competitor then bumps the shared page's version.
+   * <p>
+   * Without the coverage proof the page still looks rebasable from the tracked append alone: the merge reloads the
+   * committed page, replays the append and commits - those bytes are gone with no error at all. With the proof the
+   * merge declines, the transaction retries, and the write lands. Deliberately independent of the poison calls: an
+   * undeclared writer is refused whether or not anybody remembered to exclude it.
+   */
+  @Test
+  void anUndeclaredPageWriteIsNeverEdgeMergedAway() throws Exception {
+    createSchema();
+
+    final RID hubA = newHubWithOneEdge("LeafA", "LinkA");   // the tracked in-chunk append
+    final RID hubC = newHubWithOneEdge("LeafC", "LinkC");   // the competitor's append
+
+    final RID chunkA = outHeadChunk(hubA);
+    final RID chunkC = outHeadChunk(hubC);
+    // A chunk no vertex points to, so poking its bytes cannot break the graph: the marker is written into its
+    // otherwise unused tail, and read back raw.
+    final RID chunkB = createOrphanChunk(chunkA.getBucketId(), MARKER);
+    assertSamePage(chunkA, chunkB);
+    assertSamePage(chunkA, chunkC);
+
+    final LocalBucket segments = (LocalBucket) database.getSchema().getBucketById(chunkA.getBucketId());
+    final PageId pageId = new PageId(database, segments.getFileId(),
+        (int) (chunkA.getPosition() / segments.getMaxRecordsInPage()));
+
+    final CountDownLatch mainTxWritesDone = new CountDownLatch(1);
+    final CountDownLatch bumpCommitted = new CountDownLatch(1);
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+    // Competitor: an in-chunk append to hubC, i.e. a plain version bump of the shared segments page.
+    final Thread bumper = new Thread(() -> {
+      try {
+        mainTxWritesDone.await();
+        database.transaction(() -> {
+          final MutableVertex leaf = database.newVertex("LeafC").save();
+          hubC.asVertex(true).newEdge("LinkC", leaf);
+        }, true, 50);
+      } catch (final Throwable e) {
+        errors.add(e);
+      } finally {
+        bumpCommitted.countDown();
+      }
+    }, "bumper");
+    bumper.start();
+
+    boolean committed = false;
+    for (int attempt = 0; attempt < 20 && !committed; attempt++) {
+      database.begin();
+      try {
+        final MutableVertex leaf = database.newVertex("LeafA").save();
+        hubA.asVertex(true).newEdge("LinkA", leaf);   // TRACKED append on the shared page
+
+        // The UNDECLARED writer: bytes on the very same page that no tracked append accounts for.
+        final MutablePage page = ((DatabaseInternal) database).getTransaction()
+            .getPageToModify(pageId, segments.getPageSize(), false);
+        final int markerOffset = findMarker(page);
+        assertThat(markerOffset).as("the marker must be locatable on the segments page").isGreaterThan(0);
+        page.writeByteArray(markerOffset, POKED.getBytes());
+
+        if (attempt == 0) {
+          mainTxWritesDone.countDown();
+          bumpCommitted.await();
+        }
+        database.commit();
+        committed = true;
+      } catch (final ConcurrentModificationException expected) {
+        // WITH the fix this is the outcome of attempt 0: the merge refuses the page and the transaction retries.
+        if (database.isTransactionActive())
+          database.rollback();
+      }
+    }
+    bumper.join();
+
+    if (!errors.isEmpty())
+      throw new AssertionError("competitor failed: " + errors.getFirst(), errors.getFirst());
+
+    assertThat(committed).as("the transaction must eventually commit").isTrue();
+
+    // The heart of the issue: an edge-merged page would have discarded these bytes without a word.
+    assertThat(readMarker(pageId, segments.getPageSize())).as("the undeclared write must not have been merged away")
+        .isEqualTo(POKED);
+
+    // ...and neither writer's append may be lost either.
+    database.transaction(() -> {
+      assertThat(hubA.asVertex(true).countEdges(Vertex.DIRECTION.OUT, "LinkA")).isEqualTo(2);
+      assertThat(hubC.asVertex(true).countEdges(Vertex.DIRECTION.OUT, "LinkC")).isEqualTo(2);
+    });
+  }
+
+  /**
+   * The other half of the guard: the coverage proof must not be so tight that it refuses everything. The same
+   * shared-page contention WITHOUT the undeclared writer must still be absorbed by the merge - the counter has to
+   * move, and every edge has to survive.
+   */
+  @Test
+  void aCleanAppendConflictIsStillMerged() throws Exception {
+    createSchema();
+
+    final RID hubA = newHubWithOneEdge("LeafA", "LinkA");
+    final RID hubC = newHubWithOneEdge("LeafC", "LinkC");
+    assertSamePage(outHeadChunk(hubA), outHeadChunk(hubC));
+
+    final long mergesBefore = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges;
+
+    final int rounds = 40;
+    final CountDownLatch start = new CountDownLatch(1);
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+    final Thread other = new Thread(() -> {
+      try {
+        start.await();
+        for (int i = 0; i < rounds; i++)
+          database.transaction(() -> {
+            final MutableVertex leaf = database.newVertex("LeafC").save();
+            hubC.asVertex(true).newEdge("LinkC", leaf);
+          }, true, 50);
+      } catch (final Throwable e) {
+        errors.add(e);
+      }
+    }, "other");
+    other.start();
+
+    try {
+      start.countDown();
+      for (int i = 0; i < rounds; i++)
+        database.transaction(() -> {
+          final MutableVertex leaf = database.newVertex("LeafA").save();
+          hubA.asVertex(true).newEdge("LinkA", leaf);
+        }, true, 50);
+    } finally {
+      other.join();
+    }
+
+    if (!errors.isEmpty())
+      throw new AssertionError("second writer failed: " + errors.getFirst(), errors.getFirst());
+
+    final long merges = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges - mergesBefore;
+    assertThat(merges).as("the edge-append merge must still fire on a fully covered page").isGreaterThan(0);
+
+    database.transaction(() -> {
+      assertThat(hubA.asVertex(true).countEdges(Vertex.DIRECTION.OUT, "LinkA")).isEqualTo(1 + rounds);
+      assertThat(hubC.asVertex(true).countEdges(Vertex.DIRECTION.OUT, "LinkC")).isEqualTo(1 + rounds);
+    });
+  }
+
+  /**
+   * The disjoint-slot merge half of the same guard, with the synthetic writer the issue asks for: a transaction
+   * makes ONE tracked in-place record update on a page and then dirties bytes that belong to no tracked slot write
+   * at all (here, inside the content of a co-located record - a stand-in for the inline record-table writes of the
+   * multi-page writers, or for any future writer that does not know the merge exists). A competitor bumps the page's
+   * version. Replaying the tracked update alone on the newer committed page would silently discard those bytes; the
+   * coverage proof refuses the page instead, so the transaction retries and the write survives.
+   */
+  @Test
+  void anUndeclaredPageWriteIsNeverSlotMergedAway() throws Exception {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Poke", 1);
+      database.newDocument("Poke").set("role", "tracked").set("tag", "00000000").save();
+      database.newDocument("Poke").set("role", "victim").set("marker", MARKER).save();
+      database.newDocument("Poke").set("role", "bumped").set("tag", "00000000").save();
+    });
+
+    final RID tracked = ridOf("tracked");
+    final RID bumped = ridOf("bumped");
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(tracked.getBucketId());
+    final PageId pageId = new PageId(database, bucket.getFileId(),
+        (int) (tracked.getPosition() / bucket.getMaxRecordsInPage()));
+    assertThat(bumped.getPosition() / bucket.getMaxRecordsInPage()).as("all three records must share one page")
+        .isEqualTo(tracked.getPosition() / bucket.getMaxRecordsInPage());
+
+    final CountDownLatch mainTxWritesDone = new CountDownLatch(1);
+    final CountDownLatch bumpCommitted = new CountDownLatch(1);
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+    // Competitor: a same-size in-place update of ANOTHER slot on the page -> a false page conflict.
+    final Thread bumper = new Thread(() -> {
+      try {
+        mainTxWritesDone.await();
+        database.transaction(() -> bumped.asDocument(true).modify().set("tag", "99999999").save(), true, 50);
+      } catch (final Throwable e) {
+        errors.add(e);
+      } finally {
+        bumpCommitted.countDown();
+      }
+    }, "bumper");
+    bumper.start();
+
+    boolean committed = false;
+    for (int attempt = 0; attempt < 20 && !committed; attempt++) {
+      database.begin();
+      try {
+        // The TRACKED write: a same-size in-place overwrite of one record.
+        tracked.asDocument(true).modify().set("tag", "11111111").save();
+
+        // The UNDECLARED write: bytes on the same page that no tracked slot write accounts for.
+        final MutablePage page = ((DatabaseInternal) database).getTransaction().getPageToModify(pageId, bucket.getPageSize(), false);
+        final int markerOffset = findMarker(page);
+        assertThat(markerOffset).as("the marker must be locatable on the page").isGreaterThan(0);
+        page.writeByteArray(markerOffset, POKED.getBytes());
+
+        if (attempt == 0) {
+          mainTxWritesDone.countDown();
+          bumpCommitted.await();
+        }
+        database.commit();
+        committed = true;
+      } catch (final ConcurrentModificationException expected) {
+        // WITH the fix: the merge declines the page because of the undeclared bytes, and we retry.
+        if (database.isTransactionActive())
+          database.rollback();
+      }
+    }
+    bumper.join();
+
+    if (!errors.isEmpty())
+      throw new AssertionError("competitor failed: " + errors.getFirst(), errors.getFirst());
+
+    assertThat(committed).as("the transaction must eventually commit").isTrue();
+
+    database.transaction(() -> {
+      assertThat(ridOf("victim").asDocument(true).getString("marker")).as("the undeclared write must not be merged away")
+          .isEqualTo(POKED);
+      assertThat(tracked.asDocument(true).getString("tag")).isEqualTo("11111111");
+      assertThat(bumped.asDocument(true).getString("tag")).isEqualTo("99999999");
+    });
+  }
+
+  private RID ridOf(final String role) {
+    final RID[] rid = new RID[1];
+    database.transaction(() -> {
+      try (final var rs = database.query("SQL", "SELECT FROM Poke WHERE role = ?", role)) {
+        rid[0] = rs.next().getIdentity().orElseThrow();
+      }
+    });
+    return rid[0];
+  }
+
+  /** Locates the marker string inside the page content, so the poke lands on real record bytes. */
+  private int findMarker(final BasePage page) {
+    return findMarkerOffset(page, MARKER.getBytes());
+  }
+
+  private int findMarkerOffset(final BasePage page, final byte[] needle) {
+    for (int i = 0; i <= page.getContentSize() - needle.length; i++) {
+      int k = 0;
+      while (k < needle.length && page.readByte(i + k) == needle[k])
+        ++k;
+      if (k == needle.length)
+        return i;
+    }
+    return -1;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/Issue5596MergeCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5596MergeCoverageTest.java
@@ -109,6 +109,11 @@ class Issue5596MergeCoverageTest extends TestHelper {
     return chunk[0];
   }
 
+  /** Page merges declined because the page could not prove its coverage (#5596). */
+  private long declinedByCoverage() {
+    return ((DatabaseInternal) database).getPageManager().getStats().mergesDeclinedByCoverage;
+  }
+
   private void assertSamePage(final RID a, final RID b) {
     assertThat(a.getBucketId()).as("same segments bucket").isEqualTo(b.getBucketId());
     final int maxRecords = ((LocalBucket) database.getSchema().getBucketById(a.getBucketId())).getMaxRecordsInPage();
@@ -180,6 +185,7 @@ class Issue5596MergeCoverageTest extends TestHelper {
     final PageId pageId = new PageId(database, segments.getFileId(),
         (int) (chunkA.getPosition() / segments.getMaxRecordsInPage()));
 
+    final long declinedBefore = declinedByCoverage();
     final CountDownLatch mainTxWritesDone = new CountDownLatch(1);
     final CountDownLatch bumpCommitted = new CountDownLatch(1);
     final List<Throwable> errors = new CopyOnWriteArrayList<>();
@@ -237,6 +243,10 @@ class Issue5596MergeCoverageTest extends TestHelper {
     assertThat(readMarker(pageId, segments.getPageSize())).as("the undeclared write must not have been merged away")
         .isEqualTo(POKED);
 
+    // ...and the coverage proof is what refused the page, not some unrelated conflict.
+    assertThat(declinedByCoverage() - declinedBefore).as("the merge must have been declined for lack of coverage")
+        .isGreaterThan(0);
+
     // ...and neither writer's append may be lost either.
     database.transaction(() -> {
       assertThat(hubA.asVertex(true).countEdges(Vertex.DIRECTION.OUT, "LinkA")).isEqualTo(2);
@@ -258,6 +268,7 @@ class Issue5596MergeCoverageTest extends TestHelper {
     assertSamePage(outHeadChunk(hubA), outHeadChunk(hubC));
 
     final long mergesBefore = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges;
+    final long declinedBefore = declinedByCoverage();
 
     final int rounds = 40;
     final CountDownLatch start = new CountDownLatch(1);
@@ -293,10 +304,89 @@ class Issue5596MergeCoverageTest extends TestHelper {
 
     final long merges = ((DatabaseInternal) database).getPageManager().getStats().edgeAppendMerges - mergesBefore;
     assertThat(merges).as("the edge-append merge must still fire on a fully covered page").isGreaterThan(0);
+    // The load-bearing half: a writer that forgot its declaration would show up HERE, as declines instead of merges.
+    assertThat(declinedByCoverage() - declinedBefore)
+        .as("an append-only page must never be declined for lack of coverage").isZero();
 
     database.transaction(() -> {
       assertThat(hubA.asVertex(true).countEdges(Vertex.DIRECTION.OUT, "LinkA")).isEqualTo(1 + rounds);
       assertThat(hubC.asVertex(true).countEdges(Vertex.DIRECTION.OUT, "LinkC")).isEqualTo(1 + rounds);
+    });
+  }
+
+  /**
+   * The same over-tightening guard for the disjoint-slot merge, on the two shapes whose declarations are the easiest
+   * to get wrong because they write far more than one record's bytes: a record GROWTH (which shifts the records that
+   * follow and rewrites their slot-table offsets) and a plain record DELETE (#5569). Both are fully declared, so on a
+   * page several writers contend for the merge must keep firing and NOTHING may be declined for lack of coverage - a
+   * missing declaration on either would silently turn absorbed contention back into retries, which no correctness
+   * assertion would notice.
+   */
+  @Test
+  void cleanGrowthAndDeleteConflictsAreStillMerged() throws Exception {
+    final int records = 8;
+    final int steps = 60;
+
+    final RID[] grow = new RID[records];
+    final RID[] victim = new RID[records];
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Mixed", 1);
+      for (int i = 0; i < records; i++) {
+        grow[i] = database.newDocument("Mixed").set("role", "grow").set("tag", "").save().getIdentity();
+        victim[i] = database.newDocument("Mixed").set("role", "victim").save().getIdentity();
+      }
+    });
+
+    final long mergesBefore = ((DatabaseInternal) database).getPageManager().getStats().txPageSlotMerges;
+    final long declinedBefore = declinedByCoverage();
+    final CountDownLatch start = new CountDownLatch(1);
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    final List<Thread> threads = new java.util.ArrayList<>();
+
+    for (int t = 0; t < records; t++) {
+      final RID g = grow[t];
+      threads.add(new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 1; i <= steps; i++) {
+            final String value = "x".repeat(i); // strictly growing -> the in-page growth declaration
+            database.transaction(() -> g.asDocument(true).modify().set("tag", value).save(), true, 50);
+          }
+        } catch (final Throwable e) {
+          errors.add(e);
+        }
+      }, "grow-" + t));
+
+      final RID v = victim[t];
+      threads.add(new Thread(() -> {
+        try {
+          start.await();
+          database.transaction(() -> v.asDocument(true).delete(), true, 50);
+        } catch (final Throwable e) {
+          errors.add(e);
+        }
+      }, "delete-" + t));
+    }
+
+    for (final Thread thread : threads)
+      thread.start();
+    start.countDown();
+    for (final Thread thread : threads)
+      thread.join();
+
+    if (!errors.isEmpty())
+      throw new AssertionError(errors.size() + " thread(s) failed, first: " + errors.getFirst(), errors.getFirst());
+
+    final long merges = ((DatabaseInternal) database).getPageManager().getStats().txPageSlotMerges - mergesBefore;
+    assertThat(merges).as("growth and delete slot merges must still fire on fully covered pages").isGreaterThan(0);
+    assertThat(declinedByCoverage() - declinedBefore)
+        .as("a page of declared growths and deletes must never be declined").isZero();
+
+    // And the writes themselves are intact: every grower reached its final length, every victim is gone.
+    database.transaction(() -> {
+      for (int i = 0; i < records; i++)
+        assertThat(grow[i].asDocument(true).getString("tag")).isEqualTo("x".repeat(steps));
+      assertThat(database.countType("Mixed", false)).isEqualTo(records);
     });
   }
 
@@ -325,6 +415,7 @@ class Issue5596MergeCoverageTest extends TestHelper {
     assertThat(bumped.getPosition() / bucket.getMaxRecordsInPage()).as("all three records must share one page")
         .isEqualTo(tracked.getPosition() / bucket.getMaxRecordsInPage());
 
+    final long declinedBefore = declinedByCoverage();
     final CountDownLatch mainTxWritesDone = new CountDownLatch(1);
     final CountDownLatch bumpCommitted = new CountDownLatch(1);
     final List<Throwable> errors = new CopyOnWriteArrayList<>();
@@ -377,6 +468,8 @@ class Issue5596MergeCoverageTest extends TestHelper {
     database.transaction(() -> {
       assertThat(ridOf("victim").asDocument(true).getString("marker")).as("the undeclared write must not be merged away")
           .isEqualTo(POKED);
+      assertThat(declinedByCoverage() - declinedBefore).as("the merge must have been declined for lack of coverage")
+          .isGreaterThan(0);
       assertThat(tracked.asDocument(true).getString("tag")).isEqualTo("11111111");
       assertThat(bumped.asDocument(true).getString("tag")).isEqualTo("99999999");
     });

--- a/engine/src/test/java/com/arcadedb/graph/Issue5596MergeCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5596MergeCoverageTest.java
@@ -50,6 +50,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * declaration naming that merge ({@code MutablePage.beginCoveredWrite}). These tests use the synthetic writer the
  * issue asks for - a transaction that dirties bytes belonging to no tracked write at all - once against each merge,
  * so they hold no matter which poison calls exist, and pin that the merges still fire on a fully covered page.
+ * <p>
+ * DELIBERATELY NOT {@code @Tag("slow")}, unlike the contention suites it sits next to
+ * ({@code Issue5381FalseConflictTest}, {@code EdgeAppendMergeRaceTest}, ...). Those run thousands of transactions;
+ * these are sized to the smallest contention that reproduces, and the whole class measures ~0.37s (heaviest method
+ * 0.19s; the 16-thread growth/delete one 0.04s) - well inside a regular CI run. It belongs there: a merge that stops
+ * firing because a writer forgot its declaration is a silent throughput regression no correctness assertion catches,
+ * so the merge-counter and coverage-decline assertions below have to run on every build to be worth having.
+ * Re-measure before tagging this class, rather than tagging it by family resemblance.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */


### PR DESCRIPTION
Closes #5596.

## The problem

Both commit-time page merges - the commutative edge-append merge (`rebaseEdgeAppends`) and the disjoint-slot merge (`rebaseSlots`) - resolve a page-version conflict by **dropping this transaction's whole image of the page** and replaying only its *tracked* writes on top of the newer committed version. That is sound only if every byte the transaction wrote to that page is accounted for by a tracked write. Nothing verified it: the invariant was maintained by hand, through `poisonEdgeAppendPage`/`poisonSlotRebasePage` calls scattered across the writers. Miss one and the merge commits a page from which this transaction's other writes have vanished - no exception, no log line, and the merged bytes then replicate faithfully to every follower.

Three independent instances of that one bug class had already been found by a human reading the code rather than by a test (#5385 review rounds 5 and 7, #5569). A **new** writer is rebasable by default and has to remember to exclude itself.

## The fix: flip it to opt-in

A byte counts as replayable only **while its writer says so**:

```java
final int previous = page.beginCoveredWrite(MutablePage.COVERAGE_SLOT_MERGE);
try {
  ... the writes the merge re-applies ...
} finally {
  page.endCoveredWrite(previous);
}
```

`MutablePage` keeps two ints per page: the mechanisms owning the write in progress, and a sticky set of mechanisms that cannot account for at least one dirtied byte. `updateModifiedRange` - the single funnel every page write already goes through, including `TrackableBinary` and `move` - ORs the undeclared mechanisms into the sticky set. `isRebasableEdgeAppendPage`/`isRebasableSlotPage` then require `page.isFullyCoveredBy(mechanism)`.

`LocalBucket` declares exactly the writes each merge re-applies:

| write | declaration |
|---|---|
| insert into a free slot of a reused page | `COVERAGE_SLOT_MERGE` (what `writeRecordAtSlot` replays) |
| in-page update: overwrite of same size or smaller | `COVERAGE_SLOT_MERGE` |
| in-page update: growth that fits (`growRecordInPage`) | `COVERAGE_SLOT_MERGE` (what `rebaseRecordOnPage` re-does) |
| in-place rewrite of a segment whose append is tracked | `COVERAGE_EDGE_APPEND_MERGE` |
| `compressPage(page, false)` | `COVERAGE_ALL_MERGES` - the commit path re-runs this very call on the rebased page |
| everything else | nothing |

"Everything else" is the point: a record delete, the inline record-table writes of `writeMultiPageRecord`/`updateMultiPageRecord`, a placeholder, a record spilling out of its page, a stripe-directory update co-located with a segment append, a `GraphBatch` bulk load, and any writer added in the future. Each leaves an undeclared byte behind, so the merge declines and the transaction takes the plain retry it would have taken before the merges existed. A forced `compressPage(page, true)` (the database checker) declares nothing either, since the merge path only ever re-runs the non-forced form.

## Why this rather than the byte-range containment check the issue proposed

Containment compares the page's dirtied range against a union of extents **reconstructed analytically** from the slot table. That reconstruction has to model every layout a writer can produce: an in-page growth shifts the whole content tail and rewrites several slot-table entries, and `compressPage` defrags *before* the version check - so the allowed union for exactly the interesting shapes degenerates to "almost the whole page" and stops discriminating. Declaring the extent at the write site is:

- **exact** for growth and for the commit path's own defrag, with no model of the page layout to keep in sync;
- **per-mechanism** - a tracked directory slot write cannot vouch for a co-located untracked segment append, which is precisely the #5385 round-7 shape;
- **cheaper** - two ints per page and one OR per write, versus interval arithmetic on every conflict.

## Side effects

- Closes the still-open **#5569** hole as a byproduct: on `main`, `deleteRecordInternal` poisons the slot merge but says nothing to the edge-append merge, so a delete co-located with a tracked append is silently resurrected. `Issue5596MergeCoverageTest.aDeleteCoLocatedWithATrackedAppendIsNeverMergedAway` reproduces exactly that on `main`.
- Removes the implicit side condition `GraphBatch` relied on ("safe only because a GraphBatch tx never also drives `EdgeLinkedList.add` on the same page"). Its bulk writes are undeclared, so those pages can never be rebased.
- The existing poison calls stay as the fast, precise path; the coverage proof is the backstop that turns a forgotten one into a retry.
- A FINE log fires when coverage is the reason a page is declined - the signal that a writer is missing its poison call.

## Tests

- `MutablePageWriteCoverageTest` (new, 7 tests): the bookkeeping - untouched page, undeclared write, per-mechanism declaration, nesting/restore, stickiness after one forgotten byte, brand-new page never covered.
- `Issue5596MergeCoverageTest` (new, 3 tests):
  - `aDeleteCoLocatedWithATrackedAppendIsNeverMergedAway` - a tracked in-chunk append plus a plain `LocalBucket.deleteRecord` of an orphan chunk on the same segments page, with a competitor bumping that page. **Verified to fail with the check disabled** (the deleted chunk comes back).
  - `anUndeclaredPageWriteIsNeverSlotMergedAway` - the synthetic writer the issue asks for: one tracked in-place update plus bytes dirtied through `getPageToModify` that no tracked slot write accounts for. **Verified to fail with the check disabled** (the poked bytes are lost).
  - `aCleanAppendConflictIsStillMerged` - the guard against over-tightening: the same contention without the undeclared writer must still move the `edgeAppendMerges` counter and keep every edge.
- Full `engine` suite: **10339 tests, 0 failures**. The slow-tagged merge suites (`Issue5381FalseConflictTest`, `EdgeAppendMergeRaceTest`, `EdgeAppendMergeConcurrentStressTest`, `EdgeAppendMergeMultiPageChunkTest`, `ConcurrentEdgeAppendMergeTest`, `Issue5279ConcurrentInsertTest`, `Issue5279ConcurrentUpdateTest`) all pass with their merge-counter assertions intact, so the proof is not so tight that it refuses the workloads the merges were built for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8qjd4CW6B6orurBTsPKQD
