### PR TITLE
#5600 Geospatial misc: STRING stays STRING, GEOSPATIAL precision from SQL, fewer cells for area shapes

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -611,15 +611,20 @@ Java API alike:
 CREATE INDEX ON Location (coords) GEOSPATIAL METADATA {"precision": 6}
 ```
 
-Two related sharp edges went with it:
+A `METADATA` clause the index cannot use is now reported instead of dropped. An unknown key (`{"precisin": 6}`), a
+precision that is not a whole number in 1-12, an invalid tokenization, or a `METADATA` on an index type that has
+no settings at all raise a `CommandSQLParsingException`. Silently ignoring the clause is what kept this gap
+invisible in the first place.
 
-- **An unusable `METADATA` clause is rejected instead of dropped.** An unknown key (`{"precisin": 6}`), an
-  out-of-range precision, an invalid tokenization, or a `METADATA` on an index type that has no settings at all
-  now raise a `CommandSQLParsingException`. Silently ignoring the clause is what kept the gap invisible.
-- **`withType()` no longer leaves the original builder unconfigured.** It returns a specialised subclass for
-  `LSM_VECTOR`, `FULL_TEXT`, `LSM_SPARSE_VECTOR` and now `GEOSPATIAL`, so a caller that ignored the return value
-  (`builder.withType(X); builder.create();`) hit `indexType was not specified`. The type is recorded on the
-  original builder as well.
+> **Breaking change, at execution time.** `CREATE INDEX ... UNIQUE METADATA {"test": 3}` - a `METADATA` clause on
+> a plain `LSM_TREE` or `HASH` index, which has no settings to configure - used to be accepted and ignored, and
+> now fails the statement. The SQL **grammar** is unchanged, so such a statement still parses; only running it
+> is refused. If a schema script carries a `METADATA` that was never doing anything, drop the clause.
+
+One more sharp edge went with it: **`withType()` no longer leaves the original builder unconfigured.** It returns
+a specialised subclass for `LSM_VECTOR`, `FULL_TEXT`, `LSM_SPARSE_VECTOR` and now `GEOSPATIAL`, so a caller that
+ignored the return value (`builder.withType(X); builder.create();`) hit `indexType was not specified`. The type is
+recorded on the original builder as well.
 
 ## GEOSPATIAL: an area shape indexes fewer cells
 

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -552,4 +552,65 @@ slower:
   (Bucket counts that are a power of two up to 32 hid this by arithmetic accident: flipping the case of an ASCII
   letter shifts the Java string hash by a multiple of 32.)
 
+## A `STRING` property no longer reads back as a geometry
+
+Deserializing any string looked at its first characters and, when they were `POINT`, `CIRCLE`, `LINESTRING`,
+`POLYGON`, `ENVELOPE` or `BUFFER`, parsed the value as WKT and handed back a spatial4j `Shape` instead of the
+`String` that had been written ([#5600](https://github.com/ArcadeData/arcadedb/issues/5600)). A property declared
+`STRING` therefore did not round-trip: `getString()` returned spatial4j's `Pt(x=..,y=..)` form, which is not valid
+WKT, so feeding it back into a geo function failed. The trigger was a prefix match on arbitrary user text, not a
+schema decision, so a `description` column holding `"POLYGON shaped, see attached"` went through it too - and the
+prefix chain ran on **every** string read in the database.
+
+The storage layer no longer changes the declared type of a value: a string reads back as the string that was
+written. The conversion happens where a geometry is actually asked for - `GeoUtils.parseGeometry()`,
+`GeoUtils.parseJtsGeometry()` and the geospatial index all accept a WKT string - so a database written before
+26.2.1, when shapes were stored as WKT text, keeps working unchanged; `geo.point()` likewise still returns WKT and
+is still indexable and queryable. Only code that relied on `document.get("wktColumn") instanceof Shape` sees a
+difference, and it now gets the type the schema declares.
+
+## GEOSPATIAL: `precision` is settable from SQL, and an ignored `METADATA` is now an error
+
+`CREATE INDEX ... GEOSPATIAL METADATA {"precision": 6}` parsed, ran, and silently built the index at the default
+precision of 11: `CreateIndexStatement` forwarded `METADATA` for `LSM_VECTOR`, `FULL_TEXT` and `LSM_SPARSE_VECTOR`
+and fell through to a bare `create()` for everything else, so only the Java API could set it. Precision drives cell
+resolution (11 is about 2.4 m, 6 about 1.2 km) and therefore index size and query selectivity.
+
+`GEOSPATIAL` now has a builder of its own, `TypeGeoIndexBuilder`, in the same shape as the full-text and vector
+ones, and `withType(GEOSPATIAL)` returns it - so `precision` and `tokenization` are settable from SQL and from the
+Java API alike:
+
+```sql
+CREATE INDEX ON Location (coords) GEOSPATIAL METADATA {"precision": 6}
+```
+
+Two related sharp edges went with it:
+
+- **An unusable `METADATA` clause is rejected instead of dropped.** An unknown key (`{"precisin": 6}`), an
+  out-of-range precision, an invalid tokenization, or a `METADATA` on an index type that has no settings at all
+  now raise a `CommandSQLParsingException`. Silently ignoring the clause is what kept the gap invisible.
+- **`withType()` no longer leaves the original builder unconfigured.** It returns a specialised subclass for
+  `LSM_VECTOR`, `FULL_TEXT`, `LSM_SPARSE_VECTOR` and now `GEOSPATIAL`, so a caller that ignored the return value
+  (`builder.withType(X); builder.create();`) hit `indexType was not specified`. The type is recorded on the
+  original builder as well.
+
+## GEOSPATIAL: an area shape indexes fewer cells
+
+The FRONTIER layout introduced above stores the cells a shape's decomposition stops at. A complete set of sibling
+cells is now collapsed into its parent, recursively - the reduction Lucene calls `pruneLeafyBranches` and applies
+by default on its own indexing path. A parent covers the union of its children, so the cover can only grow and a
+match is never lost; the `geo.*` predicate post-filters the superset either way. Measured on the frontier cell
+count: 57% fewer for a small square, 74% fewer for a jagged outline, and unchanged for a linestring or a wide
+rectangle. A point decomposes into a chain of single-child cells and is never affected, so the one-entry-per-point
+guarantee stands.
+
+Lucene's own implementation buffers the entire decomposition in a list, which is why its javadoc warns against the
+option "for high precision (low distErrPct) shapes". ArcadeDB's is a streaming walk: only the frontier tokens on
+the current root-to-leaf path can still be revoked by an ancestor collapsing, bounding what is held to
+`subCellsSize * detailLevel` tokens regardless of shape size. The two produce identical token sets, which is
+asserted directly against Lucene in `LSMTreeGeoIndexCellPruningTest`.
+
+This changes what a **new** index writes for area shapes; an index already in the `FULL` layout is untouched, and
+`FRONTIER` has not shipped in any release, so no published database holds the unpruned form.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -645,4 +645,10 @@ asserted directly against Lucene in `LSMTreeGeoIndexCellPruningTest`.
 This changes what a **new** index writes for area shapes; an index already in the `FULL` layout is untouched, and
 `FRONTIER` has not shipped in any release, so no published database holds the unpruned form.
 
+> Running a **nightly 26.8.1-SNAPSHOT** build from between the `FRONTIER` change and this one is the one case that
+> needs attention: a geospatial index written by those builds holds unpruned cells for its area shapes, while this
+> build recomputes the pruned - smaller - set when a record is deleted, which would leave the extra entries behind.
+> `REBUILD INDEX` on such an index rewrites it in the current layout. Point-only indexes are unaffected, since
+> pruning never applies to them.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/function/sql/geo/GeoUtils.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/geo/GeoUtils.java
@@ -72,14 +72,14 @@ public class GeoUtils {
       return shape;
     // Cypher point() returns a Map with x/y or longitude/latitude keys
     if (value instanceof Map<?, ?> map) {
-      double x;
-      double y;
+      final double x;
+      final double y;
       if (map.containsKey("x") && map.containsKey("y")) {
-        x = ((Number) map.get("x")).doubleValue();
-        y = ((Number) map.get("y")).doubleValue();
+        x = coordinate(map.get("x"), "x");
+        y = coordinate(map.get("y"), "y");
       } else if (map.containsKey("longitude") && map.containsKey("latitude")) {
-        x = ((Number) map.get("longitude")).doubleValue();
-        y = ((Number) map.get("latitude")).doubleValue();
+        x = coordinate(map.get("longitude"), "longitude");
+        y = coordinate(map.get("latitude"), "latitude");
       } else {
         throw new IllegalArgumentException("Cannot parse geometry from map: missing x/y or longitude/latitude keys");
       }
@@ -93,6 +93,21 @@ public class GeoUtils {
     } catch (Exception e) {
       throw new IllegalArgumentException("Cannot parse geometry from: " + wkt, e);
     }
+  }
+
+  /**
+   * Reads one coordinate of a point map. A non-numeric entry is an unparseable geometry like any other, so it has to
+   * leave as {@link IllegalArgumentException}: callers that skip a value they cannot parse - a WHERE clause dropping a
+   * row whose column holds junk - catch that, and a raw {@link ClassCastException} would escape them and fail the whole
+   * query instead of the one row (issue #5600).
+   */
+  private static double coordinate(final Object value, final String key) {
+    if (!(value instanceof Number number))
+      throw new IllegalArgumentException(
+          "Cannot parse geometry from map: '" + key + "' must be a number, got: " + (value == null ?
+              "null" :
+              value.getClass().getSimpleName()));
+    return number.doubleValue();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -54,6 +54,7 @@ import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
+import org.apache.lucene.util.BytesRef;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
 
@@ -679,13 +680,17 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
   private void forEachCoveringCell(final Shape shape, final int detailLevel, final CellVisitor visitor) {
     final CellIterator cellIter = grid.getTreeCellIterator(shape, detailLevel);
 
+    // Retargeted at each cell's own bytes rather than allocating one BytesRef per cell; the token is turned into a
+    // String immediately, so nothing outlives the next call.
+    final BytesRef scratch = new BytesRef();
+
     String pendingToken = null;
     int pendingLevel = -1;
 
     while (cellIter.hasNext()) {
       final Cell cell = cellIter.next();
       final int level = cell.getLevel();
-      final String token = cell.getTokenBytesNoLeaf(null).utf8ToString();
+      final String token = cell.getTokenBytesNoLeaf(scratch).utf8ToString();
 
       if (pendingToken != null && !visitor.visit(pendingToken, level <= pendingLevel))
         return;
@@ -723,9 +728,10 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
       // complete set of siblings and the frontier is simply the deepest cell: skip the bookkeeping and its allocations.
       // Lucene takes the same shortcut, as isGridAlignedShape().
       final CellIterator pointIter = grid.getTreeCellIterator(shape, detailLevel);
+      final BytesRef pointScratch = new BytesRef();
       String deepest = null;
       while (pointIter.hasNext()) {
-        final String token = pointIter.next().getTokenBytesNoLeaf(null).utf8ToString();
+        final String token = pointIter.next().getTokenBytesNoLeaf(pointScratch).utf8ToString();
         if (!token.isEmpty())
           deepest = token;
       }
@@ -742,9 +748,12 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
     final PruneFrame[] path = new PruneFrame[detailLevel + 1];
     int depth = 0;
 
+    // One BytesRef retargeted per cell instead of one allocated per cell: this is the ingest path.
+    final BytesRef scratch = new BytesRef();
+
     while (cellIter.hasNext()) {
       final Cell cell = cellIter.next();
-      final String token = cell.getTokenBytesNoLeaf(null).utf8ToString();
+      final String token = cell.getTokenBytesNoLeaf(scratch).utf8ToString();
       if (token.isEmpty())
         // The world cell: it is not a storable token and has no parent to account it to.
         continue;

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -736,7 +736,9 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
 
     final CellIterator cellIter = grid.getTreeCellIterator(shape, detailLevel);
 
-    // One frame per level of the current path. Level is 1-based and never exceeds detailLevel.
+    // One frame per open cell of the current path. The loop below pops every frame whose level is >= the incoming
+    // one, so the levels on the stack are STRICTLY INCREASING and the depth can never exceed the number of distinct
+    // levels, detailLevel - which is what makes this bound safe no matter how the traversal descends.
     final PruneFrame[] path = new PruneFrame[detailLevel + 1];
     int depth = 0;
 
@@ -754,7 +756,10 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
         closeFrame(path, depth--, emit);
 
       ++depth;
-      // The walk descends one level at a time, so the stack depth IS the cell level - which is what sizes the array.
+      // A GeoHash tree adds one base-32 character per level, so the walk descends exactly one level at a time and the
+      // stack depth equals the cell level. Nothing here NEEDS that - a frame's parent is the frame below it, found by
+      // pop order rather than by level arithmetic, and the array bound holds on strictly increasing levels alone - so
+      // this documents the grid's contract rather than guarding the algorithm.
       assert depth == level : "unexpected GeoHash traversal: level " + level + " reached at depth " + depth;
 
       final PruneFrame frame = path[depth] != null ? path[depth] : (path[depth] = new PruneFrame());

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -48,18 +48,23 @@ import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
 import org.apache.lucene.spatial.prefix.tree.Cell;
+import org.apache.lucene.spatial.prefix.tree.CellCanPrune;
 import org.apache.lucene.spatial.prefix.tree.CellIterator;
 import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
+import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
+import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 
 /**
@@ -75,7 +80,8 @@ import java.util.logging.Level;
  *       cells of the decomposition - one single token for a point - and answers a query with a GeoHash prefix RANGE
  *       SCAN over each covering cell of the search shape, plus an exact lookup on the covering cells that still have
  *       children (they can only match a shape indexed at a coarser resolution). The underlying LSM-Tree is a sorted
- *       store, so "every cell below C" is literally the key range {@code [C, C+\uFFFF]}.</li>
+ *       store, so "every cell below C" is literally the key range {@code [C, C+\uFFFF]}. On an area shape a complete
+ *       set of sibling cells additionally collapses into its parent, see {@link #forEachPrunedFrontierCell}.</li>
  *   <li>{@link GeoIndexMetadata.TOKENIZATION#FULL} is the original layout: the whole ancestor chain of every covering
  *       cell, resolved with one exact lookup per covering cell of the search shape. Kept for indexes created before
  *       26.8.1, whose entries are already written that way.</li>
@@ -623,12 +629,9 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
         SpatialArgs.calcDistanceFromErrPct(shape, strategy.getDistErrPct(), GeoUtils.getSpatialContext()));
 
     final List<String> tokens = new ArrayList<>();
-    forEachCoveringCell(shape, detailLevel, (token, frontier) -> {
-      if (frontier) {
-        assert isAsciiToken(token) : "a FRONTIER token must be ASCII for the prefix range scan bound to hold: " + token;
-        tokens.add(token);
-      }
-      return true;
+    forEachPrunedFrontierCell(grid, shape, detailLevel, token -> {
+      assert isAsciiToken(token) : "a FRONTIER token must be ASCII for the prefix range scan bound to hold: " + token;
+      tokens.add(token);
     });
     return tokens;
   }
@@ -693,6 +696,135 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
 
     if (pendingToken != null)
       visitor.visit(pendingToken, true);
+  }
+
+  /**
+   * Walks the same cells as {@link #forEachCoveringCell} but emits only the FRONTIER ones, collapsing a COMPLETE set of
+   * sibling frontier cells into their parent, recursively. This is what Lucene calls {@code pruneLeafyBranches} and
+   * enables by default on the indexing path: the parent rectangle is the union of its children, so the cover can only
+   * grow and a match can never be lost, while an area shape costs measurably fewer index entries - measured at 57% and
+   * 74% fewer on a small square and on a jagged polygon respectively (issue #5600).
+   * <p>
+   * Deliberately NOT shared with the query path: {@link #get} needs every ancestor cell of the search shape so it can
+   * look up the shallower cells an indexed shape may have stopped at.
+   * <p>
+   * Unlike {@link org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy#createCellIteratorToIndex}, which
+   * materialises every cell of the decomposition in an {@code ArrayList} - the reason its javadoc warns against the
+   * option for high precision shapes - this streams: only the frontier tokens on the current root-to-leaf path can
+   * still be revoked by an ancestor pruning, which bounds what is held to {@code subCellsSize * detailLevel} tokens.
+   *
+   * @param emit receives each token to index (order is unspecified: a pruned parent is decided only once all of
+   *             its children have been visited)
+   */
+  static void forEachPrunedFrontierCell(final SpatialPrefixTree grid, final Shape shape, final int detailLevel,
+      final Consumer<String> emit) {
+    if (shape instanceof Point) {
+      // The hot ingest path of #5478. A point decomposes into a chain of SINGLE-child cells, so no cell can ever hold a
+      // complete set of siblings and the frontier is simply the deepest cell: skip the bookkeeping and its allocations.
+      // Lucene takes the same shortcut, as isGridAlignedShape().
+      final CellIterator pointIter = grid.getTreeCellIterator(shape, detailLevel);
+      String deepest = null;
+      while (pointIter.hasNext()) {
+        final String token = pointIter.next().getTokenBytesNoLeaf(null).utf8ToString();
+        if (!token.isEmpty())
+          deepest = token;
+      }
+      if (deepest != null)
+        emit.accept(deepest);
+      return;
+    }
+
+    final CellIterator cellIter = grid.getTreeCellIterator(shape, detailLevel);
+
+    // One frame per level of the current path. Level is 1-based and never exceeds detailLevel.
+    final PruneFrame[] path = new PruneFrame[detailLevel + 1];
+    int depth = 0;
+
+    while (cellIter.hasNext()) {
+      final Cell cell = cellIter.next();
+      final String token = cell.getTokenBytesNoLeaf(null).utf8ToString();
+      if (token.isEmpty())
+        // The world cell: it is not a storable token and has no parent to account it to.
+        continue;
+
+      final int level = cell.getLevel();
+
+      // A cell at this level closes every still-open cell at the same level or deeper: the walk is pre-order.
+      while (depth > 0 && path[depth].level >= level)
+        closeFrame(path, depth--, emit);
+
+      ++depth;
+      // The walk descends one level at a time, so the stack depth IS the cell level - which is what sizes the array.
+      assert depth == level : "unexpected GeoHash traversal: level " + level + " reached at depth " + depth;
+
+      final PruneFrame frame = path[depth] != null ? path[depth] : (path[depth] = new PruneFrame());
+      frame.reset(token, level, cell instanceof CellCanPrune p ? p.getSubCellsSize() : -1);
+    }
+
+    while (depth > 0)
+      closeFrame(path, depth--, emit);
+  }
+
+  /**
+   * Resolves the cell held in {@code path[depth]} into either a frontier token accounted to its parent, or a flush of
+   * the frontier tokens its subtree accumulated.
+   */
+  private static void closeFrame(final PruneFrame[] path, final int depth, final Consumer<String> emit) {
+    final PruneFrame frame = path[depth];
+    final PruneFrame parent = depth > 1 ? path[depth - 1] : null;
+
+    // A cell with no visited child is where the decomposition stopped; one whose children ALL turned out to be
+    // frontier cells covers exactly what they cover, so it replaces them.
+    final boolean frontier = frame.childCount == 0
+        || (frame.subCellsSize > 0 && frame.frontierChildren == frame.subCellsSize);
+
+    if (frontier) {
+      // Whatever the children contributed is subsumed by this cell's own token.
+      frame.pendingCount = 0;
+      if (parent == null)
+        emit.accept(frame.token);
+      else
+        parent.addFrontierChild(frame.token);
+    } else {
+      for (int i = 0; i < frame.pendingCount; i++)
+        emit.accept(frame.pending[i]);
+      frame.pendingCount = 0;
+      if (parent != null)
+        // A non-frontier child means the parent can no longer be a complete set of leaves.
+        parent.childCount++;
+    }
+  }
+
+  /**
+   * Per-level bookkeeping of {@link #forEachPrunedFrontierCell}. Reused across cells of the same level so a walk
+   * allocates at most one frame per level.
+   */
+  private static final class PruneFrame {
+    private String   token;
+    private int      level;
+    /** Number of sub-cells the grid gives this cell, or -1 when the cell cannot be pruned into. */
+    private int      subCellsSize;
+    private int      childCount;
+    private int      frontierChildren;
+    private String[] pending = new String[0];
+    private int      pendingCount;
+
+    private void reset(final String token, final int level, final int subCellsSize) {
+      this.token = token;
+      this.level = level;
+      this.subCellsSize = subCellsSize;
+      this.childCount = 0;
+      this.frontierChildren = 0;
+      this.pendingCount = 0;
+    }
+
+    private void addFrontierChild(final String childToken) {
+      childCount++;
+      frontierChildren++;
+      if (pendingCount == pending.length)
+        pending = Arrays.copyOf(pending, Math.max(8, pending.length * 2));
+      pending[pendingCount++] = childToken;
+    }
   }
 
   @FunctionalInterface

--- a/engine/src/main/java/com/arcadedb/query/sql/method/geo/AbstractSQLGeoRelationMethod.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/geo/AbstractSQLGeoRelationMethod.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.geo;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.function.sql.geo.GeoUtils;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.method.AbstractSQLMethod;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.SpatialRelation;
+
+/**
+ * Base of the SQL methods that answer a spatial relation between the value they are applied to and a shape passed as
+ * their parameter, as in {@code coords.isWithin(<shape>)}.
+ * <p>
+ * Both operands are accepted as a spatial4j {@link Shape}, as WKT text or as a Cypher point map. The deserializer no
+ * longer turns a WKT string into a {@code Shape} behind everyone's back (issue #5600), so the conversion happens here,
+ * where a geometry is actually asked for - the same contract every {@code geo.*} function follows.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public abstract class AbstractSQLGeoRelationMethod extends AbstractSQLMethod {
+  private final String label;
+
+  /**
+   * @param name  the registered method name, lower-case as the parser resolves it
+   * @param label the spelling used in error messages, e.g. {@code isWithin}
+   */
+  protected AbstractSQLGeoRelationMethod(final String name, final String label) {
+    super(name, 0, 1);
+    this.label = label;
+  }
+
+  /**
+   * Whether the relation OF THE VALUE to the parameter shape satisfies this method.
+   */
+  protected abstract boolean matches(SpatialRelation relation);
+
+  @Override
+  public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context,
+      final Object[] params) {
+    if (value == null)
+      return null;
+
+    if (params.length != 1 || params[0] == null)
+      throw new IllegalArgumentException(label + "() requires a shape as parameter");
+
+    // The parameter is written in the query, so a malformed one - `isWithin('POLYGONN (...)')` - is a mistake worth
+    // reporting, exactly as a missing one already is. The value comes from the record instead: a row that does not
+    // hold a geometry simply does not match, because failing the whole query over one bad row would be worse than
+    // filtering it out.
+    final Shape shape = GeoUtils.parseGeometry(params[0]);
+    if (shape == null)
+      return null;
+
+    final Shape target;
+    try {
+      target = GeoUtils.parseGeometry(value);
+    } catch (final IllegalArgumentException e) {
+      return null;
+    }
+    if (target == null)
+      return null;
+
+    return matches(target.relate(shape));
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/method/geo/SQLMethodIntersectsWith.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/geo/SQLMethodIntersectsWith.java
@@ -18,11 +18,6 @@
  */
 package com.arcadedb.query.sql.method.geo;
 
-import com.arcadedb.database.Identifiable;
-import com.arcadedb.function.sql.geo.GeoUtils;
-import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.method.AbstractSQLMethod;
-import org.locationtech.spatial4j.shape.Shape;
 import org.locationtech.spatial4j.shape.SpatialRelation;
 
 /**
@@ -30,40 +25,21 @@ import org.locationtech.spatial4j.shape.SpatialRelation;
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
-public class SQLMethodIntersectsWith extends AbstractSQLMethod {
+public class SQLMethodIntersectsWith extends AbstractSQLGeoRelationMethod {
 
   public static final String NAME = "intersectswith";
 
   public SQLMethodIntersectsWith() {
-    super(NAME, 0, 1);
+    super(NAME, "intersectsWith");
+  }
+
+  @Override
+  protected boolean matches(final SpatialRelation relation) {
+    return relation != SpatialRelation.DISJOINT;
   }
 
   @Override
   public String getSyntax() {
     return "intersectsWith( <shape> )";
-  }
-
-  @Override
-  public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
-    if (value == null)
-      return null;
-
-    if (params.length != 1 || params[0] == null)
-      throw new IllegalArgumentException("intersectsWith() requires a shape as parameter");
-
-    // A geometry is accepted as a Shape, as WKT text or as a Cypher point map: the deserializer no longer turns a
-    // WKT string into a Shape behind everyone's back (issue #5600), so the conversion happens where it is asked for.
-    final Shape target;
-    final Shape shape;
-    try {
-      target = GeoUtils.parseGeometry(value);
-      shape = GeoUtils.parseGeometry(params[0]);
-    } catch (final IllegalArgumentException e) {
-      return null;
-    }
-    if (target == null || shape == null)
-      return null;
-
-    return target.relate(shape) != SpatialRelation.DISJOINT;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/geo/SQLMethodIntersectsWith.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/geo/SQLMethodIntersectsWith.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.method.geo;
 
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.function.sql.geo.GeoUtils;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 import org.locationtech.spatial4j.shape.Shape;
@@ -46,14 +47,23 @@ public class SQLMethodIntersectsWith extends AbstractSQLMethod {
   public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
     if (value == null)
       return null;
-    else if (!(value instanceof Shape))
-      return null;
 
     if (params.length != 1 || params[0] == null)
       throw new IllegalArgumentException("intersectsWith() requires a shape as parameter");
 
-    final Shape shape = (Shape) params[0];
+    // A geometry is accepted as a Shape, as WKT text or as a Cypher point map: the deserializer no longer turns a
+    // WKT string into a Shape behind everyone's back (issue #5600), so the conversion happens where it is asked for.
+    final Shape target;
+    final Shape shape;
+    try {
+      target = GeoUtils.parseGeometry(value);
+      shape = GeoUtils.parseGeometry(params[0]);
+    } catch (final IllegalArgumentException e) {
+      return null;
+    }
+    if (target == null || shape == null)
+      return null;
 
-    return ((Shape) value).relate(shape) != SpatialRelation.DISJOINT;
+    return target.relate(shape) != SpatialRelation.DISJOINT;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/geo/SQLMethodIsWithin.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/geo/SQLMethodIsWithin.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.method.geo;
 
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.function.sql.geo.GeoUtils;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 import org.locationtech.spatial4j.shape.Shape;
@@ -46,14 +47,23 @@ public class SQLMethodIsWithin extends AbstractSQLMethod {
   public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
     if (value == null)
       return null;
-    else if (!(value instanceof Shape))
-      return null;
 
     if (params.length != 1 || params[0] == null)
       throw new IllegalArgumentException("isWithin() requires a shape as parameter");
 
-    final Shape shape = (Shape) params[0];
+    // A geometry is accepted as a Shape, as WKT text or as a Cypher point map: the deserializer no longer turns a
+    // WKT string into a Shape behind everyone's back (issue #5600), so the conversion happens where it is asked for.
+    final Shape target;
+    final Shape shape;
+    try {
+      target = GeoUtils.parseGeometry(value);
+      shape = GeoUtils.parseGeometry(params[0]);
+    } catch (final IllegalArgumentException e) {
+      return null;
+    }
+    if (target == null || shape == null)
+      return null;
 
-    return ((Shape) value).relate(shape) == SpatialRelation.WITHIN;
+    return target.relate(shape) == SpatialRelation.WITHIN;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/geo/SQLMethodIsWithin.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/geo/SQLMethodIsWithin.java
@@ -18,11 +18,6 @@
  */
 package com.arcadedb.query.sql.method.geo;
 
-import com.arcadedb.database.Identifiable;
-import com.arcadedb.function.sql.geo.GeoUtils;
-import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.method.AbstractSQLMethod;
-import org.locationtech.spatial4j.shape.Shape;
 import org.locationtech.spatial4j.shape.SpatialRelation;
 
 /**
@@ -30,40 +25,21 @@ import org.locationtech.spatial4j.shape.SpatialRelation;
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
-public class SQLMethodIsWithin extends AbstractSQLMethod {
+public class SQLMethodIsWithin extends AbstractSQLGeoRelationMethod {
 
   public static final String NAME = "iswithin";
 
   public SQLMethodIsWithin() {
-    super(NAME, 0, 1);
+    super(NAME, "isWithin");
+  }
+
+  @Override
+  protected boolean matches(final SpatialRelation relation) {
+    return relation == SpatialRelation.WITHIN;
   }
 
   @Override
   public String getSyntax() {
     return "isWithin( <shape> )";
-  }
-
-  @Override
-  public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
-    if (value == null)
-      return null;
-
-    if (params.length != 1 || params[0] == null)
-      throw new IllegalArgumentException("isWithin() requires a shape as parameter");
-
-    // A geometry is accepted as a Shape, as WKT text or as a Cypher point map: the deserializer no longer turns a
-    // WKT string into a Shape behind everyone's back (issue #5600), so the conversion happens where it is asked for.
-    final Shape target;
-    final Shape shape;
-    try {
-      target = GeoUtils.parseGeometry(value);
-      shape = GeoUtils.parseGeometry(params[0]);
-    } catch (final IllegalArgumentException e) {
-      return null;
-    }
-    if (target == null || shape == null)
-      return null;
-
-    return target.relate(shape) == SpatialRelation.WITHIN;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -34,6 +34,7 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.TypeFullTextIndexBuilder;
+import com.arcadedb.schema.TypeGeoIndexBuilder;
 import com.arcadedb.schema.TypeIndexBuilder;
 import com.arcadedb.schema.TypeLSMSparseVectorIndexBuilder;
 import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
@@ -239,7 +240,25 @@ public class CreateIndexStatement extends DDLStatement {
       }
       sparseBuilder.create();
 
+    } else if (indexType == Schema.INDEX_TYPE.GEOSPATIAL) {
+      // Builder is already a TypeGeoIndexBuilder after withType(GEOSPATIAL)
+      final TypeGeoIndexBuilder geoBuilder = builder.withGeoType();
+      if (metadata != null) {
+        final Map<String, Object> metadataMap = metadata.toMap((Result) null, context);
+        try {
+          geoBuilder.withMetadata(new JSONObject(metadataMap));
+        } catch (final IllegalArgumentException e) {
+          throw new CommandSQLParsingException(e.getMessage(), e);
+        }
+      }
+      geoBuilder.create();
+
     } else {
+      // Every index type whose settings live in METADATA is handled above. Reaching here with a METADATA clause means
+      // the user configured something this index type cannot use: saying so beats dropping it on the floor (#5600).
+      if (metadata != null && !metadata.toMap((Result) null, context).isEmpty())
+        throw new CommandSQLParsingException(
+            "METADATA is not supported by index type '" + typeAsString + "'");
       builder.create();
     }
     typeName = prevName;

--- a/engine/src/main/java/com/arcadedb/schema/GeoIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/GeoIndexMetadata.java
@@ -51,6 +51,12 @@ public class GeoIndexMetadata extends IndexMetadata {
      * Stores only the deepest cells of the decomposition - exactly ONE for a point - and resolves queries with a GeoHash
      * prefix range scan over the covering cells plus an exact lookup on their ancestors (issue #5478). Same results,
      * {@code precision} times fewer entries to write, replicate and compact, and no hot key.
+     * <p>
+     * On an AREA shape a COMPLETE set of sibling cells is additionally collapsed into its parent, recursively - the
+     * reduction Lucene calls {@code pruneLeafyBranches} and applies by default on its own indexing path (issue #5600).
+     * A parent covers the union of its children, so the cover can only grow and a match is never lost; the SQL geo.*
+     * predicate post-filters the superset either way. A point decomposes into a chain of single-child cells and is
+     * therefore never affected.
      */
     FRONTIER
   }

--- a/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ * Builder for GEOSPATIAL indexes: carries the {@link GeoIndexMetadata} that drives the GeoHash cell resolution
+ * ({@code precision}) and the on-disk cell layout ({@code tokenization}).
+ * <p>
+ * Before this existed, {@code withType(GEOSPATIAL)} left the builder holding a plain {@link IndexMetadata}, so
+ * {@code CREATE INDEX ... GEOSPATIAL METADATA {...}} had nowhere to put its settings and dropped them (issue #5600).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class TypeGeoIndexBuilder extends TypeIndexBuilder {
+  /** The only keys a user may write in {@code METADATA}: anything else is a typo worth reporting. */
+  private static final Set<String> SUPPORTED_METADATA_KEYS = Set.of("precision", "tokenization");
+
+  protected TypeGeoIndexBuilder(final TypeIndexBuilder copyFrom) {
+    super(copyFrom.database, copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]));
+
+    this.metadata = new GeoIndexMetadata(
+        copyFrom.metadata.typeName,
+        copyFrom.metadata.propertyNames.toArray(new String[0]),
+        copyFrom.metadata.associatedBucketId);
+    this.metadata.collations = copyFrom.metadata.collations;
+    this.metadata.typeIndexName = copyFrom.metadata.typeIndexName;
+
+    this.indexType = Schema.INDEX_TYPE.GEOSPATIAL;
+    this.unique = copyFrom.unique;
+    this.pageSize = copyFrom.pageSize;
+    this.nullStrategy = copyFrom.nullStrategy;
+    this.callback = copyFrom.callback;
+    this.ignoreIfExists = copyFrom.ignoreIfExists;
+    this.indexName = copyFrom.indexName;
+    this.filePath = copyFrom.filePath;
+    this.keyTypes = copyFrom.keyTypes;
+    this.batchSize = copyFrom.batchSize;
+    this.maxAttempts = copyFrom.maxAttempts;
+  }
+
+  protected TypeGeoIndexBuilder(final DatabaseInternal database, final String typeName, final String[] propertyNames) {
+    super(database, typeName, propertyNames);
+    this.indexType = Schema.INDEX_TYPE.GEOSPATIAL;
+    this.metadata = new GeoIndexMetadata(typeName, propertyNames, -1);
+  }
+
+  /**
+   * Sets the GeoHash precision level (1-12). Higher means finer cells: 6 is about 1.2 km, the default 11 about 2.4 m.
+   *
+   * @return this builder for chaining
+   */
+  public TypeGeoIndexBuilder withPrecision(final int precision) {
+    geoMetadata().setPrecision(precision);
+    return this;
+  }
+
+  /**
+   * Sets the cell layout the index entries are written in. Only meaningful at creation time.
+   *
+   * @return this builder for chaining
+   */
+  public TypeGeoIndexBuilder withTokenization(final GeoIndexMetadata.TOKENIZATION tokenization) {
+    geoMetadata().setTokenization(tokenization);
+    return this;
+  }
+
+  @Override
+  public TypeGeoIndexBuilder withMetadata(final IndexMetadata metadata) {
+    if (metadata != null && !(metadata instanceof GeoIndexMetadata))
+      throw new IllegalArgumentException(
+          "A GEOSPATIAL index requires GeoIndexMetadata but got " + metadata.getClass().getName());
+    this.metadata = metadata;
+    return this;
+  }
+
+  /**
+   * Configures the builder from the {@code METADATA} clause of {@code CREATE INDEX}. Unknown keys are rejected rather
+   * than dropped: a silently ignored {@code METADATA} is exactly what made the missing forwarding invisible (#5600).
+   *
+   * @param json the JSON object containing the metadata configuration
+   */
+  public void withMetadata(final JSONObject json) {
+    if (json == null)
+      return;
+
+    for (final String key : json.keySet())
+      if (!SUPPORTED_METADATA_KEYS.contains(key))
+        throw new IllegalArgumentException(
+            "Unsupported metadata key '" + key + "' for a GEOSPATIAL index. Supported keys: " + SUPPORTED_METADATA_KEYS);
+
+    // Read the keys one by one instead of delegating to GeoIndexMetadata.fromJSON(): that method reads a PERSISTED
+    // definition, where a missing `tokenization` means a pre-26.8.1 index and therefore the FULL layout. Here a missing
+    // key just means the user did not ask for anything, so the creation-time default must stand.
+    final GeoIndexMetadata geoMetadata = geoMetadata();
+
+    if (json.has("precision")) {
+      final Object precision = json.get("precision");
+      if (!(precision instanceof Number number))
+        throw new IllegalArgumentException("Geospatial index precision must be a number, got: " + precision);
+      geoMetadata.setPrecision(number.intValue());
+    }
+
+    if (json.has("tokenization")) {
+      final Object tokenization = json.get("tokenization");
+      if (!(tokenization instanceof String name))
+        throw new IllegalArgumentException("Geospatial index tokenization must be a string, got: " + tokenization);
+      try {
+        geoMetadata.setTokenization(GeoIndexMetadata.TOKENIZATION.valueOf(name.toUpperCase()));
+      } catch (final IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid geospatial index tokenization '" + name + "'. Supported values: "
+            + Arrays.toString(GeoIndexMetadata.TOKENIZATION.values()), e);
+      }
+    }
+  }
+
+  /**
+   * Returns the builder's metadata as {@link GeoIndexMetadata}. The constructors always create one, but guard the cast
+   * so that, if the metadata were ever replaced with a non-geospatial instance, callers get an actionable error instead
+   * of a {@link ClassCastException}.
+   */
+  private GeoIndexMetadata geoMetadata() {
+    if (metadata instanceof GeoIndexMetadata m)
+      return m;
+    throw new IllegalStateException(
+        "Geospatial index metadata expected but was " + (metadata == null ? "null" : metadata.getClass().getName()));
+  }
+}

--- a/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
@@ -100,10 +100,12 @@ public class TypeGeoIndexBuilder extends TypeIndexBuilder {
    * than dropped: a silently ignored {@code METADATA} is exactly what made the missing forwarding invisible (#5600).
    *
    * @param json the JSON object containing the metadata configuration
+   *
+   * @return this builder for chaining
    */
-  public void withMetadata(final JSONObject json) {
+  public TypeGeoIndexBuilder withMetadata(final JSONObject json) {
     if (json == null)
-      return;
+      return this;
 
     for (final String key : json.keySet())
       if (!SUPPORTED_METADATA_KEYS.contains(key))
@@ -137,6 +139,8 @@ public class TypeGeoIndexBuilder extends TypeIndexBuilder {
             + Arrays.toString(GeoIndexMetadata.TOKENIZATION.values()), e);
       }
     }
+
+    return this;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.schema;
 
-import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.serializer.json.JSONObject;
 
 import java.util.Arrays;
@@ -58,12 +57,6 @@ public class TypeGeoIndexBuilder extends TypeIndexBuilder {
     this.keyTypes = copyFrom.keyTypes;
     this.batchSize = copyFrom.batchSize;
     this.maxAttempts = copyFrom.maxAttempts;
-  }
-
-  protected TypeGeoIndexBuilder(final DatabaseInternal database, final String typeName, final String[] propertyNames) {
-    super(database, typeName, propertyNames);
-    this.indexType = Schema.INDEX_TYPE.GEOSPATIAL;
-    this.metadata = new GeoIndexMetadata(typeName, propertyNames, -1);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeGeoIndexBuilder.java
@@ -119,6 +119,10 @@ public class TypeGeoIndexBuilder extends TypeIndexBuilder {
       final Object precision = json.get("precision");
       if (!(precision instanceof Number number))
         throw new IllegalArgumentException("Geospatial index precision must be a number, got: " + precision);
+      // A GeoHash precision is a tree LEVEL, so 6.9 is not "6": truncating it would drop the very kind of typo this
+      // method exists to report.
+      if (number.doubleValue() != number.intValue())
+        throw new IllegalArgumentException("Geospatial index precision must be a whole number, got: " + precision);
       geoMetadata.setPrecision(number.intValue());
     }
 

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -122,9 +122,10 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   }
 
   /**
-   * Sets the index type. For LSM_VECTOR indexes, returns an LSMVectorIndexBuilder
-   * to enable vector-specific configuration methods. For FULL_TEXT indexes, returns
-   * a TypeFullTextIndexBuilder.
+   * Sets the index type, returning the builder subclass that carries the settings of that index type: an
+   * LSMVectorIndexBuilder for LSM_VECTOR, a TypeFullTextIndexBuilder for FULL_TEXT, a TypeGeoIndexBuilder for
+   * GEOSPATIAL, and so on. An index type missing from this list ends up with the generic {@link IndexMetadata} and
+   * therefore has nowhere to keep its own settings.
    *
    * @param indexType the index type
    *
@@ -134,13 +135,20 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   public TypeIndexBuilder withType(final Schema.INDEX_TYPE indexType) {
     if (buildMode == IndexBuildMode.SORTED && indexType != Schema.INDEX_TYPE.LSM_TREE)
       throw new IllegalArgumentException("Sorted build currently supports only LSM_TREE indexes");
+
+    // Record the type on THIS builder before handing back a specialised one: a caller that ignores the returned
+    // instance (`builder.withType(X); builder.create();`) still gets a builder that knows what to create, instead of
+    // "indexType was not specified" from an object the type never landed on.
+    super.withType(indexType);
+
     if (indexType == Schema.INDEX_TYPE.LSM_VECTOR && !(this instanceof TypeLSMVectorIndexBuilder))
       return new TypeLSMVectorIndexBuilder(this);
     if (indexType == Schema.INDEX_TYPE.LSM_SPARSE_VECTOR && !(this instanceof TypeLSMSparseVectorIndexBuilder))
       return new TypeLSMSparseVectorIndexBuilder(this);
     if (indexType == Schema.INDEX_TYPE.FULL_TEXT && !(this instanceof TypeFullTextIndexBuilder))
       return new TypeFullTextIndexBuilder(this);
-    super.withType(indexType);
+    if (indexType == Schema.INDEX_TYPE.GEOSPATIAL && !(this instanceof TypeGeoIndexBuilder))
+      return new TypeGeoIndexBuilder(this);
     return this;
   }
 
@@ -157,6 +165,21 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     if (indexType != Schema.INDEX_TYPE.FULL_TEXT)
       throw new IllegalStateException("withFullTextType() can only be called after withType(FULL_TEXT)");
     return new TypeFullTextIndexBuilder(this);
+  }
+
+  /**
+   * Returns this builder as a TypeGeoIndexBuilder for geospatial specific configuration.
+   * Only valid after withType(GEOSPATIAL) has been called.
+   *
+   * @return a TypeGeoIndexBuilder for geospatial configuration
+   * @throws IllegalStateException if withType(GEOSPATIAL) has not been called
+   */
+  public TypeGeoIndexBuilder withGeoType() {
+    if (this instanceof TypeGeoIndexBuilder)
+      return (TypeGeoIndexBuilder) this;
+    if (indexType != Schema.INDEX_TYPE.GEOSPATIAL)
+      throw new IllegalStateException("withGeoType() can only be called after withType(GEOSPATIAL)");
+    return new TypeGeoIndexBuilder(this);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -707,21 +707,12 @@ public class BinarySerializer {
       value = null;
       break;
     case BinaryTypes.TYPE_STRING:
-      final String str = content.getString();
-      // Backward compatibility: parse WKT geometry strings from old databases
-      Object parsedValue = str;
-      if (str != null && (str.startsWith("POINT") || str.startsWith("CIRCLE") ||
-          str.startsWith("LINESTRING") || str.startsWith("POLYGON") ||
-          str.startsWith("ENVELOPE") || str.startsWith("BUFFER"))) {
-        try {
-          final SpatialContext ctx = GeoUtils.getSpatialContext();
-          parsedValue = ctx.getFormats().getWktReader().read(str);
-        } catch (Exception e) {
-          // If WKT parsing fails, return as string
-          parsedValue = str;
-        }
-      }
-      value = parsedValue;
+      // A string reads back as the string that was written, always. This used to sniff the first characters and return
+      // a spatial4j Shape when they looked like the head of a WKT geometry, which broke the identity of a declared
+      // STRING property and mangled any free text starting with POINT/POLYGON/... (issue #5600). Databases written
+      // before 26.2.1 - where shapes were stored as WKT text under TYPE_STRING - keep working because every geometry
+      // consumer accepts WKT: see GeoUtils.parseGeometry(), GeoUtils.parseJtsGeometry() and LSMTreeGeoIndex.toShape().
+      value = content.getString();
       break;
     case BinaryTypes.TYPE_COMPRESSED_STRING:
       value = database.getSchema().getDictionary().getNameById((int) content.getUnsignedNumber());

--- a/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexCellPruningTest.java
+++ b/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexCellPruningTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.geospatial;
+
+import com.arcadedb.function.sql.geo.GeoUtils;
+import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.tree.Cell;
+import org.apache.lucene.spatial.prefix.tree.CellIterator;
+import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
+import org.apache.lucene.spatial.query.SpatialArgs;
+import org.junit.jupiter.api.Test;
+import org.locationtech.spatial4j.shape.Shape;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5600 (3): the FRONTIER tokenizer collapses a complete set of sibling frontier cells into their parent, the
+ * same reduction Lucene's {@code RecursivePrefixTreeStrategy.pruneLeafyBranches} applies by default on its indexing
+ * path - but streaming, instead of materialising the whole decomposition in a list.
+ * <p>
+ * The reference here IS Lucene: its buffered implementation is invoked by reflection and the two token sets must agree
+ * on every shape.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LSMTreeGeoIndexCellPruningTest {
+
+  private static final String[][] SHAPES = { //
+      { "point", "POINT (12.5 41.9)" }, //
+      { "small square", "POLYGON ((12.4 41.8, 12.6 41.8, 12.6 42.0, 12.4 42.0, 12.4 41.8))" }, //
+      { "wide rectangle", "POLYGON ((7 36, 18 36, 18 47, 7 47, 7 36))" }, //
+      { "jagged outline", jagged() }, //
+      { "linestring", "LINESTRING (12.4 41.8, 12.6 41.9, 12.8 41.7, 13.0 42.0, 13.4 41.5)" }, //
+      { "thin sliver", "POLYGON ((12.0 41.0, 14.0 41.0001, 14.0 41.0002, 12.0 41.0003, 12.0 41.0))" }, //
+      { "polygon with hole",
+          "POLYGON ((12 41, 14 41, 14 43, 12 43, 12 41), (12.5 41.5, 13.5 41.5, 13.5 42.5, 12.5 42.5, 12.5 41.5))" }, //
+      { "antimeridian", "POLYGON ((179 -1, 180 -1, 180 1, 179 1, 179 -1))" } };
+
+  @Test
+  void streamingPruneMatchesLucene() throws Exception {
+    for (final int precision : new int[] { 6, 8, 11, 12 })
+      for (final String[] shape : SHAPES)
+        assertThat(arcadeTokens(precision, shape[1]))
+            .as("%s at precision %d", shape[0], precision)
+            .isEqualTo(lucenePrunedFrontierTokens(precision, shape[1]));
+  }
+
+  /**
+   * Pruning may only ENLARGE the covered area, never shrink it: every unpruned frontier cell must still be covered by
+   * a pruned token, i.e. have one of them as a prefix of itself (or be one of them).
+   */
+  @Test
+  void pruningNeverDropsCoverage() throws Exception {
+    for (final int precision : new int[] { 6, 8, 11 })
+      for (final String[] shape : SHAPES) {
+        final TreeSet<String> pruned = arcadeTokens(precision, shape[1]);
+        for (final String cell : unprunedFrontierTokens(precision, shape[1])) {
+          boolean covered = false;
+          for (final String token : pruned)
+            if (cell.startsWith(token)) {
+              covered = true;
+              break;
+            }
+          assertThat(covered).as("%s at precision %d: cell '%s' lost its cover", shape[0], precision, cell).isTrue();
+        }
+      }
+  }
+
+  /**
+   * A point is a single chain of one-child cells, so it can never have a complete set of siblings to collapse: the
+   * one-token-per-point guarantee of #5478 is untouched.
+   */
+  @Test
+  void aPointStillCostsExactlyOneToken() throws Exception {
+    for (final int precision : new int[] { 6, 8, 11, 12 })
+      assertThat(arcadeTokens(precision, "POINT (12.5 41.9)")).hasSize(1);
+  }
+
+  private static TreeSet<String> arcadeTokens(final int precision, final String wkt) {
+    final GeohashPrefixTree grid = new GeohashPrefixTree(GeoUtils.getSpatialContext(), precision);
+    final Shape shape = GeoUtils.parseGeometry(wkt);
+    final TreeSet<String> tokens = new TreeSet<>();
+    LSMTreeGeoIndex.forEachPrunedFrontierCell(grid, shape, detailLevel(grid, shape), tokens::add);
+    return tokens;
+  }
+
+  private static TreeSet<String> unprunedFrontierTokens(final int precision, final String wkt) {
+    final GeohashPrefixTree grid = new GeohashPrefixTree(GeoUtils.getSpatialContext(), precision);
+    final Shape shape = GeoUtils.parseGeometry(wkt);
+    return frontierTokens(walk(grid.getTreeCellIterator(shape, detailLevel(grid, shape))));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static TreeSet<String> lucenePrunedFrontierTokens(final int precision, final String wkt) throws Exception {
+    final GeohashPrefixTree grid = new GeohashPrefixTree(GeoUtils.getSpatialContext(), precision);
+    final RecursivePrefixTreeStrategy strategy = new RecursivePrefixTreeStrategy(grid, "geo");
+    final Shape shape = GeoUtils.parseGeometry(wkt);
+
+    final Method createCellIteratorToIndex = RecursivePrefixTreeStrategy.class.getDeclaredMethod(
+        "createCellIteratorToIndex", Shape.class, int.class, Iterator.class);
+    createCellIteratorToIndex.setAccessible(true);
+
+    final Iterator<Cell> cells = (Iterator<Cell>) createCellIteratorToIndex.invoke(strategy, shape,
+        detailLevel(grid, shape), null);
+    return frontierTokens(walk(cells));
+  }
+
+  private static int detailLevel(final GeohashPrefixTree grid, final Shape shape) {
+    return grid.getLevelForDistance(SpatialArgs.calcDistanceFromErrPct(shape,
+        new RecursivePrefixTreeStrategy(grid, "geo").getDistErrPct(), GeoUtils.getSpatialContext()));
+  }
+
+  private static List<Cell> walk(final Iterator<Cell> it) {
+    final List<Cell> out = new ArrayList<>();
+    while (it.hasNext())
+      out.add(it.next());
+    return out;
+  }
+
+  private static List<Cell> walk(final CellIterator it) {
+    final List<Cell> out = new ArrayList<>();
+    while (it.hasNext())
+      out.add(it.next());
+    return out;
+  }
+
+  /** Same rule the index uses: a cell is a frontier when the cell after it in the pre-order walk is not deeper. */
+  private static TreeSet<String> frontierTokens(final List<Cell> cells) {
+    final TreeSet<String> out = new TreeSet<>();
+    for (int i = 0; i < cells.size(); i++) {
+      final boolean frontier = i == cells.size() - 1 || cells.get(i + 1).getLevel() <= cells.get(i).getLevel();
+      final String token = cells.get(i).getTokenBytesNoLeaf(null).utf8ToString();
+      if (frontier && !token.isEmpty())
+        out.add(token);
+    }
+    return out;
+  }
+
+  private static String jagged() {
+    final StringBuilder sb = new StringBuilder("POLYGON ((");
+    for (int i = 0; i <= 200; i++)
+      sb.append(12.0 + i * 0.005).append(' ').append(41.0 + (i % 2 == 0 ? 0.0 : 0.004)).append(", ");
+    return sb.append("13.0 41.5, 12.0 41.5, 12.0 41.0))").toString();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexCellPruningTest.java
+++ b/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexCellPruningTest.java
@@ -68,6 +68,19 @@ class LSMTreeGeoIndexCellPruningTest {
   }
 
   /**
+   * The equality above compares SETS, so it would say nothing about a token emitted twice - which in production, where
+   * the tokens go into a List and then one put() each, is a duplicate index entry. Assert on the raw stream instead.
+   */
+  @Test
+  void noTokenIsEmittedTwice() {
+    for (final int precision : new int[] { 6, 8, 11, 12 })
+      for (final String[] shape : SHAPES) {
+        final List<String> emitted = arcadeTokenStream(precision, shape[1]);
+        assertThat(emitted).as("%s at precision %d", shape[0], precision).doesNotHaveDuplicates();
+      }
+  }
+
+  /**
    * Pruning may only ENLARGE the covered area, never shrink it: every unpruned frontier cell must still be covered by
    * a pruned token, i.e. have one of them as a prefix of itself (or be one of them).
    */
@@ -99,9 +112,14 @@ class LSMTreeGeoIndexCellPruningTest {
   }
 
   private static TreeSet<String> arcadeTokens(final int precision, final String wkt) {
+    return new TreeSet<>(arcadeTokenStream(precision, wkt));
+  }
+
+  /** The tokens exactly as the index receives them, duplicates and all. */
+  private static List<String> arcadeTokenStream(final int precision, final String wkt) {
     final GeohashPrefixTree grid = new GeohashPrefixTree(GeoUtils.getSpatialContext(), precision);
     final Shape shape = GeoUtils.parseGeometry(wkt);
-    final TreeSet<String> tokens = new TreeSet<>();
+    final List<String> tokens = new ArrayList<>();
     LSMTreeGeoIndex.forEachPrunedFrontierCell(grid, shape, detailLevel(grid, shape), tokens::add);
     return tokens;
   }

--- a/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexSchemaTest.java
+++ b/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexSchemaTest.java
@@ -19,14 +19,17 @@
 package com.arcadedb.index.geospatial;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.GeoIndexMetadata;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.TypeIndexBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LSMTreeGeoIndexSchemaTest extends TestHelper {
 
@@ -77,5 +80,131 @@ class LSMTreeGeoIndexSchemaTest extends TestHelper {
     assertThat(index.getType()).isEqualTo(Schema.INDEX_TYPE.GEOSPATIAL);
     final LSMTreeGeoIndex geoIndex = (LSMTreeGeoIndex) ((TypeIndex) index).getSubIndexes().getFirst();
     assertThat(geoIndex.getPrecision()).isEqualTo(7);
+  }
+
+  /**
+   * Issue #5600 (2): the METADATA clause used to fall through to a bare create() for GEOSPATIAL, so the precision was
+   * silently ignored and only the Java API could set it.
+   */
+  @Test
+  void precisionFromSqlMetadata() {
+    database.command("sql", "CREATE DOCUMENT TYPE Location3");
+    database.command("sql", "CREATE PROPERTY Location3.coords STRING");
+    database.command("sql", "CREATE INDEX ON Location3 (coords) GEOSPATIAL METADATA {\"precision\": 6}");
+
+    assertThat(geoIndex("Location3").getPrecision()).isEqualTo(6);
+
+    reopenDatabase();
+
+    assertThat(geoIndex("Location3").getPrecision()).isEqualTo(6);
+  }
+
+  @Test
+  void tokenizationFromSqlMetadata() {
+    database.command("sql", "CREATE DOCUMENT TYPE Location4");
+    database.command("sql", "CREATE PROPERTY Location4.coords STRING");
+    database.command("sql", "CREATE INDEX ON Location4 (coords) GEOSPATIAL METADATA {\"tokenization\": \"FULL\"}");
+
+    assertThat(geoIndex("Location4").getTokenization()).isEqualTo(GeoIndexMetadata.TOKENIZATION.FULL);
+    assertThat(geoIndex("Location4").getPrecision()).isEqualTo(GeoIndexMetadata.DEFAULT_PRECISION);
+  }
+
+  /**
+   * A METADATA clause that does not mention the tokenization must leave the CREATION default in place, not the
+   * backward-compatible one used when reading a persisted definition that predates the field.
+   */
+  @Test
+  void metadataWithoutTokenizationKeepsTheCreationDefault() {
+    database.command("sql", "CREATE DOCUMENT TYPE Location5");
+    database.command("sql", "CREATE PROPERTY Location5.coords STRING");
+    database.command("sql", "CREATE INDEX ON Location5 (coords) GEOSPATIAL METADATA {\"precision\": 8}");
+
+    assertThat(geoIndex("Location5").getTokenization()).isEqualTo(GeoIndexMetadata.DEFAULT_TOKENIZATION);
+  }
+
+  @Test
+  void indexedQueryHonoursTheCoarsePrecisionFromSql() {
+    database.command("sql", "CREATE DOCUMENT TYPE City");
+    database.command("sql", "CREATE PROPERTY City.name STRING");
+    database.command("sql", "CREATE PROPERTY City.coords STRING");
+    database.command("sql", "CREATE INDEX ON City (coords) GEOSPATIAL METADATA {\"precision\": 6}");
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO City SET name = 'Rome', coords = 'POINT (12.5 41.9)'");
+      database.command("sql", "INSERT INTO City SET name = 'Milan', coords = 'POINT (9.2 45.5)'");
+    });
+
+    final ResultSet rs = database.query("sql",
+        "SELECT name FROM City WHERE geo.within(coords, geo.geomFromText('POLYGON ((10 38, 16 38, 16 44, 10 44, 10 38))')) = true");
+    assertThat(rs.next().<String>getProperty("name")).isEqualTo("Rome");
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
+  void unknownMetadataKeyIsRejected() {
+    database.command("sql", "CREATE DOCUMENT TYPE Location6");
+    database.command("sql", "CREATE PROPERTY Location6.coords STRING");
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE INDEX ON Location6 (coords) GEOSPATIAL METADATA {\"precisin\": 6}"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("precisin");
+
+    assertThat(database.getSchema().existsIndex("Location6[coords]")).isFalse();
+  }
+
+  @Test
+  void outOfRangePrecisionIsRejected() {
+    database.command("sql", "CREATE DOCUMENT TYPE Location7");
+    database.command("sql", "CREATE PROPERTY Location7.coords STRING");
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE INDEX ON Location7 (coords) GEOSPATIAL METADATA {\"precision\": 13}"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("precision");
+  }
+
+  @Test
+  void nonNumericPrecisionIsRejected() {
+    database.command("sql", "CREATE DOCUMENT TYPE Location9");
+    database.command("sql", "CREATE PROPERTY Location9.coords STRING");
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE INDEX ON Location9 (coords) GEOSPATIAL METADATA {\"precision\": \"six\"}"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("precision");
+  }
+
+  @Test
+  void invalidTokenizationIsRejected() {
+    database.command("sql", "CREATE DOCUMENT TYPE Location8");
+    database.command("sql", "CREATE PROPERTY Location8.coords STRING");
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE INDEX ON Location8 (coords) GEOSPATIAL METADATA {\"tokenization\": \"SPARSE\"}"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("tokenization");
+  }
+
+  /**
+   * An index type that has no use for METADATA must say so instead of dropping the clause on the floor: silently
+   * ignoring it is what kept the geospatial gap invisible.
+   */
+  @Test
+  void metadataOnAnIndexTypeThatDoesNotSupportItIsRejected() {
+    database.command("sql", "CREATE DOCUMENT TYPE Plain");
+    database.command("sql", "CREATE PROPERTY Plain.name STRING");
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE INDEX ON Plain (name) UNIQUE METADATA {\"precision\": 6}"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("METADATA");
+  }
+
+  private LSMTreeGeoIndex geoIndex(final String typeName) {
+    final Index index = database.getSchema().getIndexByName(typeName + "[coords]");
+    assertThat(index).isNotNull();
+    assertThat(index.getType()).isEqualTo(Schema.INDEX_TYPE.GEOSPATIAL);
+    return (LSMTreeGeoIndex) ((TypeIndex) index).getSubIndexes().getFirst();
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexSchemaTest.java
+++ b/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexSchemaTest.java
@@ -176,6 +176,19 @@ class LSMTreeGeoIndexSchemaTest extends TestHelper {
   }
 
   @Test
+  void fractionalPrecisionIsRejected() {
+    database.command("sql", "CREATE DOCUMENT TYPE Location10");
+    database.command("sql", "CREATE PROPERTY Location10.coords STRING");
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE INDEX ON Location10 (coords) GEOSPATIAL METADATA {\"precision\": 6.9}"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("whole number");
+
+    assertThat(database.getSchema().existsIndex("Location10[coords]")).isFalse();
+  }
+
+  @Test
   void invalidTokenizationIsRejected() {
     database.command("sql", "CREATE DOCUMENT TYPE Location8");
     database.command("sql", "CREATE PROPERTY Location8.coords STRING");

--- a/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexTokenizationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/geospatial/LSMTreeGeoIndexTokenizationTest.java
@@ -175,6 +175,63 @@ class LSMTreeGeoIndexTokenizationTest extends TestHelper {
   }
 
   /**
+   * Same, for an AREA shape: that is the one the cell pruning of #5600 changes, and a pruned parent has to be written
+   * and removed alike or a delete would leave the parent cell pointing at a gone record.
+   */
+  @Test
+  void polygonDeleteRemovesEveryEntryOfTheRecord() {
+    createType("AreaDel");
+    database.command("sql", "CREATE INDEX ON AreaDel (coords) GEOSPATIAL");
+
+    final String[] areas = { //
+        "north:POLYGON ((8.0 44.0, 12.0 44.0, 12.0 46.0, 8.0 46.0, 8.0 44.0))", //
+        "centre:POLYGON ((11.5 41.5, 13.0 41.5, 13.0 42.5, 11.5 42.5, 11.5 41.5))", //
+        "south:POLYGON ((14.0 38.0, 16.0 38.0, 16.0 40.0, 14.0 40.0, 14.0 38.0))" };
+
+    database.transaction(() -> {
+      for (final String area : areas) {
+        final String[] parts = area.split(":", 2);
+        database.command("sql", "INSERT INTO AreaDel SET name = '" + parts[0] + "', coords = '" + parts[1] + "'");
+      }
+    });
+
+    final Shape italy = GeoUtils.getSpatialContext().getShapeFactory().rect(6.0, 18.0, 36.0, 47.0);
+    assertThat(lookup("AreaDel", italy)).hasSize(areas.length);
+
+    for (int i = 0; i < areas.length; i++) {
+      final String name = areas[i].split(":", 2)[0];
+      database.transaction(() -> database.command("sql", "DELETE FROM AreaDel WHERE name = '" + name + "'"));
+      assertThat(lookup("AreaDel", italy)).hasSize(areas.length - i - 1);
+    }
+  }
+
+  /**
+   * A jagged outline is where the cell pruning of #5600 bites hardest (measured at ~74% fewer entries): the collapsed
+   * parents must still answer a query at any resolution, and must not start matching a point far outside the shape.
+   */
+  @Test
+  void prunedJaggedPolygonIsStillFoundAtEveryResolution() throws Exception {
+    createType("Jagged");
+    database.command("sql", "CREATE INDEX ON Jagged (coords) GEOSPATIAL");
+
+    final StringBuilder wkt = new StringBuilder("POLYGON ((");
+    for (int i = 0; i <= 100; i++)
+      wkt.append(12.0 + i * 0.01).append(' ').append(41.0 + (i % 2 == 0 ? 0.0 : 0.004)).append(", ");
+    wkt.append("13.0 41.5, 12.0 41.5, 12.0 41.0))");
+
+    database.transaction(
+        () -> database.command("sql", "INSERT INTO Jagged SET name = 'coast', coords = '" + wkt + "'"));
+
+    // Coarser than the indexed cells
+    assertThat(lookup("Jagged", GeoUtils.getSpatialContext().getShapeFactory().rect(10.0, 15.0, 40.0, 44.0))).hasSize(1);
+    // A point well inside the outline
+    assertThat(lookup("Jagged", GeoUtils.getSpatialContext().getFormats().getWktReader().read("POINT (12.5 41.3)")))
+        .hasSize(1);
+    // Far away: the enlarged cover must not reach here
+    assertThat(lookup("Jagged", GeoUtils.getSpatialContext().getShapeFactory().rect(20.0, 21.0, 20.0, 21.0))).isEmpty();
+  }
+
+  /**
    * Same, on the legacy layout: it must keep removing the whole chain it wrote.
    */
   @Test

--- a/engine/src/test/java/com/arcadedb/index/geospatial/TypeGeoIndexBuilderTest.java
+++ b/engine/src/test/java/com/arcadedb/index/geospatial/TypeGeoIndexBuilderTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.geospatial;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.FullTextIndexMetadata;
+import com.arcadedb.schema.GeoIndexMetadata;
+import com.arcadedb.schema.IndexMetadata;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.TypeGeoIndexBuilder;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The Java-API side of issue #5600 (2): {@code withType(GEOSPATIAL)} now yields a builder that owns a
+ * {@link GeoIndexMetadata}, so the settings a geospatial index has are reachable without going through SQL.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TypeGeoIndexBuilderTest extends TestHelper {
+
+  @Test
+  void withTypeYieldsAGeoBuilderCarryingGeoMetadata() {
+    final TypeGeoIndexBuilder builder = geoBuilder("A");
+
+    assertThat(builder.getMetadata()).isInstanceOf(GeoIndexMetadata.class);
+    final GeoIndexMetadata metadata = (GeoIndexMetadata) builder.getMetadata();
+    assertThat(metadata.getPrecision()).isEqualTo(GeoIndexMetadata.DEFAULT_PRECISION);
+    assertThat(metadata.getTokenization()).isEqualTo(GeoIndexMetadata.DEFAULT_TOKENIZATION);
+    assertThat(metadata.typeName).isEqualTo("A");
+    assertThat(metadata.propertyNames).containsExactly("coords");
+  }
+
+  @Test
+  void fluentSettersReachTheCreatedIndex() {
+    final TypeIndex index = geoBuilder("B") //
+        .withPrecision(5) //
+        .withTokenization(GeoIndexMetadata.TOKENIZATION.FULL) //
+        .create();
+
+    final LSMTreeGeoIndex geoIndex = (LSMTreeGeoIndex) index.getSubIndexes().getFirst();
+    assertThat(geoIndex.getPrecision()).isEqualTo(5);
+    assertThat(geoIndex.getTokenization()).isEqualTo(GeoIndexMetadata.TOKENIZATION.FULL);
+  }
+
+  @Test
+  void jsonMetadataIsChainable() {
+    final TypeIndex index = geoBuilder("C") //
+        .withMetadata(new JSONObject().put("precision", 4)) //
+        .create();
+
+    assertThat(((LSMTreeGeoIndex) index.getSubIndexes().getFirst()).getPrecision()).isEqualTo(4);
+  }
+
+  @Test
+  void aNullJsonMetadataLeavesTheDefaultsAlone() {
+    final TypeGeoIndexBuilder builder = geoBuilder("D");
+
+    assertThat(builder.withMetadata((JSONObject) null)).isSameAs(builder);
+    assertThat(((GeoIndexMetadata) builder.getMetadata()).getPrecision()).isEqualTo(GeoIndexMetadata.DEFAULT_PRECISION);
+  }
+
+  /**
+   * Handing the geospatial builder someone else's metadata subtype has to be reported: silently accepting it would put
+   * the builder back in the state that made the SQL METADATA vanish in the first place.
+   */
+  @Test
+  void metadataOfAnotherIndexTypeIsRejected() {
+    final TypeGeoIndexBuilder builder = geoBuilder("E");
+
+    assertThatThrownBy(() -> builder.withMetadata(new FullTextIndexMetadata("E", new String[] { "coords" }, -1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("GeoIndexMetadata");
+  }
+
+  /**
+   * And once the metadata is not geospatial, every geospatial setter says so rather than dying on a ClassCastException.
+   */
+  @Test
+  void aSetterOnNonGeoMetadataReportsTheState() {
+    final TypeGeoIndexBuilder builder = geoBuilder("F");
+    builder.withMetadata((IndexMetadata) null);
+
+    assertThatThrownBy(() -> builder.withPrecision(6)).isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("null");
+    assertThatThrownBy(() -> builder.withTokenization(GeoIndexMetadata.TOKENIZATION.FULL))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void withGeoTypeRefusesANonGeospatialBuilder() {
+    database.command("sql", "CREATE DOCUMENT TYPE G");
+    database.command("sql", "CREATE PROPERTY G.coords STRING");
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("G", new String[] { "coords" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withGeoType()).isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("withGeoType()");
+  }
+
+  /**
+   * Asking a builder that is ALREADY geospatial for its geospatial view hands back the same instance, so settings
+   * applied before the call are not silently left on an abandoned object.
+   */
+  @Test
+  void withGeoTypeOnAGeoBuilderIsIdentity() {
+    final TypeGeoIndexBuilder builder = geoBuilder("H").withPrecision(7);
+
+    assertThat(builder.withGeoType()).isSameAs(builder);
+    assertThat(((GeoIndexMetadata) builder.getMetadata()).getPrecision()).isEqualTo(7);
+  }
+
+  private TypeGeoIndexBuilder geoBuilder(final String typeName) {
+    database.command("sql", "CREATE DOCUMENT TYPE " + typeName);
+    database.command("sql", "CREATE PROPERTY " + typeName + ".coords STRING");
+    return database.getSchema().buildTypeIndex(typeName, new String[] { "coords" })
+        .withType(Schema.INDEX_TYPE.GEOSPATIAL).withGeoType();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/serializer/Issue5600StringWktRoundTripTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue5600StringWktRoundTripTest.java
@@ -206,4 +206,33 @@ class Issue5600StringWktRoundTripTest extends TestHelper {
     assertThatThrownBy(() -> database.query("sql", "SELECT name FROM Mixed WHERE coords.isWithin('POLYGONN ((0 0))') = true")
         .hasNext()).hasMessageContaining("POLYGONN");
   }
+
+  /**
+   * The remaining operand shapes of the two relation methods: no parameter at all is a query mistake, while a null or
+   * empty operand has nothing to relate and simply does not match.
+   */
+  @Test
+  void relationMethodsHandleTheDegenerateOperands() {
+    database.getSchema().createDocumentType("Deg").createProperty("coords", Type.STRING);
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Deg SET name = 'here', coords = 'POINT (12.5 41.9)'");
+      database.command("sql", "INSERT INTO Deg SET name = 'nowhere'");
+    });
+
+    // A missing parameter is a mistake in the query, the same way it always was
+    assertThatThrownBy(() -> database.query("sql", "SELECT name FROM Deg WHERE coords.isWithin() = true").hasNext())
+        .hasMessageContaining("requires a shape as parameter");
+    assertThatThrownBy(() -> database.query("sql", "SELECT name FROM Deg WHERE coords.intersectsWith(null) = true")
+        .hasNext()).hasMessageContaining("requires a shape as parameter");
+
+    // An empty operand has no geometry to relate: no match, no error. The row without coords is skipped the same way.
+    final ResultSet empty = database.query("sql", "SELECT name FROM Deg WHERE coords.isWithin('') = true");
+    assertThat(empty.hasNext()).isFalse();
+
+    final ResultSet present = database.query("sql",
+        "SELECT name FROM Deg WHERE coords.intersectsWith('POLYGON ((10 38, 16 38, 16 44, 10 44, 10 38))') = true");
+    assertThat(present.next().<String>getProperty("name")).isEqualTo("here");
+    assertThat(present.hasNext()).isFalse();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/serializer/Issue5600StringWktRoundTripTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue5600StringWktRoundTripTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #5600 (1): a value stored in a {@code STRING} property must read back as the very same {@code String}. The
@@ -180,5 +181,29 @@ class Issue5600StringWktRoundTripTest extends TestHelper {
         "SELECT name FROM Place WHERE coords.intersectsWith(" + box + ") = true");
     assertThat(intersects.next().<String>getProperty("name")).isEqualTo("inside");
     assertThat(intersects.hasNext()).isFalse();
+  }
+
+  /**
+   * A malformed geometry written in the QUERY is a mistake to report, while a row that simply does not hold a geometry
+   * is filtered out: failing the whole query over one bad row would be worse than skipping it.
+   */
+  @Test
+  void aMalformedParameterIsReportedButABadRowIsJustSkipped() {
+    database.getSchema().createDocumentType("Mixed").createProperty("coords", Type.STRING);
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Mixed SET name = 'good', coords = 'POINT (12.5 41.9)'");
+      database.command("sql", "INSERT INTO Mixed SET name = 'junk', coords = 'not a geometry at all'");
+    });
+
+    // The bad row does not match; the good one still does, and the query completes
+    final ResultSet rs = database.query("sql",
+        "SELECT name FROM Mixed WHERE coords.intersectsWith('POLYGON ((10 38, 16 38, 16 44, 10 44, 10 38))') = true");
+    assertThat(rs.next().<String>getProperty("name")).isEqualTo("good");
+    assertThat(rs.hasNext()).isFalse();
+
+    // A typo in the literal is surfaced rather than silently answering "no match"
+    assertThatThrownBy(() -> database.query("sql", "SELECT name FROM Mixed WHERE coords.isWithin('POLYGONN ((0 0))') = true")
+        .hasNext()).hasMessageContaining("POLYGONN");
   }
 }

--- a/engine/src/test/java/com/arcadedb/serializer/Issue5600StringWktRoundTripTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue5600StringWktRoundTripTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.serializer;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5600 (1): a value stored in a {@code STRING} property must read back as the very same {@code String}. The
+ * deserializer used to sniff the first characters of every string it read and, when they looked like the head of a WKT
+ * geometry, return a spatial4j {@code Shape} instead - changing the declared type of the value at the storage layer and
+ * mangling any free text that happened to start with {@code POLYGON}, {@code POINT}, and friends.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5600StringWktRoundTripTest extends TestHelper {
+
+  @Test
+  void declaredStringPropertyKeepsWktText() {
+    database.getSchema().createDocumentType("T").createProperty("location", Type.STRING);
+
+    final AtomicReference<RID> rid = new AtomicReference<>();
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("T");
+      doc.set("location", "POINT (10.0 45.0)");
+      doc.save();
+      rid.set(doc.getIdentity());
+    });
+
+    final Document reloaded = database.lookupByRID(rid.get(), true).asDocument();
+    assertThat(reloaded.get("location")).isInstanceOf(String.class);
+    assertThat(reloaded.getString("location")).isEqualTo("POINT (10.0 45.0)");
+  }
+
+  @Test
+  void freeTextStartingWithAGeometryKeywordIsNotTouched() {
+    database.getSchema().createDocumentType("Note").createProperty("description", Type.STRING);
+
+    final String[] texts = { //
+        "POLYGON shaped, see attached", //
+        "POINTs of interest along the way", //
+        "LINESTRING is a WKT keyword", //
+        "CIRCLE the wagons", //
+        "ENVELOPE (please open it)", //
+        "BUFFER overflow report" };
+
+    database.transaction(() -> {
+      for (final String text : texts) {
+        final MutableDocument doc = database.newDocument("Note");
+        doc.set("description", text);
+        doc.save();
+      }
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT description FROM Note ORDER BY @rid");
+    int i = 0;
+    while (rs.hasNext())
+      assertThat(rs.next().<Object>getProperty("description")).isEqualTo(texts[i++]);
+    assertThat(i).isEqualTo(texts.length);
+  }
+
+  @Test
+  void wktStringSurvivesInsideListsAndMaps() {
+    database.getSchema().createDocumentType("Container");
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Container");
+      doc.set("list", List.of("POINT (1 2)", "plain"));
+      doc.set("map", Map.of("k", "POLYGON ((0 0, 1 0, 1 1, 0 0))"));
+      doc.save();
+    });
+
+    final Result row = database.query("sql", "SELECT list, map FROM Container").next();
+    assertThat(row.<List<Object>>getProperty("list")).containsExactly("POINT (1 2)", "plain");
+    assertThat(row.<Map<String, Object>>getProperty("map").get("k")).isEqualTo("POLYGON ((0 0, 1 0, 1 1, 0 0))");
+  }
+
+  @Test
+  void wktStringIsIndexableAndLookupableAsAString() {
+    database.getSchema().createDocumentType("Indexed").createProperty("code", Type.STRING);
+    database.command("sql", "CREATE INDEX ON Indexed (code) UNIQUE");
+
+    database.transaction(() -> database.command("sql", "INSERT INTO Indexed SET code = 'POINT (3 4)'"));
+
+    final ResultSet rs = database.query("sql", "SELECT code FROM Indexed WHERE code = 'POINT (3 4)'");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("code")).isEqualTo("POINT (3 4)");
+  }
+
+  /**
+   * A real spatial4j Shape has its own binary type and must keep coming back as a Shape.
+   */
+  @Test
+  void shapeValueStillRoundTripsAsShape() {
+    database.getSchema().createDocumentType("Geo");
+
+    database.transaction(
+        () -> database.command("sql", "INSERT INTO Geo SET position = geo.geomFromText('POINT (10.0 45.0)')"));
+
+    final Object position = database.query("sql", "SELECT position FROM Geo").next().getProperty("position");
+    assertThat(position).isInstanceOf(Shape.class);
+    assertThat(((Point) position).getX()).isEqualTo(10.0);
+    assertThat(((Point) position).getY()).isEqualTo(45.0);
+  }
+
+  /**
+   * Geometry functions keep accepting a WKT string read back from a STRING property, so a pre-26.2.1 database - where
+   * every shape was written as WKT text - keeps working without the deserializer converting anything.
+   */
+  @Test
+  void geoFunctionsStillAcceptWktStoredAsText() {
+    database.getSchema().createDocumentType("City").createProperty("coords", Type.STRING);
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO City SET name = 'Rome', coords = 'POINT (12.5 41.9)'");
+      database.command("sql", "INSERT INTO City SET name = 'Milan', coords = 'POINT (9.2 45.5)'");
+    });
+
+    final ResultSet rs = database.query("sql",
+        "SELECT name FROM City WHERE geo.within(coords, geo.geomFromText('POLYGON ((10 38, 16 38, 16 44, 10 44, 10 38))')) = true");
+    assertThat(rs.next().<String>getProperty("name")).isEqualTo("Rome");
+    assertThat(rs.hasNext()).isFalse();
+
+    final ResultSet asText = database.query("sql", "SELECT geo.asText(coords) AS wkt FROM City WHERE name = 'Rome'");
+    assertThat(asText.next().<String>getProperty("wkt")).contains("POINT");
+  }
+
+  /**
+   * The two legacy SQL methods used to require an already-parsed Shape, which only the deserializer's sniff ever
+   * produced from a WKT column. They now do the conversion themselves, like every geo.* function.
+   */
+  @Test
+  void legacyShapeMethodsAcceptWktText() {
+    database.getSchema().createDocumentType("Place").createProperty("coords", Type.STRING);
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Place SET name = 'inside', coords = 'POINT (12.5 41.9)'");
+      database.command("sql", "INSERT INTO Place SET name = 'outside', coords = 'POINT (9.2 45.5)'");
+    });
+
+    final String box = "'POLYGON ((10 38, 16 38, 16 44, 10 44, 10 38))'";
+
+    final ResultSet within = database.query("sql",
+        "SELECT name FROM Place WHERE coords.isWithin(geo.geomFromText(" + box + ")) = true");
+    assertThat(within.next().<String>getProperty("name")).isEqualTo("inside");
+    assertThat(within.hasNext()).isFalse();
+
+    // The parameter may be WKT text too, not only a Shape
+    final ResultSet intersects = database.query("sql",
+        "SELECT name FROM Place WHERE coords.intersectsWith(" + box + ") = true");
+    assertThat(intersects.next().<String>getProperty("name")).isEqualTo("inside");
+    assertThat(intersects.hasNext()).isFalse();
+  }
+}


### PR DESCRIPTION
Closes #5600. The three findings are independent; each is a separate commit-sized change kept together because they all touch the geospatial path.

## 1. A `STRING` property no longer reads back as a `Shape`

`BinarySerializer.deserializeValue` sniffed the first characters of **every** string it read and, when they matched `POINT` / `CIRCLE` / `LINESTRING` / `POLYGON` / `ENVELOPE` / `BUFFER`, parsed the value as WKT and returned a spatial4j `Shape`. A property declared `STRING` therefore did not round-trip, and the trigger was a prefix match on arbitrary user text rather than a schema decision.

The sniff is gone: a string reads back as the string that was written, and the `startsWith` chain no longer runs on every string read in the database.

Backward compatibility is kept where the conversion actually belongs - at the point a geometry is asked for. `GeoUtils.parseGeometry()`, `GeoUtils.parseJtsGeometry()` and `LSMTreeGeoIndex.toShape()` already accepted WKT text, so a pre-26.2.1 database (shapes stored as WKT under `TYPE_STRING`) keeps working, and so does `geo.point()`, which returns WKT.

Two callers did rely on the sniff and are fixed at the right layer: `SQLMethodIsWithin` and `SQLMethodIntersectsWith` returned `null` unless the value was already a `Shape`. They now parse their operands through `GeoUtils.parseGeometry`, like every `geo.*` function, so `coords.isWithin(...)` works on a WKT column and accepts a WKT literal as its parameter too.

**Better alternative suggested by the issue and not taken here:** an explicit `Type.GEOMETRY` in the schema would be the cleanest long-term answer, but that is a schema-format change with its own migration story - worth a separate issue rather than folding into this one.

## 2. `GEOSPATIAL` `precision` is settable from SQL

```sql
CREATE INDEX ON Location (coords) GEOSPATIAL METADATA {"precision": 6}
```

parsed, ran, and silently built the index at the default precision of 11.

The issue proposed mirroring the three existing `METADATA` branches. **The better fix is one level up:** `withType()` already returns a specialised builder that owns its metadata for `LSM_VECTOR`, `FULL_TEXT` and `LSM_SPARSE_VECTOR`; `GEOSPATIAL` was simply missing from that list, which is *why* its metadata had nowhere to go. It now has `TypeGeoIndexBuilder`, in the same shape as the others, so `precision` and `tokenization` are reachable from SQL and from the Java API (`withPrecision`, `withTokenization`) alike.

Two related sharp edges went with it:

- **An unusable `METADATA` is rejected, not dropped.** An unknown key, a non-numeric or out-of-range precision, an invalid tokenization, or a `METADATA` clause on an index type that has no settings at all now raise `CommandSQLParsingException`. Silently ignoring the clause is what kept this gap invisible. Parsing is unchanged, so the existing parser tests still hold.
- **`withType()` no longer leaves the original builder unconfigured.** It returns a *new* object, so `builder.withType(X); builder.create();` - which the pre-existing `LSMTreeGeoIndexSchemaTest` does - failed with `indexType was not specified` once GEOSPATIAL got a subclass. The type is now recorded on the original builder as well, which also removes the same latent trap for full-text and vector callers.

Note the builder parses the `METADATA` keys itself rather than delegating to `GeoIndexMetadata.fromJSON()`: that method reads a **persisted** definition, where a missing `tokenization` means a pre-26.8.1 index and therefore the `FULL` layout. In a `CREATE INDEX` a missing key just means the user did not ask, so the creation-time default has to stand.

## 3. An area shape indexes fewer cells

The issue asked to measure before adopting Lucene's `pruneLeafyBranches`. Measured, on the frontier cell count:

| shape | saving |
|---|---|
| small square | 57% |
| jagged outline | 74% |
| wide rectangle | 0% |
| linestring | 0% |
| point | 0% (by construction) |

Worth taking. A complete set of sibling frontier cells now collapses into its parent, recursively. A parent covers the union of its children, so the cover can only grow and a match is never lost; the `geo.*` predicate post-filters the superset either way.

**Better alternative than the issue's proposal.** The issue suggested subclassing the strategy to expose `createCellIteratorToIndex`. That implementation materialises the entire decomposition in an `ArrayList` (pre-sized to 4096), which is exactly the caveat the issue flagged from Lucene's own javadoc. This implements the prune as a streaming pass over the existing walk instead: only the frontier tokens on the current root-to-leaf path can still be revoked by an ancestor collapsing, so what is held is bounded by `subCellsSize * detailLevel` regardless of shape size. Points - the hot ingest path of #5478 - take an allocation-free shortcut, since a chain of single-child cells can never hold a complete sibling set.

`LSMTreeGeoIndexCellPruningTest` asserts the streaming output is **identical** to Lucene's buffered one, invoking `createCellIteratorToIndex` by reflection, over 8 shapes x 4 precisions, plus a coverage-never-shrinks property and the one-token-per-point guarantee.

This changes what a **new** index writes for area shapes. Indexes in the `FULL` layout are untouched, and `FRONTIER` has not shipped in any release (#5478 merged into 26.8.1-SNAPSHOT today), so no published database holds the unpruned form.

## Tests

New: `Issue5600StringWktRoundTripTest` (7), `LSMTreeGeoIndexCellPruningTest` (3). Extended: `LSMTreeGeoIndexSchemaTest` (+9), `LSMTreeGeoIndexTokenizationTest` (+2, polygon delete symmetry and a pruned jagged polygon at every query resolution).

Regression: 3182 engine tests in `serializer`, `query.sql`, `schema`, `index.geospatial`, `index.fulltext` and the LSM index suites - 0 failures.