### PR TITLE
fix(mongodbw) #5583: bind $set and replacement values as parameters instead of inlining them as JSON

### DIFF
--- a/docs/5583-mongodbw-bind-update-values-as-params.md
+++ b/docs/5583-mongodbw-bind-update-values-as-params.md
@@ -150,7 +150,9 @@ than the edit. Nothing was weakened - the assertions still pin the same observab
 - `{field: null}` binds `field = :p0` with null, which does not match missing fields the way MongoDB does.
   Carried over from #5581, unfiled, not a regression.
 - `executeUpsert` / `applyOperatorsToDocument` build a record through the API rather than through SQL, so they
-  never had this exposure and are untouched.
+  never had this exposure and are untouched. They do, however, call `record.set(key, rawBsonValue)` with no
+  conversion, so unlike the update path they never turn a nested `ObjectId` into hex: the same `$set` stores a
+  different representation depending on whether the row already existed. Pre-existing, worth its own issue.
 
 ## Review cycles
 
@@ -202,9 +204,70 @@ rather than merely out of scope. Two non-blocking observations:
 2. Dotted `$set` keys deserve their own issue - agreed, and left for the developer to file rather than opened
    unilaterally. Recorded under "Follow-ups not taken" above.
 
+### Cycle 4 - `53b07cb6e` - found a server-crash bug
+
+`claude[bot]`: **LGTM**, no blocking issues, three non-blocking notes. The first one turned out to matter a great
+deal.
+
+1. *Date fidelity is only unit-tested; a wire-level round trip would guard the stated behaviour change.*
+   **Applied - and it failed.** Writing that test exposed a crash, described in full below.
+2. *The empty-`params` contract is documented but not enforced; a cheap `assert` would make a future
+   silent-overwrite loud.* **Applied** as `assert params.isEmpty()` at the top of `appendUpdateOperations`.
+   `assert` is already used in this file (line 425), so this matches local convention.
+3. *`executeUpsert` -> `applyOperatorsToDocument` does not apply the `ObjectId` -> hex conversion that
+   `toMapValue` does, so a nested `ObjectId` lands differently depending on whether the row already exists.*
+   **Verified correct** - that path calls `record.set(key, rawBsonValue)` with no conversion. Pre-existing and
+   unrelated to binding; recorded as a follow-up, not changed.
+
+#### The crash
+
+`aDateSurvivesBeingSetByAnUpdate` failed, and not on the update - on the **read-back**:
+
+```
+SEVER [MongoWireMessageEncoder] Failed to encode {...}
+java.lang.IllegalArgumentException: Unknown type: class java.time.LocalDateTime
+    at de.bwaldvogel.mongo.wire.bson.BsonEncoder.determineType(BsonEncoder.java:204)
+```
+
+The write succeeded; encoding the stored value into the wire response threw, which killed the connection and
+surfaced client-side as `MongoSocketReadException: Prematurely reached end of stream`.
+
+**This is a pre-existing defect, not one this change introduced.** Confirmed with a throwaway probe on the
+**insert** path, which this PR does not touch: `insertOne(new Document("when", date))` followed by `find` fails
+identically. `MongoDBToSqlTranslator.convertDocumentToMongoDB` passed every stored value straight through, and a
+temporal property is held as a `java.time` value, which the encoder rejects. So **any** date written through
+mongodbw and read back killed the connection.
+
+**But binding made it reachable on a path where it previously was not.** Before this change a `$set` date went
+through `JSONObject` and was stored as a *string*, which encodes fine. After it, the value is stored as a real
+`LocalDateTime`. So without a fix, this PR would have converted a lossy-but-working path into a crashing one -
+and the unit test could never have caught it, because the failure is in the response encoder.
+
+#### The fix
+
+`convertDocumentToMongoDB`'s two identical overloads now share one `convertMapToMongoDB`, and values pass through
+`toBsonValue`, which maps temporal types onto the single temporal type `BsonEncoder` accepts. Inspecting the
+encoder's bytecode shows it handles `java.time.Instant` and **not** `java.util.Date` - the first attempt
+converted to `Date` and failed the same way with `Unknown type: class java.util.Date`, so this was determined
+empirically rather than assumed. `LocalDateTime`/`LocalDate` are anchored at `ZoneOffset.UTC`, matching what
+`DateUtils` uses on the way in, so the round trip is exact. `toBsonValue` also recurses into embedded documents
+and lists, since a date can sit inside either.
+
+Four wire tests cover it: the `$set` path, the insert path (independent of this PR's change), a date nested in a
+sub-document, and the large-`Double` case from the same fidelity claim.
+
 ## Final state
 
-Three review cycles, all `LGTM` with no blocking issues at any point. Two of the seven non-blocking notes were
-applied (map presizing, precondition Javadoc), one was a real coverage gap that was filled (combined
-`$set` + `$inc`), one was declined with reasoning (`params.size()` counter), and three were pre-existing gaps
-recorded as follow-ups rather than changed.
+Four review cycles, all `LGTM` with no blocking issues at any point. Of the ten non-blocking notes: four applied
+(map presizing, precondition Javadoc, `assert params.isEmpty()`, wire-level fidelity tests), one was a coverage
+gap that was filled (combined `$set` + `$inc`), one led to the temporal-encoding fix above, one was declined with
+reasoning (`params.size()` counter), and three were pre-existing gaps recorded as follow-ups.
+
+Module total: **73 green**, up from 52.
+
+### Needs the developer's attention before merge
+
+The cycle-4 temporal-encoding fix (`MongoDBToSqlTranslator.convertMapToMongoDB` / `toBsonValue`) **has not been
+through a bot review cycle** - the 4-cycle limit was reached when it was written. It is also the one part of this
+PR that goes beyond the issue's scope. It is here because leaving it out would have shipped a regression, but it
+is genuinely a separate bug fix and a reasonable thing to split into its own PR.

--- a/docs/5583-mongodbw-bind-update-values-as-params.md
+++ b/docs/5583-mongodbw-bind-update-values-as-params.md
@@ -167,3 +167,24 @@ notes:
    `HashMap.newHashMap(size)` at `QuerySession:83`.
 2. Dotted `$set` keys - recorded above as a follow-up, not changed here.
 3. `{field: null}` - already recorded, carried over from #5581.
+
+### Cycle 2 - `5515db035`
+
+`claude[bot]`: **LGTM**, no blocking issues. Three non-blocking observations:
+
+1. *`buildValue` derives placeholder names from `params.size()`, so a future caller that pre-seeds the map would
+   get a silent collision; a threaded counter would make the invariant structural.* **Not applied.** This is the
+   same suggestion the cycle-4 reviewer made on #5581, declined then for the same reasons and explicitly marked
+   "not for this PR" here too: all four call sites pass a fresh empty map, the contract is documented on
+   `buildValue`, and changing its signature would touch every filter-path caller for a hazard that does not
+   exist today. It belongs with `buildValue`, not with this change.
+2. *No test covered a combined `$set` + `$inc` update.* **Applied** - a real coverage gap. The grammar takes
+   `updateOperation+`, so the two chain into `MERGE :p0 SET \`count\` += :p1`, and the concern worth settling was
+   whether the bound payload of `MERGE expression` would swallow the `SET` keyword that opens the next clause.
+   It does not. Added `aCombinedSetAndIncUpdateChainsTwoOperationsOverOneParameterMap` (unit, pins the exact
+   statement text and both placeholders) and `aCombinedSetAndIncUpdateAppliesBothOperations` (wire, seeds
+   `count: 1` and asserts `count == 4` with a quote-bearing `note` intact). Both pass, so this was a missing
+   test rather than a defect.
+3. Dotted `$set` keys - agreed out of scope, already disclosed above.
+
+Module total after cycle 2: **69 green** (+2).

--- a/docs/5583-mongodbw-bind-update-values-as-params.md
+++ b/docs/5583-mongodbw-bind-update-values-as-params.md
@@ -188,3 +188,23 @@ notes:
 3. Dotted `$set` keys - agreed out of scope, already disclosed above.
 
 Module total after cycle 2: **69 green** (+2).
+
+### Cycle 3 - `4f3b0891a`
+
+`claude[bot]`: **LGTM**, no blocking issues. It additionally verified that `quoteFieldPath()` ->
+`Identifier.quote()` escapes both backtick and backslash, so the deliberately-unbindable field-name half is safe
+rather than merely out of scope. Two non-blocking observations:
+
+1. *`appendUpdateOperations` is now an independently-callable seam, so it should restate `buildValue`'s
+   "params must start empty" precondition in its own Javadoc.* **Applied.** Previously the invariant was
+   guaranteed only by the single caller and pinned by one test. Stated as an invariant with no issue references,
+   per repo convention.
+2. Dotted `$set` keys deserve their own issue - agreed, and left for the developer to file rather than opened
+   unilaterally. Recorded under "Follow-ups not taken" above.
+
+## Final state
+
+Three review cycles, all `LGTM` with no blocking issues at any point. Two of the seven non-blocking notes were
+applied (map presizing, precondition Javadoc), one was a real coverage gap that was filled (combined
+`$set` + `$inc`), one was declined with reasoning (`params.size()` counter), and three were pre-existing gaps
+recorded as follow-ups rather than changed.

--- a/docs/5583-mongodbw-bind-update-values-as-params.md
+++ b/docs/5583-mongodbw-bind-update-values-as-params.md
@@ -1,0 +1,146 @@
+# 5583 - mongodbw: bind $set and replacement values as parameters
+
+Follow-up to #5579 / PR #5581. After #5581 every **filter** value is a bound SQL parameter, but the **update**
+values (`$set` and full replacement) were still spelled into the statement as a JSON literal, relying on
+`JSONObject.toString()` escaping. This closes that last gap so the "unreachable by construction" property covers
+the whole statement.
+
+## The open question the issue posed: can the grammar bind there?
+
+**Yes.** The issue flagged this as needing checking first, and possibly being the bulk of the work. It is not -
+the engine already supports both forms.
+
+`GlobalConfiguration` line 474 records that the JavaCC parser is dead: *"Deprecated, has no effect. The
+ANTLR4-based SQL parser is always used."* `StatementCache` only ever calls `SQLAntlrParser.parse`. So the
+authority is `engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4`:
+
+```
+    | MERGE expression
+    | CONTENT (json | jsonArray | inputParameter)
+```
+
+- `MERGE expression` accepts `:p0` as an ordinary expression. `SQLASTBuilder.visitUpdateOperation` recognises
+  that the expression is not a JSON literal and stores it in `UpdateOperations.expression`;
+  `UpdateExecutionPlanner` chains `UpdateMergeStep(expression)`, whose `resolveExpression` resolves the value and
+  accepts a `Map` with String keys directly (`checkStringKeys`).
+- `CONTENT ... inputParameter` is an explicit grammar alternative. `SQLASTBuilder` stores it in
+  `UpdateOperations.inputParam` and `UpdateContentStep` handles a `Map` value via `doc.fromMap(...)`.
+
+Nothing in the engine had to change. Note the JavaCC `SqlParser.java` production still only accepts `Json()`
+after MERGE/CONTENT, but that parser is unreachable, so it is left alone rather than hand-edited (there is no
+javacc plugin in the build; the generated file is checked in).
+
+## Change
+
+`MongoDBDatabaseWrapper`:
+
+- `documentToJson` / `toJsonValue` (BSON -> `JSONObject` / `JSONArray`) become `documentToMap` / `toMapValue`
+  (BSON -> `LinkedHashMap` / `ArrayList`). The nested `Document` and `List` recursion and the `ObjectId` ->
+  hex-string conversion are preserved exactly; only the container type changes. Insertion order is kept with
+  `LinkedHashMap` so the replacement document reaches the record in wire order.
+- `appendUpdateOperations` binds instead of spelling:
+
+  ```java
+  sql.append(" CONTENT ");                            // was: .append(documentToJson(u))
+  MongoDBToSqlTranslator.buildValue(sql, params, documentToMap(u));
+
+  case "$set" -> {                                    // was: .append(documentToJson(operand))
+    sql.append(" MERGE ");
+    MongoDBToSqlTranslator.buildValue(sql, params, documentToMap(operand));
+  }
+  ```
+
+  It becomes package-private `static` (it never used instance state) so a unit test in `com.arcadedb.mongo` can
+  read the generated SQL directly, the same way `MongoDBToSqlTranslatorParamsTest` drives the `protected static`
+  translator builders.
+
+Unchanged, deliberately: `$unset` and `$inc` **field names** stay on `quoteFieldPath()`. SQL cannot bind a
+property name, so that half of #5575 is untouched, same as in #5581. `$inc` already binds its operand.
+
+`JSONObject` / `JSONArray` stay imported: `handleQuery` and `json2Document` still use them on an unrelated path.
+
+## Side effect: value fidelity
+
+Same class of latent defect #5581 uncovered on the filter path. Going through `JSONObject` meant a value was
+reshaped by JSON serialisation before it reached the record. Binding hands the engine the original Java object:
+
+- `java.util.Date` was serialised by `JSONObject`'s date handling; it now arrives as a `Date`.
+- a large `Double` was written in scientific notation; it now arrives as a `Double`.
+
+Neither was a *security* hole - `JSONObject` escapes correctly, and #5581 added two round-trip tests proving it -
+but both were fidelity losses, and both are now gone.
+
+## Verification
+
+New unit tests, `MongoDBUpdateValueBindingTest` (no server, reads the generated SQL directly):
+
+| test | pins |
+|---|---|
+| `aSetOperandIsBoundRatherThanSpelledAsJson` | `MERGE :p0`, operand in the param map |
+| `aReplacementDocumentIsBoundRatherThanSpelledAsJson` | `CONTENT :p0`, document in the param map |
+| `aQuoteBearingSetValueNeverAppearsInTheStatementText` | payload text absent from the SQL |
+| `aQuoteBearingReplacementValueNeverAppearsInTheStatementText` | same for the replacement path |
+| `aNestedDocumentIsBoundAsANestedMap` | `Document` -> `Map` recursion survives |
+| `aListValueIsBoundAsAList` | `List` recursion survives, nested `Document`s inside it too |
+| `anObjectIdIsBoundAsItsHexString` | the `ObjectId` -> hex conversion is preserved |
+| `aDateIsBoundAsADateInsteadOfBeingSerialised` | fidelity, was reshaped by `JSONObject` |
+| `updateValuesAndFilterValuesShareOneParameterNumbering` | `MERGE :p0 ... WHERE ... :p1`, no collision |
+| `unsetStillSpellsFieldNamesAsQuotedIdentifiers` | the deliberate #5575 carve-out is unchanged |
+| `incStillBindsItsOperandAndQuotesItsFieldName` | #5581 behaviour unchanged |
+| `aCraftedFieldNameInASetOperandCannotBreakOutOfTheStatement` | field names inside the bound map are data now |
+
+New wire-level tests added to `MongoDBParameterBindingTest` (real server through the Mongo driver):
+
+| test | pins |
+|---|---|
+| `aNestedDocumentSurvivesBeingSetByAnUpdate` | nested map round-trips through the bound parameter |
+| `anArraySurvivesBeingSetByAnUpdate` | list round-trips |
+| `aNestedDocumentSurvivesAFullReplacement` | same on the CONTENT path |
+
+The two pre-existing round-trip tests the issue named (`aQuoteBearingValueSurvivesBeingSetByAnUpdate`,
+`aQuoteBearingValueSurvivesAFullReplacement`) are unchanged and must stay green: they are the observable contract
+and are indifferent to which mechanism provides it.
+
+### Proving the tests can fail
+
+Run in this order deliberately, so the red was recorded against the *old* implementation rather than assumed.
+`appendUpdateOperations` was first made package-private `static` with its body still on `documentToJson`, and the
+new unit test class was run against it:
+
+```
+Tests run: 12, Failures: 6, Errors: 4, Skipped: 0
+```
+
+10 of 12 red. The 2 that passed are `unsetStillSpellsFieldNamesAsQuotedIdentifiers` and
+`incStillBindsItsOperandAndQuotesItsFieldName`, which is correct: they pin behaviour this change deliberately
+leaves alone, so they must be green on both sides.
+
+The binding was applied only after that run.
+
+## Test results
+
+Whole module, after the change:
+
+```
+mvn -pl mongodbw verify
+Tests run: 67, Failures: 0, Errors: 0, Skipped: 0
+```
+
+67 up from 52 (+12 unit, +3 wire). No engine module was touched, so nothing outside `mongodbw` is in scope.
+
+The wire-level tests matter more than usual here: they are what proves the engine actually accepts `MERGE :p0`
+and `CONTENT :p0` at runtime, not just that the grammar file contains the alternatives.
+
+## Note on the two existing tests' comments
+
+`aQuoteBearingValueSurvivesBeingSetByAnUpdate` and `aQuoteBearingValueSurvivesAFullReplacement` are unchanged in
+behaviour and assertions. Their **comments** were updated: each described the value as travelling "as a JSON
+literal", which this change makes false. Leaving a comment asserting the opposite of what the code does is worse
+than the edit. Nothing was weakened - the assertions still pin the same observable contract.
+
+## Follow-ups not taken
+
+- `{field: null}` binds `field = :p0` with null, which does not match missing fields the way MongoDB does.
+  Carried over from #5581, unfiled, not a regression.
+- `executeUpsert` / `applyOperatorsToDocument` build a record through the API rather than through SQL, so they
+  never had this exposure and are untouched.

--- a/docs/5583-mongodbw-bind-update-values-as-params.md
+++ b/docs/5583-mongodbw-bind-update-values-as-params.md
@@ -140,7 +140,30 @@ than the edit. Nothing was weakened - the assertions still pin the same observab
 
 ## Follow-ups not taken
 
+- **Dotted `$set` keys do not navigate.** `{"$set": {"address.city": "Rome"}}` reaches the record as a literal
+  property named `address.city` rather than setting `city` inside `address`. `documentToMap` keeps the key
+  verbatim and `UpdateMergeStep.handleMerge` calls `doc.set(key, value)` per entry, so the behaviour is
+  byte-identical to the old JSON-literal path (`MERGE {"address.city": "Rome"}` produced the same map). Not a
+  regression and out of scope here, but worth its own issue if MongoDB dotted-path semantics are expected. Note
+  this is only the **update** side: on the filter side `quoteFieldPath()` does split the path per segment, so the
+  two halves disagree.
 - `{field: null}` binds `field = :p0` with null, which does not match missing fields the way MongoDB does.
   Carried over from #5581, unfiled, not a regression.
 - `executeUpsert` / `applyOperatorsToDocument` build a record through the API rather than through SQL, so they
   never had this exposure and are untouched.
+
+## Review cycles
+
+### Cycle 1 - `6190293b3`
+
+`claude[bot]`: **LGTM**, no blocking issues. It independently traced the grammar/engine path and confirmed the
+binding, the merge semantics, the parameter numbering, and the recursion/fidelity claims. Three non-blocking
+notes:
+
+1. `documentToMap` sized its map with `new LinkedHashMap<>(doc.size())`, which is a *capacity*, so with the
+   default 0.75 load factor it rehashes once a document has ~4 or more fields. **Applied**, using the JDK 19
+   factory `LinkedHashMap.newLinkedHashMap(doc.size())` rather than the suggested
+   `(int) (doc.size() / 0.75f) + 1`: same sizing, no arithmetic in the source, and it matches the existing
+   `HashMap.newHashMap(size)` at `QuerySession:83`.
+2. Dotted `$set` keys - recorded above as a follow-up, not changed here.
+3. `{field: null}` - already recorded, carried over from #5581.

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -633,6 +633,8 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
    * same map, which continues the numbering instead of colliding with it.
    */
   static void appendUpdateOperations(final StringBuilder sql, final Map<String, Object> params, final Document u) {
+    assert params.isEmpty();
+
     if (isReplacement(u)) {
       sql.append(" CONTENT ");
       MongoDBToSqlTranslator.buildValue(sql, params, documentToMap(u));

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -688,7 +688,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
    * order is preserved so a replacement document reaches the record in wire order.
    */
   private static Map<String, Object> documentToMap(final Document doc) {
-    final Map<String, Object> map = new LinkedHashMap<>(doc.size());
+    final Map<String, Object> map = LinkedHashMap.newLinkedHashMap(doc.size());
     for (final Map.Entry<String, Object> entry : doc.entrySet())
       map.put(entry.getKey(), toMapValue(entry.getValue()));
     return map;

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -623,9 +623,10 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     }
   }
 
-  private void appendUpdateOperations(final StringBuilder sql, final Map<String, Object> params, final Document u) {
+  static void appendUpdateOperations(final StringBuilder sql, final Map<String, Object> params, final Document u) {
     if (isReplacement(u)) {
-      sql.append(" CONTENT ").append(documentToJson(u));
+      sql.append(" CONTENT ");
+      MongoDBToSqlTranslator.buildValue(sql, params, documentToMap(u));
       return;
     }
 
@@ -633,7 +634,10 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
       final String op = entry.getKey();
       final Document operand = (Document) entry.getValue();
       switch (op) {
-      case "$set" -> sql.append(" MERGE ").append(documentToJson(operand));
+      case "$set" -> {
+        sql.append(" MERGE ");
+        MongoDBToSqlTranslator.buildValue(sql, params, documentToMap(operand));
+      }
       case "$unset" -> {
         sql.append(" REMOVE ");
         int i = 0;
@@ -679,21 +683,25 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     return 0;
   }
 
-  private static JSONObject documentToJson(final Document doc) {
-    final JSONObject json = new JSONObject();
+  /**
+   * Converts a BSON document into the map bound as the payload of {@code UPDATE ... MERGE} / {@code ... CONTENT}. Insertion
+   * order is preserved so a replacement document reaches the record in wire order.
+   */
+  private static Map<String, Object> documentToMap(final Document doc) {
+    final Map<String, Object> map = new LinkedHashMap<>(doc.size());
     for (final Map.Entry<String, Object> entry : doc.entrySet())
-      json.put(entry.getKey(), toJsonValue(entry.getValue()));
-    return json;
+      map.put(entry.getKey(), toMapValue(entry.getValue()));
+    return map;
   }
 
-  private static Object toJsonValue(final Object value) {
+  private static Object toMapValue(final Object value) {
     if (value instanceof Document document)
-      return documentToJson(document);
+      return documentToMap(document);
     else if (value instanceof List<?> list) {
-      final JSONArray array = new JSONArray();
+      final List<Object> converted = new ArrayList<>(list.size());
       for (final Object item : list)
-        array.put(toJsonValue(item));
-      return array;
+        converted.add(toMapValue(item));
+      return converted;
     } else if (value instanceof ObjectId id)
       return toHexString(id);
     return value;

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -623,6 +623,15 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     }
   }
 
+  /**
+   * Appends the update clauses for a BSON update document, binding every value it carries into {@code params} rather than
+   * spelling it into {@code sql}. Field names are the exception: SQL cannot bind a property name, so {@code $unset} and
+   * {@code $inc} quote theirs as identifiers.
+   * <p>
+   * {@code params} must be empty on entry and hold only generated placeholders afterwards: names are derived from the map's
+   * current size, so a pre-seeded map would silently reuse one. A caller that also appends a WHERE clause must share this
+   * same map, which continues the numbering instead of colliding with it.
+   */
   static void appendUpdateOperations(final StringBuilder sql, final Map<String, Object> params, final Document u) {
     if (isReplacement(u)) {
       sql.append(" CONTENT ");

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBToSqlTranslator.java
@@ -24,7 +24,14 @@ import de.bwaldvogel.mongo.backend.Utils;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.bson.ObjectId;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -215,23 +222,50 @@ public class MongoDBToSqlTranslator {
   }
 
   protected static Document convertDocumentToMongoDB(final com.arcadedb.database.Document doc) {
+    return convertMapToMongoDB(doc.toMap());
+  }
+
+  protected static Document convertDocumentToMongoDB(final Result doc) {
+    return convertMapToMongoDB(doc.toMap());
+  }
+
+  private static Document convertMapToMongoDB(final Map<String, Object> map) {
     final Document result = new Document();
-    for (final Map.Entry<String, Object> entry : doc.toMap().entrySet()) {
+    for (final Map.Entry<String, Object> entry : map.entrySet()) {
       final String p = entry.getKey();
       final Object value = entry.getValue();
-      result.put(p, "_id".equals(p) ? getObjectId((String) value) : value);
+      result.put(p, "_id".equals(p) ? getObjectId((String) value) : toBsonValue(value));
     }
     return result;
   }
 
-  protected static Document convertDocumentToMongoDB(final Result doc) {
-    final Document result = new Document();
-    for (final Map.Entry<String, Object> entry : doc.toMap().entrySet()) {
-      final String p = entry.getKey();
-      final Object value = entry.getValue();
-      result.put(p, "_id".equals(p) ? getObjectId((String) value) : value);
+  /**
+   * Maps a stored value onto a type the BSON encoder accepts. A temporal property is held as a {@code java.time} value, and
+   * the encoder handles exactly one of those, {@link Instant}, rejecting the rest outright and failing the whole response.
+   * The engine anchors a stored date to UTC, so the conversion uses the same offset and is exact.
+   */
+  @SuppressWarnings("unchecked")
+  private static Object toBsonValue(final Object value) {
+    if (value instanceof Instant)
+      return value;
+    else if (value instanceof LocalDateTime dateTime)
+      return dateTime.toInstant(ZoneOffset.UTC);
+    else if (value instanceof LocalDate date)
+      return date.atStartOfDay().toInstant(ZoneOffset.UTC);
+    else if (value instanceof ZonedDateTime dateTime)
+      return dateTime.toInstant();
+    else if (value instanceof Date date)
+      return date.toInstant();
+    else if (value instanceof Map)
+      // an embedded document can hold a temporal property of its own
+      return convertMapToMongoDB((Map<String, Object>) value);
+    else if (value instanceof List<?> list) {
+      final List<Object> converted = new ArrayList<>(list.size());
+      for (final Object item : list)
+        converted.add(toBsonValue(item));
+      return converted;
     }
-    return result;
+    return value;
   }
 
   protected static ObjectId getObjectId(final String s) {

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBParameterBindingTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBParameterBindingTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import static com.mongodb.client.model.Filters.eq;
@@ -262,6 +263,48 @@ public class MongoDBParameterBindingTest extends BaseGraphServerTest {
     final Document found = collection.find(eq("name", "target")).first();
     assertThat(found.getString("note")).isEqualTo("v1' \"x\"");
     assertThat(((Number) found.get("count")).intValue()).isEqualTo(4);
+  }
+
+  @Test
+  void aDateSurvivesBeingSetByAnUpdate() {
+    collection.insertOne(new Document("name", "target"));
+
+    // the fidelity half of the binding: routing through JSONObject reshaped a Date before it reached the record, so
+    // this guards the stated behaviour change end to end rather than only at the parameter map
+    final Date when = new Date(1_700_000_000_000L);
+    collection.updateOne(eq("name", "target"), new Document("$set", new Document("when", when)));
+
+    assertThat(collection.find(eq("name", "target")).first().getDate("when")).isEqualTo(when);
+  }
+
+  @Test
+  void aDateSurvivesBeingInsertedAndReadBack() {
+    // the insert path never went through the update binding, so this covers the read-side conversion on its own: a
+    // stored temporal property used to reach the BSON encoder as a java.time value and kill the connection
+    final Date when = new Date(1_700_000_000_000L);
+    collection.insertOne(new Document("name", "inserted").append("when", when));
+
+    assertThat(collection.find(eq("name", "inserted")).first().getDate("when")).isEqualTo(when);
+  }
+
+  @Test
+  void aDateNestedInsideASubDocumentSurvivesTheRoundTrip() {
+    final Date when = new Date(1_700_000_000_000L);
+    collection.insertOne(new Document("name", "nested").append("meta", new Document("created", when)));
+
+    final Document meta = (Document) collection.find(eq("name", "nested")).first().get("meta");
+    assertThat(meta.getDate("created")).isEqualTo(when);
+  }
+
+  @Test
+  void aLargeDoubleSurvivesBeingSetByAnUpdate() {
+    collection.insertOne(new Document("name", "target"));
+
+    // inlining stringified this into scientific notation on its way into the statement
+    final double big = 1.0E10d;
+    collection.updateOne(eq("name", "target"), new Document("$set", new Document("ratio", big)));
+
+    assertThat(((Number) collection.find(eq("name", "target")).first().get("ratio")).doubleValue()).isEqualTo(big);
   }
 
   @Test

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBParameterBindingTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBParameterBindingTest.java
@@ -199,8 +199,7 @@ public class MongoDBParameterBindingTest extends BaseGraphServerTest {
   void aQuoteBearingValueSurvivesBeingSetByAnUpdate() {
     collection.insertOne(new Document("name", "target"));
 
-    // $set values travel as a JSON literal rather than as a bound parameter, so their escaping is a separate mechanism
-    // from the WHERE clause: this pins that it actually holds
+    // $set values are bound as the payload of MERGE, so this is the observable contract the binding has to preserve
     final String awkward = "it's a \"quoted\" C:\\path";
     collection.updateOne(eq("name", "target"), new Document("$set", new Document("note", awkward)));
 
@@ -211,11 +210,44 @@ public class MongoDBParameterBindingTest extends BaseGraphServerTest {
   void aQuoteBearingValueSurvivesAFullReplacement() {
     collection.insertOne(new Document("name", "target"));
 
-    // a replacement document goes out as SQL CONTENT <json>, another inlined-JSON path
+    // a replacement document goes out as SQL CONTENT :p<n>, bound the same way
     final String awkward = "replaced' with \"quotes\"";
     collection.replaceOne(eq("name", "target"), new Document("name", "target").append("note", awkward));
 
     assertThat(collection.find(eq("name", "target")).first().getString("note")).isEqualTo(awkward);
+  }
+
+  @Test
+  void aNestedDocumentSurvivesBeingSetByAnUpdate() {
+    collection.insertOne(new Document("name", "target"));
+
+    // the bound payload is a nested Map rather than JSON text, so the nesting has to survive the parameter round trip
+    collection.updateOne(eq("name", "target"),
+        new Document("$set", new Document("address", new Document("city", "Rome").append("zip", 145))));
+
+    final Document address = (Document) collection.find(eq("name", "target")).first().get("address");
+    assertThat(address.getString("city")).isEqualTo("Rome");
+    assertThat(address.getInteger("zip")).isEqualTo(145);
+  }
+
+  @Test
+  void anArraySurvivesBeingSetByAnUpdate() {
+    collection.insertOne(new Document("name", "target"));
+
+    collection.updateOne(eq("name", "target"), new Document("$set", new Document("tags", List.of("a", "b' c"))));
+
+    assertThat(collection.find(eq("name", "target")).first().getList("tags", String.class)).containsExactly("a", "b' c");
+  }
+
+  @Test
+  void aNestedDocumentSurvivesAFullReplacement() {
+    collection.insertOne(new Document("name", "target"));
+
+    collection.replaceOne(eq("name", "target"),
+        new Document("name", "target").append("address", new Document("city", "Rome' \"quoted\"")));
+
+    final Document address = (Document) collection.find(eq("name", "target")).first().get("address");
+    assertThat(address.getString("city")).isEqualTo("Rome' \"quoted\"");
   }
 
   @Test

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBParameterBindingTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBParameterBindingTest.java
@@ -251,6 +251,20 @@ public class MongoDBParameterBindingTest extends BaseGraphServerTest {
   }
 
   @Test
+  void aCombinedSetAndIncUpdateAppliesBothOperations() {
+    collection.insertOne(new Document("name", "target").append("count", 1));
+
+    // a driver can send both operators in one update: the statement then chains MERGE :p0 with SET ... += :p1, so
+    // this is what proves the bound payload does not swallow the SET keyword that follows it
+    collection.updateOne(eq("name", "target"),
+        new Document("$set", new Document("note", "v1' \"x\"")).append("$inc", new Document("count", 3)));
+
+    final Document found = collection.find(eq("name", "target")).first();
+    assertThat(found.getString("note")).isEqualTo("v1' \"x\"");
+    assertThat(((Number) found.get("count")).intValue()).isEqualTo(4);
+  }
+
+  @Test
   void aNumericValueIsComparedAsANumberNotAsText() {
     collection.insertOne(new Document("name", "big").append("size", 10_000_000_000L));
     collection.insertOne(new Document("name", "small").append("size", 1L));

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateValueBindingTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateValueBindingTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.bson.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * An update takes its values off the wire and used to spell them into the statement as a JSON literal, so their safety rested
+ * on {@code JSONObject} escaping being correct. These tests pin the replacement contract: the payload of {@code MERGE} and of
+ * {@code CONTENT} is a bound parameter and never appears in the statement text, which is what makes injection unreachable by
+ * construction rather than by remembering to escape at each call site.
+ * <p>
+ * Field names are a deliberate exception and stay quoted: SQL cannot bind a property name.
+ * <p>
+ * {@code appendUpdateOperations} is package-private static, so a test in the same package can read the generated SQL directly
+ * instead of inferring it from a round trip.
+ */
+class MongoDBUpdateValueBindingTest {
+
+  @Test
+  void aSetOperandIsBoundRatherThanSpelledAsJson() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$set", new Document("note", "v1")));
+
+    assertThat(sql.toString()).isEqualTo(" MERGE :p0");
+    assertThat(params).containsOnlyKeys("p0");
+    assertThat(params.get("p0")).isEqualTo(Map.of("note", "v1"));
+  }
+
+  @Test
+  void aReplacementDocumentIsBoundRatherThanSpelledAsJson() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    // no $-prefixed key means a full replacement, which used to go out as CONTENT <json>
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("name", "target").append("note", "v1"));
+
+    assertThat(sql.toString()).isEqualTo(" CONTENT :p0");
+    assertThat(params).containsOnlyKeys("p0");
+    assertThat(params.get("p0")).isEqualTo(Map.of("name", "target", "note", "v1"));
+  }
+
+  @Test
+  void aQuoteBearingSetValueNeverAppearsInTheStatementText() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    final String awkward = "v1\", \"injected\": \"yes";
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$set", new Document("note", awkward)));
+
+    assertThat(sql.toString()).isEqualTo(" MERGE :p0");
+    assertThat(sql.toString()).doesNotContain("injected").doesNotContain("\"");
+    assertThat(((Map<?, ?>) params.get("p0")).get("note")).isEqualTo(awkward);
+  }
+
+  @Test
+  void aQuoteBearingReplacementValueNeverAppearsInTheStatementText() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    final String awkward = "replaced' with \"quotes\" and a C:\\path";
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("note", awkward));
+
+    assertThat(sql.toString()).isEqualTo(" CONTENT :p0");
+    assertThat(sql.toString()).doesNotContain("'").doesNotContain("\\");
+    assertThat(((Map<?, ?>) params.get("p0")).get("note")).isEqualTo(awkward);
+  }
+
+  @Test
+  void aNestedDocumentIsBoundAsANestedMap() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    final Document nested = new Document("city", "Rome").append("zip", 145);
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$set", new Document("address", nested)));
+
+    assertThat(sql.toString()).isEqualTo(" MERGE :p0");
+    final Object address = ((Map<?, ?>) params.get("p0")).get("address");
+    assertThat(address).isInstanceOf(Map.class);
+    assertThat(((Map<?, ?>) address).get("city")).isEqualTo("Rome");
+    assertThat(((Map<?, ?>) address).get("zip")).isEqualTo(145);
+  }
+
+  @Test
+  void aListValueIsBoundAsAList() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    final List<Object> tags = List.of("a", new Document("nested", "b"));
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$set", new Document("tags", tags)));
+
+    final Object bound = ((Map<?, ?>) params.get("p0")).get("tags");
+    assertThat(bound).isInstanceOf(List.class);
+    assertThat((List<?>) bound).hasSize(2);
+    assertThat(((List<?>) bound).getFirst()).isEqualTo("a");
+    // the recursion has to reach documents nested inside a list, not just documents nested inside a document
+    assertThat(((List<?>) bound).get(1)).isInstanceOf(Map.class);
+    assertThat(((Map<?, ?>) ((List<?>) bound).get(1)).get("nested")).isEqualTo("b");
+  }
+
+  @Test
+  void anObjectIdIsBoundAsItsHexString() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    final ObjectId id = new ObjectId();
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$set", new Document("ref", id)));
+
+    // an ObjectId has no SQL type: the wrapper stores it as hex text, and that conversion must survive the binding
+    final Object bound = ((Map<?, ?>) params.get("p0")).get("ref");
+    assertThat(bound).isInstanceOf(String.class);
+    assertThat((String) bound).hasSize(id.toByteArray().length * 2).matches("[0-9a-f]+");
+  }
+
+  @Test
+  void aDateIsBoundAsADateInsteadOfBeingSerialised() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    final Date when = new Date();
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$set", new Document("when", when)));
+
+    // going through JSONObject reshaped a Date before it reached the record; binding hands over the original object
+    assertThat(((Map<?, ?>) params.get("p0")).get("when")).isEqualTo(when);
+  }
+
+  @Test
+  void updateValuesAndFilterValuesShareOneParameterNumbering() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    // executeUpdate appends the operations first and the WHERE clause second, against the same map: the two halves must
+    // not collide on a placeholder name
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$set", new Document("touched", "yes")));
+    sql.append(" WHERE ");
+    MongoDBToSqlTranslator.buildExpression(sql, params, new Document("name", "target"));
+
+    assertThat(sql.toString()).isEqualTo(" MERGE :p0 WHERE `name` = :p1");
+    assertThat(params).hasSize(2);
+    assertThat(params.get("p0")).isEqualTo(Map.of("touched", "yes"));
+    assertThat(params.get("p1")).isEqualTo("target");
+  }
+
+  @Test
+  void unsetStillSpellsFieldNamesAsQuotedIdentifiers() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    final Document unset = new Document("a", "").append("b.c", "");
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$unset", unset));
+
+    // SQL cannot bind a property name, so this half stays escaped - the #5575 contract must survive the change
+    assertThat(sql.toString()).isEqualTo(" REMOVE `a`, `b`.`c`");
+    assertThat(params).isEmpty();
+  }
+
+  @Test
+  void incStillBindsItsOperandAndQuotesItsFieldName() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$inc", new Document("count", 3)));
+
+    assertThat(sql.toString()).isEqualTo(" SET `count` += :p0");
+    assertThat(params.get("p0")).isEqualTo(3);
+  }
+
+  @Test
+  void aCraftedFieldNameInASetOperandCannotBreakOutOfTheStatement() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    // inside a bound map even the key is data, so it needs no quoting and cannot reach the parser at all
+    final String crafted = "x\": 1, \"admin";
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, new Document("$set", new Document(crafted, "v1")));
+
+    assertThat(sql.toString()).isEqualTo(" MERGE :p0");
+    assertThat(sql.toString()).doesNotContain("admin");
+    final Map<?, ?> bound = (Map<?, ?>) params.get("p0");
+    assertThat(bound).hasSize(1);
+    assertThat(bound.keySet().iterator().next()).isEqualTo(crafted);
+  }
+}

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateValueBindingTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBUpdateValueBindingTest.java
@@ -193,6 +193,21 @@ class MongoDBUpdateValueBindingTest {
   }
 
   @Test
+  void aCombinedSetAndIncUpdateChainsTwoOperationsOverOneParameterMap() {
+    final StringBuilder sql = new StringBuilder();
+    final Map<String, Object> params = new HashMap<>();
+
+    final Document u = new Document("$set", new Document("note", "v1")).append("$inc", new Document("count", 3));
+    MongoDBDatabaseWrapper.appendUpdateOperations(sql, params, u);
+
+    // the grammar takes updateOperation+, so the two clauses chain; the payload of the first must not swallow the
+    // SET keyword that opens the second
+    assertThat(sql.toString()).isEqualTo(" MERGE :p0 SET `count` += :p1");
+    assertThat(params.get("p0")).isEqualTo(Map.of("note", "v1"));
+    assertThat(params.get("p1")).isEqualTo(3);
+  }
+
+  @Test
   void aCraftedFieldNameInASetOperandCannotBreakOutOfTheStatement() {
     final StringBuilder sql = new StringBuilder();
     final Map<String, Object> params = new HashMap<>();


### PR DESCRIPTION
Closes #5583

Follow-up to #5579 / PR #5581. After #5581 every **filter** value is a bound SQL parameter, but the **update** values (`$set` and full replacement) were still spelled into the statement as a JSON literal, so their safety rested on `JSONObject.toString()` escaping being correct at that one call site. `MongoDBDatabaseWrapper.appendUpdateOperations` now binds them instead: `UPDATE ... MERGE :p<n>` and `UPDATE ... CONTENT :p<n>`, joining the filter values in the parameter map the method already receives. The BSON walk that fed `JSONObject`/`JSONArray` becomes a BSON -> `LinkedHashMap`/`ArrayList` walk, preserving the nested `Document`/`List` recursion and the `ObjectId` -> hex-string conversion exactly. With that, "unreachable by construction" covers the whole statement rather than just the `WHERE` clause and `$inc`.

## The open question the issue posed: can the grammar bind there?

**Yes, and no engine change was needed.** The issue flagged this as needing checking first and possibly being the bulk of the work.

`GlobalConfiguration` (line 474) records that the JavaCC parser is dead: *"Deprecated, has no effect. The ANTLR4-based SQL parser is always used."* `StatementCache` only ever calls `SQLAntlrParser.parse`, so the authority is `SQLParser.g4`:

```
    | MERGE expression
    | CONTENT (json | jsonArray | inputParameter)
```

- `MERGE expression` accepts `:p0` as an ordinary expression. `SQLASTBuilder.visitUpdateOperation` already detects that the expression is not a JSON literal and stores it in `UpdateOperations.expression`; `UpdateMergeStep.resolveExpression` resolves it and accepts a `Map` with String keys.
- `CONTENT ... inputParameter` is an explicit grammar alternative, handled by `UpdateContentStep` via `doc.fromMap(...)`.

The JavaCC `SqlParser.java` production still only accepts `Json()` after MERGE/CONTENT, but that parser is unreachable and there is no javacc plugin in the build (the generated file is checked in), so it was left alone rather than hand-edited.

## Deliberately unchanged

`$unset` and `$inc` **field names** stay on `quoteFieldPath()`. SQL cannot bind a property name, so that half of #5575 is untouched, same as in #5581. `$inc` already binds its operand.

## Side effect: value fidelity

Same class of latent defect #5581 uncovered on the filter path. Routing through `JSONObject` reshaped a value before it reached the record; binding hands the engine the original Java object. A `java.util.Date` now arrives as a `Date`, and a large `Double` no longer arrives in scientific notation. Neither was a security hole - `JSONObject` escapes correctly, and #5581 added round-trip tests proving it - but both were fidelity losses.

## Note on two existing tests

`aQuoteBearingValueSurvivesBeingSetByAnUpdate` and `aQuoteBearingValueSurvivesAFullReplacement` are unchanged in behaviour and assertions. Their **comments** were edited: each described the value as travelling "as a JSON literal", which this change makes false. Flagging it explicitly since the workflow otherwise leaves existing tests alone.

## Test plan

- [x] `mvn -pl mongodbw verify` - **67 tests green**, up from 52 (+12 unit, +3 wire)
- [x] New unit tests `MongoDBUpdateValueBindingTest` (12, no server) read the generated SQL directly and pin: `MERGE :p0` / `CONTENT :p0`; quote- and backslash-bearing values absent from the statement text; nested `Document` -> nested `Map`; `List` recursion including documents nested inside a list; `ObjectId` -> hex; `Date` bound as a `Date`; update and filter values sharing one placeholder numbering without collision; `$unset`/`$inc` field names still quoted; a crafted field name inside a `$set` operand being data rather than syntax
- [x] New wire-level tests in `MongoDBParameterBindingTest` (3, real server through the Mongo driver) round-trip a nested document and an array through `$set`, and a nested document through `replaceOne`. These are what prove the engine actually accepts `MERGE :p0` / `CONTENT :p0` at runtime, not just that the grammar file lists the alternatives
- [x] The two pre-existing round-trip tests the issue named stay green
- [x] **Red proven before the fix**: `appendUpdateOperations` was first made package-private `static` with its body still on `documentToJson`, and the new class run against it gave `Tests run: 12, Failures: 6, Errors: 4`. The 2 that passed are the two pinning deliberately-unchanged `$unset`/`$inc` behaviour, which must be green on both sides. The binding was applied only after that run
- [x] No engine module touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
