### PR TITLE
fix(engine) #5615: keep vectors the graph build leaves unreachable searchable via the delta scan

### DIFF
--- a/docs/5615-lsm-vector-missing-from-search.md
+++ b/docs/5615-lsm-vector-missing-from-search.md
@@ -88,6 +88,12 @@ In addition to the six already recorded on the issue:
 - Only the from-scratch path needs this. Vectors ingested through the live builder are already in the delta
   buffer from insertion, so an orphan there is served by the delta scan until a rebuild absorbs it.
 
+## Scope of the guarantee
+
+This restores "every committed vector is findable" **for the running session, until the next rebuild** - not
+unconditionally. The two gaps below are inherent to serving the recovery from an in-memory buffer, and both are
+bounded by the next rebuild re-detecting the orphan.
+
 ## Known limitations
 
 - **The recovery does not survive a restart.** `deltaVectors` is in-memory, so a restart drops the re-queued
@@ -122,3 +128,25 @@ mvn -pl engine test -Dtest='com.arcadedb.index.vector.*Test'   # 246 tests, 0 fa
 The concurrency reproducer is inherently probabilistic - its flake rate on unfixed code swung between 1 run in
 1 and 1 run in 10 - so a single clean run of it never proves anything on its own. The deterministic test is
 what pins the fix.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5633
+
+### Review cycles
+
+| Cycle | Head | Outcome |
+|---|---|---|
+| 1 | `ba5ff86` | Sentinel not excluded when re-queueing - **real**, fixed (`isDeletedSentinel` + test). Three further notes assessed and documented rather than coded. |
+| 2 | `4ce9ef6` | Main ask (exception storm in the level loop) rested on a **false premise** - `OnHeapGraphIndex.getNeighborsIterator` returns `EMPTY_NODE_ITERATOR` for an absent node, verified in bytecode, and the suggested `contains()` guard would add a lookup rather than remove one. Pushed back with evidence; corrected the misleading comment that caused it. Applied the entry-node null check and the level-union note. |
+| 3 | `b1eb6e4` | Restart gap - **real**; verified the precise mechanism (the staleness check needs `graphSize < ordinalMap.length`, and an orphan is counted in the graph) and documented it. Guarded the null neighbor iterator. |
+| 4 | `f8a494d` | No blockers. Softened the framing of the guarantee to match what is delivered. |
+
+### Follow-ups not taken here
+
+- **Upstream:** why `GraphIndexBuilder.build()` leaves a node unreferenced despite calling `cleanup()`.
+- **Separate defect, unfiled:** `GraphSearcherPool.borrow` calls `drain()` *before* publishing `pooledGraph` /
+  `pooledEpoch`, so a concurrent `release` reading the still-old matching pair can return a searcher bound to
+  the old graph to the idle queue. Needs two searching threads on one index, so it is not #5615.
+- **Possible enhancement:** a bounded self-heal (one deferred rebuild when orphans are found) if orphan counts
+  are ever observed to be large in practice.

--- a/docs/5615-lsm-vector-missing-from-search.md
+++ b/docs/5615-lsm-vector-missing-from-search.md
@@ -88,6 +88,19 @@ In addition to the six already recorded on the issue:
 - Only the from-scratch path needs this. Vectors ingested through the live builder are already in the delta
   buffer from insertion, so an orphan there is served by the delta scan until a rebuild absorbs it.
 
+## Known limitations
+
+- **The recovery does not survive a restart.** `deltaVectors` is in-memory, so a restart drops the re-queued
+  entries. The persisted graph still physically contains the orphan and reports the same node count as the
+  ordinal map, so the staleness check on load (`graphSize < ordinalMap.length`) sees an up-to-date graph and
+  the vector is unsearchable again until some mutation triggers a rebuild. Closing this would mean persisting
+  the orphan set alongside the graph; it is left open because the builder defect is rare and any rebuild
+  re-detects it.
+- **An idle index keeps scanning the re-queued entries.** Re-queueing does not bump `mutationsSinceSerialize`
+  (counting it would let an orphaned index rebuild itself forever), and the decrement at the end of a rebuild
+  may cancel the inactivity timer, so there is no self-scheduled rebuild to clear them until the next real
+  mutation.
+
 ## Tests
 
 - `LSMVectorIndexGraphConnectivityTest` - deterministic coverage of the detection primitive against graphs

--- a/docs/5615-lsm-vector-missing-from-search.md
+++ b/docs/5615-lsm-vector-missing-from-search.md
@@ -72,8 +72,8 @@ In addition to the six already recorded on the issue:
    snapshotted). Dead: `graphSize == mapLen` on every failure, and the miss survives a retry.
 2. **Stale searcher handed back across a graph swap.** `GraphSearcherPool.borrow` calls `drain()` *before*
    publishing `pooledGraph`/`pooledEpoch`, so a concurrent `release` reading the still-old matching pair can
-   re-pool a searcher bound to the old graph. This is a **real race worth filing separately**, but it is not
-   this bug - the reproducer has one searching thread per index.
+   re-pool a searcher bound to the old graph. A **real race, filed as #5648**, but not this bug - the
+   reproducer has one searching thread per index.
 3. **The build reads a sentinel vector.** `ArcadePageVectorValues.getVector` returns `deletedSentinelVector` on
    eight paths, three of them silent. Instrumented all three: zero hits on a failing run.
 
@@ -145,8 +145,9 @@ https://github.com/ArcadeData/arcadedb/pull/5633
 ### Follow-ups not taken here
 
 - **Upstream:** why `GraphIndexBuilder.build()` leaves a node unreferenced despite calling `cleanup()`.
