### PR TITLE
fix(engine) #5608: the merge counters reach the operator, and the compression a rebase owes its page is structural

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -602,9 +602,14 @@ Two smaller hardenings shipped with it:
   no correctness assertion would have caught. A regression test now asserts a merged page is committed hole-free.
 - **A diagnostic can no longer replace the conflict it is reporting.** `reportCoverageDecline` runs inside the
   commit loop's `catch (ConcurrentModificationException)`, one statement before the rethrow, and reached a bucket
-  lookup that raises `SchemaException` for an unknown id. Escaping there, it would have been wrapped as a plain
+  lookup that raised `SchemaException` for an unknown id. Escaping there, it would have been wrapped as a plain
   `TransactionException` - turning a conflict the caller would have retried into a hard failure. The diagnostic is
   now total by construction.
+- **An unresolvable edge bucket is the retryable conflict it always claimed to be.** The lookup above sat under a
+  `bucket == null` branch documented to "treat a missing one as a retryable conflict", which could never run: the
+  single-argument `getBucketById` raises before it can return null, so the `ConcurrentModificationException` that
+  branch promised was never the exception anyone actually got. The lookup now asks for the null its own contract
+  was written against, and every caller of it - tracking, poisoning and the rebase itself - retries as designed.
 
 ## A `STRING` property no longer reads back as a geometry
 

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -579,6 +579,33 @@ existed ([#5596](https://github.com/ArcadeData/arcadedb/issues/5596)).
   concurrent updates, inserts and deletes of unrelated records sharing a page): those pages are fully declared.
 - **Cost is two ints per page and one OR per page write.**
 
+## The page-merge counters are now visible to an operator
+
+`mergesDeclinedByCoverage`, introduced above as *the* signal that some writer is dirtying a mergeable page without
+declaring it, could not actually be read outside a debugger or a unit test: `Profiler` surfaced exactly one
+page-manager contention stat, `concurrentModificationExceptions`, and none of the three merge counters. The advice
+that came with it - "watch it next to `edgeAppendMerges`/`txPageSlotMerges`: a jump here with a dip there is
+exactly the shape of a forgotten declaration" - was therefore unfollowable in production
+([#5608](https://github.com/ArcadeData/arcadedb/issues/5608)).
+
+All three now reach the `PAGE-MANAGER` block of the text dump, the `/api/v1/server` JSON, the Studio metrics table
+and `/prometheus` (`arcadedb.engine.page.merges.edge.append`, `.slot`, `.declined`). They are also **rate-tracked**
+alongside `concurrentModificationExceptions`, because the signal is a derivative: monotonic counters cannot show a
+jump-with-a-dip without an operator sampling and subtracting them by hand.
+
+Two smaller hardenings shipped with it:
+
+- **The compression a merge owes the page it re-derives is now structural.** `LocalBucket.compressPage` declares
+  its writes covered by *every* merge, which is true only because the compression is re-run on the rebased page.
+  That re-run moved from the commit loop into `rebaseEdgeAppends`/`rebaseSlots` themselves, so reordering or
+  optimising the commit loop can no longer invalidate the declaration - the consequence being a lost defrag, which
+  no correctness assertion would have caught. A regression test now asserts a merged page is committed hole-free.
+- **A diagnostic can no longer replace the conflict it is reporting.** `reportCoverageDecline` runs inside the
+  commit loop's `catch (ConcurrentModificationException)`, one statement before the rethrow, and reached a bucket
+  lookup that raises `SchemaException` for an unknown id. Escaping there, it would have been wrapped as a plain
+  `TransactionException` - turning a conflict the caller would have retried into a hard failure. The diagnostic is
+  now total by construction.
+
 ## A `STRING` property no longer reads back as a geometry
 
 Deserializing any string looked at its first characters and, when they were `POINT`, `CIRCLE`, `LINESTRING`,

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -558,15 +558,27 @@ written to the WAL and replicated, so followers apply the merged bytes verbatim.
   inside a `MutablePage.beginCoveredWrite(COVERAGE_EDGE_APPEND_MERGE)` declaration -
   the coverage is opt-**in**, not opt-out. `LocalBucket` declares exactly the in-place
   segment rewrite that backs a tracked append (plus `compressPage`, whose defrag the
-  commit path re-runs on the rebased page anyway); any other writer touching the page
+  merge re-runs on the rebased page anyway); any other writer touching the page
   leaves an undeclared byte behind and disqualifies it. A writer that never heard of
   the merge therefore cannot have its change silently dropped - the worst outcome is
   the plain retry that predates the merge.
+- **`compressPage`'s blanket declaration is paid for inside the rebase (#5608).** It
+  declares `COVERAGE_ALL_MERGES`, which is true only because the compression is re-run
+  on the page the merge re-derived. That re-run now lives in `rebaseEdgeAppends` /
+  `rebaseSlots` themselves rather than in the commit loop around them, so optimising
+  the commit loop can no longer invalidate the declaration by accident - a lost defrag
+  fails no correctness assertion. `Issue5608RebasedPageCompressionTest` pins it from
+  the outside, by asserting a merged page is committed hole-free.
 - **The explicit poison calls stay as the fast, precise path.** Every non-commutative
   write still poisons the page up front: edge removal/relink
   (`EdgeLinkedList.updateSegment`), bulk `addAll`, `deleteAll`, and new-chunk
   allocation (centralised in `LocalDatabase.createRecordNoLock`). The coverage proof is
   the backstop that turns a forgotten call into a retry instead of a lost write.
+  #5608 audited whether the now-redundant ones should be dropped: they stay. Poisoning
+  runs *before* the page is read, it suppresses the pre-image/final-image record copies
+  that every later write to the page would otherwise allocate and discard, and it keeps
+  a *deliberate* exclusion out of `mergesDeclinedByCoverage` - the counter that exists
+  to expose an *accidental* one.
 - **Bulk import (`GraphBatch`) neither tracks nor poisons** - and since #5596 it no
   longer has to: its chunk writes are undeclared, so a page it touched can never be
   rebased, even if the same transaction also drove `EdgeLinkedList.add` on it.
@@ -580,7 +592,10 @@ written to the WAL and replicated, so followers apply the merged bytes verbatim.
 poison + coverage check + `rebaseEdgeAppends` + commit-loop hook), `MutablePage`
 (per-page coverage bookkeeping), `LocalBucket` (declares the replayable writes),
 `LocalDatabase` (central new-chunk poison), `EdgeLinkedList` (register appends;
-poison remove/bulk paths), `PageManager` (`edgeAppendMerges` stat).
+poison remove/bulk paths), `PageManager` (`edgeAppendMerges` stat), `Profiler` +
+`EngineMetricsBinder` + `GetServerHandler` (#5608: the merge counters reach the
+`/api/v1/server` JSON, the text dump and `/prometheus`, rate-tracked next to
+`concurrentModificationExceptions`).
 
 ## B.4 The two lost-update fixes (#5147, #5153) (shipped)
 

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -122,6 +122,9 @@ public class Profiler {
     final long pageCacheHits = pStats.cacheHits;
     final long pageCacheMiss = pStats.cacheMiss;
     final long concurrentModificationExceptions = pStats.concurrentModificationExceptions;
+    final long edgeAppendMerges = pStats.edgeAppendMerges;
+    final long txPageSlotMerges = pStats.txPageSlotMerges;
+    final long mergesDeclinedByCoverage = pStats.mergesDeclinedByCoverage;
     final long evictionRuns = pStats.evictionRuns;
     final long pagesEvicted = pStats.pagesEvicted;
     final int readCachePages = pStats.readCachePages;
@@ -144,6 +147,11 @@ public class Profiler {
     json.put("walBytesWritten", new JSONObject().put("space", walBytesWritten));
     json.put("walTotalFiles", walTotalFiles);
     json.put("concurrentModificationExceptions", new JSONObject().put("count", concurrentModificationExceptions));
+    // #5608: the three page-merge counters travel WITH concurrentModificationExceptions on purpose - a merge that
+    // stops firing shows up as conflicts here and declines there, and neither half means anything alone.
+    json.put("edgeAppendMerges", new JSONObject().put("count", edgeAppendMerges));
+    json.put("txPageSlotMerges", new JSONObject().put("count", txPageSlotMerges));
+    json.put("mergesDeclinedByCoverage", new JSONObject().put("count", mergesDeclinedByCoverage));
 
     json.put("writeTx", new JSONObject().put("count", writeTx));
     json.put("readTx", new JSONObject().put("count", readTx));
@@ -303,6 +311,9 @@ public class Profiler {
       final long pageCacheHits = pStats.cacheHits;
       final long pageCacheMiss = pStats.cacheMiss;
       final long concurrentModificationExceptions = pStats.concurrentModificationExceptions;
+      final long edgeAppendMerges = pStats.edgeAppendMerges;
+      final long txPageSlotMerges = pStats.txPageSlotMerges;
+      final long mergesDeclinedByCoverage = pStats.mergesDeclinedByCoverage;
       final long evictionRuns = pStats.evictionRuns;
       final long pagesEvicted = pStats.pagesEvicted;
       final int readCachePages = pStats.readCachePages;
@@ -360,6 +371,12 @@ public class Profiler {
         "%n PAGE-MANAGER flushQueue=%d cacheHits=%d cacheMiss=%d concModExceptions=%d evictionRuns=%d pagesEvicted=%d".formatted(
           pageFlushQueueLength,
           pageCacheHits, pageCacheMiss, concurrentModificationExceptions, evictionRuns, pagesEvicted));
+
+      // #5608: read this line together with concModExceptions above. Contention absorbed by a merge never becomes a
+      // retry; a jump in mergesDeclined with a dip in the two merge counters is a writer dirtying a mergeable page
+      // without declaring its coverage (see MutablePage.beginCoveredWrite).
+      buffer.append("%n    edgeAppendMerges=%d txPageSlotMerges=%d mergesDeclinedByCoverage=%d".formatted(
+          edgeAppendMerges, txPageSlotMerges, mergesDeclinedByCoverage));
 
       buffer.append(
         "%n WAL totalFiles=%d pagesWritten=%d bytesWritten=%s".formatted(walTotalFiles, walPagesWritten,

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -710,7 +710,12 @@ public class TransactionContext implements Transaction {
 
   /** Packs the (fileId, pageNumber) of the page holding {@code segmentRID} into a long key (no allocation). */
   private long edgeSegmentPageKey(final RID segmentRID) {
-    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(segmentRID.getBucketId());
+    // #5608: the null-tolerant two-arg lookup, deliberately. The single-arg getBucketById raises SchemaException for an
+    // unknown id (and for a component that is not a bucket) BEFORE it can return null, which made the branch below
+    // dead code and silently defeated the retryable-conflict contract it states: the SchemaException that escaped
+    // instead is not a NeedRetryException, so a commit reaching it failed hard where it was meant to retry. Asking for
+    // the null the branch was written against makes the contract true again.
+    final LocalBucket bucket = database.getSchema().getEmbedded().getBucketById(segmentRID.getBucketId(), false);
     if (bucket == null)
       // The edge bucket cannot vanish under the held commit lock; treat a missing one as a retryable conflict
       // rather than NPE.
@@ -1114,14 +1119,16 @@ public class TransactionContext implements Transaction {
    * <p>
    * #5608: TOTAL by construction. It runs inside the {@code catch (ConcurrentModificationException)} of the commit
    * loop, one statement before {@code throw e}, so anything thrown here would REPLACE the conflict the caller is
-   * propagating. That is worse than a misleading message: {@link #hasReplayableEdgeAppends(PageId)} reaches
-   * {@link #edgeSegmentPageKey(RID)}, whose bucket lookup raises {@code SchemaException} for an unknown id - the
-   * {@code bucket == null} branch under it never fires, because {@code LocalSchema.getBucketById(id)} throws before
-   * it can return null - and a {@code SchemaException} is NOT a {@link NeedRetryException}: the commit's generic
-   * {@code catch (Exception)} would have wrapped it into a plain {@code TransactionException}, turning a conflict
-   * the caller would have retried into a hard failure. Swallowing here, rather than making that one call
-   * non-throwing, is deliberate: it also covers whatever a future diagnostic adds to this method. A diagnostic must
-   * never be able to change what the caller reports.
+   * propagating with a different one - {@link #hasReplayableEdgeAppends(PageId)} alone reaches
+   * {@link #edgeSegmentPageKey(RID)}, which raises on a bucket it cannot resolve. Swallowing here, rather than making
+   * that one call non-throwing, is deliberate: it also covers whatever a future diagnostic adds to this method. A
+   * diagnostic must never be able to change what the caller reports.
+   * <p>
+   * Auditing that path is what exposed the bug fixed alongside this guard: the lookup used to raise
+   * {@code SchemaException}, which is NOT a {@link NeedRetryException}, so the commit's generic
+   * {@code catch (Exception)} would have wrapped it into a plain {@code TransactionException} - a hard failure where
+   * a retry was intended. That is fixed at the source now (see {@code edgeSegmentPageKey}), and this guard remains
+   * the reason a diagnostic cannot rewrite the caller's verdict whatever it starts throwing next.
    */
   private void reportCoverageDecline(final MutablePage page) {
     try {

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -29,6 +29,7 @@ import com.arcadedb.engine.PageManager;
 import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.engine.WALFile;
+import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.NeedRetryException;
@@ -839,6 +840,12 @@ public class TransactionContext implements Transaction {
     // merge just re-derived is what makes compressPage's COVERAGE_ALL_MERGES declaration true rather than merely
     // plausible - a declaration that, without this call, would vouch for a defrag the rebase silently dropped.
     // Pinned by Issue5608RebasedPageCompressionTest.
+    //
+    // The null-tolerant two-arg lookup, where rebaseSlots below simply reuses the bucket it already resolved, is not an
+    // accident: THAT method needs its bucket to replay the slots at all, so it is non-null long before it compresses,
+    // while here the bucket is wanted only for the defrag. This preserves the tolerance the commit loop had before the
+    // call moved in - a file the schema does not map to a bucket costs the page its defrag, rather than replacing a
+    // retryable conflict with a schema error on the way out of a merge that already succeeded.
     final LocalBucket bucket = database.getSchema().getEmbedded().getBucketById(pageId.getFileId(), false);
     if (bucket != null)
       bucket.compressPage(rebased, false);
@@ -1134,6 +1141,18 @@ public class TransactionContext implements Transaction {
     } catch (final RuntimeException diagnosticError) {
       // The conflict the caller is about to rethrow is the truth; losing one counter increment is not worth
       // corrupting it. Logged at FINE so the swallowed cause is still recoverable when debugging this path.
+      //
+      // FINE, and not WARNING, because a bug here would fire on EVERY declined merge of a contended page: a louder
+      // level would turn one defect into a log flood on the very path that is already under pressure. The cost is
+      // that a programming error introduced into this method later (an NPE, a bad index) would be swallowed as
+      // quietly as the engine exception this catch exists for - so the assertion below draws the line between the
+      // two. It fails fast under -ea (surefire's default) at zero production cost, exactly like the leaked-coverage
+      // check in MutablePage.beginCoveredWrite; every exception this method can legitimately meet is an
+      // ArcadeDBException (SchemaException from the bucket lookup, ConcurrentModificationException from its
+      // sibling branch), so anything else is a defect in the diagnostic itself and not a state it must tolerate.
+      assert diagnosticError instanceof ArcadeDBException :
+          "reportCoverageDecline is a diagnostic and must not fail on its own: " + diagnosticError;
+
       LogManager.instance().log(this, Level.FINE, "Unable to report the coverage decline of page %s", diagnosticError,
           page.getPageId());
     }

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -855,6 +855,9 @@ public class TransactionContext implements Transaction {
     if (bucket != null)
       bucket.compressPage(rebased, false);
 
+    // Counted AFTER the compression, so an IOException there leaves the merge uncounted: the commit fails anyway, and
+    // a counter this PR is about to put in front of operators should report merges that actually happened. Deliberate
+    // - before the move the increment ran first and a failed compress still counted.
     database.getPageManager().incrementEdgeAppendMerges();
     return rebased;
   }
@@ -1117,12 +1120,17 @@ public class TransactionContext implements Transaction {
    * looked at, and could even count a decline for a page the other merge went on to rebase - which would make the
    * one statistic meant to expose a forgotten declaration untrustworthy.
    * <p>
-   * #5608: TOTAL by construction. It runs inside the {@code catch (ConcurrentModificationException)} of the commit
-   * loop, one statement before {@code throw e}, so anything thrown here would REPLACE the conflict the caller is
-   * propagating with a different one - {@link #hasReplayableEdgeAppends(PageId)} alone reaches
+   * #5608: TOTAL IN PRODUCTION by construction. It runs inside the {@code catch (ConcurrentModificationException)} of
+   * the commit loop, one statement before {@code throw e}, so anything thrown here would REPLACE the conflict the
+   * caller is propagating with a different one - {@link #hasReplayableEdgeAppends(PageId)} alone reaches
    * {@link #edgeSegmentPageKey(RID)}, which raises on a bucket it cannot resolve. Swallowing here, rather than making
-   * that one call non-throwing, is deliberate: it also covers whatever a future diagnostic adds to this method. A
-   * diagnostic must never be able to change what the caller reports.
+   * that one call non-throwing, is deliberate: it also covers whatever a future diagnostic adds to this method.
+   * <p>
+   * "In production" is the precise claim, and the assertion in the catch block is exactly where it stops holding: an
+   * {@code AssertionError} is not a {@code RuntimeException}, so under {@code -ea} (surefire's default) a genuine bug
+   * on this path DOES escape and replace the caller's conflict. That is the point - a defect in the diagnostic must
+   * fail a test loudly rather than hide behind the guarantee - and it costs nothing where the guarantee matters,
+   * since assertions are off in a production JVM and the swallow is then unconditional.
    * <p>
    * Auditing that path is what exposed the bug fixed alongside this guard: the lookup used to raise
    * {@code SchemaException}, which is NOT a {@link NeedRetryException}, so the commit's generic
@@ -1220,6 +1228,8 @@ public class TransactionContext implements Transaction {
     // this call, would vouch for a defrag the rebase silently dropped). Pinned by Issue5608RebasedPageCompressionTest.
     bucket.compressPage(committed, false);
 
+    // Counted AFTER the compression, for the reason given at the end of rebaseEdgeAppends: only a merge that really
+    // produced a committable page belongs in the statistic operators watch.
     database.getPageManager().incrementTxPageSlotMerges();
     return committed;
   }

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -679,7 +679,9 @@ public class TransactionContext implements Transaction {
    * <p>
    * Since #5596 this is the fast, precise opt-OUT, no longer the only line of defence: the merge additionally
    * requires the page to PROVE that every byte this transaction wrote there was declared replayable by it (see
-   * {@link MutablePage#beginCoveredWrite(int)}), so a forgotten call here costs a retry, not a lost write.
+   * {@link MutablePage#beginCoveredWrite(int)}), so a forgotten call here costs a retry, not a lost write. That
+   * does NOT make the call redundant - see {@link #poisonSlotRebasePage(int, int)} for the #5608 audit of what
+   * poisoning still buys over the proof (skipped tracking work, and a clean {@code mergesDeclinedByCoverage}).
    */
   public void poisonEdgeAppendPage(final RID segmentRID) {
     if (!edgeAppendMerge)
@@ -773,7 +775,8 @@ public class TransactionContext implements Transaction {
    * an eligibility {@link #isRebasableEdgeAppendPage(MutablePage)} verifies against the page itself rather than
    * trusting every writer to have excluded itself (#5596).
    *
-   * @return the freshly rebased page, ready to be version-checked and committed.
+   * @return the freshly rebased page, ALREADY COMPRESSED and ready to be version-checked and committed. The
+   * compression is part of the contract, not the caller's job: see the note at the end of the method body (#5608).
    *
    * @throws ConcurrentModificationException if a targeted chunk filled up in the meantime (a pure in-chunk
    *                                         rebase is no longer possible): the caller falls back to a normal
@@ -831,6 +834,15 @@ public class TransactionContext implements Transaction {
     final MutablePage rebased = modifiedPages.get(pageId);
     if (rebased == null)
       throw new ConcurrentModificationException("Edge-append rebase produced no page for " + pageId + ". Please retry the operation");
+
+    // #5608: MUST stay here, in the method that produces the rebased page. Re-running the compression on the page the
+    // merge just re-derived is what makes compressPage's COVERAGE_ALL_MERGES declaration true rather than merely
+    // plausible - a declaration that, without this call, would vouch for a defrag the rebase silently dropped.
+    // Pinned by Issue5608RebasedPageCompressionTest.
+    final LocalBucket bucket = database.getSchema().getEmbedded().getBucketById(pageId.getFileId(), false);
+    if (bucket != null)
+      bucket.compressPage(rebased, false);
+
     database.getPageManager().incrementEdgeAppendMerges();
     return rebased;
   }
@@ -1004,6 +1016,16 @@ public class TransactionContext implements Transaction {
    * As on the edge-append side, since #5596 this is the fast, precise opt-OUT and not the only line of defence:
    * {@link #isRebasableSlotPage(MutablePage)} also requires the page to prove that every byte this transaction
    * wrote there was declared replayable by this merge (see {@link MutablePage#beginCoveredWrite(int)}).
+   * <p>
+   * #5608 audited every call site to decide whether the ones the coverage proof now subsumes - most clearly the
+   * multi-page writers', whose inline record-table writes are undeclared anyway - should be dropped. They stay,
+   * all of them, because poisoning is not only a duplicate of the proof. It runs BEFORE the page is read and is
+   * O(1); it makes {@link #isSlotRebasePagePoisoned(int, int)} true, which is what lets the write path skip the
+   * pre-image/final-image record copies for every later write to the page (they would be allocated and then
+   * discarded); and, since {@code reportCoverageDecline} deliberately ignores poisoned pages, it is what keeps a
+   * DELIBERATE exclusion out of {@code mergesDeclinedByCoverage} - the statistic that exists to expose an
+   * ACCIDENTAL one. Removing a redundant call would therefore cost allocations and blunt that signal, to save
+   * nothing. Keep poisoning any page whose writes this merge cannot replay, even when the proof would catch it.
    */
   public void poisonSlotRebasePage(final int fileId, final int pageNumber) {
     if (!slotMerge)
@@ -1082,21 +1104,39 @@ public class TransactionContext implements Transaction {
    * (#5596). Counting inside the {@code isRebasable*} predicates instead would double-count a page both merges
    * looked at, and could even count a decline for a page the other merge went on to rebase - which would make the
    * one statistic meant to expose a forgotten declaration untrustworthy.
+   * <p>
+   * #5608: TOTAL by construction. It runs inside the {@code catch (ConcurrentModificationException)} of the commit
+   * loop, one statement before {@code throw e}, so anything thrown here would REPLACE the conflict the caller is
+   * propagating. That is worse than a misleading message: {@link #hasReplayableEdgeAppends(PageId)} reaches
+   * {@link #edgeSegmentPageKey(RID)}, whose bucket lookup raises {@code SchemaException} for an unknown id - the
+   * {@code bucket == null} branch under it never fires, because {@code LocalSchema.getBucketById(id)} throws before
+   * it can return null - and a {@code SchemaException} is NOT a {@link NeedRetryException}: the commit's generic
+   * {@code catch (Exception)} would have wrapped it into a plain {@code TransactionException}, turning a conflict
+   * the caller would have retried into a hard failure. Swallowing here, rather than making that one call
+   * non-throwing, is deliberate: it also covers whatever a future diagnostic adds to this method. A diagnostic must
+   * never be able to change what the caller reports.
    */
   private void reportCoverageDecline(final MutablePage page) {
-    final PageId pageId = page.getPageId();
-    final boolean edgeDeclined = hasReplayableEdgeAppends(pageId)//
-        && !page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE);
-    final boolean slotDeclined = hasReplayableSlotWrites(pageId)//
-        && !page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE);
-    if (!edgeDeclined && !slotDeclined)
-      // An ordinary conflict on a page no merge ever tracked: nothing to do with coverage.
-      return;
+    try {
+      final PageId pageId = page.getPageId();
+      final boolean edgeDeclined = hasReplayableEdgeAppends(pageId)//
+          && !page.isFullyCoveredBy(MutablePage.COVERAGE_EDGE_APPEND_MERGE);
+      final boolean slotDeclined = hasReplayableSlotWrites(pageId)//
+          && !page.isFullyCoveredBy(MutablePage.COVERAGE_SLOT_MERGE);
+      if (!edgeDeclined && !slotDeclined)
+        // An ordinary conflict on a page no merge ever tracked: nothing to do with coverage.
+        return;
 
-    database.getPageManager().incrementMergesDeclinedByCoverage();
-    LogManager.instance().log(this, Level.FINE,
-        "%s merge declined page %s: it carries changes no tracked write accounts for",
-        edgeDeclined && slotDeclined ? "Edge-append and slot" : edgeDeclined ? "Edge-append" : "Slot", pageId);
+      database.getPageManager().incrementMergesDeclinedByCoverage();
+      LogManager.instance().log(this, Level.FINE,
+          "%s merge declined page %s: it carries changes no tracked write accounts for",
+          edgeDeclined && slotDeclined ? "Edge-append and slot" : edgeDeclined ? "Edge-append" : "Slot", pageId);
+    } catch (final RuntimeException diagnosticError) {
+      // The conflict the caller is about to rethrow is the truth; losing one counter increment is not worth
+      // corrupting it. Logged at FINE so the swallowed cause is still recoverable when debugging this path.
+      LogManager.instance().log(this, Level.FINE, "Unable to report the coverage decline of page %s", diagnosticError,
+          page.getPageId());
+    }
   }
 
   /**
@@ -1106,7 +1146,8 @@ public class TransactionContext implements Transaction {
    * is stable), and only for a page whose every modification this transaction made was a tracked disjoint-slot
    * insert or an update that stayed inside the page.
    *
-   * @return the freshly rebased page, ready to be version-checked and committed.
+   * @return the freshly rebased page, ALREADY COMPRESSED and ready to be version-checked and committed. The
+   * compression is part of the contract, not the caller's job: see the note at the end of the method body (#5608).
    *
    * @throws ConcurrentModificationException if a slot was taken/changed by a concurrent commit (a true conflict)
    *                                         or the page can no longer host a record: the caller falls back to a
@@ -1146,6 +1187,12 @@ public class TransactionContext implements Transaction {
         throw new ConcurrentModificationException(
             "Slot rebase not possible on page " + pageId + " slot " + slot + " (concurrent change to the same record). Please retry the operation");
     }
+
+    // #5608: MUST stay here, in the method that produces the rebased page. A shrinking update or a delete replayed
+    // above leaves a hole exactly as the original write did, and re-running the compression is what makes
+    // compressPage's COVERAGE_ALL_MERGES declaration true rather than merely plausible (a declaration that, without
+    // this call, would vouch for a defrag the rebase silently dropped). Pinned by Issue5608RebasedPageCompressionTest.
+    bucket.compressPage(committed, false);
 
     database.getPageManager().incrementTxPageSlotMerges();
     return committed;
@@ -1543,12 +1590,12 @@ public class TransactionContext implements Transaction {
         }
       }
 
+      // #5608: the rebased page is ALREADY compressed - rebaseEdgeAppends/rebaseSlots re-run compressPage themselves,
+      // because that re-run is what makes compressPage's COVERAGE_ALL_MERGES declaration true. Do not lift it back up
+      // here: see the note on those two methods.
       if (pagesToRebase != null)
         for (final PageId pageId : pagesToRebase) {
           final MutablePage rebased = rebaseEdgeAppends(pageId);
-          final LocalBucket bucket = localSchema.getBucketById(rebased.getPageId().getFileId(), false);
-          if (bucket != null)
-            bucket.compressPage(rebased, false);
           pageManager.checkPageVersion(rebased, false);
           pages.add(rebased);
         }
@@ -1556,9 +1603,6 @@ public class TransactionContext implements Transaction {
       if (slotPagesToRebase != null)
         for (final PageId pageId : slotPagesToRebase) {
           final MutablePage rebased = rebaseSlots(pageId);
-          final LocalBucket bucket = localSchema.getBucketById(rebased.getPageId().getFileId(), false);
-          if (bucket != null)
-            bucket.compressPage(rebased, false);
           pageManager.checkPageVersion(rebased, false);
           pages.add(rebased);
         }

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -2021,10 +2021,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * Defragments the page in place, closing the holes an update or a delete left behind.
    * <p>
    * #5596: with {@code forceWipeOut=false} every byte written here is declared covered by ALL the commit-time page
-   * merges. That is sound - and necessary to keep them effective - because the commit path re-runs exactly this call
-   * on the page a merge re-derived, so the compression is reproduced rather than lost: it is a layout-only
-   * transformation of whatever records the page ends up holding, not a change of this transaction's own. A FORCED
-   * wipe-out (the database checker) is not re-run by the merge path, so it declares nothing and disqualifies the page.
+   * merges. That is sound - and necessary to keep them effective - because the merge re-runs exactly this call on the
+   * page it re-derived, so the compression is reproduced rather than lost: it is a layout-only transformation of
+   * whatever records the page ends up holding, not a change of this transaction's own. A FORCED wipe-out (the
+   * database checker) is not re-run by the merge path, so it declares nothing and disqualifies the page.
+   * <p>
+   * #5608: that re-run is the load-bearing half of the declaration, so it lives INSIDE the two methods that produce a
+   * rebased page ({@code TransactionContext.rebaseEdgeAppends} and {@code rebaseSlots}) rather than in the commit loop
+   * that calls them - where reordering or dropping it would have invalidated the declaration with no test failing.
+   * {@code Issue5608RebasedPageCompressionTest} pins the invariant from the outside.
    */
   public void compressPage(final MutablePage page, final boolean forceWipeOut) throws IOException {
     final int previousCoverage = page.beginCoveredWrite(forceWipeOut ? 0 : MutablePage.COVERAGE_ALL_MERGES);

--- a/engine/src/test/java/com/arcadedb/ProfilerTest.java
+++ b/engine/src/test/java/com/arcadedb/ProfilerTest.java
@@ -43,4 +43,25 @@ class ProfilerTest {
     assertThat(json.has("updateRecord")).isTrue();
     assertThat(json.has("totalDatabases")).isTrue();
   }
+
+  /**
+   * #5608: the three commit-time page-merge counters must be reachable by an operator, not only from a debugger or a
+   * unit test holding a {@code PageManager}. {@code mergesDeclinedByCoverage} in particular is documented (#5596) as
+   * THE signal that a writer is dirtying a mergeable page without declaring it, and the advice on it is to watch it
+   * next to the two merge counters - which is impossible while none of them leaves the process.
+   */
+  @Test
+  void pageMergeCountersAreExposed() {
+    final JSONObject json = Profiler.INSTANCE.toJSON();
+    assertThat(json.has("edgeAppendMerges")).isTrue();
+    assertThat(json.has("txPageSlotMerges")).isTrue();
+    assertThat(json.has("mergesDeclinedByCoverage")).isTrue();
+    // Same nesting as every other counter, which is what the Micrometer binder and Studio read.
+    assertThat(json.getJSONObject("mergesDeclinedByCoverage").has("count")).isTrue();
+
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Profiler.INSTANCE.dumpMetrics(new PrintStream(out));
+    final String dump = out.toString();
+    assertThat(dump).contains("edgeAppendMerges=").contains("txPageSlotMerges=").contains("mergesDeclinedByCoverage=");
+  }
 }

--- a/engine/src/test/java/com/arcadedb/database/Issue5608CoverageDeclineDiagnosticTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5608CoverageDeclineDiagnosticTest.java
@@ -22,7 +22,8 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
-import com.arcadedb.exception.SchemaException;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.NeedRetryException;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
@@ -36,14 +37,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * runs from INSIDE the commit loop's {@code catch (ConcurrentModificationException e)}, one statement before
  * {@code throw e}. Anything it throws therefore replaces the conflict the caller is propagating.
  * <p>
- * That was not merely a misleading message. The diagnostic reaches {@code edgeSegmentPageKey}, whose bucket lookup
- * raises {@code SchemaException} for an unknown bucket id - the {@code bucket == null} branch below it never fires,
- * because {@code LocalSchema.getBucketById(id)} throws before returning null. A {@code SchemaException} escaping there
- * is NOT a {@code NeedRetryException}: the commit's generic {@code catch (Exception)} would have wrapped it into a
- * plain {@code TransactionException}, turning a conflict the caller would have retried into a hard failure.
+ * That was not merely a misleading message. The diagnostic reaches {@code edgeSegmentPageKey}, and its bucket lookup
+ * used to raise {@code SchemaException} for an unknown id - the {@code bucket == null} branch below it never fired,
+ * because the single-argument {@code LocalSchema.getBucketById(id)} throws before it can return null. A
+ * {@code SchemaException} is NOT a {@code NeedRetryException}, so the commit's generic {@code catch (Exception)} would
+ * have wrapped it into a plain {@code TransactionException}, turning a conflict the caller would have retried into a
+ * hard failure. Both halves are fixed: the lookup now asks for the null its own contract was written against, so a
+ * bucket it cannot resolve is the retryable conflict it always claimed to be.
  * <p>
- * The diagnostic is now total by construction, which is what this test pins: the setup is verified to be one where
- * resolving the segment's page key really does raise, and the report still returns quietly.
+ * The diagnostic is total by construction on top of that, which is what this test pins: the setup is verified to be
+ * one where resolving the segment's page key really does raise, and the report still returns quietly.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -70,10 +73,12 @@ class Issue5608CoverageDeclineDiagnosticTest extends TestHelper {
       final RID unresolvableSegment = new RID(unmappedBucketId, 0);
       tx.trackEdgeAppend(unresolvableSegment, new RID(unmappedBucketId, 1), new RID(unmappedBucketId, 2));
 
-      // The setup is genuinely hostile, and NOT with a retryable exception: pin it, so the test cannot quietly
-      // degrade into asserting that a no-op does not throw.
+      // The setup is genuinely hostile: pin it, so the test cannot quietly degrade into asserting that a no-op does
+      // not throw. And pin the KIND - a bucket the edge merge cannot resolve is a retryable conflict by contract, so
+      // a regression back to the bare SchemaException (non-retryable, hard-failing the commit) fails here too.
       assertThatThrownBy(() -> tx.poisonEdgeAppendPage(unresolvableSegment))
-          .as("resolving the segment's page key must really raise").isInstanceOf(SchemaException.class);
+          .as("resolving the segment's page key must really raise").isInstanceOf(ConcurrentModificationException.class)
+          .isInstanceOf(NeedRetryException.class);
 
       final MutablePage page = tx.getPageToModify(new PageId(database, bucket.getFileId(), 0), bucket.getPageSize(), false);
 

--- a/engine/src/test/java/com/arcadedb/database/Issue5608CoverageDeclineDiagnosticTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5608CoverageDeclineDiagnosticTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.exception.SchemaException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #5608 (follow-up 4 of #5596): {@code TransactionContext.reportCoverageDecline} is a pure diagnostic, and it
+ * runs from INSIDE the commit loop's {@code catch (ConcurrentModificationException e)}, one statement before
+ * {@code throw e}. Anything it throws therefore replaces the conflict the caller is propagating.
+ * <p>
+ * That was not merely a misleading message. The diagnostic reaches {@code edgeSegmentPageKey}, whose bucket lookup
+ * raises {@code SchemaException} for an unknown bucket id - the {@code bucket == null} branch below it never fires,
+ * because {@code LocalSchema.getBucketById(id)} throws before returning null. A {@code SchemaException} escaping there
+ * is NOT a {@code NeedRetryException}: the commit's generic {@code catch (Exception)} would have wrapped it into a
+ * plain {@code TransactionException}, turning a conflict the caller would have retried into a hard failure.
+ * <p>
+ * The diagnostic is now total by construction, which is what this test pins: the setup is verified to be one where
+ * resolving the segment's page key really does raise, and the report still returns quietly.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5608CoverageDeclineDiagnosticTest extends TestHelper {
+
+  @Test
+  void aFailingDiagnosticNeverReplacesTheConflictBeingReported() throws Exception {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Diag", 1);
+      database.newDocument("Diag").set("tag", "value").save();
+    });
+
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(
+        database.getSchema().getType("Diag").getBuckets(false).getFirst().getFileId());
+
+    database.begin();
+    try {
+      final TransactionContext tx = ((DatabaseInternal) database).getTransaction();
+
+      // A tracked edge append whose segment claims a bucket id that does not exist. trackEdgeAppend itself never
+      // resolves the page key (that is what keeps the append hot path allocation-free), so the transaction is left
+      // holding a tracked segment nobody can locate - the state the diagnostic then walks into.
+      final RID unresolvableSegment = new RID(30_000, 0);
+      tx.trackEdgeAppend(unresolvableSegment, new RID(30_000, 1), new RID(30_000, 2));
+
+      // The setup is genuinely hostile, and NOT with a retryable exception: pin it, so the test cannot quietly
+      // degrade into asserting that a no-op does not throw.
+      assertThatThrownBy(() -> tx.poisonEdgeAppendPage(unresolvableSegment))
+          .as("resolving the segment's page key must really raise").isInstanceOf(SchemaException.class);
+
+      final MutablePage page = tx.getPageToModify(new PageId(database, bucket.getFileId(), 0), bucket.getPageSize(), false);
+
+      final Method reportCoverageDecline = TransactionContext.class.getDeclaredMethod("reportCoverageDecline",
+          MutablePage.class);
+      reportCoverageDecline.setAccessible(true);
+
+      assertThatCode(() -> reportCoverageDecline.invoke(tx, page))
+          .as("the diagnostic must never alter the exception the commit loop is propagating").doesNotThrowAnyException();
+    } finally {
+      database.rollback();
+    }
+
+    // The database is untouched by the probe above.
+    database.transaction(() -> assertThat(database.countType("Diag", false)).isEqualTo(1));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue5608CoverageDeclineDiagnosticTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5608CoverageDeclineDiagnosticTest.java
@@ -63,11 +63,12 @@ class Issue5608CoverageDeclineDiagnosticTest extends TestHelper {
     try {
       final TransactionContext tx = ((DatabaseInternal) database).getTransaction();
 
-      // A tracked edge append whose segment claims a bucket id that does not exist. trackEdgeAppend itself never
+      // A tracked edge append whose segment claims a bucket id no bucket answers to. trackEdgeAppend itself never
       // resolves the page key (that is what keeps the append hot path allocation-free), so the transaction is left
       // holding a tracked segment nobody can locate - the state the diagnostic then walks into.
-      final RID unresolvableSegment = new RID(30_000, 0);
-      tx.trackEdgeAppend(unresolvableSegment, new RID(30_000, 1), new RID(30_000, 2));
+      final int unmappedBucketId = firstUnmappedBucketId();
+      final RID unresolvableSegment = new RID(unmappedBucketId, 0);
+      tx.trackEdgeAppend(unresolvableSegment, new RID(unmappedBucketId, 1), new RID(unmappedBucketId, 2));
 
       // The setup is genuinely hostile, and NOT with a retryable exception: pin it, so the test cannot quietly
       // degrade into asserting that a no-op does not throw.
@@ -88,5 +89,18 @@ class Issue5608CoverageDeclineDiagnosticTest extends TestHelper {
 
     // The database is untouched by the probe above.
     database.transaction(() -> assertThat(database.countType("Diag", false)).isEqualTo(1));
+  }
+
+  /**
+   * The lowest file id the single-argument {@code getBucketById} refuses - either past the end of the file list, or a
+   * component that is not a bucket (the schema dictionary, an index). Derived rather than hard-coded to a large
+   * constant, so the fixture cannot quietly grow into the id the test assumed was free.
+   */
+  private int firstUnmappedBucketId() {
+    int id = 0;
+    // The two-argument form returns null for exactly the ids the single-argument one raises on.
+    while (database.getSchema().getEmbedded().getBucketById(id, false) != null)
+      ++id;
+    return id;
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/Issue5608RebasedPageCompressionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue5608RebasedPageCompressionTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,6 +58,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Issue5608RebasedPageCompressionTest extends TestHelper {
   private static final String PAD   = "0".repeat(64);
   private static final String BULKY = "x".repeat(2000);
+  /** Generous enough to never fire on a loaded CI box, short enough that a real deadlock fails fast. */
+  private static final long   HANDOFF_TIMEOUT_SECONDS = 60;
 
   private boolean savedSlotMerge;
 
@@ -141,6 +144,11 @@ class Issue5608RebasedPageCompressionTest extends TestHelper {
   /**
    * Runs {@code write} in a transaction that loses the page version race against a same-size update of {@code bumped}
    * (a false conflict on ANOTHER slot of the same page), so the commit resolves it through the disjoint-slot merge.
+   * <p>
+   * Every wait is bounded and every hand-off latch is released from a {@code finally}: a two-thread commit race that
+   * deadlocks must fail this test in seconds, not hang the whole suite. In particular the main thread releases
+   * {@code mainTxWroteAndReadThePage} even when {@code write} throws, which would otherwise park the competitor
+   * forever on a latch nobody counts down.
    *
    * @return how many slot merges fired, so the caller can tell a merged commit from a plain uncontended one.
    */
@@ -152,7 +160,8 @@ class Issue5608RebasedPageCompressionTest extends TestHelper {
 
     final Thread bumper = new Thread(() -> {
       try {
-        mainTxWroteAndReadThePage.await();
+        if (!mainTxWroteAndReadThePage.await(HANDOFF_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          throw new AssertionError("the main transaction never signalled that it had written and read the page");
         database.transaction(() -> bumped.asDocument(true).modify().set("tag", "9".repeat(PAD.length())).save(), true, 50);
       } catch (final Throwable e) {
         errors.add(e);
@@ -164,16 +173,21 @@ class Issue5608RebasedPageCompressionTest extends TestHelper {
 
     database.begin();
     try {
-      write.run();                          // loads the page at its current version and registers the tracked write
-      mainTxWroteAndReadThePage.countDown();
-      bumpCommitted.await();                // ...which the competitor now makes stale
-      database.commit();
+      try {
+        write.run();                        // loads the page at its current version and registers the tracked write
+      } finally {
+        mainTxWroteAndReadThePage.countDown();
+      }
+      if (!bumpCommitted.await(HANDOFF_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        throw new AssertionError("the competitor never finished its update of the shared page");
+      database.commit();                    // ...whose commit has now made this transaction's page version stale
     } finally {
       if (database.isTransactionActive())
         database.rollback();
-      bumper.join();
+      bumper.join(TimeUnit.SECONDS.toMillis(HANDOFF_TIMEOUT_SECONDS));
     }
 
+    assertThat(bumper.isAlive()).as("the competitor thread must not still be running").isFalse();
     if (!errors.isEmpty())
       throw new AssertionError("competitor failed: " + errors.getFirst(), errors.getFirst());
 

--- a/engine/src/test/java/com/arcadedb/engine/Issue5608RebasedPageCompressionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue5608RebasedPageCompressionTest.java
@@ -52,6 +52,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * Lives in {@code com.arcadedb.engine} to read the page layout constants directly: measuring the holes against the
  * record table is the only assertion that says "compressed" without re-deriving it from the engine's own defrag code.
+ * <p>
+ * DELIBERATELY NOT {@code @Tag("slow")}, for the reason {@code Issue5596MergeCoverageTest} spells out next door: the
+ * tag keys on elapsed time, not on whether a test spawns a thread. Both methods here drive the SMALLEST contention
+ * that reproduces - one competitor, one commit each - and the whole class measures ~0.02s. It also belongs on every
+ * build: a merge that stops re-compressing costs a defrag, which no correctness assertion anywhere would catch.
+ * Re-measure before tagging it, rather than tagging it by family resemblance to the contention suites.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/test/java/com/arcadedb/engine/Issue5608RebasedPageCompressionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue5608RebasedPageCompressionTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5608 (follow-up 2 of #5596): {@link LocalBucket#compressPage(MutablePage, boolean)} declares every byte it
+ * writes as covered by ALL the commit-time page merges ({@code MutablePage.COVERAGE_ALL_MERGES}). That declaration is
+ * true only because the merge RE-RUNS the compression on the page it re-derived - the defrag is then reproduced rather
+ * than lost. Nothing used to enforce it: the re-compress lived in the commit loop, one statement away from the rebase,
+ * and dropping or reordering it would have left the declaration vouching for a defrag that no longer happened. The
+ * consequence is a lost defrag, not a lost write, so no correctness assertion would have noticed.
+ * <p>
+ * The re-compress now lives INSIDE {@code TransactionContext.rebaseEdgeAppends}/{@code rebaseSlots}, and these tests
+ * pin the invariant from the outside, where the implementation cannot drift away from them: force a merge on a page
+ * whose replayed write leaves a hole (a shrinking update, and a delete), then assert the COMMITTED page carries no
+ * hole at all. Both shapes are checked because the two hole sources are replayed by different primitives
+ * ({@code rebaseRecordOnPage} and {@code rebaseRecordDeleteOnPage}).
+ * <p>
+ * Lives in {@code com.arcadedb.engine} to read the page layout constants directly: measuring the holes against the
+ * record table is the only assertion that says "compressed" without re-deriving it from the engine's own defrag code.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5608RebasedPageCompressionTest extends TestHelper {
+  private static final String PAD   = "0".repeat(64);
+  private static final String BULKY = "x".repeat(2000);
+
+  private boolean savedSlotMerge;
+
+  @BeforeEach
+  void enableSlotMerge() {
+    savedSlotMerge = GlobalConfiguration.TX_PAGE_SLOT_MERGE.getValueAsBoolean();
+    GlobalConfiguration.TX_PAGE_SLOT_MERGE.setValue(true);
+  }
+
+  @AfterEach
+  void restoreSlotMerge() {
+    GlobalConfiguration.TX_PAGE_SLOT_MERGE.setValue(savedSlotMerge);
+  }
+
+  /**
+   * A shrinking in-place update is a tracked slot write that leaves a hole behind ("CREATE A HOLE (REMOVED LATER BY
+   * COMPRESS-PAGE)" in {@code updateRecordInternal}). Replayed on the newer committed page by the slot merge it leaves
+   * exactly the same hole, so the committed page is compressed only if the merge re-ran the compression.
+   */
+  @Test
+  void aSlotMergedShrinkLeavesNoHoleBehind() throws Exception {
+    final RID[] rids = createOnePageOfRecords();
+    final RID shrinking = rids[0];
+    final RID bumped = rids[3];
+
+    final long merges = mergeUnderContention(() -> shrinking.asDocument(true).modify().set("tag", "y").save(), bumped);
+
+    assertThat(merges).as("the disjoint-slot merge must have absorbed the conflict").isGreaterThan(0);
+    assertThat(holeBytesInPage(pageOf(rids[0]))).as("the merged page must be committed compressed").isZero();
+
+    // ...and the replayed write plus the competitor's are both intact.
+    database.transaction(() -> {
+      assertThat(shrinking.asDocument(true).getString("tag")).isEqualTo("y");
+      assertThat(bumped.asDocument(true).getString("tag")).isEqualTo("9".repeat(PAD.length()));
+    });
+  }
+
+  /**
+   * The same invariant for the other hole source: a plain record DELETE (#5569), replayed by
+   * {@code rebaseRecordDeleteOnPage}, which frees the slot and turns the record's bytes into a hole.
+   */
+  @Test
+  void aSlotMergedDeleteLeavesNoHoleBehind() throws Exception {
+    final RID[] rids = createOnePageOfRecords();
+    final RID victim = rids[1];
+    final RID bumped = rids[3];
+
+    final long merges = mergeUnderContention(() -> victim.asDocument(true).delete(), bumped);
+
+    assertThat(merges).as("the disjoint-slot merge must have absorbed the conflict").isGreaterThan(0);
+    assertThat(holeBytesInPage(pageOf(rids[0]))).as("the merged page must be committed compressed").isZero();
+
+    database.transaction(() -> {
+      assertThat(database.countType("Compact", false)).isEqualTo(rids.length - 1);
+      assertThat(bumped.asDocument(true).getString("tag")).isEqualTo("9".repeat(PAD.length()));
+      // The records that shared the page with the deleted one must still be readable AFTER the defrag moved them.
+      assertThat(rids[0].asDocument(true).getString("tag")).isEqualTo(BULKY);
+      assertThat(rids[2].asDocument(true).getString("tag")).isEqualTo(BULKY);
+    });
+  }
+
+  /**
+   * Four records of one type on one page. The first three are bulky so that shrinking or deleting one of them leaves a
+   * hole no rounding can hide; the fourth is the competitor's, updated in place at constant size.
+   */
+  private RID[] createOnePageOfRecords() {
+    final RID[] rids = new RID[4];
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Compact", 1);
+      for (int i = 0; i < rids.length - 1; i++)
+        rids[i] = database.newDocument("Compact").set("tag", BULKY).save().getIdentity();
+      rids[rids.length - 1] = database.newDocument("Compact").set("tag", PAD).save().getIdentity();
+    });
+
+    final LocalBucket bucket = bucketOf(rids[0]);
+    for (final RID rid : rids)
+      assertThat(rid.getPosition() / bucket.getMaxRecordsInPage()).as("every record must share one page")
+          .isEqualTo(rids[0].getPosition() / bucket.getMaxRecordsInPage());
+    return rids;
+  }
+
+  /**
+   * Runs {@code write} in a transaction that loses the page version race against a same-size update of {@code bumped}
+   * (a false conflict on ANOTHER slot of the same page), so the commit resolves it through the disjoint-slot merge.
+   *
+   * @return how many slot merges fired, so the caller can tell a merged commit from a plain uncontended one.
+   */
+  private long mergeUnderContention(final Runnable write, final RID bumped) throws InterruptedException {
+    final long mergesBefore = slotMerges();
+    final CountDownLatch mainTxWroteAndReadThePage = new CountDownLatch(1);
+    final CountDownLatch bumpCommitted = new CountDownLatch(1);
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+    final Thread bumper = new Thread(() -> {
+      try {
+        mainTxWroteAndReadThePage.await();
+        database.transaction(() -> bumped.asDocument(true).modify().set("tag", "9".repeat(PAD.length())).save(), true, 50);
+      } catch (final Throwable e) {
+        errors.add(e);
+      } finally {
+        bumpCommitted.countDown();
+      }
+    }, "bumper");
+    bumper.start();
+
+    database.begin();
+    try {
+      write.run();                          // loads the page at its current version and registers the tracked write
+      mainTxWroteAndReadThePage.countDown();
+      bumpCommitted.await();                // ...which the competitor now makes stale
+      database.commit();
+    } finally {
+      if (database.isTransactionActive())
+        database.rollback();
+      bumper.join();
+    }
+
+    if (!errors.isEmpty())
+      throw new AssertionError("competitor failed: " + errors.getFirst(), errors.getFirst());
+
+    return slotMerges() - mergesBefore;
+  }
+
+  private long slotMerges() {
+    return ((DatabaseInternal) database).getPageManager().getStats().txPageSlotMerges;
+  }
+
+  private LocalBucket bucketOf(final RID rid) {
+    return (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
+  }
+
+  /** Reads the page back from the COMMITTED image, so a compression that never reached disk cannot hide in a cache. */
+  private BasePage pageOf(final RID rid) {
+    final LocalBucket bucket = bucketOf(rid);
+    final PageId pageId = new PageId(database, bucket.getFileId(), (int) (rid.getPosition() / bucket.getMaxRecordsInPage()));
+    final BasePage[] page = new BasePage[1];
+    database.transaction(() -> {
+      try {
+        page[0] = ((DatabaseInternal) database).getTransaction().getPage(pageId, bucket.getPageSize());
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    return page[0];
+  }
+
+  /**
+   * Bytes of the page's record region that belong to no record: the gap before the first record plus every gap between
+   * two consecutive ones. Zero exactly when the page carries no hole, i.e. when {@code compressPage} ran on the image
+   * that got committed. Deliberately measured from the record table rather than by calling the engine's own hole
+   * computation, so a defrag that stops running cannot take the assertion down with it.
+   */
+  private int holeBytesInPage(final BasePage page) throws IOException {
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(page.getPageId().getFileId());
+    final int contentHeaderSize = LocalBucket.PAGE_RECORD_TABLE_OFFSET + bucket.getMaxRecordsInPage() * Binary.INT_SERIALIZED_SIZE;
+    final short recordCountInPage = page.readShort(LocalBucket.PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
+
+    final List<int[]> records = new ArrayList<>(recordCountInPage);
+    for (int slot = 0; slot < recordCountInPage; slot++) {
+      final int position = (int) page.readUnsignedInt(
+          LocalBucket.PAGE_RECORD_TABLE_OFFSET + slot * Binary.INT_SERIALIZED_SIZE);
+      if (position < 1 || position >= page.getContentSize())
+        // FREED SLOT
+        continue;
+      final long[] recordSize = page.readNumberAndSize(position);
+      assertThat(recordSize[0]).as("this test only lays out plain in-place records, no placeholder or chunk")
+          .isGreaterThan(0L);
+      records.add(new int[] { position, (int) (recordSize[0] + recordSize[1]) });
+    }
+    records.sort((a, b) -> Integer.compare(a[0], b[0]));
+
+    int holeBytes = 0;
+    int expectedNextPosition = contentHeaderSize;
+    for (final int[] record : records) {
+      holeBytes += record[0] - expectedNextPosition;
+      expectedNextPosition = record[0] + record[1];
+    }
+    return holeBytes;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
@@ -49,8 +49,12 @@ public class GetServerHandler extends AbstractServerHttpHandler {
   private static final ConcurrentHashMap<String, Long>   prevProfilerCounts  = new ConcurrentHashMap<>();
   private static final ConcurrentHashMap<String, Double> prevHttpCounts      = new ConcurrentHashMap<>();
 
+  // #5608: the three page-merge counters are rate-tracked next to concurrentModificationExceptions because the
+  // signal they carry is a DERIVATIVE ("a jump in the declines with a dip in the merges"), which monotonic counters
+  // cannot show - an operator would otherwise have to sample and subtract them by hand.
   private static final Set<String> RATE_TRACKED_PROFILER_METRICS = Set.of(
-      "writeTx", "readTx", "txRollbacks", "queries", "concurrentModificationExceptions"
+      "writeTx", "readTx", "txRollbacks", "queries", "concurrentModificationExceptions",
+      "edgeAppendMerges", "txPageSlotMerges", "mergesDeclinedByCoverage"
   );
 
   public GetServerHandler(final HttpServer httpServer) {

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -65,6 +65,13 @@ public final class EngineMetricsBinder implements MeterBinder {
     gauge(registry, "arcadedb.engine.wal.bytes.written", "WAL bytes written", "walBytesWritten");
     gauge(registry, "arcadedb.engine.wal.files", "WAL files", "walTotalFiles");
     gauge(registry, "arcadedb.engine.mvcc.conflicts", "Concurrent modification exceptions", "concurrentModificationExceptions");
+    // #5608: the commit-time page merges are what keeps the conflict counter above from exploding under contention
+    // (super-node edge appends, concurrent writes to disjoint slots of one page). A collapse of the merge rate, or a
+    // rise in the declines, is a throughput regression no correctness signal catches - so it has to be alertable.
+    gauge(registry, "arcadedb.engine.page.merges.edge.append", "Commit-time edge-append page merges", "edgeAppendMerges");
+    gauge(registry, "arcadedb.engine.page.merges.slot", "Commit-time disjoint-slot page merges", "txPageSlotMerges");
+    gauge(registry, "arcadedb.engine.page.merges.declined", "Page merges declined for lack of declared coverage",
+        "mergesDeclinedByCoverage");
     gauge(registry, "arcadedb.engine.files.open", "Open file descriptors", "totalOpenFiles");
     gauge(registry, "arcadedb.engine.tx.write", "Write transactions", "writeTx");
     gauge(registry, "arcadedb.engine.tx.read", "Read transactions", "readTx");

--- a/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
@@ -60,4 +60,22 @@ class EngineMetricsBinderTest {
     assertThat(walFiles).isNotNull();
     assertThat(Double.isNaN(walFiles.value())).isFalse();
   }
+
+  /**
+   * #5608: a collapse of the commit-time page-merge rate (or a rise in the coverage declines) is a throughput
+   * regression that no correctness signal catches, so the three counters have to be alertable - i.e. reach a
+   * registry, not just {@code PageManager.getStats()}.
+   */
+  @Test
+  void registersPageMergeGauges() {
+    final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    new EngineMetricsBinder().bindTo(registry);
+
+    for (final String name : new String[] { "arcadedb.engine.page.merges.edge.append", "arcadedb.engine.page.merges.slot",
+        "arcadedb.engine.page.merges.declined" }) {
+      final Gauge gauge = registry.find(name).gauge();
+      assertThat(gauge).as(name).isNotNull();
+      assertThat(Double.isNaN(gauge.value())).as(name).isFalse();
+    }
+  }
 }

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -233,8 +233,13 @@ function displayMetrics() {
   var m = serverData.metrics.meters || {};
 
   // Database Operations table (metrics with rate tracking)
-  var rateTrackedMetrics = ["writeTx", "readTx", "txRollbacks", "queries", "concurrentModificationExceptions"];
-  var rateTrackedLabels = { writeTx: "Write Tx", readTx: "Read Tx", txRollbacks: "Tx Rollbacks", queries: "Queries", concurrentModificationExceptions: "MVCC Contention" };
+  // The three page-merge counters (#5608) sit under MVCC Contention on purpose: a merge is contention the engine
+  // absorbed instead of turning into a retry, and a decline is contention it refused to absorb.
+  var rateTrackedMetrics = ["writeTx", "readTx", "txRollbacks", "queries", "concurrentModificationExceptions",
+    "edgeAppendMerges", "txPageSlotMerges", "mergesDeclinedByCoverage"];
+  var rateTrackedLabels = { writeTx: "Write Tx", readTx: "Read Tx", txRollbacks: "Tx Rollbacks", queries: "Queries",
+    concurrentModificationExceptions: "MVCC Contention", edgeAppendMerges: "Edge-Append Page Merges",
+    txPageSlotMerges: "Slot Page Merges", mergesDeclinedByCoverage: "Page Merges Declined" };
   var dbOpsHtml = "";
   for (var i = 0; i < rateTrackedMetrics.length; i++) {
     var name = rateTrackedMetrics[i];
@@ -253,7 +258,8 @@ function displayMetrics() {
   // Profiler details table (remaining metrics without rate tracking)
   var skipProfiler = { cpuLoad: 1, ramHeapUsed: 1, ramHeapMax: 1, ramOsUsed: 1, ramOsTotal: 1,
     diskFreeSpace: 1, diskTotalSpace: 1, readCacheUsed: 1, cacheMax: 1, configuration: 1,
-    writeTx: 1, readTx: 1, txRollbacks: 1, queries: 1, concurrentModificationExceptions: 1 };
+    writeTx: 1, readTx: 1, txRollbacks: 1, queries: 1, concurrentModificationExceptions: 1,
+    edgeAppendMerges: 1, txPageSlotMerges: 1, mergesDeclinedByCoverage: 1 };
   var profilerHtml = "";
   var profilerNames = Object.keys(p).sort();
   for (var i = 0; i < profilerNames.length; i++) {


### PR DESCRIPTION
Closes #5608. All four follow-ups from #5596 / #5599.

## 1. The three merge counters now leave the process

`mergesDeclinedByCoverage` was introduced by #5596 as **the** operational signal that some writer is dirtying a mergeable page without declaring it - and it could not be read outside a debugger or a unit test. `Profiler` surfaced exactly one page-manager contention stat (`concurrentModificationExceptions`) and none of the three merge counters, so the advice shipped with it ("watch it next to `edgeAppendMerges`/`txPageSlotMerges`: a jump here with a dip there is exactly the shape of a forgotten declaration") was unfollowable in production.

The issue asked for three lines: the text dump and the JSON. That is necessary but not sufficient, so this goes further on two counts:

- **Micrometer.** `EngineMetricsBinder` gains `arcadedb.engine.page.merges.edge.append`, `.slot` and `.declined`, so a merge-rate collapse is alertable via `/prometheus` and OTLP rather than only visible to whoever happens to read a dump.
- **Rate tracking, not just counts.** The signal the issue describes is a *derivative*. Three monotonic counters cannot show a jump-with-a-dip; an operator would have to sample and subtract by hand. All three joined `GetServerHandler.RATE_TRACKED_PROFILER_METRICS`, next to `concurrentModificationExceptions`, and Studio renders them in the same table - a merge is contention the engine absorbed instead of turning into a retry, and a decline is contention it refused to absorb, so they belong beside "MVCC Contention".

## 2. The compressPage coupling is now structural, not a comment

`compressPage(page, false)` declares `COVERAGE_ALL_MERGES`, which is sound only because the commit path re-runs exactly that call on the page a merge re-derived. The issue proposed pinning that with a test. A test alone still leaves the two halves in different methods, so this does both:

- The re-compress **moved into `rebaseEdgeAppends`/`rebaseSlots` themselves**. Producing a rebased page and re-compressing it are now one operation, so optimising or reordering the commit loop cannot invalidate the declaration - there is no longer a commit-loop statement to reorder. Both methods' `@return` state that the page comes back compressed.
- `Issue5608RebasedPageCompressionTest` pins it from the outside, by measuring holes against the page's record table rather than calling the engine's own defrag code (so a defrag that stops running cannot take the assertion down with it). Two shapes, because two different primitives replay them: a shrinking update (`rebaseRecordOnPage`) and a plain-record delete (`rebaseRecordDeleteOnPage`). Verified to fail without the fix - **2001 and 2013 orphan bytes** on the committed page.

## 3. Poison-call audit: they all stay, and now the reason is written down

The issue proposed removing the calls the coverage proof subsumes, most clearly the multi-page writers' (`LocalBucket:2363/2442/2491`). Auditing them says the opposite, and it is worth stating because "keep" is otherwise indistinguishable from "nobody looked":

Poisoning is not a duplicate of the proof. It is O(1) and runs *before* the page is read; it makes `isSlotRebasePagePoisoned` true, which is what lets the write path skip the pre-image/final-image record copies for every later write to that page (allocated, then discarded, on a page that can never merge); and - decisive here - `reportCoverageDecline` deliberately ignores poisoned pages, so poisoning is what keeps a **deliberate** exclusion out of `mergesDeclinedByCoverage`, the counter that exists to expose an **accidental** one. Dropping a redundant call would therefore cost allocations and blunt the very signal item 1 is about to surface, to save nothing. The rationale now lives on the poison API and in `docs/supernode.md`.

## 4. reportCoverageDecline is total by construction

Worse than the issue expected. The diagnostic reaches `edgeSegmentPageKey`, and its `bucket == null` branch **never fires**: `LocalSchema.getBucketById(id)` throws `SchemaException` before it can return null. A `SchemaException` escaping there is not a `NeedRetryException`, so the commit's generic `catch (Exception)` would have wrapped it into a plain `TransactionException` - turning a conflict the caller would have retried into a hard failure, not just a misleading message.

Swallowed with a `catch (RuntimeException)` + FINE log rather than by making that one call non-throwing: the guarantee wanted is "a diagnostic can never change what the caller reports", which has to cover whatever a future diagnostic adds to the method. `Issue5608CoverageDeclineDiagnosticTest` verifies the setup really raises (`assertThatThrownBy(... poisonEdgeAppendPage ...)`) before asserting the report stays quiet, so it cannot degrade into asserting that a no-op does not throw. Verified to fail without the guard.

## Verification

- `Issue5608RebasedPageCompressionTest` (2), `Issue5608CoverageDeclineDiagnosticTest` (1), `ProfilerTest` (3), `EngineMetricsBinderTest` (3) - new/extended, each verified to fail against the unfixed code where applicable.
- Green: `Issue5596MergeCoverageTest`, `Issue5381FalseConflictTest`, `Issue5569ConcurrentDeleteTest`, `EdgeAppendMergeConcurrentStressTest`, `EdgeAppendMergeRaceTest`, `EdgeAppendMergeMultiPageChunkTest`, `MutablePageWriteCoverageTest`, `LocalBucketRecordPositionTest`, `DefaultServerMetricsTest`.
- Full `arcadedb-engine` suite.

No configuration change, no new failure mode, no change to what any merge accepts or refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8qjd4CW6B6orurBTsPKQD