### PR TITLE
Scope server and cluster status endpoints to the caller's databases

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -878,4 +878,26 @@ The underlying contract was loose in three places, and all three are tightened:
   `NumberFormatException`), an unknown `similarity` or `quantization` name, or an out-of-range `pqClusters` is a
   client mistake. They are reported as parsing errors now, the same treatment the `GEOSPATIAL` metadata gets.
 
+## Server and cluster status endpoints scope their per-database output to the caller
+
+The routes that enumerate the whole database registry rather than naming one database in the path now reduce
+every per-database entry they emit to the databases the caller is authorized for. This covers the `databases`
+array and the database-scoped `alerts` of `GET /api/v1/cluster`, the `ha.databases` array of
+`GET /api/v1/server?mode=cluster`, and the `metrics.sparseVectorIndexes` map of `GET /api/v1/server`. The
+server-level fields of those responses are unchanged and stay readable by any authenticated user - in
+particular `ha.leaderAddress` and `ha.replicaAddresses`, which the remote driver reads on every connection to
+route requests, and which therefore cannot be restricted to root.
+
+Two cluster endpoints move behind the root check that the seven mutating Raft endpoints already use:
+
+- **`POST /api/v1/cluster/bootstrap-state`** is a peer-to-peer RPC with no browser or driver consumer, and each
+  call computes a SHA-256 over every database directory on the node. Peers are unaffected: they reach it with
+  the cluster token forwarded as root.
+- **`GET /api/v1/cluster?presence=true`** fans that RPC out to every peer to build the presence matrix. The
+  matrix answers a whole-cluster question, and every remedy it points to (resync, transfer leadership) is
+  itself root-only. The cheap `GET /api/v1/cluster` poll without the parameter is unchanged.
+
+`GET /api/v1/cluster` also stops listing reserved internal databases such as the Raft control directory
+`.raft`, matching what the presence matrix and the bootstrap-state RPC already did.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -895,7 +895,11 @@ Two cluster endpoints move behind the root check that the seven mutating Raft en
   the cluster token forwarded as root.
 - **`GET /api/v1/cluster?presence=true`** fans that RPC out to every peer to build the presence matrix. The
   matrix answers a whole-cluster question, and every remedy it points to (resync, transfer leadership) is
-  itself root-only. The cheap `GET /api/v1/cluster` poll without the parameter is unchanged.
+  itself root-only. The cheap `GET /api/v1/cluster` poll without the parameter is unchanged. Note the root
+  check runs before the leader check, so a non-root caller passing the parameter to a **follower** now gets
+  `403` where it previously got a `200` with no matrix in it - tooling that polls followers with the flag
+  will see the change. In Studio the matrix is loaded by an explicit button, not by the cluster tab's
+  auto-poll, so a non-root operator's tab keeps working.
 
 `GET /api/v1/cluster` also stops listing reserved internal databases such as the Raft control directory
 `.raft`, matching what the presence matrix and the bootstrap-state RPC already did.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
@@ -29,6 +29,7 @@ import com.arcadedb.server.monitor.HAReplicationStatsProvider.FollowerSample;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Computes cluster-level health alerts surfaced to operators (Studio HA panel, {@code GET /api/v1/cluster}).
@@ -88,14 +89,44 @@ public class ClusterAlerts {
    */
   public static JSONArray scan(final ArcadeDBServer server, final ArcadeStateMachine stateMachine,
       final List<FollowerSample> followerSamples) {
+    return scan(server, stateMachine, followerSamples, null);
+  }
+
+  /**
+   * Scan overload that restricts every database-scoped alert to {@code visibleDatabases}.
+   * <p>
+   * Alerts are not purely server-level diagnostics: they name the databases they are about, and the
+   * single-bucket check additionally names their types. Served straight to an HTTP caller that is scoped to
+   * one database, that is a cross-tenant disclosure, so the caller passes the set it may see and the counts
+   * in each message are computed from the reduced list rather than the full one. Pass {@code null} for the
+   * unrestricted operator view (root, and the non-HTTP callers).
+   * <p>
+   * Node-scoped alerts (lagging followers) are unaffected: they describe the cluster, not a database.
+   */
+  public static JSONArray scan(final ArcadeDBServer server, final ArcadeStateMachine stateMachine,
+      final List<FollowerSample> followerSamples, final Set<String> visibleDatabases) {
     final JSONArray alerts = new JSONArray();
-    checkSingleBucketTypes(server, alerts);
+    checkSingleBucketTypes(server, alerts, visibleDatabases);
     if (stateMachine != null) {
-      checkLeaderMissingDatabases(stateMachine, alerts);
-      checkFailedAcquireDatabases(stateMachine, alerts);
+      checkLeaderMissingDatabases(stateMachine, alerts, visibleDatabases);
+      checkFailedAcquireDatabases(stateMachine, alerts, visibleDatabases);
     }
     addLaggingFollowerAlert(followerSamples, alerts);
     return alerts;
+  }
+
+  /**
+   * Reduces a list of database names to the ones the caller may see. A {@code null} filter means the
+   * unrestricted operator view and returns {@code names} untouched.
+   */
+  private static List<String> visible(final List<String> names, final Set<String> visibleDatabases) {
+    if (visibleDatabases == null || names == null || names.isEmpty())
+      return names;
+    final List<String> result = new ArrayList<>(names.size());
+    for (final String name : names)
+      if (visibleDatabases.contains(name))
+        result.add(name);
+    return result;
   }
 
   /**
@@ -153,8 +184,11 @@ public class ClusterAlerts {
    * where auto-acquire cannot reach them. The database is deliberately NOT dropped; the operator must transfer
    * leadership to a node that holds it (or resync) to redistribute it.
    */
-  static void checkLeaderMissingDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts) {
-    addLeaderMissingAlert(stateMachine.getReconciler().getDatabasesWithAcquireState(DatabaseReconciler.AcquireState.LEADER_MISSING), alerts);
+  static void checkLeaderMissingDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts,
+      final Set<String> visibleDatabases) {
+    addLeaderMissingAlert(visible(
+        stateMachine.getReconciler().getDatabasesWithAcquireState(DatabaseReconciler.AcquireState.LEADER_MISSING),
+        visibleDatabases), alerts);
   }
 
   /**
@@ -163,8 +197,11 @@ public class ClusterAlerts {
    * InstallSnapshot - which Ratis avoids in favor of log replay. Such a database can therefore stay absent
    * indefinitely even after the leader's copy is fixed, so surface it for an explicit operator resync.
    */
-  static void checkFailedAcquireDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts) {
-    addFailedAcquireAlert(stateMachine.getReconciler().getDatabasesWithAcquireState(DatabaseReconciler.AcquireState.FAILED), alerts);
+  static void checkFailedAcquireDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts,
+      final Set<String> visibleDatabases) {
+    addFailedAcquireAlert(visible(
+        stateMachine.getReconciler().getDatabasesWithAcquireState(DatabaseReconciler.AcquireState.FAILED),
+        visibleDatabases), alerts);
   }
 
   /** Pure alert builder (package-private for unit testing): appends the failed-acquire alert iff {@code failed} is non-empty. */
@@ -209,11 +246,14 @@ public class ClusterAlerts {
         .put("details", new JSONObject().put("databases", names)));
   }
 
