### PR TITLE
fix(mcp) #5585: answer malformed JSON-RPC members instead of failing the request

### DIFF
--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -201,8 +201,20 @@ public class MCPDispatcher {
     if (!isValidRequestId(id))
       return error(null, -32600, "Invalid Request: 'id' must be a string or an integer", 200);
 
-    final String method = request.getString("method", "");
-    final JSONObject params = request.getJSONObject("params", new JSONObject());
+    // Read both members under a guard rather than inline. The defaulting accessors substitute the default only for
+    // an absent or null member, so a member that is present but of another JSON type raises out of the read
+    // instead. These two reads sit above the try below, whose only block is a finally, so an unguarded raise here
+    // escapes dispatch entirely and reaches the transport as a bodiless HTTP 500 rather than a JSON-RPC envelope.
+    // Both members belong to the request object itself, which makes a wrong shape an invalid request rather than
+    // invalid params.
+    final String method;
+    final JSONObject params;
+    try {
+      method = request.getString("method", "");
+      params = request.getJSONObject("params", new JSONObject());
+    } catch (final IllegalStateException | UnsupportedOperationException e) {
+      return error(id, -32600, "Invalid Request: 'method' must be a string and 'params' an object", 200);
+    }
 
     LogManager.instance().log(this, Level.INFO, "MCP[%s] %s (user=%s)", transport, method, user.getName());
 
@@ -258,7 +270,15 @@ public class MCPDispatcher {
   }
 
   private MCPResponse resourcesRead(final Object id, final JSONObject params, final ServerSecurityUser user) {
-    final String uri = params.getString("uri", "");
+    // Guarded for the same reason as the request members in dispatch: a 'uri' present but of another JSON type
+    // raises out of the read, which sits above the try below. A wrong shape is invalid params, distinct from the
+    // resource-not-found the try answers with for a URI that is well formed but names nothing readable.
+    final String uri;
+    try {
+      uri = params.getString("uri", "");
+    } catch (final IllegalStateException | UnsupportedOperationException e) {
+      return error(id, -32602, "Invalid params: 'uri' must be a string", 200);
+    }
 
     LogManager.instance().log(this, Level.INFO, "MCP[%s] resources/read '%s' (user=%s)", transport, uri, user.getName());
 
@@ -299,7 +319,7 @@ public class MCPDispatcher {
     } catch (final SecurityException e) {
       LogManager.instance().log(this, Level.INFO, "MCP[%s] prompts/get -> permission denied: %s", transport, e.getMessage());
       return error(id, -32600, e.getMessage(), 200);
-    } catch (final IllegalArgumentException | IllegalStateException e) {
+    } catch (final IllegalArgumentException | IllegalStateException | UnsupportedOperationException e) {
       return error(id, -32602, "Invalid params: " + e.getMessage(), 200);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "MCP[%s] prompts/get -> error: %s", transport, e.getMessage());
@@ -309,8 +329,17 @@ public class MCPDispatcher {
 
   private MCPResponse toolsCall(final Object id, final JSONObject params, final ServerSecurityUser user,
       final EffectiveToolProfile profile) {
-    final String toolName = params.getString("name", "");
-    final JSONObject args = params.getJSONObject("arguments", new JSONObject());
+    // Guarded for the same reason as the request members in dispatch: a member present but of the wrong JSON type
+    // raises out of the read, and these reads sit above the try below. A malformed member here is invalid params
+    // rather than a failed tool call, so it answers with a JSON-RPC error rather than an isError tool envelope.
+    final String toolName;
+    final JSONObject args;
+    try {
+      toolName = params.getString("name", "");
+      args = params.getJSONObject("arguments", new JSONObject());
+    } catch (final IllegalStateException | UnsupportedOperationException e) {
+      return error(id, -32602, "Invalid params: 'name' must be a string and 'arguments' an object", 200);
+    }
 
     LogManager.instance()
         .log(this, Level.INFO, "MCP[%s] tools/call '%s' %s (user=%s)", transport, toolName, formatArgs(toolName, args), user.getName());

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -551,7 +551,11 @@ public class MCPDispatcher {
     if (message == null || message.has("method") || !message.has("id") || !isValidRequestId(message.opt("id")))
       return false;
 
-    return "2.0".equals(message.getString("jsonrpc", null))
+    // Compared through opt rather than read as a string. This probe runs before anything else in dispatch, so it
+    // is the one member read that cannot sit under a guard: it decides whether a reply is owed at all, and a raise
+    // here would escape as a transport failure with no envelope. opt maps any JSON shape to an object instead of
+    // demanding one, so a 'jsonrpc' that is not the string "2.0" simply means this payload is not a response.
+    return "2.0".equals(message.opt("jsonrpc"))
         && message.has("result") != message.has("error");
   }
 

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
@@ -106,6 +106,67 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
     assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32600);
   }
 
+  /**
+   * A member of the wrong JSON type must still produce a JSON-RPC envelope. The defaulting accessors fall back only
+   * for an absent or null member, so a member that is present but of another shape raises out of the read, and a
+   * read placed where nothing can answer for it reaches the transport as an HTTP 500 with no envelope at all.
+   */
+  @Test
+  void requestWithNonObjectParamsIsRejected() throws Exception {
+    final Response response = post("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\",\"params\":[\"a\"]}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32600);
+  }
+
+  @Test
+  void requestWithNonStringMethodIsRejected() throws Exception {
+    // An object, not a one-element array: Gson coerces a single-element array to that element's string form, so
+    // "method":["ping"] would silently succeed as a call to ping rather than exercising the malformed path.
+    final Response response = post("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":{}}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32600);
+  }
+
+  @Test
+  void toolsCallWithNonObjectArgumentsIsRejected() throws Exception {
+    final Response response = post(
+        "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\","
+            + "\"params\":{\"name\":\"list_databases\",\"arguments\":[\"a\"]}}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32602);
+  }
+
+  @Test
+  void resourcesReadWithNonStringUriIsRejected() throws Exception {
+    final Response response = post(
+        "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"resources/read\",\"params\":{\"uri\":{}}}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32602);
+  }
+
+  @Test
+  void promptsGetWithNonStringNameIsRejected() throws Exception {
+    final Response response = post(
+        "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"prompts/get\",\"params\":{\"name\":{}}}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32602);
+  }
+
   @Test
   void requestWithFractionalIdIsRejected() throws Exception {
     final Response response = post("{\"jsonrpc\":\"2.0\",\"id\":1.5,\"method\":\"tools/list\"}", null);

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
@@ -156,6 +156,22 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
     assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32602);
   }
 
+  /**
+   * The response probe reads 'jsonrpc' before any other member is examined, so it is the one read that cannot be
+   * placed under a guard: it decides whether a reply is owed at all. It therefore compares the member without
+   * demanding a string, and a non-string one simply means the payload is not a response.
+   */
+  @Test
+  void nonStringJsonrpcMemberIsAnsweredRatherThanFailed() throws Exception {
+    for (final String jsonrpc : new String[] { "{}", "[\"2.0\",\"x\"]" }) {
+      final Response response = post("{\"jsonrpc\":" + jsonrpc + ",\"id\":1}", null);
+
+      assertThat(response.status).as("payload with jsonrpc=%s", jsonrpc).isEqualTo(200);
+      final JSONObject json = new JSONObject(response.body);
+      assertThat(json.has("error")).as("payload with jsonrpc=%s", jsonrpc).isTrue();
+    }
+  }
+
   @Test
   void promptsGetWithNonStringNameIsRejected() throws Exception {
     final Response response = post(


### PR DESCRIPTION
## What does this PR do?

Makes every malformed JSON-RPC member on the MCP endpoint produce a JSON-RPC error envelope instead of failing the request.

The defaulting JSON accessors (`getString(name, default)`, `getJSONObject(name, default)`) fall back only when the member is **absent or null**. A member that is present but of another JSON type raises out of the read instead. Four such reads sat *above* the `try` that was meant to answer for them:

| Read | Was | Now |
|---|---|---|
| `method` in `dispatch` | HTTP 500, no body | `-32600` |
| `params` in `dispatch` | HTTP 500, no body | `-32600` |
| `name` / `arguments` in `toolsCall` | HTTP 500, no body | `-32602` |
| `uri` in `resourcesRead` | HTTP 500, no body | `-32602` |
| `name` / `arguments` in `promptsGet` | `-32603` | `-32602` |

The `dispatch` pair is the worst of them: their enclosing `try` carries only a `finally` (the `DatabaseContext` cleanup) and no `catch`, so the raise left the dispatcher entirely and the transport turned it into a bodiless HTTP 500. That affects **every** method, `ping` included, not only the two that read an `arguments` member.

`method` and `params` are members of the request object, so a wrong shape there is `-32600 Invalid Request`. `uri`, `name` and `arguments` live inside `params`, so those are `-32602 Invalid params`.

## Motivation

Closes #5585. Found while reviewing #5584, which fixed the same defect for `prompts/get` only; that fix was deliberately scoped to the surface that PR introduced, and this one covers the sites that predate it.

## Additional Notes

**Two exception types, not one.** Gson raises `IllegalStateException` when `getAsString()` or `getAsJsonObject()` meets an array of the wrong arity, but `UnsupportedOperationException` when `getAsString()` meets an object. The `prompts/get` fix in #5584 caught only the first, which is why `{"name": {}}` there answered `-32603`. Every catch here covers both.

**A Gson coercion worth knowing about.** A single-element array coerces: `{"method": ["ping"]}` yields the string `"ping"` and dispatches normally. The tests therefore use `{}` rather than a one-element array, with a comment saying why - the obvious payload silently tests nothing.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

Five tests added to `MCPTransportConformanceTest`, which already owns envelope-level conformance (invalid ids, notifications, batching). All five were confirmed to fail before the fix: four with `expected: 200 but was: 500`, and the `prompts/get` one with `expected: -32602 but was: -32603` after temporarily reverting that catch.

`MCP*Test` is 265 tests, 0 failures, on a `mvn clean` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
