### PR TITLE
fix(mcp) #5585: keep the request log's setting-key read from failing the call

### DIFF
--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -463,7 +463,7 @@ public class MCPDispatcher {
   static String formatArgs(final String toolName, final JSONObject args) {
     if (args.length() == 0)
       return "{}";
-    final boolean maskValue = "set_server_setting".equals(toolName) && isHiddenSetting(args.getString("key", null));
+    final boolean maskValue = "set_server_setting".equals(toolName) && isHiddenSetting(settingKey(args));
     final StringBuilder sb = new StringBuilder("{");
     boolean first = true;
     for (final String key : args.keySet()) {
@@ -487,6 +487,21 @@ public class MCPDispatcher {
         sb.append(key).append("=").append(value);
     }
     return sb.append("}").toString();
+  }
+
+  /**
+   * Reads the setting key for the mask decision without letting a malformed member raise. This runs while the log
+   * line is built, which is above the handler's try, so a raise here would escape the dispatcher and reach the
+   * transport as a bodiless HTTP 500. The read deliberately keeps the coercion the tool itself applies, so a key the
+   * tool will resolve is still recognised as secret; narrowing it to a plain string would leave the value unmasked
+   * for a key shape the tool nevertheless writes.
+   */
+  private static String settingKey(final JSONObject args) {
+    try {
+      return args.getString("key", null);
+    } catch (final IllegalStateException | UnsupportedOperationException e) {
+      return null;
+    }
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPDispatcherArgumentLoggingTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPDispatcherArgumentLoggingTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.mcp;
 
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -84,5 +85,28 @@ class MCPDispatcherArgumentLoggingTest {
 
     // An unknown key is rejected by the tool before it changes anything, so its value is not a secret.
     assertThat(MCPDispatcher.formatArgs("set_server_setting", args)).contains("value=\"plain\"");
+  }
+
+  @Test
+  void aSettingKeyOfAnotherJsonTypeDoesNotRaise() {
+    final JSONObject args = new JSONObject()
+        .put("key", new JSONObject())
+        .put("value", SECRET);
+
+    // This line is logged before the tool runs and above the handler's try, so a raise here escapes the dispatcher
+    // and reaches the transport as a bodiless HTTP 500 rather than a JSON-RPC envelope.
+    assertThat(MCPDispatcher.formatArgs("set_server_setting", args)).isNotNull();
+  }
+
+  @Test
+  void aSecretSettingKeyGivenAsASingleElementArrayIsStillMasked() {
+    final JSONObject args = new JSONObject()
+        .put("key", new JSONArray().put("arcadedb.server.rootPassword"))
+        .put("value", SECRET);
+
+    // Gson coerces a single-element array to that element's string form, so the tool resolves this key and does
+    // write the secret. Guarding the read must not narrow it to a plain string, or the value reaches the log
+    // unmasked while the setting is still applied.
+    assertThat(MCPDispatcher.formatArgs("set_server_setting", args)).doesNotContain(SECRET);
   }
 }

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
@@ -172,6 +172,24 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
     }
   }
 
+  /**
+   * The tools/call request log is built above the handler's try, and it resolves the setting key to decide whether
+   * to mask a secret value. A key of another JSON type raised out of that read, so the request failed before the
+   * tool ran and reached the transport as an HTTP 500 with no envelope.
+   */
+  @Test
+  void toolsCallWithNonStringSettingKeyStillAnswersWithAnEnvelope() throws Exception {
+    final Response response = post(
+        "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\","
+            + "\"params\":{\"name\":\"set_server_setting\",\"arguments\":{\"key\":{},\"value\":\"x\"}}}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.getString("jsonrpc")).isEqualTo("2.0");
+    // The argument is the tool's, not a JSON-RPC member, so the tool rejects it as a tool error rather than -32602.
+    assertThat(json.has("error") || json.getJSONObject("result").getBoolean("isError")).isTrue();
+  }
+
   @Test
   void promptsGetWithNonStringNameIsRejected() throws Exception {
     final Response response = post(


### PR DESCRIPTION
Follow-up to #5585 / #5619, which merged while this was being reviewed. It closed four malformed-member reads on the MCP endpoint; the review of that PR surfaced a fifth on the same path, which this addresses.

## The gap

`toolsCall` builds its request log line *above* the handler's `try`, and that line resolves the `key` argument to decide whether to mask a secret value:

```java
final boolean maskValue = "set_server_setting".equals(toolName) && isHiddenSetting(args.getString("key", null));
```

`getString(name, null)` defaults only for an absent or null member, so a `key` present but of another JSON type raises out of `formatArgs`, escapes `toolsCall`, passes through `dispatch`'s finally-only `try` and reaches the transport as the same bodiless HTTP 500 #5619 removed elsewhere.

Repro (the tool name must be exactly `set_server_setting`, since that gates the read):

```json
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"set_server_setting","arguments":{"key":{},"value":"x"}}}
```

## Why not `instanceof String`

The review suggested reading the key with `opt(...)` and narrowing to `rawKey instanceof String`. That fixes the raise but reopens a masking bypass: `SetServerSettingTool` resolves the key with the same coercing `getString`, so `"key": ["arcadedb.server.rootPassword"]` is a key the tool **does** write. Recognising only a plain string there would leave the secret `value` logged in clear while the setting is still applied, which is what #5508 closed.

The read is therefore guarded but keeps Gson's coercion. A key of a shape no read resolves masks nothing, which is correct: the tool rejects it before it changes anything.

Once the log line can no longer raise, the malformed argument reaches the tool inside the handler's `try` and is answered as a tool error. That is the right level: `arguments.key` is the tool's argument, not a JSON-RPC protocol member, so it is not `-32602`.

## Test plan

- [x] `MCPDispatcherArgumentLoggingTest.aSettingKeyOfAnotherJsonTypeDoesNotRaise` - proven to fail first (`UnsupportedOperationException: JsonObject` at `MCPDispatcher.formatArgs`), passes after.
- [x] `MCPDispatcherArgumentLoggingTest.aSecretSettingKeyGivenAsASingleElementArrayIsStillMasked` - pins the coercion the mask depends on, so the guard cannot be narrowed into the bypass above.
- [x] `MCPTransportConformanceTest.toolsCallWithNonStringSettingKeyStillAnswersWithAnEnvelope` - end-to-end: HTTP 200 with a well-formed JSON-RPC envelope instead of a bodiless 500.
- [x] Full MCP suite green on the rebased branch: 219 tests, 0 failures (`MCPDispatcherArgumentLoggingTest, MCPTransportConformanceTest, MCPServerPluginTest, MCPStdioServerTest, MCPResourcesTest, MCPPromptsTest`).

## Deferred from the #5619 review

- The single-element-array coercion (`{"method":["ping"]}` dispatches `ping`) is a real JSON-RPC spec deviation, out of scope here and worth its own issue. Note that it is load-bearing for the masking above, so it cannot be tightened in `formatArgs` alone.
- The combined guard messages naming both members when only one is malformed: the reviewer judged this not worth changing, and it is left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)