### PR TITLE
fix(engine) #5635: an index cursor never hands out a null entry, and a restarted index scan releases its cursors

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -878,4 +878,34 @@ The underlying contract was loose in three places, and all three are tightened:
   `NumberFormatException`), an unknown `similarity` or `quantization` name, or an out-of-range `pqClusters` is a
   client mistake. They are reported as parsing errors now, the same treatment the `GEOSPATIAL` metadata gets.
 
+## An index cursor never hands out a null entry, and a restarted index scan releases its cursors
+
+Iterating an LSM-Tree index cursor could yield a `null` element ([#5635](https://github.com/ArcadeData/arcadedb/issues/5635)).
+`hasNext()` answered on how many underlying page cursors were still live, not on whether any of them still held a
+surviving RID, so a scan that ended on a run of tombstoned keys said "yes" and then handed the caller nothing.
+`IndexCursor` is an `Iterator<Identifiable>`, so `for (final Identifiable r : cursor)` yielded that null, and the
+callers that had noticed each carried their own guard against it.
+
+`hasNext()` now prefetches: it runs the merge until it holds an entry it can actually emit, so it is exact, and
+`next()` is a pure drain that throws `NoSuchElementException` once exhausted - the contract every other index cursor
+already honoured. Two consequences were user-visible:
+
+- `SELECT min(...)` / `SELECT max(...)` read the key off the cursor after `next()`. The trailing null still moved the
+  cursor, so on a type whose lowest (or highest) keys had all been deleted the answer was one of those **deleted**
+  keys.
+- A delete-heavy index reported one entry too many in `countEntries()` - the residual #5601 chased, and the reason it
+  survived a full compaction that had already dropped every tombstone.
+
+`getRecord()` and `getKeys()` are settled at the same time: they describe the entry `next()` **last returned**. The old
+implementation peeked at the not-yet-consumed value, so a caller reading them right after `next()` saw the following
+row.
+
+Separately, `FETCH FROM INDEX` now releases its cursors on `reset()`, not only on `close()`. A restart rebuilds every
+cursor from scratch, so the previous run's had to go: a compacted-series cursor stays registered with its file and
+`dropRetiredCompactedIndexes` skips a retired file that still has one, for the lifetime of the database. The pending
+cursors were not even dropped, so a restarted scan replayed the old, partly consumed ones before reaching the new. The
+same release now covers the per-value cursors of a `key IN [...]` lookup, which nothing had ever closed, and the
+cursors held by `MIN`/`MAX`, by the full-text term walks, and by the Cypher `NodeIndexSeek` / `NodeIndexRangeScan`
+operators - all of which stop before exhaustion by design.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/function/sql/geo/SQLFunctionGeoPredicate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/geo/SQLFunctionGeoPredicate.java
@@ -239,12 +239,9 @@ public abstract class SQLFunctionGeoPredicate extends SQLFunctionAbstract implem
 
       while (true) {
         if (cursor != null) {
-          while (cursor.hasNext()) {
-            final Identifiable candidate = cursor.next();
-            if (candidate != null) {
-              pending = candidate;
-              return;
-            }
+          if (cursor.hasNext()) {
+            pending = cursor.next();
+            return;
           }
           cursor.close();
           cursor = null;

--- a/engine/src/main/java/com/arcadedb/index/IndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexCursor.java
@@ -25,13 +25,26 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
 /**
  * Cursor to browse an result set from an index.
+ * <p>
+ * <b>Contract (#5635).</b> An index cursor is a plain {@link java.util.Iterator}: {@code hasNext()} is EXACT and
+ * {@code next()} never answers null - it throws {@link java.util.NoSuchElementException} once exhausted. Implementations
+ * that have skip work to do (tombstones, deduplication, a covering-cell walk) must do it in {@code hasNext()} and cache
+ * the result, not answer optimistically and hand out a null element. Consumers must therefore not guard against a null
+ * from {@code next()}; several used to, each with its own comment, because {@code LSMTreeIndexCursor} did answer
+ * optimistically.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 @ExcludeFromJacocoGeneratedReport
 public interface IndexCursor extends Cursor {
+  /**
+   * The keys of the entry {@link #next()} last returned, or null before the first call.
+   */
   Object[] getKeys();
 
+  /**
+   * The entry {@link #next()} last returned, or null before the first call.
+   */
   Identifiable getRecord();
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
@@ -150,11 +150,13 @@ public class MultiIndexCursor implements IndexCursor {
 
     final Identifiable nextValue = cursorsNextValues.set(nextCursorIndex, null);
     currentRecord = nextValue;
-    if (cursors.get(nextCursorIndex).hasNext()) {
-      final Identifiable next = cursors.get(nextCursorIndex).next();
-      if (next != null)
-        cursorsNextValues.set(nextCursorIndex, next);
-    }
+
+    // #5635: refill this cursor's lookahead slot. An IndexCursor whose hasNext() answered true always yields a
+    // non-null element, so a live cursor's slot is never left empty - which used to happen with the optimistic
+    // hasNext() of LSMTreeIndexCursor and propagated the null straight out of this next().
+    final IndexCursor consumed = cursors.get(nextCursorIndex);
+    if (consumed.hasNext())
+      cursorsNextValues.set(nextCursorIndex, consumed.next());
 
     return nextValue;
   }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.index.fulltext;
 
-import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.function.text.TextLevenshteinDistance;
 import com.arcadedb.index.IndexCursor;
@@ -502,12 +501,13 @@ public class FullTextQueryExecutor {
    */
   private void collectAllIndexedRids(final Map<RID, AtomicInteger> scoreMap) {
     final IndexCursor cursor = index.iterateUnderlying(true, null, true);
-    while (cursor.hasNext()) {
-      // next() may return null after hasNext()==true (deleted/tombstoned entry, issue #5118); skip it.
-      final Identifiable record = cursor.next();
-      if (record == null)
-        continue;
-      scoreMap.computeIfAbsent(record.getIdentity(), k -> new AtomicInteger(1));
+    try {
+      while (cursor.hasNext())
+        scoreMap.computeIfAbsent(cursor.next().getIdentity(), k -> new AtomicInteger(1));
+    } finally {
+      // a compacted-series cursor registers with its file, so an abandoned one keeps a retired file alive for the
+      // lifetime of the database
+      cursor.close();
     }
     // A pure-negative query (only MUST_NOT clauses) has no candidate set, so the whole index must be materialized to subtract the
     // excluded RIDs and form the complement. This is O(index) in time and memory; warn (throttled) when the materialized universe
@@ -533,14 +533,11 @@ public class FullTextQueryExecutor {
     final IndexCursor cursor = index.getPostings(searchKey);
     long df = 0L;
     while (cursor.hasNext()) {
-      // next() may return null after hasNext()==true (deleted/tombstoned entry, issue #5118); skip it.
-      final Identifiable record = cursor.next();
-      if (record == null)
-        continue;
+      final RID rid = cursor.next().getIdentity();
       // Deletion markers carry a negative bucket id: they are not live documents and must not inflate the document frequency.
-      if (record.getIdentity().getBucketId() >= 0)
+      if (rid.getBucketId() >= 0)
         ++df;
-      scoreMap.computeIfAbsent(record.getIdentity(), k -> new AtomicInteger(0)).incrementAndGet();
+      scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
     }
     recordDocumentFrequency(searchKey, df);
   }
@@ -568,14 +565,11 @@ public class FullTextQueryExecutor {
       final IndexCursor cursor = index.getPostings(term.text());
       long df = 0L;
       while (cursor.hasNext()) {
-        // next() may return null after hasNext()==true (deleted/tombstoned entry, issue #5118); skip it.
-        final Identifiable record = cursor.next();
-        if (record == null)
-          continue;
+        final RID rid = cursor.next().getIdentity();
         // Deletion markers carry a negative bucket id and must not inflate the document frequency.
-        if (record.getIdentity().getBucketId() >= 0)
+        if (rid.getBucketId() >= 0)
           ++df;
-        termMatches.put(record.getIdentity(), new AtomicInteger(1));
+        termMatches.put(rid, new AtomicInteger(1));
       }
       recordDocumentFrequency(term.text(), df);
 
@@ -700,27 +694,28 @@ public class FullTextQueryExecutor {
     // Per-expanded-key document frequency for this walk, accumulated in a primitive cell (one allocation per distinct key
     // rather than a boxed Long per posting) and flushed once the range has been consumed.
     final Map<String, long[]> walkFrequencies = new HashMap<>();
-    while (cursor.hasNext()) {
-      // LSMTreeIndexCursor.next() can legitimately return null after hasNext()==true (a full-key tombstone / deleted entry it
-      // steps over while its internal iterators are still considered alive - issue #5118). Skip it instead of dereferencing.
-      final Identifiable record = cursor.next();
-      if (record == null)
-        continue;
-      final RID rid = record.getIdentity();
-      final Object[] keys = cursor.getKeys();
-      if (keys == null || keys.length == 0 || keys[0] == null)
-        continue;
-      final String key = keys[0].toString();
-      if (matcher.matches(key)) {
-        recordScoringToken(key, boost);
-        // Deletion markers carry a negative bucket id and must not inflate the document frequency.
-        if (rid.getBucketId() >= 0)
-          ++walkFrequencies.computeIfAbsent(key, k -> new long[1])[0];
-        if (!tokensOnly)
-          scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
-      } else if (rangeScan && key.compareTo(startKey) > 0 && !key.startsWith(startKey)) {
-        break;
+    try {
+      while (cursor.hasNext()) {
+        final RID rid = cursor.next().getIdentity();
+        final Object[] keys = cursor.getKeys();
+        if (keys == null || keys.length == 0 || keys[0] == null)
+          continue;
+        final String key = keys[0].toString();
+        if (matcher.matches(key)) {
+          recordScoringToken(key, boost);
+          // Deletion markers carry a negative bucket id and must not inflate the document frequency.
+          if (rid.getBucketId() >= 0)
+            ++walkFrequencies.computeIfAbsent(key, k -> new long[1])[0];
+          if (!tokensOnly)
+            scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
+        } else if (rangeScan && key.compareTo(startKey) > 0 && !key.startsWith(startKey)) {
+          break;
+        }
       }
+    } finally {
+      // the walk usually stops on the prefix boundary rather than on exhaustion, so this is the common path, not the
+      // exceptional one: a compacted-series cursor left registered would keep a retired file alive until restart
+      cursor.close();
     }
 
     for (final Map.Entry<String, long[]> frequency : walkFrequencies.entrySet())

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
@@ -304,8 +304,8 @@ public class FullTextSearch {
       for (final LSMTreeFullTextIndex ftIndex : bucketIndexes) {
         final IndexCursor postings = ftIndex.getPostings(token);
         while (postings.hasNext()) {
-          final Identifiable posting = postings.next();
-          if (posting != null && posting.getIdentity().getBucketId() >= 0)
+          // a deletion marker carries a negative bucket id: it is not a live document
+          if (postings.next().getIdentity().getBucketId() >= 0)
             ++df;
         }
       }
@@ -317,8 +317,7 @@ public class FullTextSearch {
   private static void mergeCursor(final Map<RID, Float> target, final IndexCursor cursor) {
     while (cursor.hasNext()) {
       final Identifiable match = cursor.next();
-      if (match != null)
-        target.put(canonicalRID(match.getIdentity()), cursor.getFloatScore());
+      target.put(canonicalRID(match.getIdentity()), cursor.getFloatScore());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/geospatial/GeoIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/GeoIndexCursor.java
@@ -46,9 +46,10 @@ import java.util.Set;
  * the whole ancestor chain of every cell, the set additionally absorbs the same record being found under a cell and
  * under one of its ancestors.
  * <p>
- * Unlike {@code LSMTreeIndexCursor}, this cursor is honest about {@link #hasNext()}: the lookahead needed to skip
- * already-seen RIDs also makes it exact, so {@link #next()} never answers null and throws
- * {@link NoSuchElementException} when exhausted, per the {@link Iterator} contract.
+ * {@link #hasNext()} is exact: the lookahead needed to skip already-seen RIDs also makes it honest, so {@link #next()}
+ * never answers null and throws {@link NoSuchElementException} when exhausted, per the {@link Iterator} contract. Since
+ * #5635 that is the contract of every {@link IndexCursor}, {@code LSMTreeIndexCursor} included, so the cell scans this
+ * one drains need no null guard.
  * <p>
  * A geospatial hit has no relevance to report - the materialising implementation stamped a constant 1 on every entry -
  * so the score is left at the interface default, the documented "scoring not supported" value. Nothing reads a score
@@ -114,13 +115,7 @@ class GeoIndexCursor implements IndexCursor {
     while (true) {
       if (cellCursor != null) {
         while (cellCursor.hasNext()) {
-          // A range cursor answers hasNext() optimistically and returns null once a run of tombstones leaves nothing
-          // to emit, so the result must be checked rather than dereferenced.
-          final Identifiable candidate = cellCursor.next();
-          if (candidate == null)
-            continue;
-
-          final RID rid = candidate.getIdentity();
+          final RID rid = cellCursor.next().getIdentity();
           if (seen.add(rid)) {
             nextRID = rid;
             return;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -489,15 +489,15 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
     long total = 0;
     final IndexCursor it = iterator(true);
     try {
+      // #5635: hasNext() is exact, so every next() yields a live entry. Before that it was optimistic - it answered on
+      // the number of live underlying cursors, not on whether they still held a surviving RID - and next() returned
+      // null once a trailing run of tombstones left nothing to emit, which this count read as one more entry (#5601:
+      // a fully emptied type still reported 1, and only a full compaction cleared it). Dead keys consumed mid-scan are
+      // skipped by the cursor and accounted separately in the deadEntriesSkipped stat, so what is counted here is
+      // exactly the live entries.
       while (it.hasNext()) {
-        // #5601: the returned value MUST be tested. LSMTreeIndexCursor.hasNext() is optimistic - it answers on the
-        // number of live underlying cursors, not on whether they still hold a surviving RID - so next() legitimately
-        // answers null once a trailing run of tombstones leaves nothing to emit. Counting the call instead of the
-        // value made a delete-heavy index report a residual (a fully emptied type still counted 1) that only a full
-        // compaction cleared. Dead keys consumed in the middle of the scan are already skipped by the cursor and are
-        // accounted separately in the deadEntriesSkipped stat, so what survives here is exactly the live entries.
-        if (it.next() != null)
-          ++total;
+        it.next();
+        ++total;
       }
     } finally {
       // releases the compacted-series retire guards and flushes the scan stats: a full walk of every index is the

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -36,7 +36,24 @@ import java.io.IOException;
 import java.util.*;
 
 /**
- * Index cursor doesn't remove the deleted entries.
+ * Merging cursor over the mutable pages and the compacted series of one LSM-Tree index.
+ * <p>
+ * Deleted entries are not physically removed by the index, so the merge has to step over them: a key-wide tombstone
+ * {@code (-1,-1)}, a per-RID tombstone {@code (-(bucketId+2), position)}, or a whole key group whose RIDs were all
+ * shadowed. That skip work is unbounded - compaction never purges tombstones - and it is what makes the cursor's
+ * {@link Iterator} contract non-trivial.
+ * <p>
+ * <b>#5635 - the contract.</b> {@link #hasNext()} PREFETCHES: it runs the merge until it holds a surviving RID, so it
+ * answers on what can actually be emitted rather than on how many underlying cursors are still live. {@link #next()} is
+ * then a pure drain that never returns null and throws {@link NoSuchElementException} once exhausted, like every other
+ * {@link IndexCursor} implementation. Before this, {@code hasNext()} was optimistic and a scan ending on a run of
+ * tombstoned keys handed the caller a null element - {@code IndexCursor extends Iterator<Identifiable>}, so
+ * {@code for (final Identifiable r : cursor)} yielded it. Consumers grew private guards for that null
+ * ({@code FullTextQueryExecutor} carried four); those are gone now that the contract holds here.
+ * <p>
+ * Prefetching also settles what {@link #getRecord()} and {@link #getKeys()} describe: the entry {@code next()} LAST
+ * RETURNED. The previous implementation peeked at the not-yet-consumed value at {@code currentValueIndex}, which read as
+ * "the current entry" only by accident - a caller reading them right after {@code next()} saw the FOLLOWING row.
  */
 public class LSMTreeIndexCursor implements IndexCursor {
   private final LSMTreeIndexMutable                    index;
@@ -60,6 +77,12 @@ public class LSMTreeIndexCursor implements IndexCursor {
   private       Object[]                               txCursorKeys;
   /** Dead (tombstone-resolved) keys skipped by this scan; flushed to the main index stats at scan end. */
   private       long                                   deadEntriesSkipped = 0;
+  /** Prefetched entry (#5635): produced by {@link #fetchNext()}, drained by {@link #next()}. Never a tombstone. */
+  private       RID                                    nextValue;
+  private       Object[]                               nextValueKeys;
+  /** The entry {@link #next()} last returned: what {@link #getRecord()} and {@link #getKeys()} describe. */
+  private       RID                                    lastReturnedValue;
+  private       Object[]                               lastReturnedKeys;
 
   public LSMTreeIndexCursor(final LSMTreeIndexMutable index, final boolean ascendingOrder) throws IOException {
     this(index, ascendingOrder, null, true, null, true);
@@ -333,28 +356,70 @@ public class LSMTreeIndexCursor implements IndexCursor {
     return -1L;
   }
 
+  /**
+   * Exact (#5635): the merge is run up front, so this answers on a RID the cursor can actually hand out. The work it
+   * does is the work {@link #next()} used to do; nothing is done twice, since the prefetched entry is cached until
+   * drained.
+   */
   @Override
   public boolean hasNext() {
-    return validIterators > 0 || (currentValues != null && currentValueIndex < currentValues.length) || txCursor != null;
+    if (nextValue == null)
+      fetchNext();
+    return nextValue != null;
   }
 
   @Override
   public RID next() {
-    // Termination: every round either returns a value, consumes one RID from currentValues, or
-    // consumes one key by advancing every contributing cursor via advanceCursor(), which throws on
-    // the only non-terminating state (a stuck cursor); the tx overlay is a bounded collection.
-    // No iteration budget is imposed: a long tombstone run to skip is legal work (compaction never
-    // purges tombstones) and its length is unrelated to the number of cursors, so any count-based
-    // heuristic here misfires on delete-heavy workloads and fails healthy queries.
-    do {
+    if (nextValue == null)
+      fetchNext();
+
+    if (nextValue == null)
+      throw new NoSuchElementException("Index '" + index.getName() + "' cursor is exhausted");
+
+    lastReturnedValue = nextValue;
+    lastReturnedKeys = nextValueKeys;
+    nextValue = null;
+    nextValueKeys = null;
+    return lastReturnedValue;
+  }
+
+  /**
+   * Whether any SOURCE of entries is left: a live underlying cursor, the RIDs of the key group currently loaded, or the
+   * in-transaction overlay. This is what {@code hasNext()} used to answer directly - optimistic, because a live source
+   * may still hold nothing but tombstones - and it is now only the loop condition of {@link #fetchNext()}.
+   */
+  private boolean hasMoreSources() {
+    return validIterators > 0 || (currentValues != null && currentValueIndex < currentValues.length) || txCursor != null;
+  }
+
+  /**
+   * Advances the merge until it holds a surviving RID in {@link #nextValue}, or leaves it null when the scan is over.
+   * <p>
+   * Termination: every round either produces a value, consumes one RID from currentValues, or consumes one key by
+   * advancing every contributing cursor via advanceCursor(), which throws on the only non-terminating state (a stuck
+   * cursor); the tx overlay is a bounded collection. No iteration budget is imposed: a long tombstone run to skip is
+   * legal work (compaction never purges tombstones) and its length is unrelated to the number of cursors, so any
+   * count-based heuristic here misfires on delete-heavy workloads and fails healthy queries.
+   */
+  private void fetchNext() {
+    while (true) {
       if (currentValues != null && currentValueIndex < currentValues.length) {
         final RID value = currentValues[currentValueIndex++];
-        if (value != null && !index.isDeletedEntry(value))
-          return value;
+        if (value != null && !index.isDeletedEntry(value)) {
+          nextValue = value;
+          nextValueKeys = currentKeys;
+          return;
+        }
 
         continue;
       }
 
+      if (!hasMoreSources()) {
+        flushScanStats();
+        return;
+      }
+
+      currentValues = null;
       currentValueIndex = 0;
 
       Object[] minorKey = null;
@@ -408,7 +473,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
       if (minorKey == null) {
         validIterators = 0;
         flushScanStats();
-        return null;//throw new NoSuchElementException();
+        return;
       }
 
       currentKeys = minorKey;
@@ -505,12 +570,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
 
       if (txCursor == null || !txCursor.hasNext())
         getClosestEntryInTx(currentKeys != null ? currentKeys : fromKeys, false);
-
-    } while (
-        (currentValues == null || currentValues.length == 0 || (currentValueIndex < currentValues.length && index.isDeletedEntry(
-            currentValues[currentValueIndex]))) && hasNext());
-
-    return currentValues == null || currentValueIndex >= currentValues.length ? null : currentValues[currentValueIndex++];
+    }
   }
 
   /**
@@ -635,19 +695,16 @@ public class LSMTreeIndexCursor implements IndexCursor {
 
   }
 
+  /** The keys of the entry {@link #next()} last returned, or null before the first one (#5635). */
   @Override
   public Object[] getKeys() {
-    return currentKeys;
+    return lastReturnedKeys;
   }
 
+  /** The entry {@link #next()} last returned, or null before the first one (#5635). */
   @Override
   public Identifiable getRecord() {
-    if (currentValues != null && currentValueIndex < currentValues.length) {
-      final RID value = currentValues[currentValueIndex];
-      if (!index.isDeletedEntry(value))
-        return value;
-    }
-    return null;
+    return lastReturnedValue;
   }
 
   @Override
@@ -656,6 +713,14 @@ public class LSMTreeIndexCursor implements IndexCursor {
       if (it != null)
         it.close();
     Arrays.fill(pageCursors, null);
+    // a closed cursor is exhausted: drop the prefetched entry and the merge state so hasNext() cannot resurrect it
+    validIterators = 0;
+    txCursor = null;
+    txCursorKeys = null;
+    currentValues = null;
+    currentValueIndex = 0;
+    nextValue = null;
+    nextValueKeys = null;
     flushScanStats();
   }
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -101,6 +101,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.Timer;
@@ -3922,7 +3923,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
         @Override
         public Identifiable next() {
           if (!hasNext())
-            return null;
+            // #5635: an exhausted IndexCursor throws, it does not hand the caller a null element
+            throw new NoSuchElementException();
           return resultRIDs.get(position++);
         }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeIndexRangeScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeIndexRangeScan.java
@@ -252,7 +252,12 @@ public class NodeIndexRangeScan extends AbstractPhysicalOperator {
 
       @Override
       public void close() {
-        // IndexCursor doesn't need explicit closing
+        // #5635: an index cursor DOES need explicit closing - a compacted-series cursor registers with its file, so a
+        // scan abandoned on a LIMIT would keep a retired file alive until the next database restart.
+        if (cursor != null) {
+          cursor.close();
+          cursor = null;
+        }
       }
     };
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeIndexSeek.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeIndexSeek.java
@@ -217,6 +217,12 @@ public class NodeIndexSeek extends AbstractPhysicalOperator {
         while (buffer.size() < n) {
           // Advance to the next seek value when the current cursor is exhausted.
           if (cursor == null || !cursor.hasNext()) {
+            if (cursor != null) {
+              // release the drained cursor before opening the next one: a compacted-series cursor holds its file's
+              // retire guard, and an IN list opens one cursor per value (#5635)
+              cursor.close();
+              cursor = null;
+            }
             if (seekIndex >= seekKeys.size()) {
               finished = true;
               return;
@@ -246,7 +252,12 @@ public class NodeIndexSeek extends AbstractPhysicalOperator {
 
       @Override
       public void close() {
-        // IndexCursor doesn't need explicit closing
+        // #5635: an index cursor DOES need explicit closing - a compacted-series cursor registers with its file, so a
+        // scan abandoned on a LIMIT would keep a retired file alive until the next database restart.
+        if (cursor != null) {
+          cursor.close();
+          cursor = null;
+        }
       }
     };
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -51,14 +51,23 @@ import java.util.*;
  */
 public class FetchFromIndexStep extends AbstractExecutionStep {
   protected final String                                         indexName;
-  private final   List<IndexCursor>                              nextCursors = new ArrayList<>();
+  /** Package-private so a test can observe that a restart released them instead of only dropping the references. */
+  final           List<IndexCursor>                              nextCursors = new ArrayList<>();
+  /**
+   * The per-value cursors an {@code IN} condition opens ({@link #processInCondition()} hands each to
+   * {@code customIterator} rather than to {@code nextCursors}). Held here only so {@link #releaseCursors()} can close
+   * them: nothing else ever would, so an {@code IN} list left the same retired-file guard behind that {@code close()}
+   * exists to release.
+   */
+  final           List<IndexCursor>                              customCursors = new ArrayList<>();
   protected       RangeIndex                                     index;
   protected       BooleanExpression                              condition;
   private       BinaryCondition additionalRangeCondition;
   private final boolean         orderAsc;
   private       long            count       = 0;
   private         boolean                                        inited      = false;
-  private         IndexCursor                                    cursor;
+  /** Package-private for the same reason as {@link #nextCursors}. */
+  IndexCursor                                                    cursor;
   private         MultiIterator<Map.Entry<Object, Identifiable>> customIterator;
   private         Iterator<?>                                    nullKeyIterator;
   private         Pair<Object, Identifiable>                     nextEntry   = null;
@@ -184,10 +193,17 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
   @Override
   public void close() {
-    // Release the index cursors even when the scan did not run to exhaustion (e.g. a LIMIT was
-    // reached or the result set was closed early): compacted-series cursors register with their
-    // file so a full compaction defers dropping it, and an unclosed cursor would keep the retired
-    // file alive until the next database restart.
+    releaseCursors();
+    super.close();
+  }
+
+  /**
+   * Releases the index cursors even when the scan did not run to exhaustion (e.g. a LIMIT was reached, the result set
+   * was closed early, or the step is being restarted): compacted-series cursors register with their file so a full
+   * compaction defers dropping it, and an unclosed cursor would keep the retired file alive until the next database
+   * restart.
+   */
+  private void releaseCursors() {
     if (cursor != null) {
       cursor.close();
       cursor = null;
@@ -195,8 +211,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     for (final IndexCursor c : nextCursors)
       c.close();
     nextCursors.clear();
-
-    super.close();
+    for (final IndexCursor c : customCursors)
+      c.close();
+    customCursors.clear();
   }
 
   private void updateIndexStats() {
@@ -278,6 +295,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       customIterator = new MultiIterator<>();
       for (final Object item : MultiValue.getMultiValueIterable(rightValue)) {
         final IndexCursor localCursor = createCursor(equals, unwrapSubQueryResult(item), context);
+        customCursors.add(localCursor);
 
         customIterator.addIterator(new Iterator<Map.Entry>() {
           @Override
@@ -661,8 +679,25 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     return result;
   }
 
+  /**
+   * Restarts the step: {@code inited} goes back to false and {@code init()} rebuilds the whole cursor set from scratch
+   * (that is what {@code UpdateExecutionPlan.reset()} relies on - it re-runs the plan straight after). So the cursors of
+   * the previous run must be RELEASED here, not just dropped (#5635):
+   * <ul>
+   *   <li>a {@code LSMTreeIndexUnderlyingCompactedSeriesCursor} stays registered with its file, and
+   *       {@code LSMTreeIndex.dropRetiredCompactedIndexes} skips a retired file that still has one - for the lifetime of
+   *       the database, since nothing else will ever close it;</li>
+   *   <li>{@code nextCursors} was not even cleared, so the pending cursors of the previous run survived into the new one
+   *       and {@code init()} appended to them: the restarted scan replayed the OLD, partly consumed cursors before
+   *       reaching the ones it had just opened.</li>
+   * </ul>
+   * Not propagated to {@code prev}: {@code SelectExecutionPlan.reset()} walks every step itself, so a step that reset
+   * its predecessor would reset it twice.
+   */
   @Override
   public void reset() {
+    releaseCursors();
+
     index = null;
     condition = condition == null ? null : condition.copy();
     additionalRangeCondition = additionalRangeCondition == null ? null : additionalRangeCondition.copy();
@@ -671,10 +706,10 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     count = 0;
 
     inited = false;
-    cursor = null;
     customIterator = null;
     nullKeyIterator = null;
     nextEntry = null;
+    nextEntryScore = 0f;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MaxMinFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MaxMinFromIndexStep.java
@@ -78,22 +78,31 @@ public class MaxMinFromIndexStep extends AbstractExecutionStep {
           // The first non-null key is the result
           final IndexCursor cursor = index.iterator(!max);
 
-          while (cursor.hasNext()) {
-            cursor.next(); // advance to get the key
-            final Object key = cursor.getKeys();
+          try {
+            while (cursor.hasNext()) {
+              // #5635: the cursor answers hasNext() exactly, so this entry is live and the key it leaves behind is a
+              // key that still has a record. While hasNext() was optimistic, a fully tombstoned end of the key space
+              // let the loop consume a null and read the DELETED key it had stepped over.
+              cursor.next(); // advance to get the key
+              final Object key = cursor.getKeys();
 
-            if (key != null) {
-              // Handle single-key vs multi-key indexes
-              if (key instanceof final Object[] keys) {
-                if (keys.length > 0 && keys[0] != null) {
-                  resultValue = keys[0];
+              if (key != null) {
+                // Handle single-key vs multi-key indexes
+                if (key instanceof final Object[] keys) {
+                  if (keys.length > 0 && keys[0] != null) {
+                    resultValue = keys[0];
+                    break;
+                  }
+                } else {
+                  resultValue = key;
                   break;
                 }
-              } else {
-                resultValue = key;
-                break;
               }
             }
+          } finally {
+            // MIN/MAX stops on the FIRST entry, so the scan is abandoned by design: a compacted-series cursor left
+            // registered here would keep a retired file alive until the next database restart.
+            cursor.close();
           }
 
           executed = true;

--- a/engine/src/test/java/com/arcadedb/index/geospatial/GeoIndexCursorTest.java
+++ b/engine/src/test/java/com/arcadedb/index/geospatial/GeoIndexCursorTest.java
@@ -75,7 +75,7 @@ class GeoIndexCursorTest {
     }
   }
 
-  /** A cell scan that records its own close(), and can be told to answer a null like an optimistic LSM range cursor. */
+  /** A cell scan that records its own close(), so a test can assert the chaining released it. */
   private static class TrackingCursor implements IndexCursor {
     private final List<RID> rids;
     private       int       position;
@@ -211,24 +211,71 @@ class GeoIndexCursorTest {
     assertThat(cursor.hasNext()).isFalse();
   }
 
+  /**
+   * #5635: the cell scans are driven STRICTLY - {@code next()} is only ever called after {@code hasNext()} answered
+   * true - so they need no null guard. This replaces the #5609 test that fed a null through a cell scan to mimic the
+   * optimistic {@code LSMTreeIndexCursor}: since #5635 an index cursor that answers {@code hasNext()} true always
+   * yields a real element, and one that is exhausted throws. A cell scan built on that contract is used here, so an
+   * over-eager {@code next()} anywhere in the chaining logic surfaces as a {@link NoSuchElementException} rather than
+   * being silently absorbed.
+   */
   @Test
-  void aNullFromAnOptimisticCellScanIsSkipped() {
+  void cellScansAreDrivenStrictlyThroughHasNext() {
     final String wkt = "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))";
-    final RID live = new RID(4, 9);
+    final RID first = new RID(4, 9);
+    final RID second = new RID(4, 10);
 
-    final GeoIndexCursor cursor = new GeoIndexCursor(KEYS, newWalk(wkt), (token, frontier) -> {
-      // mimics LSMTreeIndexCursor: hasNext() is optimistic and next() answers null on a tombstone run
-      final List<RID> values = new ArrayList<>();
-      values.add(null);
-      values.add(live);
-      return new TrackingCursor(values);
+    final List<RID> remaining = new ArrayList<>(List.of(first, second));
+    final GeoIndexCursor cursor = new GeoIndexCursor(KEYS, newWalk(wkt), (token, frontier) -> new IndexCursor() {
+      @Override
+      public boolean hasNext() {
+        return !remaining.isEmpty();
+      }
+
+      @Override
+      public Identifiable next() {
+        if (remaining.isEmpty())
+          throw new NoSuchElementException();
+        return remaining.removeFirst();
+      }
+
+      @Override
+      public Object[] getKeys() {
+        return null;
+      }
+
+      @Override
+      public Identifiable getRecord() {
+        return null;
+      }
+
+      @Override
+      public BinaryComparator getComparator() {
+        return null;
+      }
+
+      @Override
+      public byte[] getBinaryKeyTypes() {
+        return new byte[0];
+      }
+
+      @Override
+      public long estimateSize() {
+        return -1L;
+      }
+
+      @Override
+      public Iterator<Identifiable> iterator() {
+        return this;
+      }
     });
 
     final List<Identifiable> emitted = new ArrayList<>();
     while (cursor.hasNext())
       emitted.add(cursor.next());
 
-    assertThat(emitted).containsExactly(live);
+    // the walk opens a cell scan per covering cell; only the first one holds anything, and the rest are empty
+    assertThat(emitted).containsExactly(first, second);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexCursorContractTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexCursorContractTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.RangeIndex;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * #5635 (follow-up of #5601): {@link LSMTreeIndexCursor} must honour the {@link Iterator} contract.
+ * <p>
+ * {@code hasNext()} used to answer on how many underlying page cursors were still live, not on whether any of them still
+ * held a surviving RID. A scan that ended on a run of tombstoned keys therefore answered {@code true} and then handed the
+ * caller a {@code null} element out of {@code next()} - {@code IndexCursor extends Iterator<Identifiable>}, so
+ * {@code for (final Identifiable r : cursor)} yielded null. Every consumer that noticed grew its own guard
+ * ({@code FullTextQueryExecutor} had four, {@code GeoIndexCursor} one, {@code MultiIndexCursor} propagated it upward) and
+ * the ones that did not silently counted the null as a row: that was the whole residual of #5601's
+ * {@code countEntries()}, and it is what made {@code SELECT max(id)} report a deleted key.
+ * <p>
+ * The tests drive the BUCKET-level index, so the cursor under test is a bare {@link LSMTreeIndexCursor} rather than the
+ * {@code MultiIndexCursor} a {@link TypeIndex} wraps it in - the wrapper happens to absorb the null, which is exactly why
+ * the defect stayed invisible for so long. The fixture is the delete-heavy shape the defect needs: a contiguous run of
+ * tombstones at BOTH ends of the key space, so an ascending scan starts inside one and ends inside the other.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LSMTreeIndexCursorContractTest extends TestHelper {
+  private static final String TYPE_NAME     = "Measurement";
+  private static final int    TOTAL         = 4_000;
+  // survivors are the middle slice: [SURVIVOR_FROM, SURVIVOR_TO)
+  private static final int    SURVIVOR_FROM = 1_800;
+  private static final int    SURVIVOR_TO   = 1_900;
+  private static final int    SURVIVORS     = SURVIVOR_TO - SURVIVOR_FROM;
+
+  @Override
+  public void beforeTest() {
+    // keep compaction manual so each test controls the index shape deterministically
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+  }
+
+  @Test
+  void iteratingNeverYieldsNull() {
+    final RangeIndex index = createTypeWithTombstoneRunsAtBothEnds();
+    database.transaction(() -> {
+      assertNoNullElement(index.range(true, new Object[] { 0 }, true, new Object[] { TOTAL }, true));
+      assertNoNullElement(index.range(false, new Object[] { TOTAL }, true, new Object[] { 0 }, true));
+      assertNoNullElement(index.iterator(true));
+      assertNoNullElement(index.iterator(false));
+    });
+  }
+
+  @Test
+  void iteratingNeverYieldsNullAfterCompaction() throws Exception {
+    final RangeIndex index = createTypeWithTombstoneRunsAtBothEnds();
+    assertThat(((LSMTreeIndex) index).scheduleCompaction()).isTrue();
+    assertThat(((LSMTreeIndex) index).compact()).isTrue();
+    database.transaction(() -> {
+      assertNoNullElement(index.range(true, new Object[] { 0 }, true, new Object[] { TOTAL }, true));
+      assertNoNullElement(index.range(false, new Object[] { TOTAL }, true, new Object[] { 0 }, true));
+    });
+  }
+
+  /**
+   * The naive count - one {@code ++} per {@code next()} call, with no null filtering - must agree with the number of
+   * live records. This is exactly what #5601's {@code countEntries()} did, and the trailing null was its whole residual.
+   */
+  @Test
+  void naiveCountMatchesTheNumberOfLiveEntries() {
+    final RangeIndex index = createTypeWithTombstoneRunsAtBothEnds();
+    database.transaction(() -> {
+      assertThat(countEveryNextCall(index.range(true, new Object[] { 0 }, true, new Object[] { TOTAL }, true)))
+          .isEqualTo(SURVIVORS);
+      assertThat(countEveryNextCall(index.range(false, new Object[] { TOTAL }, true, new Object[] { 0 }, true)))
+          .isEqualTo(SURVIVORS);
+    });
+  }
+
+  /**
+   * Per {@link Iterator}, an exhausted cursor throws instead of answering null - which is what every other
+   * {@link IndexCursor} implementation already does ({@code EmptyIndexCursor}, {@code TempIndexCursor},
+   * {@code MultiIndexCursor}, {@code GeoIndexCursor}).
+   */
+  @Test
+  void exhaustedCursorThrowsNoSuchElement() {
+    final RangeIndex index = createTypeWithTombstoneRunsAtBothEnds();
+    database.transaction(() -> {
+      final IndexCursor cursor = index.range(true, new Object[] { 0 }, true, new Object[] { TOTAL }, true);
+      try {
+        int found = 0;
+        while (cursor.hasNext()) {
+          assertThat(cursor.next()).isNotNull();
+          ++found;
+        }
+        assertThat(found).as("precondition: the scan must have emitted the survivors").isEqualTo(SURVIVORS);
+        assertThatThrownBy(cursor::next).isInstanceOf(NoSuchElementException.class);
+      } finally {
+        cursor.close();
+      }
+    });
+  }
+
+  /**
+   * A range that covers nothing but tombstones must be empty on the very first {@code hasNext()}, not "one null long".
+   */
+  @Test
+  void rangeCoveringOnlyTombstonesIsEmpty() {
+    final RangeIndex index = createTypeWithTombstoneRunsAtBothEnds();
+    database.transaction(() -> {
+      final IndexCursor cursor = index.range(true, new Object[] { 0 }, true, new Object[] { SURVIVOR_FROM - 1 }, true);
+      try {
+        assertThat(cursor.hasNext()).isFalse();
+        assertThatThrownBy(cursor::next).isInstanceOf(NoSuchElementException.class);
+      } finally {
+        cursor.close();
+      }
+    });
+  }
+
+  /**
+   * {@code getRecord()} and {@code getKeys()} must describe the entry {@code next()} just returned. The old
+   * implementation peeked at the NOT yet consumed value instead, so a caller reading {@code getRecord()} after
+   * {@code next()} saw the following row - or null on the last one of a key group.
+   */
+  @Test
+  void getRecordAndGetKeysDescribeTheLastReturnedEntry() {
+    final RangeIndex index = createTypeWithTombstoneRunsAtBothEnds();
+    database.transaction(() -> {
+      final IndexCursor cursor = index.range(true, new Object[] { 0 }, true, new Object[] { TOTAL }, true);
+      try {
+        int expectedId = SURVIVOR_FROM;
+        while (cursor.hasNext()) {
+          final Identifiable returned = cursor.next();
+          assertThat(cursor.getRecord()).isEqualTo(returned);
+          assertThat(cursor.getKeys()).containsExactly(expectedId);
+          assertThat(((Document) returned.getRecord()).getInteger("id")).isEqualTo(expectedId);
+          ++expectedId;
+        }
+        assertThat(expectedId).isEqualTo(SURVIVOR_TO);
+      } finally {
+        cursor.close();
+      }
+    });
+  }
+
+  /**
+   * MIN/MAX read the key off the cursor after {@code next()}. With the old contract the trailing null still moved the
+   * cursor, so the key left behind was a deleted one: {@code SELECT max(id)} answered with a tombstoned id.
+   */
+  @Test
+  void minAndMaxSkipTheTombstoneRuns() {
+    createTypeWithTombstoneRunsAtBothEnds();
+    database.transaction(() -> {
+      assertThat(database.query("sql", "SELECT min(id) AS m FROM " + TYPE_NAME).next().<Integer>getProperty("m"))
+          .isEqualTo(SURVIVOR_FROM);
+      assertThat(database.query("sql", "SELECT max(id) AS m FROM " + TYPE_NAME).next().<Integer>getProperty("m"))
+          .isEqualTo(SURVIVOR_TO - 1);
+    });
+  }
+
+  /**
+   * The same shape through the SQL pipeline: an indexed range whose scan ends inside a tombstone run must not produce a
+   * phantom row. {@code FetchFromIndexStep} pairs {@code cursor.getKeys()} with whatever {@code next()} answered, so a
+   * null became an index entry with a null {@code rid}.
+   */
+  @Test
+  void indexedRangeQueryReturnsOnlyLiveRecords() {
+    createTypeWithTombstoneRunsAtBothEnds();
+    database.transaction(() -> {
+      final List<Integer> ids = new ArrayList<>();
+      database.query("sql", "SELECT id FROM " + TYPE_NAME + " WHERE id >= 0 AND id <= " + TOTAL + " ORDER BY id")
+          .forEachRemaining(r -> ids.add(r.getProperty("id")));
+      assertThat(ids).hasSize(SURVIVORS).doesNotContainNull();
+      assertThat(ids.getFirst()).isEqualTo(SURVIVOR_FROM);
+      assertThat(ids.getLast()).isEqualTo(SURVIVOR_TO - 1);
+    });
+  }
+
+  private RangeIndex createTypeWithTombstoneRunsAtBothEnds() {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("id", Integer.class);
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "id" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).withPageSize(64 * 1024).create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < TOTAL; ++i)
+        database.newDocument(TYPE_NAME).set("id", i).save();
+    });
+
+    // collect the victims with a bucket scan (no index range scan) and delete them
+    final List<RID> toDelete = new ArrayList<>(TOTAL);
+    database.transaction(() -> {
+      for (final Iterator<Record> it = database.iterateType(TYPE_NAME, false); it.hasNext(); ) {
+        final Document doc = (Document) it.next();
+        final int id = doc.getInteger("id");
+        if (id < SURVIVOR_FROM || id >= SURVIVOR_TO)
+          toDelete.add(doc.getIdentity());
+      }
+    });
+    database.transaction(() -> {
+      for (final RID rid : toDelete)
+        database.deleteRecord(rid.getRecord());
+    });
+
+    final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getPolymorphicIndexByProperties("id");
+    // the single bucket-level index: its cursors are bare LSMTreeIndexCursor, not wrapped in a MultiIndexCursor
+    return (RangeIndex) typeIndex.getIndexesOnBuckets()[0];
+  }
+
+  private static void assertNoNullElement(final IndexCursor cursor) {
+    try {
+      int found = 0;
+      // the for-each is the point: IndexCursor is an Iterable<Identifiable>, so this is the contract under test
+      for (final Identifiable entry : cursor) {
+        assertThat(entry).as("iterating an index cursor must never yield a null element").isNotNull();
+        ++found;
+      }
+      assertThat(found).isEqualTo(SURVIVORS);
+    } finally {
+      cursor.close();
+    }
+  }
+
+  private static int countEveryNextCall(final IndexCursor cursor) {
+    try {
+      int count = 0;
+      while (cursor.hasNext()) {
+        cursor.next();
+        ++count;
+      }
+      return count;
+    } finally {
+      cursor.close();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexCursorTombstoneRunTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LSMTreeIndexCursorTombstoneRunTest.java
@@ -134,10 +134,16 @@ class LSMTreeIndexCursorTombstoneRunTest extends TestHelper {
   }
 
   private static int countEntries(final IndexCursor cursor) {
-    int count = 0;
-    while (cursor.hasNext())
-      if (cursor.next() != null)
+    try {
+      // no null filtering: since #5635 hasNext() is exact, so every next() yields a real entry
+      int count = 0;
+      while (cursor.hasNext()) {
+        assertThat(cursor.next()).isNotNull();
         ++count;
-    return count;
+      }
+      return count;
+    } finally {
+      cursor.close();
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/FetchFromIndexStepResetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/FetchFromIndexStepResetTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.serializer.BinaryComparator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5635: {@code FetchFromIndexStep.reset()} restarts the step - {@code inited} goes back to false and {@code init()}
+ * rebuilds every cursor - so the cursors of the previous run have to be RELEASED, not merely dereferenced.
+ * <p>
+ * {@code close()} has said as much since #5601: a {@code LSMTreeIndexUnderlyingCompactedSeriesCursor} registers with its
+ * file, and {@code LSMTreeIndex.dropRetiredCompactedIndexes} skips a retired file that still has one - nothing else will
+ * ever close a cursor the step dropped, so the file stays on disk until the next database restart. {@code reset()} did
+ * not do any of it, and it did not even CLEAR {@code nextCursors}: the pending cursors of the previous run survived into
+ * the new one, and {@code init()} appended to them, so the restarted scan replayed the old, partly consumed cursors
+ * first.
+ * <p>
+ * The sibling step, {@code FetchFromIndexedFunctionStep}, got the closing behaviour in #5609
+ * ({@code FetchFromIndexedFunctionStepCloseTest}); this pins the same guarantee on the step every indexed query goes
+ * through.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class FetchFromIndexStepResetTest extends TestHelper {
+  private static final String TYPE_NAME = "Reading";
+  private static final int    TOTAL     = 200;
+
+  /** Wraps a real index cursor so the test can observe whether the step closed it. */
+  private static class TrackingCursor implements IndexCursor {
+    private final IndexCursor delegate;
+    private       boolean     closed;
+
+    TrackingCursor(final IndexCursor delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return delegate.hasNext();
+    }
+
+    @Override
+    public Identifiable next() {
+      return delegate.next();
+    }
+
+    @Override
+    public Object[] getKeys() {
+      return delegate.getKeys();
+    }
+
+    @Override
+    public Identifiable getRecord() {
+      return delegate.getRecord();
+    }
+
+    @Override
+    public BinaryComparator getComparator() {
+      return delegate.getComparator();
+    }
+
+    @Override
+    public byte[] getBinaryKeyTypes() {
+      return delegate.getBinaryKeyTypes();
+    }
+
+    @Override
+    public long estimateSize() {
+      return delegate.estimateSize();
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+      delegate.close();
+    }
+
+    @Override
+    public Iterator<Identifiable> iterator() {
+      return this;
+    }
+  }
+
+  @Test
+  void resetClosesTheCurrentCursor() {
+    createReadings();
+
+    final ResultSet resultSet = database.query("sql", "SELECT id FROM " + TYPE_NAME + " WHERE id > 10 LIMIT 1");
+    try {
+      assertThat(resultSet.hasNext()).isTrue();
+      resultSet.next();
+
+      final FetchFromIndexStep step = indexStep(resultSet);
+      // mid-scan: the step is holding an open cursor, which is exactly the state reset() has to release
+      assertThat((Object) step.cursor).as("precondition: the scan must still be holding a cursor").isNotNull();
+
+      final TrackingCursor tracker = new TrackingCursor(step.cursor);
+      step.cursor = tracker;
+
+      step.reset();
+
+      assertThat(tracker.closed).as("a reset re-runs the scan, so the previous cursor must be released first").isTrue();
+      assertThat((Object) step.cursor).isNull();
+    } finally {
+      resultSet.close();
+    }
+  }
+
+  /**
+   * The pending cursors of a cartesian-product key: not closed, and - worse - not even dropped, so they leaked into the
+   * restarted scan.
+   */
+  @Test
+  void resetClosesAndClearsThePendingCursors() {
+    createReadings();
+
+    final ResultSet resultSet = database.query("sql",
+        "SELECT id FROM " + TYPE_NAME + " WHERE id IN [11, 12, 13] AND id > 0 LIMIT 1");
+    try {
+      assertThat(resultSet.hasNext()).isTrue();
+      resultSet.next();
+
+      final FetchFromIndexStep step = indexStep(resultSet);
+      assertThat(step.nextCursors).as("precondition: a multi-value key must have planned more than one cursor")
+          .isNotEmpty();
+
+      final List<TrackingCursor> trackers = new ArrayList<>();
+      for (int i = 0; i < step.nextCursors.size(); i++) {
+        final TrackingCursor tracker = new TrackingCursor(step.nextCursors.get(i));
+        trackers.add(tracker);
+        step.nextCursors.set(i, tracker);
+      }
+
+      step.reset();
+
+      assertThat(trackers).allMatch(t -> t.closed, "every pending cursor is released");
+      assertThat(step.nextCursors).as("a pending cursor left here would be replayed by the restarted scan").isEmpty();
+    } finally {
+      resultSet.close();
+    }
+  }
+
+  /**
+   * The {@code key IN [...]} path - reachable with an index as the query target - hands its per-value cursors to
+   * {@code customIterator}, which never closed them at all: not on {@code reset()}, not even on {@code close()}.
+   */
+  @Test
+  void resetClosesTheCursorsOfAnInCondition() {
+    createReadings();
+
+    final ResultSet resultSet = database.query("sql",
+        "SELECT FROM INDEX:`" + indexName() + "` WHERE key IN [11, 12, 13]");
+    try {
+      assertThat(resultSet.hasNext()).isTrue();
+      resultSet.next();
+
+      final FetchFromIndexStep step = indexStep(resultSet);
+      assertThat(step.customCursors).as("precondition: an IN list must have opened one cursor per value").isNotEmpty();
+
+      final List<TrackingCursor> trackers = new ArrayList<>();
+      for (int i = 0; i < step.customCursors.size(); i++) {
+        final TrackingCursor tracker = new TrackingCursor(step.customCursors.get(i));
+        trackers.add(tracker);
+        step.customCursors.set(i, tracker);
+      }
+
+      step.reset();
+
+      assertThat(trackers).allMatch(t -> t.closed, "every IN-list cursor is released");
+      assertThat(step.customCursors).isEmpty();
+    } finally {
+      resultSet.close();
+    }
+  }
+
+  /**
+   * The behavioural consequence of the un-cleared {@code nextCursors}: a restarted step must produce the same rows as a
+   * fresh one, not the tail of the previous run followed by the new scan.
+   */
+  @Test
+  void aRestartedStepReplaysTheScanFromTheBeginning() {
+    createReadings();
+
+    final ResultSet resultSet = database.query("sql",
+        "SELECT id FROM " + TYPE_NAME + " WHERE id IN [11, 12, 13] AND id > 0 LIMIT 1");
+    assertThat(resultSet.hasNext()).isTrue();
+    resultSet.next();
+
+    // NOT closed: the step is restarted with its pending cursors still loaded, which is the state reset() must handle
+    // on its own. Closing the result set first would clear them through close() and make this hold vacuously.
+    final FetchFromIndexStep step = indexStep(resultSet);
+    assertThat(step.nextCursors).as("precondition: the restart must happen with a pending cursor loaded").isNotEmpty();
+
+    final List<Object> firstRun = new ArrayList<>();
+    step.reset();
+    collectRids(step, firstRun);
+    assertThat(firstRun).as("the restarted scan must see every matching key exactly once").hasSize(3);
+    assertThat(firstRun).doesNotHaveDuplicates();
+
+    final List<Object> secondRun = new ArrayList<>();
+    step.reset();
+    collectRids(step, secondRun);
+    assertThat(secondRun).isEqualTo(firstRun);
+
+    step.close();
+  }
+
+  private void collectRids(final FetchFromIndexStep step, final List<Object> out) {
+    while (true) {
+      final ResultSet rs = step.syncPull(step.context, 100);
+      if (!rs.hasNext())
+        return;
+      while (rs.hasNext())
+        out.add(rs.next().getProperty("rid"));
+    }
+  }
+
+  private FetchFromIndexStep indexStep(final ResultSet resultSet) {
+    final List<FetchFromIndexStep> found = new ArrayList<>();
+    collect(resultSet.getExecutionPlan().orElseThrow().getSteps(), found);
+    assertThat(found).as("the query must have planned an index fetch").hasSize(1);
+    return found.getFirst();
+  }
+
+  private void collect(final List<ExecutionStep> steps, final List<FetchFromIndexStep> found) {
+    for (final ExecutionStep step : steps) {
+      if (step instanceof final FetchFromIndexStep fetch)
+        found.add(fetch);
+      collect(step.getSubSteps(), found);
+    }
+  }
+
+  private String indexName() {
+    return database.getSchema().getType(TYPE_NAME).getPolymorphicIndexByProperties("id").getName();
+  }
+
+  private void createReadings() {
+    database.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+    database.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".id INTEGER");
+    database.command("sql", "CREATE INDEX ON " + TYPE_NAME + " (id) UNIQUE");
+
+    database.transaction(() -> {
+      for (int i = 0; i < TOTAL; ++i)
+        database.newDocument(TYPE_NAME).set("id", i).save();
+    });
+  }
+}


### PR DESCRIPTION
Closes #5635.

Both follow-ups of #5601 / #5609, in one change because the second half of the first one (removing the private null guards consumers had grown) only makes sense once the contract holds.

## 1. `LSMTreeIndexCursor.next()` could return `null` after `hasNext()` returned true

`hasNext()` answered on how many underlying page cursors were still live, not on whether any of them still held a surviving RID. A scan that ended on a run of tombstoned keys therefore said "yes" and then handed the caller nothing. `IndexCursor extends Iterator<Identifiable>`, so `for (final Identifiable r : cursor)` yielded that null.

**`hasNext()` now prefetches**: it runs the merge until it holds an entry it can actually emit, so it is exact, and `next()` is a pure drain. The work it does is the work `next()` used to do - the prefetched entry is cached until drained, so nothing happens twice.

**`next()` throws `NoSuchElementException` when exhausted**, rather than keeping the null for one release. That is the option the issue left open, and the reason for picking it is that this class was the odd one out, not the norm: `EmptyIndexCursor`, `TempIndexCursor`, `IndexCursorCollection`, `MultiIndexCursor` and `GeoIndexCursor` all throw already, and every `range()` / `iterator()` caller in the tree drives the cursor with `hasNext()`. A caller that already handled the null still works - it just never sees one.

Two consequences were user-visible, beyond the `countEntries()` residual the issue mentions:

- **`SELECT min(...)` / `SELECT max(...)` could answer with a deleted key.** `MaxMinFromIndexStep` reads the key off the cursor *after* `next()`. The trailing null still moved the cursor, so on a type whose lowest (or highest) keys had all been deleted, the key left behind was a tombstoned one.
- **`countEntries()` counted the null as an entry** - #5601's residual, and the reason it survived a full compaction that had already dropped every tombstone.

**`getRecord()` and `getKeys()` are settled at the same time**: they describe the entry `next()` **last returned**. The old implementation peeked at the not-yet-consumed value at `currentValueIndex`, which read as "the current entry" only by accident - a caller reading them right after `next()` saw the *following* row. This is what `TempIndexCursor`, `IndexCursorCollection`, `MultiIndexCursor` and `GeoIndexCursor` already do, so it is an alignment rather than a new rule.

**The guards are removed in the same change**, so there is one contract rather than a mix: `FullTextQueryExecutor` (four sites, from #5118), `GeoIndexCursor.fetchNext()`, `SQLFunctionGeoPredicate`, `MultiIndexCursor` (which propagated the null upward), `FullTextSearch` and `LSMTreeIndex.countEntries()`. `LSMVectorIndex`'s inline cursor also throws now instead of answering null. The contract is documented once, on `IndexCursor`.

## 2. `FetchFromIndexStep.reset()` dropped its cursors without closing them

A reset *restarts* the step - `inited` goes back to false and `init()` rebuilds every cursor from scratch, which is what `UpdateExecutionPlan.reset()` relies on (it re-runs the plan straight after). So the previous run's cursors have to be released, exactly as `close()` already documents: a `LSMTreeIndexUnderlyingCompactedSeriesCursor` stays registered with its file, and `dropRetiredCompactedIndexes` skips a retired file that still has one - for the lifetime of the database, since nothing else will ever close it.

It was worse than a leak. **`nextCursors` was not even cleared**, so the pending cursors of the previous run survived into the new one and `init()` appended to them: the restarted scan replayed the old, partly consumed cursors before reaching the ones it had just opened.

`close()` and `reset()` now share one release path. It also covers the per-value cursors of a `key IN [...]` lookup, which `processInCondition()` hands to `customIterator` - nothing had ever closed those, not even `close()`.

`reset()` is still not propagated to `prev`: `SelectExecutionPlan.reset()` walks every step itself, so a step that reset its predecessor would reset it twice. That is now stated in the javadoc rather than left as a question.

The same abandoned-cursor leak is fixed where the contract change took me: `MaxMinFromIndexStep` (stops on the first entry by design), the full-text term walks in `FullTextQueryExecutor` (a prefix walk stops on the prefix boundary, so early exit is the common path), and the Cypher `NodeIndexSeek` / `NodeIndexRangeScan` operators, whose `close()` carried a `// IndexCursor doesn't need explicit closing` comment that has been wrong since #5601. `NodeIndexSeek` also rotates one cursor per `IN` value and dropped each one on the way.

## Tests

`LSMTreeIndexCursorContractTest` - 8 tests over a fixture with a contiguous tombstone run at **both** ends of the key space (3,900 of 4,000 records deleted), driving the **bucket-level** index so the cursor under test is a bare `LSMTreeIndexCursor` rather than the `MultiIndexCursor` a `TypeIndex` wraps it in. The wrapper happens to absorb the null, which is a large part of why this stayed invisible. 6 of the 8 fail on `main`: the for-each yielding null (mutable pages and after a full compaction), the naive count being one too high, `next()` not throwing, a tombstones-only range not being empty, and `getRecord()`/`getKeys()` describing the wrong entry.

`FetchFromIndexStepResetTest` - 4 tests, all failing on `main`. Tracking cursors pulled out of a real execution plan prove `reset()` reaches and closes the current cursor, the pending `nextCursors`, and the `IN`-list cursors; a fourth asserts the behavioural consequence, that a restarted step replays the scan from the beginning instead of the tail of the previous run. Each asserts its precondition first (the step is mid-scan, holding an open cursor), so none of them can hold vacuously.

`LSMTreeIndexCursorTombstoneRunTest` loses its local `countEntries` workaround - it skipped nulls, and now asserts they never appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puky78GhudfgTHPtYSuFPm
