### PR TITLE
fix(engine) #5492: execute SQL statements against the replicated database instance

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
@@ -112,7 +112,7 @@ public class SQLQueryEngine implements QueryEngine {
     context.setInputParameters(parameters);
     context.setConfiguration(configuration);
 
-    return statement.execute(database, parameters, context);
+    return statement.execute(executionDatabase(), parameters, context);
   }
 
   @Override
@@ -121,7 +121,25 @@ public class SQLQueryEngine implements QueryEngine {
     statement.setLimit(new Limit(JJTLIMIT).setValue((int) database.getResultSetLimit()));
     final CommandContext context = new BasicCommandContext();
     context.setConfiguration(configuration);
-    return statement.execute(database, parameters, context);
+    return statement.execute(executionDatabase(), parameters, context);
+  }
+
+  /**
+   * The database a statement executes against, and therefore the one {@code CommandContext.getDatabase()} returns.
+   * <p>
+   * Statements that commit mid-execution - {@code TRUNCATE TYPE}/{@code BUCKET} batching every
+   * {@link com.arcadedb.GlobalConfiguration#TRUNCATE_BATCH_SIZE} records, {@code REBUILD INDEX}, {@code BatchStep} -
+   * call {@code commit()} on whatever this returns. Handing them the raw instance means those commits go straight to
+   * {@code LocalDatabase.commit()}, which on an HA leader applies the pages locally and never proposes them to Raft:
+   * followers then trail by exactly those page versions and the next replicated entry touching one of them fails the
+   * version check (#5492).
+   * <p>
+   * {@code SQLScriptQueryEngine} has always resolved the wrapper for the same reason, which is why the identical
+   * statements replicate correctly under {@code sqlscript} and not under {@code sql}. Off HA the wrapper is the
+   * instance itself, so this is a no-op there.
+   */
+  private DatabaseInternal executionDatabase() {
+    return database.getWrappedDatabaseInstance();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
@@ -137,6 +137,11 @@ public class SQLQueryEngine implements QueryEngine {
    * {@code SQLScriptQueryEngine} has always resolved the wrapper for the same reason, which is why the identical
    * statements replicate correctly under {@code sqlscript} and not under {@code sql}. Off HA the wrapper is the
    * instance itself, so this is a no-op there.
+   * <p>
+   * Every path in this class that hands a database to {@code Statement.execute} must use this, not the field: both
+   * {@code command()} overloads and {@code analyze()}'s {@code AnalyzedQuery.execute()}. The engine itself is bound
+   * to the inner instance ({@code RaftReplicatedDatabase.getQueryEngine} delegates to {@code proxied}), so the field
+   * is never the right answer for execution.
    */
   private DatabaseInternal executionDatabase() {
     return database.getWrappedDatabaseInstance();
@@ -166,7 +171,11 @@ public class SQLQueryEngine implements QueryEngine {
         final long resultSetLimit = database.getResultSetLimit();
         if (resultSetLimit > 0)
           statement.setLimit(new Limit(JJTLIMIT).setValue((int) resultSetLimit));
-        return statement.execute(database, parameters);
+        // Same resolution as command(): this is a third execution entry point, not an analysis-only one.
+        // The MCP command tool runs SQL exclusively through here (analyze() once, then execute(); the
+        // database.command() fallback is only reached by engines whose execute() returns null), so leaving
+        // the raw instance here would keep #5492 open for that caller alone.
+        return statement.execute(executionDatabase(), parameters);
       }
     };
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
@@ -138,10 +138,17 @@ public class SQLQueryEngine implements QueryEngine {
    * statements replicate correctly under {@code sqlscript} and not under {@code sql}. Off HA the wrapper is the
    * instance itself, so this is a no-op there.
    * <p>
-   * Every path in this class that hands a database to {@code Statement.execute} must use this, not the field: both
-   * {@code command()} overloads and {@code analyze()}'s {@code AnalyzedQuery.execute()}. The engine itself is bound
-   * to the inner instance ({@code RaftReplicatedDatabase.getQueryEngine} delegates to {@code proxied}), so the field
-   * is never the right answer for execution.
+   * <b>Which paths must use this:</b> every one that can carry a statement that commits - both {@code command()}
+   * overloads and {@code analyze()}'s {@code AnalyzedQuery.execute()}. {@code analyze()} is included because it is
+   * not gated on idempotency: the MCP command tool executes writes through it, so it can carry a {@code TRUNCATE}.
+   * <p>
+   * The two {@code query()} overloads deliberately keep the field. They throw
+   * {@link com.arcadedb.exception.QueryNotIdempotentException} before execution for anything non-idempotent, so no
+   * statement reaching them can commit, and leaving them alone keeps read traffic - including follower-local reads -
+   * resolving exactly as it did before. Add a new entry point that can execute a write, and it belongs on this
+   * method; the engine itself is bound to the inner instance
+   * ({@code RaftReplicatedDatabase.getQueryEngine} delegates to {@code proxied}), so the field is never the right
+   * answer for anything that might commit.
    */
   private DatabaseInternal executionDatabase() {
     return database.getWrappedDatabaseInstance();

--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -34,17 +34,17 @@ Each has its own local `excludeId` derivation (`leaderId != null ? leaderId : lo
 
 **Any change to what "replica" means must be applied to all three.** Grep `RaftHAServer.java` for `getPeers()` before claiming such a fix is complete. This has already caused one incomplete fix that review caught.
 
-## Known sharp edge: materialized views break page-version replication
+## Anything that commits must hold the WRAPPED database instance, not the inner one
 
-Unresolved as of 2026-07, tracked in #5492 - delete this section when that closes. Established by a controlled A/B run on a 3-node cluster, identical load, only the schema differing:
+`LocalDatabase.commit()` writes pages locally. `RaftReplicatedDatabase.commit()` proposes them to Raft and *then* writes them. Code holding the wrong one of the two commits successfully, applies its pages on the leader, and replicates nothing. Followers trail by exactly those page versions, and the next replicated entry touching one of them fails its version check - `WALVersionGapException`, database marked diverged, snapshot resync, and the entry after it breaks the same way. Nothing throws at the point of the mistake, so the symptom always surfaces somewhere else.
 
-- **With** a `REFRESH INCREMENTAL` materialized view: 2041/3000 writes fail, 12 snapshot-resync cycles in ~9 s, nodes never converge.
-- **Without** it: 3000/3000 writes, zero errors, immediate convergence.
+`getWrappedDatabaseInstance()` returns the Raft wrapper under HA and the instance itself off it, so resolving it is always correct and never costs anything.
 
-The leader ships a `TX_ENTRY` whose page version is ahead of what followers hold, first appearing on the view's own backing bucket. Followers throw `WALVersionGapException`, trigger a full snapshot resync, and the resync does not repair it - the next entry gaps again on a different file. Meanwhile every request to a resyncing follower is deflected with a 503, so writes routed through it are dropped. The end state is lost committed writes, not split-brain.
+This was #5492. `SQLQueryEngine` handed statements the raw instance, so `CommandContext.getDatabase()` was the inner `LocalDatabase`, and every statement that commits mid-execution bypassed replication: `TRUNCATE TYPE`/`BUCKET` batching every `TRUNCATE_BATCH_SIZE` (default **1000**) records, `REBUILD INDEX`, `BatchStep`. `SQLScriptQueryEngine` had always resolved the wrapper before running the *same statement classes*, which is why an identical `TRUNCATE` replicated under `sqlscript` and not under `sql`.
 
-The exact leader-side path is **not** proven, and it has never been reproduced in-process: a 3-node harness on `BaseRaftHATest` sees zero gaps with writes on the leader, writes through a follower, with and without a unique index on the source type. The container A/B is the only known reproduction. Two theories are ruled out and should not be re-proposed: `LocalSchema` is constructed with `wrappedDatabaseInstance`, so the refresh does go through `RaftReplicatedDatabase` rather than committing on the inner `LocalDatabase`; and #5503 (concurrent writes on a shared follower handle) is a different failure mode - `Invalid record size ... deleting record`, no version gap - whose control arm was clean.
+Two things about how it hid, both worth generalizing:
 
-One leader-side hole of exactly this shape **has** been found and closed: `recordFileChanges` drained the buffered WAL of commits that ran inside the DDL callback but omitted it from the send guard, so a callback that wrote records without creating a file or moving the schema version had its pages applied on the leader and never shipped. That is fixed, and `applySchemaEntry` now recognizes the resulting WAL-only entry and skips the schema reload for it, as it already did for sealed-only TimeSeries entries. It did not close the materialized-view A/B, so the section stays.
+- **A default-sized threshold can look like a heisenbug.** It reproduced only above 1000 records in one statement, so every in-process attempt (180 to 450 records) saw a clean cluster and the failure was written off as needing container-level concurrency. If a replication bug reproduces in containers and not in process, compare the *sizes* before theorizing about timing.
+- **A materialized view was the trigger only because it truncates constantly.** `MaterializedViewRefresher` truncates and rebuilds its backing type on every source commit, so a view over 1000+ rows crossed the boundary on every refresh. The view was the amplifier, not the defect - `TRUNCATE TYPE` over 1000 records through `/api/v1/command` with `language=sql` was enough on its own.
 
-If you are investigating unexplained replication gaps, check whether the failing database has a materialized view before going further.
+When adding any code path that commits, ask which instance it holds. `Issue5492TruncateBatchNotReplicatedIT` guards the statement path; it asserts the WAL gap counter *before* querying the follower, because the resync reinstalls the follower's database and a stale handle then throws `DatabaseIsClosed`, which reads like infrastructure noise rather than divergence.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5492TruncateBatchNotReplicatedIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5492TruncateBatchNotReplicatedIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5492: a statement that commits mid-execution committed on the inner
+ * {@code LocalDatabase} instead of the Raft wrapper, so those commits applied pages on the leader and were never
+ * proposed to Raft.
+ * <p>
+ * {@code TRUNCATE TYPE} deletes in batches of {@link GlobalConfiguration#TRUNCATE_BATCH_SIZE} (default 1000),
+ * calling {@code commit()} on {@code CommandContext.getDatabase()} after each. {@code SQLQueryEngine} handed
+ * statements the raw instance, so on an HA leader that resolved to {@code LocalDatabase.commit()} - pages published
+ * locally, nothing replicated. Followers then trail by exactly those page versions, and the next replicated entry
+ * touching one of those pages fails its version check with {@code WALVersionGapException}, marking the database
+ * diverged and triggering a snapshot resync that the next entry immediately re-breaks.
+ * <p>
+ * {@code SQLScriptQueryEngine} has always resolved {@code getWrappedDatabaseInstance()}, which is why the identical
+ * statement replicates correctly under {@code sqlscript} and not under {@code sql}. That asymmetry was the defect.
+ * <p>
+ * The batch size is lowered here because the default of 1000 is also why this never reproduced in-process: earlier
+ * harnesses truncated 180 to 450 records, so {@code count % 1000 == 0} never held and no mid-statement commit ever
+ * ran. The materialized view of the original report refreshes a 3000-row view, which crosses it on every refresh.
+ * <p>
+ * Both halves are asserted separately, so a regression that loses the deletes is distinguishable from one that also
+ * diverges the cluster.
+ */
+@Tag("slow")
+class Issue5492TruncateBatchNotReplicatedIT extends BaseRaftHATest {
+
+  private static final String TYPE_NAME  = "TruncateBatchDoc";
+  private static final int    BATCH_SIZE = 2;
+  private static final int    RECORDS    = 5;
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  @AfterEach
+  void cleanupHooks() {
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = null;
+  }
+
+  @Test
+  void truncateBatchCommitsReachFollowers() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = 1 - leaderIndex;
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+
+    // RECORDS deleted in batches of BATCH_SIZE leaves at least one mid-statement commit that is not the
+    // statement's last, which is the one whose pages went missing.
+    leaderDb.getConfiguration().setValue(GlobalConfiguration.TRUNCATE_BATCH_SIZE, BATCH_SIZE);
+
+    leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+    for (int i = 0; i < RECORDS; i++)
+      leaderDb.command("sql", "INSERT INTO " + TYPE_NAME + " SET id = " + i);
+
+    waitForAllServers();
+    assertThat(awaitCountOn(followerIndex, RECORDS)).as("baseline replicated before the truncate").isEqualTo(RECORDS);
+
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
+
+    // Run it exactly as MaterializedViewRefresher does: a dedicated transaction on the wrapper, with the
+    // statement issued through the 'sql' engine. The batch commits happen inside, before this one returns.
+    final DatabaseInternal wrapped = ((DatabaseInternal) leaderDb).getWrappedDatabaseInstance();
+    wrapped.transaction(() -> wrapped.command("sql", "TRUNCATE TYPE `" + TYPE_NAME + "`").close(), false);
+
+    assertThat(countOn(leaderIndex)).as("leader truncated the type").isZero();
+
+    waitForAllServers();
+
+    // Asserted before any follower query: the statement's last batch IS replicated, and it carries page
+    // versions the follower cannot reach because the earlier batches never shipped, so the gap fires here.
+    // The resync it triggers reinstalls the follower's database, which would otherwise surface as an
+    // unrelated-looking DatabaseIsClosed from the count below rather than as the divergence it is.
+    assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
+        .as("follower must see no WAL version gap: every batch commit of the truncate has to be replicated")
+        .isZero();
+
+    assertThat(awaitCountOn(followerIndex, 0))
+        .as("every batch commit of the truncate must reach the follower, not only the statement's last one")
+        .isZero();
+
+    // A page bumped on the leader but not on the follower does not fail until something touches it again,
+    // so an ordinary replicated write into the same bucket is what would surface a surviving gap.
+    leaderDb.command("sql", "INSERT INTO " + TYPE_NAME + " SET id = 100");
+    waitForAllServers();
+
+    assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
+        .as("no WAL version gap after a subsequent ordinary write into the truncated bucket")
+        .isZero();
+    assertThat(awaitCountOn(followerIndex, 1))
+        .as("follower converges with the leader after the subsequent ordinary write")
+        .isEqualTo(1);
+  }
+
+  /**
+   * Counts through a freshly resolved database handle. A snapshot resync reinstalls the follower's database, so a
+   * handle cached before it throws {@code DatabaseIsClosed} - which reads like an infrastructure failure rather than
+   * the divergence that caused it.
+   */
+  private long countOn(final int serverIndex) {
+    // count(id) rather than count(*): the latter reads a cached per-bucket counter, which is the wrong tool
+    // when the question is whether the pages themselves arrived.
+    final Database db = getServerDatabase(serverIndex, getDatabaseName());
+    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + TYPE_NAME).next().getProperty("cnt"))
+        .longValue();
+  }
+
+  private long awaitCountOn(final int serverIndex, final long expected) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    long count = -1;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        count = countOn(serverIndex);
+        if (count == expected)
+          return count;
+      } catch (final RuntimeException e) {
+        // Mid-resync the database is closed and being reinstalled; keep polling until the deadline.
+        count = -1;
+      }
+      Thread.sleep(250);
+    }
+    return count;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5492TruncateBatchNotReplicatedIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5492TruncateBatchNotReplicatedIT.java
@@ -21,10 +21,13 @@ package com.arcadedb.server.ha.raft;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.QueryEngine;
+import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,7 +57,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("slow")
 class Issue5492TruncateBatchNotReplicatedIT extends BaseRaftHATest {
 
-  private static final String TYPE_NAME  = "TruncateBatchDoc";
+  private static final String TYPE_COMMAND  = "TruncateBatchDoc";
+  private static final String TYPE_ANALYZED = "TruncateBatchAnalyzedDoc";
   private static final int    BATCH_SIZE = 2;
   private static final int    RECORDS    = 5;
 
@@ -80,21 +84,21 @@ class Issue5492TruncateBatchNotReplicatedIT extends BaseRaftHATest {
     // statement's last, which is the one whose pages went missing.
     leaderDb.getConfiguration().setValue(GlobalConfiguration.TRUNCATE_BATCH_SIZE, BATCH_SIZE);
 
-    leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+    leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_COMMAND);
     for (int i = 0; i < RECORDS; i++)
-      leaderDb.command("sql", "INSERT INTO " + TYPE_NAME + " SET id = " + i);
+      leaderDb.command("sql", "INSERT INTO " + TYPE_COMMAND + " SET id = " + i);
 
     waitForAllServers();
-    assertThat(awaitCountOn(followerIndex, RECORDS)).as("baseline replicated before the truncate").isEqualTo(RECORDS);
+    assertThat(awaitCountOn(followerIndex, TYPE_COMMAND, RECORDS)).as("baseline replicated before the truncate").isEqualTo(RECORDS);
 
     ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
 
     // Run it exactly as MaterializedViewRefresher does: a dedicated transaction on the wrapper, with the
     // statement issued through the 'sql' engine. The batch commits happen inside, before this one returns.
     final DatabaseInternal wrapped = ((DatabaseInternal) leaderDb).getWrappedDatabaseInstance();
-    wrapped.transaction(() -> wrapped.command("sql", "TRUNCATE TYPE `" + TYPE_NAME + "`").close(), false);
+    wrapped.transaction(() -> wrapped.command("sql", "TRUNCATE TYPE `" + TYPE_COMMAND + "`").close(), false);
 
-    assertThat(countOn(leaderIndex)).as("leader truncated the type").isZero();
+    assertThat(countOn(leaderIndex, TYPE_COMMAND)).as("leader truncated the type").isZero();
 
     waitForAllServers();
 
@@ -106,21 +110,68 @@ class Issue5492TruncateBatchNotReplicatedIT extends BaseRaftHATest {
         .as("follower must see no WAL version gap: every batch commit of the truncate has to be replicated")
         .isZero();
 
-    assertThat(awaitCountOn(followerIndex, 0))
+    assertThat(awaitCountOn(followerIndex, TYPE_COMMAND, 0))
         .as("every batch commit of the truncate must reach the follower, not only the statement's last one")
         .isZero();
 
     // A page bumped on the leader but not on the follower does not fail until something touches it again,
     // so an ordinary replicated write into the same bucket is what would surface a surviving gap.
-    leaderDb.command("sql", "INSERT INTO " + TYPE_NAME + " SET id = 100");
+    leaderDb.command("sql", "INSERT INTO " + TYPE_COMMAND + " SET id = 100");
     waitForAllServers();
 
     assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
         .as("no WAL version gap after a subsequent ordinary write into the truncated bucket")
         .isZero();
-    assertThat(awaitCountOn(followerIndex, 1))
+    assertThat(awaitCountOn(followerIndex, TYPE_COMMAND, 1))
         .as("follower converges with the leader after the subsequent ordinary write")
         .isEqualTo(1);
+  }
+
+  /**
+   * The MCP command tool ({@code ExecuteCommandTool}) never calls {@code command()}: it analyzes once and runs SQL
+   * through {@code AnalyzedQuery.execute()}, falling back to {@code database.command()} only for engines whose
+   * {@code execute()} returns null. That is a second entry point into statement execution, and it took its own fix -
+   * so it takes its own test, or a refactor reopens #5492 for that caller alone with everything else still green.
+   */
+  @Test
+  void truncateBatchCommitsReachFollowersViaAnalyzedQuery() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = 1 - leaderIndex;
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.getConfiguration().setValue(GlobalConfiguration.TRUNCATE_BATCH_SIZE, BATCH_SIZE);
+
+    leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_ANALYZED);
+    for (int i = 0; i < RECORDS; i++)
+      leaderDb.command("sql", "INSERT INTO " + TYPE_ANALYZED + " SET id = " + i);
+
+    waitForAllServers();
+    assertThat(awaitCountOn(followerIndex, TYPE_ANALYZED, RECORDS)).as("baseline replicated before the truncate").isEqualTo(RECORDS);
+
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
+
+    // Exactly the MCP tool's shape: resolve the engine off the database, analyze, then execute.
+    final DatabaseInternal wrapped = ((DatabaseInternal) leaderDb).getWrappedDatabaseInstance();
+    wrapped.transaction(() -> {
+      final QueryEngine.AnalyzedQuery analyzed = wrapped.getQueryEngine("sql")
+          .analyze("TRUNCATE TYPE `" + TYPE_ANALYZED + "`");
+      final ResultSet rs = analyzed.execute(Collections.emptyMap());
+      // Cast to Object: ResultSet extends both Iterator and Spliterator, so the AssertJ overloads are ambiguous.
+      assertThat((Object) rs).as("SQL analyze().execute() returns a result set rather than deferring to command()")
+          .isNotNull();
+      rs.close();
+    }, false);
+
+    assertThat(countOn(leaderIndex, TYPE_ANALYZED)).as("leader truncated the type").isZero();
+
+    waitForAllServers();
+    assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
+        .as("no WAL version gap when the truncate runs through analyze().execute()")
+        .isZero();
+    assertThat(awaitCountOn(followerIndex, TYPE_ANALYZED, 0))
+        .as("batch commits must replicate on the analyzed-query path too, not only through command()")
+        .isZero();
   }
 
   /**
@@ -128,20 +179,20 @@ class Issue5492TruncateBatchNotReplicatedIT extends BaseRaftHATest {
    * handle cached before it throws {@code DatabaseIsClosed} - which reads like an infrastructure failure rather than
    * the divergence that caused it.
    */
-  private long countOn(final int serverIndex) {
+  private long countOn(final int serverIndex, final String typeName) {
     // count(id) rather than count(*): the latter reads a cached per-bucket counter, which is the wrong tool
     // when the question is whether the pages themselves arrived.
     final Database db = getServerDatabase(serverIndex, getDatabaseName());
-    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + TYPE_NAME).next().getProperty("cnt"))
+    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + typeName).next().getProperty("cnt"))
         .longValue();
   }
 
-  private long awaitCountOn(final int serverIndex, final long expected) throws InterruptedException {
+  private long awaitCountOn(final int serverIndex, final String typeName, final long expected) throws InterruptedException {
     final long deadline = System.currentTimeMillis() + 30_000;
     long count = -1;
     while (System.currentTimeMillis() < deadline) {
       try {
-        count = countOn(serverIndex);
+        count = countOn(serverIndex, typeName);
         if (count == expected)
           return count;
       } catch (final RuntimeException e) {

--- a/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
@@ -35,14 +35,17 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 class ThreeNodesLoadTestIT extends ContainersTestTemplate {
 
-  private static final String SERVER_LIST             = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
-  private static final int    SCHEMA_TIMEOUT_SECONDS  = 60;
+  private static final String SERVER_LIST            = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
+  private static final int    SCHEMA_TIMEOUT_SECONDS = 60;
+  /** Logged exactly once by every server that starts, so it proves the log scan itself is working. */
+  private static final String CANARY_MARKER          = "ArcadeDB Server started";
 
   @AfterEach
   @Override
@@ -248,12 +251,33 @@ class ThreeNodesLoadTestIT extends ContainersTestTemplate {
     // Match the text the servers actually log. The exception's class name never reaches the log, and the phrase
     // "snapshot resync required" belongs to the exception message rather than to any logged line - grepping for
     // either reports a clean run against a log holding tens of thousands of gaps.
-    logger.info("Total page version gaps: {}", countInContainerLogs("does not match with existent version"));
-    logger.info("Total gap-triggered resyncs: {}", countInContainerLogs("triggering snapshot resync"));
-    logger.info("Total resyncs completed: {}", countInContainerLogs("Snapshot resync completed"));
-    // Counted on the leader, which serves one snapshot per resync cycle. The 503 a resyncing follower returns is not
-    // logged server-side, so the client-side error counters below are what stands in for the deflected writes.
-    logger.info("Total snapshots served: {}", countInContainerLogs("Serving database snapshot for"));
+    //
+    // All four in one call: each one re-pulls every container's full stdout, which on a diverging run is megabytes.
+    // "Serving database snapshot for" is counted on the leader, which serves one snapshot per resync cycle; the 503 a
+    // resyncing follower returns is not logged server-side, so the client-side counters below stand in for the
+    // writes it deflected.
+    final Map<String, Integer> markers = countInContainerLogs(
+        "does not match with existent version",
+        "triggering snapshot resync",
+        "Snapshot resync completed",
+        "Serving database snapshot for",
+        CANARY_MARKER);
+    logger.info("Total page version gaps: {}", markers.get("does not match with existent version"));
+    logger.info("Total gap-triggered resyncs: {}", markers.get("triggering snapshot resync"));
+    logger.info("Total resyncs completed: {}", markers.get("Snapshot resync completed"));
+    logger.info("Total snapshots served: {}", markers.get("Serving database snapshot for"));
+
+    // The four counters above read zero both when the cluster is healthy and when the scan is broken - a marker that
+    // no longer matches what the servers log is indistinguishable from a clean run, and that already happened once on
+    // this harness. The canary appears exactly once per container in every run, so a zero here means the numbers above
+    // carry no information rather than good news.
+    final int canary = markers.get(CANARY_MARKER);
+    if (canary < containers.size())
+      logger.error("Log scan is unreliable: canary '{}' found {} times across {} containers, expected one each. "
+          + "Treat the counters above as unmeasured, not as zero.", CANARY_MARKER, canary, containers.size());
+    else
+      logger.info("Log scan self-check: canary '{}' found {} times across {} containers", CANARY_MARKER, canary,
+          containers.size());
     logger.info("Failed user writes: {}", sumCounter("arcadedb.test.inserted.users.error"));
     logger.info("Failed photo writes: {}", sumCounter("arcadedb.test.inserted.photos.error"));
     // Authoritative per-node record counts. countType() reads a cached counter that drifts independently of

--- a/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
@@ -204,9 +204,48 @@ class ThreeNodesLoadTestIT extends ContainersTestTemplate {
     db3.assertThatFriendshipCountIs(expectedFriendshipCount);
     db3.assertThatLikesCountIs(expectedLikeCount);
 
+    // The assertions above read countType()'s cached counter, which drifts independently of replication
+    // (#5152/#5154). A run that lost committed writes passes them whenever the drift cancels the loss out - so the
+    // guard that actually decides this test is a full scan on every node. This is the shape #5492 produced: one
+    // follower held 29991 of 30000 photos by scan while the counters agreed.
+    for (final DatabaseWrapper db : List.of(db1, db2, db3)) {
+      db.assertThatScannedCountIs("User", expectedUsersCount);
+      db.assertThatScannedCountIs("Photo", expectedPhotoCount);
+    }
+
+    if (withMaterializedView)
+      assertViewConvergedAcrossNodes(db1, db2, db3);
+
     db1.close();
     db2.close();
     db3.close();
+  }
+
+  /**
+   * Requires the view to hold the same non-empty row count on every node.
+   * <p>
+   * Deliberately not an equality check against the user count: the refresh is scheduled from a post-commit callback,
+   * so the exact number of rows at the end depends on refresh timing and asserting it would trade a real guard for a
+   * flaky one. Equal-and-non-empty is the replication invariant, and it is exactly what #5492 broke - the view stood
+   * at 3000 / 3000 / 0, and earlier at 999 / 3000 / 3000.
+   */
+  private void assertViewConvergedAcrossNodes(final DatabaseWrapper db1, final DatabaseWrapper db2,
+      final DatabaseWrapper db3) {
+    Awaitility.await("materialized view converges on every node")
+        .atMost(2, TimeUnit.MINUTES)
+        .pollInterval(5, TimeUnit.SECONDS)
+        .until(() -> {
+          try {
+            final long v1 = db1.countUserStats();
+            final long v2 = db2.countUserStats();
+            final long v3 = db3.countUserStats();
+            logger.info("UserStats convergence check: {} / {} / {}", v1, v2, v3);
+            return v1 > 0 && v1 == v2 && v1 == v3;
+          } catch (final RuntimeException e) {
+            logger.debug("View convergence check transient failure: {}", e.getMessage());
+            return false;
+          }
+        });
   }
 
   private void awaitConvergence(final DatabaseWrapper db1, final DatabaseWrapper db2, final DatabaseWrapper db3) {

--- a/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
@@ -26,6 +26,8 @@ import io.micrometer.core.instrument.Metrics;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -39,7 +41,8 @@ import java.util.concurrent.TimeUnit;
 
 class ThreeNodesLoadTestIT extends ContainersTestTemplate {
 
-  private static final String SERVER_LIST = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
+  private static final String SERVER_LIST             = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
+  private static final int    SCHEMA_TIMEOUT_SECONDS  = 60;
 
   @AfterEach
   @Override
@@ -53,6 +56,26 @@ class ThreeNodesLoadTestIT extends ContainersTestTemplate {
   @EnumSource(DatabaseWrapper.Protocol.class)
   @DisplayName("Three-node Raft HA: replication across all nodes with consistency check")
   void threeNodeReplication(DatabaseWrapper.Protocol protocol) throws InterruptedException {
+    runThreeNodeLoad(protocol, false);
+  }
+
+  /**
+   * Materialized-view arm of the #5492 A/B. Identical to {@link #threeNodeReplication} in every respect except that
+   * the schema carries a {@code REFRESH INCREMENTAL} view over {@code User}; the issue reports that this alone turns a
+   * clean 3000/3000 run into 2041/3000 failed writes, a non-terminating snapshot-resync loop and one node holding a
+   * strict subset of the committed users.
+   * <p>
+   * Runs over HTTP only, matching the client the original report used, so the arms differ by the view and nothing else.
+   */
+  @Test
+  @Tag("slow")
+  @DisplayName("Three-node Raft HA: a REFRESH INCREMENTAL materialized view must not cost committed writes (#5492)")
+  void threeNodeReplicationWithMaterializedView() throws InterruptedException {
+    runThreeNodeLoad(DatabaseWrapper.Protocol.HTTP, true);
+  }
+
+  private void runThreeNodeLoad(final DatabaseWrapper.Protocol protocol, final boolean withMaterializedView)
+      throws InterruptedException {
     createArcadeContainer("arcadedb-0", SERVER_LIST, "majority", network);
     createArcadeContainer("arcadedb-1", SERVER_LIST, "majority", network);
     createArcadeContainer("arcadedb-2", SERVER_LIST, "majority", network);
@@ -69,14 +92,22 @@ class ThreeNodesLoadTestIT extends ContainersTestTemplate {
     ServerWrapper leaderServer = servers.get(findLeaderIndex(servers));
     final DatabaseWrapper leaderDb = new DatabaseWrapper(leaderServer, idSupplier, wordSupplier);
     leaderDb.createDatabase();
-    leaderDb.createSchema();
+    leaderDb.createSchema(withMaterializedView);
     leaderDb.close();
 
-    TimeUnit.SECONDS.sleep(5); // Wait for schema to be replicated to all nodes
-    logger.info("Checking schema replicated to all nodes");
-    db1.checkSchema();
-    db2.checkSchema();
-    db3.checkSchema();
+    logger.info("Waiting for the schema to replicate to all nodes");
+    final long schemaStart = System.currentTimeMillis();
+    db1.awaitSchema(SCHEMA_TIMEOUT_SECONDS);
+    db2.awaitSchema(SCHEMA_TIMEOUT_SECONDS);
+    db3.awaitSchema(SCHEMA_TIMEOUT_SECONDS);
+    logger.info("Schema readable on all three nodes after {} ms", System.currentTimeMillis() - schemaStart);
+    if (withMaterializedView) {
+      final long viewStart = System.currentTimeMillis();
+      db1.awaitMaterializedView(SCHEMA_TIMEOUT_SECONDS);
+      db2.awaitMaterializedView(SCHEMA_TIMEOUT_SECONDS);
+      db3.awaitMaterializedView(SCHEMA_TIMEOUT_SECONDS);
+      logger.info("Materialized view readable on all three nodes after {} ms", System.currentTimeMillis() - viewStart);
+    }
 
     final int numOfThreads = 3; //number of threads to use to insert users and photos
     final int numOfUsers = 1000; // Each thread will create 200000 users
@@ -144,6 +175,38 @@ class ThreeNodesLoadTestIT extends ContainersTestTemplate {
     logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
     logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
 
+    try {
+      awaitConvergence(db1, db2, db3);
+    } finally {
+      // Always report the replication signatures, on the happy path too: a run can converge on record counts and
+      // still have logged version gaps and resyncs, and that difference is what decides #5492.
+      logReplicationSignatures(withMaterializedView, db1, db2, db3);
+    }
+
+    Metrics.globalRegistry.getMeters().forEach(meter ->
+        logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure()));
+
+    db1.assertThatUserCountIs(expectedUsersCount);
+    db1.assertThatPhotoCountIs(expectedPhotoCount);
+    db1.assertThatFriendshipCountIs(expectedFriendshipCount);
+    db1.assertThatLikesCountIs(expectedLikeCount);
+
+    db2.assertThatUserCountIs(expectedUsersCount);
+    db2.assertThatPhotoCountIs(expectedPhotoCount);
+    db2.assertThatFriendshipCountIs(expectedFriendshipCount);
+    db2.assertThatLikesCountIs(expectedLikeCount);
+
+    db3.assertThatUserCountIs(expectedUsersCount);
+    db3.assertThatPhotoCountIs(expectedPhotoCount);
+    db3.assertThatFriendshipCountIs(expectedFriendshipCount);
+    db3.assertThatLikesCountIs(expectedLikeCount);
+
+    db1.close();
+    db2.close();
+    db3.close();
+  }
+
+  private void awaitConvergence(final DatabaseWrapper db1, final DatabaseWrapper db2, final DatabaseWrapper db3) {
     Awaitility.await()
         .atMost(2, TimeUnit.MINUTES)
         .pollInterval(10, TimeUnit.SECONDS)
@@ -172,27 +235,44 @@ class ThreeNodesLoadTestIT extends ContainersTestTemplate {
             return false;
           }
         });
+  }
 
-    Metrics.globalRegistry.getMeters().forEach(meter ->
-        logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure()));
-
-    db1.assertThatUserCountIs(expectedUsersCount);
-    db1.assertThatPhotoCountIs(expectedPhotoCount);
-    db1.assertThatFriendshipCountIs(expectedFriendshipCount);
-    db1.assertThatLikesCountIs(expectedLikeCount);
-
-    db2.assertThatUserCountIs(expectedUsersCount);
-    db2.assertThatPhotoCountIs(expectedPhotoCount);
-    db2.assertThatFriendshipCountIs(expectedFriendshipCount);
-    db2.assertThatLikesCountIs(expectedLikeCount);
-
-    db3.assertThatUserCountIs(expectedUsersCount);
-    db3.assertThatPhotoCountIs(expectedPhotoCount);
-    db3.assertThatFriendshipCountIs(expectedFriendshipCount);
-    db3.assertThatLikesCountIs(expectedLikeCount);
-
-    db1.close();
-    db2.close();
-    db3.close();
+  /**
+   * Logs the numbers that distinguish the two arms of the #5492 A/B. Counting the log markers matters because record
+   * counts alone cannot tell a cluster that never diverged from one that diverged and resynced back into agreement.
+   */
+  private void logReplicationSignatures(final boolean withMaterializedView, final DatabaseWrapper db1,
+      final DatabaseWrapper db2, final DatabaseWrapper db3) {
+    logger.info("=== #5492 signatures (materialized view: {}) ===", withMaterializedView ? "PRESENT" : "absent");
+    dumpContainerLogs(withMaterializedView ? "5492-with-view" : "5492-no-view");
+    // Match the text the servers actually log. The exception's class name never reaches the log, and the phrase
+    // "snapshot resync required" belongs to the exception message rather than to any logged line - grepping for
+    // either reports a clean run against a log holding tens of thousands of gaps.
+    logger.info("Total page version gaps: {}", countInContainerLogs("does not match with existent version"));
+    logger.info("Total gap-triggered resyncs: {}", countInContainerLogs("triggering snapshot resync"));
+    logger.info("Total resyncs completed: {}", countInContainerLogs("Snapshot resync completed"));
+    // Counted on the leader, which serves one snapshot per resync cycle. The 503 a resyncing follower returns is not
+    // logged server-side, so the client-side error counters below are what stands in for the deflected writes.
+    logger.info("Total snapshots served: {}", countInContainerLogs("Serving database snapshot for"));
+    logger.info("Failed user writes: {}", sumCounter("arcadedb.test.inserted.users.error"));
+    logger.info("Failed photo writes: {}", sumCounter("arcadedb.test.inserted.photos.error"));
+    // Authoritative per-node record counts. countType() reads a cached counter that drifts independently of
+    // replication (#5152/#5154), so a disagreement there has to be confirmed by a scan before it means data loss.
+    try {
+      logger.info("Scanned Users per node: {} / {} / {}", db1.scanCount("User"), db2.scanCount("User"),
+          db3.scanCount("User"));
+      logger.info("Scanned Photos per node: {} / {} / {}", db1.scanCount("Photo"), db2.scanCount("Photo"),
+          db3.scanCount("Photo"));
+    } catch (final RuntimeException e) {
+      logger.warn("Could not scan per-node record counts: {}", e.getMessage());
+    }
+    if (withMaterializedView) {
+      try {
+        logger.info("UserStats rows per node: {} / {} / {}", db1.countUserStats(), db2.countUserStats(),
+            db3.countUserStats());
+      } catch (final RuntimeException e) {
+        logger.warn("Could not read UserStats row counts: {}", e.getMessage());
+      }
+    }
   }
 }

--- a/load-tests/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
@@ -697,26 +697,6 @@ public abstract class ContainersTestTemplate {
   }
 
   /**
-   * Counts how many times a marker appears in each container's stdout, and logs the per-container tally.
-   * Used to turn a replication failure into a number: {@code WALVersionGapException} occurrences and snapshot-resync
-   * cycles are the signature of #5492, and a run that converges on counts can still have logged them.
-   *
-   * @param marker substring to look for, matched literally
-   *
-   * @return total occurrences across every container
-   */
-  /**
-   * Sums a counter over the per-test {@link #loggingMeterRegistry} rather than {@link Metrics#globalRegistry}.
-   * A meter on the global composite reports the value of one arbitrarily chosen child registry, not the sum, and this
-   * class adds and removes a backing registry around every test - so reading a counter off the composite can return
-   * another test method's value or zero. The per-test registry is created fresh in setup, which makes the value both
-   * unambiguous and scoped to the run being measured.
-   *
-   * @param name counter name, matched exactly
-   *
-   * @return summed count across every counter registered under that name
-   */
-  /**
    * Writes each container's stdout to {@code target/container-logs/<label>-<name>.log} while the containers are still
    * up. Testcontainers removes them during teardown, taking the logs with them, so anything not written out here
    * cannot be examined after the run - which matters when a count printed at the end raises a question the raw log is
@@ -744,10 +724,33 @@ public abstract class ContainersTestTemplate {
     }
   }
 
+  /**
+   * Sums a counter over the per-test {@link #loggingMeterRegistry} rather than {@link Metrics#globalRegistry}.
+   * A meter on the global composite reports the value of one arbitrarily chosen child registry, not the sum, and this
+   * class adds and removes a backing registry around every test - so reading a counter off the composite can return
+   * another test method's value or zero. The per-test registry is created fresh in setup, which makes the value both
+   * unambiguous and scoped to the run being measured.
+   *
+   * @param name counter name, matched exactly
+   *
+   * @return summed count across every counter registered under that name
+   */
   protected double sumCounter(final String name) {
     return loggingMeterRegistry.find(name).counters().stream().mapToDouble(Counter::count).sum();
   }
 
+  /**
+   * Counts how many times a marker appears in each container's stdout, and logs the per-container tally.
+   * Used to turn a replication failure into a number: page-version gaps and snapshot-resync cycles are the signature
+   * of #5492, and a run that converges on record counts can still have logged them.
+   * <p>
+   * Match what the servers actually log. Neither the exception class name nor the text of a message passed to a
+   * {@code throw} reaches the log, so a marker taken from either counts zero against a log full of the event.
+   *
+   * @param marker substring to look for, matched literally
+   *
+   * @return total occurrences across every container
+   */
   protected int countInContainerLogs(final String marker) {
     int total = 0;
     for (final GenericContainer<?> container : containers) {

--- a/load-tests/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
@@ -26,6 +26,7 @@ import com.arcadedb.utility.FileUtils;
 
 import com.github.dockerjava.api.model.ContainerNetwork;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
 import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
@@ -67,7 +68,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 public abstract class ContainersTestTemplate {
-  public static final String                    IMAGE      = "arcadedata/arcadedb:latest";
+  /**
+   * Image under test. Override with {@code -Darcadedb.test.image=arcadedata/arcadedb:26.8.1-SNAPSHOT} to pin a locally
+   * built tag instead of whatever {@code :latest} happens to point at, so a run's result names the build it tested.
+   */
+  public static final String                    IMAGE      = System.getProperty("arcadedb.test.image",
+      "arcadedata/arcadedb:latest");
   public static final String                    PASSWORD   = "playwithdata";
   public static final String                    DATABASE   = "playwithpictures";
   protected           LoggingMeterRegistry      loggingMeterRegistry;
@@ -688,6 +694,77 @@ public abstract class ContainersTestTemplate {
         logger.info("Container {} is running", name);
       }
     }
+  }
+
+  /**
+   * Counts how many times a marker appears in each container's stdout, and logs the per-container tally.
+   * Used to turn a replication failure into a number: {@code WALVersionGapException} occurrences and snapshot-resync
+   * cycles are the signature of #5492, and a run that converges on counts can still have logged them.
+   *
+   * @param marker substring to look for, matched literally
+   *
+   * @return total occurrences across every container
+   */
+  /**
+   * Sums a counter over the per-test {@link #loggingMeterRegistry} rather than {@link Metrics#globalRegistry}.
+   * A meter on the global composite reports the value of one arbitrarily chosen child registry, not the sum, and this
+   * class adds and removes a backing registry around every test - so reading a counter off the composite can return
+   * another test method's value or zero. The per-test registry is created fresh in setup, which makes the value both
+   * unambiguous and scoped to the run being measured.
+   *
+   * @param name counter name, matched exactly
+   *
+   * @return summed count across every counter registered under that name
+   */
+  /**
+   * Writes each container's stdout to {@code target/container-logs/<label>-<name>.log} while the containers are still
+   * up. Testcontainers removes them during teardown, taking the logs with them, so anything not written out here
+   * cannot be examined after the run - which matters when a count printed at the end raises a question the raw log is
+   * the only thing that can answer.
+   *
+   * @param label prefix identifying the scenario, so arms of the same comparison do not overwrite each other
+   */
+  protected void dumpContainerLogs(final String label) {
+    final Path target = Path.of("target", "container-logs");
+    try {
+      Files.createDirectories(target);
+    } catch (final IOException e) {
+      logger.warn("Could not create {}: {}", target, e.getMessage());
+      return;
+    }
+    for (final GenericContainer<?> container : containers) {
+      final String name = container.getContainerName().replace("/", "");
+      final Path file = target.resolve(label + "-" + name + ".log");
+      try {
+        Files.writeString(file, container.getLogs());
+        logger.info("Wrote container log to {}", file.toAbsolutePath());
+      } catch (final Exception e) {
+        logger.warn("Could not write log of container {}: {}", name, e.getMessage());
+      }
+    }
+  }
+
+  protected double sumCounter(final String name) {
+    return loggingMeterRegistry.find(name).counters().stream().mapToDouble(Counter::count).sum();
+  }
+
+  protected int countInContainerLogs(final String marker) {
+    int total = 0;
+    for (final GenericContainer<?> container : containers) {
+      final String name = container.getContainerName();
+      int occurrences = 0;
+      try {
+        final String logs = container.getLogs();
+        for (int from = logs.indexOf(marker); from >= 0; from = logs.indexOf(marker, from + marker.length()))
+          ++occurrences;
+      } catch (final Exception e) {
+        logger.warn("Could not read logs of container {} looking for '{}': {}", name, marker, e.getMessage());
+        continue;
+      }
+      logger.info("Container {}: '{}' x{}", name, marker, occurrences);
+      total += occurrences;
+    }
+    return total;
   }
 
   /**

--- a/load-tests/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
@@ -62,7 +62,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -713,7 +715,7 @@ public abstract class ContainersTestTemplate {
       return;
     }
     for (final GenericContainer<?> container : containers) {
-      final String name = container.getContainerName().replace("/", "");
+      final String name = containerLabel(container);
       final Path file = target.resolve(label + "-" + name + ".log");
       try {
         Files.writeString(file, container.getLogs());
@@ -752,22 +754,51 @@ public abstract class ContainersTestTemplate {
    * @return total occurrences across every container
    */
   protected int countInContainerLogs(final String marker) {
-    int total = 0;
+    return countInContainerLogs(new String[] { marker }).get(marker);
+  }
+
+  /**
+   * Counts several markers in one pass over each container's stdout.
+   * <p>
+   * {@code getLogs()} pulls the container's entire stdout over the Docker API and materializes it as a String, which
+   * on a diverging run is megabytes. Counting markers one call at a time re-fetches and re-scans all of it per marker,
+   * so every marker a caller wants belongs in a single call.
+   *
+   * @param markers substrings to look for, each matched literally
+   *
+   * @return per-marker total occurrences across every container, in the order given
+   */
+  protected Map<String, Integer> countInContainerLogs(final String... markers) {
+    final Map<String, Integer> totals = new LinkedHashMap<>();
+    for (final String marker : markers)
+      totals.put(marker, 0);
+
     for (final GenericContainer<?> container : containers) {
-      final String name = container.getContainerName();
-      int occurrences = 0;
+      final String name = containerLabel(container);
+      final String logs;
       try {
-        final String logs = container.getLogs();
-        for (int from = logs.indexOf(marker); from >= 0; from = logs.indexOf(marker, from + marker.length()))
-          ++occurrences;
+        logs = container.getLogs();
       } catch (final Exception e) {
-        logger.warn("Could not read logs of container {} looking for '{}': {}", name, marker, e.getMessage());
+        logger.warn("Could not read logs of container {}: {}", name, e.getMessage());
         continue;
       }
-      logger.info("Container {}: '{}' x{}", name, marker, occurrences);
-      total += occurrences;
+      for (final String marker : markers) {
+        int occurrences = 0;
+        for (int from = logs.indexOf(marker); from >= 0; from = logs.indexOf(marker, from + marker.length()))
+          ++occurrences;
+        logger.info("Container {}: '{}' x{}", name, marker, occurrences);
+        totals.merge(marker, occurrences, Integer::sum);
+      }
     }
-    return total;
+    return totals;
+  }
+
+  /**
+   * Container name without the leading slash Docker prefixes it with, so log lines and dumped file names agree.
+   */
+  private String containerLabel(final GenericContainer<?> container) {
+    final String name = container.getContainerName();
+    return name != null && name.startsWith("/") ? name.substring(1) : name;
   }
 
   /**

--- a/load-tests/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
@@ -153,6 +153,19 @@ public class DatabaseWrapper {
    * It also creates properties for User and Photo vertex types.
    */
   public void createSchema() {
+    createSchema(false);
+  }
+
+  /**
+   * Creates the schema, optionally adding the {@code UserStats} materialized view over {@code User}.
+   * <p>
+   * The view is the only difference between the two arms of the #5492 A/B: the same load against the same cluster is
+   * reported to lose committed writes when it is present and to run clean when it is not. Keep every other aspect of
+   * the two arms identical, or the comparison proves nothing.
+   *
+   * @param withMaterializedView whether to create the {@code REFRESH INCREMENTAL} view
+   */
+  public void createSchema(final boolean withMaterializedView) {
     // Retry to handle the case where the database is still being replicated/opened after Raft creation.
     // In a Raft cluster, the leader commits database creation to the log, but the local state machine
     // may not have opened the database yet when the next command arrives.
@@ -160,6 +173,8 @@ public class DatabaseWrapper {
     for (int attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         createSchemaInternal();
+        if (withMaterializedView)
+          createMaterializedView();
         return;
       } catch (final Exception e) {
         if (attempt == maxAttempts)
@@ -207,16 +222,24 @@ public class DatabaseWrapper {
 
 
             """);
+  }
 
-/**
- *             CREATE MATERIALIZED VIEW UserStats AS
- *               SELECT id AS userId,
- *                 out('HasUploaded').in('Likes').size() AS totalLikes,
- *                 out('FriendOf').size() AS totalFriendships
- *               FROM User
- *               REFRESH INCREMENTAL;
- */
-
+  /**
+   * Creates the {@code UserStats} materialized view that #5492 reports as the trigger for the replication gap.
+   * Issued as its own command rather than inside the schema script so that a failure here is not mistaken for a
+   * failure to create the base types.
+   */
+  private void createMaterializedView() {
+    logger.info("Creating materialized view UserStats (REFRESH INCREMENTAL)");
+    db.command("sql",
+        """
+            CREATE MATERIALIZED VIEW UserStats AS
+              SELECT id AS userId,
+                out('HasUploaded').in('Likes').size() AS totalLikes,
+                out('FriendOf').size() AS totalFriendships
+              FROM User
+              REFRESH INCREMENTAL\
+            """);
   }
 
   /**
@@ -230,6 +253,76 @@ public class DatabaseWrapper {
     assertThat(schema.existsType("HasUploaded")).isTrue();
     assertThat(schema.existsType("FriendOf")).isTrue();
     assertThat(schema.existsType("Likes")).isTrue();
+  }
+
+  /**
+   * Checks that the materialized view replicated to this node, by querying it: a view this node never received fails
+   * the query outright, which is the assertion. The row count itself carries no information here, since the check runs
+   * before the load starts.
+   * <p>
+   * Queried rather than looked up through {@link RemoteSchema}, which reports types and does not list views.
+   */
+  public void checkMaterializedView() {
+    countUserStats();
+  }
+
+  /**
+   * Waits until this node answers {@link #checkSchema()}, and reports how long that took.
+   * <p>
+   * A follower applying a schema entry reopens the database, during which it answers
+   * {@code Database '...' is not available}. How long that window lasts is exactly what the two arms of the #5492 A/B
+   * should be compared on, so it is measured rather than slept through: a fixed sleep either hides a real regression
+   * or fails the run before it reaches the load phase where the reported symptom lives.
+   *
+   * @param timeoutSeconds how long to keep retrying before failing
+   *
+   * @return milliseconds waited before the schema was readable
+   */
+  public long awaitSchema(final int timeoutSeconds) {
+    return await(timeoutSeconds, this::checkSchema, "schema");
+  }
+
+  /**
+   * Waits until the materialized view is queryable on this node. See {@link #awaitSchema(int)}.
+   *
+   * @param timeoutSeconds how long to keep retrying before failing
+   *
+   * @return milliseconds waited before the view was readable
+   */
+  public long awaitMaterializedView(final int timeoutSeconds) {
+    return await(timeoutSeconds, this::checkMaterializedView, "materialized view");
+  }
+
+  private long await(final int timeoutSeconds, final Runnable check, final String what) {
+    final long start = System.currentTimeMillis();
+    final long deadline = start + timeoutSeconds * 1000L;
+    Throwable last = null;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        check.run();
+        return System.currentTimeMillis() - start;
+      } catch (final RuntimeException | AssertionError e) {
+        last = e;
+        try {
+          Thread.sleep(500);
+        } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    }
+    throw new AssertionError(
+        "Node " + server.host() + ":" + server.httpPort() + " did not expose the " + what + " within " + timeoutSeconds
+            + "s: " + (last != null ? last.getMessage() : "unknown"), last);
+  }
+
+  /**
+   * @return number of rows currently held by the {@code UserStats} materialized view on this node
+   */
+  public long countUserStats() {
+    try (final ResultSet resultSet = db.query("sql", "SELECT count(*) AS total FROM UserStats")) {
+      return resultSet.hasNext() ? resultSet.next().<Number>getProperty("total").longValue() : 0;
+    }
   }
 
   /**
@@ -480,6 +573,24 @@ public class DatabaseWrapper {
 
   public long countUsers() {
     return db.countType("User", false);
+  }
+
+  /**
+   * Counts records of a type by full scan, bypassing the cached bucket counter that {@link #countUsers()} and
+   * {@link #countPhotos()} read through {@code countType()}.
+   * <p>
+   * The cached counter is known to drift from the stored records (#5152/#5154), so a per-node difference in
+   * {@code countType()} is not by itself evidence of a replication defect. {@code count(@rid)} scans and is
+   * authoritative, which is what separates "this node is missing records" from "this node's counter is wrong".
+   *
+   * @param typeName type to scan
+   *
+   * @return number of records actually stored on this node
+   */
+  public long scanCount(final String typeName) {
+    try (final ResultSet resultSet = db.query("sql", "SELECT count(@rid) AS total FROM " + typeName)) {
+      return resultSet.hasNext() ? resultSet.next().<Number>getProperty("total").longValue() : 0;
+    }
   }
 
   public long countPhotos() {

--- a/load-tests/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
@@ -539,6 +539,45 @@ public class DatabaseWrapper {
     assertThat(actual).isEqualTo(expectedCount);
   }
 
+  /**
+   * Asserts a per-node record count by full scan rather than through the cached bucket counter.
+   * <p>
+   * This is the assertion that has to decide the run. {@link #assertThatUserCountIs(int)} and its siblings read
+   * {@code countType()}, whose counter drifts independently of replication (#5152/#5154) - so a run that really did
+   * lose committed writes can pass it whenever the drift happens to cancel the loss out, which is precisely the
+   * failure #5492 produced. Retries on the same 30 s budget, since Raft replication is asynchronous.
+   *
+   * @param typeName      type to scan
+   * @param expectedCount records this node must hold
+   */
+  public void assertThatScannedCountIs(final String typeName, final int expectedCount) {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    long actual = -1;
+    Exception lastException = null;
+    do {
+      try {
+        actual = scanCount(typeName);
+        if (actual == expectedCount)
+          return;
+        lastException = null;
+      } catch (final Exception e) {
+        lastException = e;
+      }
+      if (System.currentTimeMillis() < deadline) {
+        try {
+          Thread.sleep(2_000);
+        } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    } while (System.currentTimeMillis() < deadline);
+    if (lastException != null)
+      throw new AssertionError("Expected " + expectedCount + " scanned " + typeName
+          + " but the database was not available after 30s: " + lastException.getMessage(), lastException);
+    assertThat(actual).as("scanned %s count on this node", typeName).isEqualTo(expectedCount);
+  }
+
   public List<Integer> getUserIds(int numOfUsers, int skip) {
     ResultSet resultSet = db.query("sql", "SELECT id  FROM User ORDER BY id SKIP ? LIMIT ?", skip, numOfUsers);
     return resultSet.stream()


### PR DESCRIPTION
Fixes #5492.

## Root cause

`SQLQueryEngine` executed statements against the raw `DatabaseInternal` it was constructed with. On an HA leader, `RaftReplicatedDatabase.command()` delegates to `proxied.command(...)`, so `CommandContext.getDatabase()` resolved to the inner `LocalDatabase` - and every `commit()` a statement issues *itself* went straight to `LocalDatabase.commit()`, bypassing Raft.

`TRUNCATE TYPE` deletes in batches of `TRUNCATE_BATCH_SIZE` (default 1000), committing after each batch. Truncating more than one batch therefore published pages on the leader that no follower ever received. Follower page versions trail by exactly those writes, and the next replicated entry touching one of those pages fails its version check:

```
PageId(playwithpictures/142/0) version in WAL (2205) does not match with existent version (2203)
```

`WALVersionGapException` -> database marked diverged -> snapshot resync -> the next entry breaks the same way.

`SQLScriptQueryEngine` has **always** resolved `getWrappedDatabaseInstance()` before executing the very same statement classes. That is why an identical `TRUNCATE` replicates correctly under `sqlscript` and not under `sql`. The asymmetry was the defect.

## Why a materialized view was needed to see it

`MaterializedViewRefresher` truncates and rebuilds the backing type on every source commit, via `database.command("sql", "TRUNCATE TYPE ...")`. A view over 3000 rows crosses the 1000-record batch boundary on every refresh.

It also explains why this **never reproduced in process**: earlier harnesses truncated 180 to 450 records, so `count % 1000 == 0` never held and no mid-statement commit ever ran. Not a concurrency heisenbug, a threshold.

The bug is not view-specific. Any `TRUNCATE TYPE` over 1000 records issued through `/api/v1/command` with `language=sql` on an HA leader silently fails to replicate its first N-1 batches.

## Fix

One line of behavior, at the single point where the execution database is chosen: `SQLQueryEngine` now resolves `getWrappedDatabaseInstance()`, matching `SQLScriptQueryEngine`. Off HA the wrapper is the instance itself, so nothing changes there. The `query()` paths are deliberately untouched - they are gated on `isIdempotent()` and never commit.

## Evidence: 3-node container A/B

Image built from this branch's parent (`726633d3c`, containing both #5502 and #5537), same load, only the schema differing.

| Signal, per follower | With the view | Control (HTTP and GRPC) |
|---|---|---|
| Page version gaps | 24002 / 23924 | 0 |
| Gap-triggered resyncs | 357 / 356 | 0 |
| Snapshots served by leader | 712 | 0 |
| Scanned `Photo` per node | 30000 / 30000 / **29991** | 30000 / 30000 / 30000 |
| `UserStats` rows per node | 3000 / 3000 / **0** | n/a |
| Load phase | ~4.8 min | ~1.5 min |

First gap byte-identical on both followers 1 ms apart, on the view's own backing bucket - the leader-side shape the issue predicted.

Record loss is confirmed by `count(@rid)` scan, not `countType()`, whose cached counter drifts independently (#5152/#5154).

## Test plan

- [x] `Issue5492TruncateBatchNotReplicatedIT` - 2-node cluster, batch size lowered, `TRUNCATE` issued exactly as the refresher issues it. **Verified failing before the fix**: `[follower must see no WAL version gap] but was: 1`. Passes after.
- [x] Asserts the gap counter *before* querying the follower: the resync reinstalls the follower's database, which otherwise surfaces as an unrelated-looking `DatabaseIsClosed`.
- [x] `ThreeNodesLoadTestIT` now carries both arms of the A/B, so the comparison is reproducible rather than a one-off local run. The materialized view that was sitting commented out in `DatabaseWrapper` is restored and wired to the MV arm only.
- [ ] Nightly load-tests workflow dispatched against this branch (link in a comment below).

## Harness changes worth a look

- `ContainersTestTemplate.IMAGE` is overridable via `-Darcadedb.test.image`, so a run names the build it tested.
- Container stdout is dumped to `target/container-logs/` before teardown - testcontainers removes the containers, and without this the raw log cannot be consulted afterwards.
- Counters are summed over the per-test registry rather than read off `Metrics.globalRegistry`: a meter on the composite reports one arbitrarily chosen child, and this class adds/removes a backing registry around every test.
- The fixed 5-second sleep waiting for schema replication is now a measured wait. It was too tight (schema needs ~8.5 s here) and failed the first MV run before it reached the load phase.

**Reviewer note:** the judgment call is the blast radius of `executionDatabase()`. Every `sql` statement now sees the wrapper. The argument that this is safe is that `sqlscript` already runs these same statement classes with the wrapper today; if you think some statement depends on receiving the inner instance, say which and I will narrow the fix to the batching sites (`TruncateTypeStatement`, `TruncateBucketStatement`, `RebuildTypeStatement`, `BatchStep`).
