### PR TITLE
fix(mcp) #5620: type-check string-typed JSON-RPC members instead of coercing them

### DIFF
--- a/docs/5620-mcp-single-element-array-coercion.md
+++ b/docs/5620-mcp-single-element-array-coercion.md
@@ -135,6 +135,46 @@ went through the same authentication, profile and permission gates.
 The guards sit on the request-parsing path and cost one `instanceof` per member, replacing an accessor call
 that did strictly more work.
 
+## Review
+
+PR: https://github.com/ArcadeData/arcadedb/pull/5623
+
+### Cycle 1 - `216cfe73a`
+
+No `claude` review arrived within the 15-minute window; only `codacy-production[bot]` reported (0 issues,
+0 complexity). While that cycle was waiting, #5619 merged to main, so `origin/main` was merged in and the
+overlap resolved as described above. That produced `61bb20fa5`.
+
+### Cycle 2 - `61bb20fa5`
+
+`claude[bot]` reviewed: LGTM, with three observations marked non-blocking. All three were assessed and none
+resulted in a code change. Nothing was deferred.
+
+**1. "`resourcesRead` hardcodes the catch message while `toolsCall`/`promptsGet` use `e.getMessage()`" -
+declined, premise is inverted.** Three of the four guards hardcode their message (`dispatch`,
+`resourcesRead`, `toolsCall`); only `promptsGet` relays `e.getMessage()`. The split is structural rather
+than accidental:
+
+- A guard wrapped tightly around member reads states the expected shape, because its catch also covers
+  Gson's `IllegalStateException` / `UnsupportedOperationException` from the object-typed read beside it.
+  Those carry internal text such as `Not a JSON Object: ["a"]`, so relaying them would both read as noise
+  and echo fragments of the request payload back to the client.
+- `promptsGet`'s catch is the broad handler one: it also covers `MCPPrompts.get` raising
+  `IllegalArgumentException` for an unknown prompt, where the message is the whole point of the answer.
+
+Aligning `resourcesRead` to `e.getMessage()` would make it inconsistent with the two guards it sits next to
+in order to match the one that is a different kind of catch. The messages are also #5619's, unchanged here
+on purpose.
+
+**2. "`promptsGet`'s catch now also absorbs `IllegalArgumentException` from `MCPPrompts.get`" - no action,
+and the review agrees.** That catch already listed `IllegalArgumentException` before this change, so the
+mapping of unknown-prompt to `-32602` is pre-existing and untouched.
+
+**3. "The doc still cites pre-merge counts (30/276) while the PR body says 36/282" - declined, already
+correct.** The committed doc carries both, deliberately: the 30/276 figures are the before-and-after of the
+fix itself and are what demonstrate the tests failed first, while the post-merge 36/282 figures follow on
+the next two lines.
+
 ## Follow-ups
 
 - PR #5622 is still open and fixes `formatArgs`' read of `arguments.key` by catching. It does not conflict

