### PR TITLE
fix(engine) #5603: refuse a partition key whose bucket is not a function of the index key

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -552,4 +552,47 @@ slower:
   (Bucket counts that are a power of two up to 32 hid this by arithmetic accident: flipping the case of an ASCII
   letter shifts the Java string hash by a multiple of 32.)
 
+## Partitioned types: an unusable partition key is refused instead of quietly breaking `UNIQUE`
+
+Third and last of the series, and the one that closes the hole rather than the symptom
+([#5603](https://github.com/ArcadeData/arcadedb/issues/5603)). On a partitioned type a `UNIQUE` index is a set of
+per-bucket sub-indexes, so the constraint is global only while every record carrying one index key lands in one
+bucket. Placement hashes the value; the index decides two keys are equal a different way. Where those disagree the
+same key lives in several buckets and **each of them accepts its own copy**. Measured against a round-robin control
+that rejects the duplicate every time, a partitioned type admitted 3 of 4 rescaled `DECIMAL` values, 3 of 6
+identical `BINARY` values and 3 of 6 spellings of one instant:
+
+- **`BINARY`** - the stored form is a `byte[]`, which inherits identity `hashCode`, so every single write of the
+  same bytes drew a fresh bucket;
+- **`DECIMAL`** - `BigDecimal.hashCode` folds in the scale, so `1.1` and `1.10` hash apart while the index compares
+  them equal;
+- **`DATE`/`DATETIME` under a zone-carrying `dateTimeImplementation`** (`ZonedDateTime`, `Calendar`) - only the
+  instant reaches disk, so the writer's zone is hashed at placement and gone on the way back. The zone-free
+  implementations (`java.util.Date`, `Instant`, `LocalDate`, `LocalDateTime`) round-trip unchanged and are
+  unaffected.
+
+Such a partition is now never pruned, which restores the constraint by making the uniqueness check fan out, and
+**`ALTER TYPE ... BucketSelectionStrategy partitioned(...)` refuses the configuration outright** rather than
+attaching it and letting the damage surface at read time - the common root behind #5589 and #5595. `COLLATE CI`,
+already unprunable since #5595, is refused on the same footing. Placement is untouched, so no existing database
+needs a repartition.
+
+- **An existing database in one of these states still opens.** The same check runs when the schema is read back,
+  but only logs a warning: a refusal at load would turn a slow database into an unopenable one. Once open, its
+  `UNIQUE` index is enforced again. Duplicates already on disk are not retro-validated - scan those indexes and
+  `REBUILD INDEX` them.
+- **A second index on non-partition properties is a warning, not a refusal.** Those lookups fan out (#5589), which
+  is correct but no faster than not partitioning; the schema is otherwise perfectly reasonable, so it is reported
+  and accepted.
+- **`ALTER TYPE ... BucketSelectionStrategy` now says what actually went wrong.** Every failure used to be
+  rewritten as `implementation '...' was not found`, so a `partitioned('x')` rejected for want of a unique index on
+  `x` sent you hunting for a typo in a name that was perfectly valid. A genuinely unknown implementation still
+  reports that it cannot be found.
+
+Two states the issue asked about turned out not to be reachable, and are pinned by tests rather than fixed: an
+**undeclared partition property** cannot occur, because the strategy demands a unique automatic index and an index
+cannot be created on a property that does not exist; and a **`DATETIME` key under a non-default
+`dateTimeImplementation` does not shift bucket across a rebuild**, because the write path already truncates to the
+declared precision, so a freshly built record and one deserialized from disk hash identically.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -567,9 +567,10 @@ identical `BINARY` values and 3 of 6 spellings of one instant:
 - **`DECIMAL`** - `BigDecimal.hashCode` folds in the scale, so `1.1` and `1.10` hash apart while the index compares
   them equal;
 - **`DATE`/`DATETIME` under a zone-carrying `dateTimeImplementation`** (`ZonedDateTime`, `Calendar`) - only the
-  instant reaches disk, so the writer's zone is hashed at placement and gone on the way back. The zone-free
-  implementations (`java.util.Date`, `Instant`, `LocalDate`, `LocalDateTime`) round-trip unchanged and are
-  unaffected.
+  instant reaches disk, so the writer's zone is hashed at placement and gone on the way back. This covers every
+  datetime precision (`DATETIME_SECOND`, `DATETIME_MICROS`, `DATETIME_NANOS`), which the deserializer reads back
+  through the configured implementation just like the base type. The zone-free implementations (`java.util.Date`,
+  `Instant`, `LocalDate`, `LocalDateTime`) round-trip unchanged and are unaffected.
 
 Such a partition is now never pruned, which restores the constraint by making the uniqueness check fan out, and
 **`ALTER TYPE ... BucketSelectionStrategy partitioned(...)` refuses the configuration outright** rather than

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -588,7 +588,8 @@ needs a repartition.
 - **`ALTER TYPE ... BucketSelectionStrategy` now says what actually went wrong.** Every failure used to be
   rewritten as `implementation '...' was not found`, so a `partitioned('x')` rejected for want of a unique index on
   `x` sent you hunting for a typo in a name that was perfectly valid. A genuinely unknown implementation still
-  reports that it cannot be found.
+  reports that it cannot be found. Only the message changed: the refusal is still a client error and still answers
+  HTTP 400.
 
 Two states the issue asked about turned out not to be reachable, and are pinned by tests rather than fixed: an
 **undeclared partition property** cannot occur, because the strategy demands a unique automatic index and an index

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
@@ -19,6 +19,7 @@
 package com.arcadedb.database.bucketselectionstrategy;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.log.LogManager;
@@ -297,10 +298,35 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
   private static boolean hashAgreesWithIndexKeyIdentity(final Database database, final Type propertyType) {
     return switch (propertyType) {
       case BOOLEAN, BYTE, SHORT, INTEGER, LONG, FLOAT, DOUBLE, STRING, LINK -> true;
-      case DATE, DATETIME, DATETIME_SECOND, DATETIME_MICROS, DATETIME_NANOS ->
-          isZoneFree(propertyType.getJavaImplementation(database));
+      case DATE, DATETIME, DATETIME_SECOND, DATETIME_MICROS, DATETIME_NANOS -> isZoneFree(readBackClass(database, propertyType));
       default -> false;
     };
+  }
+
+  /**
+   * The class the binary deserializer will hand a temporal property back as, which is what decides whether the zone a
+   * record was placed under survives a round trip.
+   * <p>
+   * Asked of the serializer directly rather than through {@link Type#getJavaImplementation}, which resolves the
+   * configured implementation for {@code DATE} and {@code DATETIME} only and answers the static default
+   * ({@code LocalDateTime}) for the three precision subtypes. {@code BinarySerializer.deserializeValue} passes the
+   * configured {@code dateTimeImplementation} for all four datetime binary types, so reading the subtypes through that
+   * helper would report every one of them zone-free and admit exactly the configuration this guard exists to catch -
+   * measured: a {@code DATETIME_NANOS} partition key under {@code ZonedDateTime} let 3 of 6 writes of a single instant
+   * into a UNIQUE index.
+   * <p>
+   * {@code getJavaImplementation} is left alone deliberately. Its other caller is the write path's
+   * {@code convertValueToSchemaType}, where the same mismatch is inert - {@code Type.convert} returns an
+   * already-temporal value untouched, so the conversion target is never consulted for one - and changing it would
+   * alter the class a subtype property converts a String or a Long to, a wider behaviour change than this guard needs.
+   */
+  private static Class<?> readBackClass(final Database database, final Type propertyType) {
+    if (!(database instanceof DatabaseInternal internal))
+      return propertyType.getJavaImplementation(database);
+
+    return propertyType == Type.DATE ?
+        internal.getSerializer().getDateImplementation() :
+        internal.getSerializer().getDateTimeImplementation();
   }
 
   private static boolean isZoneFree(final Class<?> implementation) {

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
@@ -31,11 +31,15 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -329,9 +333,20 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
         internal.getSerializer().getDateTimeImplementation();
   }
 
+  /**
+   * Whether a temporal implementation carries nothing beyond the instant that reaches disk, so that a value hashes
+   * the same before and after a round trip.
+   * <p>
+   * An allow-list, like the {@code Type} switch above and for the same reason: a deny-list of the zone-carrying
+   * classes would silently pass any implementation nobody thought to name - including one configured by a user -
+   * which is exactly the failure this guard exists to prevent. These four are the zone-free half of what
+   * {@code DateUtils.dateTime}/{@code DateUtils.date} can construct; the rest ({@link Calendar},
+   * {@link ZonedDateTime}, {@link OffsetDateTime}) carry a zone that placement hashes and the deserializer cannot
+   * give back.
+   */
   private static boolean isZoneFree(final Class<?> implementation) {
-    return implementation != Calendar.class && implementation != ZonedDateTime.class
-        && implementation != OffsetDateTime.class;
+    return implementation == Date.class || implementation == Instant.class || implementation == LocalDate.class
+        || implementation == LocalDateTime.class;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
@@ -30,7 +30,10 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -45,9 +48,17 @@ import java.util.logging.Level;
  * coerced and stored; a lookup ({@link #getBucketIdByKeys}) is handed the caller's raw key. Since {@code hashCode()} is
  * type-dependent, the lookup side normalises its key to the declared property type before hashing (issue #5595), and
  * declines to prune - answering -1, which callers read as "search every bucket" - whenever it cannot reproduce the
- * stored form: an undeclared property, a value that will not coerce, or a case-insensitive partition index, whose two
- * spellings are one index key but were placed in two different buckets. Placement itself is never altered, so no
- * existing database needs a repartition.
+ * stored form. Placement itself is never altered, so no existing database needs a repartition.
+ * <p>
+ * <b>The bucket must be a function of the index key.</b> Pruning is only half of what the modulus buys: a UNIQUE index
+ * on a partitioned type is a set of per-bucket sub-indexes, so the constraint is global only while every record
+ * carrying one index key lands in one bucket. Where the hash disagrees with the way the index decides two keys are
+ * equal, the same key lives in several buckets and each of them accepts its own copy - a UNIQUE index that silently
+ * holds duplicates. Measured on {@code BINARY} (a {@code byte[]} hashes by identity), {@code DECIMAL} ({@code 1.1} and
+ * {@code 1.10} are one index key but two hash codes) and a {@code DATE}/{@code DATETIME} key read back through a
+ * zone-carrying implementation (the writer's zone is hashed, only the instant is stored). Those partitions are
+ * therefore never pruned either, which restores the constraint by making the check fan out; see
+ * {@link #checkSuitability()}, which the schema layer uses to refuse such a configuration outright (issue #5603).
  *
  * @author Luca Garulli
  */
@@ -88,7 +99,62 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
 
     final TypeIndex index = type.getPolymorphicIndexByProperties(propertyNames);
     if (index == null || !index.isAutomatic() || !index.isUnique())
-      throw new IllegalArgumentException("Cannot find a unique index on properties " + propertyNames);
+      throw new IllegalArgumentException(
+          "cannot find a unique automatic index on the partition properties " + propertyNames);
+  }
+
+  /**
+   * A verdict on the partition configuration, split by what it costs.
+   * <p>
+   * A {@code blocker} is a state in which {@link #getBucketIdByKeys} can never answer anything but -1, so the type
+   * pays the strategy's constraints - a partition key that must not be updated, an uneven bucket fill - and gets
+   * nothing back. Assigning the strategy into such a state is refused; finding an existing database in one is only
+   * warned about, so it still opens.
+   * <p>
+   * A {@code warning} is a configuration that prunes, just less than the wording suggests. Today that is a second
+   * index on properties the partition does not cover: those lookups cannot be pruned (issue #5589) and fan out
+   * across every bucket, which is correct but no faster than not partitioning at all.
+   */
+  public record Suitability(List<String> blockers, List<String> warnings) {
+    public boolean canPrune() {
+      return blockers.isEmpty();
+    }
+  }
+
+  /**
+   * Diagnoses the partition configuration for the schema layer. Cold path only - called when the strategy is assigned
+   * and when a database is reopened, never per query, so it is free to allocate the messages it reports.
+   * <p>
+   * The rules are the ones {@link #getBucketIdByKeys} enforces silently, said out loud: a configuration reported here
+   * as a blocker is exactly one in which that method returns -1 for every key it will ever be handed.
+   */
+  public Suitability checkSuitability() {
+    final Database database = type.getSchema().getEmbedded().getDatabase();
+    final List<String> blockers = new ArrayList<>();
+    final List<String> warnings = new ArrayList<>();
+
+    for (final String propertyName : propertyNames) {
+      final Property property = type.getPolymorphicPropertyIfExists(propertyName);
+      if (property == null)
+        blockers.add("partition property '" + propertyName + "' is not declared in the schema, so a record keeps "
+            + "whatever Java type its writer happened to use and no lookup key can be normalised to match it");
+      else if (!hashAgreesWithIndexKeyIdentity(database, property.getType()))
+        blockers.add("partition property '" + propertyName + "' is declared " + property.getType()
+            + ", whose stored form does not hash the way the index compares keys, so one key would be spread over "
+            + "several buckets and a UNIQUE index on it would admit duplicates");
+    }
+
+    if (partitionKeyIsCaseInsensitive())
+      blockers.add("the index on " + propertyNames + " is declared COLLATE CI, and case folding is an index-level "
+          + "normalisation that placement never applies, so the two spellings of one key sit in two buckets");
+
+    for (final TypeIndex index : type.getAllIndexes(true))
+      if (!coversPartitionProperties(index.getPropertyNames()))
+        warnings.add("index '" + index.getName() + "' is on " + index.getPropertyNames() + " rather than the "
+            + "partition properties " + propertyNames + ", so lookups through it cannot be pruned to one bucket and "
+            + "fan out across all of them");
+
+    return new Suitability(Collections.unmodifiableList(blockers), Collections.unmodifiableList(warnings));
   }
 
   @Override
@@ -185,6 +251,11 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
     if (property == null)
       return UNKNOWN_STORED_FORM;
 
+    // Reproducing the stored form is not enough on its own: the hash of that form has to agree with the way the
+    // index decides two keys are equal, or one key spans several buckets. See hashAgreesWithIndexKeyIdentity.
+    if (!hashAgreesWithIndexKeyIdentity(database, property.getType()))
+      return UNKNOWN_STORED_FORM;
+
     try {
       final Object converted = Type.convert(database, value, property.getType().getJavaImplementation(database), property);
       return converted != null ? converted : UNKNOWN_STORED_FORM;
@@ -201,6 +272,43 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
   }
 
   /**
+   * Whether {@code Object.hashCode()} on the stored form of a {@code propertyType} value is a faithful stand-in for
+   * the way the index decides two keys are equal. Only then does one index key map to exactly one bucket, which is
+   * what both the pruning and - more importantly - the global reach of a UNIQUE constraint rest on.
+   * <p>
+   * Deliberately an ALLOW-list. A type that is not named here declines to prune, so a {@code Type} added later is
+   * merely slower until someone confirms it belongs, rather than silently placing one key in several buckets.
+   * <p>
+   * The exclusions, each measured against a round-robin control that rejects the duplicate every time:
+   * <ul>
+   *   <li>{@code BINARY} - the stored form is a {@code byte[]}, which inherits identity {@code hashCode}, so every
+   *       single write of the same bytes draws a fresh bucket.</li>
+   *   <li>{@code DECIMAL} - {@code BigDecimal.hashCode} folds in the scale, so {@code 1.1} and {@code 1.10} hash
+   *       apart while the index compares them equal.</li>
+   *   <li>{@code LIST}, {@code MAP}, {@code EMBEDDED} and the {@code ARRAY_OF_*} family - structurally the same
+   *       identity-hash problem as {@code BINARY} (and not indexable today, so this is a guard, not a fix).</li>
+   *   <li>{@code DATE}/{@code DATETIME*} read back as a {@link Calendar}, {@link ZonedDateTime} or
+   *       {@link OffsetDateTime} - only the instant reaches disk, so the writer's zone is hashed at placement and
+   *       lost on the way back. Two records for the same instant written from different zones are one index key in
+   *       two buckets. The zone-free implementations ({@code java.util.Date}, {@code Instant}, {@code LocalDate},
+   *       {@code LocalDateTime}) round-trip unchanged and stay prunable.</li>
+   * </ul>
+   */
+  private static boolean hashAgreesWithIndexKeyIdentity(final Database database, final Type propertyType) {
+    return switch (propertyType) {
+      case BOOLEAN, BYTE, SHORT, INTEGER, LONG, FLOAT, DOUBLE, STRING, LINK -> true;
+      case DATE, DATETIME, DATETIME_SECOND, DATETIME_MICROS, DATETIME_NANOS ->
+          isZoneFree(propertyType.getJavaImplementation(database));
+      default -> false;
+    };
+  }
+
+  private static boolean isZoneFree(final Class<?> implementation) {
+    return implementation != Calendar.class && implementation != ZonedDateTime.class
+        && implementation != OffsetDateTime.class;
+  }
+
+  /**
    * Whether {@code lookupProperties} is exactly this strategy's partition property set, with one key value each.
    * <p>
    * Order is deliberately NOT required: the hash both sides compute is a SUM over the per-value hash codes, which
@@ -214,12 +322,21 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
    * keys hold one to three properties, and this runs on a per-query path.
    */
   private boolean coversPartitionProperties(final List<String> lookupProperties, final Object[] keyValues) {
+    return keyValues.length == propertyNames.size() && coversPartitionProperties(lookupProperties);
+  }
+
+  /**
+   * The property-set half of {@link #coversPartitionProperties(List, Object[])}, without the arity check on the key
+   * values. Also used to tell a type's own partition index apart from its other indexes, which is the same question:
+   * does this property set hash to the bucket placement chose?
+   */
+  private boolean coversPartitionProperties(final List<String> lookupProperties) {
     if (lookupProperties == null)
       // THE CALLER COULD NOT SAY WHICH PROPERTIES THE KEYS BELONG TO: UNVERIFIABLE, SO NOT A MATCH
       return false;
 
     final int size = propertyNames.size();
-    if (lookupProperties.size() != size || keyValues.length != size)
+    if (lookupProperties.size() != size)
       return false;
 
     for (int i = 0; i < size; i++) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
@@ -181,7 +181,14 @@ public class AlterTypeStatement extends DDLStatement {
           // with a partition key whose stored form cannot be hashed consistently - sent the user hunting for a typo
           // in a name that was perfectly valid. The genuinely unknown implementation still says so: that case
           // arrives with its own "Cannot find bucket selection strategy class" message, which this keeps.
-          throw new CommandExecutionException(
+          // <p>
+          // The exception TYPE stays a CommandParsingException subtype, and only the message changes. Refusing a
+          // strategy is a client-side DDL mistake, and CommandParsingException is what the HTTP layer maps to 400
+          // (AbstractServerHttpHandler, both the plain and the transaction-wrapped arm); a CommandExecutionException
+          // would be answered 500, telling clients and load balancers to retry a request that can only ever fail the
+          // same way. Statement-level validation refusals elsewhere in this package (see RebuildTypeStatement's
+          // repartition gate) classify the same way.
+          throw new CommandSQLParsingException(
               "Cannot set bucket selection strategy '" + implName + "' on type '" + type.getName() + "': "
                   + e.getMessage(), e);
         }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
@@ -176,7 +176,14 @@ public class AlterTypeStatement extends DDLStatement {
           // not get masked as a parsing error.
           throw e;
         } catch (final Exception e) {
-          throw new CommandSQLParsingException("Bucket selection strategy implementation '" + implName + "' was not found", e);
+          // Report why the strategy was refused rather than claiming it does not exist. Every failure used to be
+          // rewritten as "was not found", so `partitioned('x')` with no unique index on x - or, since issue #5603,
+          // with a partition key whose stored form cannot be hashed consistently - sent the user hunting for a typo
+          // in a name that was perfectly valid. The genuinely unknown implementation still says so: that case
+          // arrives with its own "Cannot find bucket selection strategy class" message, which this keeps.
+          throw new CommandExecutionException(
+              "Cannot set bucket selection strategy '" + implName + "' on type '" + type.getName() + "': "
+                  + e.getMessage(), e);
         }
         break;
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
@@ -23,6 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.exception.SchemaException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.Result;
@@ -175,7 +176,7 @@ public class AlterTypeStatement extends DDLStatement {
           // Permission failures (UPDATE_SCHEMA) must surface as-is so the HTTP layer maps them to 403,
           // not get masked as a parsing error.
           throw e;
-        } catch (final Exception e) {
+        } catch (final IllegalArgumentException | SchemaException e) {
           // Report why the strategy was refused rather than claiming it does not exist. Every failure used to be
           // rewritten as "was not found", so `partitioned('x')` with no unique index on x - or, since issue #5603,
           // with a partition key whose stored form cannot be hashed consistently - sent the user hunting for a typo
@@ -188,6 +189,12 @@ public class AlterTypeStatement extends DDLStatement {
           // would be answered 500, telling clients and load balancers to retry a request that can only ever fail the
           // same way. Statement-level validation refusals elsewhere in this package (see RebuildTypeStatement's
           // repartition gate) classify the same way.
+          // <p>
+          // Only the two types a REFUSAL can arrive as are caught: IllegalArgumentException from the strategy's own
+          // unique-index check, and SchemaException from the suitability check and from an unresolvable
+          // implementation name. Catching Exception would hand the same "your DDL is wrong" 400 to a failure that is
+          // nothing of the sort - an NPE, a persistence error - and the sharper message this now carries would make
+          // that misclassification read as authoritative. Anything else propagates and is classified on its merits.
           throw new CommandSQLParsingException(
               "Cannot set bucket selection strategy '" + implName + "' on type '" + type.getName() + "': "
                   + e.getMessage(), e);

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -747,6 +747,8 @@ public class LocalDocumentType implements DocumentType {
       if (selectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
         reportPartitionSuitability(partitioned);
     } catch (final RuntimeException e) {
+      // Restoring the reference is the whole rollback: previous was bound to this type when it was assigned, and
+      // nothing here unbinds it, so re-invoking previous.setType(this) would be a no-op.
       this.bucketSelectionStrategy = previous;
       throw e;
     }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -738,7 +738,18 @@ public class LocalDocumentType implements DocumentType {
     checkForSchemaMutation();
     final BucketSelectionStrategy previous = this.bucketSelectionStrategy;
     this.bucketSelectionStrategy = selectionStrategy;
-    this.bucketSelectionStrategy.setType(this);
+    try {
+      // The field is assigned before this so the strategy can read back the type it is being bound to, which means
+      // anything thrown from here would otherwise leave the type carrying a strategy the DDL went on to reject.
+      // Both validations live inside the try: the unique-index requirement, and the suitability check that refuses a
+      // partition which could never prune (issue #5603).
+      this.bucketSelectionStrategy.setType(this);
+      if (selectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
+        reportPartitionSuitability(partitioned);
+    } catch (final RuntimeException e) {
+      this.bucketSelectionStrategy = previous;
+      throw e;
+    }
     // Strategy-change flag flip (issue #4087). Switching the bucket-selection strategy on a
     // populated type can leave existing records in buckets that no longer match the new
     // strategy's hash. Two cases set the flag:
@@ -762,7 +773,54 @@ public class LocalDocumentType implements DocumentType {
       // every other site that mutates this flag. Direct field assignment would only work because
       // the wrapping DDL happens to save the schema afterward; relying on that is brittle.
       setNeedsRepartition(true);
+
     return this;
+  }
+
+  /**
+   * Reports what the partition configuration will actually do, at the moment it is chosen rather than at the first
+   * query that comes up short (issue #5603).
+   * <p>
+   * Both #5589 and #5595 were the same story from the user's side: the strategy attached without complaint and the
+   * damage - missing rows, duplicates in a UNIQUE index, an unexplained slowdown - surfaced much later at read time,
+   * with nothing tying it back to the {@code ALTER TYPE}. The read side is fixed; this is the other half, saying so
+   * up front.
+   * <p>
+   * <b>Refuse a new assignment, only warn on reload.</b> A blocker means the strategy can never prune, so accepting
+   * it is accepting pure cost, and the DDL that asks for it is refused. The identical state read back out of
+   * {@code schema.json} is only logged: an existing database has records placed under that strategy already and must
+   * still open - a refusal there would turn a slow database into an unopenable one. Note the asymmetry is in the
+   * reaction, not the diagnosis; both paths run the same check.
+   * <p>
+   * Warnings never refuse. A second index on non-partition properties is a perfectly reasonable schema, it just does
+   * not benefit from the partitioning, and it is common enough that refusing it would be hostile. They are reported
+   * last so a configuration that is about to be refused outright does not first draw advice on how to speed it up.
+   */
+  private void reportPartitionSuitability(final PartitionedBucketSelectionStrategy partitioned) {
+    final PartitionedBucketSelectionStrategy.Suitability suitability = partitioned.checkSuitability();
+
+    if (!suitability.canPrune()) {
+      final String reasons = String.join("; ", suitability.blockers());
+
+      if (!schema.isReadingFromFile())
+        throw new SchemaException(
+            "Cannot use the partitioned bucket selection strategy on " + partitioned.getProperties() + " for type '"
+                + name + "': " + reasons
+                + ". Every lookup would fan out across all buckets, so the partitioning would cost the placement "
+                + "constraints and return nothing. Use `round-robin` instead, or change the partition key.");
+
+      LogManager.instance().log(this, Level.WARNING, """
+          Type '%s' is configured with the partitioned bucket selection strategy on %s, but it can never prune a \
+          lookup to one bucket because %s. Queries stay correct - every lookup fans out across all %d buckets - but \
+          the partitioning buys nothing. Switch the type back to `round-robin`, or fix the configuration and run \
+          `REBUILD TYPE %s WITH repartition = true`.""", null, name, partitioned.getProperties(), reasons,
+          buckets.size(), name);
+    }
+
+    for (final String warning : suitability.warnings())
+      LogManager.instance().log(this, Level.WARNING,
+          "Type '%s' uses the partitioned bucket selection strategy on %s, but %s", null, name,
+          partitioned.getProperties(), warning);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -797,6 +797,14 @@ public class LocalDocumentType implements DocumentType {
    * Warnings never refuse. A second index on non-partition properties is a perfectly reasonable schema, it just does
    * not benefit from the partitioning, and it is common enough that refusing it would be hostile. They are reported
    * last so a configuration that is about to be refused outright does not first draw advice on how to speed it up.
+   * <p>
+   * <b>Warnings are assignment-time advice, so they are not repeated on reload.</b> They say "this is not the shape
+   * you probably meant", which is worth one line at the moment the shape is chosen and nothing at all on every
+   * subsequent open of a database whose schema has not changed since. Left unconditional they would put a WARNING
+   * per startup, forever, against a schema that was accepted and is working as designed - the kind of line operators
+   * learn to filter out, taking the blockers below with it. Blockers do repeat on every open, deliberately: those
+   * describe a database that is still paying for a strategy it cannot use, and that stays worth saying until
+   * somebody acts on it.
    */
   private void reportPartitionSuitability(final PartitionedBucketSelectionStrategy partitioned) {
     final PartitionedBucketSelectionStrategy.Suitability suitability = partitioned.checkSuitability();
@@ -818,6 +826,9 @@ public class LocalDocumentType implements DocumentType {
           `REBUILD TYPE %s WITH repartition = true`.""", null, name, partitioned.getProperties(), reasons,
           buckets.size(), name);
     }
+
+    if (schema.isReadingFromFile())
+      return;
 
     for (final String warning : suitability.warnings())
       LogManager.instance().log(this, Level.WARNING,

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedBoxedKeyLookupTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedBoxedKeyLookupTest.java
@@ -238,6 +238,10 @@ class PartitionedBoxedKeyLookupTest extends TestHelper {
    * The bucket count is deliberately NOT a power of two. Flipping the case of an ASCII letter shifts the Java string
    * hash by a multiple of 32, so with 8 or 16 buckets the two spellings land on the same bucket by arithmetic
    * accident and the defect stays invisible; with 3 they diverge for every value below.
+   * <p>
+   * The collation is switched on AFTER the strategy is attached, because since issue #5603 asking for this
+   * combination outright is refused. Which is the point of keeping this test: the index behind a partition can be
+   * dropped and recreated at any time, so the runtime decline still has to hold on its own.
    */
   @Test
   void aCaseInsensitivePartitionIndexStillFindsEverySpelling() {
@@ -247,10 +251,15 @@ class PartitionedBoxedKeyLookupTest extends TestHelper {
     database.transaction(() -> {
       database.getSchema().buildDocumentType().withName(typeName).withTotalBuckets(3).create();
       database.command("sql", "CREATE PROPERTY " + typeName + ".name STRING");
-      database.command("sql", "CREATE INDEX ON " + typeName + " (name COLLATE CI) UNIQUE");
+      database.command("sql", "CREATE INDEX ON " + typeName + " (name) UNIQUE");
       database.command("sql", "ALTER TYPE " + typeName + " BucketSelectionStrategy `partitioned('name')`");
       for (final String value : values)
         database.newDocument(typeName).set("name", value).save();
+    });
+
+    database.transaction(() -> {
+      database.command("sql", "DROP INDEX `" + typeName + "[name]`");
+      database.command("sql", "CREATE INDEX ON " + typeName + " (name COLLATE CI) UNIQUE");
     });
 
     final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType(typeName);

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
 import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.log.Logger;
 import com.arcadedb.schema.LocalDocumentType;
@@ -102,14 +103,21 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
         () -> database.command("sql", "ALTER TYPE " + typeName + " BucketSelectionStrategy `partitioned('k')`"));
   }
 
-  /** Number of the given values the UNIQUE index let through. Anything above 1 is a broken constraint. */
+  /**
+   * Number of the given values the UNIQUE index let through. Anything above 1 is a broken constraint.
+   * <p>
+   * Only a {@link DuplicatedKeyException} counts as the constraint holding, and every other failure propagates.
+   * Swallowing all of them would let an unrelated error be tallied as a rejection, which is the difference between
+   * "the constraint held" and "nothing was written for some other reason" - and it would make every count in this
+   * class meaningless in exactly the direction that reads as success.
+   */
   private int insertAll(final String typeName, final Object... values) {
     int admitted = 0;
     for (final Object value : values) {
       try {
         database.transaction(() -> database.newDocument(typeName).set("k", value).save());
         admitted++;
-      } catch (final Exception e) {
+      } catch (final DuplicatedKeyException e) {
         // THE CONSTRAINT HELD
       }
     }
@@ -355,6 +363,35 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
     createIndexedType("OneIdx", "STRING");
 
     assertThat(captureWarnings(() -> partition("OneIdx"))).noneMatch(m -> m.contains("OneIdx"));
+  }
+
+  /**
+   * The fan-out warning is advice about the shape just chosen, so it is said once, at assignment, and never again on
+   * reopening a database whose schema has not changed. Unconditional it would be a WARNING per startup, forever,
+   * against a schema that was accepted and works as designed - the kind of line operators learn to filter out, which
+   * would take the blocker warnings with it.
+   */
+  @Test
+  void theFanOutWarningIsNotRepeatedOnEveryReopen() throws Exception {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("ReopenIdx").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY ReopenIdx.k STRING");
+      database.command("sql", "CREATE PROPERTY ReopenIdx.code STRING");
+      database.command("sql", "CREATE INDEX ON ReopenIdx(k) UNIQUE");
+      database.command("sql", "CREATE INDEX ON ReopenIdx(code) UNIQUE");
+    });
+    partition("ReopenIdx");
+    // The schema is flushed explicitly because `ALTER TYPE ... BucketSelectionStrategy` does not persist on its own -
+    // the strategy lives in memory until some later schema mutation happens to save, so without this the type would
+    // reopen as round-robin and the test would pass for the wrong reason. Pre-existing and unrelated to this change
+    // (reproduced on the unmodified sources); reported separately.
+    ((LocalSchema) database.getSchema().getEmbedded()).saveConfiguration();
+    database.close();
+
+    final List<String> warnings = captureWarnings(() -> database = factory.open());
+
+    assertThat(warnings).as("an accepted schema must not warn again on every open").noneMatch(m -> m.contains("ReopenIdx"));
+    assertThat(database.getSchema().getType("ReopenIdx").getBucketSelectionStrategy().getName()).isEqualTo("partitioned");
   }
 
   // ---------------------------------------------------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
@@ -24,7 +24,7 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.log.Logger;
 import com.arcadedb.schema.LocalDocumentType;
@@ -201,7 +201,10 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
   @Test
   void aRefusedAssignmentLeavesThePreviousStrategyInPlace() {
     createIndexedType("Rollback", "BINARY");
-    assertThatThrownBy(() -> partition("Rollback")).isInstanceOf(CommandExecutionException.class);
+    // A CommandParsingException subtype, which is what the HTTP layer maps to 400 - a refusal is a client-side DDL
+    // mistake, and a CommandExecutionException here would be answered 500. Pinned end to end by
+    // PartitionedStrategyRefusalHttpTest in the server module.
+    assertThatThrownBy(() -> partition("Rollback")).isInstanceOf(CommandParsingException.class);
 
     assertThat(database.getSchema().getType("Rollback").getBucketSelectionStrategy().getName())
         .isEqualTo(new RoundRobinBucketSelectionStrategy().getName());

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
@@ -161,13 +161,24 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
         .hasMessageContaining("DECIMAL");
   }
 
+  /**
+   * Every datetime precision, not only the base type. {@code Type.getJavaImplementation} resolves the configured
+   * implementation for {@code DATE} and {@code DATETIME} alone and answers the static {@code LocalDateTime} default
+   * for the three precision subtypes, while the deserializer honours the configured class for all four - so asking it
+   * for the read-back class reported every subtype zone-free and let the configuration through.
+   */
   @Test
-  void aZoneCarryingDateTimeImplementationIsRefused() {
+  void aZoneCarryingDateTimeImplementationIsRefusedAtEveryPrecision() {
     useDateTimeImplementation(ZonedDateTime.class);
-    createIndexedType("ZonedPart", "DATETIME");
-    assertThatThrownBy(() -> partition("ZonedPart"))
-        .as("only the instant is stored, so the writer's zone cannot be recovered")
-        .hasMessageContaining("DATETIME");
+
+    for (final String propertyType : new String[] { "DATETIME", "DATETIME_SECOND", "DATETIME_MICROS",
+        "DATETIME_NANOS" }) {
+      final String typeName = "Zoned" + propertyType;
+      createIndexedType(typeName, propertyType);
+      assertThatThrownBy(() -> partition(typeName))
+          .as("%s: only the instant is stored, so the writer's zone cannot be recovered", propertyType)
+          .hasMessageContaining(propertyType);
+    }
   }
 
   @Test
@@ -235,6 +246,24 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
         .as("six spellings of one instant against a UNIQUE index")
         .isEqualTo(1);
     assertThat(database.countType("ZoneDrift", false)).isEqualTo(1);
+  }
+
+  /**
+   * The same proof one precision down. Before the read-back class was resolved for the subtypes, a
+   * {@code DATETIME_NANOS} partition key under {@code ZonedDateTime} was accepted outright - no runtime setting had
+   * to change to get there - and admitted 3 of these 6 writes of a single instant.
+   */
+  @Test
+  void aUniqueIndexHoldsOnASubPrecisionDateTimePartitionKey() {
+    useDateTimeImplementation(Date.class);
+    createIndexedType("NanoDrift", "DATETIME_NANOS");
+    partition("NanoDrift");
+
+    useDateTimeImplementation(ZonedDateTime.class);
+
+    assertThat(insertAll("NanoDrift", oneInstantInSixZones()))
+        .as("six spellings of one instant against a UNIQUE DATETIME_NANOS index")
+        .isEqualTo(1);
   }
 
   /** Control for the above: the same six writes on a type that never prunes. */

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
@@ -202,6 +202,62 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
   }
 
   /**
+   * A composite partition is only as prunable as its worst component: one unsuitable property in the set is enough,
+   * because placement sums the per-value hashes and the sum is no more reproducible than any term in it. The
+   * suitable component must not mask it.
+   */
+  @Test
+  void oneUnsuitableComponentRefusesTheWholeCompositePartition() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("Composite").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY Composite.a STRING");
+      database.command("sql", "CREATE PROPERTY Composite.b DECIMAL");
+      database.command("sql", "CREATE INDEX ON Composite(a,b) UNIQUE");
+    });
+
+    assertThatThrownBy(() -> database.transaction(() -> database.command("sql",
+        "ALTER TYPE Composite BucketSelectionStrategy `partitioned('a','b')`")))
+        .as("the DECIMAL component alone makes the composite partition unprunable")
+        .hasMessageContaining("DECIMAL")
+        .hasMessageContaining("'b'");
+  }
+
+  /**
+   * The composite counterpart of the fan-out advisory, and the case {@code coversPartitionProperties} exists for: an
+   * index on a strict SUBSET of the partition properties hashes fewer values than placement did, so it cannot be
+   * pruned to one bucket either. Accepted, and reported.
+   */
+  @Test
+  void anIndexOnPartOfACompositePartitionIsWarnedAbout() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("CompositeSubset").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY CompositeSubset.a STRING");
+      database.command("sql", "CREATE PROPERTY CompositeSubset.b STRING");
+      database.command("sql", "CREATE INDEX ON CompositeSubset(a,b) UNIQUE");
+      database.command("sql", "CREATE INDEX ON CompositeSubset(a) NOTUNIQUE");
+    });
+
+    final List<String> warnings = captureWarnings(() -> database.transaction(() -> database.command("sql",
+        "ALTER TYPE CompositeSubset BucketSelectionStrategy `partitioned('a','b')`")));
+
+    assertThat(database.getSchema().getType("CompositeSubset").getBucketSelectionStrategy().getName())
+        .as("a partial index is a warning, never a refusal")
+        .isEqualTo("partitioned");
+    assertThat(warnings).anyMatch(m -> m.contains("CompositeSubset") && m.contains("[a]"));
+
+    // And the runtime guard agrees with the diagnosis: a key covering only part of the partition declines to prune.
+    final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType("CompositeSubset");
+    final PartitionedBucketSelectionStrategy strategy =
+        (PartitionedBucketSelectionStrategy) type.getBucketSelectionStrategy();
+    assertThat(strategy.getBucketIdByKeys(List.of("a"), new Object[] { "acme" }, false))
+        .as("a partial key hashes fewer values than placement did")
+        .isEqualTo(-1);
+    assertThat(strategy.getBucketIdByKeys(List.of("a", "b"), new Object[] { "acme", "eu" }, false))
+        .as("but the full composite key still prunes")
+        .isNotEqualTo(-1);
+  }
+
+  /**
    * A refused assignment must leave nothing behind. The strategy is stored on the type before it is validated - it
    * has to be, so it can read back the type it is being bound to - so a refusal that does not put the previous one
    * back leaves the type running the very strategy the DDL just rejected.

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.partitioning;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
+import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
+import com.arcadedb.schema.LocalDocumentType;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #5603, the follow-ups to #5589 and #5595. Both of those fixed the read side of
+ * {@code PartitionedBucketSelectionStrategy}: a lookup that could not reach the bucket placement chose learned to
+ * decline and fan out. What was left is that nothing told you when you configured a type into a state where that is
+ * the only possible answer - the strategy attached without complaint and the cost surfaced much later, as an
+ * unexplained slowdown or, worse, as duplicates in a UNIQUE index.
+ * <p>
+ * The duplicates are the part that had not been measured. On a partitioned type a UNIQUE index is a set of per-bucket
+ * sub-indexes, so the constraint is global only while every record carrying one index key lands in one bucket. Where
+ * the hash placement uses disagrees with the way the index compares keys, each bucket accepts its own copy. Three
+ * declared types did exactly that, and every one of them is proven here against a round-robin control that rejects
+ * the duplicate every time:
+ * <ul>
+ *   <li>{@code BINARY} - a {@code byte[]} hashes by identity, so every write of the same bytes drew a fresh bucket;</li>
+ *   <li>{@code DECIMAL} - {@code 1.1} and {@code 1.10} are one index key but two hash codes;</li>
+ *   <li>{@code DATETIME} under a zone-carrying implementation - only the instant reaches disk, so the writer's zone
+ *       is hashed at placement and gone on the way back.</li>
+ * </ul>
+ * Such a configuration is now refused when it is assigned, and merely warned about when an existing database is read
+ * back in one - a refusal at load would turn a slow database into an unopenable one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PartitionedStrategySuitabilityTest extends TestHelper {
+
+  private static final int BUCKETS = 3;
+
+  /**
+   * The date/time implementation is a runtime setting, not part of the schema: switching it mid-test is how an
+   * already-partitioned type is driven into - and out of - a state its partition key cannot survive.
+   */
+  private void useDateTimeImplementation(final Class<?> implementation) {
+    try {
+      ((DatabaseInternal) database).getSerializer().setDateTimeImplementation(implementation);
+    } catch (final ClassNotFoundException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private void createIndexedType(final String typeName, final String propertyType) {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(typeName).withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY " + typeName + ".k " + propertyType);
+      database.command("sql", "CREATE INDEX ON " + typeName + "(k) UNIQUE");
+    });
+  }
+
+  private void partition(final String typeName) {
+    database.transaction(
+        () -> database.command("sql", "ALTER TYPE " + typeName + " BucketSelectionStrategy `partitioned('k')`"));
+  }
+
+  /** Number of the given values the UNIQUE index let through. Anything above 1 is a broken constraint. */
+  private int insertAll(final String typeName, final Object... values) {
+    int admitted = 0;
+    for (final Object value : values) {
+      try {
+        database.transaction(() -> database.newDocument(typeName).set("k", value).save());
+        admitted++;
+      } catch (final Exception e) {
+        // THE CONSTRAINT HELD
+      }
+    }
+    return admitted;
+  }
+
+  /** Six writes of the same bytes. Distinct instances, so identity hashing scatters them across the buckets. */
+  private static Object[] sameBytesSixTimes() {
+    final Object[] values = new Object[6];
+    for (int i = 0; i < values.length; i++)
+      values[i] = new byte[] { 1, 2, 3, 4 };
+    return values;
+  }
+
+  /** One instant, spelled in six zones. The index sees one key; {@code ZonedDateTime.hashCode} sees six. */
+  private static Object[] oneInstantInSixZones() {
+    final ZonedDateTime base = ZonedDateTime.of(2020, 9, 13, 14, 26, 40, 0, ZoneId.of("Europe/Rome"));
+    final String[] zones = { "Europe/Rome", "Asia/Tokyo", "America/New_York", "UTC", "Australia/Sydney", "Africa/Cairo" };
+    final Object[] values = new Object[zones.length];
+    for (int i = 0; i < zones.length; i++)
+      values[i] = base.withZoneSameInstant(ZoneId.of(zones[i]));
+    return values;
+  }
+
+  /** Four spellings of one number. {@code BigDecimal.hashCode} folds in the scale; the index compares by value. */
+  private static Object[] oneNumberInFourScales() {
+    return new Object[] { new BigDecimal("1.1"), new BigDecimal("1.10"), new BigDecimal("1.100"),
+        new BigDecimal("1.1000") };
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // The configuration is refused where pruning could never happen.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aBinaryPartitionKeyIsRefused() {
+    createIndexedType("BinPart", "BINARY");
+    assertThatThrownBy(() -> partition("BinPart"))
+        .as("a byte[] hashes by identity, so it can never resolve a bucket")
+        .hasMessageContaining("BINARY")
+        .hasMessageContaining("UNIQUE");
+  }
+
+  @Test
+  void aDecimalPartitionKeyIsRefused() {
+    createIndexedType("DecPart", "DECIMAL");
+    assertThatThrownBy(() -> partition("DecPart"))
+        .as("BigDecimal hashes the scale the index ignores")
+        .hasMessageContaining("DECIMAL");
+  }
+
+  @Test
+  void aZoneCarryingDateTimeImplementationIsRefused() {
+    useDateTimeImplementation(ZonedDateTime.class);
+    createIndexedType("ZonedPart", "DATETIME");
+    assertThatThrownBy(() -> partition("ZonedPart"))
+        .as("only the instant is stored, so the writer's zone cannot be recovered")
+        .hasMessageContaining("DATETIME");
+  }
+
+  @Test
+  void aCaseInsensitivePartitionIndexIsRefused() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("CiPart").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY CiPart.k STRING");
+      database.command("sql", "CREATE INDEX ON CiPart (k COLLATE CI) UNIQUE");
+    });
+    assertThatThrownBy(() -> partition("CiPart"))
+        .as("case folding is an index-level normalisation placement never applies")
+        .hasMessageContaining("COLLATE CI");
+  }
+
+  /**
+   * A refused assignment must leave nothing behind. The strategy is stored on the type before it is validated - it
+   * has to be, so it can read back the type it is being bound to - so a refusal that does not put the previous one
+   * back leaves the type running the very strategy the DDL just rejected.
+   */
+  @Test
+  void aRefusedAssignmentLeavesThePreviousStrategyInPlace() {
+    createIndexedType("Rollback", "BINARY");
+    assertThatThrownBy(() -> partition("Rollback")).isInstanceOf(CommandExecutionException.class);
+
+    assertThat(database.getSchema().getType("Rollback").getBucketSelectionStrategy().getName())
+        .isEqualTo(new RoundRobinBucketSelectionStrategy().getName());
+
+    // And the type is still usable: placement falls back to round-robin, so the UNIQUE index is global again.
+    assertThat(insertAll("Rollback", sameBytesSixTimes())).isEqualTo(1);
+  }
+
+  /**
+   * A zone-free implementation round-trips unchanged, so the very same {@code DATETIME} partition key that the test
+   * above refuses is accepted here. Pins that the refusal keys on the configured implementation and not on the
+   * declared type, which is what makes it recoverable by changing a setting rather than the schema.
+   */
+  @Test
+  void aZoneFreeDateTimeImplementationIsAccepted() {
+    useDateTimeImplementation(Date.class);
+    createIndexedType("DatePart", "DATETIME");
+    partition("DatePart");
+
+    assertThat(database.getSchema().getType("DatePart").getBucketSelectionStrategy().getName()).isEqualTo("partitioned");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Everything the refusal is meant to prevent, measured against a round-robin control.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * The end-to-end proof, on the one unsuitable state that is still reachable after the refusal: the date/time
+   * implementation is a runtime setting, so a type partitioned on a {@code DATETIME} key while it was
+   * {@code java.util.Date} keeps that strategy after the setting is changed to a zone-carrying class. Before the fix
+   * the pruned uniqueness check looked in one bucket and admitted 3 of the 6 writes of a single instant.
+   */
+  @Test
+  void aUniqueIndexHoldsAfterTheDateTimeImplementationTurnsZoneCarrying() {
+    useDateTimeImplementation(Date.class);
+    createIndexedType("ZoneDrift", "DATETIME");
+    partition("ZoneDrift");
+
+    useDateTimeImplementation(ZonedDateTime.class);
+
+    assertThat(insertAll("ZoneDrift", oneInstantInSixZones()))
+        .as("six spellings of one instant against a UNIQUE index")
+        .isEqualTo(1);
+    assertThat(database.countType("ZoneDrift", false)).isEqualTo(1);
+  }
+
+  /** Control for the above: the same six writes on a type that never prunes. */
+  @Test
+  void aRoundRobinTypeRejectsTheSameInstantInEveryZone() {
+    useDateTimeImplementation(ZonedDateTime.class);
+    createIndexedType("ZoneControl", "DATETIME");
+
+    assertThat(insertAll("ZoneControl", oneInstantInSixZones())).isEqualTo(1);
+  }
+
+  /** Control: a UNIQUE index on a plain type has always caught these; only the partitioned path let them through. */
+  @Test
+  void aRoundRobinTypeRejectsRepeatedBytesAndRescaledDecimals() {
+    createIndexedType("BinControl", "BINARY");
+    assertThat(insertAll("BinControl", sameBytesSixTimes())).isEqualTo(1);
+
+    createIndexedType("DecControl", "DECIMAL");
+    assertThat(insertAll("DecControl", oneNumberInFourScales())).isEqualTo(1);
+  }
+
+  /**
+   * A database created before the fix carries the refused configuration in its {@code schema.json}. It must still
+   * open - refusing at load would make a slow database unopenable - and, once open, the UNIQUE index it was silently
+   * violating must hold again, because the strategy declines to prune and the check fans out.
+   * <p>
+   * The strategy is injected straight into the persisted schema because there is no longer any way to ask for it:
+   * that is the point of the refusal, and it is exactly the state an upgraded database arrives in.
+   */
+  @Test
+  void anAlreadyPartitionedBinaryTypeStillOpensAndRegainsItsUniqueConstraint() throws Exception {
+    createIndexedType("LegacyBin", "BINARY");
+
+    final File schemaFile = ((LocalSchema) database.getSchema().getEmbedded()).getConfigurationFile();
+    database.close();
+
+    final JSONObject schemaJson = new JSONObject(FileUtils.readFileAsString(schemaFile));
+    schemaJson.getJSONObject("types").getJSONObject("LegacyBin").put("bucketSelectionStrategy",
+        new JSONObject().put("name", "partitioned").put("properties", new JSONArray(List.of("k"))));
+    try (final FileWriter writer = new FileWriter(schemaFile)) {
+      writer.write(schemaJson.toString());
+    }
+
+    final List<String> warnings = captureWarnings(() -> database = factory.open());
+
+    assertThat(database.getSchema().getType("LegacyBin").getBucketSelectionStrategy().getName())
+        .as("the persisted strategy is kept, not silently swapped out from under the records")
+        .isEqualTo("partitioned");
+    assertThat(warnings)
+        .as("opening a database in a state that can never prune must say so")
+        .anyMatch(m -> m.contains("LegacyBin") && m.contains("BINARY"));
+
+    assertThat(insertAll("LegacyBin", sameBytesSixTimes()))
+        .as("the UNIQUE index holds again because the pruned lookup gave way to a fan-out")
+        .isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Warnings, which never refuse.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * A second index on properties the partition does not cover cannot be pruned (issue #5589) and fans out. That is a
+   * perfectly reasonable schema, just one that gets less out of the partitioning than the wording suggests, so it is
+   * reported and accepted.
+   */
+  @Test
+  void aSecondIndexOnOtherPropertiesIsWarnedAboutAndAccepted() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("TwoIdx").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY TwoIdx.k STRING");
+      database.command("sql", "CREATE PROPERTY TwoIdx.code STRING");
+      database.command("sql", "CREATE INDEX ON TwoIdx(k) UNIQUE");
+      database.command("sql", "CREATE INDEX ON TwoIdx(code) UNIQUE");
+    });
+
+    final List<String> warnings = captureWarnings(() -> partition("TwoIdx"));
+
+    assertThat(database.getSchema().getType("TwoIdx").getBucketSelectionStrategy().getName()).isEqualTo("partitioned");
+    assertThat(warnings).anyMatch(m -> m.contains("TwoIdx") && m.contains("code"));
+  }
+
+  /** A partition whose only index is its own must not draw the fan-out warning. */
+  @Test
+  void aSingleIndexPartitionIsWarningFree() {
+    createIndexedType("OneIdx", "STRING");
+
+    assertThat(captureWarnings(() -> partition("OneIdx"))).noneMatch(m -> m.contains("OneIdx"));
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // The DDL says what actually went wrong.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * {@code ALTER TYPE ... BucketSelectionStrategy} used to rewrite every failure as "was not found", which sent the
+   * user hunting for a typo in a name that was perfectly valid.
+   */
+  @Test
+  void aMissingUniqueIndexReportsWhyRatherThanClaimingTheStrategyDoesNotExist() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("NoIdx").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY NoIdx.k STRING");
+    });
+
+    assertThatThrownBy(() -> partition("NoIdx"))
+        .hasMessageContaining("unique automatic index")
+        .hasMessageNotContaining("was not found");
+  }
+
+  /** ...while a genuinely unknown implementation still says it cannot be found. */
+  @Test
+  void anUnknownStrategyStillReportsThatItCannotBeFound() {
+    database.transaction(() -> database.getSchema().buildDocumentType().withName("Unknown").create());
+
+    assertThatThrownBy(() -> database.transaction(
+        () -> database.command("sql", "ALTER TYPE Unknown BucketSelectionStrategy `no.such.Strategy`")))
+        .hasMessageContaining("Cannot find bucket selection strategy class");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // The suitable case keeps pruning: without this, a regression to an unconditional -1 would pass every test above.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aSuitablePartitionStillPrunesToTheBucketPlacementChose() {
+    createIndexedType("Good", "STRING");
+    partition("Good");
+    database.transaction(() -> database.newDocument("Good").set("k", "acme").save());
+
+    final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType("Good");
+    final PartitionedBucketSelectionStrategy strategy =
+        (PartitionedBucketSelectionStrategy) type.getBucketSelectionStrategy();
+
+    final int lookupBucket = strategy.getBucketIdByKeys(List.of("k"), new Object[] { "acme" }, false);
+    assertThat(lookupBucket).as("a suitable partition must still prune").isNotEqualTo(-1);
+    assertThat(type.getBucketIdByRecord(database.iterateType("Good", false).next().asDocument(), false).getFileId())
+        .as("and prune to the bucket the record was actually placed in")
+        .isEqualTo(type.getBuckets(false).get(lookupBucket).getFileId());
+  }
+
+  /** {@link PartitionedBucketSelectionStrategy#checkSuitability()} is the single source both reactions read. */
+  @Test
+  void checkSuitabilityNamesEveryBlockerAndWarning() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("Diag").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY Diag.k DECIMAL");
+      database.command("sql", "CREATE PROPERTY Diag.code STRING");
+      database.command("sql", "CREATE INDEX ON Diag(k) UNIQUE");
+      database.command("sql", "CREATE INDEX ON Diag(code) UNIQUE");
+    });
+
+    final PartitionedBucketSelectionStrategy strategy = new PartitionedBucketSelectionStrategy(List.of("k"));
+    strategy.setType((LocalDocumentType) database.getSchema().getType("Diag"));
+
+    final PartitionedBucketSelectionStrategy.Suitability suitability = strategy.checkSuitability();
+    assertThat(suitability.canPrune()).isFalse();
+    assertThat(suitability.blockers()).singleElement().asString().contains("DECIMAL");
+    assertThat(suitability.warnings()).singleElement().asString().contains("code");
+
+    assertThat(strategy.getBucketIdByKeys(List.of("k"), new Object[] { new BigDecimal("1.1") }, false))
+        .as("a blocked partition declines to prune, whatever the key")
+        .isEqualTo(-1);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Placement has to survive a round trip through disk, or a rebuild would relocate correctly placed records.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * {@code getBucketIdByRecord} runs on a freshly built {@code MutableDocument} when a record is inserted, and again
+   * on one deserialized from disk when {@code REBUILD TYPE ... WITH repartition = true} decides whether to move it.
+   * If those two disagree the rebuild relocates records that were correctly placed, and every subsequent lookup - which
+   * hashes the in-memory form - misses them.
+   * <p>
+   * Issue #5603 asked specifically about a {@code DATETIME} key under a non-default {@code dateTimeImplementation},
+   * on the theory that a sub-millisecond value kept its extra digits in memory and lost them on disk. It does not:
+   * {@code MutableDocument.convertValueToSchemaType} truncates to the declared precision on the way in, so both sides
+   * see the same truncated value - which is why {@code Instant} with nanoseconds is in the matrix below rather than
+   * in a fix. The types that genuinely did drift are the ones the suitability check now refuses.
+   */
+  @Test
+  void placementSurvivesARoundTripThroughDiskForEveryPrunableKeyType() {
+    useDateTimeImplementation(Instant.class);
+
+    assertPlacementSurvivesRoundTrip("RtString", "STRING", "acme");
+    assertPlacementSurvivesRoundTrip("RtLong", "LONG", -8589934592L);
+    assertPlacementSurvivesRoundTrip("RtInteger", "INTEGER", -12345);
+    assertPlacementSurvivesRoundTrip("RtShort", "SHORT", (short) -12);
+    assertPlacementSurvivesRoundTrip("RtByte", "BYTE", (byte) 7);
+    assertPlacementSurvivesRoundTrip("RtFloat", "FLOAT", -1.5f);
+    assertPlacementSurvivesRoundTrip("RtDouble", "DOUBLE", -1.5d);
+    assertPlacementSurvivesRoundTrip("RtBoolean", "BOOLEAN", Boolean.TRUE);
+    // The exact case the issue proposed: sub-millisecond precision on a millisecond-precision DATETIME property.
+    assertPlacementSurvivesRoundTrip("RtInstant", "DATETIME", Instant.ofEpochSecond(1600000000L, 123456789));
+    assertPlacementSurvivesRoundTrip("RtInstantNanos", "DATETIME_NANOS", Instant.ofEpochSecond(1600000000L, 123456789));
+  }
+
+  private void assertPlacementSurvivesRoundTrip(final String typeName, final String propertyType, final Object value) {
+    createIndexedType(typeName, propertyType);
+    partition(typeName);
+
+    final RID[] rid = new RID[1];
+    database.transaction(() -> {
+      final MutableDocument document = database.newDocument(typeName).set("k", value);
+      document.save();
+      rid[0] = document.getIdentity();
+    });
+
+    // A fresh transaction, so the record is deserialized rather than served from the writing transaction's cache.
+    database.transaction(() -> assertThat(database.getSchema().getType(typeName)
+        .getBucketIdByRecord(database.lookupByRID(rid[0], true).asDocument(), false).getFileId())
+        .as("%s placement recomputed from the record as it was read back", propertyType)
+        .isEqualTo(rid[0].getBucketId()));
+  }
+
+  /**
+   * Issue #5603 item 2 asked whether an UNDECLARED partition property could place {@code 5} and {@code 5L} in
+   * different buckets, since neither side has a conversion target. It cannot be reached: the strategy demands a
+   * unique automatic index on the partition properties, and an index cannot be created on a property that does not
+   * exist. Pinned here so that loosening either of those two rules fails loudly rather than reopening the hole - the
+   * strategy's own blocker for an undeclared property stays as the backstop.
+   */
+  @Test
+  void anUndeclaredPartitionPropertyCannotBeIndexedAndThereforeCannotBePartitionedOn() {
+    database.transaction(() -> database.getSchema().buildDocumentType().withName("Undeclared")
+        .withTotalBuckets(BUCKETS).create());
+
+    assertThatThrownBy(() -> database.transaction(() -> database.getSchema()
+        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Undeclared", "k")))
+        .as("a unique index is the gate the partition strategy depends on")
+        .hasMessageContaining("the property does not exist");
+
+    assertThatThrownBy(() -> partition("Undeclared")).hasMessageContaining("unique automatic index");
+  }
+
+  @Override
+  protected String getDatabasePath() {
+    return "target/databases/PartitionedStrategySuitabilityTest";
+  }
+
+  /**
+   * Runs {@code action} with the engine's own {@link Logger} swapped for one that records, and returns the WARNING
+   * (or worse) messages it saw.
+   * <p>
+   * Deliberately not a {@code java.util.logging} handler. The test resources set {@code com.arcadedb.level=SEVERE},
+   * so whether a WARNING ever reaches a JUL handler depends on which loggers the rest of the suite happened to
+   * reconfigure first - a capture that passes on its own and fails in a full run. Swapping the logger sees the
+   * message before any level is consulted. {@link LogManager#getLogger()} exists for exactly this.
+   */
+  private static List<String> captureWarnings(final Runnable action) {
+    final CapturingLogger capturing = new CapturingLogger(LogManager.instance().getLogger());
+    LogManager.instance().setLogger(capturing);
+    try {
+      action.run();
+    } finally {
+      LogManager.instance().setLogger(capturing.delegate);
+    }
+    return capturing.messages;
+  }
+
+  private static final class CapturingLogger implements Logger {
+    private final Logger       delegate;
+    private final List<String> messages = new CopyOnWriteArrayList<>();
+
+    private CapturingLogger(final Logger delegate) {
+      this.delegate = delegate;
+    }
+
+    private void record(final Level level, final String message, final Object... args) {
+      if (message == null || level.intValue() < Level.WARNING.intValue())
+        return;
+      try {
+        messages.add(args.length > 0 ? message.formatted(args) : message);
+      } catch (final Exception ignored) {
+        messages.add(message);
+      }
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+        final Object arg15, final Object arg16, final Object arg17) {
+      record(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
+          arg15, arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      record(level, message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/PartitionedStrategyRefusalHttpTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/PartitionedStrategyRefusalHttpTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5603. A refused {@code ALTER TYPE ... BucketSelectionStrategy} is a client-side DDL mistake, so it has to
+ * come back as HTTP 400.
+ * <p>
+ * This pins the status because the classification is easy to lose by accident: the handler decides between 400 and
+ * 500 on whether the thrown exception is a {@link com.arcadedb.exception.CommandParsingException}, and it does so in
+ * two places - once for a plainly thrown exception and once for the same exception wrapped by the auto-commit
+ * transaction wrapper. Rewriting the refusal as a {@code CommandExecutionException} to carry a better message, which
+ * is exactly what the message fix in this issue set out to do, silently turns it into a 500 that tells clients and
+ * load balancers to retry a request that can only ever fail the same way.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PartitionedStrategyRefusalHttpTest extends BaseGraphServerTest {
+
+  private static final String DATABASE_NAME = "graph";
+
+  /** A partition key whose stored form does not hash the way the index compares keys: refused, and that is a 400. */
+  @Test
+  void anUnsuitablePartitionKeyIsRejectedAsAClientError() throws Exception {
+    testEachServer(serverIndex -> {
+      executeCommand(serverIndex, "sql", "CREATE DOCUMENT TYPE BinPartHttp BUCKETS 3");
+      executeCommand(serverIndex, "sql", "CREATE PROPERTY BinPartHttp.k BINARY");
+      executeCommand(serverIndex, "sql", "CREATE INDEX ON BinPartHttp(k) UNIQUE");
+
+      final JSONObject error = commandExpecting(serverIndex, 400,
+          "ALTER TYPE BinPartHttp BucketSelectionStrategy `partitioned('k')`");
+
+      // Asserting the status alone would not do: an unrelated 400 would pass for the refusal under test.
+      assertThat(error.getString("detail"))
+          .as("the reason travels to the client, not just the status")
+          .contains("BINARY");
+    });
+  }
+
+  /** The same for the missing-index refusal, which is the older of the two and reaches the client the same way. */
+  @Test
+  void aPartitionWithoutItsUniqueIndexIsRejectedAsAClientError() throws Exception {
+    testEachServer(serverIndex -> {
+      executeCommand(serverIndex, "sql", "CREATE DOCUMENT TYPE NoIdxHttp BUCKETS 3");
+      executeCommand(serverIndex, "sql", "CREATE PROPERTY NoIdxHttp.k STRING");
+
+      final JSONObject error = commandExpecting(serverIndex, 400,
+          "ALTER TYPE NoIdxHttp BucketSelectionStrategy `partitioned('k')`");
+
+      assertThat(error.getString("detail")).contains("unique automatic index");
+      assertThat(error.getString("detail"))
+          .as("and no longer claims a perfectly valid name does not exist")
+          .doesNotContain("was not found");
+    });
+  }
+
+  /** A suitable partition key over the same endpoint, so the test above cannot pass by refusing everything. */
+  @Test
+  void aSuitablePartitionKeyIsAccepted() throws Exception {
+    testEachServer(serverIndex -> {
+      executeCommand(serverIndex, "sql", "CREATE DOCUMENT TYPE OkPartHttp BUCKETS 3");
+      executeCommand(serverIndex, "sql", "CREATE PROPERTY OkPartHttp.k STRING");
+      executeCommand(serverIndex, "sql", "CREATE INDEX ON OkPartHttp(k) UNIQUE");
+
+      commandExpecting(serverIndex, 200, "ALTER TYPE OkPartHttp BucketSelectionStrategy `partitioned('k')`");
+    });
+  }
+
+  /** Posts a SQL command, asserts the HTTP status, and returns the parsed body (the error body on a failure). */
+  private JSONObject commandExpecting(final int serverIndex, final int expectedStatus, final String sql)
+      throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/" + DATABASE_NAME).openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+
+    final JSONObject payload = new JSONObject();
+    payload.put("language", "sql");
+    payload.put("command", sql);
+    formatPayload(connection, payload);
+    connection.connect();
+
+    try {
+      // The status is read BEFORE the body: which stream carries it depends on the status, and asking for the error
+      // stream of a successful response hands back null. Reading it first also means a wrong status is reported as
+      // the mismatch it is, rather than as a NullPointerException on the stream that was not there.
+      final int status = connection.getResponseCode();
+      final String body = status < 400 ? readResponse(connection) : readError(connection);
+      assertThat(status).as("HTTP status for `%s`; body: %s", sql, body).isEqualTo(expectedStatus);
+      return new JSONObject(body);
+    } finally {
+      connection.disconnect();
+    }
+  }
+}


### PR DESCRIPTION
Closes #5603.

Follow-up to #5589 (PR #5591) and #5595 (PR #5598), which fixed the *read* side of `PartitionedBucketSelectionStrategy`. What was left is that nothing warned you when a type was configured into a state where declining to prune is the only possible answer.

## What measuring it turned up

A live correctness bug none of the three follow-up items named.

On a partitioned type a `UNIQUE` index is a set of **per-bucket** sub-indexes, so the constraint is global only while every record carrying one index key lands in one bucket. Placement hashes the value; the index decides two keys are equal a different way. Where those disagree, the same key lives in several buckets and **each of them accepts its own copy**.

| partition key | partitioned type | round-robin control |
|---|---|---|
| `BINARY`, 6 writes of the same `byte[]` | **3 admitted** | 1 |
| `DECIMAL`, `1.1` / `1.10` / `1.100` / `1.1000` | **3 admitted** | 1 |
| `DATETIME` under `ZonedDateTime`, one instant in 6 zones | **3 admitted** | 1 |

- **`BINARY`** - the stored form is a `byte[]`, which inherits identity `hashCode`, so every single write of the same bytes drew a fresh bucket.
- **`DECIMAL`** - `BigDecimal.hashCode` folds in the scale, so `1.1` and `1.10` hash apart while the index compares them equal.
- **`DATE`/`DATETIME` under a zone-carrying `dateTimeImplementation`** (`ZonedDateTime`, `Calendar`) - only the instant reaches disk, so the writer's zone is hashed at placement and gone on the way back. The zone-free implementations (`java.util.Date`, `Instant`, `LocalDate`, `LocalDateTime`) round-trip unchanged and stay prunable.

## The fix

Rather than the three symptom checks item 1 proposed, the check is derived from the invariant the whole strategy rests on: **the bucket must be a function of the index key.** `hashAgreesWithIndexKeyIdentity` is an *allow*-list over `Type`, so a type added later is merely slower until someone confirms it belongs, instead of silently placing one key in several buckets.

- Such a partition is **never pruned**, which restores the `UNIQUE` constraint by making the check fan out - the same remedy #5595 applied to `COLLATE CI`.
- `ALTER TYPE ... BucketSelectionStrategy partitioned(...)` **refuses** the configuration outright. `COLLATE CI` is refused on the same footing.
- **An existing database still opens.** The same check runs on schema reload but only logs a warning: a refusal at load would turn a slow database into an unopenable one. Once open, its `UNIQUE` index is enforced again.
- **Placement is untouched**, so no existing database needs a repartition.

Beyond the ask:

- **A second index on non-partition properties is a warning, not a refusal.** Those lookups fan out (#5589), which is correct but no faster than not partitioning; the schema is otherwise reasonable.
- **`ALTER TYPE` says what actually went wrong.** Every failure used to be rewritten as `implementation '...' was not found`, so a `partitioned('x')` rejected for want of a unique index on `x` sent you hunting for a typo in a name that was perfectly valid. A genuinely unknown implementation still reports that it cannot be found. (Only the message changed. The exception stays a `CommandParsingException` subtype: that is what the HTTP layer keys on for 400, and a `CommandExecutionException` would be answered 500 - telling clients and load balancers to retry a request that can only ever fail the same way. Pinned end-to-end by `PartitionedStrategyRefusalHttpTest`.)
- **A refused assignment rolls back.** The strategy is stored on the type before it is validated - it has to be, so it can read back the type it is binding to - so a refusal that did not restore the previous one left the type running the strategy the DDL had just rejected. That leak predates this PR; `setType`'s own unique-index refusal hit it too.

## Two items that are not bugs

- **Item 2, an undeclared partition property.** Not reachable: the strategy demands a unique automatic index, and an index cannot be created on a property that does not exist (`createTypeIndex` refuses; the OpenCypher `CREATE INDEX` path creates a *non-unique* index, which `setType` then rejects). `DROP PROPERTY` refuses while the index stands. Pinned by a test rather than fixed; the strategy keeps a defensive blocker for it.
- **Item 3, a `DATETIME` key shifting bucket across a rebuild.** Does not reproduce as described: `MutableDocument.convertValueToSchemaType` already truncates to the declared precision on the way in, so an `Instant` carrying nanoseconds on a millisecond `DATETIME` property hashes identically before and after a disk round-trip. The drift is the **zone**, not the precision, which is why it is in the blocker list above instead. A round-trip test pins the invariant across 10 key types.

## Alternatives considered and rejected

- **Make the broken types work by normalising placement** - `Arrays.hashCode` for `BINARY`, `stripTrailingZeros` for `DECIMAL`, UTC for zoned temporals. Correct by construction, but it changes placement, so a database that is currently *consistent* (every value written at one scale, or from one zone) would find its records in buckets the new hash no longer points at - trading a slowdown for a fresh correctness break. `REBUILD TYPE ... WITH repartition = true` is refused on graph types, so there is no clean migration. Same reasoning that rejected `serializeKeyForHashing` in #5595. `BINARY` is the one case where no existing database can be consistent, so changing its placement would be safe - but a one-type exception buys an exotic key type at the cost of a uniform rule.
- **Warning instead of refusal for a new assignment.** The issue itself proposed the split that is implemented here, and a blocker means the strategy can never prune: accepting it is accepting the placement constraints for nothing.
- **Warning when an index is created or recollated on an already-partitioned type**, which is how the refusal can still be circumvented (and what `PartitionedBoxedKeyLookupTest` now does deliberately). Not implemented: `addIndexInternal` runs once per bucket, so the natural hook would log N times per index, and the DDL-level hook is a wider change than this issue asks for. The state is caught on the next reopen, and the runtime decline keeps it correct meanwhile. Worth a follow-up if you want it closed.

## Follow-up found while addressing review (pre-existing, not fixed here)

`ALTER TYPE ... BucketSelectionStrategy` **does not persist**. The strategy is set in memory and `schema.json` never
gains a `bucketSelectionStrategy` entry unless some later schema mutation happens to flush it, so a type partitioned
by that DDL alone comes back as `round-robin` after a restart. Reproduced on the unmodified sources (stashing this
PR's three main-source files changes nothing), so it predates this change and is out of scope here - flagged for a
separate issue. It is why the reopen test below saves the schema explicitly.

## Verification

- New `engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java`, 18 tests. **8 go red** with the two guards neutered; the round-robin controls and the "a suitable partition still prunes to the bucket placement chose" test stay green, so the suite can tell the fix apart from a regression to an unconditional `-1`.
- `PartitionedBoxedKeyLookupTest.aCaseInsensitivePartitionIndexStillFindsEverySpelling` now switches the collation on *after* the strategy is attached, since asking for the combination outright is refused. That is worth keeping: it proves the runtime decline holds on its own.
- Full engine suite: **10417 tests, 0 failures, 0 errors**. Whole reactor compiles.

## Files

- `engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java`
- `engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java`
- `engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java`
- `engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java` (new)
- `engine/src/test/java/com/arcadedb/partitioning/PartitionedBoxedKeyLookupTest.java`
- `docs/release-26.8.1.md`