-- **Separate defect, unfiled:** `GraphSearcherPool.borrow` calls `drain()` *before* publishing `pooledGraph` /
-  `pooledEpoch`, so a concurrent `release` reading the still-old matching pair can return a searcher bound to
-  the old graph to the idle queue. Needs two searching threads on one index, so it is not #5615.
+- **Separate defect, filed as #5648:** `GraphSearcherPool.borrow` calls `drain()` *before* publishing
+  `pooledGraph` / `pooledEpoch`, so a concurrent `release` reading the still-old matching pair can return a
+  searcher bound to the old graph to the idle queue. Needs two searching threads on one index, so it is not
+  #5615, but it produces the same silent wrong-result symptom.
 - **Possible enhancement:** a bounded self-heal (one deferred rebuild when orphans are found) if orphan counts
   are ever observed to be large in practice.

--- a/docs/5615-lsm-vector-missing-from-search.md
+++ b/docs/5615-lsm-vector-missing-from-search.md
@@ -77,12 +77,24 @@ In addition to the six already recorded on the issue:
 3. **The build reads a sentinel vector.** `ArcadePageVectorValues.getVector` returns `deletedSentinelVector` on
    eight paths, three of them silent. Instrumented all three: zero hits on a failing run.
 
+## Review notes
+
+- The walk runs on every rebuild, including the common no-orphan case: an O(V+E) pass plus a transient
+  `boolean[upper]` + `int[upper]`. It is off the write lock and bounded by the graph the build just produced,
+  which is far more expensive, so it is not worth pooling the arrays unless profiling says otherwise.
+- `getVector` never returns null - an unreadable ordinal comes back as the sentinel - so the recovery path
+  explicitly rejects the sentinel. The location check ahead of it cannot stand in: it reads the live index
+  rather than the build snapshot, and says nothing about the document-read failures that also yield a sentinel.
+- Only the from-scratch path needs this. Vectors ingested through the live builder are already in the delta
+  buffer from insertion, so an orphan there is served by the delta scan until a rebuild absorbs it.
+
 ## Tests
 
 - `LSMVectorIndexGraphConnectivityTest` - deterministic coverage of the detection primitive against graphs
   whose shape is fixed by the test: a fully connected chain, a node with out-edges and no in-edges, several
-  orphans at once, a disconnected cycle, and an empty graph. Stubbing `findUnreachableOrdinals` to a no-op
-  fails 3 of the 5, confirming they bind.
+  orphans at once, a disconnected cycle, and an empty graph, plus one case pinning that the sentinel is
+  distinguishable from a real vector. Stubbing `findUnreachableOrdinals` to a no-op fails 3 of the 6, and
+  stubbing `isDeletedSentinel` to `false` fails 1 more, confirming they bind.
 - `LSMVectorIndexConcurrentRebuildVisibilityTest` - the end-to-end reproducer, which on a miss now reports
   whether the vector is reachable from the entry node at all.
 
@@ -91,7 +103,7 @@ In addition to the six already recorded on the issue:
 ```
 mvn -pl engine test -Dtest=LSMVectorIndexGraphConnectivityTest
 mvn -pl engine test -Dtest=LSMVectorIndexConcurrentRebuildVisibilityTest -Dgroups=slow -DexcludedGroups=
-mvn -pl engine test -Dtest='com.arcadedb.index.vector.*Test'
+mvn -pl engine test -Dtest='com.arcadedb.index.vector.*Test'   # 246 tests, 0 failures
 ```
 
 The concurrency reproducer is inherently probabilistic - its flake rate on unfixed code swung between 1 run in

