### PR TITLE
fix(engine) #5626: walk the subquery bodies the parse-time checks claimed were validated elsewhere

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -933,9 +933,19 @@ Two expression positions that were leaves for the same reason are covered too: a
 `BooleanCoercionExpression` - byte-for-byte the same behaviour, minus the blind spot. Procedure `CALL` arguments
 and the `LOAD CSV FROM` url expression are walked as well.
 
+Working out what a name is - a node, a relationship, a path - was written twice, once for a statement and once
+for a subquery body, and the two had already drifted. They are one construction now, which closed an asymmetry
+older than this issue: the statement's copy dropped every kind at a `WITH *`, because it kept only what the
+projection names, while the body's copy passed the incoming scope through.
+
 > **Potentially breaking, in the same way #5602 was.** A query whose bad call sits inside a subquery body is now
 > rejected before it starts rather than failing at runtime - or, where the subquery matched no row, rather than
 > quietly answering `false` / `0` / `[]`. The call was always wrong. One shape worth calling out: `type(b)` where
 > `b` is a node, written inside a subquery, is now the type error it already was outside one.
+>
+> A second shape comes from the shared scope construction: a kind now survives `WITH *`, so
+> `MATCH p = (a)-[:KNOWS]->(b) WITH * RETURN p.name` is rejected as the path-property access it always was,
+> where before the `WITH *` made the engine forget `p` was a path and the query failed at runtime instead. A
+> projection that names what it keeps is unaffected - `WITH 1 AS p` still stops `p` being a path.
 
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -922,7 +922,10 @@ produced for it rather than by re-lexing, and the traversal descends into it - a
 Crossing into a body changes the variable scope, so a check that reads variable kinds (`type()` wants a
 relationship, `p.name` needs `p` not to be a path) re-binds itself to the kinds the body declares, over the ones it
 inherits; an implicit `CALL { }` imports nothing, so a name the body binds for itself shadows the outer one rather
-than answering for it.
+than answering for it. A body's kinds are built by walking its clauses in order, so the two spellings of the same
+import - `CALL (p) { ... }` and a leading `WITH p` - answer alike, while `WITH 1 AS p` stops `p` being a path. Each
+branch of a `UNION` is a scope in its own right: a variable only one branch declares is checked against the kind
+that branch gives it, instead of being dropped for the branches disagreeing about it.
 
 Two expression positions that were leaves for the same reason are covered too: an `EXISTS { }` written as a bare
 `WHERE` predicate, and a function call used as one (`WHERE isEmpty(x)`), each used to get an anonymous

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -878,4 +878,35 @@ The underlying contract was loose in three places, and all three are tightened:
   `NumberFormatException`), an unknown `similarity` or `quantization` name, or an out-of-range `pqClusters` is a
   client mistake. They are reported as parsing errors now, the same treatment the `GEOSPATIAL` metadata gets.
 