--- a/docs/5620-mcp-single-element-array-coercion.md
+++ b/docs/5620-mcp-single-element-array-coercion.md
@@ -1,0 +1,113 @@
+# 5620 - MCP: a single-element array is coerced to a string
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5620
+
+## Root cause
+
+`MCPDispatcher` read every string-typed protocol member through
+`JSONObject.getString(name, default)`, which is `if (isNull(name)) return default;` followed by
+`getElement(name).getAsString()`. That last call is Gson's, and Gson converts rather than checks:
+
+| value          | `getAsString()`                |
+|----------------|--------------------------------|
+| `"ping"`       | `"ping"`                       |
+| `["ping"]`     | `"ping"` - unwrapped silently  |
+| `["ping","x"]` | `IllegalStateException`        |
+| `42` / `true`  | `"42"` / `"true"`              |
+| `{}`           | `UnsupportedOperationException` |
+
+`JsonArray.getAsString()` delegates to its single element when `size() == 1`. The arity of the array
+therefore decided the outcome: `{"jsonrpc":"2.0","id":1,"method":["ping"]}` executed `ping` and returned a
+success result, while the same member holding two elements was refused. JSON-RPC 2.0 draws no such
+distinction - `method` is a String or the request is invalid.
+
+The bare-primitive conversion is the same defect seen from another side: `{"method":42}` reached the
+dispatch switch as `"42"` and was answered `-32601 Method not found` rather than as an invalid request.
+
+Four members were affected, all of them string-typed by the protocol:
+
+- `method` on the request object
+- `params.uri` on `resources/read`
+- `params.name` on `tools/call`
+- `params.name` on `prompts/get`
+
+## Fix
+
+`MCPDispatcher.stringMember(json, name, default)` decides on the value's own JSON type instead of on what a
+converting accessor makes of it. `JSONObject.opt` maps each JSON type to its Java counterpart without
+converting between them and never raises, so comparing its result against `String` admits exactly the JSON
+strings. Absent and JSON-null still fall back to the default, matching the accessor it replaces; any other
+shape raises `IllegalArgumentException`, which each caller translates into the error that fits where the
+member sits:
+
+- `method` - `-32600 Invalid Request`, since the member belongs to the request envelope itself.
+- `params.uri`, `params.name` - `-32602 Invalid params`.
+
+For `tools/call` the guard deliberately answers with a JSON-RPC error rather than the `isError` tool
+envelope its `try` block produces: no tool was named, so no tool can have failed. An absent `name` still
+defaults to the empty string and still reaches the unknown-tool path as before, which keeps a malformed
+member distinguishable from a missing one.
+
+The object-typed members (`params`, `params.arguments`) are untouched: `getAsJsonObject()` raises for a
+JSON array of any size, so the arity coercion never applied to them.
+
+## Relationship to #5619
+
+PR #5619 (issue #5585) is open on `issue-5585-mcp-malformed-params` and wraps the same four reads in
+`try`/`catch (IllegalStateException | UnsupportedOperationException)` so a wrong-shaped member produces a
+JSON-RPC envelope instead of a bodiless HTTP 500. This change and that one overlap on the string-typed
+members and will conflict textually.
+
+They are not redundant, and the resolution is mechanical. Type-checking subsumes catching *for the string
+members*: once `stringMember` refuses every non-string shape up front, nothing in those reads can raise
+`IllegalStateException` or `UnsupportedOperationException`, so the #5619 guards around them become dead.
+What #5619 still carries and this change does not touch:
+
+- the object-typed reads (`params`, `params.arguments`), where the raise is still the only signal
+- the `isResponse` probe reading `jsonrpc` through `opt`
+- the widened `UnsupportedOperationException` catch in `promptsGet`
+
+Whichever merges second should keep the `stringMember` reads and keep #5619's guards only on the
+object-typed members and `isResponse`.
+
+## Tests
+
+Six methods added to `server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java`. Every
+payload names a target that exists, so before the fix the coerced value was dispatched and the call
+succeeded - the assertions were verified to fail on the unfixed code, not merely to pass on the fixed one.
+
+| test | payload | expected |
+|---|---|---|
+| `requestWithSingleElementArrayMethodIsRejected` | `"method":["ping"]` | `-32600` |
+| `requestWithNonStringPrimitiveMethodIsRejected` | `"method":42`, `"method":true` | `-32600` |
+| `toolsCallWithSingleElementArrayNameIsRejected` | `"name":["list_databases"]` | `-32602` |
+| `resourcesReadWithSingleElementArrayUriIsRejected` | `"uri":["arcadedb://graph/schema"]` | `-32602` |
+| `promptsGetWithSingleElementArrayNameIsRejected` | `"name":["graphrag_query"]` with both required arguments | `-32602` |
+| `absentAndNullStringMembersStillFallBackToTheirDefault` | no `params`, `{}`, `{"name":null}` | `isError` tool envelope, not `-32602` |
+
+The `prompts/get` case supplies `database` and `question` on purpose: without them the request fails on the
+missing-required-argument path with the same `-32602`, and the test would pass against the unfixed code
+while proving nothing.
+
+### Results
+
+- Before the fix: `Tests run: 30, Failures: 5` - the five new malformed-member tests, and only those.
+- After the fix: `Tests run: 30, Failures: 0`.
+- Regression sweep over the MCP surface (`MCP*Test`, `HybridSearch*Test`, `GetServerSettings*`):
+  `Tests run: 276, Failures: 0, Errors: 0, Skipped: 0`.
+
+## Impact
+
+Requests that were previously accepted through the coercion are now refused. That is the intent of the
+issue, and the blast radius is small: a client sending `["ping"]` where `ping` belongs is malformed, and no
+ArcadeDB client library produces that shape. No security consequence either way - the coerced method always
+went through the same authentication, profile and permission gates.
+
+The guards sit on the request-parsing path and cost one `instanceof` per member, replacing an accessor call
+that did strictly more work.
+
+## Follow-ups
+
+- Reconcile with #5619 at merge time as described above.
+- Other handlers reading request JSON through `getString(name, default)` inherit the same coercion. Nothing
+  outside `MCPDispatcher` was surveyed here; a sweep of the HTTP handler surface would be a separate change.

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPDispatcher.java
@@ -201,7 +201,12 @@ public class MCPDispatcher {
     if (!isValidRequestId(id))
       return error(null, -32600, "Invalid Request: 'id' must be a string or an integer", 200);
 
-    final String method = request.getString("method", "");
+    final String method;
+    try {
+      method = stringMember(request, "method", "");
+    } catch (final IllegalArgumentException e) {
+      return error(id, -32600, "Invalid Request: " + e.getMessage(), 200);
+    }
     final JSONObject params = request.getJSONObject("params", new JSONObject());
 
     LogManager.instance().log(this, Level.INFO, "MCP[%s] %s (user=%s)", transport, method, user.getName());
@@ -258,7 +263,12 @@ public class MCPDispatcher {
   }
 
   private MCPResponse resourcesRead(final Object id, final JSONObject params, final ServerSecurityUser user) {
-    final String uri = params.getString("uri", "");
+    final String uri;
+    try {
+      uri = stringMember(params, "uri", "");
+    } catch (final IllegalArgumentException e) {
+      return error(id, -32602, "Invalid params: " + e.getMessage(), 200);
+    }
 
     LogManager.instance().log(this, Level.INFO, "MCP[%s] resources/read '%s' (user=%s)", transport, uri, user.getName());
 
@@ -290,7 +300,7 @@ public class MCPDispatcher {
     // only for an absent or null member, so a member of the wrong JSON shape raises instead. That is a malformed
     // request rather than a server fault, and answering it needs the -32602 mapping below.
     try {
-      final String name = params.getString("name", "");
+      final String name = stringMember(params, "name", "");
       final JSONObject args = params.getJSONObject("arguments", new JSONObject());
 
       LogManager.instance().log(this, Level.INFO, "MCP[%s] prompts/get '%s' (user=%s)", transport, name, user.getName());
@@ -309,7 +319,14 @@ public class MCPDispatcher {
 
   private MCPResponse toolsCall(final Object id, final JSONObject params, final ServerSecurityUser user,
       final EffectiveToolProfile profile) {
-    final String toolName = params.getString("name", "");
+    final String toolName;
+    try {
+      toolName = stringMember(params, "name", "");
+    } catch (final IllegalArgumentException e) {
+      // A malformed member is a protocol-level fault, so it answers with a JSON-RPC error rather than the isError
+      // tool envelope the try below produces: no tool was named, so no tool can have failed.
+      return error(id, -32602, "Invalid params: " + e.getMessage(), 200);
+    }
     final JSONObject args = params.getJSONObject("arguments", new JSONObject());
 
     LogManager.instance()
@@ -506,6 +523,28 @@ public class MCPDispatcher {
     result.put("content", content);
     result.put("isError", true);
     return result(id, result);
+  }
+
+  /**
+   * Reads a member that the protocol types as a string, deciding on the value's own JSON type rather than on what
+   * a converting accessor makes of it. {@link JSONObject#getString(String, String)} delegates to Gson, which
+   * unwraps a one-element array to that element and stringifies a bare number or boolean, raising only for any
+   * other shape. Array arity would then decide whether a request is executed or refused. {@link JSONObject#opt}
+   * maps each JSON type to its Java counterpart without converting between them, so comparing the result against
+   * String admits the JSON strings and nothing else.
+   *
+   * @return the member's value, or defaultValue when the member is absent or JSON null.
+   *
+   * @throws IllegalArgumentException when the member is present with any other JSON type. Callers translate this
+   *                                  into the JSON-RPC error that fits where the member sits.
+   */
+  private static String stringMember(final JSONObject json, final String name, final String defaultValue) {
+    final Object value = json.opt(name);
+    if (value == null)
+      return defaultValue;
+    if (value instanceof String string)
+      return string;
+    throw new IllegalArgumentException("'" + name + "' must be a string");
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
+++ b/server/src/test/java/com/arcadedb/server/mcp/MCPTransportConformanceTest.java
@@ -106,6 +106,103 @@ class MCPTransportConformanceTest extends BaseGraphServerTest {
     assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32600);
   }
 
+  /**
+   * JSON-RPC 2.0 types 'method' as a String, but the value used to be read through an accessor that delegates to
+   * Gson, which unwraps a one-element array to that element and raises only for any other size. Array arity
+   * therefore decided whether the request was executed or rejected: {@code ["ping"]} dispatched ping while
+   * {@code ["ping","x"]} was refused. Both are the same malformed shape and both must be refused.
+   */
+  @Test
+  void requestWithSingleElementArrayMethodIsRejected() throws Exception {
+    final Response response = post("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":[\"ping\"]}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("result")).isFalse();
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32600);
+  }
+
+  /**
+   * The accessor also stringifies a bare non-string primitive, so a numeric or boolean 'method' used to reach the
+   * dispatch switch as its text form and be answered with 'Method not found' rather than an invalid request.
+   */
+  @Test
+  void requestWithNonStringPrimitiveMethodIsRejected() throws Exception {
+    for (final String method : new String[] { "42", "true" }) {
+      final Response response = post("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":" + method + "}", null);
+
+      assertThat(response.status).as("method=%s", method).isEqualTo(200);
+      final JSONObject json = new JSONObject(response.body);
+      assertThat(json.has("error")).as("method=%s", method).isTrue();
+      assertThat(json.getJSONObject("error").getInt("code")).as("method=%s", method).isEqualTo(-32600);
+    }
+  }
+
+  /**
+   * The same coercion applied to every string-typed params member. Each payload below names a target that exists,
+   * so before the fix the coerced value was dispatched and the call succeeded.
+   */
+  @Test
+  void toolsCallWithSingleElementArrayNameIsRejected() throws Exception {
+    final Response response = post(
+        "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":[\"list_databases\"]}}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("result")).isFalse();
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32602);
+  }
+
+  @Test
+  void resourcesReadWithSingleElementArrayUriIsRejected() throws Exception {
+    final Response response = post(
+        "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"resources/read\","
+            + "\"params\":{\"uri\":[\"arcadedb://graph/schema\"]}}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("result")).isFalse();
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32602);
+  }
+
+  @Test
+  void promptsGetWithSingleElementArrayNameIsRejected() throws Exception {
+    // Both required arguments are supplied, so the only thing wrong with this request is the shape of 'name'.
+    // Omitting them would make the assertion pass on the missing-argument path and prove nothing.
+    final Response response = post(
+        "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"prompts/get\","
+            + "\"params\":{\"name\":[\"graphrag_query\"],"
+            + "\"arguments\":{\"database\":\"graph\",\"question\":\"who?\"}}}", null);
+
+    assertThat(response.status).isEqualTo(200);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("result")).isFalse();
+    assertThat(json.has("error")).isTrue();
+    assertThat(json.getJSONObject("error").getInt("code")).isEqualTo(-32602);
+  }
+
+  /**
+   * The guard rejects by JSON type, so an absent member must still fall back to its default rather than be caught
+   * by it. A request with no 'params' reaches the same handler as one carrying an empty object.
+   */
+  @Test
+  void absentAndNullStringMembersStillFallBackToTheirDefault() throws Exception {
+    for (final String params : new String[] { "", ",\"params\":{}", ",\"params\":{\"name\":null}" }) {
+      final Response response = post("{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\"" + params + "}", null);
+
+      assertThat(response.status).as("params=%s", params).isEqualTo(200);
+      final JSONObject json = new JSONObject(response.body);
+      // An absent name defaults to the empty string, which is a well-formed request naming no tool. That is an
+      // unknown tool, answered as an isError tool envelope, and must stay distinct from the -32602 a malformed
+      // member now produces.
+      assertThat(json.has("error")).as("params=%s", params).isFalse();
+      assertThat(json.getJSONObject("result").getBoolean("isError")).as("params=%s", params).isTrue();
+    }
+  }
+
   @Test
   void requestWithFractionalIdIsRejected() throws Exception {
     final Response response = post("{\"jsonrpc\":\"2.0\",\"id\":1.5,\"method\":\"tools/list\"}", null);


### PR DESCRIPTION
Closes #5620

`MCPDispatcher` read every string-typed protocol member through `JSONObject.getString(name, default)`, which ends in Gson's `getAsString()`. Gson converts rather than checks: `JsonArray.getAsString()` delegates to its single element when `size() == 1` and raises for any other size, and a bare number or boolean is stringified. The arity of an array therefore decided the outcome, so `{"jsonrpc":"2.0","id":1,"method":["ping"]}` executed `ping` and returned a success result while `["ping","x"]` was refused, and `{"method":42}` reached the dispatch switch as `"42"` and was answered `-32601` rather than as an invalid request. JSON-RPC 2.0 types `method` as a String; it draws no distinction by arity. The same applied to `params.uri` on `resources/read` and `params.name` on `tools/call` and `prompts/get`. This adds `MCPDispatcher.stringMember`, which decides on the value's own JSON type by comparing `JSONObject.opt` against `String` - `opt` maps each JSON type to its Java counterpart without converting between them - and raises `IllegalArgumentException` for any other shape. Absent and JSON-null still fall back to the default, so a missing member stays distinguishable from a malformed one.

### Merged with #5619

#5619 merged to main as `bfdc3a837` while this branch was open, so `origin/main` has been merged in and the overlap resolved here. The two are complementary and the result keeps both:

- **String-typed members** (`method`, `params.uri`, `params.name`) now read through `stringMember`. #5619's guard placement, error codes and messages are kept as-is; only the read changed, and `IllegalArgumentException` was added to each catch.
- **Object-typed members** (`params`, `params.arguments`) keep #5619's accessor and catch untouched - `getAsJsonObject()` raises for an array of any size, so arity never decided anything there.
- **`isResponse`** keeps #5619's `opt("jsonrpc")` comparison; **`promptsGet`** keeps its widened catch.

### Why these members are narrowed and `arguments.key` is not

Narrowing a read to `instanceof String` is unsafe when a *second* reader of the same member still coerces - that is the `formatArgs` / `SetServerSettingTool` masking bypass that #5622 is fixing by catching instead. Every member narrowed here was grepped for other readers first:

| member | other readers | coercing? |
|---|---|---|
| `method` | `has("method")` in `dispatch` and `isResponse` | existence checks only |
| `params.uri` | none | - |
| `params.name` (tools/call) | `formatArgs(toolName, args)` | receives the value resolved here, not a second read |
| `params.name` (prompts/get) | none | - |

Each has exactly one coercing reader, which is the one narrowed. `arguments.key` - the member that does have two readers - is deliberately untouched, so this does not conflict with #5622.

## Test plan

Six methods added to `MCPTransportConformanceTest`, which now runs 36 (24 pre-existing + 6 from #5619 + 6 here). Every payload names a target that exists, so on the unfixed code the coerced value was dispatched and the call succeeded - the assertions were verified to fail before the fix, not merely to pass after it.

- [x] `"method":["ping"]` is answered `-32600` instead of executing `ping`
- [x] `"method":42` and `"method":true` are answered `-32600` instead of `-32601 Method not found`
- [x] `tools/call` with `"name":["list_databases"]` is answered `-32602` instead of listing the databases
- [x] `resources/read` with `"uri":["arcadedb://graph/schema"]` is answered `-32602` instead of returning the schema
- [x] `prompts/get` with `"name":["graphrag_query"]` and both required arguments supplied is answered `-32602` (the arguments are supplied on purpose: without them the request fails on the missing-argument path with the same code and the test would prove nothing)
- [x] absent `params`, `"params":{}` and `"params":{"name":null}` still fall back to the default and still produce the unknown-tool `isError` envelope rather than `-32602`
- [x] `mvn -pl server test -Dtest=MCPTransportConformanceTest` - 5 failures before the fix, 0 after; 36/36 after merging main
- [x] Regression sweep `mvn -pl server test -Dtest='MCP*Test,HybridSearch*Test,GetServerSettings*'` - `Tests run: 282, Failures: 0, Errors: 0, Skipped: 0`

One comment inherited from #5619 was corrected rather than carried over: `requestWithNonStringMethodIsRejected` justified its use of `{}` by saying `"method":["ping"]` "would silently succeed", which this change makes untrue.
