### PR TITLE
fix(engine) #5637: persist the partition strategy, and report the index change that undoes it

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -9,7 +9,10 @@ exclude_paths:
   - "**/*.sh"
   - "**/*.bat"
   - "**/*.md"
-  - "**/src/test/*"
+  # Recursive: the single-star form only matched the direct children of src/test (i.e. the `java`
+  # directory itself), so test sources were in practice excluded only when their name happened to end
+  # in Test.java or IT.java. A test-support class named anything else was analysed as production code.
+  - "**/src/test/**"
   - "**/*Test.java"
   - "**/*IT.java"
   - "**/*CharStream.java"

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -918,6 +918,10 @@ left the write to somebody else - the flag *about* the partitioning (`needsRepar
 partitioning did not. Databases whose strategy never reached `schema.json` simply need the `ALTER TYPE` re-issued;
 placement of existing records is unaffected either way, since the hash is the same one.
 
+The fix is on the mutator, not on `partitioned`, so `thread` stops being lost across a restart on the same terms.
+`round-robin` is the default and is deliberately still absent from `schema.json`, which is how reverting to it
+persists.
+
 **An index created on an already-partitioned type is diagnosed when it is created.** #5603 refuses an unsuitable
 partition at assignment time, but the same state was reachable by reordering the DDL - attach the strategy first,
 then create the index that makes it unprunable:

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -904,4 +904,48 @@ Two cluster endpoints move behind the root check that the seven mutating Raft en
 `GET /api/v1/cluster` also stops listing reserved internal databases such as the Raft control directory
 `.raft`, matching what the presence matrix and the bootstrap-state RPC already did.
 
+## Partitioned types survive a restart, and a later `CREATE INDEX` says what it cost the partitioning
+
+Two loose ends of the partitioned-strategy series, both about what happens to a type *after* it has been configured
+([#5637](https://github.com/ArcadeData/arcadedb/issues/5637)).
+
+**`ALTER TYPE ... BucketSelectionStrategy` is persisted.** The strategy was set in memory and nothing wrote it out,
+so a type partitioned by that DDL alone came back **`round-robin` after a restart** - unless some later, unrelated
+schema mutation happened to flush the configuration first. This hit *correctly* configured types, which is what
+makes it worse than the states #5603 refuses: new records were placed round-robin among rows the partition hash had
+placed, every partition-aware lookup silently fanned out, and nothing warned. It is the one schema mutator that
+left the write to somebody else - the flag *about* the partitioning (`needsRepartition`) saved itself while the
+partitioning did not. Databases whose strategy never reached `schema.json` simply need the `ALTER TYPE` re-issued;
+placement of existing records is unaffected either way, since the hash is the same one.
+
+**An index created on an already-partitioned type is diagnosed when it is created.** #5603 refuses an unsuitable
+partition at assignment time, but the same state was reachable by reordering the DDL - attach the strategy first,
+then create the index that makes it unprunable:
+
+```sql
+ALTER TYPE T BucketSelectionStrategy `partitioned('name')`;   -- accepted
+DROP INDEX `T[name]`;
+CREATE INDEX ON T (name COLLATE CI) UNIQUE;                   -- used to be silent
+```
+
+Correctness always held - the strategy declines to prune, so lookups fan out and `UNIQUE` stays global - but
+between the `CREATE INDEX` and the next restart nothing said the partitioning had stopped doing anything. The same
+applied to an index on non-partition properties, which drew the fan-out advisory at assignment time and nothing
+when it arrived later. `CREATE INDEX` now re-runs the same check and reports the result. It never refuses: at
+assignment time the strategy is what was asked for and a blocked one is pure cost, whereas here the index is what
+was asked for and it is useful, so the partitioning is what gives way. An index change that leaves the partition
+exactly as suitable as it was stays quiet.
+
+**A partitioned type whose index has been dropped opens again.** Binding the strategy demanded the unique automatic
+index on the partition properties, and it did so on every rebind - including the one the schema loader performs on
+every open. With the strategy now reaching `schema.json`, a `DROP INDEX` on the partition key made the next open
+throw *from inside the loader*, which aborts everything it has not reached yet: the remaining types' strategies,
+the triggers, the function libraries, the extensions, and the compaction file-migration map WAL recovery redirects
+through - reported only as `Error on loading schema. The schema will be reset`. Binding no longer validates
+anything; the requirement moved to the suitability check, which refuses it at assignment time exactly as before and
+warns about it on load. The type keeps its partitioned placement, so records written after the index was dropped
+still land where a lookup would look for them. Any other unusable strategy - an implementation class that no longer
+resolves, say - now falls back to `round-robin` for that one type with a warning naming it, instead of costing the
+rest of the schema.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
@@ -97,31 +97,39 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
     return copy;
   }
 
+  /**
+   * Binds the strategy to its type. Binding only: it must never throw.
+   * <p>
+   * This runs on every rebind, not just when the user asks for the strategy - {@code addIndexInternal} calls it once
+   * per bucket index, {@code addBucketInternal} on every bucket added, and the schema loader on every open - so a
+   * validation failure here is a failure of whatever operation happened to touch the type. It used to demand the
+   * unique automatic index on the partition properties, which made a database whose partition index had been dropped
+   * unopenable: the loader binds the persisted strategy inside its own try/catch, so the throw aborted the rest of
+   * the load - triggers, function libraries, extensions and the compaction file-migration map - and the schema was
+   * reported as "reset" (issue #5637). That requirement now lives in {@link #checkSuitability()}, which the schema
+   * layer refuses on at assignment time and only warns about when it reads an existing database back.
+   */
   @Override
   public void setType(final LocalDocumentType type) {
     super.setType(type);
     this.type = type;
-
-    final TypeIndex index = type.getPolymorphicIndexByProperties(propertyNames);
-    if (index == null || !index.isAutomatic() || !index.isUnique())
-      throw new IllegalArgumentException(
-          "cannot find a unique automatic index on the partition properties " + propertyNames);
   }
 
   /**
    * A verdict on the partition configuration, split by what it costs.
    * <p>
-   * A {@code blocker} is a state in which {@link #getBucketIdByKeys} can never answer anything but -1, so the type
-   * pays the strategy's constraints - a partition key that must not be updated, an uneven bucket fill - and gets
-   * nothing back. Assigning the strategy into such a state is refused; finding an existing database in one is only
-   * warned about, so it still opens.
+   * A {@code blocker} is a state the strategy must not be assigned into, because the type pays the strategy's
+   * constraints - a partition key that must not be updated, an uneven bucket fill - and gets nothing usable back:
+   * either {@link #getBucketIdByKeys} can never answer anything but -1, or the unique automatic index those pruned
+   * lookups would go through is not there at all. Assigning the strategy into such a state is refused; finding an
+   * existing database in one is only warned about, so it still opens.
    * <p>
    * A {@code warning} is a configuration that prunes, just less than the wording suggests. Today that is a second
    * index on properties the partition does not cover: those lookups cannot be pruned (issue #5589) and fan out
    * across every bucket, which is correct but no faster than not partitioning at all.
    */
   public record Suitability(List<String> blockers, List<String> warnings) {
-    public boolean canPrune() {
+    public boolean isUsable() {
       return blockers.isEmpty();
     }
   }
@@ -130,13 +138,21 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
    * Diagnoses the partition configuration for the schema layer. Cold path only - called when the strategy is assigned
    * and when a database is reopened, never per query, so it is free to allocate the messages it reports.
    * <p>
-   * The rules are the ones {@link #getBucketIdByKeys} enforces silently, said out loud: a configuration reported here
-   * as a blocker is exactly one in which that method returns -1 for every key it will ever be handed.
+   * Most of the rules are the ones {@link #getBucketIdByKeys} enforces silently, said out loud: a configuration
+   * reported below as a hashing blocker is exactly one in which that method returns -1 for every key it will ever be
+   * handed. The first blocker is the odd one out - a missing partition index does not stop the strategy from
+   * computing a bucket, it removes the index lookup that would have been pruned by it - and it is grouped here
+   * because it draws the same reaction: refuse the assignment, warn about a database already in that state.
    */
   public Suitability checkSuitability() {
     final Database database = type.getSchema().getEmbedded().getDatabase();
     final List<String> blockers = new ArrayList<>();
     final List<String> warnings = new ArrayList<>();
+
+    final TypeIndex partitionIndex = type.getPolymorphicIndexByProperties(propertyNames);
+    if (partitionIndex == null || !partitionIndex.isAutomatic() || !partitionIndex.isUnique())
+      blockers.add("cannot find a unique automatic index on the partition properties " + propertyNames
+          + ", which is what a pruned lookup would go through");
 
     for (final String propertyName : propertyNames) {
       final Property property = type.getPolymorphicPropertyIfExists(propertyName);

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -741,6 +741,19 @@ public class LocalDocumentType implements DocumentType {
 
   @Override
   public DocumentType setBucketSelectionStrategy(final BucketSelectionStrategy selectionStrategy) {
+    return setBucketSelectionStrategy(selectionStrategy, true);
+  }
+
+  /**
+   * @param persistOnItsOwn {@code false} for a caller that is already inside a {@link LocalSchema#recordFileChanges}
+   *                        block, which saves the schema when it completes. That save carries the strategy just as
+   *                        this method's own would - the field is assigned before either runs - so persisting here
+   *                        as well would rewrite {@code schema.json} twice for one operation. Every caller that is
+   *                        the whole operation passes {@code true}: the point of issue #5637 is that this mutator
+   *                        must not depend on somebody else writing for it.
+   */
+  private DocumentType setBucketSelectionStrategy(final BucketSelectionStrategy selectionStrategy,
+      final boolean persistOnItsOwn) {
     checkForSchemaMutation();
     final BucketSelectionStrategy previous = this.bucketSelectionStrategy;
     this.bucketSelectionStrategy = selectionStrategy;
@@ -806,9 +819,10 @@ public class LocalDocumentType implements DocumentType {
     // memory and round-robin in schema.json - exactly the shape this issue is about. A skip-if-unchanged guard would
     // read the in-memory value, conclude nothing changed, and turn that repair into a silent no-op. The cost of not
     // guarding is one rewrite of schema.json per redundant DDL statement, on a path measured in statements per
-    // database lifetime. What IS skipped is the write the needsRepartition flip just made in this same call, which
-    // is a different redundancy: same call, same file, same content.
-    if (!schema.isReadingFromFile() && !alreadySaved)
+    // database lifetime. What IS skipped are two writes that would be redundant within one operation rather than
+    // across two DDL statements: the one the needsRepartition flip just made in this same call, and the one an
+    // enclosing recordFileChanges block is going to make on its way out (see persistOnItsOwn).
+    if (!schema.isReadingFromFile() && !alreadySaved && persistOnItsOwn)
       schema.saveConfiguration();
 
     return this;
@@ -1864,8 +1878,9 @@ public class LocalDocumentType implements DocumentType {
       }
 
       if (!superType.getBucketSelectionStrategy().getName().equalsIgnoreCase(getBucketSelectionStrategy().getName()))
-        // INHERIT THE BUCKET SELECTION STRATEGY FROM THE SUPER TYPE
-        setBucketSelectionStrategy(superType.getBucketSelectionStrategy().copy());
+        // INHERIT THE BUCKET SELECTION STRATEGY FROM THE SUPER TYPE. The enclosing recordFileChanges saves the
+        // schema when it completes, and that write carries this strategy, so the setter does not persist on its own.
+        setBucketSelectionStrategy(superType.getBucketSelectionStrategy().copy(), false);
 
       return null;
     });

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -692,14 +692,20 @@ public class LocalDocumentType implements DocumentType {
    * survives a server restart. During schema load that call is a no-op (the schema's own
    * {@code readingFromFile} guard postpones the write), so this is safe to call regardless of
    * the load state.
+   *
+   * @return {@code true} when the value transitioned and the schema was therefore saved. Lets a caller that was
+   * going to save anyway skip a second full rewrite of {@code schema.json} in the same call; every other caller is
+   * free to ignore it.
    */
-  public void setNeedsRepartition(final boolean needsRepartition) {
+  public boolean setNeedsRepartition(final boolean needsRepartition) {
     // CAS guarantees that the save fires exactly once per real transition: only the thread that
     // observes the opposite value and successfully flips it proceeds; any concurrent caller
     // requesting the same target value either loses the race (CAS returns false) or finds the
     // value already at the target. Both cases skip the {@code schema.saveConfiguration()} call.
-    if (this.needsRepartition.compareAndSet(!needsRepartition, needsRepartition))
-      schema.saveConfiguration();
+    if (!this.needsRepartition.compareAndSet(!needsRepartition, needsRepartition))
+      return false;
+    schema.saveConfiguration();
+    return true;
   }
 
   /**
@@ -768,6 +774,7 @@ public class LocalDocumentType implements DocumentType {
     // LocalSchema right after this call, and {@code hasAnyRecord()} would walk every bucket
     // and call {@code count()} (per-bucket I/O) producing a value that's about to be
     // overwritten anyway.
+    boolean alreadySaved = false;
     if (!schema.isReadingFromFile()
         && selectionStrategy instanceof PartitionedBucketSelectionStrategy newPartitioned
         && partitionShapeChanged(previous, newPartitioned)
@@ -775,7 +782,10 @@ public class LocalDocumentType implements DocumentType {
       // Use the typed setter so the schema-save-on-transition contract fires consistently with
       // every other site that mutates this flag. Direct field assignment would only work because
       // the wrapping DDL happens to save the schema afterward; relying on that is brittle.
-      setNeedsRepartition(true);
+      // Its answer says whether that contract already wrote the file, which is the same write the
+      // block below would make - the strategy field was assigned before this, so the flag's save
+      // carries it. Only a real transition saves, so this stays false when the flag was already set.
+      alreadySaved = setNeedsRepartition(true);
 
     // Persist the strategy itself (issue #5637). This is the one schema mutator that used to leave the write to
     // somebody else - every sibling either calls saveConfiguration() directly (setAliases, LocalProperty's setters)
@@ -796,8 +806,9 @@ public class LocalDocumentType implements DocumentType {
     // memory and round-robin in schema.json - exactly the shape this issue is about. A skip-if-unchanged guard would
     // read the in-memory value, conclude nothing changed, and turn that repair into a silent no-op. The cost of not
     // guarding is one rewrite of schema.json per redundant DDL statement, on a path measured in statements per
-    // database lifetime.
-    if (!schema.isReadingFromFile())
+    // database lifetime. What IS skipped is the write the needsRepartition flip just made in this same call, which
+    // is a different redundancy: same call, same file, same content.
+    if (!schema.isReadingFromFile() && !alreadySaved)
       schema.saveConfiguration();
 
     return this;

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -741,11 +741,12 @@ public class LocalDocumentType implements DocumentType {
     try {
       // The field is assigned before this so the strategy can read back the type it is being bound to, which means
       // anything thrown from here would otherwise leave the type carrying a strategy the DDL went on to reject.
-      // Both validations live inside the try: the unique-index requirement, and the suitability check that refuses a
-      // partition which could never prune (issue #5603).
+      // Binding no longer validates anything (see PartitionedBucketSelectionStrategy.setType); every refusal comes
+      // out of the suitability check below, which is also what makes the reaction depend on how we got here.
       this.bucketSelectionStrategy.setType(this);
       if (selectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
-        reportPartitionSuitability(partitioned);
+        reportPartitionSuitability(partitioned,
+            schema.isReadingFromFile() ? PartitionReport.RELOAD : PartitionReport.ASSIGNMENT);
     } catch (final RuntimeException e) {
       // Restoring the reference is the whole rollback: previous was bound to this type when it was assigned, and
       // nothing here unbinds it, so re-invoking previous.setType(this) would be a no-op.
@@ -776,11 +777,50 @@ public class LocalDocumentType implements DocumentType {
       // the wrapping DDL happens to save the schema afterward; relying on that is brittle.
       setNeedsRepartition(true);
 
+    // Persist the strategy itself (issue #5637). This is the one schema mutator that used to leave the write to
+    // somebody else - every sibling either calls saveConfiguration() directly (setAliases, LocalProperty's setters)
+    // or goes through recordFileChanges, which calls it - so a type partitioned by `ALTER TYPE ...
+    // BucketSelectionStrategy` and nothing else reopened as round-robin. That is worse than an unsuitable partition
+    // being accepted: a correctly configured type lost its pruning across a restart AND started placing new records
+    // round-robin among rows the partition hash had placed, with nothing said anywhere. The flag ABOUT the
+    // partitioning persisted (see setNeedsRepartition above) while the partitioning did not.
+    //
+    // Skipped while the schema is being read back, where the value being assigned is the one just read from
+    // schema.json: saveConfiguration() would only mark the schema dirty, and LocalSchema flushes that at the end of
+    // load, rewriting an identical file on every single open of any partitioned database.
+    if (!schema.isReadingFromFile())
+      schema.saveConfiguration();
+
     return this;
   }
 
   /**
-   * Reports what the partition configuration will actually do, at the moment it is chosen rather than at the first
+   * How the caller wants a partition diagnosis reacted to. The diagnosis itself is identical in all three cases -
+   * {@link PartitionedBucketSelectionStrategy#checkSuitability()} is the single source - and only the reaction moves.
+   */
+  private enum PartitionReport {
+    /**
+     * The user is choosing the strategy right now. A blocker is refused outright and warnings are advice worth one
+     * line at the moment the shape is chosen.
+     */
+    ASSIGNMENT,
+    /**
+     * The strategy is being read back out of {@code schema.json}. A refusal here would turn a slow database into an
+     * unopenable one, so a blocker is only logged; warnings are suppressed, because they describe a schema that was
+     * accepted and is working as designed and would otherwise put a WARNING on every startup, forever - the kind of
+     * line operators learn to filter out, taking the blockers with it.
+     */
+    RELOAD,
+    /**
+     * A later schema change (an index created on an already-partitioned type) has just re-decided the answer
+     * (issue #5637). Everything is reported and nothing is refused: the index is what the user asked for and it is
+     * useful, whereas at assignment time the strategy was what was asked for and a blocked one is pure cost.
+     */
+    SCHEMA_CHANGE
+  }
+
+  /**
+   * Reports what the partition configuration will actually do, at the moment it is decided rather than at the first
    * query that comes up short (issue #5603).
    * <p>
    * Both #5589 and #5595 were the same story from the user's side: the strategy attached without complaint and the
@@ -788,52 +828,62 @@ public class LocalDocumentType implements DocumentType {
    * with nothing tying it back to the {@code ALTER TYPE}. The read side is fixed; this is the other half, saying so
    * up front.
    * <p>
-   * <b>Refuse a new assignment, only warn on reload.</b> A blocker means the strategy can never prune, so accepting
-   * it is accepting pure cost, and the DDL that asks for it is refused. The identical state read back out of
-   * {@code schema.json} is only logged: an existing database has records placed under that strategy already and must
-   * still open - a refusal there would turn a slow database into an unopenable one. Note the asymmetry is in the
-   * reaction, not the diagnosis; both paths run the same check.
+   * <b>The moment is not only the assignment.</b> A partition's suitability is a fact about the type AND its indexes,
+   * so a {@code CREATE INDEX} that lands afterwards can flip the answer - recollating the partition index {@code
+   * COLLATE CI} makes it unprunable, and an index on other properties adds a lookup that fans out. That reordering
+   * of the same DDL walked straight past the assignment-time check, which is why {@link TypeIndexBuilder} calls this
+   * too (issue #5637).
    * <p>
-   * Warnings never refuse. A second index on non-partition properties is a perfectly reasonable schema, it just does
-   * not benefit from the partitioning, and it is common enough that refusing it would be hostile. They are reported
-   * last so a configuration that is about to be refused outright does not first draw advice on how to speed it up.
-   * <p>
-   * <b>Warnings are assignment-time advice, so they are not repeated on reload.</b> They say "this is not the shape
-   * you probably meant", which is worth one line at the moment the shape is chosen and nothing at all on every
-   * subsequent open of a database whose schema has not changed since. Left unconditional they would put a WARNING
-   * per startup, forever, against a schema that was accepted and is working as designed - the kind of line operators
-   * learn to filter out, taking the blockers below with it. Blockers do repeat on every open, deliberately: those
-   * describe a database that is still paying for a strategy it cannot use, and that stays worth saying until
-   * somebody acts on it.
+   * Blockers repeat on every open, deliberately: those describe a database that is still paying for a strategy it
+   * cannot use, and that stays worth saying until somebody acts on it. Warnings never refuse anywhere - a second
+   * index on non-partition properties is a perfectly reasonable schema, it just does not benefit from the
+   * partitioning - and they are reported last, so a configuration that is about to be refused outright does not
+   * first draw advice on how to speed it up.
+   *
+   * @param mode what to do with the diagnosis; see {@link PartitionReport}
    */