+## Cypher: a subquery body is validated like the query around it
+
+The widening of #5602 left one place the walk could not reach, and the class it was written on said so in the
+opposite direction: the bodies of `EXISTS { }`, `COUNT { }` and `COLLECT { }` were "parsed on their own and
+validated then". They were not. Each of the three keeps its body as text and re-parses it once per outer row, and
+a body that cannot run is absorbed into the expression's neutral value - `false`, `0`, an empty list. A `CALL { }`
+body was never handed to this phase at all ([#5626](https://github.com/ArcadeData/arcadedb/issues/5626)).
+
+So `MATCH (n:P) WHERE abs('x') > 0 RETURN n` was rejected before it started, while the identical call one level in,
+`MATCH (n:P) WHERE EXISTS { MATCH (m:P) WHERE abs('x') > 0 RETURN m } RETURN n`, was accepted - the very
+clause-dependent asymmetry #5602 set out to remove. Neo4j type-checks a subquery body exactly as it does the query
+around it.
+
+The three expressions now carry their body as an AST alongside the text, built from the parse tree ANTLR already
+produced for it rather than by re-lexing, and the traversal descends into it - as it does into a `CALL { }` body.
+Crossing into a body changes the variable scope, so a check that reads variable kinds (`type()` wants a
+relationship, `p.name` needs `p` not to be a path) re-binds itself to the kinds the body declares, over the ones it
+inherits; an implicit `CALL { }` imports nothing, so a name the body binds for itself shadows the outer one rather
+than answering for it.
+
+Two expression positions that were leaves for the same reason are covered too: an `EXISTS { }` written as a bare
+`WHERE` predicate, and a function call used as one (`WHERE isEmpty(x)`), each used to get an anonymous
+`BooleanExpression` adapter that the traversal could only treat as a leaf. Both are now the ordinary
+`BooleanCoercionExpression` - byte-for-byte the same behaviour, minus the blind spot. Procedure `CALL` arguments
+and the `LOAD CSV FROM` url expression are walked as well.
+
+> **Potentially breaking, in the same way #5602 was.** A query whose bad call sits inside a subquery body is now
+> rejected before it starts rather than failing at runtime - or, where the subquery matched no row, rather than
+> quietly answering `false` / `0` / `[]`. The call was always wrong. One shape worth calling out: `type(b)` where
+> `b` is a node, written inside a subquery, is now the type error it already was outside one.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CollectExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CollectExpression.java
@@ -42,12 +42,14 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class CollectExpression implements Expression {
-  private final String subquery;
-  private final String text;
+  private final String          subquery;
+  private final String          text;
+  private final CypherStatement parsedSubquery;
 
-  public CollectExpression(final String subquery, final String text) {
+  public CollectExpression(final String subquery, final String text, final CypherStatement parsedSubquery) {
     this.subquery = subquery;
     this.text = text;
+    this.parsedSubquery = parsedSubquery;
   }
 
   @Override
@@ -98,5 +100,14 @@ public class CollectExpression implements Expression {
 
   public String getSubquery() {
     return subquery;
+  }
+
+  /**
+   * The body as an AST. The body still executes from {@link #getSubquery()}, because what runs is the text after
+   * {@link CorrelatedSubqueryRewriter} has correlated it to the outer row, which differs row by row. This AST is the
+   * body as written, and exists so that the parse-time checks reach inside it (issue #5626).
+   */
+  public CypherStatement getParsedSubquery() {
+    return parsedSubquery;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CountExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CountExpression.java
@@ -40,12 +40,14 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class CountExpression implements Expression {
-  private final String subquery;
-  private final String text;
+  private final String          subquery;
+  private final String          text;
+  private final CypherStatement parsedSubquery;
 
-  public CountExpression(final String subquery, final String text) {
+  public CountExpression(final String subquery, final String text, final CypherStatement parsedSubquery) {
     this.subquery = subquery;
     this.text = text;
+    this.parsedSubquery = parsedSubquery;
   }
 
   @Override
@@ -98,5 +100,14 @@ public class CountExpression implements Expression {
 
   public String getSubquery() {
     return subquery;
+  }
+
+  /**
+   * The body as an AST. The body still executes from {@link #getSubquery()}, because what runs is the text after
+   * {@link CorrelatedSubqueryRewriter} has correlated it to the outer row, which differs row by row. This AST is the
+   * body as written, and exists so that the parse-time checks reach inside it (issue #5626).
+   */
+  public CypherStatement getParsedSubquery() {
+    return parsedSubquery;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ExistsExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ExistsExpression.java
@@ -34,12 +34,23 @@ import java.util.logging.Level;
  * Returns true if the pattern/subquery has at least one match, false otherwise.
  */
 public class ExistsExpression implements Expression {
-  private final String subquery;
-  private final String text;
+  private final String          subquery;
+  private final String          text;
+  private final CypherStatement parsedSubquery;
 
+  /**
+   * Used by the runtime paths that synthesize an existential subquery from a pattern already held as an AST
+   * ({@link PatternPredicateExpression}). Such an expression is built while the query runs, never handed to the
+   * parse-time validation, so it carries no parsed body.
+   */
   public ExistsExpression(final String subquery, final String text) {
+    this(subquery, text, null);
+  }
+
+  public ExistsExpression(final String subquery, final String text, final CypherStatement parsedSubquery) {
     this.subquery = subquery;
     this.text = text;
+    this.parsedSubquery = parsedSubquery;
   }
 
   @Override
@@ -84,5 +95,16 @@ public class ExistsExpression implements Expression {
 
   public String getSubquery() {
     return subquery;
+  }
+
+  /**
+   * The body as an AST, or {@code null} when this expression was synthesized at runtime rather than parsed.
+   * <p>
+   * The body still executes from {@link #getSubquery()}, because what runs is the text after
+   * {@link CorrelatedSubqueryRewriter} has correlated it to the outer row, which differs row by row. This AST is the
+   * body as written, and exists so that the parse-time checks reach inside it (issue #5626).
+   */
+  public CypherStatement getParsedSubquery() {
+    return parsedSubquery;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -32,7 +32,6 @@ import com.arcadedb.query.opencypher.ast.CypherStatement;
 import com.arcadedb.query.opencypher.ast.CypherTransactionStatement;
 import com.arcadedb.query.opencypher.ast.DeleteClause;
 import com.arcadedb.query.opencypher.ast.Direction;
-import com.arcadedb.query.opencypher.ast.ExistsExpression;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.FinishClause;
 import com.arcadedb.query.opencypher.ast.ForeachClause;
@@ -76,8 +75,6 @@ import com.arcadedb.query.opencypher.rewriter.ExpressionRewriter;
 import com.arcadedb.query.opencypher.rewriter.InlineNodeWhereHoister;
 import com.arcadedb.query.opencypher.rewriter.LabelPredicateHoister;
 import com.arcadedb.query.opencypher.rewriter.ProjectedOrderByNormalizer;
-import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.Result;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -1347,23 +1344,11 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
     final Cypher25Parser.ExistsExpressionContext existsExpr = expressionBuilder.findExistsExpressionRecursive(expr6);
     if (existsExpr != null && compCtx == null
         && existsExpr.getText().length() >= expr6.getText().length() - 2) {
-      // Parse the EXISTS expression and wrap it as a boolean expression
-      final ExistsExpression exists = expressionBuilder.parseExistsExpression(existsExpr);
-      // ExistsExpression implements Expression, we need to wrap it to return as BooleanExpression
-      // Create an adapter that evaluates the EXISTS expression as a boolean
-      return new BooleanExpression() {
-        @Override
-        public boolean evaluate(final Result result,
-            final CommandContext context) {
-          final Object value = exists.evaluate(result, context);
-          return value instanceof Boolean && (Boolean) value;
-        }
-
-        @Override
-        public String getText() {
-          return exists.getText();
-        }
-      };
+      // ExistsExpression implements Expression, so it has to be adapted to be returned as a BooleanExpression.
+      // Wrap via BooleanCoercionExpression (rather than an anonymous adapter, which the walk of
+      // CypherExpressionWalker could only treat as a leaf) so that the parse-time checks reach the subquery body
+      // inside it - it was the anonymous adapter that hid an EXISTS written in a WHERE (issue #5626).
+      return new BooleanCoercionExpression(expressionBuilder.parseExistsExpression(existsExpr));
     }
 
     // Check if expression6 contains a parenthesized expression
@@ -1486,37 +1471,12 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
       return new BooleanCoercionExpression(listPredExpr);
     }
 
-    // Check if the expression is a function call used as a predicate (e.g., isEmpty(x), exists(x))
-    final Cypher25Parser.FunctionInvocationContext funcCtx = expressionBuilder.findFunctionInvocationRecursive(expr6);
-    if (funcCtx != null) {
-      final Expression funcExpr = expressionBuilder.parseExpressionFromText(expr6);
-      return new BooleanExpression() {
-        @Override
-        public boolean evaluate(final Result result, final CommandContext context) {
-          final Object value = funcExpr.evaluate(result, context);
-          return value instanceof Boolean && (Boolean) value;
-        }
-
-        @Override
-        public Object evaluateTernary(final Result result, final CommandContext context) {
-          final Object value = funcExpr.evaluate(result, context);
-          if (value == null)
-            return null;
-          if (value instanceof Boolean)
-            return value;
-          return Boolean.TRUE;
-        }
-
-        @Override
-        public String getText() {
-          return funcExpr.getText();
-        }
-      };
-    }
-
     // No special boolean form matched. Parse as a generic expression and adapt
     // it to a boolean predicate. Covers bare boolean literals (WHERE true /
-    // WHERE false), boolean-typed properties, parameters, etc.
+    // WHERE false), boolean-typed properties, parameters, and a function call used as a predicate
+    // (isEmpty(x), exists(x), ...) - that last one used to get an anonymous adapter of its own here, byte-for-byte
+    // equivalent to BooleanCoercionExpression except that CypherExpressionWalker could only treat it as a leaf, so
+    // the call inside it escaped the parse-time checks (issue #5626).
     final Expression parsedExpr = expressionBuilder.parseExpressionFromText(expr6);
     if (parsedExpr != null)
       return new BooleanCoercionExpression(parsedExpr);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.opencypher.temporal.CypherLocalDateTime;
 import com.arcadedb.query.opencypher.temporal.CypherTemporalValue;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.log.LogManager;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -40,6 +41,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * Handles expression parsing for the Cypher AST builder.
@@ -1857,6 +1859,14 @@ class CypherExpressionBuilder {
    * <p>
    * A body written as a bare pattern - {@code EXISTS { (n)-[:KNOWS]->(m) }} - has no {@code queryWithLocalDefinitions}
    * of its own and is wrapped into the {@code MATCH} the executor synthesizes for it anyway.
+   * <p>
+   * <b>A body this cannot build is not a query this rejects.</b> Building the AST here puts the statement builder on
+   * the parse path of a body that used to be carried as text and only re-parsed at execution, so a construct ANTLR
+   * accepts but the builder cannot assemble would turn a query that used to run into a parse failure - a regression,
+   * and one this issue has no business causing. The build is therefore best-effort: on failure the body stays text
+   * only, the walk treats the expression as a leaf exactly as it did before #5626, and execution re-parses the text
+   * as it always has. Logged at {@code FINE} so the gap is still discoverable rather than permanent, since a body
+   * with no AST is a body the parse-time checks do not see.
    *
    * @param queryCtx   the body when it is a full query, or null when it is a bare pattern
    * @param patternCtx the pattern list of a bare-pattern body, or null
@@ -1864,20 +1874,27 @@ class CypherExpressionBuilder {
    */
   private static CypherStatement parseSubqueryBody(final Cypher25Parser.QueryWithLocalDefinitionsContext queryCtx,
       final Cypher25Parser.PatternListContext patternCtx, final Cypher25Parser.WhereClauseContext whereCtx) {
-    // A fresh builder: CypherASTBuilder holds no state across a visit, and the expression builder it owns is the one
-    // running right now, so it cannot be reused re-entrantly.
-    final CypherASTBuilder astBuilder = new CypherASTBuilder();
-
-    if (queryCtx != null)
-      return astBuilder.visitQueryWithLocalDefinitions(queryCtx);
-
-    if (patternCtx == null)
+    if (queryCtx == null && patternCtx == null)
       return null;
 
-    final StatementBuilder builder = new StatementBuilder();
-    builder.addMatch(new MatchClause(astBuilder.visitPatternList(patternCtx), false,
-        whereCtx != null ? astBuilder.visitWhereClause(whereCtx) : null));
-    return builder.build();
+    try {
+      // A fresh builder: CypherASTBuilder holds no state across a visit, and the expression builder it owns is the one
+      // running right now, so it cannot be reused re-entrantly.
+      final CypherASTBuilder astBuilder = new CypherASTBuilder();
+
+      if (queryCtx != null)
+        return astBuilder.visitQueryWithLocalDefinitions(queryCtx);
+
+      final StatementBuilder builder = new StatementBuilder();
+      builder.addMatch(new MatchClause(astBuilder.visitPatternList(patternCtx), false,
+          whereCtx != null ? astBuilder.visitWhereClause(whereCtx) : null));
+      return builder.build();
+    } catch (final Exception e) {
+      LogManager.instance().log(CypherExpressionBuilder.class, Level.FINE,
+          "Cannot build the AST of subquery body '%s': it keeps its text and escapes the parse-time checks", e,
+          CypherASTBuilder.getOriginalText(queryCtx != null ? queryCtx : patternCtx));
+      return null;
+    }
   }
 
   /**
@@ -1901,8 +1918,11 @@ class CypherExpressionBuilder {
       throw new CommandParsingException(
           "InvalidClauseComposition: COLLECT subquery cannot contain update clauses");
 
-    // No pattern/where context to pass: unlike EXISTS and COUNT, a COLLECT body has no bare-pattern form in the
-    // grammar - it has to RETURN the value being collected - so it is always a queryWithLocalDefinitions.
+    // No pattern/where context to pass, and none to miss: the grammar gives COLLECT one alternative where EXISTS and
+    // COUNT have two - "collectExpression: COLLECT LCURLY queryWithLocalDefinitions RCURLY" against
+    // "... (queryWithLocalDefinitions | matchMode? patternList whereClause?) ..." - because a COLLECT body has to
+    // RETURN the value being collected. So queryWithLocalDefinitions() is never null here, and a COLLECT body can
+    // never end up without an AST and quietly skip the checks this issue exists to reach it with.
     return new CollectExpression(subquery, text, parseSubqueryBody(ctx.queryWithLocalDefinitions(), null, null));
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -1848,8 +1848,12 @@ class CypherExpressionBuilder {
    * <p>
    * The three subquery expressions keep their body as text and re-parse it once per outer row - what runs is the
    * text after {@link CorrelatedSubqueryRewriter} has correlated it to that row, so the text has to stay. This
-   * builds the body <i>as written</i> alongside it, off the existing sub-tree rather than by re-lexing the text, so
-   * the extra AST costs one tree walk and no second parse.
+   * builds the body <i>as written</i> alongside it, off the existing sub-tree rather than by re-lexing the text.
+   * <p>
+   * What that costs is a full statement build over an existing sub-tree, not a bare tree walk: the visit goes through
+   * the same {@link CypherASTBuilder} pipeline any statement does, rewriters included. It is bounded by the size of
+   * the body, it is paid once per distinct query text since the plan is cached, and it buys the checks a body they
+   * can walk - but a reader sizing it should read it as "one more statement built", not "one traversal".
    * <p>
    * A body written as a bare pattern - {@code EXISTS { (n)-[:KNOWS]->(m) }} - has no {@code queryWithLocalDefinitions}
    * of its own and is wrapped into the {@code MATCH} the executor synthesizes for it anyway.
@@ -1897,6 +1901,8 @@ class CypherExpressionBuilder {
       throw new CommandParsingException(
           "InvalidClauseComposition: COLLECT subquery cannot contain update clauses");
 
+    // No pattern/where context to pass: unlike EXISTS and COUNT, a COLLECT body has no bare-pattern form in the
+    // grammar - it has to RETURN the value being collected - so it is always a queryWithLocalDefinitions.
     return new CollectExpression(subquery, text, parseSubqueryBody(ctx.queryWithLocalDefinitions(), null, null));
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.parser;
 import com.arcadedb.database.Document;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.query.opencypher.ast.*;
 import com.arcadedb.query.opencypher.grammar.Cypher25Parser;
 import com.arcadedb.query.opencypher.temporal.CypherDate;
@@ -28,7 +29,6 @@ import com.arcadedb.query.opencypher.temporal.CypherLocalDateTime;
 import com.arcadedb.query.opencypher.temporal.CypherTemporalValue;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
-import com.arcadedb.log.LogManager;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -1889,10 +1889,19 @@ class CypherExpressionBuilder {
       builder.addMatch(new MatchClause(astBuilder.visitPatternList(patternCtx), false,
           whereCtx != null ? astBuilder.visitWhereClause(whereCtx) : null));
       return builder.build();
-    } catch (final Exception e) {
+    } catch (final CommandParsingException e) {
+      // The builder refusing a body it does not support is the case this fallback is for, and it is not news.
       LogManager.instance().log(CypherExpressionBuilder.class, Level.FINE,
           "Cannot build the AST of subquery body '%s': it keeps its text and escapes the parse-time checks", e,
           CypherASTBuilder.getOriginalText(queryCtx != null ? queryCtx : patternCtx));
+      return null;
+    } catch (final RuntimeException e) {
+      // Anything else is a defect in the builder rather than a body it declines, and the cost of it is invisible -
+      // the query still runs, the checks just stop seeing inside that body. WARNING so a degraded body shows up in
+      // an ordinary log instead of only under FINE, which is the difference between discoverable and theoretical.
+      LogManager.instance().log(CypherExpressionBuilder.class, Level.WARNING,
+          "Unexpected failure building the AST of subquery body '%s': it keeps its text and escapes the parse-time "
+              + "checks", e, CypherASTBuilder.getOriginalText(queryCtx != null ? queryCtx : patternCtx));
       return null;
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -1838,7 +1838,42 @@ class CypherExpressionBuilder {
       subquery = subquery + " RETURN true";
     }
 
-    return new ExistsExpression(subquery, text);
+    return new ExistsExpression(subquery, text,
+        parseSubqueryBody(ctx.queryWithLocalDefinitions(), ctx.patternList(), ctx.whereClause()));
+  }
+
+  /**
+   * Builds the AST of a subquery body from the parse tree ANTLR already produced for it, so that the parse-time
+   * checks of {@link CypherSemanticValidator} can walk inside it (issue #5626).
+   * <p>
+   * The three subquery expressions keep their body as text and re-parse it once per outer row - what runs is the
+   * text after {@link CorrelatedSubqueryRewriter} has correlated it to that row, so the text has to stay. This
+   * builds the body <i>as written</i> alongside it, off the existing sub-tree rather than by re-lexing the text, so
+   * the extra AST costs one tree walk and no second parse.
+   * <p>
+   * A body written as a bare pattern - {@code EXISTS { (n)-[:KNOWS]->(m) }} - has no {@code queryWithLocalDefinitions}
+   * of its own and is wrapped into the {@code MATCH} the executor synthesizes for it anyway.
+   *
+   * @param queryCtx   the body when it is a full query, or null when it is a bare pattern
+   * @param patternCtx the pattern list of a bare-pattern body, or null
+   * @param whereCtx   the trailing WHERE of a bare-pattern body, or null
+   */
+  private static CypherStatement parseSubqueryBody(final Cypher25Parser.QueryWithLocalDefinitionsContext queryCtx,
+      final Cypher25Parser.PatternListContext patternCtx, final Cypher25Parser.WhereClauseContext whereCtx) {
+    // A fresh builder: CypherASTBuilder holds no state across a visit, and the expression builder it owns is the one
+    // running right now, so it cannot be reused re-entrantly.
+    final CypherASTBuilder astBuilder = new CypherASTBuilder();
+
+    if (queryCtx != null)
+      return astBuilder.visitQueryWithLocalDefinitions(queryCtx);
+
+    if (patternCtx == null)
+      return null;
+
+    final StatementBuilder builder = new StatementBuilder();
+    builder.addMatch(new MatchClause(astBuilder.visitPatternList(patternCtx), false,
+        whereCtx != null ? astBuilder.visitWhereClause(whereCtx) : null));
+    return builder.build();
   }
 
   /**
@@ -1862,7 +1897,7 @@ class CypherExpressionBuilder {
       throw new CommandParsingException(
           "InvalidClauseComposition: COLLECT subquery cannot contain update clauses");
 
-    return new CollectExpression(subquery, text);
+    return new CollectExpression(subquery, text, parseSubqueryBody(ctx.queryWithLocalDefinitions(), null, null));
   }
 
   /**
@@ -1894,7 +1929,8 @@ class CypherExpressionBuilder {
       subquery = subquery + " RETURN 1";
     }
 
-    return new CountExpression(subquery, text);
+    return new CountExpression(subquery, text,
+        parseSubqueryBody(ctx.queryWithLocalDefinitions(), ctx.patternList(), ctx.whereClause()));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -71,8 +71,11 @@ import com.arcadedb.query.opencypher.ast.UnionStatement;
 import com.arcadedb.query.opencypher.ast.UnwindClause;
 import com.arcadedb.query.opencypher.ast.WithClause;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Visits every expression a statement contains, wherever it appears: inside another expression, inside a predicate,
@@ -119,10 +122,11 @@ public final class CypherExpressionWalker {
     void visit(Expression expression);
 
     /**
-     * Called when the walk is about to descend into the body of a nested statement - a {@code CALL { ... }} clause or
-     * an {@code EXISTS}/{@code COUNT}/{@code COLLECT} subquery expression. Returning {@code this} keeps the same
-     * check running inside the body; returning a different visitor is how a check whose meaning depends on the
-     * variable scope re-binds itself to the inner one; returning {@code null} skips the body.
+     * Called when the walk is about to descend into a statement that binds its own variables - the body of a
+     * {@code CALL { ... }} clause or of an {@code EXISTS}/{@code COUNT}/{@code COLLECT} subquery expression, and each
+     * branch of a {@code UNION}. Returning {@code this} keeps the same check running inside it; returning a different
+     * visitor is how a check whose meaning depends on the variable scope re-binds itself to the inner one; returning
+     * {@code null} skips it.
      */
     default Visitor forNestedStatement(final CypherStatement statement) {
       return this;
@@ -142,9 +146,12 @@ public final class CypherExpressionWalker {
     if (statement == null)
       return;
 
+    // Each branch of a UNION binds its own variables, so each is entered as a nested statement in its own right:
+    // a check that reads variable kinds gets the kinds of the branch it is looking at, not an intersection over all
+    // of them, which would silently skip a variable only one branch declares.
     if (statement instanceof UnionStatement union) {
       for (final CypherStatement query : union.getQueries())
-        walk(query, visitor);
+        walkNested(query, visitor);
       return;
     }
 
@@ -160,15 +167,27 @@ public final class CypherExpressionWalker {
     walk(statement.getSkip(), visitor);
     walk(statement.getLimit(), visitor);
 
+    // A WITH can be registered on the ordered list, on the statement, or on both, depending on the builder path that
+    // produced it, and every one of them has to be covered. Which ones the ordered walk already reached is tracked by
+    // identity so the second pass adds only what it missed: visiting an expression exactly once is what lets a
+    // visitor keep state, and a visitor that could not would be a trap for the next one written.
+    Set<WithClause> alreadyWalked = null;
+
     final List<ClauseEntry> clauses = statement.getClausesInOrder();
     if (clauses != null)
-      for (int i = 0; i < clauses.size(); i++)
-        walkClause(clauses.get(i), visitor);
+      for (int i = 0; i < clauses.size(); i++) {
+        final ClauseEntry entry = clauses.get(i);
+        if (entry.getType() == ClauseEntry.ClauseType.WITH) {
+          if (alreadyWalked == null)
+            alreadyWalked = Collections.newSetFromMap(new IdentityHashMap<>());
+          alreadyWalked.add(entry.getTypedClause());
+        }
+        walkClause(entry, visitor);
+      }
 
-    // A WITH not present in the ordered list (some builder paths register it only on the statement) still has to be
-    // covered, and walking one twice is harmless - a visitor of this phase is pure.
     for (final WithClause withClause : statement.getWithClauses())
-      walkWith(withClause, visitor);
+      if (alreadyWalked == null || !alreadyWalked.contains(withClause))
+        walkWith(withClause, visitor);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -117,7 +117,10 @@ public final class CypherExpressionWalker {
   @FunctionalInterface
   public interface Visitor {
     /**
-     * Called once per expression node, parents before children.
+     * Called once per expression node, parents before children. Once means once: a node the AST makes reachable by
+     * two routes is still visited a single time, so a visitor that accumulates - a counter, a collector - is safe.
+     * The same expression object appearing at two genuinely different places in the query is two nodes and is
+     * visited twice, which is what a check of any kind wants.
      */
     void visit(Expression expression);
 
@@ -169,8 +172,9 @@ public final class CypherExpressionWalker {
 
     // A WITH can be registered on the ordered list, on the statement, or on both, depending on the builder path that
     // produced it, and every one of them has to be covered. Which ones the ordered walk already reached is tracked by
-    // identity so the second pass adds only what it missed: visiting an expression exactly once is what lets a
-    // visitor keep state, and a visitor that could not would be a trap for the next one written.
+    // identity so the second pass adds only what it missed - the one place in this traversal where the same expression
+    // was otherwise reachable twice. Everywhere else once-only falls out of each arm below walking a part of the tree
+    // no other arm does, which is a property to preserve when adding one, not something enforced here.
     Set<WithClause> alreadyWalked = null;
 
     final List<ClauseEntry> clauses = statement.getClausesInOrder();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -71,11 +71,8 @@ import com.arcadedb.query.opencypher.ast.UnionStatement;
 import com.arcadedb.query.opencypher.ast.UnwindClause;
 import com.arcadedb.query.opencypher.ast.WithClause;
 
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Visits every expression a statement contains, wherever it appears: inside another expression, inside a predicate,
@@ -117,10 +114,10 @@ public final class CypherExpressionWalker {
   @FunctionalInterface
   public interface Visitor {
     /**
-     * Called once per expression node, parents before children. Once means once: a node the AST makes reachable by
-     * two routes is still visited a single time, so a visitor that accumulates - a counter, a collector - is safe.
-     * The same expression object appearing at two genuinely different places in the query is two nodes and is
-     * visited twice, which is what a check of any kind wants.
+     * Called once per expression node, parents before children. Once means once - a visitor that accumulates, a
+     * counter or a collector, is safe - and it is structural rather than guarded: each arm of the walk covers a part
+     * of the tree no other arm does. Preserve that when adding an arm; walking a clause from two places is how the
+     * property gets lost.
      */
     void visit(Expression expression);
 
@@ -170,28 +167,16 @@ public final class CypherExpressionWalker {
     walk(statement.getSkip(), visitor);
     walk(statement.getLimit(), visitor);
 
-    // A WITH can be registered on the ordered list, on the statement, or on both, depending on the builder path that
-    // produced it, and every one of them has to be covered. Which ones the ordered walk already reached is tracked by
-    // identity so the second pass adds only what it missed - the one place in this traversal where the same expression
-    // was otherwise reachable twice. Everywhere else once-only falls out of each arm below walking a part of the tree
-    // no other arm does, which is a property to preserve when adding one, not something enforced here.
-    Set<WithClause> alreadyWalked = null;
-
+    // The ordered clause list is the whole clause tree, WITH included: StatementBuilder.addWith is the one place a
+    // WITH is registered and it puts the same object on both getWithClauses() and this list, so walking the second
+    // collection as well would walk every WITH twice rather than reach one this misses. That invariant is what makes
+    // once-only structural here instead of guarded, and CypherSubqueryParseTimeValidationIssue5626Test pins it -
+    // a builder path that ever registers a WITH on the statement alone has to add it here too, or the walk, and every
+    // check running through it, will not see it.
     final List<ClauseEntry> clauses = statement.getClausesInOrder();
     if (clauses != null)
-      for (int i = 0; i < clauses.size(); i++) {
-        final ClauseEntry entry = clauses.get(i);
-        if (entry.getType() == ClauseEntry.ClauseType.WITH) {
-          if (alreadyWalked == null)
-            alreadyWalked = Collections.newSetFromMap(new IdentityHashMap<>());
-          alreadyWalked.add(entry.getTypedClause());
-        }
-        walkClause(entry, visitor);
-      }
-
-    for (final WithClause withClause : statement.getWithClauses())
-      if (alreadyWalked == null || !alreadyWalked.contains(withClause))
-        walkWith(withClause, visitor);
+      for (int i = 0; i < clauses.size(); i++)
+        walkClause(clauses.get(i), visitor);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -23,11 +23,20 @@ import com.arcadedb.query.opencypher.ast.ArithmeticExpression;
 import com.arcadedb.query.opencypher.ast.BooleanCoercionExpression;
 import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.BooleanWrapperExpression;
+import com.arcadedb.query.opencypher.ast.CallClause;
 import com.arcadedb.query.opencypher.ast.CaseAlternative;
 import com.arcadedb.query.opencypher.ast.CaseExpression;
+import com.arcadedb.query.opencypher.ast.ClauseEntry;
+import com.arcadedb.query.opencypher.ast.CollectExpression;
 import com.arcadedb.query.opencypher.ast.ComparisonExpression;
 import com.arcadedb.query.opencypher.ast.ComparisonExpressionWrapper;
+import com.arcadedb.query.opencypher.ast.CountExpression;
+import com.arcadedb.query.opencypher.ast.CreateClause;
+import com.arcadedb.query.opencypher.ast.CypherStatement;
+import com.arcadedb.query.opencypher.ast.DeleteClause;
+import com.arcadedb.query.opencypher.ast.ExistsExpression;
 import com.arcadedb.query.opencypher.ast.Expression;
+import com.arcadedb.query.opencypher.ast.ForeachClause;
 import com.arcadedb.query.opencypher.ast.FunctionCallExpression;
 import com.arcadedb.query.opencypher.ast.InExpression;
 import com.arcadedb.query.opencypher.ast.IsNullExpression;
@@ -38,26 +47,36 @@ import com.arcadedb.query.opencypher.ast.ListExpression;
 import com.arcadedb.query.opencypher.ast.ListIndexExpression;
 import com.arcadedb.query.opencypher.ast.ListPredicateExpression;
 import com.arcadedb.query.opencypher.ast.ListSliceExpression;
+import com.arcadedb.query.opencypher.ast.LoadCSVClause;
 import com.arcadedb.query.opencypher.ast.LogicalExpression;
 import com.arcadedb.query.opencypher.ast.MapExpression;
 import com.arcadedb.query.opencypher.ast.MapProjectionExpression;
+import com.arcadedb.query.opencypher.ast.MatchClause;
+import com.arcadedb.query.opencypher.ast.MergeClause;
 import com.arcadedb.query.opencypher.ast.NodePattern;
+import com.arcadedb.query.opencypher.ast.OrderByClause;
 import com.arcadedb.query.opencypher.ast.PathPattern;
 import com.arcadedb.query.opencypher.ast.PatternComprehensionExpression;
 import com.arcadedb.query.opencypher.ast.PatternPredicateExpression;
 import com.arcadedb.query.opencypher.ast.ReduceExpression;
 import com.arcadedb.query.opencypher.ast.RegexExpression;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
+import com.arcadedb.query.opencypher.ast.ReturnClause;
+import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.ast.ShortestPathExpression;
 import com.arcadedb.query.opencypher.ast.StringMatchExpression;
+import com.arcadedb.query.opencypher.ast.SubqueryClause;
 import com.arcadedb.query.opencypher.ast.TernaryLogicalExpression;
+import com.arcadedb.query.opencypher.ast.UnionStatement;
+import com.arcadedb.query.opencypher.ast.UnwindClause;
+import com.arcadedb.query.opencypher.ast.WithClause;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 /**
- * Visits every expression nested inside an expression, a predicate or a graph pattern.
+ * Visits every expression a statement contains, wherever it appears: inside another expression, inside a predicate,
+ * inside a graph pattern, and inside the body of a nested subquery.
  * <p>
  * Written for {@link CypherSemanticValidator}, whose parse-time checks each used to carry their own partial recursion:
  * one that only descended into a function's arguments, another that only knew about four expression shapes. A single
@@ -66,9 +85,19 @@ import java.util.function.Consumer;
  * {@code UNWIND}, {@code SET}, {@code CREATE} and {@code MERGE} without each clause growing its own walker
  * (issue #5602).
  * <p>
- * The visitor is called on every expression node including the root, parents before children. Traversal stops at a
- * subquery held as unparsed text ({@code EXISTS { ... }}, {@code COUNT { ... }}, {@code COLLECT { ... }}): those are
- * parsed on their own and validated then, and there is no AST here to walk.
+ * The visitor is called on every expression node including the root, parents before children.
+ * <p>
+ * <b>Subquery bodies are part of the walk.</b> A {@code CALL { ... }} clause and the three subquery expressions -
+ * {@code EXISTS { ... }}, {@code COUNT { ... }}, {@code COLLECT { ... }} - each hold a statement of their own, and the
+ * walk descends into it. Until issue #5626 it did not, and this class asserted the opposite: that those bodies were
+ * "parsed on their own and validated then". They were not - the three keep their body as text and re-parse it once per
+ * outer row, where a failure is absorbed into the expression's neutral value, and a {@code CALL} body was never handed
+ * to this phase at all. So {@code WHERE EXISTS { MATCH (m) WHERE abs('x') > 0 RETURN m }} was accepted while the
+ * identical call written in the outer {@code WHERE} was rejected before the query ran.
+ * <p>
+ * Crossing into a body changes the variable scope, so the descent goes through
+ * {@link Visitor#forNestedStatement(CypherStatement)}: a check that reads variable kinds re-binds itself to the inner
+ * scope there, and one that does not simply keeps the same visitor.
  * <p>
  * <b>Add a case here when introducing an expression type that nests other expressions.</b> The {@code default} arms
  * treat an unrecognised type as a leaf, which is right for a literal or a variable but silently hides whatever a new
@@ -79,18 +108,182 @@ import java.util.function.Consumer;
  */
 public final class CypherExpressionWalker {
 
+  /**
+   * Receives every expression the walk reaches, and decides what happens at the boundary of a nested statement.
+   */
+  @FunctionalInterface
+  public interface Visitor {
+    /**
+     * Called once per expression node, parents before children.
+     */
+    void visit(Expression expression);
+
+    /**
+     * Called when the walk is about to descend into the body of a nested statement - a {@code CALL { ... }} clause or
+     * an {@code EXISTS}/{@code COUNT}/{@code COLLECT} subquery expression. Returning {@code this} keeps the same
+     * check running inside the body; returning a different visitor is how a check whose meaning depends on the
+     * variable scope re-binds itself to the inner one; returning {@code null} skips the body.
+     */
+    default Visitor forNestedStatement(final CypherStatement statement) {
+      return this;
+    }
+  }
+
   private CypherExpressionWalker() {
     // utility class
   }
 
   /**
+   * Visits every expression of {@code statement}: its projections, the expressions of each of its clauses, its
+   * {@code ORDER BY}/{@code SKIP}/{@code LIMIT}, and - through {@link Visitor#forNestedStatement} - the bodies of the
+   * subqueries it contains.
+   */
+  public static void walk(final CypherStatement statement, final Visitor visitor) {
+    if (statement == null)
+      return;
+
+    if (statement instanceof UnionStatement union) {
+      for (final CypherStatement query : union.getQueries())
+        walk(query, visitor);
+      return;
+    }
+
+    final ReturnClause returnClause = statement.getReturnClause();
+    if (returnClause != null)
+      for (final ReturnClause.ReturnItem item : returnClause.getReturnItems())
+        walk(item.getExpression(), visitor);
+
+    // The top-level ORDER BY / SKIP / LIMIT belong to the statement rather than to any clause entry, and are walked
+    // here for the same reason walkWith() walks a WITH's: leaving them out is the clause-dependent asymmetry this
+    // traversal exists to remove.
+    walkOrderBy(statement.getOrderByClause(), visitor);
+    walk(statement.getSkip(), visitor);
+    walk(statement.getLimit(), visitor);
+
+    final List<ClauseEntry> clauses = statement.getClausesInOrder();
+    if (clauses != null)
+      for (int i = 0; i < clauses.size(); i++)
+        walkClause(clauses.get(i), visitor);
+
+    // A WITH not present in the ordered list (some builder paths register it only on the statement) still has to be
+    // covered, and walking one twice is harmless - a visitor of this phase is pure.
+    for (final WithClause withClause : statement.getWithClauses())
+      walkWith(withClause, visitor);
+  }
+
+  /**
+   * Visits every expression of one clause.
+   */
+  private static void walkClause(final ClauseEntry entry, final Visitor visitor) {
+    switch (entry.getType()) {
+    case MATCH -> {
+      final MatchClause matchClause = entry.getTypedClause();
+      if (matchClause.hasWhereClause())
+        walk(matchClause.getWhereClause().getConditionExpression(), visitor);
+      if (matchClause.getPathPatterns() != null)
+        for (final PathPattern pattern : matchClause.getPathPatterns())
+          walk(pattern, visitor);
+    }
+    case WITH -> walkWith(entry.getTypedClause(), visitor);
+    case UNWIND -> walk(((UnwindClause) entry.getTypedClause()).getListExpression(), visitor);
+    case CREATE -> {
+      final CreateClause createClause = entry.getTypedClause();
+      if (createClause.getPathPatterns() != null)
+        for (final PathPattern pattern : createClause.getPathPatterns())
+          walk(pattern, visitor);
+    }
+    case MERGE -> {
+      final MergeClause mergeClause = entry.getTypedClause();
+      walk(mergeClause.getPathPattern(), visitor);
+      walkSet(mergeClause.getOnCreateSet(), visitor);
+      walkSet(mergeClause.getOnMatchSet(), visitor);
+    }
+    case SET -> walkSet(entry.getTypedClause(), visitor);
+    case DELETE -> {
+      final DeleteClause deleteClause = entry.getTypedClause();
+      if (deleteClause.getExpressions() != null)
+        for (final Expression expression : deleteClause.getExpressions())
+          walk(expression, visitor);
+    }
+    case FOREACH -> {
+      final ForeachClause foreachClause = entry.getTypedClause();
+      walk(foreachClause.getListExpression(), visitor);
+      if (foreachClause.getInnerClauses() != null)
+        for (final ClauseEntry inner : foreachClause.getInnerClauses())
+          walkClause(inner, visitor);
+    }
+    case CALL -> {
+      final CallClause callClause = entry.getTypedClause();
+      if (callClause.getArguments() != null)
+        for (final Expression argument : callClause.getArguments())
+          walk(argument, visitor);
+      if (callClause.getYieldWhere() != null)
+        walk(callClause.getYieldWhere().getConditionExpression(), visitor);
+    }
+    case SUBQUERY -> {
+      final SubqueryClause subqueryClause = entry.getTypedClause();
+      walk(subqueryClause.getBatchSize(), visitor);
+      walkNested(subqueryClause.getInnerStatement(), visitor);
+    }
+    case LOAD_CSV -> walk(((LoadCSVClause) entry.getTypedClause()).getUrlExpression(), visitor);
+    default -> {
+      // RETURN is walked from the statement, and REMOVE / FINISH name variables, properties and labels rather than
+      // carrying an expression of their own.
+    }
+    }
+  }
+
+  /**
+   * Descends into the body of a nested subquery, handing the visitor the chance to re-bind itself to the inner
+   * variable scope first.
+   */
+  private static void walkNested(final CypherStatement statement, final Visitor visitor) {
+    if (statement == null)
+      return;
+
+    final Visitor nested = visitor.forNestedStatement(statement);
+    if (nested != null)
+      walk(statement, nested);
+  }
+
+  private static void walkWith(final WithClause withClause, final Visitor visitor) {
+    if (withClause == null)
+      return;
+    for (final ReturnClause.ReturnItem item : withClause.getItems())
+      walk(item.getExpression(), visitor);
+    if (withClause.getWhereClause() != null)
+      walk(withClause.getWhereClause().getConditionExpression(), visitor);
+    walkOrderBy(withClause.getOrderByClause(), visitor);
+    walk(withClause.getSkip(), visitor);
+    walk(withClause.getLimit(), visitor);
+  }
+
+  private static void walkSet(final SetClause setClause, final Visitor visitor) {
+    if (setClause == null)
+      return;
+    for (final SetClause.SetItem item : setClause.getItems()) {
+      walk(item.getTargetExpression(), visitor);
+      walk(item.getKeyExpression(), visitor);
+      walk(item.getValueExpression(), visitor);
+    }
+  }
+
+  private static void walkOrderBy(final OrderByClause orderBy, final Visitor visitor) {
+    if (orderBy == null || orderBy.getItems() == null)
+      return;
+    for (final OrderByClause.OrderByItem item : orderBy.getItems())
+      // An ORDER BY item keeps its expression as text and, when the builder could parse one, as an AST too.
+      walk(item.getExpressionAST(), visitor);
+  }
+
+  /**
    * Visits {@code expr} and everything nested inside it.
    */
-  public static void walk(final Expression expr, final Consumer<Expression> visitor) {
+  public static void walk(final Expression expr, final Visitor visitor) {
     if (expr == null)
       return;
 
-    visitor.accept(expr);
+    visitor.visit(expr);
 
     switch (expr) {
     case FunctionCallExpression func -> walkAll(func.getArguments(), visitor);
@@ -156,8 +349,11 @@ public final class CypherExpressionWalker {
       walk(comprehension.getMapExpression(), visitor);
     }
     case ShortestPathExpression shortestPath -> walk(shortestPath.getPathPattern(), visitor);
+    case ExistsExpression exists -> walkNested(exists.getParsedSubquery(), visitor);
+    case CountExpression count -> walkNested(count.getParsedSubquery(), visitor);
+    case CollectExpression collect -> walkNested(collect.getParsedSubquery(), visitor);
     default -> {
-      // A leaf: literal, variable, parameter, property access, or a subquery kept as text.
+      // A leaf: literal, variable, parameter or property access.
     }
     }
   }
@@ -165,7 +361,7 @@ public final class CypherExpressionWalker {
   /**
    * Visits every expression nested inside a predicate.
    */
-  public static void walk(final BooleanExpression expr, final Consumer<Expression> visitor) {
+  public static void walk(final BooleanExpression expr, final Visitor visitor) {
     if (expr == null)
       return;
 
@@ -196,7 +392,7 @@ public final class CypherExpressionWalker {
     case BooleanCoercionExpression coercion -> walk(coercion.getExpression(), visitor);
     case PatternPredicateExpression pattern -> walk(pattern.getPathPattern(), visitor);
     default -> {
-      // A predicate with no nested expression to reach, or one whose body is kept as unparsed text.
+      // A predicate with no nested expression to reach.
     }
     }
   }
@@ -205,7 +401,7 @@ public final class CypherExpressionWalker {
    * Visits every expression nested inside a graph pattern: the inline property values of each node and relationship,
    * their dynamic labels, and any inline {@code WHERE}. This is how {@code CREATE (n:P {age: abs('x')})} is reached.
    */
-  public static void walk(final PathPattern pattern, final Consumer<Expression> visitor) {
+  public static void walk(final PathPattern pattern, final Visitor visitor) {
     if (pattern == null)
       return;
 
@@ -231,7 +427,7 @@ public final class CypherExpressionWalker {
    * Inline pattern properties are held as {@code Map<String, Object>}: a value is an {@link Expression} when the query
    * wrote one and a plain constant when the builder already folded it, so only the former can be walked.
    */
-  private static void walkPatternProperties(final Map<String, Object> properties, final Consumer<Expression> visitor) {
+  private static void walkPatternProperties(final Map<String, Object> properties, final Visitor visitor) {
     if (properties == null || properties.isEmpty())
       return;
 
@@ -240,7 +436,7 @@ public final class CypherExpressionWalker {
         walk(expression, visitor);
   }
 
-  private static void walkAll(final List<Expression> expressions, final Consumer<Expression> visitor) {
+  private static void walkAll(final List<Expression> expressions, final Visitor visitor) {
     if (expressions == null)
       return;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -1777,86 +1777,77 @@ public class CypherSemanticValidator {
   }
 
   /**
-   * The variable kinds visible inside a nested subquery body: what the body declares itself, over what it inherits
-   * from the enclosing scope.
+   * The variable kinds visible inside a nested subquery body: what the body's own clauses declare, over what it
+   * inherits from the enclosing scope.
    * <p>
-   * A body that re-uses an enclosing name for something of its own has to shadow it, or the enclosing kind would
-   * decide a check about a different variable. That is only possible where the enclosing scope is not automatically
-   * imported - an implicit {@code CALL { ... }}, which imports nothing - because the three subquery expressions see
-   * the outer row and re-declaring one of its variables there is an error in its own right. A name the body binds by
-   * any means is therefore dropped from what it inherits, whether or not the binding says which kind it is.
+   * The body's clauses are walked in order, the same way {@link #validateVariableTypes} walks a statement's, because
+   * the kinds a body ends up with are built the same way: a graph pattern declares them, a {@code WITH} resets the
+   * scope to what it projects and carries a kind through only where the item is a plain variable reference, and a
+   * binding that says nothing about the kind - an {@code UNWIND} variable, a {@code YIELD} output - drops whatever the
+   * name held.
+   * <p>
+   * Inheriting the enclosing kinds is what the three subquery expressions need, since they see the outer row. An
+   * implicit {@code CALL { ... }} imports nothing, so it inherits kinds for names its body cannot legally reference -
+   * harmless, because {@link #validateVariableScope} runs first and reports such a reference as the undefined variable
+   * it is, before this phase gets to read a kind for it.
    */
   private static Map<String, VarType> nestedVarTypes(final Map<String, VarType> outer, final CypherStatement nested) {
-    final Map<String, VarType> declared = new HashMap<>();
-    final Set<String> bound = new HashSet<>();
-    collectNestedDeclarations(nested, declared, bound);
-
-    if (outer.isEmpty())
-      return declared;
-
-    for (final Map.Entry<String, VarType> entry : outer.entrySet())
-      if (!bound.contains(entry.getKey()))
-        declared.putIfAbsent(entry.getKey(), entry.getValue());
-    return declared;
-  }
-
-  /**
-   * Collects, for one subquery body, the kinds its own graph patterns declare and every name it binds by any means.
-   * A name bound without a knowable kind - a {@code WITH} projection, an {@code UNWIND} variable, a {@code YIELD}
-   * output - lands in {@code bound} only, which is enough to stop the enclosing kind from being inherited for it.
-   */
-  private static void collectNestedDeclarations(final CypherStatement statement, final Map<String, VarType> declared,
-      final Set<String> bound) {
-    if (statement instanceof UnionStatement union) {
-      for (final CypherStatement branch : union.getQueries())
-        collectNestedDeclarations(branch, declared, bound);
-      return;
+    if (nested instanceof UnionStatement union) {
+      // One map has to serve every branch, so a name survives only where the branches agree on its kind.
+      Map<String, VarType> merged = null;
+      for (final CypherStatement branch : union.getQueries()) {
+        final Map<String, VarType> branchTypes = nestedVarTypes(outer, branch);
+        if (merged == null)
+          merged = branchTypes;
+        else
+          merged.entrySet().removeIf(entry -> entry.getValue() != branchTypes.get(entry.getKey()));
+      }
+      return merged != null ? merged : new HashMap<>(outer);
     }
 
-    for (final ClauseEntry entry : statement.getClausesInOrder()) {
+    final Map<String, VarType> scope = new HashMap<>(outer);
+    final List<ClauseEntry> clauses = nested.getClausesInOrder();
+    if (clauses == null)
+      return scope;
+
+    for (final ClauseEntry entry : clauses) {
       switch (entry.getType()) {
       case MATCH -> {
         final MatchClause matchClause = entry.getTypedClause();
         if (matchClause.hasPathPatterns())
           for (final PathPattern path : matchClause.getPathPatterns())
-            collectPatternVarTypes(path, declared, bound);
+            declarePatternVarTypes(path, scope);
       }
       case CREATE -> {
         final CreateClause createClause = entry.getTypedClause();
         if (createClause != null && !createClause.isEmpty())
           for (final PathPattern path : createClause.getPathPatterns())
-            collectPatternVarTypes(path, declared, bound);
+            declarePatternVarTypes(path, scope);
       }
       case MERGE -> {
         final MergeClause mergeClause = entry.getTypedClause();
         if (mergeClause != null)
-          collectPatternVarTypes(mergeClause.getPathPattern(), declared, bound);
+          declarePatternVarTypes(mergeClause.getPathPattern(), scope);
       }
-      case WITH -> {
-        final WithClause withClause = entry.getTypedClause();
-        for (final ReturnClause.ReturnItem item : withClause.getItems())
-          if (item.getOutputName() != null)
-            bound.add(item.getOutputName());
-      }
-      case UNWIND -> bound.add(((UnwindClause) entry.getTypedClause()).getVariable());
-      case LOAD_CSV -> bound.add(((LoadCSVClause) entry.getTypedClause()).getVariable());
-      case FOREACH -> bound.add(((ForeachClause) entry.getTypedClause()).getVariable());
+      case WITH -> applyWithProjection(entry.getTypedClause(), scope);
+      case UNWIND -> scope.remove(((UnwindClause) entry.getTypedClause()).getVariable());
+      case LOAD_CSV -> scope.remove(((LoadCSVClause) entry.getTypedClause()).getVariable());
+      case FOREACH -> scope.remove(((ForeachClause) entry.getTypedClause()).getVariable());
       case CALL -> {
         final CallClause callClause = entry.getTypedClause();
         if (callClause.hasYield())
           for (final CallClause.YieldItem item : callClause.getYieldItems())
-            bound.add(item.getOutputName());
+            scope.remove(item.getOutputName());
       }
       case SUBQUERY -> {
-        // What a nested CALL subquery returns enters this body's scope; the body of that subquery is a scope of its
-        // own and gets its own map when the walk descends into it.
+        // What a nested CALL subquery returns enters this body's scope under a kind this phase does not track back
+        // through it; the body of that subquery is a scope of its own and gets its own map when the walk descends.
         final SubqueryClause subqueryClause = entry.getTypedClause();
         if (subqueryClause.getInnerStatement() != null) {
           final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
           if (innerReturn != null)
             for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems())
-              if (item.getOutputName() != null)
-                bound.add(item.getOutputName());
+              scope.remove(item.getOutputName());
         }
       }
       default -> {
@@ -1864,33 +1855,58 @@ public class CypherSemanticValidator {
       }
       }
     }
+    return scope;
   }
 
-  private static void collectPatternVarTypes(final PathPattern path, final Map<String, VarType> declared,
-      final Set<String> bound) {
+  /**
+   * Applies a body's {@code WITH} to the kinds in scope. The clause resets the scope to what it projects, and only an
+   * item that is a plain variable reference carries that variable's kind through under its output name - which is what
+   * keeps an importing {@code WITH p} (or a renaming {@code WITH p AS q}) a path, while {@code WITH 1 AS p} stops
+   * being one.
+   */
+  private static void applyWithProjection(final WithClause withClause, final Map<String, VarType> scope) {
+    boolean star = false;
+    final Map<String, VarType> carried = new HashMap<>();
+    final Set<String> lost = new HashSet<>();
+
+    for (final ReturnClause.ReturnItem item : withClause.getItems()) {
+      final Expression expr = item.getExpression();
+      if (expr instanceof StarExpression
+          || (expr instanceof VariableExpression variable && "*".equals(variable.getVariableName()))) {
+        star = true;
+        continue;
+      }
+      final String outputName = item.getOutputName();
+      if (outputName == null)
+        continue;
+      final VarType carriedType = expr instanceof VariableExpression variable ?
+          scope.get(variable.getVariableName()) :
+          null;
+      if (carriedType != null)
+        carried.put(outputName, carriedType);
+      else
+        lost.add(outputName);
+    }
+
+    // WITH * passes the incoming scope through; anything else keeps only what it projects.
+    if (!star)
+      scope.clear();
+    scope.keySet().removeAll(lost);
+    scope.putAll(carried);
+  }
+
+  private static void declarePatternVarTypes(final PathPattern path, final Map<String, VarType> scope) {
     if (path == null)
       return;
 
     if (path.hasPathVariable())
-      declareNested(path.getPathVariable(), VarType.PATH, declared, bound);
+      scope.put(path.getPathVariable(), VarType.PATH);
     for (final NodePattern node : path.getNodes())
-      declareNested(node.getVariable(), VarType.NODE, declared, bound);
+      if (node.getVariable() != null)
+        scope.put(node.getVariable(), VarType.NODE);
     for (final RelationshipPattern rel : path.getRelationships())
-      declareNested(rel.getVariable(), VarType.RELATIONSHIP, declared, bound);
-  }
-
-  /**
-   * A name declared twice with different kinds inside one body is invalid Cypher, reported elsewhere; here it is left
-   * without a kind rather than arbitrarily given one of the two.
-   */
-  private static void declareNested(final String name, final VarType type, final Map<String, VarType> declared,
-      final Set<String> bound) {
-    if (name == null)
-      return;
-    bound.add(name);
-    final VarType existing = declared.putIfAbsent(name, type);
-    if (existing != null && existing != type)
-      declared.remove(name);
+      if (rel.getVariable() != null)
+        scope.put(rel.getVariable(), VarType.RELATIONSHIP);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -1792,18 +1792,12 @@ public class CypherSemanticValidator {
    * it is, before this phase gets to read a kind for it.
    */
   private static Map<String, VarType> nestedVarTypes(final Map<String, VarType> outer, final CypherStatement nested) {
-    if (nested instanceof UnionStatement union) {
-      // One map has to serve every branch, so a name survives only where the branches agree on its kind.
-      Map<String, VarType> merged = null;
-      for (final CypherStatement branch : union.getQueries()) {
-        final Map<String, VarType> branchTypes = nestedVarTypes(outer, branch);
-        if (merged == null)
-          merged = branchTypes;
-        else
-          merged.entrySet().removeIf(entry -> entry.getValue() != branchTypes.get(entry.getKey()));
-      }
-      return merged != null ? merged : new HashMap<>(outer);
-    }
+    // A UNION declares nothing of its own - each branch is a scope of its own and is entered as a nested statement
+    // in its own right, so it is the branch, not the union, that builds a scope over what is inherited here.
+    // (UnionStatement.getClausesInOrder() answers with its FIRST branch's clauses, which is why this returns before
+    // the loop below rather than falling through an empty one.)
+    if (nested instanceof UnionStatement)
+      return new HashMap<>(outer);
 
     final Map<String, VarType> scope = new HashMap<>(outer);
     final List<ClauseEntry> clauses = nested.getClausesInOrder();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -116,106 +116,185 @@ public class CypherSemanticValidator {
   // ========================
 
   private void validateVariableTypes(final CypherStatement statement) {
-    // Walk clauses in order if available, otherwise walk MATCH + CREATE + MERGE
-    final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
-    if (clausesInOrder != null && !clausesInOrder.isEmpty()) {
-      for (final ClauseEntry entry : clausesInOrder) {
-        switch (entry.getType()) {
-          case MATCH:
-            final MatchClause matchClause = entry.getTypedClause();
-            if (matchClause.hasPathPatterns())
-              for (final PathPattern path : matchClause.getPathPatterns())
-                registerPathPatternVarTypes(path, varTypes);
-            break;
-          case CREATE:
-            final CreateClause createClause = entry.getTypedClause();
-            if (createClause != null && !createClause.isEmpty())
-              for (final PathPattern path : createClause.getPathPatterns())
-                registerPathPatternVarTypes(path, varTypes);
-            break;
-          case MERGE:
-            final MergeClause mergeClause = entry.getTypedClause();
-            if (mergeClause != null)
-              registerPathPatternVarTypes(mergeClause.getPathPattern(), varTypes);
-            break;
-          case WITH:
-            // WITH resets scope. Variables projected through WITH may keep their type
-            // if they directly reference a pattern variable. For literal values (numbers,
-            // strings, booleans, maps), mark as SCALAR to detect type conflicts.
-            // For complex expressions, don't track type to avoid false positives.
-            final WithClause withClauseTypes = entry.getTypedClause();
-            final Map<String, VarType> newVarTypes = new HashMap<>();
-            for (final ReturnClause.ReturnItem item : withClauseTypes.getItems()) {
-              final String outputName = item.getOutputName();
-              if (outputName == null || "*".equals(outputName))
-                continue;
-              // Check if the expression is a simple variable reference that preserves type
-              if (item.getExpression() instanceof VariableExpression) {
-                final String srcVar = ((VariableExpression) item.getExpression()).getVariableName();
-                final VarType srcType = varTypes.get(srcVar);
-                if (srcType != null) {
-                  newVarTypes.put(outputName, srcType);
-                  continue;
-                }
-              }
-              // Only mark as SCALAR for clear non-null literal values
-              if (item.getExpression() instanceof LiteralExpression) {
-                final Object litVal = ((LiteralExpression) item.getExpression()).getValue();
-                if (litVal != null)
-                  newVarTypes.put(outputName, VarType.SCALAR);
-              } else if (item.getExpression() instanceof MapExpression
-                  || isLiteralListExpression(item.getExpression()))
-                newVarTypes.put(outputName, VarType.SCALAR);
-              // A list containing node variables (e.g., [n]) cannot be used as a node
-              else if (item.getExpression() instanceof ListExpression && containsNodeVariable(item.getExpression()))
-                newVarTypes.put(outputName, VarType.SCALAR);
-              // For complex expressions (list indexing, function calls, etc.)
-              // don't track type to avoid false positives
-            }
-            varTypes.clear();
-            varTypes.putAll(newVarTypes);
-            break;
-          case UNWIND:
-            // UNWIND variable type depends on the list content, can't determine at parse time
-            break;
-          default:
-            break;
-        }
-      }
-    } else {
-      // Fallback: walk match clauses + create + merge
+    // The field is refilled rather than replaced: the later phases hold this same map.
+    varTypes.clear();
+    varTypes.putAll(buildVarTypes(statement, Map.of(), true));
+  }
+
+  /**
+   * Builds the variable kinds a statement's clauses declare, walking them in order: a graph pattern declares them, a
+   * {@code WITH} resets the scope to what it projects, and a binding that says nothing about the kind - an
+   * {@code UNWIND} variable, a {@code YIELD} output - drops whatever the name held.
+   * <p>
+   * One construction serves both the statement being validated and the body of a subquery inside it. They used to be
+   * two, which is how the two spellings of the same import came to disagree (#5626) - the kind of drift that follows
+   * from writing the same walk twice, and the reason this is one method with two parameters rather than two methods
+   * that resemble each other:
+   * <ul>
+   * <li>{@code inherited} is empty for the statement, which declares its scope from nothing, and the enclosing scope
+   * for a subquery body, which sees the outer row. See {@link #nestedVarTypes} for what that inheritance means for a
+   * {@code CALL { }} body, which imports nothing.</li>
+   * <li>{@code raiseOnKindClash} is on for the statement, where a name declared as two different kinds is the
+   * {@code VariableTypeConflict} this phase exists to raise, and off inside a body, where a name the body binds for
+   * itself legitimately shadows an outer one of another kind.</li>
+   * </ul>
+   */
+  private static Map<String, VarType> buildVarTypes(final CypherStatement statement,
+      final Map<String, VarType> inherited, final boolean raiseOnKindClash) {
+    final Map<String, VarType> scope = new HashMap<>(inherited);
+
+    final List<ClauseEntry> clauses = statement.getClausesInOrder();
+    if (clauses == null || clauses.isEmpty()) {
+      // Some builder paths leave the ordered list empty; the per-kind getters still answer.
       for (final MatchClause matchClause : statement.getMatchClauses())
         if (matchClause.hasPathPatterns())
           for (final PathPattern path : matchClause.getPathPatterns())
-            registerPathPatternVarTypes(path, varTypes);
+            declarePatternVarTypes(path, scope, raiseOnKindClash);
 
       if (statement.getCreateClause() != null && !statement.getCreateClause().isEmpty())
         for (final PathPattern path : statement.getCreateClause().getPathPatterns())
-          registerPathPatternVarTypes(path, varTypes);
+          declarePatternVarTypes(path, scope, raiseOnKindClash);
 
       if (statement.getMergeClause() != null)
-        registerPathPatternVarTypes(statement.getMergeClause().getPathPattern(), varTypes);
+        declarePatternVarTypes(statement.getMergeClause().getPathPattern(), scope, raiseOnKindClash);
+
+      return scope;
     }
+
+    for (final ClauseEntry entry : clauses) {
+      switch (entry.getType()) {
+      case MATCH -> {
+        final MatchClause matchClause = entry.getTypedClause();
+        if (matchClause.hasPathPatterns())
+          for (final PathPattern path : matchClause.getPathPatterns())
+            declarePatternVarTypes(path, scope, raiseOnKindClash);
+      }
+      case CREATE -> {
+        final CreateClause createClause = entry.getTypedClause();
+        if (createClause != null && !createClause.isEmpty())
+          for (final PathPattern path : createClause.getPathPatterns())
+            declarePatternVarTypes(path, scope, raiseOnKindClash);
+      }
+      case MERGE -> {
+        final MergeClause mergeClause = entry.getTypedClause();
+        if (mergeClause != null)
+          declarePatternVarTypes(mergeClause.getPathPattern(), scope, raiseOnKindClash);
+      }
+      case WITH -> applyWithProjection(entry.getTypedClause(), scope);
+      case UNWIND -> scope.remove(((UnwindClause) entry.getTypedClause()).getVariable());
+      case LOAD_CSV -> scope.remove(((LoadCSVClause) entry.getTypedClause()).getVariable());
+      // Only the FOREACH variable itself: what the clause's inner CREATE/MERGE bind lives and dies inside the loop
+      // and is not in scope after it, so declaring those kinds here would be declaring them where they cannot be
+      // referenced. The expression walk still descends into the inner clauses and checks them against this scope.
+      case FOREACH -> scope.remove(((ForeachClause) entry.getTypedClause()).getVariable());
+      case CALL -> {
+        final CallClause callClause = entry.getTypedClause();
+        if (callClause.hasYield())
+          for (final CallClause.YieldItem item : callClause.getYieldItems())
+            scope.remove(item.getOutputName());
+      }
+      case SUBQUERY -> {
+        // What a nested CALL subquery returns enters this scope under a kind this phase does not track back through
+        // it; that subquery's body is a scope of its own and gets its own map when the walk descends.
+        final SubqueryClause subqueryClause = entry.getTypedClause();
+        if (subqueryClause.getInnerStatement() != null) {
+          final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
+          if (innerReturn != null)
+            for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems())
+              scope.remove(item.getOutputName());
+        }
+      }
+      default -> {
+        // No binding of its own.
+      }
+      }
+    }
+    return scope;
   }
 
-  private void registerPathPatternVarTypes(final PathPattern path, final Map<String, VarType> varTypes) {
-    if (path.hasPathVariable())
-      registerVar(path.getPathVariable(), VarType.PATH, varTypes);
+  /**
+   * Applies a {@code WITH} to the kinds in scope: the clause resets the scope to what it projects, and each item
+   * carries through whatever kind {@link #projectedVarType} can read off its expression. That is what keeps an
+   * importing {@code WITH p} - and a renaming {@code WITH p AS q} - a path, while {@code WITH 1 AS p} stops being one.
+   * <p>
+   * {@code WITH *} passes the incoming scope through, so a kind survives a projection that does not name it.
+   */
+  private static void applyWithProjection(final WithClause withClause, final Map<String, VarType> scope) {
+    boolean star = false;
+    final Map<String, VarType> carried = new HashMap<>();
+    final Set<String> lost = new HashSet<>();
 
+    for (final ReturnClause.ReturnItem item : withClause.getItems()) {
+      final Expression expr = item.getExpression();
+      if (expr instanceof StarExpression
+          || (expr instanceof VariableExpression variable && "*".equals(variable.getVariableName()))) {
+        star = true;
+        continue;
+      }
+      final String outputName = item.getOutputName();
+      if (outputName == null || "*".equals(outputName))
+        continue;
+
+      final VarType projected = projectedVarType(expr, scope);
+      if (projected != null)
+        carried.put(outputName, projected);
+      else
+        lost.add(outputName);
+    }
+
+    if (!star)
+      scope.clear();
+    scope.keySet().removeAll(lost);
+    scope.putAll(carried);
+  }
+
+  /**
+   * The kind a {@code WITH} item projects, or null when the expression says nothing about it - which is the answer
+   * for anything computed (a function call, an index into a list), because guessing there is how a check starts
+   * rejecting valid queries.
+   */
+  private static VarType projectedVarType(final Expression expr, final Map<String, VarType> scope) {
+    // A plain reference carries the source variable's kind, and carries none when the source has none.
+    if (expr instanceof VariableExpression variable)
+      return scope.get(variable.getVariableName());
+
+    // A value that is plainly not a graph element is SCALAR rather than untracked, so using it as one is caught.
+    if (expr instanceof LiteralExpression literal)
+      return literal.getValue() != null ? VarType.SCALAR : null;
+    if (expr instanceof MapExpression || isLiteralListExpression(expr))
+      return VarType.SCALAR;
+    // A list holding node variables, [n], is itself not a node.
+    if (expr instanceof ListExpression && containsNodeVariable(expr, scope))
+      return VarType.SCALAR;
+
+    return null;
+  }
+
+  private static void declarePatternVarTypes(final PathPattern path, final Map<String, VarType> scope,
+      final boolean raiseOnKindClash) {
+    if (path == null)
+      return;
+
+    if (path.hasPathVariable())
+      declareVar(path.getPathVariable(), VarType.PATH, scope, raiseOnKindClash);
     for (final NodePattern node : path.getNodes())
       if (node.getVariable() != null)
-        registerVar(node.getVariable(), VarType.NODE, varTypes);
-
+        declareVar(node.getVariable(), VarType.NODE, scope, raiseOnKindClash);
     for (final RelationshipPattern rel : path.getRelationships())
       if (rel.getVariable() != null)
-        registerVar(rel.getVariable(), VarType.RELATIONSHIP, varTypes);
+        declareVar(rel.getVariable(), VarType.RELATIONSHIP, scope, raiseOnKindClash);
   }
 
-  private void registerVar(final String name, final VarType type, final Map<String, VarType> varTypes) {
-    final VarType existing = varTypes.get(name);
-    if (existing != null && existing != type)
-      throw new CommandParsingException("VariableTypeConflict: Variable '" + name + "' already defined as " + existing + ", cannot redefine as " + type);
-    varTypes.put(name, type);
+  private static void declareVar(final String name, final VarType type, final Map<String, VarType> scope,
+      final boolean raiseOnKindClash) {
+    if (raiseOnKindClash) {
+      final VarType existing = scope.get(name);
+      if (existing != null && existing != type)
+        throw new CommandParsingException(
+            "VariableTypeConflict: Variable '" + name + "' already defined as " + existing + ", cannot redefine as "
+                + type);
+    }
+    scope.put(name, type);
   }
 
   // ==============================
@@ -845,11 +924,11 @@ public class CypherSemanticValidator {
     return true;
   }
 
-  private boolean containsNodeVariable(final Expression expr) {
+  private static boolean containsNodeVariable(final Expression expr, final Map<String, VarType> scope) {
     if (expr instanceof ListExpression)
       for (final Expression elem : ((ListExpression) expr).getElements()) {
         if (elem instanceof VariableExpression) {
-          final VarType type = varTypes.get(((VariableExpression) elem).getVariableName());
+          final VarType type = scope.get(((VariableExpression) elem).getVariableName());
           if (type == VarType.NODE)
             return true;
         }
@@ -1780,11 +1859,11 @@ public class CypherSemanticValidator {
    * The variable kinds visible inside a nested subquery body: what the body's own clauses declare, over what it
    * inherits from the enclosing scope.
    * <p>
-   * The body's clauses are walked in order, the same way {@link #validateVariableTypes} walks a statement's, because
-   * the kinds a body ends up with are built the same way: a graph pattern declares them, a {@code WITH} resets the
-   * scope to what it projects and carries a kind through only where the item is a plain variable reference, and a
-   * binding that says nothing about the kind - an {@code UNWIND} variable, a {@code YIELD} output - drops whatever the
-   * name held.
+   * The body's clauses are walked by {@link #buildVarTypes}, the same construction {@link #validateVariableTypes}
+   * runs on the statement, because the kinds a body ends up with are built the same way - and because two copies of
+   * that walk is what let the two spellings of the same import disagree in the first place. What differs is only what
+   * this passes it: an inherited scope instead of an empty one, and no raise on a kind clash, since a name the body
+   * binds for itself may legitimately shadow an outer one of another kind.
    * <p>
    * Inheriting the enclosing kinds is what the three subquery expressions need, since they see the outer row. An
    * implicit {@code CALL { ... }} imports nothing, so it inherits kinds for names its body cannot legally reference -
@@ -1803,116 +1882,11 @@ public class CypherSemanticValidator {
     // A UNION declares nothing of its own - each branch is a scope of its own and is entered as a nested statement
     // in its own right, so it is the branch, not the union, that builds a scope over what is inherited here.
     // (UnionStatement.getClausesInOrder() answers with its FIRST branch's clauses, which is why this returns before
-    // the loop below rather than falling through an empty one.)
+    // delegating rather than letting the shared build walk them as if they were the union's.)
     if (nested instanceof UnionStatement)
       return new HashMap<>(outer);
 
-    final Map<String, VarType> scope = new HashMap<>(outer);
-    final List<ClauseEntry> clauses = nested.getClausesInOrder();
-    if (clauses == null)
-      return scope;
-
-    for (final ClauseEntry entry : clauses) {
-      switch (entry.getType()) {
-      case MATCH -> {
-        final MatchClause matchClause = entry.getTypedClause();
-        if (matchClause.hasPathPatterns())
-          for (final PathPattern path : matchClause.getPathPatterns())
-            declarePatternVarTypes(path, scope);
-      }
-      case CREATE -> {
-        final CreateClause createClause = entry.getTypedClause();
-        if (createClause != null && !createClause.isEmpty())
-          for (final PathPattern path : createClause.getPathPatterns())
-            declarePatternVarTypes(path, scope);
-      }
-      case MERGE -> {
-        final MergeClause mergeClause = entry.getTypedClause();
-        if (mergeClause != null)
-          declarePatternVarTypes(mergeClause.getPathPattern(), scope);
-      }
-      case WITH -> applyWithProjection(entry.getTypedClause(), scope);
-      case UNWIND -> scope.remove(((UnwindClause) entry.getTypedClause()).getVariable());
-      case LOAD_CSV -> scope.remove(((LoadCSVClause) entry.getTypedClause()).getVariable());
-      // Only the FOREACH variable itself: what the clause's inner CREATE/MERGE bind lives and dies inside the loop
-      // and is not in scope after it, so declaring those kinds here would be declaring them where they cannot be
-      // referenced. The walk still descends into the inner clauses - that is walkClause's FOREACH arm - and checks
-      // their expressions against the scope the loop was entered with.
-      case FOREACH -> scope.remove(((ForeachClause) entry.getTypedClause()).getVariable());
-      case CALL -> {
-        final CallClause callClause = entry.getTypedClause();
-        if (callClause.hasYield())
-          for (final CallClause.YieldItem item : callClause.getYieldItems())
-            scope.remove(item.getOutputName());
-      }
-      case SUBQUERY -> {
-        // What a nested CALL subquery returns enters this body's scope under a kind this phase does not track back
-        // through it; the body of that subquery is a scope of its own and gets its own map when the walk descends.
-        final SubqueryClause subqueryClause = entry.getTypedClause();
-        if (subqueryClause.getInnerStatement() != null) {
-          final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
-          if (innerReturn != null)
-            for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems())
-              scope.remove(item.getOutputName());
-        }
-      }
-      default -> {
-        // No binding of its own.
-      }
-      }
-    }
-    return scope;
-  }
-
-  /**
-   * Applies a body's {@code WITH} to the kinds in scope. The clause resets the scope to what it projects, and only an
-   * item that is a plain variable reference carries that variable's kind through under its output name - which is what
-   * keeps an importing {@code WITH p} (or a renaming {@code WITH p AS q}) a path, while {@code WITH 1 AS p} stops
-   * being one.
-   */
-  private static void applyWithProjection(final WithClause withClause, final Map<String, VarType> scope) {
-    boolean star = false;
-    final Map<String, VarType> carried = new HashMap<>();
-    final Set<String> lost = new HashSet<>();
-
-    for (final ReturnClause.ReturnItem item : withClause.getItems()) {
-      final Expression expr = item.getExpression();
-      if (expr instanceof StarExpression
-          || (expr instanceof VariableExpression variable && "*".equals(variable.getVariableName()))) {
-        star = true;
-        continue;
-      }
-      final String outputName = item.getOutputName();
-      if (outputName == null)
-        continue;
-      final VarType carriedType = expr instanceof VariableExpression variable ?
-          scope.get(variable.getVariableName()) :
-          null;
-      if (carriedType != null)
-        carried.put(outputName, carriedType);
-      else
-        lost.add(outputName);
-    }
-
-    // WITH * passes the incoming scope through; anything else keeps only what it projects.
-    if (!star)
-      scope.clear();
-    scope.keySet().removeAll(lost);
-    scope.putAll(carried);
-  }
-
-  private static void declarePatternVarTypes(final PathPattern path, final Map<String, VarType> scope) {
-    if (path == null)
-      return;
-
-    if (path.hasPathVariable())
-      scope.put(path.getPathVariable(), VarType.PATH);
-    for (final NodePattern node : path.getNodes())
-      if (node.getVariable() != null)
-        scope.put(node.getVariable(), VarType.NODE);
-    for (final RelationshipPattern rel : path.getRelationships())
-      if (rel.getVariable() != null)
-        scope.put(rel.getVariable(), VarType.RELATIONSHIP);
+    return buildVarTypes(nested, outer, false);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -25,7 +25,6 @@ import com.arcadedb.function.math.RoundFunction;
 import com.arcadedb.query.opencypher.ast.*;
 
 import java.util.*;
-import java.util.function.Consumer;
 
 /**
  * Semantic validator for Cypher statements.
@@ -1741,114 +1740,164 @@ public class CypherSemanticValidator {
    * {@code MATCH} or a {@code WITH} - now run wherever an expression appears. A call that reaches a row still fails
    * with the same message from the function's own runtime guard, so what changes is when the client is told, not what
    * they are told.
+   * <p>
+   * Issue #5626 closed the last gap: the body of a {@code CALL { ... }} clause and of the three subquery expressions
+   * ({@code EXISTS}, {@code COUNT}, {@code COLLECT}) are walked too. Each body is a scope of its own, so the visitor
+   * re-binds itself to the variable kinds visible inside it - see {@link FunctionArgumentChecks#forNestedStatement}.
    */
   private void validateFunctionArgumentTypes(final CypherStatement statement) {
-    final Consumer<Expression> checks = expression -> {
-      checkFunctionArgTypes(expression);
-      checkPropertyAccessOnPath(expression);
-    };
-
-    if (statement.getReturnClause() != null)
-      for (final ReturnClause.ReturnItem item : statement.getReturnClause().getReturnItems())
-        CypherExpressionWalker.walk(item.getExpression(), checks);
-    walkOrderBy(statement.getOrderByClause(), checks);
-    // The top-level ORDER BY / SKIP / LIMIT belong to the statement rather than to any clause entry, and are walked
-    // here for the same reason walkWith() walks a WITH's: leaving them out is the clause-dependent asymmetry this
-    // widening exists to remove.
-    CypherExpressionWalker.walk(statement.getSkip(), checks);
-    CypherExpressionWalker.walk(statement.getLimit(), checks);
-
-    final List<ClauseEntry> clauses = statement.getClausesInOrder();
-    if (clauses != null)
-      for (final ClauseEntry entry : clauses)
-        walkClause(entry, checks);
-
-    // A WITH not present in the ordered list (some builder paths register it only on the statement) still has to be
-    // covered, and walking one twice is harmless - the checks are pure.
-    for (final WithClause withClause : statement.getWithClauses())
-      walkWith(withClause, checks);
+    CypherExpressionWalker.walk(statement, new FunctionArgumentChecks(varTypes));
   }
 
-  private void walkClause(final ClauseEntry entry, final Consumer<Expression> checks) {
-    switch (entry.getType()) {
-    case MATCH -> {
-      final MatchClause matchClause = entry.getTypedClause();
-      if (matchClause.hasWhereClause())
-        CypherExpressionWalker.walk(matchClause.getWhereClause().getConditionExpression(), checks);
-      if (matchClause.getPathPatterns() != null)
-        for (final PathPattern pattern : matchClause.getPathPatterns())
-          CypherExpressionWalker.walk(pattern, checks);
+  /**
+   * The function checks bound to one variable scope.
+   * <p>
+   * Most of what they look at - the function name, how many arguments it was given, whether a literal argument is of
+   * a type the function accepts - is the same wherever the call was written. What is not is the <i>kind</i> of a
+   * variable ({@code length(node)}, {@code p.name} on a path), and a subquery body has a variable scope of its own:
+   * hence one instance per scope rather than one per statement.
+   */
+  private final class FunctionArgumentChecks implements CypherExpressionWalker.Visitor {
+    private final Map<String, VarType> scope;
+
+    private FunctionArgumentChecks(final Map<String, VarType> scope) {
+      this.scope = scope;
     }
-    case WITH -> walkWith(entry.getTypedClause(), checks);
-    case UNWIND -> CypherExpressionWalker.walk(((UnwindClause) entry.getTypedClause()).getListExpression(), checks);
-    case CREATE -> {
-      final CreateClause createClause = entry.getTypedClause();
-      if (createClause.getPathPatterns() != null)
-        for (final PathPattern pattern : createClause.getPathPatterns())
-          CypherExpressionWalker.walk(pattern, checks);
+
+    @Override
+    public void visit(final Expression expression) {
+      checkFunctionArgTypes(expression, scope);
+      checkPropertyAccessOnPath(expression, scope);
     }
-    case MERGE -> {
-      final MergeClause mergeClause = entry.getTypedClause();
-      CypherExpressionWalker.walk(mergeClause.getPathPattern(), checks);
-      walkSet(mergeClause.getOnCreateSet(), checks);
-      walkSet(mergeClause.getOnMatchSet(), checks);
-    }
-    case SET -> walkSet(entry.getTypedClause(), checks);
-    case DELETE -> {
-      final DeleteClause deleteClause = entry.getTypedClause();
-      if (deleteClause.getExpressions() != null)
-        for (final Expression expression : deleteClause.getExpressions())
-          CypherExpressionWalker.walk(expression, checks);
-    }
-    case FOREACH -> {
-      final ForeachClause foreachClause = entry.getTypedClause();
-      CypherExpressionWalker.walk(foreachClause.getListExpression(), checks);
-      if (foreachClause.getInnerClauses() != null)
-        for (final ClauseEntry inner : foreachClause.getInnerClauses())
-          walkClause(inner, checks);
-    }
-    default -> {
-      // RETURN is walked from the statement, and CALL / SUBQUERY / LOAD CSV / FINISH carry no expression this
-      // validation applies to - a subquery is a statement of its own and is validated when it is parsed.
-    }
+
+    @Override
+    public CypherExpressionWalker.Visitor forNestedStatement(final CypherStatement nested) {
+      return new FunctionArgumentChecks(nestedVarTypes(scope, nested));
     }
   }
 
-  private void walkWith(final WithClause withClause, final Consumer<Expression> checks) {
-    if (withClause == null)
+  /**
+   * The variable kinds visible inside a nested subquery body: what the body declares itself, over what it inherits
+   * from the enclosing scope.
+   * <p>
+   * A body that re-uses an enclosing name for something of its own has to shadow it, or the enclosing kind would
+   * decide a check about a different variable. That is only possible where the enclosing scope is not automatically
+   * imported - an implicit {@code CALL { ... }}, which imports nothing - because the three subquery expressions see
+   * the outer row and re-declaring one of its variables there is an error in its own right. A name the body binds by
+   * any means is therefore dropped from what it inherits, whether or not the binding says which kind it is.
+   */
+  private static Map<String, VarType> nestedVarTypes(final Map<String, VarType> outer, final CypherStatement nested) {
+    final Map<String, VarType> declared = new HashMap<>();
+    final Set<String> bound = new HashSet<>();
+    collectNestedDeclarations(nested, declared, bound);
+
+    if (outer.isEmpty())
+      return declared;
+
+    for (final Map.Entry<String, VarType> entry : outer.entrySet())
+      if (!bound.contains(entry.getKey()))
+        declared.putIfAbsent(entry.getKey(), entry.getValue());
+    return declared;
+  }
+
+  /**
+   * Collects, for one subquery body, the kinds its own graph patterns declare and every name it binds by any means.
+   * A name bound without a knowable kind - a {@code WITH} projection, an {@code UNWIND} variable, a {@code YIELD}
+   * output - lands in {@code bound} only, which is enough to stop the enclosing kind from being inherited for it.
+   */
+  private static void collectNestedDeclarations(final CypherStatement statement, final Map<String, VarType> declared,
+      final Set<String> bound) {
+    if (statement instanceof UnionStatement union) {
+      for (final CypherStatement branch : union.getQueries())
+        collectNestedDeclarations(branch, declared, bound);
       return;
-    for (final ReturnClause.ReturnItem item : withClause.getItems())
-      CypherExpressionWalker.walk(item.getExpression(), checks);
-    if (withClause.getWhereClause() != null)
-      CypherExpressionWalker.walk(withClause.getWhereClause().getConditionExpression(), checks);
-    walkOrderBy(withClause.getOrderByClause(), checks);
-    CypherExpressionWalker.walk(withClause.getSkip(), checks);
-    CypherExpressionWalker.walk(withClause.getLimit(), checks);
-  }
+    }
 
-  private void walkSet(final SetClause setClause, final Consumer<Expression> checks) {
-    if (setClause == null)
-      return;
-    for (final SetClause.SetItem item : setClause.getItems()) {
-      CypherExpressionWalker.walk(item.getTargetExpression(), checks);
-      CypherExpressionWalker.walk(item.getKeyExpression(), checks);
-      CypherExpressionWalker.walk(item.getValueExpression(), checks);
+    for (final ClauseEntry entry : statement.getClausesInOrder()) {
+      switch (entry.getType()) {
+      case MATCH -> {
+        final MatchClause matchClause = entry.getTypedClause();
+        if (matchClause.hasPathPatterns())
+          for (final PathPattern path : matchClause.getPathPatterns())
+            collectPatternVarTypes(path, declared, bound);
+      }
+      case CREATE -> {
+        final CreateClause createClause = entry.getTypedClause();
+        if (createClause != null && !createClause.isEmpty())
+          for (final PathPattern path : createClause.getPathPatterns())
+            collectPatternVarTypes(path, declared, bound);
+      }
+      case MERGE -> {
+        final MergeClause mergeClause = entry.getTypedClause();
+        if (mergeClause != null)
+          collectPatternVarTypes(mergeClause.getPathPattern(), declared, bound);
+      }
+      case WITH -> {
+        final WithClause withClause = entry.getTypedClause();
+        for (final ReturnClause.ReturnItem item : withClause.getItems())
+          if (item.getOutputName() != null)
+            bound.add(item.getOutputName());
+      }
+      case UNWIND -> bound.add(((UnwindClause) entry.getTypedClause()).getVariable());
+      case LOAD_CSV -> bound.add(((LoadCSVClause) entry.getTypedClause()).getVariable());
+      case FOREACH -> bound.add(((ForeachClause) entry.getTypedClause()).getVariable());
+      case CALL -> {
+        final CallClause callClause = entry.getTypedClause();
+        if (callClause.hasYield())
+          for (final CallClause.YieldItem item : callClause.getYieldItems())
+            bound.add(item.getOutputName());
+      }
+      case SUBQUERY -> {
+        // What a nested CALL subquery returns enters this body's scope; the body of that subquery is a scope of its
+        // own and gets its own map when the walk descends into it.
+        final SubqueryClause subqueryClause = entry.getTypedClause();
+        if (subqueryClause.getInnerStatement() != null) {
+          final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
+          if (innerReturn != null)
+            for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems())
+              if (item.getOutputName() != null)
+                bound.add(item.getOutputName());
+        }
+      }
+      default -> {
+        // No binding of its own.
+      }
+      }
     }
   }
 
-  private void walkOrderBy(final OrderByClause orderBy, final Consumer<Expression> checks) {
-    if (orderBy == null || orderBy.getItems() == null)
+  private static void collectPatternVarTypes(final PathPattern path, final Map<String, VarType> declared,
+      final Set<String> bound) {
+    if (path == null)
       return;
-    for (final OrderByClause.OrderByItem item : orderBy.getItems())
-      // An ORDER BY item keeps its expression as text and, when the builder could parse one, as an AST too.
-      CypherExpressionWalker.walk(item.getExpressionAST(), checks);
+
+    if (path.hasPathVariable())
+      declareNested(path.getPathVariable(), VarType.PATH, declared, bound);
+    for (final NodePattern node : path.getNodes())
+      declareNested(node.getVariable(), VarType.NODE, declared, bound);
+    for (final RelationshipPattern rel : path.getRelationships())
+      declareNested(rel.getVariable(), VarType.RELATIONSHIP, declared, bound);
+  }
+
+  /**
+   * A name declared twice with different kinds inside one body is invalid Cypher, reported elsewhere; here it is left
+   * without a kind rather than arbitrarily given one of the two.
+   */
+  private static void declareNested(final String name, final VarType type, final Map<String, VarType> declared,
+      final Set<String> bound) {
+    if (name == null)
+      return;
+    bound.add(name);
+    final VarType existing = declared.putIfAbsent(name, type);
+    if (existing != null && existing != type)
+      declared.remove(name);
   }
 
   /**
    * The per-expression function checks. Called on every node of the traversal, so it inspects only the node handed to
    * it: descending into a function's arguments is {@link CypherExpressionWalker}'s job.
    */
-  private void checkFunctionArgTypes(final Expression expr) {
+  private void checkFunctionArgTypes(final Expression expr, final Map<String, VarType> scope) {
     if (!(expr instanceof FunctionCallExpression func))
       return;
 
@@ -1873,7 +1922,7 @@ public class CypherSemanticValidator {
       final Expression arg = args.get(0);
       if (numeric == null)
         checkStaticallyKnownArgType(name, arg);
-      final VarType argType = getExpressionType(arg);
+      final VarType argType = getExpressionType(arg, scope);
       if (argType != null) {
         switch (name) {
           case "length":
@@ -1981,15 +2030,15 @@ public class CypherSemanticValidator {
    * A path variable holds a whole path, so {@code p.name} names nothing. Called on every node of the traversal, which
    * is why it inspects only the node handed to it rather than recursing.
    */
-  private void checkPropertyAccessOnPath(final Expression expr) {
-    if (expr instanceof PropertyAccessExpression access && varTypes.get(access.getVariableName()) == VarType.PATH)
+  private void checkPropertyAccessOnPath(final Expression expr, final Map<String, VarType> scope) {
+    if (expr instanceof PropertyAccessExpression access && scope.get(access.getVariableName()) == VarType.PATH)
       throw new CommandParsingException("InvalidArgumentType: Property access on a path variable is not allowed");
   }
 
-  private VarType getExpressionType(final Expression expr) {
+  private VarType getExpressionType(final Expression expr, final Map<String, VarType> scope) {
     if (expr instanceof VariableExpression) {
       final String varName = ((VariableExpression) expr).getVariableName();
-      return varTypes.get(varName);
+      return scope.get(varName);
     }
     return null;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -118,7 +118,7 @@ public class CypherSemanticValidator {
   private void validateVariableTypes(final CypherStatement statement) {
     // The field is refilled rather than replaced: the later phases hold this same map.
     varTypes.clear();
-    varTypes.putAll(buildVarTypes(statement, Map.of(), true));
+    varTypes.putAll(buildVarTypes(statement, Map.of()));
   }
 
   /**
@@ -128,20 +128,24 @@ public class CypherSemanticValidator {
    * <p>
    * One construction serves both the statement being validated and the body of a subquery inside it. They used to be
    * two, which is how the two spellings of the same import came to disagree (#5626) - the kind of drift that follows
-   * from writing the same walk twice, and the reason this is one method with two parameters rather than two methods
-   * that resemble each other:
-   * <ul>
-   * <li>{@code inherited} is empty for the statement, which declares its scope from nothing, and the enclosing scope
-   * for a subquery body, which sees the outer row. See {@link #nestedVarTypes} for what that inheritance means for a
-   * {@code CALL { }} body, which imports nothing.</li>
-   * <li>{@code raiseOnKindClash} is on for the statement, where a name declared as two different kinds is the
-   * {@code VariableTypeConflict} this phase exists to raise, and off inside a body, where a name the body binds for
-   * itself legitimately shadows an outer one of another kind.</li>
-   * </ul>
+   * from writing the same walk twice. What separates the two callers is one argument: {@code inherited} is empty for
+   * the statement, which declares its scope from nothing, and the enclosing scope for a subquery body, which sees the
+   * outer row. See {@link #nestedVarTypes} for what that inheritance means for a {@code CALL { }} body, which imports
+   * nothing.
+   * <p>
+   * <b>Shadowing an inherited name is not the same as clashing with one declared here.</b> Declaring {@code x} a node
+   * and then a relationship is the {@code VariableTypeConflict} this phase exists to raise, and it is raised inside a
+   * body exactly as outside one - which is the whole point of #5626. Re-declaring a name the body only <i>inherited</i>
+   * is not that: an implicit {@code CALL { }} imports nothing, so a body is free to bind a name the enclosing query
+   * happens to use for something else. The two are told apart by tracking which names this scope declared itself,
+   * rather than by a flag that would have to turn the check off wholesale to allow the second.
    */
   private static Map<String, VarType> buildVarTypes(final CypherStatement statement,
-      final Map<String, VarType> inherited, final boolean raiseOnKindClash) {
+      final Map<String, VarType> inherited) {
     final Map<String, VarType> scope = new HashMap<>(inherited);
+    // The names this scope declares for itself, as opposed to the ones it inherited: only a clash between two of
+    // these is a conflict. Empty for a statement, so there every clash is one.
+    final Set<String> declaredHere = new HashSet<>();
 
     final List<ClauseEntry> clauses = statement.getClausesInOrder();
     if (clauses == null || clauses.isEmpty()) {
@@ -149,14 +153,14 @@ public class CypherSemanticValidator {
       for (final MatchClause matchClause : statement.getMatchClauses())
         if (matchClause.hasPathPatterns())
           for (final PathPattern path : matchClause.getPathPatterns())
-            declarePatternVarTypes(path, scope, raiseOnKindClash);
+            declarePatternVarTypes(path, scope, declaredHere);
 
       if (statement.getCreateClause() != null && !statement.getCreateClause().isEmpty())
         for (final PathPattern path : statement.getCreateClause().getPathPatterns())
-          declarePatternVarTypes(path, scope, raiseOnKindClash);
+          declarePatternVarTypes(path, scope, declaredHere);
 
       if (statement.getMergeClause() != null)
-        declarePatternVarTypes(statement.getMergeClause().getPathPattern(), scope, raiseOnKindClash);
+        declarePatternVarTypes(statement.getMergeClause().getPathPattern(), scope, declaredHere);
 
       return scope;
     }
@@ -167,31 +171,31 @@ public class CypherSemanticValidator {
         final MatchClause matchClause = entry.getTypedClause();
         if (matchClause.hasPathPatterns())
           for (final PathPattern path : matchClause.getPathPatterns())
-            declarePatternVarTypes(path, scope, raiseOnKindClash);
+            declarePatternVarTypes(path, scope, declaredHere);
       }
       case CREATE -> {
         final CreateClause createClause = entry.getTypedClause();
         if (createClause != null && !createClause.isEmpty())
           for (final PathPattern path : createClause.getPathPatterns())
-            declarePatternVarTypes(path, scope, raiseOnKindClash);
+            declarePatternVarTypes(path, scope, declaredHere);
       }
       case MERGE -> {
         final MergeClause mergeClause = entry.getTypedClause();
         if (mergeClause != null)
-          declarePatternVarTypes(mergeClause.getPathPattern(), scope, raiseOnKindClash);
+          declarePatternVarTypes(mergeClause.getPathPattern(), scope, declaredHere);
       }
-      case WITH -> applyWithProjection(entry.getTypedClause(), scope);
-      case UNWIND -> scope.remove(((UnwindClause) entry.getTypedClause()).getVariable());
-      case LOAD_CSV -> scope.remove(((LoadCSVClause) entry.getTypedClause()).getVariable());
+      case WITH -> applyWithProjection(entry.getTypedClause(), scope, declaredHere);
+      case UNWIND -> forget(((UnwindClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
+      case LOAD_CSV -> forget(((LoadCSVClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
       // Only the FOREACH variable itself: what the clause's inner CREATE/MERGE bind lives and dies inside the loop
       // and is not in scope after it, so declaring those kinds here would be declaring them where they cannot be
       // referenced. The expression walk still descends into the inner clauses and checks them against this scope.
-      case FOREACH -> scope.remove(((ForeachClause) entry.getTypedClause()).getVariable());
+      case FOREACH -> forget(((ForeachClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
       case CALL -> {
         final CallClause callClause = entry.getTypedClause();
         if (callClause.hasYield())
           for (final CallClause.YieldItem item : callClause.getYieldItems())
-            scope.remove(item.getOutputName());
+            forget(item.getOutputName(), scope, declaredHere);
       }
       case SUBQUERY -> {
         // What a nested CALL subquery returns enters this scope under a kind this phase does not track back through
@@ -201,7 +205,7 @@ public class CypherSemanticValidator {
           final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
           if (innerReturn != null)
             for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems())
-              scope.remove(item.getOutputName());
+              forget(item.getOutputName(), scope, declaredHere);
         }
       }
       default -> {
@@ -218,8 +222,13 @@ public class CypherSemanticValidator {
    * importing {@code WITH p} - and a renaming {@code WITH p AS q} - a path, while {@code WITH 1 AS p} stops being one.
    * <p>
    * {@code WITH *} passes the incoming scope through, so a kind survives a projection that does not name it.
+   * <p>
+   * What the clause projects becomes this scope's own, whether the name came from here or was inherited: past a
+   * {@code WITH p} the body has restated {@code p}, so a later clause declaring it something else is the conflict a
+   * restatement makes it, not the shadowing an inherited name would have allowed.
    */
-  private static void applyWithProjection(final WithClause withClause, final Map<String, VarType> scope) {
+  private static void applyWithProjection(final WithClause withClause, final Map<String, VarType> scope,
+      final Set<String> declaredHere) {
     boolean star = false;
     final Map<String, VarType> carried = new HashMap<>();
     final Set<String> lost = new HashSet<>();
@@ -242,10 +251,14 @@ public class CypherSemanticValidator {
         lost.add(outputName);
     }
 
-    if (!star)
+    if (!star) {
       scope.clear();
+      declaredHere.clear();
+    }
     scope.keySet().removeAll(lost);
+    declaredHere.removeAll(lost);
     scope.putAll(carried);
+    declaredHere.addAll(carried.keySet());
   }
 
   /**
@@ -271,30 +284,44 @@ public class CypherSemanticValidator {
   }
 
   private static void declarePatternVarTypes(final PathPattern path, final Map<String, VarType> scope,
-      final boolean raiseOnKindClash) {
+      final Set<String> declaredHere) {
     if (path == null)
       return;
 
     if (path.hasPathVariable())
-      declareVar(path.getPathVariable(), VarType.PATH, scope, raiseOnKindClash);
+      declareVar(path.getPathVariable(), VarType.PATH, scope, declaredHere);
     for (final NodePattern node : path.getNodes())
       if (node.getVariable() != null)
-        declareVar(node.getVariable(), VarType.NODE, scope, raiseOnKindClash);
+        declareVar(node.getVariable(), VarType.NODE, scope, declaredHere);
     for (final RelationshipPattern rel : path.getRelationships())
       if (rel.getVariable() != null)
-        declareVar(rel.getVariable(), VarType.RELATIONSHIP, scope, raiseOnKindClash);
+        declareVar(rel.getVariable(), VarType.RELATIONSHIP, scope, declaredHere);
   }
 
+  /**
+   * Declares one name as one kind. A second declaration of a name <i>this scope already declared</i>, as a different
+   * kind, is the conflict; a first declaration of a name the scope merely inherited is shadowing, and is allowed.
+   */
   private static void declareVar(final String name, final VarType type, final Map<String, VarType> scope,
-      final boolean raiseOnKindClash) {
-    if (raiseOnKindClash) {
-      final VarType existing = scope.get(name);
-      if (existing != null && existing != type)
-        throw new CommandParsingException(
-            "VariableTypeConflict: Variable '" + name + "' already defined as " + existing + ", cannot redefine as "
-                + type);
-    }
+      final Set<String> declaredHere) {
+    final VarType existing = scope.get(name);
+    if (existing != null && existing != type && declaredHere.contains(name))
+      throw new CommandParsingException(
+          "VariableTypeConflict: Variable '" + name + "' already defined as " + existing + ", cannot redefine as "
+              + type);
+
     scope.put(name, type);
+    declaredHere.add(name);
+  }
+
+  /**
+   * Drops a name bound by something that says nothing about its kind - an {@code UNWIND} variable, a {@code YIELD}
+   * output. It leaves this scope's declarations too, so a later pattern may declare it afresh without clashing with
+   * a kind the name no longer has.
+   */
+  private static void forget(final String name, final Map<String, VarType> scope, final Set<String> declaredHere) {
+    scope.remove(name);
+    declaredHere.remove(name);
   }
 
   // ==============================
@@ -1886,7 +1913,7 @@ public class CypherSemanticValidator {
     if (nested instanceof UnionStatement)
       return new HashMap<>(outer);
 
-    return buildVarTypes(nested, outer, false);
+    return buildVarTypes(nested, outer);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -1790,6 +1790,14 @@ public class CypherSemanticValidator {
    * implicit {@code CALL { ... }} imports nothing, so it inherits kinds for names its body cannot legally reference -
    * harmless, because {@link #validateVariableScope} runs first and reports such a reference as the undefined variable
    * it is, before this phase gets to read a kind for it.
+   * <p>
+   * What comes back is the body's <i>end</i> state, one map applied to every expression in it wherever that expression
+   * sits - deliberately, because it is the same approximation the top-level statement already runs on ({@code varTypes}
+   * is one map for the whole statement), and answering a body more precisely than the query around it would put back a
+   * clause-dependent asymmetry of exactly the kind #5602 and this issue exist to remove. It errs one way only: a name a
+   * later {@code WITH} re-binds to something kindless loses its kind for the clauses before it too, so a check is
+   * missed, never invented. It cannot err the other way, because the only rebinding Cypher allows on a bound name is a
+   * {@code WITH} projection, which can drop a kind but never turn a name into a path.
    */
   private static Map<String, VarType> nestedVarTypes(final Map<String, VarType> outer, final CypherStatement nested) {
     // A UNION declares nothing of its own - each branch is a scope of its own and is entered as a nested statement
@@ -1826,6 +1834,10 @@ public class CypherSemanticValidator {
       case WITH -> applyWithProjection(entry.getTypedClause(), scope);
       case UNWIND -> scope.remove(((UnwindClause) entry.getTypedClause()).getVariable());
       case LOAD_CSV -> scope.remove(((LoadCSVClause) entry.getTypedClause()).getVariable());
+      // Only the FOREACH variable itself: what the clause's inner CREATE/MERGE bind lives and dies inside the loop
+      // and is not in scope after it, so declaring those kinds here would be declaring them where they cannot be
+      // referenced. The walk still descends into the inner clauses - that is walkClause's FOREACH arm - and checks
+      // their expressions against the scope the loop was entered with.
       case FOREACH -> scope.remove(((ForeachClause) entry.getTypedClause()).getVariable());
       case CALL -> {
         final CallClause callClause = entry.getTypedClause();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
@@ -347,10 +347,15 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
   // ===================== the walker visits each expression exactly once =====================
 
   /**
-   * A {@code WITH} can be registered on the ordered clause list, on the statement, or on both, and the walk has to
-   * cover all three without visiting one twice - which is what lets a visitor accumulate rather than only assert.
-   * The precondition is asserted first: without a query whose WITH really is registered on both, the count below
-   * would pass for the trivial reason that there was nothing to double-visit.
+   * The walk covers the whole clause tree from the ordered clause list alone, which is only correct because a
+   * {@code WITH} registered on {@code getWithClauses()} is the very same object registered on
+   * {@code getClausesInOrder()} - one builder method puts it on both. Asserted here rather than assumed, because a
+   * builder path that ever registered a WITH on the statement alone would make the walk, and every check running
+   * through it, silently skip that clause.
+   * <p>
+   * The visit count then holds the other half: no expression is reached twice, which is what lets a visitor
+   * accumulate rather than only assert. It is checked on a query with a WITH in the outer statement and another in a
+   * {@code CALL} body, so a double-registration would have to show up in both scopes to go unnoticed.
    */
   @Test
   void everyExpressionIsVisitedExactlyOnce() {
@@ -358,16 +363,16 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
         "MATCH (n:P) WITH n, abs(n.age) AS a WHERE a > 0 "
             + "CALL { MATCH (m:P) WITH m WHERE m.age > 0 RETURN m.name AS b } RETURN a, b ORDER BY a");
 
-    final List<ClauseEntry> clauses = statement.getClausesInOrder();
-    final List<WithClause> ordered = clauses.stream()
+    final List<WithClause> ordered = statement.getClausesInOrder().stream()
         .filter(entry -> entry.getType() == ClauseEntry.ClauseType.WITH)
         .map(entry -> (WithClause) entry.getTypedClause())
         .toList();
     assertThat(ordered).isNotEmpty();
     assertThat(statement.getWithClauses()).isNotEmpty();
-    assertThat(statement.getWithClauses().stream().anyMatch(w -> ordered.stream().anyMatch(o -> o == w)))
-        .as("the query must have a WITH registered on both collections, or this test proves nothing")
-        .isTrue();
+    for (final WithClause withClause : statement.getWithClauses())
+      assertThat(ordered.stream().anyMatch(entry -> entry == withClause))
+          .as("a WITH on the statement must be the same instance on the ordered list, or the walk would miss it")
+          .isTrue();
 
     final Map<Expression, Integer> visits = new IdentityHashMap<>();
     CypherExpressionWalker.walk(statement, expression -> visits.merge(expression, 1, Integer::sum));

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
@@ -454,6 +454,34 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
     assertThatCode(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) WITH 1 AS p RETURN p")).doesNotThrowAnyException();
   }
 
+  /**
+   * A name declared twice as two different kinds is a {@code VariableTypeConflict}, and it is one inside a body for
+   * the same reason it is one outside: that is what "validate a body like the query around it" means.
+   * <p>
+   * What must still be allowed is the other thing that looks like it. A body that binds a name the enclosing query
+   * also uses is shadowing, not clashing - an implicit {@code CALL { }} imports nothing, so the outer name is not
+   * one the body is redefining. Both are asserted, because a check that told them apart in only one direction would
+   * either miss the conflict or reject the shadow.
+   */
+  @Test
+  void aKindClashInsideABodyIsAConflictWhileShadowingAnOuterNameIsNot() {
+    assertThatThrownBy(() -> explain("MATCH (x:P) MATCH ()-[x]->() RETURN x"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("VariableTypeConflict");
+    assertThatThrownBy(
+        () -> explain("MATCH (n:P) WHERE EXISTS { MATCH (x:P) MATCH ()-[x]->() RETURN x } RETURN n"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("VariableTypeConflict");
+    assertThatThrownBy(
+        () -> explain("MATCH (n:P) CALL { MATCH (x:P) MATCH ()-[x]->() RETURN x AS r } RETURN r"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("VariableTypeConflict");
+
+    // Shadowing: the body binds a name the outer query declared as another kind, and imports nothing.
+    assertThatCode(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL { MATCH (p:P) RETURN p.name AS n } RETURN n"))
+        .doesNotThrowAnyException();
+  }
+
   private List<String> names(final String query) {
     final List<String> result = new ArrayList<>();
     try (final ResultSet rs = database.query("opencypher", query)) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5626: the body of a subquery escaped the parse-time argument validation that
+ * issue #5602 had just extended to every other clause.
+ *
+ * <p>{@code abs('x')} is rejected before the query runs when written in a {@code WHERE}, and was let through when
+ * written inside {@code EXISTS { }}, {@code COUNT { }}, {@code COLLECT { }} or a {@code CALL { }} body. The runtime
+ * check still caught it whenever the subquery actually executed, but a subquery over a pattern matching no row never
+ * runs it - and the three expression forms absorb a failure into their neutral value, so the mistake could surface as
+ * a plain {@code false} / {@code 0} / {@code []} instead of an error. Neo4j type-checks a subquery body exactly as it
+ * does the enclosing query.
+ *
+ * <p>The queries here are run under {@code EXPLAIN}, so they are parsed and planned but never executed: what they
+ * assert is that the failure happens before any row is touched.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher",
+        "CREATE (a:P {name: 'a', age: 30})-[:KNOWS {since: 2020}]->(b:P {name: 'b', age: 40})");
+  }
+
+  // ===================== the reproducer, one shape per subquery form =====================
+
+  @Test
+  void existsSubqueryBodyIsValidated() {
+    assertRejectedLikeTheOuterWhere("MATCH (n:P) WHERE EXISTS { MATCH (m:P) WHERE abs('x') > 0 RETURN m } RETURN n");
+  }
+
+  @Test
+  void countSubqueryBodyIsValidated() {
+    assertRejectedLikeTheOuterWhere("MATCH (n:P) RETURN COUNT { MATCH (m:P) WHERE abs('x') > 0 RETURN m } AS r");
+  }
+
+  @Test
+  void collectSubqueryBodyIsValidated() {
+    assertRejectedLikeTheOuterWhere("MATCH (n:P) RETURN COLLECT { MATCH (m:P) WHERE abs('x') > 0 RETURN m } AS r");
+  }
+
+  @Test
+  void callSubqueryBodyIsValidated() {
+    assertRejectedLikeTheOuterWhere("MATCH (n:P) CALL { MATCH (m:P) WHERE abs('x') > 0 RETURN m } RETURN n");
+  }
+
+  /**
+   * The asymmetry the issue reports: the same call is rejected in the outer WHERE and must be rejected in the body
+   * too, with the same class and the same message.
+   */
+  private void assertRejectedLikeTheOuterWhere(final String queryWithSubquery) {
+    assertThatThrownBy(() -> explain("MATCH (n:P) WHERE abs('x') > 0 RETURN n"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> explain(queryWithSubquery))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()")
+        .hasMessageContaining("STRING");
+  }
+
+  // ===================== every check of the phase reaches inside, not only the type one =====================
+
+  /**
+   * The predicate here is a bare function call rather than a comparison, which used to get an anonymous
+   * {@code BooleanExpression} adapter of its own - a leaf as far as the walk was concerned - so the call inside it
+   * escaped the checks whether it was written in a subquery body or in the enclosing {@code WHERE}.
+   */
+  @Test
+  void unknownFunctionAsABarePredicateIsRejectedInsideAndOutside() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) WHERE nosuchfn(n) RETURN n"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("nosuchfn");
+    assertThatThrownBy(() -> explain("MATCH (n:P) WHERE EXISTS { MATCH (m:P) WHERE nosuchfn(m) RETURN m } RETURN n"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("nosuchfn");
+  }
+
+  @Test
+  void wrongArgumentCountInsideASubqueryBodyIsRejected() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) RETURN COUNT { MATCH (m:P) WHERE atan2(1) > 0 RETURN m } AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("atan2");
+  }
+
+  @Test
+  void propertyAccessOnAPathVariableInsideASubqueryBodyIsRejected() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) RETURN COLLECT { MATCH q = (m:P)-->() RETURN q.name } AS r"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+  }
+
+  // ===================== the positions a body can be written in =====================
+
+  @Test
+  void barePatternExistsBodyIsValidated() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) WHERE EXISTS { (n)-[:KNOWS]->(m) WHERE abs('x') > 0 } RETURN n"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  @Test
+  void barePatternCountBodyIsValidated() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) RETURN COUNT { (n)-[:KNOWS]->(m) WHERE abs('x') > 0 } AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  @Test
+  void negatedExistsBodyIsValidated() {
+    assertThatThrownBy(
+        () -> explain("MATCH (n:P) WHERE NOT EXISTS { MATCH (m:P) WHERE abs('x') > 0 RETURN m } RETURN n"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  @Test
+  void existsBodyInsideAConjunctionIsValidated() {
+    assertThatThrownBy(() -> explain(
+        "MATCH (n:P) WHERE n.age > 1 AND EXISTS { MATCH (m:P) WHERE abs('x') > 0 RETURN m } RETURN n"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  @Test
+  void subqueryNestedInsideAnotherSubqueryIsValidated() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) WHERE EXISTS { MATCH (m:P) "
+        + "WHERE COUNT { MATCH (o:P) WHERE abs('x') > 0 RETURN o } > 0 RETURN m } RETURN n"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  @Test
+  void unionBranchOfACallBodyIsValidated() {
+    assertThatThrownBy(() -> explain("CALL { MATCH (m:P) RETURN m.name AS x "
+        + "UNION MATCH (o:P) WHERE abs('x') > 0 RETURN o.name AS x } RETURN x"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  @Test
+  void subqueryBodyOfAWithWhereIsValidated() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) WITH n WHERE EXISTS { MATCH (m:P) WHERE abs('x') > 0 RETURN m } "
+        + "RETURN n"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  // ===================== two more expression positions the same walk now reaches =====================
+
+  @Test
+  void procedureCallArgumentIsValidated() {
+    assertThatThrownBy(() -> explain("CALL algo.degree(abs('x')) YIELD node RETURN node"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  @Test
+  void loadCsvUrlExpressionIsValidated() {
+    assertThatThrownBy(() -> explain("LOAD CSV FROM abs('x') AS row RETURN row"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("abs()");
+  }
+
+  // ===================== nothing valid is newly rejected =====================
+
+  @Test
+  void aCorrelatedSubqueryBodyStillParses() {
+    assertThatCode(() -> explain("MATCH (n:P) WHERE EXISTS { MATCH (n)-[:KNOWS]->(m:P) WHERE m.age > n.age RETURN m } "
+        + "RETURN n")).doesNotThrowAnyException();
+  }
+
+  /**
+   * {@code type()} wants a relationship and {@code labels()} a node: both are answered from the kinds the body itself
+   * declares, not from the enclosing statement's.
+   */
+  @Test
+  void variableKindsAreReadFromTheBodyThatDeclaresThem() {
+    assertThatCode(() -> explain("MATCH (n:P) RETURN COLLECT { MATCH (a:P)-[r:KNOWS]->(b:P) RETURN type(r) } AS r"))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> explain("MATCH (n:P) RETURN COLLECT { MATCH (a:P)-[r:KNOWS]->(b:P) RETURN labels(a) } AS r"))
+        .doesNotThrowAnyException();
+  }
+
+  /**
+   * An implicit {@code CALL { }} imports nothing, so a body is free to re-use an enclosing name for something of its
+   * own kind. The enclosing kind must not decide a check about the body's variable: here {@code p} is a path outside
+   * and a node inside, and {@code p.name} inside is a plain property read.
+   */
+  @Test
+  void anUnimportedOuterNameDoesNotDecideTheBodysCheck() {
+    assertThatCode(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL { MATCH (p:P) RETURN p.name AS n } "
+        + "RETURN n")).doesNotThrowAnyException();
+  }
+
+  /** The enclosing kind still applies to a name the body does not re-declare. */
+  @Test
+  void anOuterPathVariableIsStillAPathInsideACorrelatedBody() {
+    assertThatThrownBy(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) "
+        + "RETURN COLLECT { MATCH (m:P) RETURN p.name } AS r"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+  }
+
+  // ===================== EXISTS in a WHERE still evaluates as before =====================
+
+  @Test
+  void existsInWhereStillFiltersCorrectly() {
+    assertThat(names("MATCH (n:P) WHERE EXISTS { MATCH (n)-[:KNOWS]->(:P) } RETURN n.name AS name ORDER BY name"))
+        .containsExactly("a");
+    assertThat(names("MATCH (n:P) WHERE NOT EXISTS { MATCH (n)-[:KNOWS]->(:P) } RETURN n.name AS name ORDER BY name"))
+        .containsExactly("b");
+    assertThat(names("MATCH (n:P) WHERE EXISTS { MATCH (m:P) WHERE m.age > 100 RETURN m } RETURN n.name AS name"))
+        .isEmpty();
+  }
+
+  @Test
+  void countAndCollectSubqueriesStillEvaluate() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:P {name: 'a'}) RETURN COUNT { (n)-[:KNOWS]->(:P) } AS c, "
+            + "COLLECT { MATCH (n)-[:KNOWS]->(m:P) RETURN m.name } AS names")) {
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(1L);
+      assertThat((List<Object>) row.getProperty("names")).containsExactly("b");
+    }
+  }
+
+  private List<String> names(final String query) {
+    final List<String> result = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        result.add(rs.next().getProperty("name"));
+    }
+    return result;
+  }
+
+  private void explain(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
@@ -434,6 +434,26 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
     }
   }
 
+  /**
+   * Kind propagation is one construction now, shared by the statement and by a subquery body, and folding them
+   * together closed an asymmetry that predated this issue: the statement's copy dropped every kind at a {@code
+   * WITH *} because it kept only what the projection names, while the body's copy passed the incoming scope
+   * through. So the same path access was rejected inside a body and accepted outside one - the shape #5602 and
+   * #5626 exist to remove, in the phase that decides what a name is.
+   */
+  @Test
+  void aKindSurvivesWithStarInsideAndOutsideASubqueryBody() {
+    assertThatThrownBy(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) WITH * RETURN p.name"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+    assertThatThrownBy(() -> explain(
+        "MATCH (n:P) RETURN COLLECT { MATCH p = (a:P)-[:KNOWS]->(b:P) WITH * RETURN p.name } AS r"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+    // A projection that names what it keeps still drops the rest, inside and outside alike.
+    assertThatCode(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) WITH 1 AS p RETURN p")).doesNotThrowAnyException();
+  }
+
   private List<String> names(final String query) {
     final List<String> result = new ArrayList<>();
     try (final ResultSet rs = database.query("opencypher", query)) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
@@ -22,8 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.opencypher.ast.ClauseEntry;
+import com.arcadedb.query.opencypher.ast.CollectExpression;
+import com.arcadedb.query.opencypher.ast.CountExpression;
 import com.arcadedb.query.opencypher.ast.CypherStatement;
+import com.arcadedb.query.opencypher.ast.ExistsExpression;
 import com.arcadedb.query.opencypher.ast.Expression;
+import com.arcadedb.query.opencypher.ast.ListExpression;
+import com.arcadedb.query.opencypher.ast.VariableExpression;
 import com.arcadedb.query.opencypher.ast.WithClause;
 import com.arcadedb.query.opencypher.parser.Cypher25AntlrParser;
 import com.arcadedb.query.opencypher.parser.CypherExpressionWalker;
@@ -380,6 +385,53 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
     assertThat(visits).isNotEmpty();
     assertThat(visits.entrySet().stream().filter(entry -> entry.getValue() > 1).map(entry -> entry.getKey().getText())
         .toList()).isEmpty();
+  }
+
+  /**
+   * Building the body AST puts the statement builder on the parse path of something that used to be carried as text,
+   * so a body it cannot assemble must leave the query alone rather than fail it: the build is best-effort and the
+   * expression keeps a null body. What that costs is coverage - the walk sees a leaf, exactly as it did before
+   * #5626 - and what it must not cost is an exception, which would turn a running query into a parse error.
+   * <p>
+   * The three expressions are checked in the shape the fallback leaves them, and the walk is asserted to have
+   * carried on past each: a null body that stopped the traversal would take the rest of the query's checks with it.
+   * <p>
+   * The visitor here dereferences the statement it is handed, the way the validator's does when it builds the inner
+   * scope. That is the assertion that matters: the guarantee is not "the walk survives a null body" but "a boundary
+   * hook is never called with one", and only a visitor that reads the statement can tell the two apart.
+   */
+  @Test
+  void aSubqueryExpressionWithNoBodyIsALeafRatherThanAFailure() {
+    final List<Expression> withoutBody = List.of(
+        new ExistsExpression("MATCH (m:P) RETURN m", "EXISTS { MATCH (m:P) RETURN m }", null),
+        new CountExpression("MATCH (m:P) RETURN m", "COUNT { MATCH (m:P) RETURN m }", null),
+        new CollectExpression("MATCH (m:P) RETURN m.name", "COLLECT { MATCH (m:P) RETURN m.name }", null));
+
+    for (final Expression subquery : withoutBody) {
+      final List<Expression> visited = new ArrayList<>();
+      final Expression sibling = new VariableExpression("afterTheSubquery");
+      final Expression enclosing = new ListExpression(List.of(subquery, sibling), "[subquery, afterTheSubquery]");
+
+      final CypherExpressionWalker.Visitor readsTheNestedStatement = new CypherExpressionWalker.Visitor() {
+        @Override
+        public void visit(final Expression expression) {
+          visited.add(expression);
+        }
+
+        @Override
+        public CypherExpressionWalker.Visitor forNestedStatement(final CypherStatement nested) {
+          nested.getClausesInOrder();
+          return this;
+        }
+      };
+
+      assertThatCode(() -> CypherExpressionWalker.walk(enclosing, readsTheNestedStatement)).doesNotThrowAnyException();
+
+      assertThat(visited).contains(subquery);
+      assertThat(visited)
+          .as("the walk must carry on past a body-less subquery, not stop at it")
+          .contains(sibling);
+    }
   }
 
   private List<String> names(final String query) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
@@ -21,12 +21,20 @@ package com.arcadedb.query.opencypher;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.opencypher.ast.ClauseEntry;
+import com.arcadedb.query.opencypher.ast.CypherStatement;
+import com.arcadedb.query.opencypher.ast.Expression;
+import com.arcadedb.query.opencypher.ast.WithClause;
+import com.arcadedb.query.opencypher.parser.Cypher25AntlrParser;
+import com.arcadedb.query.opencypher.parser.CypherExpressionWalker;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -334,6 +342,39 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
       assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(1L);
       assertThat((List<Object>) row.getProperty("names")).containsExactly("b");
     }
+  }
+
+  // ===================== the walker visits each expression exactly once =====================
+
+  /**
+   * A {@code WITH} can be registered on the ordered clause list, on the statement, or on both, and the walk has to
+   * cover all three without visiting one twice - which is what lets a visitor accumulate rather than only assert.
+   * The precondition is asserted first: without a query whose WITH really is registered on both, the count below
+   * would pass for the trivial reason that there was nothing to double-visit.
+   */
+  @Test
+  void everyExpressionIsVisitedExactlyOnce() {
+    final CypherStatement statement = new Cypher25AntlrParser().parse(
+        "MATCH (n:P) WITH n, abs(n.age) AS a WHERE a > 0 "
+            + "CALL { MATCH (m:P) WITH m WHERE m.age > 0 RETURN m.name AS b } RETURN a, b ORDER BY a");
+
+    final List<ClauseEntry> clauses = statement.getClausesInOrder();
+    final List<WithClause> ordered = clauses.stream()
+        .filter(entry -> entry.getType() == ClauseEntry.ClauseType.WITH)
+        .map(entry -> (WithClause) entry.getTypedClause())
+        .toList();
+    assertThat(ordered).isNotEmpty();
+    assertThat(statement.getWithClauses()).isNotEmpty();
+    assertThat(statement.getWithClauses().stream().anyMatch(w -> ordered.stream().anyMatch(o -> o == w)))
+        .as("the query must have a WITH registered on both collections, or this test proves nothing")
+        .isTrue();
+
+    final Map<Expression, Integer> visits = new IdentityHashMap<>();
+    CypherExpressionWalker.walk(statement, expression -> visits.merge(expression, 1, Integer::sum));
+
+    assertThat(visits).isNotEmpty();
+    assertThat(visits.entrySet().stream().filter(entry -> entry.getValue() > 1).map(entry -> entry.getKey().getText())
+        .toList()).isEmpty();
   }
 
   private List<String> names(final String query) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
@@ -236,6 +236,58 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
         .hasMessageContaining("path variable");
   }
 
+  /**
+   * A body that imports an enclosing variable keeps its kind, however it imports it: through the explicit scope list,
+   * through a leading {@code WITH}, or renamed on the way in. What decides the kind is that the item is a plain
+   * variable reference, not the clause it was written in.
+   */
+  @Test
+  void anImportedOuterPathVariableKeepsItsKind() {
+    assertThatThrownBy(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL (p) { RETURN p.name AS n } RETURN n"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+    assertThatThrownBy(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL { WITH p RETURN p.name AS n } RETURN n"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+    assertThatThrownBy(
+        () -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL (p) { WITH p AS q RETURN q.name AS n } RETURN n"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+    assertThatThrownBy(() -> explain("MATCH (n:P) RETURN COLLECT { MATCH q = (m:P)-->() WITH q RETURN q.name } AS r"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+  }
+
+  /** A {@code WITH} that computes rather than passes through drops the kind, and a renamed one carries it. */
+  @Test
+  void aWithProjectionDecidesWhichKindSurvivesIt() {
+    // Re-bound to a number: no longer a path, so the property read is no longer this phase's business.
+    assertThatCode(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL (p) { WITH 1 AS p RETURN p AS n } RETURN n"))
+        .doesNotThrowAnyException();
+    // Renamed pass-through: still a node, still a relationship.
+    assertThatCode(() -> explain("MATCH (n:P) RETURN COLLECT { MATCH (m:P) WITH m AS x RETURN labels(x) } AS r"))
+        .doesNotThrowAnyException();
+    assertThatCode(
+        () -> explain("MATCH (n:P) RETURN COLLECT { MATCH (m:P)-[r:KNOWS]->() WITH r AS e RETURN type(e) } AS r"))
+        .doesNotThrowAnyException();
+    // WITH * passes the whole scope through.
+    assertThatCode(() -> explain("MATCH (n:P) RETURN COLLECT { MATCH (m:P) WITH *, 1 AS z RETURN labels(m) } AS r"))
+        .doesNotThrowAnyException();
+  }
+
+  /**
+   * An implicit {@code CALL { }} imports nothing, so its body may not reference an enclosing variable at all. The
+   * kinds it inherits are therefore never consulted for such a name: the scope check runs first and reports it as the
+   * undefined variable it is, rather than this phase answering about a variable the body cannot see.
+   */
+  @Test
+  void anUnimportedReferenceIsReportedAsUndefinedNotAsAKindError() {
+    assertThatThrownBy(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL { RETURN p.name } RETURN *"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("UndefinedVariable")
+        .hasMessageContaining("'p'");
+  }
+
   // ===================== EXISTS in a WHERE still evaluates as before =====================
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryParseTimeValidationIssue5626Test.java
@@ -172,6 +172,26 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
         .hasMessageContaining("abs()");
   }
 
+  /**
+   * Each branch of a {@code UNION} binds its own variables and is entered as a scope of its own, so a check that
+   * reads variable kinds sees the branch it is looking at. Merging the branches into one scope instead would keep
+   * only what they agree on, and a variable declared by a single branch would escape - asserted from both branch
+   * positions, since a scope taken from one branch would still answer for that one.
+   */
+  @Test
+  void aKindIsReadFromTheUnionBranchThatDeclaresIt() {
+    assertThatThrownBy(() -> explain("CALL { MATCH (a:P) RETURN a.name AS x "
+        + "UNION MATCH q = (m:P)-->() RETURN q.name AS x } RETURN x"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+    assertThatThrownBy(() -> explain("CALL { MATCH q = (m:P)-->() RETURN q.name AS x "
+        + "UNION MATCH (a:P) RETURN a.name AS x } RETURN x"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("path variable");
+    assertThatCode(() -> explain("CALL { MATCH (a:P) RETURN a.name AS x "
+        + "UNION MATCH (b:P) RETURN b.name AS x } RETURN x")).doesNotThrowAnyException();
+  }
+
   @Test
   void subqueryBodyOfAWithWhereIsValidated() {
     assertThatThrownBy(() -> explain("MATCH (n:P) WITH n WHERE EXISTS { MATCH (m:P) WHERE abs('x') > 0 RETURN m } "
@@ -283,6 +303,11 @@ class CypherSubqueryParseTimeValidationIssue5626Test extends TestHelper {
   @Test
   void anUnimportedReferenceIsReportedAsUndefinedNotAsAKindError() {
     assertThatThrownBy(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL { RETURN p.name } RETURN *"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("UndefinedVariable")
+        .hasMessageContaining("'p'");
+    // The explicit empty scope list imports nothing either, and is answered the same way.
+    assertThatThrownBy(() -> explain("MATCH p = (a:P)-[:KNOWS]->(b:P) CALL () { RETURN p.name AS n } RETURN n"))
         .isInstanceOf(CommandSemanticException.class)
         .hasMessageContaining("UndefinedVariable")
         .hasMessageContaining("'p'");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5228CallMatchEdgeLabelEntityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5228CallMatchEdgeLabelEntityTest.java
@@ -19,11 +19,13 @@
 package com.arcadedb.query.opencypher;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression tests for issue #5228: in the new scoped subquery syntax {@code CALL () { ... }} /
@@ -35,9 +37,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This is the same defect as issue #5226 (the O(1) type-count fast path counted edges) combined
  * with the general MATCH kind guard of issue #5194; both are fixed on main. Where the #5226 suite
  * asserts the aggregated {@code count(b)} and a {@code labels(b)} probe, this suite locks down the
- * reporter's remaining diagnostic angle: returning the raw entity {@code b} and probing
- * {@code type(b)} must yield <em>no rows at all</em>, for every {@code CALL} variant reported.
- * Labels and relationship types are separate namespaces in Cypher; Neo4j returns no rows here.
+ * reporter's remaining diagnostic angle: returning the raw entity {@code b} must yield <em>no rows
+ * at all</em>, for every {@code CALL} variant reported. Labels and relationship types are separate
+ * namespaces in Cypher; Neo4j returns no rows here.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -79,11 +81,27 @@ class Issue5228CallMatchEdgeLabelEntityTest extends TestHelper {
     assertThat(rowCount("CALL () { MATCH (b:EdgeLabel) RETURN b AS b } RETURN b")).isEqualTo(0);
   }
 
-  /** The reporter's diagnostic probe: labels()/type() must not surface any relationship. */
+  /** The reporter's diagnostic probe: labels() must not surface any relationship. */
   @Test
-  void scopedCallNoImportTypeAndLabelsProbeYieldsNoRows() {
+  void scopedCallNoImportLabelsProbeYieldsNoRows() {
     assertThat(rowCount(
-        "CALL () { MATCH (b:EdgeLabel) RETURN labels(b) AS lbls, type(b) AS t } RETURN lbls, t")).isEqualTo(0);
+        "CALL () { MATCH (b:EdgeLabel) RETURN labels(b) AS lbls } RETURN lbls")).isEqualTo(0);
+  }
+
+  /**
+   * The other half of the reporter's probe, {@code type(b)}, asks a node for a relationship type and so is a type
+   * error before the query runs - the answer it was written to produce cannot exist. It reads the same inside the
+   * subquery as it does outside it: the clause an expression sits in has no bearing on whether the call is valid
+   * (issue #5626).
+   */
+  @Test
+  void typeProbeOnANodeIsRejectedInsideAndOutsideTheSubquery() {
+    assertThatThrownBy(() -> rowCount("CALL () { MATCH (b:EdgeLabel) RETURN type(b) AS t } RETURN t"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument");
+    assertThatThrownBy(() -> rowCount("MATCH (b:EdgeLabel) RETURN type(b) AS t"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("type() requires a relationship argument");
   }
 
   /** {@code CALL (a)} importing an outer variable, returning the entity. */


### PR DESCRIPTION
Closes #5626.

`CypherExpressionWalker` stopped at a subquery held as text, and its class Javadoc explained why: *"those are parsed on their own and validated then, and there is no AST here to walk."* The issue is right that the second half is false. It turns out a fourth body was escaping too, for a different reason, and two whole predicates were escaping for a third.

### What actually escaped

| shape | why the walk did not reach it |
|---|---|
| `EXISTS { }` / `COUNT { }` / `COLLECT { }` | body kept as text, no AST to descend into |
| `CALL { }` | `walkClause`'s `default` arm skipped it, on the same "validated when it is parsed" belief |
| `WHERE EXISTS { ... }` | the builder wrapped it in an **anonymous** `BooleanExpression`, a leaf to the walk |
| `WHERE isEmpty(x)` - a function call as a bare predicate | same: a second anonymous adapter |

The last two are the trap this class's own Javadoc warns about (*"the `default` arms treat an unrecognised type as a leaf ... with nothing failing to say so"*), and they meant the reproducer in the issue was under-stating the reach: the first of the three forms was invisible even before the body question.

### The fix

**The three expressions now carry their body as a `CypherStatement` alongside the text**, and the walk descends into it - as it now does into a `CALL { }` body.

The issue's second option, taken, with one correction to its rationale: **this does not remove the re-parse.** What executes is not the body as written but the body after `CorrelatedSubqueryRewriter` has pinned the outer row into it, which differs row by row, so the text has to stay and the runtime parse with it. What the AST costs is therefore not free - but it is not a second lex either: it is built from the parse tree ANTLR already produced for the body (`ctx.queryWithLocalDefinitions()`, or the `patternList`/`whereClause` of a bare-pattern body), so it is one tree walk at parse time, once per distinct query text.

**The two anonymous adapters are gone.** Both were byte-for-byte `BooleanCoercionExpression` - same `evaluate`, same `evaluateTernary`, same `getText` - so they are now that named node, which the walk already knew. The function-call one turned out to be wholly redundant with the generic arm three lines below it (both call `parseExpressionFromText(expr6)` and wrap the result), and its removal also fixes a latent NPE: it wrapped a possibly-null expression, where the generic arm falls back properly.

**A body is a scope of its own.** Reusing the enclosing `varTypes` map for it would have been wrong in both directions, so the visitor re-binds itself at the boundary (`Visitor.forNestedStatement`): the kinds the body declares, over the ones it inherits, with any name the body binds by any means dropped from what it inherits. That is what keeps

```cypher
MATCH p = (a:P)-[:KNOWS]->(b:P) CALL { MATCH (p:P) RETURN p.name AS n } RETURN n
```

legal - an implicit `CALL { }` imports nothing, so the body's `p` is its own node and `p.name` is a plain property read, not property access on the outer path.

Two more expression positions the same traversal now reaches: procedure `CALL` arguments and the `LOAD CSV FROM` url.

### Behaviour change

Same shape as #5602's: a bad call inside a subquery body is now rejected before the query starts instead of failing at runtime - or, where the subquery matched no row, instead of quietly answering `false` / `0` / `[]`. No check is new; only its reach.

One existing test changed. `Issue5228CallMatchEdgeLabelEntityTest` probed `CALL () { MATCH (b:EdgeLabel) RETURN labels(b), type(b) }` and asserted zero rows; `type(b)` on a node is the type error it already was outside a subquery, so that half of the probe now asserts the rejection - and asserts it identically inside and outside, which is the point of the issue.

### Verified against Neo4j

Neo4j runs semantic analysis over the whole query including subquery bodies: `abs('x')` is `Type mismatch: expected Float or Integer but was String` at compile time wherever it is written, and `type(node)` is `Type mismatch: expected Relationship but was Node`. Neither is a Cypher usage mistake on the reporter's side.

### Tests

`CypherSubqueryParseTimeValidationIssue5626Test` - 22 tests, all under `EXPLAIN` so the query is parsed and planned but never executed:

- the reproducer for each of the four body kinds, each asserting the *same* class and message as the identical call in the outer `WHERE`
- every check of the phase reaching inside, not only the type one: unknown name, wrong arity, property access on a path variable
- the positions a body can be written in: bare pattern, negated, inside a conjunction, in a `WITH ... WHERE`, nested one subquery inside another, a `UNION` branch of a `CALL` body
- procedure `CALL` arguments and `LOAD CSV FROM`
- no false rejection: a correlated body, variable kinds read from the body that declares them, the unimported-shadowing case above, and the converse (an outer path variable is still a path in a body that does not re-declare it)
- `EXISTS` / `COUNT` / `COLLECT` still evaluate to the same answers after the adapter swap

Green: engine `query.**` + `function.**` 11311/0, `query.opencypher.**` 7808/0, bolt 93/0, the server Cypher HTTP ITs 20/0.

### Follow-up worth filing separately

The per-row re-parse is still there, and is a much larger cost than anything here: `EXISTS { }` lexes, parses, validates and plans its body once for every outer row. Now that the body exists as an AST, correlating it as an AST - binding the outer row into parameters rather than splicing text - would remove that, and would also retire `CorrelatedSubqueryRewriter`'s text scanning, which is where #4995, #5165, #5461 and #5464 all came from.
