### PR TITLE
fix(engine) #5615: make the vector searcher-pool epoch strictly monotonic

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -5545,11 +5545,19 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
   /**
    * Epoch used to decide whether a pooled searcher (and the graph view it holds) is still valid. It must change on
-   * anything that can alter what a search would see: a graph rebuild swaps {@link #graphIndex}, and every
-   * insert/update/delete bumps {@link #mutationsSinceSerialize}.
+   * anything that can alter what a search would see: a graph rebuild swaps {@link #graphIndex} and advances
+   * {@link #rebuildSnapshotGeneration}, and every insert/update/delete bumps {@link #mutationsSinceSerialize}.
+   * <p>
+   * The value never repeats. That matters because graph identity is not a sufficient guard on its own: the
+   * live-builder path keeps serving searches from the same graph instance while it grows, so the epoch is the only
+   * thing that can tell a pooled view its contents moved underneath it.
    */
   private long searcherPoolEpoch() {
-    return mutationsSinceSerialize.get();
+    // The mutation counter alone cannot carry this: a rebuild subtracts back exactly what it absorbed
+    // (mutationsAtBuildStart), so a settled index reads the same value after every rebuild and an epoch taken from it
+    // repeats. Pairing it with the rebuild generation, which only ever increases, makes the epoch strictly monotonic
+    // across both kinds of event. The generation occupies the high bits so ordinary mutations still move the low ones.
+    return (rebuildSnapshotGeneration << 32) | (mutationsSinceSerialize.get() & 0xFFFFFFFFL);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexSearcherEpochTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexSearcherEpochTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Type;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The searcher-pool epoch must never repeat a value it has already handed out.
+ * <p>
+ * A pooled {@code GraphSearcher} holds a graph {@code View} that can pin snapshot state, so it may only be recycled
+ * while nothing a search depends on has moved. The pool decides that from the pair (graph identity, epoch). The graph
+ * identity alone is not enough: the live-builder path keeps searching the same graph instance while it grows, so the
+ * epoch is the only signal that the contents changed. An epoch that returns to an earlier value therefore makes a
+ * stale view look reusable.
+ */
+class LSMVectorIndexSearcherEpochTest extends TestHelper {
+
+  private static final int EMBEDDING_DIM = 8;
+
+  @Test
+  void epochNeverRepeatsAcrossRebuilds() throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 1);
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Epoch");
+      database.getSchema().getType("Epoch").createProperty("vector", Type.ARRAY_OF_FLOATS);
+      database.command("sql", """
+          CREATE INDEX ON Epoch (vector) LSM_VECTOR
+          METADATA {
+              "dimensions": %d,
+              "similarity": "EUCLIDEAN"
+          }""".formatted(EMBEDDING_DIM));
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Epoch[vector]");
+    final LSMVectorIndex index = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    final Method epoch = LSMVectorIndex.class.getDeclaredMethod("searcherPoolEpoch");
+    epoch.setAccessible(true);
+
+    final Random random = new Random(11);
+
+    // Let the inactivity timer do a real rebuild, which is what drains the mutation counter. Forcing it through
+    // compact() does not take that path.
+    insert(random, 20);
+    awaitSettled(index);
+    final long afterFirstRebuild = (long) epoch.invoke(index);
+
+    insert(random, 20);
+    awaitSettled(index);
+    final long afterSecondRebuild = (long) epoch.invoke(index);
+
+    // Both rebuilds settle the mutation counter back to the same value, so an epoch derived from that counter alone
+    // hands out the same number twice with two different graphs behind it.
+    assertThat(afterSecondRebuild)
+        .as("epoch must differ across a rebuild, otherwise a searcher pooled against the previous graph looks reusable")
+        .isNotEqualTo(afterFirstRebuild);
+  }
+
+  private static void awaitSettled(final LSMVectorIndex index) {
+    Awaitility.await("rebuild drains the mutation counter").atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(50))
+        .until(() -> index.getStats().get("mutationsSinceRebuild") <= 0L
+            && index.getStats().get("asyncRebuildInProgress") == 0L);
+  }
+
+  private void insert(final Random random, final int count) {
+    database.transaction(() -> {
+      for (int i = 0; i < count; i++) {
+        final float[] vector = new float[EMBEDDING_DIM];
+        for (int j = 0; j < EMBEDDING_DIM; j++)
+          vector[j] = random.nextFloat() * 100.0f;
+        final var doc = database.newDocument("Epoch");
+        doc.set("vector", vector);
+        doc.save();
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Problem

`LSMVectorIndex.searcherPoolEpoch()` returns `mutationsSinceSerialize.get()` alone. A rebuild ends with

```java
mutationsSinceSerialize.addAndGet(-mutationsAtBuildStart);
```

subtracting back exactly what it absorbed, so a settled index reads the same counter value after every rebuild and the epoch repeats a number it has already handed out. The method's own Javadoc states the opposite:

> It must change on anything that can alter what a search would see: a graph rebuild swaps `graphIndex` [...]

It does not.

## Why the graph identity check is not enough on its own

`GraphSearcherPool.borrow` reuses a pooled searcher only when `pooledGraph == graph && pooledEpoch == epoch`, and a full rebuild does publish a new graph instance, so that arm covers the rebuild case today. The gap is the live-builder path: `findNeighborsFromVector` serves searches from `liveBuilder.getGraph()` while the builder keeps growing **that same instance**. Identity is unchanged there, so the epoch is the only thing that can tell a pooled `GraphSearcher` - which holds a graph `View` that may pin snapshot state - that the contents moved underneath it.

This is a latent contract violation rather than a reproduced user-visible failure, and it is reported as such. It was found while investigating #5615 and is **not** a fix for it; #5615 stays open.

## Change

Pair the mutation counter with `rebuildSnapshotGeneration`, which only ever increases:

```java
return (rebuildSnapshotGeneration << 32) | (mutationsSinceSerialize.get() & 0xFFFFFFFFL);
```

The generation takes the high bits so ordinary mutations still move the low ones. No new field, no new synchronization: `rebuildSnapshotGeneration` is already `volatile long` and already advanced once per rebuild. This is the same "version probe" idiom the engine uses elsewhere (`FileManager.modificationCount`).

## Test plan

- [ ] `LSMVectorIndexSearcherEpochTest.epochNeverRepeatsAcrossRebuilds` - settles the index through two real inactivity-timer rebuilds and asserts the epoch differs. Verified to **fail on main** (both reads are `0`) and pass with the change.
- [ ] `mvn -pl engine test -Dtest='com.arcadedb.index.vector.*Test'` - 228 tests, green.
- [ ] `mvn -pl engine test -Dtest='com.arcadedb.function.sql.vector.*Test'` - 297 tests, green.

Note the test drives the rebuild through the inactivity timer on purpose: `compact()` does not take the path that drains the mutation counter, so a `compact()`-based version of this test passes on unfixed code and proves nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