-  static void checkSingleBucketTypes(final ArcadeDBServer server, final JSONArray alerts) {
+  static void checkSingleBucketTypes(final ArcadeDBServer server, final JSONArray alerts,
+      final Set<String> visibleDatabases) {
     final JSONObject byDatabase = new JSONObject();
     int totalTypes = 0;
 
     for (final String dbName : server.getDatabaseNames()) {
+      if (visibleDatabases != null && !visibleDatabases.contains(dbName))
+        continue;
       try {
         // allowLoad=false: never re-open a database just to compute a status poll.
         final ServerDatabase db = server.getDatabase(dbName, false, false);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -149,8 +149,16 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
 
     // Per-database list, used by Studio to render per-database actions (e.g. the emergency
     // "Resync from Leader" control on followers) and to surface bootstrap baselines when present.
+    // Scoped to the caller: the cluster status is server-level, but a database row carries that
+    // database's transaction id and bootstrap fingerprint, which belong to its tenant alone.
+    final Set<String> authorizedDatabases = filterAuthorizedDatabases(user, httpServer.getServer().getDatabaseNames());
     final JSONArray databases = new JSONArray();
-    for (final String dbName : httpServer.getServer().getDatabaseNames()) {
+    for (final String dbName : authorizedDatabases) {
+      // Reserved internal databases (the Raft control directory '.raft') are not operator-visible state:
+      // the presence matrix and the bootstrap-state RPC both skip them, and offering Studio a per-database
+      // action row for one would be meaningless.
+      if (ArcadeDBServer.isReservedDatabaseName(dbName))
+        continue;
       final JSONObject dbJson = new JSONObject();
       dbJson.put("name", dbName);
       final ArcadeStateMachine.BootstrapBaseline baseline = stateMachine.getBootstrapBaseline(dbName);
@@ -172,12 +180,22 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
 
     // Optional per-database x per-node presence matrix (issue #4727), gated behind ?presence=true so the
     // cheap auto-poll never triggers the peer fan-out. Built on the leader; followers return only their own.
-    if (isLeader && isPresenceRequested(exchange))
-      response.put("databasePresence", buildPresenceMatrix(raftHAServer, localPeerId));
+    // Root-only, and checked before the fan-out runs: the matrix answers a whole-cluster question ("which
+    // node is missing which database") that no single tenant can act on - every remedy it points to (resync,
+    // transfer leadership) is itself root-only - and each request costs one bootstrap-state RPC per peer,
+    // which may open a closed database on the far side.
+    if (isPresenceRequested(exchange)) {
+      checkRootUser(user);
+      if (isLeader)
+        response.put("databasePresence", buildPresenceMatrix(raftHAServer, localPeerId));
+    }
 
     // Cluster-level health alerts (e.g. single-bucket types that serialize concurrent writes on the
     // leader). Surfaced in Studio's HA panel so operators see actionable warnings without log-grepping.
-    response.put("alerts", ClusterAlerts.scan(httpServer.getServer(), stateMachine, followerSamples));
+    // Scoped like the database list above, because the alert payloads name databases and, for the
+    // single-bucket check, their type names too.
+    response.put("alerts",
+        ClusterAlerts.scan(httpServer.getServer(), stateMachine, followerSamples, authorizedDatabases));
 
     return new ExecutionResponse(200, response.toString());
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -151,14 +151,15 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
     // "Resync from Leader" control on followers) and to surface bootstrap baselines when present.
     // Scoped to the caller: the cluster status is server-level, but a database row carries that
     // database's transaction id and bootstrap fingerprint, which belong to its tenant alone.
+    // Reserved internal databases (the Raft control directory '.raft') are not operator-visible state: the
+    // presence matrix and the bootstrap-state RPC both skip them, and offering Studio a per-database action
+    // row for one would be meaningless. Dropped once, here, rather than inside the loop below, so that the
+    // databases array and the alerts payload built from the same set agree on what exists.
     final Set<String> authorizedDatabases = filterAuthorizedDatabases(user, httpServer.getServer().getDatabaseNames());
+    authorizedDatabases.removeIf(ArcadeDBServer::isReservedDatabaseName);
+
     final JSONArray databases = new JSONArray();
     for (final String dbName : authorizedDatabases) {
-      // Reserved internal databases (the Raft control directory '.raft') are not operator-visible state:
-      // the presence matrix and the bootstrap-state RPC both skip them, and offering Studio a per-database
-      // action row for one would be meaningless.
-      if (ArcadeDBServer.isReservedDatabaseName(dbName))
-        continue;
       final JSONObject dbJson = new JSONObject();
       dbJson.put("name", dbName);
       final ArcadeStateMachine.BootstrapBaseline baseline = stateMachine.getBootstrapBaseline(dbName);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostBootstrapStateHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostBootstrapStateHandler.java
@@ -59,7 +59,8 @@ import java.util.logging.Level;
  * <p>
  * Authentication is inherited from {@link AbstractServerHttpHandler}: the standard
  * {@code X-ArcadeDB-Cluster-Token} + {@code X-ArcadeDB-Forwarded-User} pair used by every other
- * peer-to-peer cluster RPC.
+ * peer-to-peer cluster RPC. Authorization is the root check below, which that pair satisfies because peers
+ * forward as root.
  */
 public class PostBootstrapStateHandler extends AbstractServerHttpHandler {
 
@@ -73,6 +74,13 @@ public class PostBootstrapStateHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
       final JSONObject payload) {
+    // Root-only, like every other cluster RPC: peers reach this endpoint with the cluster token forwarded
+    // as root, so the legitimate caller is unaffected, while an ordinary authenticated user has no business
+    // here. Filtering the response by authorization would not be enough - the work itself is the problem,
+    // since each call computes a SHA-256 over every database directory on the node and may open a database
+    // that was deliberately left closed.
+    checkRootUser(user);
+
     final RaftHAServer raftHAServer = plugin.getRaftHAServer();
     if (raftHAServer == null)
       return new ExecutionResponse(400, new JSONObject().put("error", "Raft HA is not enabled").toString());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterInfoDatabaseScopingIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterInfoDatabaseScopingIT.java
@@ -59,6 +59,10 @@ class ClusterInfoDatabaseScopingIT extends BaseRaftHATest {
   private static final String OTHER_TENANT_DATABASE = "zzsecretdb79wq";
   private static final String OTHER_TENANT_TYPE     = "ZzSecretType79wq";
 
+  /** A reserved internal name (leading dot) registered at runtime, which no caller should be shown. */
+  private static final String RESERVED_DATABASE = ".zzreserved79wq";
+  private static final String RESERVED_TYPE     = "ZzReservedType79wq";
+
   private static final String TENANT_USER     = "tenant79wq";
   private static final String TENANT_PASSWORD = "tenantpassword79wq";
 
@@ -98,7 +102,19 @@ class ClusterInfoDatabaseScopingIT extends BaseRaftHATest {
       assertThat(rootView).as("root keeps the unfiltered operator view")
           .contains(getDatabaseName(), OTHER_TENANT_DATABASE);
       assertThat(rootView).as("reserved internal databases are not operator-visible state")
-          .noneMatch(name -> name.startsWith(ArcadeDBServer.RESERVED_DATABASE_PREFIX));
+          .noneMatch(ArcadeDBServer::isReservedDatabaseName);
+
+      // The databases array and the alerts payload are built from one set, so they must agree on what
+      // exists. Guarded by the precondition below: the single-bucket alert has to be live for its silence
+      // about the reserved database to mean anything.
+      assertThat(singleBucketAlertDatabases(root.json()))
+          .as("precondition: the single-bucket-types alert must actually be firing")
+          .contains(OTHER_TENANT_DATABASE);
+      assertThat(singleBucketAlertDatabases(root.json()))
+          .as("alerts must not name a reserved database the databases array already excludes")
+          .noneMatch(ArcadeDBServer::isReservedDatabaseName);
+      assertThat(root.body).as("nor may its schema leak through the alert payload")
+          .doesNotContain(RESERVED_TYPE);
     });
   }
 
@@ -192,35 +208,50 @@ class ClusterInfoDatabaseScopingIT extends BaseRaftHATest {
   // ---------------------------------------------------------------------------------------------
 
   /**
-   * Runs {@code body} with a second database holding one single-bucket type, so the
-   * {@code single-bucket-types} alert has a type name to disclose. The database is created on every node
-   * before the type is added: the schema DDL runs through the Raft-wrapped handle and replicates, and a
-   * peer that does not hold the database would quarantine the entry and churn snapshot resyncs. The
-   * database and the tenant user are always removed afterwards, whatever the outcome.
+   * Runs {@code body} with two extra databases present, each holding one single-bucket type so the
+   * {@code single-bucket-types} alert has a type name to disclose for it:
+   * <ul>
+   *   <li>{@link #OTHER_TENANT_DATABASE} - another tenant's database, which the scoped user must not see;</li>
+   *   <li>{@link #RESERVED_DATABASE} - a reserved internal name, which nobody, root included, should see.
+   *       Only the startup directory scan filters reserved names; {@code createDatabase} does not, so a
+   *       reserved name genuinely reaches the registry at runtime and the assertion on it is not vacuous.</li>
+   * </ul>
+   * Both are created on every node before their type is added: the schema DDL runs through the Raft-wrapped
+   * handle and replicates, and a peer that does not hold the database would quarantine the entry and churn
+   * snapshot resyncs. Everything, including the tenant user, is removed afterwards whatever the outcome.
    */
   private void withOtherTenantDatabase(final int serverIndex, final ThrowingRunnable body) throws Exception {
-    for (int i = 0; i < getServerCount(); i++)
-      getServer(i).createDatabase(OTHER_TENANT_DATABASE, ComponentFile.MODE.READ_WRITE);
+    createOnEveryNode(OTHER_TENANT_DATABASE, OTHER_TENANT_TYPE, serverIndex);
     try {
-      final ServerDatabase other = getServer(serverIndex).getDatabase(OTHER_TENANT_DATABASE);
-      other.getSchema().createDocumentType(OTHER_TENANT_TYPE, 1);
-      body.run();
+      createOnEveryNode(RESERVED_DATABASE, RESERVED_TYPE, serverIndex);
+      try {
+        body.run();
+      } finally {
+        dropFromEveryNode(RESERVED_DATABASE);
+      }
     } finally {
       dropTenantUser(serverIndex);
-      dropOtherTenantDatabase();
+      dropFromEveryNode(OTHER_TENANT_DATABASE);
     }
   }
 
-  private void dropOtherTenantDatabase() {
+  private void createOnEveryNode(final String databaseName, final String typeName, final int serverIndex) {
+    for (int i = 0; i < getServerCount(); i++)
+      getServer(i).createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
+    final ServerDatabase db = getServer(serverIndex).getDatabase(databaseName);
+    db.getSchema().createDocumentType(typeName, 1);
+  }
+
+  private void dropFromEveryNode(final String databaseName) {
     for (int i = 0; i < getServerCount(); i++) {
       final ArcadeDBServer server = getServer(i);
-      if (server == null || !server.existsDatabase(OTHER_TENANT_DATABASE))
+      if (server == null || !server.existsDatabase(databaseName))
         continue;
       // ServerDatabase refuses drop()/close() because the handle is shared, and dropping through the
       // Raft-wrapped handle would replicate the drop; go through the embedded instance so each node
       // cleans up its own copy, then unregister it from that server's registry.
-      server.getDatabase(OTHER_TENANT_DATABASE).getEmbedded().drop();
-      server.removeDatabase(OTHER_TENANT_DATABASE);
+      server.getDatabase(databaseName).getEmbedded().drop();
+      server.removeDatabase(databaseName);
     }
   }
 
@@ -238,6 +269,17 @@ class ClusterInfoDatabaseScopingIT extends BaseRaftHATest {
     final ServerSecurity security = getServer(serverIndex).getSecurity();
     if (security.getUser(TENANT_USER) != null)
       security.dropUser(TENANT_USER);
+  }
+
+  /** The database names the {@code single-bucket-types} alert reports, or an empty list when it is absent. */
+  private static List<String> singleBucketAlertDatabases(final JSONObject response) {
+    final JSONArray alerts = response.getJSONArray("alerts");
+    for (int i = 0; i < alerts.length(); i++) {
+      final JSONObject alert = alerts.getJSONObject(i);
+      if ("single-bucket-types".equals(alert.getString("id", "")))
+        return new ArrayList<>(alert.getJSONObject("details").getJSONObject("databases").keySet());
+    }
+    return List.of();
   }
 
   private static List<String> databaseNames(final JSONArray databases) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterInfoDatabaseScopingIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterInfoDatabaseScopingIT.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerDatabase;
+import com.arcadedb.server.security.ServerSecurity;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The cluster-info endpoints authenticate but must also authorize what they disclose: a user granted
+ * access to one database must never learn the name, transaction state, bootstrap fingerprint or schema
+ * of another tenant's database through them.
+ * <p>
+ * Three surfaces are covered, because the database registry is enumerated in three different places:
+ * <ul>
+ *   <li>{@code GET /api/v1/cluster} - the {@code databases} array and the {@code alerts} payload, which
+ *       carries per-database type names;</li>
+ *   <li>{@code GET /api/v1/server?mode=cluster} - the {@code ha.databases} array;</li>
+ *   <li>{@code POST /api/v1/cluster/bootstrap-state} - per-database SHA-256 directory fingerprints.</li>
+ * </ul>
+ * The counter-tests matter as much as the leak tests: the topology fields of {@code ?mode=cluster} feed
+ * the remote driver's leader/replica routing for every user, so scoping must not turn into a blanket
+ * rejection there.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ClusterInfoDatabaseScopingIT extends BaseRaftHATest {
+
+  /** Deliberately distinctive so a substring assertion over the whole response body cannot match by accident. */
+  private static final String OTHER_TENANT_DATABASE = "zzsecretdb79wq";
+  private static final String OTHER_TENANT_TYPE     = "ZzSecretType79wq";
+
+  private static final String TENANT_USER     = "tenant79wq";
+  private static final String TENANT_PASSWORD = "tenantpassword79wq";
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  /**
+   * The {@code databases} array and the type names embedded in {@code alerts} must be scoped to what the
+   * caller may access, while root keeps the full operator view.
+   */
+  @Test
+  void clusterEndpointScopesDatabaseDisclosureToAuthorizedDatabases() throws Exception {
+    final int node = findLeaderIndex();
+    assertThat(node).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+
+    withOtherTenantDatabase(node, () -> {
+      createTenantUser(node);
+
+      final Response tenant = call(node, "GET", "/api/v1/cluster", null, TENANT_USER, TENANT_PASSWORD);
+      assertThat(tenant.status).as("a scoped tenant may still read cluster status").isEqualTo(200);
+      assertThat(tenant.body)
+          .as("the other tenant's database name must not appear anywhere in the payload")
+          .doesNotContain(OTHER_TENANT_DATABASE);
+      assertThat(tenant.body)
+          .as("the other tenant's schema must not leak through the single-bucket-types alert")
+          .doesNotContain(OTHER_TENANT_TYPE);
+      assertThat(databaseNames(tenant.json().getJSONArray("databases")))
+          .as("the tenant sees exactly the database it is authorized for")
+          .containsExactly(getDatabaseName());
+
+      // Counter-test: without it the assertions above would also pass on a handler that returns nothing.
+      final Response root = call(node, "GET", "/api/v1/cluster", null, "root", DEFAULT_PASSWORD_FOR_TESTS);
+      assertThat(root.status).isEqualTo(200);
+      final List<String> rootView = databaseNames(root.json().getJSONArray("databases"));
+      assertThat(rootView).as("root keeps the unfiltered operator view")
+          .contains(getDatabaseName(), OTHER_TENANT_DATABASE);
+      assertThat(rootView).as("reserved internal databases are not operator-visible state")
+          .noneMatch(name -> name.startsWith(ArcadeDBServer.RESERVED_DATABASE_PREFIX));
+    });
+  }
+
+  /**
+   * {@code GET /api/v1/server?mode=cluster} enumerates the same registry under {@code ha.databases}.
+   */
+  @Test
+  void serverClusterModeScopesDatabaseDisclosureToAuthorizedDatabases() throws Exception {
+    final int node = findLeaderIndex();
+    assertThat(node).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+
+    withOtherTenantDatabase(node, () -> {
+      createTenantUser(node);
+
+      final Response tenant = call(node, "GET", "/api/v1/server?mode=cluster", null, TENANT_USER, TENANT_PASSWORD);
+      assertThat(tenant.status).isEqualTo(200);
+      assertThat(tenant.body).doesNotContain(OTHER_TENANT_DATABASE);
+      assertThat(databaseNames(tenant.json().getJSONObject("ha").getJSONArray("databases")))
+          .containsExactly(getDatabaseName());
+
+      final Response root = call(node, "GET", "/api/v1/server?mode=cluster", null, "root", DEFAULT_PASSWORD_FOR_TESTS);
+      assertThat(root.status).isEqualTo(200);
+      assertThat(databaseNames(root.json().getJSONObject("ha").getJSONArray("databases")))
+          .contains(getDatabaseName(), OTHER_TENANT_DATABASE);
+    });
+  }
+
+  /**
+   * The remote driver calls {@code ?mode=cluster} on every connection, as whatever user the application
+   * uses, and reads {@code ha.leaderAddress} / {@code ha.replicaAddresses} to route requests. Scoping the
+   * database list must not regress into rejecting non-root callers outright, which would break routing for
+   * every non-root application.
+   */
+  @Test
+  void serverClusterModeKeepsTopologyReadableByNonRootForDriverRouting() throws Exception {
+    final int node = findLeaderIndex();
+    assertThat(node).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+
+    createTenantUser(node);
+
+    final Response tenant = call(node, "GET", "/api/v1/server?mode=cluster", null, TENANT_USER, TENANT_PASSWORD);
+    assertThat(tenant.status).as("non-root must not be rejected: the driver rethrows 403 instead of falling back")
+        .isEqualTo(200);
+
+    final JSONObject ha = tenant.json().getJSONObject("ha");
+    assertThat(ha.has("leaderAddress")).as("driver routing needs the leader address").isTrue();
+    assertThat(ha.has("replicaAddresses")).as("driver routing needs the replica addresses").isTrue();
+  }
+
+  /**
+   * {@code POST /api/v1/cluster/bootstrap-state} is a peer-to-peer RPC: peers reach it with the cluster
+   * token forwarded as root. It has no browser or driver consumer, and it computes a SHA-256 over every
+   * database directory, so it belongs with the mutating cluster endpoints behind the root check rather
+   * than merely being filtered.
+   */
+  @Test
+  void bootstrapStateRequiresRoot() throws Exception {
+    final int node = findLeaderIndex();
+    assertThat(node).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+
+    createTenantUser(node);
+
+    assertThat(call(node, "POST", "/api/v1/cluster/bootstrap-state", new JSONObject(), TENANT_USER, TENANT_PASSWORD).status)
+        .as("a non-root tenant must not be able to fingerprint every database on the node").isEqualTo(403);
+
+    final Response root = call(node, "POST", "/api/v1/cluster/bootstrap-state", new JSONObject(), "root",
+        DEFAULT_PASSWORD_FOR_TESTS);
+    assertThat(root.status).as("root (and therefore the peer RPC, which forwards as root) still passes").isEqualTo(200);
+    assertThat(root.json().getJSONArray("databases").length()).isPositive();
+  }
+
+  /**
+   * The presence matrix fans bootstrap-state RPCs out to every peer, and every action it informs
+   * (resync, transfer leader) is already root-only, so the fan-out itself is gated on root.
+   */
+  @Test
+  void presenceMatrixRequiresRoot() throws Exception {
+    final int node = findLeaderIndex();
+    assertThat(node).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+
+    createTenantUser(node);
+
+    assertThat(call(node, "GET", "/api/v1/cluster?presence=true", null, TENANT_USER, TENANT_PASSWORD).status)
+        .as("the peer fan-out is an operator diagnostic").isEqualTo(403);
+    assertThat(call(node, "GET", "/api/v1/cluster", null, TENANT_USER, TENANT_PASSWORD).status)
+        .as("the cheap poll stays available to the tenant").isEqualTo(200);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  //  Fixture helpers
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Runs {@code body} with a second database holding one single-bucket type, so the
+   * {@code single-bucket-types} alert has a type name to disclose. The database is created on every node
+   * before the type is added: the schema DDL runs through the Raft-wrapped handle and replicates, and a
+   * peer that does not hold the database would quarantine the entry and churn snapshot resyncs. The
+   * database and the tenant user are always removed afterwards, whatever the outcome.
+   */
+  private void withOtherTenantDatabase(final int serverIndex, final ThrowingRunnable body) throws Exception {
+    for (int i = 0; i < getServerCount(); i++)
+      getServer(i).createDatabase(OTHER_TENANT_DATABASE, ComponentFile.MODE.READ_WRITE);
+    try {
+      final ServerDatabase other = getServer(serverIndex).getDatabase(OTHER_TENANT_DATABASE);
+      other.getSchema().createDocumentType(OTHER_TENANT_TYPE, 1);
+      body.run();
+    } finally {
+      dropTenantUser(serverIndex);
+      dropOtherTenantDatabase();
+    }
+  }
+
+  private void dropOtherTenantDatabase() {
+    for (int i = 0; i < getServerCount(); i++) {
+      final ArcadeDBServer server = getServer(i);
+      if (server == null || !server.existsDatabase(OTHER_TENANT_DATABASE))
+        continue;
+      // ServerDatabase refuses drop()/close() because the handle is shared, and dropping through the
+      // Raft-wrapped handle would replicate the drop; go through the embedded instance so each node
+      // cleans up its own copy, then unregister it from that server's registry.
+      server.getDatabase(OTHER_TENANT_DATABASE).getEmbedded().drop();
+      server.removeDatabase(OTHER_TENANT_DATABASE);
+    }
+  }
+
+  private void createTenantUser(final int serverIndex) {
+    final ServerSecurity security = getServer(serverIndex).getSecurity();
+    if (security.getUser(TENANT_USER) != null)
+      return;
+    security.createUser(new JSONObject()
+        .put("name", TENANT_USER)
+        .put("password", security.encodePassword(TENANT_PASSWORD))
+        .put("databases", new JSONObject().put(getDatabaseName(), new JSONArray(new String[] { "admin" }))));
+  }
+
+  private void dropTenantUser(final int serverIndex) {
+    final ServerSecurity security = getServer(serverIndex).getSecurity();
+    if (security.getUser(TENANT_USER) != null)
+      security.dropUser(TENANT_USER);
+  }
+
+  private static List<String> databaseNames(final JSONArray databases) {
+    final List<String> names = new ArrayList<>(databases.length());
+    for (int i = 0; i < databases.length(); i++)
+      names.add(databases.getJSONObject(i).getString("name"));
+    return names;
+  }
+
+  private Response call(final int serverIndex, final String method, final String path, final JSONObject body,
+      final String user, final String password) throws Exception {
+    final int port = getServer(serverIndex).getHttpServer().getPort();
+    final HttpURLConnection conn = (HttpURLConnection) new URI("http://localhost:" + port + path).toURL().openConnection();
+    conn.setRequestMethod(method);
+    conn.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8)));
+    try {
+      if (body != null) {
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.getOutputStream().write(body.toString().getBytes(StandardCharsets.UTF_8));
+      }
+      final int status = conn.getResponseCode();
+      final var stream = status < 400 ? conn.getInputStream() : conn.getErrorStream();
+      final String payload = stream == null ? "" : new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+      return new Response(status, payload);
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private record Response(int status, String body) {
+    JSONObject json() {
+      return new JSONObject(body);
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -52,9 +52,11 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
@@ -889,6 +891,28 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       throw new IllegalArgumentException("Database parameter is null");
     if (user != null && !user.canAccessToDatabase(databaseName))
       throw new SecurityException("User '" + user.getName() + "' is not allowed to access database '" + databaseName + "'");
+  }
+
+  /**
+   * Companion of {@link #checkAuthorizationOnDatabase} for the server-scoped routes that enumerate the whole
+   * database registry instead of naming one database in the path (database listing, server status, cluster
+   * status). Those routes stay open to any authenticated user because what they primarily report is
+   * server-level - but every per-database entry they emit has to be reduced to what the caller may access,
+   * otherwise a tenant scoped to one database learns the names of all the others, and with them whatever the
+   * route hangs off a name: transaction ids, bootstrap fingerprints, schema, index metrics.
+   * <p>
+   * Authorization is delegated to {@link ServerSecurityUser#canAccessToDatabase}, so the wildcard grant is
+   * honoured in exactly one place. A {@code null} user means the route runs without authentication and
+   * everything is returned, matching the permissive behaviour of {@link #checkAuthorizationOnDatabase}.
+   *
+   * @return a new set holding the accessible subset, in the iteration order of {@code databaseNames}
+   */
+  protected Set<String> filterAuthorizedDatabases(final ServerSecurityUser user, final Collection<String> databaseNames) {
+    final Set<String> authorized = new LinkedHashSet<>(databaseNames.size());
+    for (final String databaseName : databaseNames)
+      if (user == null || user.canAccessToDatabase(databaseName))
+        authorized.add(databaseName);
+    return authorized;
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDatabasesHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDatabasesHandler.java
@@ -26,7 +26,6 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
 import io.undertow.server.HttpServerExchange;
 
-import java.util.HashSet;
 import java.util.Set;
 
 @Deprecated
@@ -38,11 +37,7 @@ public class GetDatabasesHandler extends AbstractServerHttpHandler {
   @Override
   protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload)
       throws Exception {
-    final Set<String> installedDatabases = new HashSet<>(httpServer.getServer().getDatabaseNames());
-    final Set<String> allowedDatabases = user.getAuthorizedDatabases();
-
-    if (!allowedDatabases.contains("*"))
-      installedDatabases.retainAll(allowedDatabases);
+    final Set<String> installedDatabases = filterAuthorizedDatabases(user, httpServer.getServer().getDatabaseNames());
 
     final JSONObject response = new JSONObject()
         .put("version", Constants.getVersion())

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetExistsDatabaseHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetExistsDatabaseHandler.java
@@ -41,8 +41,12 @@ public class GetExistsDatabaseHandler extends AbstractServerHttpHandler {
     final ArcadeDBServer server = httpServer.getServer();
     Metrics.counter("http.exists-database").increment();
 
-    final boolean existsDatabase = filterAuthorizedDatabases(user, server.getDatabaseNames())
-        .contains(databaseName.getFirst());
+    // Deliberately not filterAuthorizedDatabases(): this route tests a single name, so building the whole
+    // authorized set to look one entry up would allocate proportionally to the number of databases on the
+    // server for a constant-time question. The two conjuncts are the same predicate that helper applies -
+    // installed, and accessible to the caller - just evaluated for one name.
+    final String requested = databaseName.getFirst();
+    final boolean existsDatabase = server.getDatabaseNames().contains(requested) && user.canAccessToDatabase(requested);
 
     final JSONObject response = new JSONObject();
     response.put("result", existsDatabase);

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetExistsDatabaseHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetExistsDatabaseHandler.java
@@ -26,8 +26,6 @@ import io.micrometer.core.instrument.Metrics;
 import io.undertow.server.HttpServerExchange;
 
 import java.util.Deque;
-import java.util.HashSet;
-import java.util.Set;
 
 public class GetExistsDatabaseHandler extends AbstractServerHttpHandler {
   public GetExistsDatabaseHandler(final HttpServer httpServer) {
@@ -43,13 +41,8 @@ public class GetExistsDatabaseHandler extends AbstractServerHttpHandler {
     final ArcadeDBServer server = httpServer.getServer();
     Metrics.counter("http.exists-database").increment();
 
-    final Set<String> installedDatabases = new HashSet<>(server.getDatabaseNames());
-    final Set<String> allowedDatabases = user.getAuthorizedDatabases();
-
-    if (!allowedDatabases.contains("*"))
-      installedDatabases.retainAll(allowedDatabases);
-
-    final boolean existsDatabase = installedDatabases.contains(databaseName.getFirst());
+    final boolean existsDatabase = filterAuthorizedDatabases(user, server.getDatabaseNames())
+        .contains(databaseName.getFirst());
 
     final JSONObject response = new JSONObject();
     response.put("result", existsDatabase);

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetExistsDatabaseHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetExistsDatabaseHandler.java
@@ -43,10 +43,12 @@ public class GetExistsDatabaseHandler extends AbstractServerHttpHandler {
 
     // Deliberately not filterAuthorizedDatabases(): this route tests a single name, so building the whole
     // authorized set to look one entry up would allocate proportionally to the number of databases on the
-    // server for a constant-time question. The two conjuncts are the same predicate that helper applies -
-    // installed, and accessible to the caller - just evaluated for one name.
+    // server for a constant-time question. The conjuncts below are the same predicate that helper applies -
+    // installed, and accessible to the caller - just evaluated for one name, including its null-user
+    // contract, so the two paths cannot drift on what an unauthenticated route is allowed to report.
     final String requested = databaseName.getFirst();
-    final boolean existsDatabase = server.getDatabaseNames().contains(requested) && user.canAccessToDatabase(requested);
+    final boolean existsDatabase = server.getDatabaseNames().contains(requested)
+        && (user == null || user.canAccessToDatabase(requested));
 
     final JSONObject response = new JSONObject();
     response.put("result", existsDatabase);

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
@@ -76,7 +76,7 @@ public class GetServerHandler extends AbstractServerHttpHandler {
       exportMetrics(response, user);
       exportSettings(response);
     } else if ("cluster".equals(mode)) {
-      exportCluster(exchange, response, user);
+      exportCluster(response, user);
     }
 
     Metrics.counter("http.server-info").increment();
@@ -91,7 +91,7 @@ public class GetServerHandler extends AbstractServerHttpHandler {
    * blanket root check here would break every non-root client. The per-database rows are a different matter
    * and are scoped to the caller.
    */
-  private void exportCluster(final HttpServerExchange exchange, final JSONObject response, final ServerSecurityUser user) {
+  private void exportCluster(final JSONObject response, final ServerSecurityUser user) {
     final HAServerPlugin ha = httpServer.getServer().getHA();
     if (ha != null) {
       final JSONObject haJSON = new JSONObject();

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
@@ -73,10 +73,10 @@ public class GetServerHandler extends AbstractServerHttpHandler {
     if ("basic".equals(mode)) {
       // JUST RETURN BASIC SERVER DATA (name and version)
     } else if ("default".equals(mode)) {
-      exportMetrics(response);
+      exportMetrics(response, user);
       exportSettings(response);
     } else if ("cluster".equals(mode)) {
-      exportCluster(exchange, response);
+      exportCluster(exchange, response, user);
     }
 
     Metrics.counter("http.server-info").increment();
@@ -84,7 +84,14 @@ public class GetServerHandler extends AbstractServerHttpHandler {
     return new ExecutionResponse(200, response.toString());
   }
 
-  private void exportCluster(final HttpServerExchange exchange, final JSONObject response) {
+  /**
+   * Emits the {@code ha} section. The topology fields ({@code leaderAddress}, {@code replicaAddresses},
+   * {@code network}) are server-level and stay readable by every authenticated user: the remote driver calls
+   * this route on each connection, as whatever user the application uses, and routes requests from them - a
+   * blanket root check here would break every non-root client. The per-database rows are a different matter
+   * and are scoped to the caller.
+   */
+  private void exportCluster(final HttpServerExchange exchange, final JSONObject response, final ServerSecurityUser user) {
     final HAServerPlugin ha = httpServer.getServer().getHA();
     if (ha != null) {
       final JSONObject haJSON = new JSONObject();
@@ -97,7 +104,7 @@ public class GetServerHandler extends AbstractServerHttpHandler {
 
       final JSONArray databases = new JSONArray();
 
-      for (String dbName : httpServer.getServer().getDatabaseNames()) {
+      for (final String dbName : filterAuthorizedDatabases(user, httpServer.getServer().getDatabaseNames())) {
         // Never expose reserved internal databases (e.g. the Raft control directory '.raft').
         if (ArcadeDBServer.isReservedDatabaseName(dbName))
           continue;
@@ -122,7 +129,7 @@ public class GetServerHandler extends AbstractServerHttpHandler {
     }
   }
 
-  private void exportMetrics(final JSONObject response) {
+  private void exportMetrics(final JSONObject response, final ServerSecurityUser user) {
     final JSONObject metricsJSON = new JSONObject();
     response.put("metrics", metricsJSON);
 
@@ -187,7 +194,7 @@ public class GetServerHandler extends AbstractServerHttpHandler {
     // per-bucket sub-indexes; surfaced on the Studio Server tab so operators can see compaction
     // lag (memtable not draining) and segment-count growth without log-grepping. The shape is
     // {dbName: {indexName: {memtablePostings, segmentCount, totalPostings}}}.
-    metricsJSON.put("sparseVectorIndexes", buildSparseVectorIndexesJSON());
+    metricsJSON.put("sparseVectorIndexes", buildSparseVectorIndexesJSON(user));
 
     int serverEventsSummaryErrors = 0;
     int serverEventsSummaryWarnings = 0;
@@ -306,9 +313,9 @@ public class GetServerHandler extends AbstractServerHttpHandler {
    * handful of sparse indexes) the cost is negligible. Future caching could amortize it on
    * deployments with thousands of indexes per database; not worth the staleness budget today.
    */
-  private JSONObject buildSparseVectorIndexesJSON() {
+  private JSONObject buildSparseVectorIndexesJSON(final ServerSecurityUser user) {
     final JSONObject byDatabase = new JSONObject();
-    for (final String dbName : httpServer.getServer().getDatabaseNames()) {
+    for (final String dbName : filterAuthorizedDatabases(user, httpServer.getServer().getDatabaseNames())) {
       try {
         // Use the {@code allowLoad=false} variant so a database that was unloaded between
         // getDatabaseNames() and getDatabase() does NOT get re-opened by the metrics scrape.

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -197,11 +197,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     final ArcadeDBServer server = httpServer.getServer();
     Metrics.counter("http.list-databases").increment();
 
-    final Set<String> installedDatabases = new HashSet<>(server.getDatabaseNames());
-    final Set<String> allowedDatabases = user.getAuthorizedDatabases();
-
-    if (!allowedDatabases.contains("*"))
-      installedDatabases.retainAll(allowedDatabases);
+    final Set<String> installedDatabases = filterAuthorizedDatabases(user, server.getDatabaseNames());
 
     final JSONObject response = new JSONObject().put("result", new JSONArray(installedDatabases));
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
@@ -122,11 +122,16 @@ public class PluginApiSpec implements OpenApiContributor {
         """
             Reports this server's Raft role, the current leader, and per-peer replication health \
             including match and next index, lag, and round-trip latency. Answers 503 until Raft has \
-            started, because the route is registered before the Raft server comes up. """
+            started, because the route is registered before the Raft server comes up.
+
+            The cluster and peer fields are server-level and readable by any authenticated user. The \
+            'databases' array and the database-scoped 'alerts' are restricted to the databases the \
+            caller is authorized for, so a user granted one database does not learn the others. """
             + RAFT_REQUIRED);
     get.addParametersItem(SpecBuilders.queryParam("presence",
         "When present with no value, 'true' or '1', includes the per-database x per-peer presence "
-            + "matrix in the 'databasePresence' field. Built only on the leader; a follower ignores it.",
+            + "matrix in the 'databasePresence' field. Restricted to the root user, because it fans a "
+            + "bootstrap-state RPC out to every peer. Built only on the leader; a follower ignores it.",
         false, "boolean"));
     get.setResponses(SpecBuilders.standardResponses("200",
         SpecBuilders.jsonResponse("Cluster status", "ClusterStatus"),
@@ -260,7 +265,10 @@ public class PluginApiSpec implements OpenApiContributor {
             Reports this peer's fingerprint and last transaction id for every database. Used by the \
             bootstrap leader at first cluster formation to decide which copy of each database wins. \
             A database this peer cannot read is reported with an 'error' and a last transaction id of \
-            -1 rather than omitted. """ + RAFT_REQUIRED);
+            -1 rather than omitted.
+
+            Restricted to the root user; peers satisfy this by forwarding as root with the cluster \
+            token. """ + RAFT_REQUIRED);
     post.setResponses(SpecBuilders.standardResponses("200",
         SpecBuilders.jsonResponse("Bootstrap state", "BootstrapStateResponse"),
         "400", "401", "403", "500"));

--- a/server/src/test/java/com/arcadedb/server/ServerMetricsDatabaseScopingIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerMetricsDatabaseScopingIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.security.ServerSecurity;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code GET /api/v1/server} in its default mode reports {@code metrics.sparseVectorIndexes} keyed by
+ * database name, so it enumerates the whole registry exactly like the cluster routes do - but without
+ * needing HA, which is why it is covered here rather than next to
+ * {@code ClusterInfoDatabaseScopingIT} in the ha-raft module.
+ * <p>
+ * The root assertions are not decoration: they establish that the other tenant's database really does
+ * produce a metrics row. Without them the tenant-side assertion would pass just as happily against a
+ * server where no sparse index exists at all, which is the shape this map has by default.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ServerMetricsDatabaseScopingIT extends BaseGraphServerTest {
+
+  private static final String OTHER_TENANT_DATABASE = "zzsparsemetricsdb";
+  private static final String OTHER_TENANT_TYPE     = "ZzSparseRecord";
+
+  private static final String TENANT_USER     = "tenantmetrics79wq";
+  private static final String TENANT_PASSWORD = "tenantpassword79wq";
+
+  @Test
+  void sparseVectorIndexMetricsAreScopedToAuthorizedDatabases() throws Exception {
+    createOtherTenantDatabaseWithSparseIndex();
+    try {
+      createTenantUser();
+
+      final Response root = call("root", DEFAULT_PASSWORD_FOR_TESTS);
+      assertThat(root.status).isEqualTo(200);
+      final JSONObject rootMetrics = root.json().getJSONObject("metrics").getJSONObject("sparseVectorIndexes");
+      assertThat(rootMetrics.keySet())
+          .as("precondition: the other tenant's sparse index must produce a metrics row for root to see")
+          .contains(OTHER_TENANT_DATABASE);
+
+      final Response tenant = call(TENANT_USER, TENANT_PASSWORD);
+      assertThat(tenant.status).as("a scoped tenant may still read server metrics").isEqualTo(200);
+      assertThat(tenant.body)
+          .as("the other tenant's database name must not appear anywhere in the payload")
+          .doesNotContain(OTHER_TENANT_DATABASE);
+      assertThat(tenant.json().getJSONObject("metrics").getJSONObject("sparseVectorIndexes").keySet())
+          .as("the tenant sees no row for a database it is not authorized for")
+          .doesNotContain(OTHER_TENANT_DATABASE);
+    } finally {
+      dropTenantUser();
+      dropOtherTenantDatabase();
+    }
+  }
+
+  private void createOtherTenantDatabaseWithSparseIndex() {
+    final ServerDatabase db = getServer(0).createDatabase(OTHER_TENANT_DATABASE, ComponentFile.MODE.READ_WRITE);
+    db.command("sql", "CREATE DOCUMENT TYPE " + OTHER_TENANT_TYPE + " BUCKETS 1");
+    db.command("sql", "CREATE PROPERTY " + OTHER_TENANT_TYPE + ".tokens ARRAY_OF_INTEGERS");
+    db.command("sql", "CREATE PROPERTY " + OTHER_TENANT_TYPE + ".weights ARRAY_OF_FLOATS");
+    db.command("sql", "CREATE INDEX ON " + OTHER_TENANT_TYPE + " (tokens, weights) LSM_SPARSE_VECTOR"
+        + " METADATA { dimensions: 8, weightQuantization: 'FP32' }");
+    db.newDocument(OTHER_TENANT_TYPE)
+        .set("tokens", new int[] { 1, 5 })
+        .set("weights", new float[] { 0.1f, 0.3f })
+        .save();
+  }
+
+  private void dropOtherTenantDatabase() {
+    final ArcadeDBServer server = getServer(0);
+    if (server == null || !server.existsDatabase(OTHER_TENANT_DATABASE))
+      return;
+    // ServerDatabase refuses drop() because the handle is shared: go through the embedded instance,
+    // then unregister the now-deleted database from the server registry.
+    server.getDatabase(OTHER_TENANT_DATABASE).getEmbedded().drop();
+    server.removeDatabase(OTHER_TENANT_DATABASE);
+  }
+
+  private void createTenantUser() {
+    final ServerSecurity security = getServer(0).getSecurity();
+    if (security.getUser(TENANT_USER) != null)
+      return;
+    security.createUser(new JSONObject()
+        .put("name", TENANT_USER)
+        .put("password", security.encodePassword(TENANT_PASSWORD))
+        .put("databases", new JSONObject().put(getDatabaseName(), new JSONArray(new String[] { "admin" }))));
+  }
+
+  private void dropTenantUser() {
+    final ServerSecurity security = getServer(0).getSecurity();
+    if (security.getUser(TENANT_USER) != null)
+      security.dropUser(TENANT_USER);
+  }
+
+  private Response call(final String user, final String password) throws Exception {
+    final int port = getServer(0).getHttpServer().getPort();
+    final HttpURLConnection conn = (HttpURLConnection) new URI(
+        "http://localhost:" + port + "/api/v1/server").toURL().openConnection();
+    conn.setRequestMethod("GET");
+    conn.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8)));
+    try {
+      final int status = conn.getResponseCode();
+      final var stream = status < 400 ? conn.getInputStream() : conn.getErrorStream();
+      final String payload = stream == null ? "" : new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+      return new Response(status, payload);
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private record Response(int status, String body) {
+    JSONObject json() {
+      return new JSONObject(body);
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/AbstractServerHttpHandlerDatabaseScopingTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/AbstractServerHttpHandlerDatabaseScopingTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.server.HttpServerExchange;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AbstractServerHttpHandler#filterAuthorizedDatabases}, the primitive the routes that
+ * enumerate the whole database registry (database listing, server status, cluster status) reduce their
+ * per-database output with. Every one of those routes is one missing call away from a cross-database
+ * disclosure, so the primitive itself is pinned down here rather than only through the routes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class AbstractServerHttpHandlerDatabaseScopingTest {
+
+  /** Minimal concrete handler: the method under test needs no server, exchange or request state. */
+  private static class TestHandler extends AbstractServerHttpHandler {
+    TestHandler() {
+      super(null);
+    }
+
+    @Override
+    protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+        final JSONObject payload) {
+      throw new UnsupportedOperationException("not exercised");
+    }
+  }
+
+  private final TestHandler handler = new TestHandler();
+
+  private static final Set<String> INSTALLED = new LinkedHashSet<>(List.of("alpha", "beta", "gamma"));
+
+  @Test
+  void keepsOnlyTheDatabasesTheUserIsGranted() {
+    assertThat(handler.filterAuthorizedDatabases(user("beta"), INSTALLED)).containsExactly("beta");
+  }
+
+  @Test
+  void keepsEverythingForAWildcardGrant() {
+    assertThat(handler.filterAuthorizedDatabases(user("*"), INSTALLED)).containsExactly("alpha", "beta", "gamma");
+  }
+
+  @Test
+  void returnsNothingForAUserGrantedNoDatabase() {
+    assertThat(handler.filterAuthorizedDatabases(user(), INSTALLED)).isEmpty();
+  }
+
+  /**
+   * A grant naming a database that is not installed must not conjure it into the result: the output is a
+   * subset of what the server actually holds, never of what the user configuration mentions.
+   */
+  @Test
+  void neverReportsADatabaseTheServerDoesNotHold() {
+    assertThat(handler.filterAuthorizedDatabases(user("beta", "delta"), INSTALLED)).containsExactly("beta");
+  }
+
+  @Test
+  void preservesTheIterationOrderOfTheInstalledSet() {
+    assertThat(handler.filterAuthorizedDatabases(user("*"), INSTALLED)).containsExactlyElementsOf(INSTALLED);
+  }
+
+  /** A null user means the route runs unauthenticated, matching {@code checkAuthorizationOnDatabase}. */
+  @Test
+  void returnsEverythingWhenThereIsNoAuthenticatedUser() {
+    assertThat(handler.filterAuthorizedDatabases(null, INSTALLED)).containsExactlyElementsOf(INSTALLED);
+  }
+
+  @Test
+  void doesNotAliasTheCallerSet() {
+    final Set<String> result = handler.filterAuthorizedDatabases(user("*"), INSTALLED);
+    result.clear();
+    assertThat(INSTALLED).as("the installed set must survive a caller mutating the returned one").hasSize(3);
+  }
+
+  private static ServerSecurityUser user(final String... databases) {
+    final JSONObject granted = new JSONObject();
+    for (final String database : databases)
+      granted.put(database, new JSONArray(new String[] { "admin" }));
+    return new ServerSecurityUser(null,
+        new JSONObject().put("name", "tenant").put("databases", granted));
+  }
+}


### PR DESCRIPTION
## What

The HTTP routes that enumerate the **whole database registry** (rather than naming one database in the path) reported every database on the node to any authenticated user. A user granted access to one database learned the names of all the others, plus whatever each route hangs off a name.

Three surfaces:

| Route | Leaked |
|---|---|
| `GET /api/v1/cluster` | `databases[]` (name, `bootstrapLastTxId`, `bootstrapFingerprint`, acquire status) and `alerts`, whose `single-bucket-types` payload additionally names **types** per database |
| `GET /api/v1/server?mode=cluster` | `ha.databases[]` (name, quorum) |
| `GET /api/v1/server` (default mode) | `metrics.sparseVectorIndexes`, keyed by database name |
| `POST /api/v1/cluster/bootstrap-state` | per-database SHA-256 directory fingerprints and last transaction ids |

The asymmetry that shows the intent: all seven **mutating** Raft endpoints (`PostAddPeer`, `PostTransferLeader`, `PostStepDown`, `PostLeave`, `DeletePeer`, `PostResyncDatabase`, `PostVerifyDatabase`) call `checkRootUser`; the read siblings called nothing. `GetDatabasesHandler` shows the intended shape for the listing routes - `retainAll(user.getAuthorizedDatabases())` - which these omitted.

## How

**One filter, one place.** `AbstractServerHttpHandler#filterAuthorizedDatabases` sits next to `checkAuthorizationOnDatabase` (the GHSA-x8mg gate) and delegates to `ServerSecurityUser#canAccessToDatabase`, so the wildcard grant is interpreted in exactly one place. The three handlers that each hand-rolled the same `retainAll` idiom - `GetDatabasesHandler`, `GetExistsDatabaseHandler`, `PostServerCommandHandler#listDatabases` - now share it, so there are four call sites of one primitive instead of seven copies of an idiom.

**Scope, don't reject, on the status routes.** `?mode=cluster` is called by `RemoteHttpComponent#requestClusterConfiguration` on *every* remote-driver connection, as whatever user the application uses, to read `ha.leaderAddress` / `ha.replicaAddresses` for routing - and a 403 there is rethrown as `SecurityException` rather than falling back to the direct connection. A blanket root check would have broken every non-root client. So server-level fields stay open and only per-database rows are scoped. There is a test pinning this.

**`ClusterAlerts` becomes authorization-aware** rather than being filtered after the fact: the counts inside each alert message are recomputed from the reduced list, so a scoped caller does not read "3 database(s) failed to acquire" next to one name. Node-scoped alerts (lagging followers) are untouched - they describe the cluster, not a database.

**Two endpoints move behind `checkRootUser`**, where filtering the response would not have been enough:

- `POST /api/v1/cluster/bootstrap-state` - a peer-to-peer RPC with no browser or driver consumer. The *work* is the problem, not just the output: each call SHA-256s every database directory on the node and may open a database deliberately left closed. Peers are unaffected, they forward as root with the cluster token.
- `GET /api/v1/cluster?presence=true` - fans that RPC out to every peer. It answers a whole-cluster question, and every remedy it points to (resync, transfer leadership) is already root-only. Checked *before* the fan-out runs. The cheap poll without the parameter is unchanged and still available to tenants.

**Also fixed while in the loop:** `GET /api/v1/cluster` listed reserved internal databases (`.raft`), unlike the presence matrix and the bootstrap-state RPC in the same module, which both skip them.

## Alternative considered

Making the whole cluster-info surface root-only, matching the mutating siblings, would be simpler and leaves no partial-disclosure surface. Rejected: it breaks remote-driver routing for every non-root application, and Studio's cluster tab is not root-gated in the UI. Scoping the database-derived content while leaving topology alone draws the line where the data actually changes owner.

## Tests

`ClusterInfoDatabaseScopingIT` (ha-raft, 2-node cluster) - 5 tests, 4 of which fail on `main`:

- tenant scoped to one database gets a `GET /api/v1/cluster` whose **entire body** contains neither the other database's name nor its type name (a whole-body substring assertion, so it covers `databases[]`, `alerts` and anything added later), while root still sees both
- same for `?mode=cluster`
- **counter-test:** a non-root user still gets `200` from `?mode=cluster` with `leaderAddress` and `replicaAddresses` present - guards the driver-routing path against a future "just make it root-only"
- `bootstrap-state` is `403` for a tenant and `200` for root
- `?presence=true` is `403` for a tenant while the plain poll stays `200`

`AbstractServerHttpHandlerDatabaseScopingTest` (server, 7 tests) pins the primitive itself: scoped grant, wildcard, no grant, a grant naming a database the server does not hold, iteration order, null user, and no aliasing of the caller's set.

Verified red before / green after; the pre-fix run reproduced all four leaks.

**Regression runs, all green:** `server` `http.handler` package (354), `server` `com.arcadedb.remote` package (48, driver), `server` security/user-management/HTTP set (129), ha-raft cluster tests (24) and ha-raft bootstrap/cluster-formation tests (19).

## Behavior change

A non-root caller's `GET /api/v1/cluster` and `GET /api/v1/server` responses now list only their own databases, and `bootstrap-state` / `?presence=true` require root. Release note added to `docs/release-26.8.1.md`.