--- a/docs/5615-lsm-vector-missing-from-search.md
+++ b/docs/5615-lsm-vector-missing-from-search.md
@@ -1,0 +1,99 @@
+# #5615 - LSM vector index: a committed vector is intermittently missing from search
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5615
+
+## Root cause
+
+A graph rebuild occasionally emits an **orphan node**: a node that is present in the graph and carries a full
+set of outgoing edges, but has **zero incoming edges**. Beam search starts at the entry node and only ever
+follows edges forward, so an orphan can never be visited - at any `efSearch`, however good its score. The
+vector itself, the location index, the ordinal map and the scoring path are all correct, which is why every
+post-hoc diagnostic looked clean and why nine earlier theories all failed.
+
+## Evidence
+
+Reproducer: `LSMVectorIndexConcurrentRebuildVisibilityTest` (4 concurrent indexes,
+`VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD=8`, inactivity rebuild 1 ms). Instrumented to walk the graph at the
+moment of a miss, it reported:
+
+```
+batch 15: #1:8382 -> #1:6156
+  retryHit=false wideEfHit=false
+  rankProbe: expectedOrdinal=1500 expectedScore=1.0 betterScoring=0 bestOrdinal=1500 bestScore=1.0
+             graphSize=1600 mapLen=1600
+  reach:     entryNode=1050 visited=1599 ofUpperBound=1600
+             targetReachable=false targetInGraph=true targetOutDegree=32 targetInEdges=0
+```
+
+- `expectedScore=1.0`, `betterScoring=0` - scored through exactly the `ArcadePageVectorValues` the search
+  builds, the missing vector is the **globally best-scoring node**. The scoring input is not the problem.
+- `graphSize == mapLen` - graph and ordinal map agree, so this is not a publication tear.
+- `targetInEdges=0`, `visited=1599 of 1600` - BFS from the entry node reaches every node except this one.
+- `retryHit=false`, `wideEfHit=false` (efSearch=2000 against a 1600-node graph) - the miss is **stable**, not
+  a transient race in the read path. That single bit is what eliminated the remaining concurrency theories.
+
+A second probe placed directly after `builder.build(vectors)` closed the causal chain. On a failing run:
+
+```
+PROBE5615 ORPHANS index=Vec3_0_... count=3 of 800 upper=800 sample=252(deg=32) 257(deg=32) 258(deg=32)
+...
+batch 7: #10:250 -> #10:65 ... expectedOrdinal=258 ... targetInEdges=0
+```
+
+The build reported three orphans; the search then missed **ordinal 258**, one of those exact three. Passing
+runs reported zero orphan builds.
+
+Note `GraphIndexBuilder.build()` does call `cleanup()` (verified in the 4.0.0-rc.7 bytecode:
+`submit(addNodes) -> join -> cleanup`), and cleanup has connectivity machinery. It nonetheless leaves these
+nodes unreferenced under concurrent rebuild pressure.
+
+## The fix
+
+`LSMVectorIndex.findUnreachableOrdinals` walks every edge from the graph entry node after a build and returns
+the ordinals nothing reaches. `buildGraphFromScratchExclusively` re-queues those vectors into the delta buffer,
+where `mergeWithDeltaScan` - an exhaustive linear scan - keeps them searchable until the next rebuild wires
+them into the graph.
+
+Two details worth noting:
+
+- The walk and the vector reads run **before** the write lock is reacquired, so an O(V+E) traversal never
+  stalls concurrent searches.
+- Vectors at or past `deltaSnapshotId` are skipped: the existing trim already carries them over, and re-adding
+  them would score the same vector twice in the delta scan.
+
+Reachability is walked from the entry node rather than counted as in-degree, because a disconnected cycle gives
+every node an in-edge while remaining unreachable.
+
+## Theories eliminated (do not re-walk)
+
+In addition to the six already recorded on the issue:
+
+1. **Torn read of `graphIndex` inside the search** (read at several points after `ordinalToVectorId` is
+   snapshotted). Dead: `graphSize == mapLen` on every failure, and the miss survives a retry.
+2. **Stale searcher handed back across a graph swap.** `GraphSearcherPool.borrow` calls `drain()` *before*
+   publishing `pooledGraph`/`pooledEpoch`, so a concurrent `release` reading the still-old matching pair can
+   re-pool a searcher bound to the old graph. This is a **real race worth filing separately**, but it is not
+   this bug - the reproducer has one searching thread per index.
+3. **The build reads a sentinel vector.** `ArcadePageVectorValues.getVector` returns `deletedSentinelVector` on
+   eight paths, three of them silent. Instrumented all three: zero hits on a failing run.
+
+## Tests
+
+- `LSMVectorIndexGraphConnectivityTest` - deterministic coverage of the detection primitive against graphs
+  whose shape is fixed by the test: a fully connected chain, a node with out-edges and no in-edges, several
+  orphans at once, a disconnected cycle, and an empty graph. Stubbing `findUnreachableOrdinals` to a no-op
+  fails 3 of the 5, confirming they bind.
+- `LSMVectorIndexConcurrentRebuildVisibilityTest` - the end-to-end reproducer, which on a miss now reports
+  whether the vector is reachable from the entry node at all.
+
+## Verification
+
+```
+mvn -pl engine test -Dtest=LSMVectorIndexGraphConnectivityTest
+mvn -pl engine test -Dtest=LSMVectorIndexConcurrentRebuildVisibilityTest -Dgroups=slow -DexcludedGroups=
+mvn -pl engine test -Dtest='com.arcadedb.index.vector.*Test'
+```
+
+The concurrency reproducer is inherently probabilistic - its flake rate on unfixed code swung between 1 run in
+1 and 1 run in 10 - so a single clean run of it never proves anything on its own. The deterministic test is
+what pins the fix.

--- a/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
@@ -123,6 +123,15 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
     this.deletedSentinelVector = createDeletedSentinelVector(dimensions);
   }
 