-  private void reportPartitionSuitability(final PartitionedBucketSelectionStrategy partitioned) {
+  private void reportPartitionSuitability(final PartitionedBucketSelectionStrategy partitioned,
+      final PartitionReport mode) {
     final PartitionedBucketSelectionStrategy.Suitability suitability = partitioned.checkSuitability();
 
-    if (!suitability.canPrune()) {
+    if (!suitability.isUsable()) {
       final String reasons = String.join("; ", suitability.blockers());
 
-      if (!schema.isReadingFromFile())
+      if (mode == PartitionReport.ASSIGNMENT)
         throw new SchemaException(
             "Cannot use the partitioned bucket selection strategy on " + partitioned.getProperties() + " for type '"
                 + name + "': " + reasons
-                + ". Every lookup would fan out across all buckets, so the partitioning would cost the placement "
-                + "constraints and return nothing. Use `round-robin` instead, or change the partition key.");
+                + ". No lookup would ever be pruned to one bucket, so the partitioning would cost the placement "
+                + "constraints and return nothing. Use `round-robin` instead, or fix the partition key or its index.");
 
       LogManager.instance().log(this, Level.WARNING, """
-          Type '%s' is configured with the partitioned bucket selection strategy on %s, but it can never prune a \
-          lookup to one bucket because %s. Queries stay correct - every lookup fans out across all %d buckets - but \
-          the partitioning buys nothing. Switch the type back to `round-robin`, or fix the configuration and run \
+          Type '%s' is configured with the partitioned bucket selection strategy on %s, but no lookup can be pruned \
+          to one bucket because %s. Queries stay correct - every lookup fans out across all %d buckets - but the \
+          partitioning buys nothing. Switch the type back to `round-robin`, or fix the configuration and run \
           `REBUILD TYPE %s WITH repartition = true`.""", null, name, partitioned.getProperties(), reasons,
           buckets.size(), name);
     }
 
-    if (schema.isReadingFromFile())
+    if (mode == PartitionReport.RELOAD)
       return;
 
     for (final String warning : suitability.warnings())
       LogManager.instance().log(this, Level.WARNING,
           "Type '%s' uses the partitioned bucket selection strategy on %s, but %s", null, name,
           partitioned.getProperties(), warning);
+  }
+
+  /**
+   * Re-runs the partition diagnosis after a schema change that can have altered it, reporting everything and
+   * refusing nothing (issue #5637). A no-op on a type that is not partitioned.
+   * <p>
+   * Called from {@link TypeIndexBuilder}, which runs once per {@code CREATE INDEX}. The obvious hook,
+   * {@link #addIndexInternal}, runs once per BUCKET, so it would multiply every line by the bucket count and fire
+   * during schema reload as well.
+   */
+  void reportPartitionSuitabilityAfterSchemaChange() {
+    if (bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
+      reportPartitionSuitability(partitioned, PartitionReport.SCHEMA_CHANGE);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -788,6 +788,15 @@ public class LocalDocumentType implements DocumentType {
     // Skipped while the schema is being read back, where the value being assigned is the one just read from
     // schema.json: saveConfiguration() would only mark the schema dirty, and LocalSchema flushes that at the end of
     // load, rewriting an identical file on every single open of any partitioned database.
+    //
+    // Deliberately NOT also skipped when the new strategy is equivalent to the previous one, which several sibling
+    // mutators do guard on. Re-issuing the same `ALTER TYPE ... BucketSelectionStrategy` is the operator's way of
+    // forcing the in-memory strategy back onto disk, and the two can genuinely diverge: saveConfiguration() reports
+    // an IOException by logging SEVERE and returning, so a transient disk failure leaves a type partitioned in
+    // memory and round-robin in schema.json - exactly the shape this issue is about. A skip-if-unchanged guard would
+    // read the in-memory value, conclude nothing changed, and turn that repair into a silent no-op. The cost of not
+    // guarding is one rewrite of schema.json per redundant DDL statement, on a path measured in statements per
+    // database lifetime.
     if (!schema.isReadingFromFile())
       schema.saveConfiguration();
 
@@ -815,6 +824,14 @@ public class LocalDocumentType implements DocumentType {
      * A later schema change (an index created on an already-partitioned type) has just re-decided the answer
      * (issue #5637). Everything is reported and nothing is refused: the index is what the user asked for and it is
      * useful, whereas at assignment time the strategy was what was asked for and a blocked one is pure cost.
+     * <p>
+     * <b>The whole current picture is reported, not the delta.</b> A type already carrying a fan-out advisory for an
+     * index on {@code code} draws it again when a third index is created, even though that DDL did not cause it. The
+     * alternative - work out which lines the new index is responsible for - would mean either matching on message
+     * text or teaching {@code checkSuitability()} to attribute each finding to an index, and it would report a state
+     * as partly acceptable while the enclosing paragraph says it is not. This says the same thing every time it is
+     * asked, which is what makes the answer worth reading; a {@code CREATE INDEX} is rare, deliberate DDL, and the
+     * line count is bounded by the number of indexes on the type.
      */
     SCHEMA_CHANGE
   }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1888,6 +1888,14 @@ public class LocalDocumentType implements DocumentType {
       if (!superType.getBucketSelectionStrategy().getName().equalsIgnoreCase(getBucketSelectionStrategy().getName()))
         // INHERIT THE BUCKET SELECTION STRATEGY FROM THE SUPER TYPE. The enclosing recordFileChanges saves the
         // schema when it completes, and that write carries this strategy, so the setter does not persist on its own.
+        //
+        // An inherited partition that is unsuitable for this subtype still refuses here, as it always has: what
+        // changed with issue #5637 is that the refusal now arrives as the SchemaException the suitability check
+        // raises rather than the IllegalArgumentException the binding used to throw. Checked against every caller
+        // of addSuperType - CreateTypeAbstractStatement, AlterTypeStatement's SUPERTYPE branch, TypeBuilder, the
+        // Cypher Labels helper, and LocalSchema's dropType re-attach - and none of them catches either type, so
+        // nothing distinguishes the two. Neither is a CommandParsingException, so the HTTP status is unchanged too.
+        // (AlterTypeStatement's one catch names both, but it guards the BucketSelectionStrategy branch, not this.)
         setBucketSelectionStrategy(superType.getBucketSelectionStrategy().copy(), false);
 
       return null;

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -922,6 +922,14 @@ public class LocalDocumentType implements DocumentType {
    * Called from {@link TypeIndexBuilder}, which runs once per {@code CREATE INDEX}. The obvious hook,
    * {@link #addIndexInternal}, runs once per BUCKET, so it would multiply every line by the bucket count and fire
    * during schema reload as well.
+   * <p>
+   * <b>{@code DROP INDEX} deliberately does not call this, which leaves one case reported only on the next open.</b>
+   * Recollating an index is a drop followed by a create, so a hook on the drop would announce "there is no unique
+   * automatic index on the partition properties" in the middle of a sequence that is about to put one back - a line
+   * that is true for the instant it is printed, misleading by the time it is read, and printed ahead of the accurate
+   * one the create emits. That leaves a drop with no create after it saying nothing until the database is reopened,
+   * where the blocker is reported and then repeats on every open. Closing that properly means deferring the
+   * diagnosis to the end of the enclosing transaction rather than moving the hook, which is tracked as issue #5646.
    */
   void reportPartitionSuitabilityAfterSchemaChange() {
     if (bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1902,6 +1902,11 @@ public class LocalSchema implements Schema {
             // property of this database and worth a WARNING. Anything else reaching here is a fault in the bind
             // path itself, and would otherwise be indistinguishable from an expected refusal in the log of a
             // database that opens successfully.
+            // IllegalArgumentException is listed alongside SchemaException for the strategies this engine does not
+            // ship: a custom BucketSelectionStrategy named by class in schema.json runs its own setType() here, and
+            // rejecting the type it is handed is what that exception is for. The engine's own strategies no longer
+            // raise it from the bind path - that is the change this issue made - so on a stock database only the
+            // SchemaException arm fires.
             final boolean expected = e instanceof SchemaException || e instanceof IllegalArgumentException;
             LogManager.instance().log(this, expected ? Level.WARNING : Level.SEVERE,
                 "Cannot restore the '%s' bucket selection strategy on type '%s': %s. The type falls back to `%s`",

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1895,7 +1895,15 @@ public class LocalSchema implements Schema {
             // and the compaction file-migration map WAL recovery redirects through - while the outer catch reports
             // the whole schema as "reset". The type stays on its default round-robin strategy, which loses the
             // partition pruning but leaves a database that opens and says why.
-            LogManager.instance().log(this, Level.WARNING,
+            //
+            // The catch has to be broad to give that guarantee, so the LEVEL carries what the type cannot: a
+            // SchemaException or IllegalArgumentException is the strategy declining to be restored - an
+            // unresolvable implementation class, a configuration the suitability check refuses - which is a
+            // property of this database and worth a WARNING. Anything else reaching here is a fault in the bind
+            // path itself, and would otherwise be indistinguishable from an expected refusal in the log of a
+            // database that opens successfully.
+            final boolean expected = e instanceof SchemaException || e instanceof IllegalArgumentException;
+            LogManager.instance().log(this, expected ? Level.WARNING : Level.SEVERE,
                 "Cannot restore the '%s' bucket selection strategy on type '%s': %s. The type falls back to `%s`",
                 e, bucketSelectionStrategy.getString("name"), typeName, e.getMessage(),
                 RoundRobinBucketSelectionStrategy.NAME);

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1905,8 +1905,11 @@ public class LocalSchema implements Schema {
             final boolean expected = e instanceof SchemaException || e instanceof IllegalArgumentException;
             LogManager.instance().log(this, expected ? Level.WARNING : Level.SEVERE,
                 "Cannot restore the '%s' bucket selection strategy on type '%s': %s. The type falls back to `%s`",
-                e, bucketSelectionStrategy.getString("name"), typeName, e.getMessage(),
-                RoundRobinBucketSelectionStrategy.NAME);
+                // Falling back to toString() because the failures this catch is broad enough to reach include the
+                // ones that carry no message - an NPE most of all - and "...: null" names neither what went wrong
+                // nor where, on the one line an operator is likely to read.
+                e, bucketSelectionStrategy.getString("name"), typeName,
+                e.getMessage() != null ? e.getMessage() : e.toString(), RoundRobinBucketSelectionStrategy.NAME);
           }
         }
         // Restore the persisted needsRepartition flag AFTER the strategy is set. We always force

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1886,7 +1886,20 @@ public class LocalSchema implements Schema {
               new Object[0];
 
           final DocumentType type = getType(typeName);
-          type.setBucketSelectionStrategy(bucketSelectionStrategy.getString("name"), properties);
+          try {
+            type.setBucketSelectionStrategy(bucketSelectionStrategy.getString("name"), properties);
+          } catch (final Exception e) {
+            // One type's strategy must not take the rest of the load down with it (issue #5637). This block sits
+            // near the end of readConfiguration, so an exception escaping here aborts every remaining type's
+            // strategy AND everything the loader has not reached yet - triggers, function libraries, extensions,
+            // and the compaction file-migration map WAL recovery redirects through - while the outer catch reports
+            // the whole schema as "reset". The type stays on its default round-robin strategy, which loses the
+            // partition pruning but leaves a database that opens and says why.
+            LogManager.instance().log(this, Level.WARNING,
+                "Cannot restore the '%s' bucket selection strategy on type '%s': %s. The type falls back to `%s`",
+                e, bucketSelectionStrategy.getString("name"), typeName, e.getMessage(),
+                RoundRobinBucketSelectionStrategy.NAME);
+          }
         }
         // Restore the persisted needsRepartition flag AFTER the strategy is set. We always force
         // the flag to the persisted value (true OR false), because {@link

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -424,7 +424,17 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     // for and a blocked one is pure cost, whereas here the INDEX is what was asked for and it is useful, so the
     // partitioning is what gives way. Outside the try/catch above on purpose - a diagnostic must not be able to undo
     // an index that was built successfully by falling into the cleanup arm.
-    type.reportPartitionSuitabilityAfterSchemaChange();
+    try {
+      type.reportPartitionSuitabilityAfterSchemaChange();
+    } catch (final RuntimeException e) {
+      // Same reasoning one step further. By this point the index is built, committed and registered on the type, so
+      // letting anything unexpected out of the diagnosis would fail the command over an index that exists - and the
+      // obvious retry then fails again with "already exists". SCHEMA_CHANGE mode cannot raise the refusal, so this
+      // only catches a genuine fault in the check or the logging, which is worth a line and nothing more.
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot report the partition suitability of type '%s' after creating the index on %s. The index itself was "
+              + "created successfully", e, metadata.typeName, metadata.propertyNames);
+    }
 
     return created;
   }

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -359,6 +359,7 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     if (sortedBuild)
       validateSortedBuildPreconditions();
 
+    final TypeIndex created;
     try {
       final long recordFileChangesStarted = System.nanoTime();
       schema.recordFileChanges(() -> {
@@ -395,7 +396,8 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
             System.nanoTime() - sortedBuildStarted);
         emitSortedBuildMetrics(completed);
       }
-      return type.getIndexByProperties(metadata.propertyNames);
+
+      created = type.getIndexByProperties(metadata.propertyNames);
     } catch (final NeedRetryException e) {
       if (cleanupIndexes(schema, indexes, e)
           && (recoveryMarker[0] == null || recoveryMarker[0].baselineRestored(database)))
@@ -411,6 +413,20 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
       throw new IndexException("Error on creating index on type '" + metadata.typeName + "', properties " + metadata.propertyNames
           + (e.getMessage() != null ? ": " + e.getMessage() : ""), e);
     }
+
+    // An index is half of what decides whether a partition is any use, so one created after the strategy was assigned
+    // can undo the check that accepted it: recollating the partition index COLLATE CI makes it unprunable, and an
+    // index on other properties adds a lookup that fans out (issue #5637). Reported from here rather than from
+    // LocalDocumentType.addIndexInternal, which runs once per BUCKET and also during schema reload, so the same lines
+    // would be multiplied by the bucket count and repeated on every open.
+    // <p>
+    // Never refuses, unlike the identical diagnosis at assignment time: there the strategy was what the user asked
+    // for and a blocked one is pure cost, whereas here the INDEX is what was asked for and it is useful, so the
+    // partitioning is what gives way. Outside the try/catch above on purpose - a diagnostic must not be able to undo
+    // an index that was built successfully by falling into the cleanup arm.
+    type.reportPartitionSuitabilityAfterSchemaChange();
+
+    return created;
   }
 
   protected Index createBucketIndex(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -419,7 +419,7 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     // index on other properties adds a lookup that fans out (issue #5637). Reported from here rather than from
     // LocalDocumentType.addIndexInternal, which runs once per BUCKET and also during schema reload, so the same lines
     // would be multiplied by the bucket count and repeated on every open.
-    // <p>
+    //
     // Never refuses, unlike the identical diagnosis at assignment time: there the strategy was what the user asked
     // for and a blocked one is pure cost, whereas here the INDEX is what was asked for and it is useful, so the
     // partitioning is what gives way. Outside the try/catch above on purpose - a diagnostic must not be able to undo

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.partitioning;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5637, the two loose ends of the partitioned-strategy series (#5589, #5595, #5603).
+ * <p>
+ * Both are about what happens to a partitioned type <i>after</i> it has been configured. #5603 made the moment of
+ * configuration honest - an unsuitable partition is refused, a partly useful one is reported - but said nothing about
+ * the two ways a type can leave that moment behind: a restart, which used to drop the strategy entirely, and a later
+ * {@code CREATE INDEX}, which can undo the very suitability that was just checked.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PartitionedStrategyLifecycleTest extends TestHelper {
+
+  private static final int BUCKETS = 3;
+
+  private void createPartitionedType(final String typeName) {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(typeName).withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY " + typeName + ".k STRING");
+      database.command("sql", "CREATE PROPERTY " + typeName + ".code STRING");
+      database.command("sql", "CREATE INDEX ON " + typeName + "(k) UNIQUE");
+    });
+    database.transaction(
+        () -> database.command("sql", "ALTER TYPE " + typeName + " BucketSelectionStrategy `partitioned('k')`"));
+  }
+
+  private JSONObject persistedType(final String typeName) throws IOException {
+    final JSONObject schemaJson = new JSONObject(
+        FileUtils.readFileAsString(((LocalSchema) database.getSchema().getEmbedded()).getConfigurationFile()));
+    return schemaJson.getJSONObject("types").getJSONObject(typeName);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // 1. The strategy has to reach schema.json on its own.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * {@code ALTER TYPE ... BucketSelectionStrategy} set the strategy in memory and nothing wrote it out, so a type
+   * partitioned by that DDL alone came back round-robin after a restart: new records placed round-robin among rows
+   * that were placed by the partition hash, every partition-aware lookup silently fanning out, and no warning
+   * anywhere. Whether it survived depended on whether some later, unrelated schema mutation happened to flush the
+   * configuration first.
+   */
+  @Test
+  void theStrategyReachesSchemaJsonWithNoLaterSchemaMutation() throws IOException {
+    createPartitionedType("Persisted");
+
+    assertThat(persistedType("Persisted").has("bucketSelectionStrategy"))
+        .as("the DDL must persist the strategy itself, not wait for an unrelated mutation to flush it")
+        .isTrue();
+  }
+
+  @Test
+  void theStrategySurvivesAReopen() {
+    createPartitionedType("Reopened");
+    reopenDatabase();
+
+    assertThat(database.getSchema().getType("Reopened").getBucketSelectionStrategy().getName())
+        .as("a type partitioned by DDL alone must still be partitioned after a restart")
+        .isEqualTo("partitioned");
+  }
+
+  /** Setting the same strategy back to the default has to be persisted too, or the reopen resurrects the old one. */
+  @Test
+  void revertingToRoundRobinIsPersistedAsWell() throws IOException {
+    createPartitionedType("Reverted");
+    database.transaction(() -> database.command("sql", "ALTER TYPE Reverted BucketSelectionStrategy `round-robin`"));
+
+    assertThat(persistedType("Reverted").has("bucketSelectionStrategy"))
+        .as("round-robin is the default and is deliberately not written out")
+        .isFalse();
+
+    reopenDatabase();
+    assertThat(database.getSchema().getType("Reverted").getBucketSelectionStrategy().getName())
+        .isEqualTo("round-robin");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // 2. An index created after the strategy can undo the suitability that was checked when it was assigned.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * #5603 refuses a case-insensitive partition index at assignment time, but the same state is reachable by
+   * reordering the DDL: attach the strategy first, then recollate the index underneath it. Correctness holds - the
+   * strategy declines to prune, so lookups fan out and UNIQUE stays global - but nothing said the partitioning had
+   * stopped doing anything.
+   */
+  @Test
+  void recollatingThePartitionIndexToCaseInsensitiveIsReported() {
+    createPartitionedType("Recollated");
+
+    final List<String> warnings = captureWarnings(() -> database.transaction(() -> {
+      database.command("sql", "DROP INDEX `Recollated[k]`");
+      database.command("sql", "CREATE INDEX ON Recollated (k COLLATE CI) UNIQUE");
+    }));
+
+    assertThat(warnings)
+        .as("an index change that makes the partition unprunable must say so when it happens")
+        .anyMatch(m -> m.contains("Recollated") && m.contains("COLLATE CI"));
+  }
+
+  /**
+   * The same asymmetry on the advisory half: a second index on non-partition properties draws the fan-out advisory
+   * when the strategy is assigned after it, and used to draw nothing at all when it arrived afterwards.
+   */
+  @Test
+  void anIndexOnNonPartitionPropertiesArrivingLaterIsReported() {
+    createPartitionedType("LateIndex");
+
+    final List<String> warnings = captureWarnings(
+        () -> database.transaction(() -> database.command("sql", "CREATE INDEX ON LateIndex(code) UNIQUE")));
+
+    assertThat(warnings).anyMatch(m -> m.contains("LateIndex") && m.contains("code"));
+  }
+
+  /**
+   * The control that keeps the two tests above honest: an index change that leaves the partition exactly as suitable
+   * as it was must stay quiet, or the report is just noise on every {@code CREATE INDEX}.
+   */
+  @Test
+  void anIndexChangeThatChangesNothingStaysQuiet() {
+    createPartitionedType("Quiet");
+
+    final List<String> warnings = captureWarnings(() -> database.transaction(() -> {
+      database.command("sql", "DROP INDEX `Quiet[k]`");
+      database.command("sql", "CREATE INDEX ON Quiet(k) UNIQUE");
+    }));
+
+    assertThat(warnings).as("re-creating the partition index unchanged is not worth a line")
+        .noneMatch(m -> m.contains("Quiet"));
+  }
+
+  /** And a type that is not partitioned at all must never be diagnosed. */
+  @Test
+  void aRoundRobinTypeIsNeverDiagnosedOnIndexCreation() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("Plain").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY Plain.k STRING");
+      database.command("sql", "CREATE PROPERTY Plain.code STRING");
+    });
+
+    final List<String> warnings = captureWarnings(() -> database.transaction(() -> {
+      database.command("sql", "CREATE INDEX ON Plain(k) UNIQUE");
+      database.command("sql", "CREATE INDEX ON Plain(code COLLATE CI) UNIQUE");
+    }));
+
+    assertThat(warnings).noneMatch(m -> m.contains("Plain"));
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // 3. Persisting the strategy makes the DROP INDEX state reachable across a restart.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * The unique index the strategy is assigned against can be dropped afterwards - nothing re-checks it, and
+   * {@link com.arcadedb.partitioning.PartitionedBoxedKeyLookupTest} depends on being able to drop and recreate it.
+   * Now that the strategy is persisted, that state reaches the next open, where the schema loader binds the strategy
+   * back onto the type. If binding still demands the index, the database simply does not open.
+   */
+  @Test
+  void aPartitionedTypeWhoseIndexWasDroppedStillOpens() {
+    createPartitionedType("Orphaned");
+    database.transaction(() -> {
+      database.command("sql", "DROP INDEX `Orphaned[k]`");
+      database.newDocument("Orphaned").set("k", "acme").save();
+    });
+
+    final List<String> warnings = captureWarnings(this::reopenDatabase);
+
+    assertThat(warnings).as("and says what is missing rather than opening silently degraded")
+        .anyMatch(m -> m.contains("Orphaned") && m.contains("unique automatic index"));
+    assertThat(database.getSchema().getType("Orphaned").getBucketSelectionStrategy().getName())
+        .as("the strategy is kept: it still places records, and swapping it for round-robin would scatter every "
+            + "record written from here on among rows the partition hash placed")
+        .isEqualTo("partitioned");
+    assertThat(database.query("sql", "SELECT FROM Orphaned").stream().count()).isEqualTo(1);
+  }
+
+  /**
+   * The same fault isolation, from the other direction: a strategy whose implementation class cannot be resolved at
+   * all. Nothing about it is recoverable, but it must not take the rest of the schema down - the strategy block runs
+   * near the end of the loader, so an exception escaping it drops everything the loader has not reached yet.
+   * <p>
+   * The extension is what pins that, rather than a second type: types are registered before the strategy block, so
+   * one would survive either way, while extensions are read strictly after it.
+   */
+  @Test
+  void anUnresolvableStrategyDoesNotCostTheRestOfTheSchema() throws IOException {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("Broken").withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY Broken.k STRING");
+      database.getSchema().setExtension("lifecycle-probe", new JSONObject().put("loaded", true));
+    });
+
+    final LocalSchema schema = (LocalSchema) database.getSchema().getEmbedded();
+    final File schemaFile = schema.getConfigurationFile();
+    database.close();
+
+    final JSONObject schemaJson = new JSONObject(FileUtils.readFileAsString(schemaFile));
+    schemaJson.getJSONObject("types").getJSONObject("Broken")
+        .put("bucketSelectionStrategy", new JSONObject().put("name", "com.acme.NoSuchStrategy"));
+    try (final FileWriter writer = new FileWriter(schemaFile)) {
+      writer.write(schemaJson.toString());
+    }
+
+    database = factory.open();
+
+    assertThat(database.getSchema().getType("Broken").getBucketSelectionStrategy().getName())
+        .as("an unusable strategy falls back to the default").isEqualTo("round-robin");
+    assertThat(database.getSchema().getExtension("lifecycle-probe"))
+        .as("and everything the loader reads after the strategies is still there").isNotNull();
+  }
+
+  @Override
+  protected String getDatabasePath() {
+    return "target/databases/PartitionedStrategyLifecycleTest";
+  }
+
+  /**
+   * Runs {@code action} with the engine's own {@link Logger} swapped for one that records, and returns the WARNING
+   * (or worse) messages it saw. Deliberately not a {@code java.util.logging} handler: the test resources set
+   * {@code com.arcadedb.level=SEVERE}, so whether a WARNING reaches a JUL handler depends on which loggers the rest
+   * of the suite happened to reconfigure first.
+   */
+  private static List<String> captureWarnings(final Runnable action) {
+    final CapturingLogger capturing = new CapturingLogger(LogManager.instance().getLogger());
+    LogManager.instance().setLogger(capturing);
+    try {
+      action.run();
+    } finally {
+      LogManager.instance().setLogger(capturing.delegate);
+    }
+    return capturing.messages;
+  }
+
+  private static final class CapturingLogger implements Logger {
+    private final Logger       delegate;
+    private final List<String> messages = new CopyOnWriteArrayList<>();
+
+    private CapturingLogger(final Logger delegate) {
+      this.delegate = delegate;
+    }
+
+    private void record(final Level level, final String message, final Object... args) {
+      if (message == null || level.intValue() < Level.WARNING.intValue())
+        return;
+      try {
+        messages.add(args.length > 0 ? message.formatted(args) : message);
+      } catch (final Exception ignored) {
+        messages.add(message);
+      }
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+        final Object arg15, final Object arg16, final Object arg17) {
+      record(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
+          arg15, arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      record(level, message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -33,6 +33,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 
+import static com.arcadedb.partitioning.WarningCapture.captureSevere;
 import static com.arcadedb.partitioning.WarningCapture.captureWarnings;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -240,12 +241,20 @@ class PartitionedStrategyLifecycleTest extends TestHelper {
       writer.write(schemaJson.toString());
     }
 
-    database = factory.open();
+    final List<String> severe = captureSevere(() -> database = factory.open());
 
     assertThat(database.getSchema().getType("Broken").getBucketSelectionStrategy().getName())
         .as("an unusable strategy falls back to the default").isEqualTo("round-robin");
     assertThat(database.getSchema().getExtension("lifecycle-probe"))
         .as("and everything the loader reads after the strategies is still there").isNotNull();
+
+    // The catch that provides the isolation has to be broad, so the level is what separates "this database is
+    // configured that way" from "the bind path is broken". A strategy declining to be restored is the former, and
+    // reporting it at SEVERE would leave a real fault here indistinguishable from it.
+    assertThat(severe).as("a refused strategy is a property of the database, not an engine fault")
+        .noneMatch(m -> m.contains("Broken"));
+    assertThat(severe).as("and the schema is emphatically not reset")
+        .noneMatch(m -> m.contains("The schema will be reset"));
   }
 
   // ---------------------------------------------------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -262,7 +262,7 @@ class PartitionedStrategyLifecycleTest extends TestHelper {
    * DIFFERENT one crashes on the first indexed insert, because {@code TypeIndex.getIndexesByKeys} applies the bucket
    * index it derived from the parent's modulus to {@code s.getBuckets(false)} of each subtype. That is unrelated to
    * this issue - the line predates the whole partitioned-strategy series and nothing here touches it - so it is
-   * reported separately rather than pinned by a test that would fail for a different reason than it claims.
+   * reported as issue #5645 rather than pinned by a test that would fail for a different reason than it claims.
    */
   @Test
   void aSubtypeInheritsAPartitionedStrategyAndItStillPrunes() throws IOException {

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -19,6 +19,9 @@
 package com.arcadedb.partitioning;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
@@ -243,6 +246,64 @@ class PartitionedStrategyLifecycleTest extends TestHelper {
         .as("an unusable strategy falls back to the default").isEqualTo("round-robin");
     assertThat(database.getSchema().getExtension("lifecycle-probe"))
         .as("and everything the loader reads after the strategies is still there").isNotNull();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // 4. Inheritance, which reaches the assignment path without any ALTER TYPE.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * {@code addSuperType} copies the super type's strategy onto the subtype, which now routes through the same
+   * refusal as an explicit {@code ALTER TYPE} rather than through the check that used to live in
+   * {@code setType}. The happy path has to keep working: the subtype gets the parent's index first, so the
+   * inherited partition is suitable, prunes, and is persisted on the subtype in its own right.
+   * <p>
+   * The subtype declares the same bucket count as its parent deliberately. A partitioned type whose subtype has a
+   * DIFFERENT one crashes on the first indexed insert, because {@code TypeIndex.getIndexesByKeys} applies the bucket
+   * index it derived from the parent's modulus to {@code s.getBuckets(false)} of each subtype. That is unrelated to
+   * this issue - the line predates the whole partitioned-strategy series and nothing here touches it - so it is
+   * reported separately rather than pinned by a test that would fail for a different reason than it claims.
+   */
+  @Test
+  void aSubtypeInheritsAPartitionedStrategyAndItStillPrunes() throws IOException {
+    createPartitionedType("Base");
+    database.transaction(() -> database.command("sql", "CREATE DOCUMENT TYPE Derived EXTENDS Base BUCKETS " + BUCKETS));
+
+    final LocalDocumentType derived = (LocalDocumentType) database.getSchema().getType("Derived");
+    assertThat(derived.getBucketSelectionStrategy().getName()).isEqualTo("partitioned");
+    assertThat(persistedType("Derived").has("bucketSelectionStrategy"))
+        .as("an inherited strategy is the subtype's own state and has to be persisted as such").isTrue();
+
+    final PartitionedBucketSelectionStrategy strategy =
+        (PartitionedBucketSelectionStrategy) derived.getBucketSelectionStrategy();
+    assertThat(strategy.getBucketIdByKeys(List.of("k"), new Object[] { "acme" }, false))
+        .as("the inherited partition must be suitable, not merely attached").isNotEqualTo(-1);
+
+    database.transaction(() -> database.newDocument("Derived").set("k", "acme").save());
+    assertThat(database.query("sql", "SELECT FROM Derived WHERE k = 'acme'").stream().count()).isEqualTo(1);
+  }
+
+  /**
+   * The other order, which is how a subtype can reach the inheritance copy without the parent's index having been
+   * created for it: the subtype exists before the parent is partitioned, so nothing re-runs on it until a
+   * {@code DROP TYPE} in the middle of the hierarchy re-attaches it to the grandparent and copies the strategy
+   * down. This is the one caller that passes {@code createIndexes = false}.
+   */
+  @Test
+  void droppingAPartitionedTypeInTheMiddleOfAHierarchyDoesNotBreakTheSubtype() {
+    createPartitionedType("Grand");
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Middle EXTENDS Grand");
+      database.command("sql", "CREATE DOCUMENT TYPE Leaf EXTENDS Middle");
+      database.command("sql", "DROP TYPE Middle");
+    });
+
+    assertThat(database.getSchema().existsType("Leaf")).isTrue();
+    assertThat(database.getSchema().getType("Leaf").getSuperTypes())
+        .as("the leaf is re-attached to the grandparent")
+        .extracting(DocumentType::getName).containsExactly("Grand");
+    assertThat(database.getSchema().getType("Leaf").getBucketSelectionStrategy().getName())
+        .isEqualTo("partitioned");
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -19,8 +19,6 @@
 package com.arcadedb.partitioning;
 
 import com.arcadedb.TestHelper;
-import com.arcadedb.log.LogManager;
-import com.arcadedb.log.Logger;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
@@ -31,9 +29,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Level;
 
+import static com.arcadedb.partitioning.WarningCapture.captureWarnings;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -253,63 +250,4 @@ class PartitionedStrategyLifecycleTest extends TestHelper {
     return "target/databases/PartitionedStrategyLifecycleTest";
   }
 
-  /**
-   * Runs {@code action} with the engine's own {@link Logger} swapped for one that records, and returns the WARNING
-   * (or worse) messages it saw. Deliberately not a {@code java.util.logging} handler: the test resources set
-   * {@code com.arcadedb.level=SEVERE}, so whether a WARNING reaches a JUL handler depends on which loggers the rest
-   * of the suite happened to reconfigure first.
-   */
-  private static List<String> captureWarnings(final Runnable action) {
-    final CapturingLogger capturing = new CapturingLogger(LogManager.instance().getLogger());
-    LogManager.instance().setLogger(capturing);
-    try {
-      action.run();
-    } finally {
-      LogManager.instance().setLogger(capturing.delegate);
-    }
-    return capturing.messages;
-  }
-
-  private static final class CapturingLogger implements Logger {
-    private final Logger       delegate;
-    private final List<String> messages = new CopyOnWriteArrayList<>();
-
-    private CapturingLogger(final Logger delegate) {
-      this.delegate = delegate;
-    }
-
-    private void record(final Level level, final String message, final Object... args) {
-      if (message == null || level.intValue() < Level.WARNING.intValue())
-        return;
-      try {
-        messages.add(args.length > 0 ? message.formatted(args) : message);
-      } catch (final Exception ignored) {
-        messages.add(message);
-      }
-    }
-
-    @Override
-    public void log(final Object requester, final Level level, final String message, final Throwable exception,
-        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
-        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
-        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
-        final Object arg15, final Object arg16, final Object arg17) {
-      record(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
-          arg15, arg16, arg17);
-      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
-          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
-    }
-
-    @Override
-    public void log(final Object requester, final Level level, final String message, final Throwable exception,
-        final String context, final Object... args) {
-      record(level, message, args);
-      delegate.log(requester, level, message, exception, context, args);
-    }
-
-    @Override
-    public void flush() {
-      delegate.flush();
-    }
-  }
 }

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
@@ -437,11 +437,6 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
       database.command("sql", "CREATE INDEX ON ReopenIdx(code) UNIQUE");
     });
     partition("ReopenIdx");
-    // The schema is flushed explicitly because `ALTER TYPE ... BucketSelectionStrategy` does not persist on its own -
-    // the strategy lives in memory until some later schema mutation happens to save, so without this the type would
-    // reopen as round-robin and the test would pass for the wrong reason. Pre-existing and unrelated to this change
-    // (reproduced on the unmodified sources); reported separately.
-    ((LocalSchema) database.getSchema().getEmbedded()).saveConfiguration();
     database.close();
 
     final List<String> warnings = captureWarnings(() -> database = factory.open());
@@ -516,7 +511,7 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
     strategy.setType((LocalDocumentType) database.getSchema().getType("Diag"));
 
     final PartitionedBucketSelectionStrategy.Suitability suitability = strategy.checkSuitability();
-    assertThat(suitability.canPrune()).isFalse();
+    assertThat(suitability.isUsable()).isFalse();
     assertThat(suitability.blockers()).singleElement().asString().contains("DECIMAL");
     assertThat(suitability.warnings()).singleElement().asString().contains("code");
 

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
@@ -26,8 +26,6 @@ import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionS
 import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.DuplicatedKeyException;
-import com.arcadedb.log.LogManager;
-import com.arcadedb.log.Logger;
 import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.Schema;
@@ -45,9 +43,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Level;
 
+import static com.arcadedb.partitioning.WarningCapture.captureWarnings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -596,66 +593,4 @@ class PartitionedStrategySuitabilityTest extends TestHelper {
     return "target/databases/PartitionedStrategySuitabilityTest";
   }
 
-  /**
-   * Runs {@code action} with the engine's own {@link Logger} swapped for one that records, and returns the WARNING
-   * (or worse) messages it saw.
-   * <p>
-   * Deliberately not a {@code java.util.logging} handler. The test resources set {@code com.arcadedb.level=SEVERE},
-   * so whether a WARNING ever reaches a JUL handler depends on which loggers the rest of the suite happened to
-   * reconfigure first - a capture that passes on its own and fails in a full run. Swapping the logger sees the
-   * message before any level is consulted. {@link LogManager#getLogger()} exists for exactly this.
-   */
-  private static List<String> captureWarnings(final Runnable action) {
-    final CapturingLogger capturing = new CapturingLogger(LogManager.instance().getLogger());
-    LogManager.instance().setLogger(capturing);
-    try {
-      action.run();
-    } finally {
-      LogManager.instance().setLogger(capturing.delegate);
-    }
-    return capturing.messages;
-  }
-
-  private static final class CapturingLogger implements Logger {
-    private final Logger       delegate;
-    private final List<String> messages = new CopyOnWriteArrayList<>();
-
-    private CapturingLogger(final Logger delegate) {
-      this.delegate = delegate;
-    }
-
-    private void record(final Level level, final String message, final Object... args) {
-      if (message == null || level.intValue() < Level.WARNING.intValue())
-        return;
-      try {
-        messages.add(args.length > 0 ? message.formatted(args) : message);
-      } catch (final Exception ignored) {
-        messages.add(message);
-      }
-    }
-
-    @Override
-    public void log(final Object requester, final Level level, final String message, final Throwable exception,
-        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
-        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
-        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
-        final Object arg15, final Object arg16, final Object arg17) {
-      record(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
-          arg15, arg16, arg17);
-      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
-          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
-    }
-
-    @Override
-    public void log(final Object requester, final Level level, final String message, final Throwable exception,
-        final String context, final Object... args) {
-      record(level, message, args);
-      delegate.log(requester, level, message, exception, context, args);
-    }
-
-    @Override
-    public void flush() {
-      delegate.flush();
-    }
-  }
 }

--- a/engine/src/test/java/com/arcadedb/partitioning/WarningCapture.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/WarningCapture.java
@@ -49,7 +49,19 @@ final class WarningCapture {
 
   /** Runs {@code action} and returns the WARNING-or-worse messages the engine logged while it ran. */
   static List<String> captureWarnings(final Runnable action) {
-    final CapturingLogger capturing = new CapturingLogger(LogManager.instance().getLogger());
+    return capture(action, Level.WARNING);
+  }
+
+  /**
+   * The same, restricted to SEVERE. Lets a test assert that a condition it expects to be reported is reported at the
+   * level that says "this database is configured that way" rather than the one that says "the engine is broken".
+   */
+  static List<String> captureSevere(final Runnable action) {
+    return capture(action, Level.SEVERE);
+  }
+
+  private static List<String> capture(final Runnable action, final Level minimum) {
+    final CapturingLogger capturing = new CapturingLogger(LogManager.instance().getLogger(), minimum);
     LogManager.instance().setLogger(capturing);
     try {
       action.run();
@@ -61,14 +73,16 @@ final class WarningCapture {
 
   private static final class CapturingLogger implements Logger {
     private final Logger       delegate;
+    private final Level        minimum;
     private final List<String> messages = new CopyOnWriteArrayList<>();
 
-    private CapturingLogger(final Logger delegate) {
+    private CapturingLogger(final Logger delegate, final Level minimum) {
       this.delegate = delegate;
+      this.minimum = minimum;
     }
 
     private void record(final Level level, final String message, final Object... args) {
-      if (message == null || level.intValue() < Level.WARNING.intValue())
+      if (message == null || level.intValue() < minimum.intValue())
         return;
       try {
         messages.add(args.length > 0 ? message.formatted(args) : message);

--- a/engine/src/test/java/com/arcadedb/partitioning/WarningCapture.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/WarningCapture.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.partitioning;
+
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+
+/**
+ * Collects the WARNING (or worse) lines the engine logs while a block of code runs. Shared by the partitioned
+ * strategy tests, whose whole subject is what gets reported and what deliberately does not.
+ * <p>
+ * Deliberately not a {@code java.util.logging} handler. The test resources set {@code com.arcadedb.level=SEVERE}, so
+ * whether a WARNING ever reaches a JUL handler depends on which loggers the rest of the suite happened to
+ * reconfigure first - a capture that passes on its own and fails in a full run. Swapping the engine's own
+ * {@link Logger} sees the message before any level is consulted, which is what {@link LogManager#getLogger()} exists
+ * for.
+ * <p>
+ * <b>The swap is process-global</b>, so this only holds while the JVM runs one test at a time. That is the engine
+ * suite's configuration today, and it is the same assumption every other log-asserting test in this module makes.
+ * Under parallel execution the capture would see another test's lines and vice versa; the {@code finally} restore
+ * would still put the original logger back, so the damage would be false assertions rather than a leaked logger.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class WarningCapture {
+
+  private WarningCapture() {
+  }
+
+  /** Runs {@code action} and returns the WARNING-or-worse messages the engine logged while it ran. */
+  static List<String> captureWarnings(final Runnable action) {
+    final CapturingLogger capturing = new CapturingLogger(LogManager.instance().getLogger());
+    LogManager.instance().setLogger(capturing);
+    try {
+      action.run();
+    } finally {
+      LogManager.instance().setLogger(capturing.delegate);
+    }
+    return capturing.messages;
+  }
+
+  private static final class CapturingLogger implements Logger {
+    private final Logger       delegate;
+    private final List<String> messages = new CopyOnWriteArrayList<>();
+
+    private CapturingLogger(final Logger delegate) {
+      this.delegate = delegate;
+    }
+
+    private void record(final Level level, final String message, final Object... args) {
+      if (message == null || level.intValue() < Level.WARNING.intValue())
+        return;
+      try {
+        messages.add(args.length > 0 ? message.formatted(args) : message);
+      } catch (final Exception ignored) {
+        // A message whose placeholders do not match the arguments is still worth having in the list verbatim:
+        // dropping it would turn a formatting bug into a test that silently stops seeing the line it asserts on.
+        messages.add(message);
+      }
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+        final Object arg15, final Object arg16, final Object arg17) {
+      record(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
+          arg15, arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      record(level, message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
+  }
+}


### PR DESCRIPTION
Closes #5637.

Two loose ends of the partitioned-strategy series (#5589, #5595, #5603), both about what happens to a type *after* it has been configured.

## 1. `ALTER TYPE ... BucketSelectionStrategy` is persisted

The strategy was set in memory and nothing wrote it out, so a type partitioned by that DDL alone came back **`round-robin` after a restart** - unless some later, unrelated schema mutation happened to flush the configuration first. This hits *correctly* configured types, which is what makes it worse than the states #5603 refuses: new records were placed round-robin among rows the partition hash had placed, every partition-aware lookup silently fanned out, and nothing warned.

It is the one schema mutator that left the write to somebody else - every sibling either calls `saveConfiguration()` directly or goes through `recordFileChanges`, which does - and the flag *about* the partitioning (`needsRepartition`, in the same class) saved itself while the partitioning did not. It now saves, skipped while the schema is being read back so a partitioned database does not rewrite an identical `schema.json` on every open.

## 2. An index created on an already-partitioned type is diagnosed when it is created

#5603 refuses an unsuitable partition at assignment time, but the same state was reachable by reordering the DDL:

```sql
ALTER TYPE T BucketSelectionStrategy `partitioned('name')`;   -- accepted
DROP INDEX `T[name]`;
CREATE INDEX ON T (name COLLATE CI) UNIQUE;                   -- used to be silent
```

Correctness always held - the strategy declines to prune, so lookups fan out and `UNIQUE` stays global - but between the `CREATE INDEX` and the next restart nothing said the partitioning had stopped doing anything. `TypeIndexBuilder.create()` now re-runs the same check, once per `CREATE INDEX` rather than once per bucket (which is why the hook is not in `addIndexInternal`, and why it does not fire during schema reload).

It **never refuses**: at assignment time the strategy is what was asked for and a blocked one is pure cost, whereas here the index is what was asked for and it is useful, so the partitioning is what gives way. An index change that leaves the partition exactly as suitable as it was stays quiet.

## 3. Persisting the strategy made a pre-existing fault reachable

Binding the strategy demanded the unique automatic index on the partition properties, and did so on *every* rebind - including the one the schema loader performs on every open. With the strategy now reaching `schema.json`, a `DROP INDEX` on the partition key made the next open throw **from inside the loader**, which aborts everything it has not reached yet: the remaining types' strategies, the triggers, the function libraries, the extensions, and the compaction file-migration map WAL recovery redirects through - surfacing only as `Error on loading schema. The schema will be reset`.

Binding no longer validates anything. The requirement moved into `checkSuitability()`, which still refuses it at assignment time and now warns about it on load, so the type keeps its partitioned placement and records written after the index was dropped still land where a lookup would look for them.

The refusal is not byte-for-byte what it was, and anything matching on the old form should know it: it used to be an `IllegalArgumentException` thrown straight out of `setType`, and it is now a `SchemaException` raised by the suitability check and wrapped in the usual "Cannot use the partitioned bucket selection strategy on ... for type ..." sentence. What is unchanged is what callers actually depend on - the `cannot find a unique automatic index on the partition properties [...]` substring, and the `CommandSQLParsingException` -> HTTP 400 classification, since `AlterTypeStatement` already caught both exception types. `LocalSchema` additionally isolates a per-type strategy failure, so any other unusable strategy - an implementation class that no longer resolves, say - costs that one type its pruning instead of the rest of the schema.

`Suitability.canPrune()` is renamed `isUsable()`: a missing partition index does not stop the strategy computing a bucket, it removes the index lookup that would have been pruned, so the old name no longer described the whole set.

## Verification

New `PartitionedStrategyLifecycleTest` (9 tests). Four were red before the fix (persistence to `schema.json`, survival of a reopen, and both index-change reports), and the two load-path guards were mutation-checked individually - reinstating the binding validation reddens `aPartitionedTypeWhoseIndexWasDroppedStillOpens`, removing the loader's per-type catch reddens `anUnresolvableStrategyDoesNotCostTheRestOfTheSchema`. Three controls keep them honest: an unchanged index re-creation stays quiet, a round-robin type is never diagnosed, and reverting to `round-robin` persists as the absence of the entry.

The explicit `saveConfiguration()` workaround in `PartitionedStrategySuitabilityTest.theFanOutWarningIsNotRepeatedOnEveryReopen`, added in #5605 with a comment saying why, comes out.

Full `arcadedb-engine` suite green (10545 tests, 0 failures), plus `PartitionedStrategyRefusalHttpTest` in `arcadedb-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dDUKvQXJGBBoXiEQgtc2v
