### PR TITLE
fix(studio) #5580: carry schema names in data-* attributes instead of inline onclick handlers

### DIFF
--- a/docs/5580-studio-inline-onclick-data-attributes.md
+++ b/docs/5580-studio-inline-onclick-data-attributes.md
@@ -114,6 +114,23 @@ two things most likely to have silently sunk the approach: that single-quoted at
 The bot noted it could not execute `node --test` in its sandbox and read the tests instead of running them.
 The 41/41 result is reproduced locally, and the revert-one-renderer falsification check is recorded above.
 
+### Cycle 2 - `6d83c305b`
+
+**LGTM** again, with four non-blocking observations. Three of them (icon clicks inside buttons dispatching
+via `this` rather than `event.target`; `preventDefault` without `stopPropagation`; the `change` handler
+correctly omitting `preventDefault` so the native `<select>` dropdown still opens) were confirmations that
+the current behaviour is right, not requests to change it.
+
+The fourth was worth acting on: because the dispatch is bound to `document`, the `data-action` values form a
+page-wide namespace, and a future control elsewhere in Studio reusing one of these names would be routed
+here too. **Applied** - the registry comment now spells that out for the next contributor.
+
+### Unrelated CI
+
+`Meterian Scanner workflow` fails on this branch, and also on the five most recent `main` commits. This
+change touches no dependency manifest (only `studio-database.js`, two test files and this doc), so the
+failure is pre-existing and unrelated. `Studio Security Audit` passes.
+
 ## Out of scope / follow-ups
 
 - `restoreBackupAction` / `deleteBackupAction` (backup file names) and `updateDatabaseSetting` (setting

--- a/docs/5580-studio-inline-onclick-data-attributes.md
+++ b/docs/5580-studio-inline-onclick-data-attributes.md
@@ -63,9 +63,11 @@ boolean, so a type legitimately named `123` or `true` would reach `quoteSqlName(
 The repartition button from #4087 was folded into the same mechanism, and its bespoke
 `.js-repartition-btn` wiring removed, so the file now has exactly one pattern.
 
-Section-header buttons (`createType`, `createMaterializedView`, `createGraphAnalyticalView`,
-`createTimeSeriesType`) keep their inline `onclick`: they pass no argument, so they never enter the
-nested-context problem. The tests assert this distinction rather than banning `onclick` outright.
+Section-header buttons keep their inline `onclick`, because none of them carries a user-controlled name.
+`createTimeSeriesType()`, `createMaterializedView()` and `createGraphAnalyticalView()` pass no argument at
+all. `createType(sec.key)` does pass one, but `sec.key` is a fixed section constant from the hardcoded
+`sections` array (`vertex` / `edge` / `document`), never schema-derived, so it cannot contain a quote. The
+tests assert the no-argument shape on the renderers they cover rather than banning `onclick` outright.
 
 Small extractions were made so the generated HTML is reachable from tests without a DOM:
 `renderTypeLink`, `renderTypeSidebarBadge` (which also de-duplicates two near-identical badge loops),
@@ -124,6 +126,22 @@ the current behaviour is right, not requests to change it.
 The fourth was worth acting on: because the dispatch is bound to `document`, the `data-action` values form a
 page-wide namespace, and a future control elsewhere in Studio reusing one of these names would be routed
 here too. **Applied** - the registry comment now spells that out for the next contributor.
+
+### Cycle 3 - `664bcbb1d`
+
+**LGTM**, with four minor notes. Two were acted on:
+
+- `schemaActionAttrs` does not escape its `action` parameter. Safe today because every caller passes a
+  string literal, and the registry-coverage test fails at CI if that ever changes - but the assumption was
+  undocumented. **Applied** as a comment.
+- The writeup claimed section-header buttons "pass no argument". Checked against the code: **the bot is
+  right and the claim was inaccurate**. `createType(sec.key)` at `studio-database.js:3497` does pass one.
+  It is benign - `sec.key` is a fixed constant from the hardcoded `sections` array, never schema-derived -
+  but the blanket statement was wrong. **Corrected** above and in the PR description.
+
+The other two (delete the dead `renderMaterializedViewsSidebarSection`; open a tracking issue for the
+`studio-security.js` `.data()` coercion) are follow-ups outside this change. No issue was filed, since
+opening one is outside this task's mandate - see the list below.
 
 ### Unrelated CI
 

--- a/docs/5580-studio-inline-onclick-data-attributes.md
+++ b/docs/5580-studio-inline-onclick-data-attributes.md
@@ -93,6 +93,27 @@ its extraction harness because `renderIndexes` now calls `schemaActionAttrs`; no
 22 rendered controls fired their handler and delivered the name ``a"b'c`d\e<f>&g`` byte-exact, with zero
 corrupted arguments. The same page confirms the pre-fix spelling raises a `SyntaxError` and never fires.
 
+## Review cycles
+
+PR: https://github.com/ArcadeData/arcadedb/pull/5634
+
+### Cycle 1 - `36a3cb88d`
+
+`claude[bot]` reviewed and concluded **LGTM**, with four non-blocking notes. It independently confirmed the
+two things most likely to have silently sunk the approach: that single-quoted attributes are safe because
+`escapeHtml` escapes `'` as `&#039;`, and that the two-name argument order (`dropProperty(type, property)`,
+`dropIndex(index, type)`) is preserved at every converted site.
+
+| Note | Assessment | Action |
+|---|---|---|
+| Dead `id` on the repartition button | Verified against the code. The `id` is emitted but referenced nowhere in JS, HTML, CSS or the e2e module. `git show origin/main` shows it was **already** unreferenced before this change - the old wiring keyed on `.js-repartition-btn`, not the id - so the bot's "with `.js-repartition-btn` gone" framing is slightly off, but the conclusion holds | **Applied.** Removed `btnId` and the `id` attribute |
+| `renderMaterializedViewsSidebarSection` dead + duplicated | Agreed, and the bot agreed the convert-not-delete choice was reasonable | No change; follow-up below |
+| `studio-security.js` still uses `$(this).data("name")` | Correct, same coercion footgun | No change; left for the developer to file, since opening issues is outside this task's mandate |
+| Remaining inline handlers confirmed benign | Matches the scope analysis | No change |
+
+The bot noted it could not execute `node --test` in its sandbox and read the tests instead of running them.
+The 41/41 result is reproduced locally, and the revert-one-renderer falsification check is recorded above.
+
 ## Out of scope / follow-ups
 
 - `restoreBackupAction` / `deleteBackupAction` (backup file names) and `updateDatabaseSetting` (setting

--- a/docs/5580-studio-inline-onclick-data-attributes.md
+++ b/docs/5580-studio-inline-onclick-data-attributes.md
@@ -143,6 +143,25 @@ The other two (delete the dead `renderMaterializedViewsSidebarSection`; open a t
 `studio-security.js` `.data()` coercion) are follow-ups outside this change. No issue was filed, since
 opening one is outside this task's mandate - see the list below.
 
+### Cycle 4 - `4bd1906a4`
+
+**LGTM.** Four non-blocking notes, none requiring a code change:
+
+- `updateDatabaseSetting` (`studio-database.js:4004`) emits both `row[0]` and `row[1]` with zero escaping,
+  and `row[1]` is the setting *value*, which is more free-form than the key. Out of scope here, but a
+  sharper observation than the original follow-up note - carried into the list below.
+- The click delegation itself has no automated test (the renderers do). Correct, and a conscious tradeoff:
+  there is no jsdom in the suite, so the dispatch is covered by the Chrome pass recorded above.
+- `studio-security.js` `.data()` coercion - already listed as a follow-up.
+- A claimed styling delta on the MV source-type links. **Checked and rejected:** the bot stated the anchor
+  "picks up `.link` styling it did not have before", but `git show origin/main` confirms the original
+  anchor already carried `class='link'`. The only real change is that `font-weight:600` moved from the
+  anchor's inline style to a wrapping span, and `.link` (`css/studio.css:228`) sets only `color`, no
+  `font-weight` - so the inherited value applies unopposed and the rendering is identical. No change made.
+
+Final state: **max-cycles-reached** (4 of 4), with four consecutive LGTMs and no outstanding code defects.
+Every cycle after the first produced only documentation or comment changes.
+
 ### Unrelated CI
 
 `Meterian Scanner workflow` fails on this branch, and also on the five most recent `main` commits. This
@@ -153,7 +172,10 @@ failure is pre-existing and unrelated. `Studio Security Audit` passes.
 
 - `restoreBackupAction` / `deleteBackupAction` (backup file names) and `updateDatabaseSetting` (setting
   keys) still use inline handlers. They carry server-generated or fixed-vocabulary values, not schema
-  names, so they were left alone to keep this diff to the issue's subject.
+  names, so they were left alone to keep this diff to the issue's subject. Note from review cycle 4:
+  `updateDatabaseSetting` at `studio-database.js:4004` interpolates **both** `row[0]` (key) and `row[1]`
+  (value) with no escaping at all, and the value is far more free-form than the key - this is the strongest
+  candidate of the three for a follow-up.
 - `studio-security.js` reads its delegated values with `$(this).data("name")`. For user and group names
   that looks numeric (`"123"`), jQuery coerces to a number. Not triggered by this issue, worth a separate
   look.

--- a/docs/5580-studio-inline-onclick-data-attributes.md
+++ b/docs/5580-studio-inline-onclick-data-attributes.md
@@ -1,0 +1,106 @@
+# 5580 - Studio: replace inline onclick handlers carrying schema names with data-* attributes
+
+Follow-up to #5575. Branch `fix/5580-studio-inline-onclick-data-attributes`.
+
+## Root cause
+
+`studio-database.js` built roughly twenty controls by concatenating a schema object name into an inline
+`onclick` attribute:
+
+```js
+html += "<button ... onclick='dropType(\"" + escapeHtml(row.name) + "\")'>...";
+```
+
+The name lands in three nested contexts at once and only the first is escaped:
+
+1. HTML attribute value - handled by `escapeHtml`.
+2. JS string literal - not handled. The browser HTML-decodes the attribute *before* parsing it as JavaScript,
+   so `&quot;` turns back into `"` and terminates the string early.
+3. Handler argument - never reached, because step 2 already failed.
+
+Verified in Chrome against the pre-fix spelling with the name ``a"b'c`d\e<f>&g``: the browser parses the
+attribute as `dropType("a"b'c`d\e<f>&g")` and raises
+`SyntaxError: missing ) after argument list`. The button is inert - the action silently does nothing.
+
+Several call sites were worse than the documented case and interpolated the name with **no escaping at all**
+(`showTypeDetail` on super/sub type links, `browseType` in the query sidebar, `dropProperty`, `dropIndex`),
+which makes a crafted type name a stored-XSS vector, not only a broken button.
+
+All of these names are reachable: `CREATE DOCUMENT TYPE` accepts back-ticked names containing quotes,
+back-ticks and backslashes.
+
+## Fix
+
+One escaping point, one dispatch point.
+
+`schemaActionAttrs(action, name, parent)` is now the only place a schema name is spelled into an attribute.
+It emits `data-action` plus `data-name` (and `data-parent` for the two actions that need the owning type),
+each HTML-escaped exactly once. The value is read back through `dataset`, which the browser hands over as a
+plain string with no further interpretation - one context instead of three.
+
+Two delegated registries on `document` dispatch the actions (`schemaClickActions`, `schemaChangeActions`).
+Delegation was chosen over per-container wiring because the fragments are produced by shared renderers
+(`renderProperties`, `renderIndexes`, the sidebar badge builders) that are injected into more than one
+container; a document-level handler survives every `.html()` replacement without re-wiring.
+
+The registry doubles as the allowlist: an unknown `data-action` falls through untouched, so
+`studio-security.js` keeps its own document-level `[data-action='…']` handlers unaffected.
+
+Handlers read `this.dataset.*`, never jQuery's `.data()`. `.data()` coerces values that look numeric or
+boolean, so a type legitimately named `123` or `true` would reach `quoteSqlName()` as a number or a boolean.
+
+### Converted call sites (19 actions)
+
+| Area | Actions |
+|---|---|
+| Schema sidebar / query sidebar badges | `show-type-detail`, `browse-type` |
+| Type detail | `create-property`, `create-index`, `run-repartition`, `browse-records`, `browse-records-with-connections`, `count-records`, `drop-type` |
+| Super / sub type and MV source-type links | `show-type-detail` |
+| Property and index tables | `drop-property`, `drop-index` |
+| Materialized views | `show-materialized-view-detail`, `refresh-materialized-view`, `alter-materialized-view`, `drop-materialized-view` |
+| Graph analytical views | `show-gav-detail`, `rebuild-gav`, `drop-gav`, `alter-gav-update-mode` (a `change` on the update-mode select) |
+
+The repartition button from #4087 was folded into the same mechanism, and its bespoke
+`.js-repartition-btn` wiring removed, so the file now has exactly one pattern.
+
+Section-header buttons (`createType`, `createMaterializedView`, `createGraphAnalyticalView`,
+`createTimeSeriesType`) keep their inline `onclick`: they pass no argument, so they never enter the
+nested-context problem. The tests assert this distinction rather than banning `onclick` outright.
+
+Small extractions were made so the generated HTML is reachable from tests without a DOM:
+`renderTypeLink`, `renderTypeSidebarBadge` (which also de-duplicates two near-identical badge loops),
+`renderTypeQuickActions`, `renderMaterializedViewQuickActions`.
+
+## Verification
+
+`studio/test/schema-action-attributes.test.js` - 17 new tests on Node's built-in runner:
+
+- every renderer round-trips eight hostile names (`a"b`, `a'b`, `` a`b ``, `a\b`, `a<script>…`, `a&b`,
+  `x"); alert(1); //`, `it's a "type"`) through the attribute and back, byte-exact;
+- no attribute value contains an unencoded markup character;
+- no inline handler carries an argument;
+- source-level guards: every emitted `data-action` has a registry entry, and no registry entry is dead
+  weight. A typo on either side renders a button that silently does nothing, which no runtime test would
+  catch.
+
+**Proof the tests fail without the fix:** reverting only `renderTypeLink` to the old inline spelling makes
+`type links carry the name in a data attribute, not an onclick` fail (16/17), and restoring it returns 17/17.
+
+**Full studio suite:** 41/41 pass (`npm test`). `render-indexes.test.js` needed two added `eval` lines in
+its extraction harness because `renderIndexes` now calls `schemaActionAttrs`; no assertion was changed.
+
+**Browser verification** (the issue asks for it; Chrome, jQuery 4 + the real dispatcher and renderers): all
+22 rendered controls fired their handler and delivered the name ``a"b'c`d\e<f>&g`` byte-exact, with zero
+corrupted arguments. The same page confirms the pre-fix spelling raises a `SyntaxError` and never fires.
+
+## Out of scope / follow-ups
+
+- `restoreBackupAction` / `deleteBackupAction` (backup file names) and `updateDatabaseSetting` (setting
+  keys) still use inline handlers. They carry server-generated or fixed-vocabulary values, not schema
+  names, so they were left alone to keep this diff to the issue's subject.
+- `studio-security.js` reads its delegated values with `$(this).data("name")`. For user and group names
+  that looks numeric (`"123"`), jQuery coerces to a number. Not triggered by this issue, worth a separate
+  look.
+- `renderMaterializedViewsSidebarSection` is dead code (defined, never called) and an exact duplicate of
+  `renderMaterializedViewsSidebarBadges` plus a section wrapper. Converted for consistency rather than
+  deleted, to keep this change focused.

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3355,6 +3355,10 @@ function fetchSchemaTypes(callback) {
 // attribute has one context: the value is HTML-escaped once and read back through dataset, which the browser
 // returns as a plain string with no further interpretation. `parent` carries the owning type for the actions
 // that need two names (drop-property, drop-index).
+//
+// `action` is deliberately not escaped: it is always a string literal chosen from the registries below,
+// never a runtime value. `name` and `parent` are the untrusted halves. The "every emitted data-action is
+// covered by a dispatch registry" test fails at CI if a caller ever passes something else.
 function schemaActionAttrs(action, name, parent) {
   let attrs = " data-action='" + action + "' data-name='" + escapeHtml(name) + "'";
   if (parent != null) attrs += " data-parent='" + escapeHtml(parent) + "'";

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3561,7 +3561,6 @@ function showTypeDetail(typeName) {
   // refreshes the schema view on completion. Records are SAFE while the flag is true (queries
   // fan out and stay correct), but the optimisation is off until the rebuild runs.
   if (row.needsRepartition === true) {
-    let btnId = "btnRepartition_" + row.name.replace(/[^a-zA-Z0-9]/g, "_");
     html += "<div class='alert alert-warning d-flex align-items-center justify-content-between' role='alert' style='margin-bottom:14px;'>";
     html += "  <div>";
     html += "    <i class='fa fa-triangle-exclamation me-2'></i>";
@@ -3569,7 +3568,7 @@ function showTypeDetail(typeName) {
     html += "    A bucket was added/dropped or the strategy changed; partition-aware query pruning is suppressed for this type. ";
     html += "    Queries remain correct but lose the optimisation until a repartition rebuild runs.";
     html += "  </div>";
-    html += "  <button id='" + escapeHtml(btnId) + "' class='btn btn-sm btn-warning'" + schemaActionAttrs("run-repartition", row.name) + ">";
+    html += "  <button class='btn btn-sm btn-warning'" + schemaActionAttrs("run-repartition", row.name) + ">";
     html += "    <i class='fa fa-rotate'></i> Run Repartition";
     html += "  </button>";
     html += "</div>";

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3401,6 +3401,11 @@ function renderMaterializedViewQuickActions(view) {
 // own document-level handlers. Values are read from dataset, never from jQuery's .data(): schema names may
 // look numeric or boolean ("123", "true") and .data() would coerce those away from the string the SQL layer
 // expects.
+//
+// Note for anyone adding a control elsewhere in Studio: because the dispatch is bound to document, the
+// data-action values below form a page-wide namespace. Reusing one of these names for an unrelated control
+// anywhere in the DOM would route its clicks here as well, so pick a distinct value (or a distinct
+// container-scoped handler) rather than a name that already appears in either registry.
 var schemaClickActions = {
   "show-type-detail": function (d) { showTypeDetail(d.name); },
   "browse-type": function (d) { browseType(d.name); },

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3349,6 +3349,98 @@ function fetchSchemaTypes(callback) {
     });
 }
 
+// The single place where a schema object name is spelled into an HTML attribute (issue #5580). An inline
+// onclick nests three contexts - HTML attribute, JS string literal, handler argument - and escapes only the
+// first, so a name holding a double quote decodes back to `"` and breaks out of the JS string. A data-*
+// attribute has one context: the value is HTML-escaped once and read back through dataset, which the browser
+// returns as a plain string with no further interpretation. `parent` carries the owning type for the actions
+// that need two names (drop-property, drop-index).
+function schemaActionAttrs(action, name, parent) {
+  let attrs = " data-action='" + action + "' data-name='" + escapeHtml(name) + "'";
+  if (parent != null) attrs += " data-parent='" + escapeHtml(parent) + "'";
+  return attrs;
+}
+
+function renderTypeLink(typeName) {
+  return "<a class='link' href='#'" + schemaActionAttrs("show-type-detail", typeName) + ">" + escapeHtml(typeName) + "</a>";
+}
+
+function renderTypeSidebarBadge(row, color, action) {
+  let name = escapeHtml(row.name);
+  let records = (row.records || 0).toLocaleString();
+  return (
+    "<a class='sidebar-badge' href='#' style='background-color: " + color + "'" +
+    schemaActionAttrs(action, row.name) +
+    " title='" + name + " (" + records + " records)'>" +
+    "<span class='sidebar-badge-name'>" + name + "</span>" +
+    "<span class='sidebar-badge-count'>" + records + "</span>" +
+    "</a>"
+  );
+}
+
+function renderTypeQuickActions(row) {
+  let html = "<button class='btn btn-sm db-action-btn'" + schemaActionAttrs("browse-records", row.name) + "><i class='fa fa-table'></i> Browse records</button>";
+  if (row.type == "vertex")
+    html += "<button class='btn btn-sm db-action-btn'" + schemaActionAttrs("browse-records-with-connections", row.name) + "><i class='fa fa-project-diagram'></i> With connections</button>";
+  html += "<button class='btn btn-sm db-action-btn'" + schemaActionAttrs("count-records", row.name) + "><i class='fa fa-calculator'></i> Count records</button>";
+  html += "<button class='btn btn-sm db-action-btn db-action-btn-danger'" + schemaActionAttrs("drop-type", row.name) + "><i class='fa fa-trash'></i> Drop Type</button>";
+  return html;
+}
+
+function renderMaterializedViewQuickActions(view) {
+  return (
+    "<button class='btn btn-sm db-action-btn'" + schemaActionAttrs("refresh-materialized-view", view.name) + "><i class='fa fa-sync'></i> Refresh Now</button>" +
+    "<button class='btn btn-sm db-action-btn'" + schemaActionAttrs("browse-records", view.name) + "><i class='fa fa-table'></i> Browse Records</button>" +
+    "<button class='btn btn-sm db-action-btn'" + schemaActionAttrs("alter-materialized-view", view.name) + "><i class='fa fa-pen'></i> Alter Refresh Mode</button>" +
+    "<button class='btn btn-sm db-action-btn db-action-btn-danger'" + schemaActionAttrs("drop-materialized-view", view.name) + "><i class='fa fa-trash'></i> Drop View</button>"
+  );
+}
+
+// Delegated handlers for the schema actions emitted by schemaActionAttrs(). The registry doubles as the
+// allowlist: an unknown data-action falls through untouched, which is what lets studio-security.js keep its
+// own document-level handlers. Values are read from dataset, never from jQuery's .data(): schema names may
+// look numeric or boolean ("123", "true") and .data() would coerce those away from the string the SQL layer
+// expects.
+var schemaClickActions = {
+  "show-type-detail": function (d) { showTypeDetail(d.name); },
+  "browse-type": function (d) { browseType(d.name); },
+  "browse-records": function (d) { browseRecords(d.name); },
+  "browse-records-with-connections": function (d) { browseRecordsWithConnections(d.name); },
+  "count-records": function (d) { countRecords(d.name); },
+  "create-property": function (d) { createProperty(d.name); },
+  "create-index": function (d) { createIndex(d.name); },
+  "drop-type": function (d) { dropType(d.name); },
+  "drop-property": function (d) { dropProperty(d.parent, d.name); },
+  "drop-index": function (d) { dropIndex(d.name, d.parent); },
+  "run-repartition": function (d) { runRepartition(d.name); },
+  "show-materialized-view-detail": function (d) { showMaterializedViewDetail(d.name); },
+  "refresh-materialized-view": function (d) { refreshMaterializedView(d.name); },
+  "alter-materialized-view": function (d) { alterMaterializedView(d.name); },
+  "drop-materialized-view": function (d) { dropMaterializedView(d.name); },
+  "show-gav-detail": function (d) { showGavDetail(d.name); },
+  "rebuild-gav": function (d) { rebuildGav(d.name); },
+  "drop-gav": function (d) { dropGav(d.name); }
+};
+
+var schemaChangeActions = {
+  "alter-gav-update-mode": function (d, value) { alterGavUpdateMode(d.name, value); }
+};
+
+$(document).ready(function () {
+  $(document).on("click", "[data-action]", function (e) {
+    let handler = schemaClickActions[this.dataset.action];
+    if (handler == null) return;
+    e.preventDefault();
+    handler(this.dataset);
+  });
+
+  $(document).on("change", "[data-action]", function () {
+    let handler = schemaChangeActions[this.dataset.action];
+    if (handler == null) return;
+    handler(this.dataset, this.value);
+  });
+});
+
 function displaySchema(onReady) {
   fetchSchemaTypes(function (types) {
     // Build sub-types map
@@ -3406,14 +3498,7 @@ function displaySchema(onReady) {
         let row = items[j];
         let color = colors[j % colors.length];
         globalSidebarTypeColors[row.name] = color;
-        let name = escapeHtml(row.name);
-        let records = (row.records || 0).toLocaleString();
-        html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
-        html += "onclick='showTypeDetail(\"" + row.name.replace(/"/g, "&quot;") + "\"); return false;' ";
-        html += "title='" + name + " (" + records + " records)'>";
-        html += "<span class='sidebar-badge-name'>" + name + "</span>";
-        html += "<span class='sidebar-badge-count'>" + records + "</span>";
-        html += "</a>";
+        html += renderTypeSidebarBadge(row, color, "show-type-detail");
       }
 
       html += "</div></div>";
@@ -3477,13 +3562,6 @@ function showTypeDetail(typeName) {
   // fan out and stay correct), but the optimisation is off until the rebuild runs.
   if (row.needsRepartition === true) {
     let btnId = "btnRepartition_" + row.name.replace(/[^a-zA-Z0-9]/g, "_");
-    // The button is wired programmatically (via addEventListener after the HTML lands in the
-    // DOM) rather than through an inline onclick. Inline handlers embedding row.name into a
-    // JS-string-in-HTML-attribute context are double-escape territory: even with escapeHtml,
-    // a name containing a literal double-quote escapes back to `"` after HTML decoding and
-    // breaks out of the JS string. The data-* attribute carries the untrusted value through
-    // a single HTML-escaping; the click handler reads it via dataset.typeName which the
-    // browser exposes as a plain string with no further interpretation.
     html += "<div class='alert alert-warning d-flex align-items-center justify-content-between' role='alert' style='margin-bottom:14px;'>";
     html += "  <div>";
     html += "    <i class='fa fa-triangle-exclamation me-2'></i>";
@@ -3491,7 +3569,7 @@ function showTypeDetail(typeName) {
     html += "    A bucket was added/dropped or the strategy changed; partition-aware query pruning is suppressed for this type. ";
     html += "    Queries remain correct but lose the optimisation until a repartition rebuild runs.";
     html += "  </div>";
-    html += "  <button id='" + escapeHtml(btnId) + "' class='btn btn-sm btn-warning js-repartition-btn' data-type-name='" + escapeHtml(row.name) + "'>";
+    html += "  <button id='" + escapeHtml(btnId) + "' class='btn btn-sm btn-warning'" + schemaActionAttrs("run-repartition", row.name) + ">";
     html += "    <i class='fa fa-rotate'></i> Run Repartition";
     html += "  </button>";
     html += "</div>";
@@ -3502,7 +3580,7 @@ function showTypeDetail(typeName) {
     html += "<div class='db-type-meta'>Super Types: ";
     for (let ptidx in row.parentTypes) {
       if (ptidx > 0) html += ", ";
-      html += "<a class='link' href='#' onclick='showTypeDetail(\"" + row.parentTypes[ptidx] + "\"); return false;'>" + escapeHtml(row.parentTypes[ptidx]) + "</a>";
+      html += renderTypeLink(row.parentTypes[ptidx]);
     }
     html += "</div>";
   }
@@ -3513,7 +3591,7 @@ function showTypeDetail(typeName) {
     html += "<div class='db-type-meta'>Sub Types: ";
     for (let stidx in typeSubTypes) {
       if (stidx > 0) html += ", ";
-      html += "<a class='link' href='#' onclick='showTypeDetail(\"" + typeSubTypes[stidx] + "\"); return false;'>" + escapeHtml(typeSubTypes[stidx]) + "</a>";
+      html += renderTypeLink(typeSubTypes[stidx]);
     }
     html += "</div>";
   }
@@ -3551,7 +3629,7 @@ function showTypeDetail(typeName) {
     html += "<div class='db-detail-section'>";
     html += "<div class='d-flex align-items-center justify-content-between mb-2'>";
     html += "<h6 class='mb-0'><i class='fa fa-list'></i> Properties</h6>";
-    html += "<button class='btn btn-sm btn-outline-primary' onclick='createProperty(\"" + row.name.replace(/"/g, "&quot;") + "\"); return false;'><i class='fa fa-plus'></i> Add Property</button>";
+    html += "<button class='btn btn-sm btn-outline-primary'" + schemaActionAttrs("create-property", row.name) + "><i class='fa fa-plus'></i> Add Property</button>";
     html += "</div>";
     let propHtml = renderProperties(row, types);
     if (propHtml == "") {
@@ -3570,7 +3648,7 @@ function showTypeDetail(typeName) {
     html += "<div class='db-detail-section'>";
     html += "<div class='d-flex align-items-center justify-content-between mb-2'>";
     html += "<h6 class='mb-0'><i class='fa fa-bolt'></i> Indexes</h6>";
-    html += "<button class='btn btn-sm btn-outline-primary' onclick='createIndex(\"" + row.name.replace(/"/g, "&quot;") + "\"); return false;'><i class='fa fa-plus'></i> Add Index</button>";
+    html += "<button class='btn btn-sm btn-outline-primary'" + schemaActionAttrs("create-index", row.name) + "><i class='fa fa-plus'></i> Add Index</button>";
     html += "</div>";
     let idxHtml = renderIndexes(row, types);
     if (idxHtml != "") {
@@ -3663,24 +3741,11 @@ function showTypeDetail(typeName) {
   html += "<div class='db-detail-section'>";
   html += "<h6><i class='fa fa-play-circle'></i> Quick Actions</h6>";
   html += "<div class='d-flex flex-wrap gap-2'>";
-  html += "<button class='btn btn-sm db-action-btn' onclick='browseRecords(\"" + escapeHtml(row.name) + "\")'><i class='fa fa-table'></i> Browse records</button>";
-  if (row.type == "vertex")
-    html += "<button class='btn btn-sm db-action-btn' onclick='browseRecordsWithConnections(\"" + escapeHtml(row.name) + "\")'><i class='fa fa-project-diagram'></i> With connections</button>";
-  html += "<button class='btn btn-sm db-action-btn' onclick='countRecords(\"" + escapeHtml(row.name) + "\")'><i class='fa fa-calculator'></i> Count records</button>";
-  html += "<button class='btn btn-sm db-action-btn db-action-btn-danger' onclick='dropType(\"" + escapeHtml(row.name) + "\")'><i class='fa fa-trash'></i> Drop Type</button>";
+  html += renderTypeQuickActions(row);
   html += "</div>";
   html += "</div>";
 
   $("#dbTypeDetail").html(html);
-
-  // Wire the repartition button (issue #4087). Done programmatically rather than via inline
-  // onclick so the type name carries through a single HTML-escape (in the data-type-name
-  // attribute) and is read back as a plain string via dataset.typeName, with no JS-string
-  // interpretation. Avoids the double-escape footgun on type names with embedded quotes.
-  $("#dbTypeDetail .js-repartition-btn").on("click", function (e) {
-    e.preventDefault();
-    runRepartition(this.dataset.typeName);
-  });
 }
 
 var sidebarBadgeColors = {
@@ -3733,14 +3798,7 @@ function populateQuerySidebar() {
       let row = items[j];
       let color = palette[j % palette.length];
       globalSidebarTypeColors[row.name] = color;
-      let name = escapeHtml(row.name);
-      let records = (row.records || 0).toLocaleString();
-      html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
-      html += "onclick='browseType(\"" + row.name + "\"); return false;' ";
-      html += "title='" + name + " (" + records + " records)'>";
-      html += "<span class='sidebar-badge-name'>" + name + "</span>";
-      html += "<span class='sidebar-badge-count'>" + records + "</span>";
-      html += "</a>";
+      html += renderTypeSidebarBadge(row, color, "browse-type");
     }
 
     html += "</div></div>";
@@ -3819,11 +3877,9 @@ function renderProperties(row, results) {
 
     panelHtml += "<td>" + (totalIndexes > 0 ? totalIndexes : "None") + "</td>";
     panelHtml +=
-      "<td><button class='btn btn-sm db-action-btn db-action-btn-danger' onclick='dropProperty(\"" +
-      row.name +
-      '", "' +
-      property.name +
-      "\")'><i class='fa fa-minus'></i> Drop Property</button></td></tr>";
+      "<td><button class='btn btn-sm db-action-btn db-action-btn-danger'" +
+      schemaActionAttrs("drop-property", property.name, row.name) +
+      "><i class='fa fa-minus'></i> Drop Property</button></td></tr>";
 
     if (property.custom != null && Object.keys(property.custom).length > 0) {
       panelHtml += "<td></td>";
@@ -3870,7 +3926,7 @@ function renderIndexes(row, results, seen) {
 
     panelHtml += "<td>" + (index.unique ? true : false) + "</td>";
     panelHtml += "<td>" + (index.automatic ? true : false) + "</td>";
-    panelHtml += "<td><button class='btn btn-sm db-action-btn db-action-btn-danger' onclick='dropIndex(\"" + index.name + "\", \"" + row.name.replace(/"/g, "&quot;") + "\")'><i class='fa fa-minus'></i> Drop Index</button></td></tr>";
+    panelHtml += "<td><button class='btn btn-sm db-action-btn db-action-btn-danger'" + schemaActionAttrs("drop-index", index.name, row.name) + "><i class='fa fa-minus'></i> Drop Index</button></td></tr>";
   }
 
   // Recurse into parent types so inherited indexes appear in the child type detail (issue #4140).
@@ -4358,21 +4414,12 @@ function renderMaterializedViewsSidebarSection(views, isQuerySidebar) {
     let name = escapeHtml(view.name);
     let statusClass = "mv-status-dot-" + (view.status || "valid").toLowerCase();
 
-    if (isQuerySidebar) {
-      html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
-      html += "onclick='browseRecords(\"" + escapeHtml(view.name) + "\"); return false;' ";
-      html += "title='" + name + " (Materialized View)'>";
-      html += "<span class='mv-status-dot " + statusClass + "'></span>";
-      html += "<span class='sidebar-badge-name'>" + name + "</span>";
-      html += "</a>";
-    } else {
-      html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
-      html += "onclick='showMaterializedViewDetail(\"" + view.name.replace(/"/g, "&quot;") + "\"); return false;' ";
-      html += "title='" + name + " (Materialized View)'>";
-      html += "<span class='mv-status-dot " + statusClass + "'></span>";
-      html += "<span class='sidebar-badge-name'>" + name + "</span>";
-      html += "</a>";
-    }
+    html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "'";
+    html += schemaActionAttrs(isQuerySidebar ? "browse-records" : "show-materialized-view-detail", view.name);
+    html += " title='" + name + " (Materialized View)'>";
+    html += "<span class='mv-status-dot " + statusClass + "'></span>";
+    html += "<span class='sidebar-badge-name'>" + name + "</span>";
+    html += "</a>";
   }
 
   html += "</div></div>";
@@ -4402,21 +4449,12 @@ function renderMaterializedViewsSidebarBadges(views, isQuerySidebar) {
     let name = escapeHtml(view.name);
     let statusClass = "mv-status-dot-" + (view.status || "valid").toLowerCase();
 
-    if (isQuerySidebar) {
-      html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
-      html += "onclick='browseRecords(\"" + escapeHtml(view.name) + "\"); return false;' ";
-      html += "title='" + name + " (Materialized View)'>";
-      html += "<span class='mv-status-dot " + statusClass + "'></span>";
-      html += "<span class='sidebar-badge-name'>" + name + "</span>";
-      html += "</a>";
-    } else {
-      html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
-      html += "onclick='showMaterializedViewDetail(\"" + view.name.replace(/"/g, "&quot;") + "\"); return false;' ";
-      html += "title='" + name + " (Materialized View)'>";
-      html += "<span class='mv-status-dot " + statusClass + "'></span>";
-      html += "<span class='sidebar-badge-name'>" + name + "</span>";
-      html += "</a>";
-    }
+    html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "'";
+    html += schemaActionAttrs(isQuerySidebar ? "browse-records" : "show-materialized-view-detail", view.name);
+    html += " title='" + name + " (Materialized View)'>";
+    html += "<span class='mv-status-dot " + statusClass + "'></span>";
+    html += "<span class='sidebar-badge-name'>" + name + "</span>";
+    html += "</a>";
   }
 
   html += "</div>";
@@ -4474,10 +4512,10 @@ function renderGavSidebarBadges(gavs, isQuerySidebar) {
     let name = escapeHtml(gav.name);
     let statusClass = mvStatusDotClass(gav.status);
 
-    html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "' ";
+    html += "<a class='sidebar-badge' href='#' style='background-color: " + color + "'";
     if (!isQuerySidebar)
-      html += "onclick='showGavDetail(\"" + gav.name.replace(/"/g, "&quot;") + "\"); return false;' ";
-    html += "title='" + name + " (Graph Analytical View)'>";
+      html += schemaActionAttrs("show-gav-detail", gav.name);
+    html += " title='" + name + " (Graph Analytical View)'>";
     html += "<span class='mv-status-dot " + statusClass + "'></span>";
     html += "<span class='sidebar-badge-name'>" + name + "</span>";
     html += "</a>";
@@ -4528,10 +4566,9 @@ function showGavDetail(gavName) {
   if (gav.edgePropertyFilter && gav.edgePropertyFilter.length > 0)
     html += "<div class='mv-info-row'><span class='mv-info-label'>Edge Properties:</span> " + escapeHtml(gav.edgePropertyFilter.join(", ")) + "</div>";
 
-  let safeName = gav.name.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/"/g, "&quot;");
   let currentMode = escapeHtml(gav.updateMode || "OFF");
   html += "<div class='mv-info-row'><span class='mv-info-label'>Update Mode:</span> ";
-  html += "<select class='form-select form-select-sm d-inline-block' style='width:auto;' id='gavUpdateModeSelect' onchange='alterGavUpdateMode(\"" + safeName + "\", this.value)'>";
+  html += "<select class='form-select form-select-sm d-inline-block' style='width:auto;' id='gavUpdateModeSelect'" + schemaActionAttrs("alter-gav-update-mode", gav.name) + ">";
   let modes = ["OFF", "SYNCHRONOUS", "ASYNCHRONOUS"];
   for (let m = 0; m < modes.length; m++)
     html += "<option value='" + modes[m] + "'" + (modes[m] === currentMode ? " selected" : "") + ">" + modes[m] + "</option>";
@@ -4551,8 +4588,8 @@ function showGavDetail(gavName) {
 
   // Actions
   html += "<div class='mt-3 d-flex gap-2'>";
-  html += "<button class='btn btn-sm btn-outline-primary' onclick='rebuildGav(\"" + safeName + "\")'><i class='fa fa-sync'></i> Rebuild</button>";
-  html += "<button class='btn btn-sm btn-outline-danger' onclick='dropGav(\"" + safeName + "\")'><i class='fa fa-trash'></i> Drop</button>";
+  html += "<button class='btn btn-sm btn-outline-primary'" + schemaActionAttrs("rebuild-gav", gav.name) + "><i class='fa fa-sync'></i> Rebuild</button>";
+  html += "<button class='btn btn-sm btn-outline-danger'" + schemaActionAttrs("drop-gav", gav.name) + "><i class='fa fa-trash'></i> Drop</button>";
   html += "</div>";
 
   html += "</div>";
@@ -5138,8 +5175,7 @@ function showMaterializedViewDetail(viewName) {
     html += "<h6><i class='fa fa-link'></i> Source Types</h6>";
     html += "<div class='d-flex flex-wrap gap-2'>";
     for (let i = 0; i < view.sourceTypes.length; i++) {
-      let st = view.sourceTypes[i];
-      html += "<a class='link' href='#' onclick='showTypeDetail(\"" + escapeHtml(st) + "\"); return false;' style='font-weight:600;'>" + escapeHtml(st) + "</a>";
+      html += "<span style='font-weight:600;'>" + renderTypeLink(view.sourceTypes[i]) + "</span>";
     }
     html += "</div></div>";
   }
@@ -5192,10 +5228,7 @@ function showMaterializedViewDetail(viewName) {
   html += "<div class='db-detail-section'>";
   html += "<h6><i class='fa fa-play-circle'></i> Quick Actions</h6>";
   html += "<div class='d-flex flex-wrap gap-2'>";
-  html += "<button class='btn btn-sm db-action-btn' onclick='refreshMaterializedView(\"" + escapeHtml(view.name) + "\")'><i class='fa fa-sync'></i> Refresh Now</button>";
-  html += "<button class='btn btn-sm db-action-btn' onclick='browseRecords(\"" + escapeHtml(view.name) + "\")'><i class='fa fa-table'></i> Browse Records</button>";
-  html += "<button class='btn btn-sm db-action-btn' onclick='alterMaterializedView(\"" + escapeHtml(view.name) + "\")'><i class='fa fa-pen'></i> Alter Refresh Mode</button>";
-  html += "<button class='btn btn-sm db-action-btn db-action-btn-danger' onclick='dropMaterializedView(\"" + escapeHtml(view.name) + "\")'><i class='fa fa-trash'></i> Drop View</button>";
+  html += renderMaterializedViewQuickActions(view);
   html += "</div></div>";
 
   $("#dbTypeDetail").html(html);

--- a/studio/test/render-indexes.test.js
+++ b/studio/test/render-indexes.test.js
@@ -53,7 +53,14 @@ function extractFn(name) {
   return src.substring(start, i);
 }
 
+// renderIndexes builds the Drop Index button through schemaActionAttrs (issue #5580), which escapes
+// the name with escapeHtml from studio-utils.js. Both are pulled in so the function evaluates standalone.
+const utilsSrc = fs.readFileSync(path.join(__dirname, "..", "src", "main", "resources", "static", "js", "studio-utils.js"), "utf8");
+const escapeHtmlStart = utilsSrc.indexOf("function escapeHtml(");
+eval(utilsSrc.substring(escapeHtmlStart, utilsSrc.indexOf("\n}", escapeHtmlStart) + 2));
+
 eval(extractFn("findTypeInResult"));
+eval(extractFn("schemaActionAttrs"));
 eval(extractFn("renderIndexes"));
 
 test("inherited index from a single parent type appears under the child detail", () => {

--- a/studio/test/schema-action-attributes.test.js
+++ b/studio/test/schema-action-attributes.test.js
@@ -1,0 +1,331 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+
+// Regression test for issue #5580: schema object names must not be rendered into an inline onclick
+// attribute. There the name lands in three nested contexts at once - HTML attribute, JS string
+// literal, and finally the handler argument - while only the first one is escaped, so a name holding
+// a double quote decodes back to `"` and breaks out of the JS string. The remedy is a data-* attribute
+// (one HTML-escape) read back through dataset (a plain string, no further interpretation).
+//
+// Run with:
+//
+//     node --test studio/test/schema-action-attributes.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const STATIC_JS = path.join(__dirname, "..", "src", "main", "resources", "static", "js");
+const src = fs.readFileSync(path.join(STATIC_JS, "studio-database.js"), "utf8");
+const utilsSrc = fs.readFileSync(path.join(STATIC_JS, "studio-utils.js"), "utf8");
+
+function extractFrom(source, name) {
+  const start = source.indexOf("function " + name + "(");
+  if (start < 0) throw new Error("function not found: " + name);
+  let i = source.indexOf("{", start);
+  let depth = 1;
+  i++;
+  while (i < source.length && depth > 0) {
+    const c = source[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    i++;
+  }
+  return source.substring(start, i);
+}
+
+const extractFn = (name) => extractFrom(src, name);
+
+eval(extractFrom(utilsSrc, "escapeHtml"));
+eval(extractFn("schemaActionAttrs"));
+eval(extractFn("renderTypeLink"));
+eval(extractFn("renderTypeSidebarBadge"));
+eval(extractFn("renderTypeQuickActions"));
+eval(extractFn("renderMaterializedViewQuickActions"));
+eval(extractFn("findTypeInResult"));
+eval(extractFn("renderProperties"));
+eval(extractFn("renderIndexes"));
+eval(extractFn("renderMaterializedViewsSidebarBadges"));
+eval(extractFn("mvStatusDotClass"));
+eval(extractFn("renderGavSidebarBadges"));
+
+// sidebarBadgeColors is a top-level var in studio-database.js, needed by the MV badge renderer.
+const sidebarBadgeColors = { materializedView: ["#a855f7", "#9333ea"] };
+
+// Names that break the inline-onclick pattern. Every one of them is creatable through
+// `CREATE DOCUMENT TYPE` with a back-quoted name, so they can genuinely reach these renderers.
+const HOSTILE_NAMES = [
+  'a"b',
+  "a'b",
+  "a`b",
+  "a\\b",
+  "a<script>alert(1)</script>b",
+  "a&b",
+  'x"); alert(1); //',
+  "it's a \"type\"",
+];
+
+/** Reverses escapeHtml, i.e. what the browser does when it hands the value back through dataset. */
+function htmlDecode(value) {
+  return value
+    .replace(/&#039;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+/** Reads every single-quoted `data-<attr>` value out of a rendered HTML fragment, decoded. */
+function readDataAttrs(html, attr) {
+  const out = [];
+  const re = new RegExp("data-" + attr + "='([^']*)'", "g");
+  let m;
+  while ((m = re.exec(html)) !== null) out.push(htmlDecode(m[1]));
+  return out;
+}
+
+/**
+ * An inline handler is only safe when it carries no argument at all. The section headers keep theirs
+ * ("createMaterializedView(); return false;") because they pass nothing; the moment a name becomes an
+ * argument it enters the JS-string-inside-an-HTML-attribute context that issue #5580 is about.
+ */
+function assertNoArgumentCarryingInlineHandler(html) {
+  const re = /onclick='([^']*)'/g;
+  let m;
+  while ((m = re.exec(html)) !== null)
+    assert.ok(/^[A-Za-z_$][\w$]*\(\);(\s*return false;)?\s*$/.test(m[1]), "inline handler must not carry an argument: " + m[1]);
+}
+
+/** A name is safe in an attribute only if it can never terminate it: no raw quote, `<` or `&`. */
+function assertNoAttributeBreakout(html) {
+  // Everything between the delimiters of a data-* attribute must be free of raw single quotes.
+  const re = /data-[a-z-]+='([^']*)'/g;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    assert.ok(!/[<>&](?!(amp|quot|lt|gt|#039);)/.test(m[1]), "attribute value holds an unencoded markup character: " + m[1]);
+  }
+}
+
+test("schemaActionAttrs escapes the name exactly once and round-trips through dataset", () => {
+  for (const name of HOSTILE_NAMES) {
+    const attrs = schemaActionAttrs("drop-type", name);
+    assert.ok(attrs.includes("data-action='drop-type'"), "action must be emitted");
+    assert.deepStrictEqual(readDataAttrs(attrs, "name"), [name], "name must survive one HTML-escape unchanged: " + name);
+    assertNoAttributeBreakout(attrs);
+  }
+});
+
+test("schemaActionAttrs carries the owning type in data-parent when given", () => {
+  const attrs = schemaActionAttrs("drop-property", 'prop"1', 'Type"A');
+  assert.deepStrictEqual(readDataAttrs(attrs, "name"), ['prop"1']);
+  assert.deepStrictEqual(readDataAttrs(attrs, "parent"), ['Type"A']);
+});
+
+test("schemaActionAttrs omits data-parent when no owner is given", () => {
+  assert.ok(!schemaActionAttrs("drop-type", "T").includes("data-parent"), "no spurious empty data-parent attribute");
+});
+
+test("type links carry the name in a data attribute, not an onclick", () => {
+  for (const name of HOSTILE_NAMES) {
+    const html = renderTypeLink(name);
+    assert.ok(!html.includes("onclick"), "type link must not use an inline handler: " + html);
+    assert.deepStrictEqual(readDataAttrs(html, "name"), [name]);
+    assertNoAttributeBreakout(html);
+  }
+});
+
+test("sidebar type badges carry the name in a data attribute, not an onclick", () => {
+  for (const name of HOSTILE_NAMES) {
+    const html = renderTypeSidebarBadge({ name: name, records: 7 }, "#3b82f6", "show-type-detail");
+    assert.ok(!html.includes("onclick"), "sidebar badge must not use an inline handler: " + html);
+    assert.deepStrictEqual(readDataAttrs(html, "name"), [name]);
+    assert.ok(html.includes("data-action='show-type-detail'"), "badge must declare the requested action");
+    assertNoAttributeBreakout(html);
+  }
+});
+
+test("sidebar type badges honour the action they are rendered for", () => {
+  const html = renderTypeSidebarBadge({ name: "Person", records: 1 }, "#3b82f6", "browse-type");
+  assert.ok(html.includes("data-action='browse-type'"));
+});
+
+test("type quick actions carry the name in a data attribute, not an onclick", () => {
+  for (const name of HOSTILE_NAMES) {
+    const html = renderTypeQuickActions({ name: name, type: "vertex" });
+    assert.ok(!html.includes("onclick"), "quick actions must not use inline handlers: " + html);
+    for (const decoded of readDataAttrs(html, "name")) assert.strictEqual(decoded, name);
+    assertNoAttributeBreakout(html);
+  }
+});
+
+test("type quick actions cover browse, count and drop, plus connections for vertices only", () => {
+  const vertex = renderTypeQuickActions({ name: "Person", type: "vertex" });
+  assert.ok(vertex.includes("data-action='browse-records'"));
+  assert.ok(vertex.includes("data-action='browse-records-with-connections'"));
+  assert.ok(vertex.includes("data-action='count-records'"));
+  assert.ok(vertex.includes("data-action='drop-type'"));
+
+  const doc = renderTypeQuickActions({ name: "Log", type: "document" });
+  assert.ok(!doc.includes("browse-records-with-connections"), "non-vertex types have no connections action");
+  assert.ok(doc.includes("data-action='browse-records'"));
+});
+
+test("materialized view quick actions carry the name in a data attribute, not an onclick", () => {
+  for (const name of HOSTILE_NAMES) {
+    const html = renderMaterializedViewQuickActions({ name: name });
+    assert.ok(!html.includes("onclick"), "MV quick actions must not use inline handlers: " + html);
+    for (const decoded of readDataAttrs(html, "name")) assert.strictEqual(decoded, name);
+    assertNoAttributeBreakout(html);
+  }
+  const html = renderMaterializedViewQuickActions({ name: "SalesMv" });
+  assert.ok(html.includes("data-action='refresh-materialized-view'"));
+  assert.ok(html.includes("data-action='browse-records'"));
+  assert.ok(html.includes("data-action='alter-materialized-view'"));
+  assert.ok(html.includes("data-action='drop-materialized-view'"));
+});
+
+test("property rows drop-property through data attributes, not an onclick", () => {
+  for (const name of HOSTILE_NAMES) {
+    const row = { name: name, parentTypes: "", properties: [{ name: name + "-prop", type: "STRING" }], indexes: [] };
+    const html = renderProperties(row, [row]);
+    assert.ok(!html.includes("onclick"), "property row must not use an inline handler: " + html);
+    assert.deepStrictEqual(readDataAttrs(html, "name"), [name + "-prop"], "data-name is the property being dropped");
+    assert.deepStrictEqual(readDataAttrs(html, "parent"), [name], "data-parent is the owning type");
+    assertNoAttributeBreakout(html);
+  }
+});
+
+test("index rows drop-index through data attributes, not an onclick", () => {
+  for (const name of HOSTILE_NAMES) {
+    const row = {
+      name: name,
+      parentTypes: [],
+      indexes: [{ name: name + "[k]", typeName: name, properties: ["k"], type: "LSM_TREE", unique: false, automatic: true }],
+    };
+    const html = renderIndexes(row, [row]);
+    assert.ok(!html.includes("onclick"), "index row must not use an inline handler: " + html);
+    assert.deepStrictEqual(readDataAttrs(html, "name"), [name + "[k]"], "data-name is the index being dropped");
+    assert.deepStrictEqual(readDataAttrs(html, "parent"), [name], "data-parent is the owning type");
+    assertNoAttributeBreakout(html);
+  }
+});
+
+test("materialized view sidebar badges carry the name in a data attribute, not an onclick", () => {
+  for (const name of HOSTILE_NAMES) {
+    const views = [{ name: name, status: "VALID" }];
+
+    const schemaSidebar = renderMaterializedViewsSidebarBadges(views, false);
+    assertNoArgumentCarryingInlineHandler(schemaSidebar);
+    assert.deepStrictEqual(readDataAttrs(schemaSidebar, "name"), [name]);
+    assert.ok(schemaSidebar.includes("data-action='show-materialized-view-detail'"));
+
+    const querySidebar = renderMaterializedViewsSidebarBadges(views, true);
+    assertNoArgumentCarryingInlineHandler(querySidebar);
+    assert.deepStrictEqual(readDataAttrs(querySidebar, "name"), [name]);
+    assert.ok(querySidebar.includes("data-action='browse-records'"));
+  }
+});
+
+test("graph analytical view sidebar badges carry the name in a data attribute, not an onclick", () => {
+  for (const name of HOSTILE_NAMES) {
+    const html = renderGavSidebarBadges([{ name: name, status: "VALID" }], false);
+    assertNoArgumentCarryingInlineHandler(html);
+    assert.deepStrictEqual(readDataAttrs(html, "name"), [name]);
+    assert.ok(html.includes("data-action='show-gav-detail'"));
+    assertNoAttributeBreakout(html);
+  }
+});
+
+test("graph analytical view badges stay inert in the query sidebar", () => {
+  const html = renderGavSidebarBadges([{ name: "Ranks", status: "VALID" }], true);
+  assert.ok(!html.includes("data-action="), "the query sidebar renders GAV badges without an action");
+});
+
+/**
+ * Every action string the renderers can emit. Actions reach an attribute either as a literal argument to
+ * schemaActionAttrs() - including through a ternary - or as the `action` parameter of
+ * renderTypeSidebarBadge(), so both call shapes are scanned.
+ */
+function emittedActions() {
+  const actions = new Set();
+  for (const call of ["schemaActionAttrs(", "renderTypeSidebarBadge("]) {
+    let i = src.indexOf(call);
+    while (i >= 0) {
+      let j = i + call.length;
+      let depth = 1;
+      while (j < src.length && depth > 0) {
+        if (src[j] === "(") depth++;
+        else if (src[j] === ")") depth--;
+        j++;
+      }
+      const args = src.substring(i + call.length, j - 1);
+      const re = /"([a-z][a-z0-9]*(?:-[a-z0-9]+)+)"/g;
+      let m;
+      while ((m = re.exec(args)) !== null) actions.add(m[1]);
+      i = src.indexOf(call, j);
+    }
+  }
+  return actions;
+}
+
+/** Collects the action keys of a `var <name> = { ... };` registry literal in studio-database.js. */
+function registryKeys(registryName) {
+  const start = src.indexOf("var " + registryName + " = {");
+  assert.notStrictEqual(start, -1, "registry not found: " + registryName);
+  const end = src.indexOf("\n};", start);
+  assert.notStrictEqual(end, -1, "registry not terminated: " + registryName);
+  const body = src.substring(start, end);
+  const keys = new Set();
+  const re = /"([a-z0-9-]+)":\s*function/g;
+  let m;
+  while ((m = re.exec(body)) !== null) keys.add(m[1]);
+  return keys;
+}
+
+// Source-level guard: every action string emitted through schemaActionAttrs must be present in one of the
+// dispatch registries, otherwise the control renders but silently does nothing when clicked. A typo on
+// either side is invisible in the browser, so it is caught here instead.
+test("every emitted data-action is covered by a dispatch registry", () => {
+  const emitted = emittedActions();
+  assert.ok(emitted.size >= 15, "expected the schema renderers to emit the full action set, found " + emitted.size);
+
+  const handled = new Set([...registryKeys("schemaClickActions"), ...registryKeys("schemaChangeActions")]);
+  for (const action of emitted) assert.ok(handled.has(action), "no delegated handler for data-action='" + action + "'");
+});
+
+test("no dispatch registry entry is dead weight", () => {
+  const emitted = emittedActions();
+  for (const action of [...registryKeys("schemaClickActions"), ...registryKeys("schemaChangeActions")])
+    assert.ok(emitted.has(action), "registry handles data-action='" + action + "' but nothing emits it");
+});
+
+// The names reaching these renderers are schema identifiers, so a value that looks like a number or a
+// boolean is a legitimate type name. jQuery's .data() coerces those ("123" -> 123, "true" -> true);
+// dataset does not. The handlers must therefore read dataset, or a type named `123` reaches
+// quoteSqlName() as a number.
+test("delegated handlers read dataset rather than jQuery .data()", () => {
+  const start = src.indexOf("Delegated handlers for the schema actions");
+  assert.notStrictEqual(start, -1, "dispatcher block not found");
+  const block = src.substring(start, src.indexOf("function displaySchema("));
+  assert.ok(block.includes("this.dataset.action"), "the dispatcher must key off dataset.action");
+  assert.ok(!/\$\(this\)\.data\(/.test(block), "jQuery .data() coerces numeric and boolean-looking names, use dataset");
+});


### PR DESCRIPTION
Closes #5580

Follow-up to #5575.

## Summary

Around twenty controls in `studio-database.js` concatenated a schema object name into an inline `onclick`. The name landed in three nested contexts at once - HTML attribute, JS string literal, handler argument - while only the first was escaped. The browser HTML-decodes the attribute *before* parsing it as JavaScript, so a name containing a double quote terminated the string early and the button became inert. Verified in Chrome with the name ``a"b'c`d\e<f>&g``: the pre-fix spelling parses as `dropType("a"b'c`d\e<f>&g")` and raises `SyntaxError: missing ) after argument list`. Several call sites were worse than the documented case and interpolated the name with **no escaping at all** (`showTypeDetail` on super/sub type links, `browseType`, `dropProperty`, `dropIndex`), making a crafted type name a stored-XSS vector rather than just a broken button. All such names are reachable, since `CREATE DOCUMENT TYPE` accepts back-ticked names containing quotes, back-ticks and backslashes.

`schemaActionAttrs(action, name, parent)` is now the only place a schema name is spelled into an attribute: one HTML-escape, emitted as `data-action` / `data-name` / `data-parent`, read back through `dataset` as a plain string. Two delegated registries on `document` dispatch the 19 actions. Delegation beats per-container wiring here because shared renderers (`renderProperties`, `renderIndexes`, the badge builders) are injected into more than one container, and a document-level handler survives every `.html()` replacement. The registry doubles as the allowlist, so an unknown `data-action` falls through untouched and `studio-security.js` keeps its own `[data-action='…']` handlers. Handlers read `this.dataset.*` rather than jQuery's `.data()`, which coerces values that look numeric or boolean - a type legitimately named `123` would otherwise reach `quoteSqlName()` as a number.

The #4087 repartition button was folded into the same mechanism and its bespoke `.js-repartition-btn` wiring removed, so the file now has exactly one pattern. Section-header buttons keep their inline `onclick`, because none carries a user-controlled name. `createTimeSeriesType()`, `createMaterializedView()` and `createGraphAnalyticalView()` pass no argument at all; `createType(sec.key)` does pass one, but `sec.key` is a fixed section constant from the hardcoded `sections` array (`vertex` / `edge` / `document`), never schema-derived. (Corrected in review cycle 3 - the original wording here said they all "pass no argument", which was inaccurate.)

## Test plan

- [x] `cd studio && npm test` - 41/41 pass, including 17 new tests in `studio/test/schema-action-attributes.test.js`
- [x] Every renderer round-trips eight hostile names (`a"b`, `a'b`, `` a`b ``, `a\b`, `a<script>…`, `a&b`, `x"); alert(1); //`, `it's a "type"`) through the attribute and back, byte-exact
- [x] Source-level guards: every emitted `data-action` has a registry entry, and no registry entry is dead weight (a typo either side renders a button that silently does nothing)
- [x] **Proof the tests can fail:** reverting only `renderTypeLink` to the old inline spelling drops the suite to 16/17; restoring it returns 17/17
- [x] **Browser verification** (Chrome, jQuery 4, real dispatcher and renderers): all 22 rendered controls fired and delivered ``a"b'c`d\e<f>&g`` byte-exact, zero corrupted arguments; the same page confirms the pre-fix spelling raises `SyntaxError` and never fires
- [ ] Reviewer sanity check in a running Studio: create a type named ``a"b``, open the Database tab, and use the sidebar badge, quick-action buttons, Drop Property / Drop Index, and the MV / GAV panes

### Note on an existing test

`studio/test/render-indexes.test.js` gained two `eval` lines in its extraction harness, because `renderIndexes` now calls `schemaActionAttrs` (which calls `escapeHtml`) and the harness evaluates functions standalone. No assertion was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