+  /**
+   * Whether this is the placeholder handed back for a vector that could not be read. {@link #getVector} never
+   * returns null - a deleted, missing or unreadable ordinal yields the sentinel so JVector's traversal does not
+   * NPE (issue #3715) - so a caller that needs a genuine vector has to ask.
+   */
+  boolean isDeletedSentinel(final VectorFloat<?> vector) {
+    return vector == deletedSentinelVector;
+  }
+
   @Override
   public int size() {
     return ordinalToVectorId != null ? ordinalToVectorId.length : 0;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -68,6 +68,7 @@ import com.arcadedb.utility.RidHashSet;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.NodesIterator;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
@@ -1396,6 +1397,72 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Using a per-index pool allows us to cancel long-running builds on shutdown
    * by calling shutdownNow() on this pool.
    */
+  /**
+   * Ordinals that no path from the entry node reaches. Beam search only ever follows edges forward from the entry
+   * node, so such a node can never be returned no matter how wide the beam - the graph build occasionally leaves one
+   * with a full out-degree and no in-edges (issue #5615). Callers keep those vectors searchable through the delta
+   * scan instead.
+   *
+   * @return the unreachable ordinals, empty when every node is reachable
+   */
+  int[] findUnreachableOrdinals(final ImmutableGraphIndex graph) {
+    try (final ImmutableGraphIndex.View view = graph.getView()) {
+      final int upper = graph.getIdUpperBound();
+      if (upper <= 0)
+        return EMPTY_ORDINALS;
+
+      final boolean[] reached = new boolean[upper];
+      final int[] queue = new int[upper];
+      int head = 0, tail = 0;
+
+      final int entry = view.entryNode().node;
+      if (entry < 0 || entry >= upper)
+        return EMPTY_ORDINALS;
+      reached[entry] = true;
+      queue[tail++] = entry;
+
+      final int maxLevel = graph.getMaxLevel();
+      while (head < tail) {
+        final int node = queue[head++];
+        for (int level = 0; level <= maxLevel; level++) {
+          final NodesIterator neighbors;
+          try {
+            neighbors = view.getNeighborsIterator(level, node);
+          } catch (final Exception e) {
+            // A node absent from this level is normal in a hierarchical graph.
+            continue;
+          }
+          while (neighbors.hasNext()) {
+            final int next = neighbors.nextInt();
+            if (next >= 0 && next < upper && !reached[next]) {
+              reached[next] = true;
+              queue[tail++] = next;
+            }
+          }
+        }
+      }
+
+      int unreachable = 0;
+      for (int node = 0; node < upper; node++)
+        if (!reached[node] && graph.containsNode(node))
+          unreachable++;
+
+      if (unreachable == 0)
+        return EMPTY_ORDINALS;
+
+      final int[] result = new int[unreachable];
+      int i = 0;
+      for (int node = 0; node < upper; node++)
+        if (!reached[node] && graph.containsNode(node))
+          result[i++] = node;
+      return result;
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Could not verify graph connectivity for index %s: %s", indexName, e.getMessage());
+      return EMPTY_ORDINALS;
+    }
+  }
+
   private synchronized ForkJoinPool getOrCreateGraphBuildPool() {
     ForkJoinPool pool = graphBuildPool;
     if (pool == null || pool.isShutdown()) {
@@ -1987,6 +2054,31 @@ public class LSMVectorIndex implements Index, IndexInternal {
         throw e;
       }
 
+      // The build occasionally leaves a node with a full out-degree and no in-edges, which no beam search can reach
+      // at any efSearch (issue #5615). Collect those vectors here, before the write lock, so neither the O(V+E)
+      // walk nor the vector reads stall concurrent searches; they are re-queued into the delta buffer below and
+      // stay searchable through the delta scan until the next rebuild wires them into the graph.
+      final List<DeltaVectorEntry> unreachableEntries = new ArrayList<>();
+      for (final int ordinal : findUnreachableOrdinals(builtGraph)) {
+        if (ordinal >= finalActiveVectorIds.length)
+          continue;
+        final int vectorId = finalActiveVectorIds[ordinal];
+        // Anything at or past the snapshot is already carried over by the trim below; re-adding it here would
+        // score the same vector twice in the delta scan.
+        if (vectorId >= deltaSnapshotId)
+          continue;
+        final VectorLocationIndex.VectorLocation loc = vectorIndex.getLocation(vectorId);
+        if (loc == null || loc.deleted)
+          continue;
+        final VectorFloat<?> vector = vectors.getVector(ordinal);
+        if (vector != null)
+          unreachableEntries.add(new DeltaVectorEntry(vectorId, loc.rid, vector));
+      }
+      if (!unreachableEntries.isEmpty())
+        LogManager.instance().log(this, Level.WARNING,
+            "Graph build left %d of %d vectors unreachable for index %s: serving them from the delta scan until the "
+                + "next rebuild", unreachableEntries.size(), finalActiveVectorIds.length, indexName);
+
       // Reacquire write lock to update graph state
       lock.writeLock().lock();
       try {
@@ -2001,6 +2093,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
         for (final DeltaVectorEntry e : deltaVectors)
           if (e.vectorId >= deltaSnapshotId)
             remaining.add(e);
+
+        remaining.addAll(unreachableEntries);
+
         this.deltaVectors = remaining;
 
         // Subtract only mutations present at build start, preserving concurrent ones
@@ -2412,6 +2507,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Above this threshold, a full rebuild can take seconds to minutes, so async is preferred.
    */
   private static final int ASYNC_REBUILD_MIN_GRAPH_SIZE = 1000;
+  private static final int[] EMPTY_ORDINALS             = new int[0];
 
   /**
    * Check if the graph needs rebuilding before a search, and trigger the appropriate rebuild strategy.

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1402,6 +1402,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * node, so such a node can never be returned no matter how wide the beam - the graph build occasionally leaves one
    * with a full out-degree and no in-edges (issue #5615). Callers keep those vectors searchable through the delta
    * scan instead.
+   * <p>
+   * The walk unions the edges of every level, while a search descends the levels before beam-searching level 0.
+   * Union-reachability is therefore a superset of what a search can reach: this never invents an orphan, but a node
+   * reachable only through a higher-level in-edge is not reported. That suits the observed defect, which is a node
+   * with no in-edges at any level, and keeps the check conservative - a false orphan would cost a duplicate delta
+   * entry on every search.
    *
    * @return the unreachable ordinals, empty when every node is reachable
    */
@@ -1415,7 +1421,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final int[] queue = new int[upper];
       int head = 0, tail = 0;
 
-      final int entry = view.entryNode().node;
+      final ImmutableGraphIndex.NodeAtLevel entryNode = view.entryNode();
+      if (entryNode == null) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Graph for index %s has no entry node, skipping the connectivity check", indexName);
+        return EMPTY_ORDINALS;
+      }
+      final int entry = entryNode.node;
       if (entry < 0 || entry >= upper)
         return EMPTY_ORDINALS;
       reached[entry] = true;
@@ -1427,9 +1439,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
         for (int level = 0; level <= maxLevel; level++) {
           final NodesIterator neighbors;
           try {
+            // A node absent from a level yields an empty iterator rather than an exception
+            // (OnHeapGraphIndex.getNeighborsIterator returns EMPTY_NODE_ITERATOR for both an out-of-range level
+            // and an unmapped node), so this walks the levels without paying for control flow. The catch only
+            // guards View implementations that choose to throw instead.
             neighbors = view.getNeighborsIterator(level, node);
           } catch (final Exception e) {
-            // A node absent from this level is normal in a hierarchical graph.
             continue;
           }
           while (neighbors.hasNext()) {

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1447,6 +1447,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
           } catch (final Exception e) {
             continue;
           }
+          // Skip one node rather than letting an NPE unwind to the outer catch, which would abandon the walk and
+          // silently treat every remaining node as reachable.
+          if (neighbors == null)
+            continue;
           while (neighbors.hasNext()) {
             final int next = neighbors.nextInt();
             if (next >= 0 && next < upper && !reached[next]) {
@@ -2079,8 +2083,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // rebuild absorbs it - at which point this check runs over it.
       //
       // Re-queueing deliberately does not bump mutationsSinceSerialize: a re-queued vector is not a mutation, and
-      // counting it would let an index whose last build orphaned a node rebuild itself forever. The cost is that
-      // on an otherwise idle index those entries are scanned by every search until the next real mutation.
+      // counting it would let an index whose last build orphaned a node rebuild itself forever. Two consequences,
+      // both accepted:
+      //  - the decrement just above may take the counter to zero and cancel the inactivity rebuild timer, so an
+      //    otherwise idle index has no self-scheduled path out of scanning these entries until the next real
+      //    mutation. That is the price of not spinning on rebuilds;
+      //  - deltaVectors is in-memory, so a restart drops the re-queue. The persisted graph still physically holds
+      //    the orphan and reports the same node count as the ordinal map, so the staleness check on load sees an
+      //    up-to-date graph and the vector is unsearchable again until some mutation triggers a rebuild. Closing
+      //    that would mean persisting the orphan set; it is left open because any rebuild re-detects it.
       final List<DeltaVectorEntry> unreachableEntries = new ArrayList<>();
       for (final int ordinal : findUnreachableOrdinals(builtGraph)) {
         if (ordinal >= finalActiveVectorIds.length)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2058,6 +2058,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // at any efSearch (issue #5615). Collect those vectors here, before the write lock, so neither the O(V+E)
       // walk nor the vector reads stall concurrent searches; they are re-queued into the delta buffer below and
       // stay searchable through the delta scan until the next rebuild wires them into the graph.
+      //
+      // Only the from-scratch build needs this. Vectors ingested through the live builder are already in the
+      // delta buffer from the moment they are inserted, so an orphan there is served by the delta scan until a
+      // rebuild absorbs it - at which point this check runs over it.
+      //
+      // Re-queueing deliberately does not bump mutationsSinceSerialize: a re-queued vector is not a mutation, and
+      // counting it would let an index whose last build orphaned a node rebuild itself forever. The cost is that
+      // on an otherwise idle index those entries are scanned by every search until the next real mutation.
       final List<DeltaVectorEntry> unreachableEntries = new ArrayList<>();
       for (final int ordinal : findUnreachableOrdinals(builtGraph)) {
         if (ordinal >= finalActiveVectorIds.length)
@@ -2070,9 +2078,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
         final VectorLocationIndex.VectorLocation loc = vectorIndex.getLocation(vectorId);
         if (loc == null || loc.deleted)
           continue;
+        // getVector() resolves the location through the build snapshot and never returns null: an unreadable
+        // ordinal comes back as the sentinel, which would pair a real RID with a meaningless distance in the
+        // delta scan. The location check above cannot stand in for this - it reads the live index, not the
+        // snapshot, and says nothing about the six document-read failures that also yield the sentinel.
         final VectorFloat<?> vector = vectors.getVector(ordinal);
-        if (vector != null)
-          unreachableEntries.add(new DeltaVectorEntry(vectorId, loc.rid, vector));
+        if (vector == null || (vectors instanceof final ArcadePageVectorValues pageValues
+            && pageValues.isDeletedSentinel(vector)))
+          continue;
+        unreachableEntries.add(new DeltaVectorEntry(vectorId, loc.rid, vector));
       }
       if (!unreachableEntries.isEmpty())
         LogManager.instance().log(this, Level.WARNING,

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexConcurrentRebuildVisibilityTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexConcurrentRebuildVisibilityTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.Pair;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.NodesIterator;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A committed vector stays reachable while several indexes rebuild concurrently (issue #5615).
+ * <p>
+ * Every rebuild in the JVM serializes on one permit of {@code REBUILD_SEMAPHORE}, so a single index in isolation
+ * never experiences the contention the Python bindings suite does, where many indexes live in one JVM. This drives
+ * several indexes at once.
+ * <p>
+ * The defect this guards against is a graph build that emits a node with a full set of outgoing edges and no
+ * incoming ones. Beam search only ever walks edges forward from the entry node, so such a node can never be
+ * returned however good its score - the miss is stable across retries and survives any {@code efSearch}. On a miss
+ * the test therefore reports whether the vector is reachable from the entry node at all, which is what separates
+ * this from ordinary ANN recall.
+ */
+@Tag("slow")
+class LSMVectorIndexConcurrentRebuildVisibilityTest extends TestHelper {
+
+  private static final int EMBEDDING_DIM = 32;
+  private static final int INDEXES       = 4;
+  private static final int BATCHES       = 20;
+  private static final int BATCH         = 100;
+
+  @Test
+  void committedVectorsStayReachableWhileIndexesRebuild() throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, 8);
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 1);
+
+    for (int t = 0; t < INDEXES; t++) {
+      final String typeName = "Vec" + t;
+      database.transaction(() -> {
+        database.getSchema().createDocumentType(typeName);
+        database.getSchema().getType(typeName).createProperty("vector", Type.ARRAY_OF_FLOATS);
+        database.command("sql", """
+            CREATE INDEX ON %s (vector) LSM_VECTOR
+            METADATA {
+                "dimensions": %d,
+                "similarity": "EUCLIDEAN"
+            }""".formatted(typeName, EMBEDDING_DIM));
+      });
+    }
+
+    final List<String> misses = new CopyOnWriteArrayList<>();
+    final ExecutorService executor = Executors.newFixedThreadPool(INDEXES);
+    final CountDownLatch start = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(INDEXES);
+
+    for (int t = 0; t < INDEXES; t++) {
+      final String typeName = "Vec" + t;
+      final long seed = 1000L + t;
+      executor.submit(() -> {
+        try {
+          start.await();
+          driveOneIndex(typeName, seed, misses);
+        } catch (final Exception e) {
+          misses.add(typeName + " thread failed: " + e);
+        } finally {
+          done.countDown();
+        }
+      });
+    }
+
+    start.countDown();
+    assertThat(done.await(10, TimeUnit.MINUTES)).as("writers finished").isTrue();
+    executor.shutdownNow();
+
+    assertThat(misses).as("every committed vector must stay reachable while other indexes rebuild").isEmpty();
+  }
+
+  private void driveOneIndex(final String typeName, final long seed, final List<String> misses) {
+    final Random random = new Random(seed);
+    final Map<RID, float[]> committed = new LinkedHashMap<>();
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName(typeName + "[vector]");
+    final LSMVectorIndex index = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    for (int batch = 0; batch < BATCHES && misses.isEmpty(); batch++) {
+      final List<float[]> pending = new ArrayList<>(BATCH);
+      for (int i = 0; i < BATCH; i++)
+        pending.add(randomVector(random));
+
+      database.transaction(() -> {
+        for (final float[] vector : pending) {
+          final var doc = database.newDocument(typeName);
+          doc.set("vector", vector);
+          doc.save();
+          committed.put(doc.getIdentity(), vector);
+        }
+      });
+
+      for (final Map.Entry<RID, float[]> e : committed.entrySet()) {
+        final List<Pair<RID, Float>> hits = index.findNeighborsFromVector(e.getValue(), 1);
+        if (hits.isEmpty() || !hits.getFirst().getFirst().equals(e.getKey())) {
+          misses.add(typeName + " batch " + batch + ": " + e.getKey() + " -> "
+              + (hits.isEmpty() ? "no hit" : hits.getFirst().getFirst().toString()) + " | " + diagnose(index, e.getKey()));
+          return;
+        }
+      }
+    }
+  }
+
+  /**
+   * Where the engine believes this RID lives, and whether the graph can reach it at all. A miss reported with
+   * {@code reachableFromEntry=false} is the orphaned-node defect; one reported with {@code true} is something new
+   * and should not be assumed to be the same bug.
+   */
+  private static String diagnose(final LSMVectorIndex index, final RID rid) {
+    try {
+      final VectorLocationIndex locations = readField(index, "vectorIndex");
+      final int[] vectorIds = locations.getVectorIdsForRid(rid);
+
+      // DeltaVectorEntry is a private nested class, so its elements are inspected reflectively too.
+      final List<?> delta = readField(index, "deltaVectors");
+      boolean inDelta = false;
+      for (final Object entry : delta) {
+        final Field ridField = entry.getClass().getDeclaredField("rid");
+        ridField.setAccessible(true);
+        if (rid.equals(ridField.get(entry))) {
+          inDelta = true;
+          break;
+        }
+      }
+
+      final int[] ordinalMap = readField(index, "ordinalToVectorId");
+      int ordinal = -1;
+      if (ordinalMap != null)
+        for (int o = 0; o < ordinalMap.length && ordinal < 0; o++)
+          for (final int vectorId : vectorIds)
+            if (ordinalMap[o] == vectorId) {
+              ordinal = o;
+              break;
+            }
+
+      final ImmutableGraphIndex graph = readField(index, "graphIndex");
+
+      return "vectorIds=" + java.util.Arrays.toString(vectorIds) + " inDelta=" + inDelta + " ordinal=" + ordinal
+          + " deltaSize=" + delta.size() + " ordinalMapSize=" + (ordinalMap == null ? -1 : ordinalMap.length)
+          + " graphSize=" + (graph == null ? -1 : graph.size())
+          + " reachableFromEntry=" + (graph == null || ordinal < 0 ? "n/a" : reachable(graph, ordinal));
+    } catch (final Exception e) {
+      return "diagnostics unavailable: " + e;
+    }
+  }
+
+  /**
+   * Walks every edge from the graph entry node. Beam search can only ever return what this walk visits.
+   */
+  private static boolean reachable(final ImmutableGraphIndex graph, final int target) {
+    try (final ImmutableGraphIndex.View view = graph.getView()) {
+      final int upper = graph.getIdUpperBound();
+      if (target < 0 || target >= upper)
+        return false;
+
+      final boolean[] seen = new boolean[upper];
+      final ArrayDeque<Integer> queue = new ArrayDeque<>();
+      final int entry = view.entryNode().node;
+      seen[entry] = true;
+      queue.add(entry);
+
+      while (!queue.isEmpty()) {
+        final int node = queue.poll();
+        for (int level = 0; level <= graph.getMaxLevel(); level++) {
+          final NodesIterator neighbors;
+          try {
+            neighbors = view.getNeighborsIterator(level, node);
+          } catch (final Exception ignored) {
+            continue;
+          }
+          while (neighbors.hasNext()) {
+            final int next = neighbors.nextInt();
+            if (next >= 0 && next < upper && !seen[next]) {
+              seen[next] = true;
+              queue.add(next);
+            }
+          }
+        }
+      }
+      return seen[target];
+    } catch (final Exception e) {
+      return false;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T readField(final LSMVectorIndex index, final String name) throws Exception {
+    final Field field = LSMVectorIndex.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return (T) field.get(index);
+  }
+
+  private static float[] randomVector(final Random random) {
+    final float[] vector = new float[EMBEDDING_DIM];
+    for (int i = 0; i < EMBEDDING_DIM; i++)
+      vector[i] = random.nextFloat() * 100.0f;
+    return vector;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphConnectivityTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphConnectivityTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Type;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.NodesIterator;
+import io.github.jbellis.jvector.util.Bits;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unreachable-node detection, the primitive behind the fix for issue #5615.
+ * <p>
+ * A graph build occasionally emits a node carrying a full set of outgoing edges and no incoming ones. Beam search
+ * only ever walks edges forward from the entry node, so such a node can never be returned at any {@code efSearch},
+ * however good its score. The engine detects those nodes after a build and keeps their vectors reachable through
+ * the delta scan; this pins the detection itself against graphs whose shape is known exactly, which the
+ * concurrency reproducer cannot do.
+ *
+ * @see LSMVectorIndexConcurrentRebuildVisibilityTest
+ */
+class LSMVectorIndexGraphConnectivityTest extends TestHelper {
+
+  @Test
+  void everyNodeReachableFromEntryReportsNoOrphans() {
+    // 0 -> 1 -> 2 -> 3, entry 0. Every node is on the path.
+    final int[][] edges = { { 1 }, { 2 }, { 3 }, {} };
+
+    assertThat(index().findUnreachableOrdinals(new FixedGraph(edges, 0))).isEmpty();
+  }
+
+  @Test
+  void nodeWithOutgoingEdgesButNoIncomingIsReportedUnreachable() {
+    // 2 points at 0 and 1 but nothing points at 2 - exactly the shape observed on issue #5615.
+    final int[][] edges = { { 1 }, { 0 }, { 0, 1 } };
+
+    assertThat(index().findUnreachableOrdinals(new FixedGraph(edges, 0))).containsExactly(2);
+  }
+
+  @Test
+  void severalOrphansAreAllReported() {
+    final int[][] edges = { { 1 }, { 0 }, { 0 }, { 1 }, {} };
+
+    assertThat(index().findUnreachableOrdinals(new FixedGraph(edges, 0))).containsExactly(2, 3, 4);
+  }
+
+  @Test
+  void aDisconnectedCycleIsUnreachableEvenThoughEveryNodeHasIncomingEdges() {
+    // 2 <-> 3 is a closed pair: both have an in-edge, neither is reachable from entry 0. An in-degree count
+    // would call this healthy, which is why reachability is walked from the entry node instead.
+    final int[][] edges = { { 1 }, { 0 }, { 3 }, { 2 } };
+
+    assertThat(index().findUnreachableOrdinals(new FixedGraph(edges, 0))).containsExactly(2, 3);
+  }
+
+  @Test
+  void anEmptyGraphReportsNothing() {
+    assertThat(index().findUnreachableOrdinals(new FixedGraph(new int[0][], 0))).isEmpty();
+  }
+
+  private LSMVectorIndex index() {
+    database.transaction(() -> {
+      if (!database.getSchema().existsType("Probe")) {
+        database.getSchema().createDocumentType("Probe");
+        database.getSchema().getType("Probe").createProperty("vector", Type.ARRAY_OF_FLOATS);
+        database.command("sql", """
+            CREATE INDEX ON Probe (vector) LSM_VECTOR
+            METADATA { "dimensions": 4, "similarity": "EUCLIDEAN" }""");
+      }
+    });
+    final var typeIndex = database.getSchema().getIndexByName("Probe[vector]");
+    return (LSMVectorIndex) ((TypeIndex) typeIndex).getIndexesOnBuckets()[0];
+  }
+
+  /**
+   * A flat graph whose adjacency is fixed by the test. Only the members the reachability walk touches are
+   * implemented; anything else throws so an unnoticed dependency cannot pass silently.
+   */
+  private record FixedGraph(int[][] edges, int entry) implements ImmutableGraphIndex {
+
+    @Override
+    public ImmutableGraphIndex.View getView() {
+      return new View() {
+        @Override
+        public NodesIterator getNeighborsIterator(final int level, final int node) {
+          return new NodesIterator.ArrayNodesIterator(edges[node]);
+        }
+
+        @Override
+        public void processNeighbors(final int a, final int b, final io.github.jbellis.jvector.graph.similarity.ScoreFunction f,
+            final IntMarker m, final NeighborProcessor p) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int size() {
+          return edges.length;
+        }
+
+        @Override
+        public NodeAtLevel entryNode() {
+          return edges.length == 0 ? null : new NodeAtLevel(0, entry);
+        }
+
+        @Override
+        public Bits liveNodes() {
+          return Bits.ALL;
+        }
+
+        @Override
+        public boolean contains(final int level, final int node) {
+          return level == 0 && node >= 0 && node < edges.length;
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+
+    @Override
+    public int size() {
+      return edges.length;
+    }
+
+    @Override
+    public int getIdUpperBound() {
+      return edges.length;
+    }
+
+    @Override
+    public boolean containsNode(final int node) {
+      return node >= 0 && node < edges.length;
+    }
+
+    @Override
+    public int getMaxLevel() {
+      return 0;
+    }
+
+    @Override
+    public boolean isHierarchical() {
+      return false;
+    }
+
+    @Override
+    public int getDegree(final int node) {
+      return edges[node].length;
+    }
+
+    @Override
+    public NodesIterator getNodes(final int level) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int maxDegree() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Integer> maxDegrees() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getDimension() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double getAverageDegree(final int level) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int size(final int level) {
+      return edges.length;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphConnectivityTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphConnectivityTest.java
@@ -19,11 +19,14 @@
 package com.arcadedb.index.vector;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.Type;
 import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.NodesIterator;
 import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -78,6 +81,28 @@ class LSMVectorIndexGraphConnectivityTest extends TestHelper {
   @Test
   void anEmptyGraphReportsNothing() {
     assertThat(index().findUnreachableOrdinals(new FixedGraph(new int[0][], 0))).isEmpty();
+  }
+
+  /**
+   * An unreadable ordinal must not be re-queued into the delta buffer. {@code getVector} never returns null - it
+   * hands back a sentinel - so the recovery path has to ask whether the vector is real, otherwise it pairs a
+   * genuine RID with a meaningless distance and the delta scan reports a hit at the wrong distance.
+   */
+  @Test
+  void theSentinelIsDistinguishableFromARealVector() {
+    final VectorLocationIndex locations = new VectorLocationIndex();
+    final ArcadePageVectorValues values = new ArcadePageVectorValues((DatabaseInternal) database, 4, "vector", locations, new int[] { 7 });
+
+    // Ordinal 0 maps to vectorId 7, which has no location at all, so the read cannot succeed.
+    final VectorFloat<?> unreadable = values.getVector(0);
+    assertThat(unreadable).as("getVector never returns null").isNotNull();
+    assertThat(values.isDeletedSentinel(unreadable)).as("an unreadable ordinal yields the sentinel").isTrue();
+
+    // Anything out of range is the sentinel too, and a genuine vector is not.
+    assertThat(values.isDeletedSentinel(values.getVector(99))).isTrue();
+    assertThat(values.isDeletedSentinel(
+        VectorizationProvider.getInstance().getVectorTypeSupport().createFloatVector(new float[] { 1, 2, 3, 4 })))
+        .as("a real vector is not the sentinel").isFalse();
   }
 
   private LSMVectorIndex index() {


### PR DESCRIPTION
Closes #5615

## Root cause

A graph rebuild occasionally emits an **orphan node**: present in the graph and carrying a full set of outgoing edges, but with **zero incoming edges**. Beam search starts at the entry node and only ever follows edges forward, so an orphan can never be visited - at any `efSearch`, however good its score. The vector, the location index, the ordinal map and the scoring path are all correct, which is why the symptom looked like a delta-retention or publication race for so long and why nine earlier theories all failed.

Instrumenting the reproducer to walk the graph at the moment of a miss:

```
batch 15: #1:8382 -> #1:6156
  retryHit=false wideEfHit=false
  rankProbe: expectedOrdinal=1500 expectedScore=1.0 betterScoring=0 bestOrdinal=1500 bestScore=1.0
             graphSize=1600 mapLen=1600
  reach:     entryNode=1050 visited=1599 ofUpperBound=1600
             targetReachable=false targetInGraph=true targetOutDegree=32 targetInEdges=0
```

The missing vector is the globally best-scoring node (`betterScoring=0`), graph and ordinal map agree on size, and a BFS from the entry node reaches 1599 of 1600 nodes - every one except this. `retryHit=false` and `wideEfHit=false` (efSearch=2000 against a 1600-node graph) show the miss is stable rather than a transient read-path race.

A second probe placed directly after `builder.build(vectors)` closed the chain: on a failing run the build reported `ORPHANS count=3 sample=252(deg=32) 257(deg=32) 258(deg=32)` and the search then missed ordinal **258**, one of those three. Passing runs reported zero orphan builds.

`GraphIndexBuilder.build()` does call `cleanup()` (verified in the 4.0.0-rc.7 bytecode: `submit(addNodes) -> join -> cleanup`), and cleanup has connectivity machinery. It nonetheless leaves these nodes unreferenced under concurrent rebuild pressure.

## The change

`findUnreachableOrdinals` walks every edge from the graph entry node after a build and returns the ordinals nothing reaches. `buildGraphFromScratchExclusively` re-queues those vectors into the delta buffer, where `mergeWithDeltaScan` - an exhaustive linear scan - keeps them searchable until the next rebuild wires them into the graph.

- The walk and the vector reads run **before** the write lock is reacquired, so an O(V+E) traversal never stalls concurrent searches.
- Vectors at or past `deltaSnapshotId` are skipped: the existing trim already carries them over, and re-adding them would score the same vector twice in the delta scan.
- Reachability is walked from the entry node rather than counted as in-degree, because a disconnected cycle gives every node an in-edge while remaining unreachable.

This is a safety net at the ArcadeDB layer that restores the "every committed vector is findable" guarantee. It does not address why the builder produces the orphan, which is worth reporting upstream.

## Test plan

- [x] `LSMVectorIndexGraphConnectivityTest` - 5 deterministic cases against graphs whose shape is fixed by the test: a connected chain, a node with out-edges and no in-edges, several orphans at once, a disconnected cycle, and an empty graph. Stubbing `findUnreachableOrdinals` to a no-op fails 3 of the 5, confirming they bind.
- [x] `LSMVectorIndexConcurrentRebuildVisibilityTest` - the end-to-end reproducer, which on a miss now reports whether the vector is reachable from the entry node at all.
- [x] `mvn -pl engine test -Dtest='com.arcadedb.index.vector.*Test'` - 245 tests, 0 failures, 0 errors.

Note the concurrency reproducer is inherently probabilistic: its flake rate on unfixed code swung between 1 run in 1 and 1 run in 10, so a single clean run of it proves little on its own. The deterministic test is what pins the fix.