### PR TITLE
fix(engine) #5648: never hand out a pooled graph searcher bound to a replaced graph

### DIFF
--- a/docs/5648-graphsearcherpool-stale-searcher.md
+++ b/docs/5648-graphsearcherpool-stale-searcher.md
@@ -84,6 +84,37 @@ back the searcher bound to the replaced graph. The two guard tests passed before
 | `LSMVectorIndexSearcherPoolTest`, `LSMVectorIndexSearcherEpochTest`, `LSMVectorIndexConcurrentRebuildVisibilityTest`, `DeltaScanVectorSearchTest`, `LSMVectorIndexRebuildTest` | 24/24 pass |
 | Full `com.arcadedb.index.vector` package (benchmark/slow excluded) | 198/198 pass |
 
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5653
+
+### Review cycles
+
+**Cycle 1 - `22d4da2ab`** - LGTM with two optional nits and one benign edge flagged for the record.
+
+- *Reference-identity nit.* The bot reported that the records' generated `equals`/`hashCode` go unused because
+  "all comparisons are reference-based", and asked for a comment explaining that `==` on a record is intentional.
+  Checked against the code first: no `Identity` or `Pooled` instance is ever compared with `==` anywhere. The
+  comparisons are on their **fields** - an `ImmutableGraphIndex` reference and a primitive `long`. The framing was
+  therefore inaccurate, but the readability concern underneath it was real, so the comment added documents the
+  claim that is actually load-bearing: a rebuild publishes a new graph instance and a searcher's `View` is bound
+  to the exact instance it was built from, so graphs must match by reference however equal their contents.
+- *Rebuild-storm over-reclamation.* Confirmed real. The reuse loop matches against the caller's own pair rather
+  than the current published one, so if the identity moves on again mid-loop, an entry a concurrent `release`
+  queued under the newer identity is closed here even though it was still usable. Behaviour left unchanged - it
+  costs one searcher reallocation and can never return a wrong searcher, whereas re-reading the published
+  identity per iteration would put a volatile read on the search path to buy nothing but pooling efficiency. The
+  reasoning is now recorded in the loop so it reads as a deliberate trade-off.
+
+**Cycle 2 - `845434997`** - clean approval. Three non-blocking observations, none requesting a change:
+`size()`/`idleCount` is approximate under races (fine for metrics; the new tests are single-threaded so they are
+unaffected), the rebuild-storm trade-off is well documented, and `getDeclaredConstructors()[0]` is safe for a
+record because the canonical constructor is the only declared one. The bot independently confirmed that
+correctness no longer depends on the published identity at all, so every racy path degrades to an extra
+allocation rather than a wrong result.
+
+Final state: **clean-approval**.
+
 ## Notes
 
 `searcherPoolEpoch()` was made strictly monotonic separately in #5621. This change is about the publication order

--- a/docs/5648-graphsearcherpool-stale-searcher.md
+++ b/docs/5648-graphsearcherpool-stale-searcher.md
@@ -1,0 +1,90 @@
+# 5648 - GraphSearcherPool can hand out a searcher bound to a replaced graph
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5648
+
+## Root cause
+
+`GraphSearcherPool` guarded reuse with two independent volatile fields, `pooledGraph` and `pooledEpoch`, and
+`borrow` drained the idle queue **before** publishing them:
+
+```java
+if (pooledGraph != graph || pooledEpoch != epoch) {
+  drain();              // empties the queue
+  pooledGraph = graph;  // publishes only now
+  pooledEpoch = epoch;
+  return new GraphSearcher(graph);
+}
+```
+
+A `release` running inside that window still reads the outgoing pair, matches it, and offers its searcher into the
+queue after the drain has already swept past. The next `borrow` matches the newly published pair and polls that
+searcher straight back out, so a search over the new graph runs on a `GraphSearcher` whose `View` was captured
+from the old one.
+
+The queue itself carried no record of which graph or epoch an entry belonged to, so `borrow` had no way to tell a
+valid entry from a stale one. Draining is inherently racy against a concurrent `release`, which means the sweep
+alone can never be the guarantee.
+
+Two narrower windows shared the cause: `pooledGraph` was written before `pooledEpoch`, leaving the pair
+transiently `(G_new, E_old)`, and `clear()` nulled `pooledGraph` before draining.
+
+## Impact
+
+`findNeighborsFromVector` scores and maps ordinals through the **new** epoch's vector values and
+`ordinalToVectorId` snapshot while the borrowed searcher traverses the **old** graph's edges. The result is
+silently wrong neighbours - unrelated RIDs, or misses - with no exception and nothing left behind to attribute
+them to. It needs two concurrent searches on one index plus a graph swap or mutation, which is ordinary server
+workload (concurrent HTTP query handlers against one index).
+
+## Fix
+
+`engine/src/main/java/com/arcadedb/index/vector/GraphSearcherPool.java`
+
+1. **Every queued searcher carries the identity it was pooled under** (`Pooled` record), and `borrow` verifies it
+   on the way out, closing and skipping anything that does not match the caller's own graph and epoch. This is
+   what actually closes the race: whatever a `release` manages to leave in the queue, a borrower never trusts it.
+2. **The published identity is a single immutable `Identity` record** behind one volatile field, so the pair can
+   no longer be read half-updated.
+3. **The identity is published before the drain**, so a `release` still running under the outgoing one rejects its
+   searcher rather than re-pooling behind the sweep.
+
+The sweep in `borrow` and the identity check in `release` are retained, but they are now only early-reclamation
+optimizations rather than the correctness guarantee.
+
+Cost: one small `Pooled` record (three fields) per `release`. That is negligible next to the `GraphSearcher` the
+pool exists to avoid reallocating - its growable candidate heap and two result heaps were the single largest
+source of garbage in a dense-search workload.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/index/vector/GraphSearcherPoolStaleGraphTest.java` (new, 5 tests)
+
+The interleaving needs a `release` to land between a `borrow`'s drain and its publish - a two-instruction window
+that no amount of thread scheduling reproduces reliably. The tests therefore assert the **state** that window
+leaves behind (the queue holding an entry pooled under one identity while the pool advertises another) and require
+the pool never to hand it out. That state is unreachable through the public API once the fix is in, so it is
+planted on the private identity field by reflection, mirroring the reflection already used by
+`LSMVectorIndexSearcherEpochTest`.
+
+- `borrowNeverHandsOutASearcherPooledUnderAReplacedGraph` - the graph swap case from the issue
+- `borrowNeverHandsOutASearcherPooledUnderAStaleEpoch` - same graph instance, mutated underneath (live-builder path)
+- `everyStaleEntryIsReclaimedBeforeAFreshSearcherIsBuilt` - all stale entries dropped, none left occupying the pool
+- `aReleaseUnderASupersededIdentityIsNotPooled` - guards publish-before-drain
+- `anUnchangedIdentityStillReusesThePooledSearcher` - guards against the check becoming so strict that pooling stops
+
+**Proven to fail first.** Run against the unfixed pool (with `plantIdentity` pointed at the old `pooledGraph` /
+`pooledEpoch` fields), the three reproducers failed with `Expected not same: GraphSearcher@...` - the pool handing
+back the searcher bound to the replaced graph. The two guard tests passed before and after, as intended.
+
+### Results
+
+| Suite | Result |
+|---|---|
+| `GraphSearcherPoolStaleGraphTest` | 5/5 pass |
+| `LSMVectorIndexSearcherPoolTest`, `LSMVectorIndexSearcherEpochTest`, `LSMVectorIndexConcurrentRebuildVisibilityTest`, `DeltaScanVectorSearchTest`, `LSMVectorIndexRebuildTest` | 24/24 pass |
+| Full `com.arcadedb.index.vector` package (benchmark/slow excluded) | 198/198 pass |
+
+## Notes
+
+`searcherPoolEpoch()` was made strictly monotonic separately in #5621. This change is about the publication order
+and the trustworthiness of the queue's contents, not the epoch value.

--- a/engine/src/main/java/com/arcadedb/index/vector/GraphSearcherPool.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/GraphSearcherPool.java
@@ -45,16 +45,35 @@ import java.util.logging.Level;
  * {@code ConcurrentGraphIndexView} pins a completion timestamp), so it may only be recycled while both the graph
  * instance and the index's mutation counter are unchanged. Any insert, delete or graph rebuild moves the epoch and
  * the pooled searchers are closed instead of being handed out again.
+ * <p>
+ * Every queued searcher carries the identity it was pooled under, and {@link #borrow} checks it on the way out
+ * (issue #5648). Emptying the queue when the identity changes cannot be relied on by itself: a {@code release}
+ * that read the outgoing identity a moment earlier can still land its searcher after that sweep has passed, and
+ * the next borrow would then hand out a searcher whose {@code View} walks the replaced graph while the caller
+ * scores through the new one - wrong neighbours, silently, with nothing left behind to attribute them to. The
+ * sweep and the identity check in {@code release} are therefore only there to reclaim searchers early; what makes
+ * the pool safe is that a borrower never trusts what it polled.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class GraphSearcherPool {
-  private final ConcurrentLinkedQueue<GraphSearcher> idle      = new ConcurrentLinkedQueue<>();
-  private final AtomicInteger                        idleCount = new AtomicInteger();
-  private final int                                  maxIdle;
+  /**
+   * The (graph, epoch) pair the pool currently serves. Held as one value so it can never be read half-updated.
+   */
+  private record Identity(ImmutableGraphIndex graph, long epoch) {
+  }
 
-  private volatile ImmutableGraphIndex pooledGraph;
-  private volatile long                pooledEpoch;
+  /**
+   * A queued searcher together with the identity it was pooled under, so {@link #borrow} can reject it.
+   */
+  private record Pooled(GraphSearcher searcher, ImmutableGraphIndex graph, long epoch) {
+  }
+
+  private final ConcurrentLinkedQueue<Pooled> idle      = new ConcurrentLinkedQueue<>();
+  private final AtomicInteger                 idleCount = new AtomicInteger();
+  private final int                           maxIdle;
+
+  private volatile Identity pooled;
 
   /**
    * @param maxIdle maximum number of searchers kept alive between queries; values below 1 disable pooling
@@ -71,20 +90,23 @@ public class GraphSearcherPool {
     if (maxIdle < 1)
       return new GraphSearcher(graph);
 
-    if (pooledGraph != graph || pooledEpoch != epoch) {
-      // The graph was swapped (rebuild) or the index mutated: nothing already pooled may be reused.
+    final Identity current = pooled;
+    if (current == null || current.graph != graph || current.epoch != epoch) {
+      // The graph was swapped (rebuild) or the index mutated: nothing already pooled may be reused. Publish first
+      // so a release still running under the outgoing identity rejects its searcher instead of re-pooling it.
+      pooled = new Identity(graph, epoch);
       drain();
-      pooledGraph = graph;
-      pooledEpoch = epoch;
       return new GraphSearcher(graph);
     }
 
-    final GraphSearcher searcher = idle.poll();
-    if (searcher == null)
-      return new GraphSearcher(graph);
-
-    idleCount.decrementAndGet();
-    return searcher;
+    for (Pooled entry; (entry = poll()) != null; ) {
+      if (entry.graph == graph && entry.epoch == epoch)
+        return entry.searcher;
+      // Pooled under an identity this caller does not share: it was queued by a release racing an identity
+      // change, after the sweep for that change had already passed. Reclaim it and keep looking.
+      close(entry.searcher);
+    }
+    return new GraphSearcher(graph);
   }
 
   /**
@@ -95,7 +117,8 @@ public class GraphSearcherPool {
     if (searcher == null)
       return;
 
-    if (maxIdle < 1 || pooledGraph != graph || pooledEpoch != epoch) {
+    final Identity current = pooled;
+    if (maxIdle < 1 || current == null || current.graph != graph || current.epoch != epoch) {
       close(searcher);
       return;
     }
@@ -107,7 +130,7 @@ public class GraphSearcherPool {
     }
 
     idleCount.incrementAndGet();
-    idle.offer(searcher);
+    idle.offer(new Pooled(searcher, graph, epoch));
   }
 
   /**
@@ -115,7 +138,7 @@ public class GraphSearcherPool {
    * replaced.
    */
   public void clear() {
-    pooledGraph = null;
+    pooled = null;
     drain();
   }
 
@@ -127,11 +150,15 @@ public class GraphSearcherPool {
   }
 
   private void drain() {
-    GraphSearcher searcher;
-    while ((searcher = idle.poll()) != null) {
+    for (Pooled entry; (entry = poll()) != null; )
+      close(entry.searcher);
+  }
+
+  private Pooled poll() {
+    final Pooled entry = idle.poll();
+    if (entry != null)
       idleCount.decrementAndGet();
-      close(searcher);
-    }
+    return entry;
   }
 
   private static void close(final GraphSearcher searcher) {

--- a/engine/src/main/java/com/arcadedb/index/vector/GraphSearcherPool.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/GraphSearcherPool.java
@@ -59,6 +59,10 @@ import java.util.logging.Level;
 public class GraphSearcherPool {
   /**
    * The (graph, epoch) pair the pool currently serves. Held as one value so it can never be read half-updated.
+   * <p>
+   * Both this and {@link Pooled} match their graph by <b>reference</b>, never by {@code equals}: a rebuild
+   * publishes a new {@code ImmutableGraphIndex} instance, and a searcher's {@code View} is bound to the exact
+   * instance it was built from, so two distinct instances are never interchangeable however equal their contents.
    */
   private record Identity(ImmutableGraphIndex graph, long epoch) {
   }
@@ -104,6 +108,13 @@ public class GraphSearcherPool {
         return entry.searcher;
       // Pooled under an identity this caller does not share: it was queued by a release racing an identity
       // change, after the sweep for that change had already passed. Reclaim it and keep looking.
+      //
+      // Matching against the caller's own pair rather than the current one is deliberate. Should the identity
+      // move on again while this loop runs, an entry a concurrent release queued under that newer identity is
+      // closed here even though it was still usable. That costs one searcher reallocation under a rebuild
+      // storm and can never return a wrong searcher, which is the trade-off a best-effort sweep is allowed to
+      // make; re-reading the published identity per iteration would put a volatile read on the search path to
+      // buy nothing but pooling efficiency.
       close(entry.searcher);
     }
     return new GraphSearcher(graph);

--- a/engine/src/test/java/com/arcadedb/index/vector/GraphSearcherPoolStaleGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/GraphSearcherPoolStaleGraphTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.GraphSearcher;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5648: {@link GraphSearcherPool} could hand out a {@link GraphSearcher} bound to a
+ * graph that had already been replaced.
+ * <p>
+ * The interleaving that produces it needs a {@code release} running under the outgoing identity to land its
+ * searcher in the idle queue after the incoming {@code borrow} has drained but before it has published, which is
+ * a two-instruction window that no amount of thread scheduling reproduces reliably. These tests therefore assert
+ * the state that window leaves behind - the queue holding an entry pooled under one identity while the pool
+ * advertises another - and require the pool to never hand that entry out. That state is unreachable through the
+ * public API once the fix is in, so it is planted directly on the private field.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphSearcherPoolStaleGraphTest {
+  private static final VectorTypeSupport VTS        = VectorizationProvider.getInstance().getVectorTypeSupport();
+  private static final int               DIMENSIONS = 8;
+
+  private ImmutableGraphIndex graphOne;
+  private ImmutableGraphIndex graphTwo;
+
+  @BeforeEach
+  void buildGraphs() throws Exception {
+    graphOne = buildGraph(11);
+    graphTwo = buildGraph(22);
+  }
+
+  @AfterEach
+  void closeGraphs() throws Exception {
+    graphOne.close();
+    graphTwo.close();
+  }
+
+  @Test
+  void borrowNeverHandsOutASearcherPooledUnderAReplacedGraph() throws Exception {
+    final GraphSearcherPool pool = new GraphSearcherPool(4);
+
+    // The pool starts serving graphOne, and a searcher built for it goes back into the idle queue.
+    final GraphSearcher stale = pool.borrow(graphOne, 1L);
+    pool.release(stale, graphOne, 1L);
+    assertThat(pool.size()).isOne();
+
+    // A rebuild swapped the graph. This is the state the #5648 window leaves: the identity moved on, but the
+    // searcher a concurrent release put back is still sitting in the queue, still bound to graphOne.
+    plantIdentity(pool, graphTwo, 2L);
+
+    final GraphSearcher borrowed = pool.borrow(graphTwo, 2L);
+    try {
+      assertThat(borrowed).as("a searcher built for the replaced graph must never be handed out").isNotSameAs(stale);
+    } finally {
+      closeQuietly(borrowed);
+    }
+
+    assertThat(pool.size()).as("the stale entry must be reclaimed, not left occupying the pool").isZero();
+  }
+
+  @Test
+  void borrowNeverHandsOutASearcherPooledUnderAStaleEpoch() throws Exception {
+    final GraphSearcherPool pool = new GraphSearcherPool(4);
+
+    // Same graph instance, but the index mutated underneath it: the live-builder path keeps serving searches from
+    // one graph object while it grows, so identity alone cannot tell the pooled view its contents moved.
+    final GraphSearcher stale = pool.borrow(graphOne, 1L);
+    pool.release(stale, graphOne, 1L);
+
+    plantIdentity(pool, graphOne, 2L);
+
+    final GraphSearcher borrowed = pool.borrow(graphOne, 2L);
+    try {
+      assertThat(borrowed).as("a searcher pooled under an older epoch must never be handed out").isNotSameAs(stale);
+    } finally {
+      closeQuietly(borrowed);
+    }
+
+    assertThat(pool.size()).isZero();
+  }
+
+  @Test
+  void everyStaleEntryIsReclaimedBeforeAFreshSearcherIsBuilt() throws Exception {
+    final GraphSearcherPool pool = new GraphSearcherPool(4);
+
+    // Borrow before releasing anything, so three distinct searchers end up queued rather than one recycled.
+    final List<GraphSearcher> staleSearchers = new ArrayList<>();
+    for (int i = 0; i < 3; i++)
+      staleSearchers.add(pool.borrow(graphOne, 1L));
+    for (final GraphSearcher searcher : staleSearchers)
+      pool.release(searcher, graphOne, 1L);
+    assertThat(pool.size()).isEqualTo(3);
+
+    plantIdentity(pool, graphTwo, 2L);
+
+    final GraphSearcher borrowed = pool.borrow(graphTwo, 2L);
+    try {
+      assertThat(staleSearchers).as("no queued entry bound to the old graph may escape").doesNotContain(borrowed);
+    } finally {
+      closeQuietly(borrowed);
+    }
+
+    assertThat(pool.size()).as("a borrow must drop every stale entry it walks past").isZero();
+  }
+
+  @Test
+  void aReleaseUnderASupersededIdentityIsNotPooled() {
+    final GraphSearcherPool pool = new GraphSearcherPool(4);
+
+    final GraphSearcher onOldGraph = pool.borrow(graphOne, 1L);
+
+    // A borrow for the new graph publishes the new identity, so the in-flight search on the old one must find its
+    // searcher rejected when it finally returns it.
+    closeQuietly(pool.borrow(graphTwo, 2L));
+    pool.release(onOldGraph, graphOne, 1L);
+
+    assertThat(pool.size()).as("a searcher returned under a superseded identity must be closed, not pooled").isZero();
+  }
+
+  @Test
+  void anUnchangedIdentityStillReusesThePooledSearcher() {
+    final GraphSearcherPool pool = new GraphSearcherPool(4);
+
+    final GraphSearcher first = pool.borrow(graphOne, 1L);
+    pool.release(first, graphOne, 1L);
+
+    final GraphSearcher second = pool.borrow(graphOne, 1L);
+    try {
+      assertThat(second).as("the identity check must not become so strict that pooling stops working").isSameAs(first);
+    } finally {
+      closeQuietly(second);
+    }
+  }
+
+  /**
+   * Writes the pool's published identity without going through {@code borrow}, so the idle queue keeps the entries
+   * pooled under the previous one. That is exactly what a {@code release} racing an identity change leaves behind,
+   * and it is deliberately not reachable through the public API.
+   */
+  private static void plantIdentity(final GraphSearcherPool pool, final ImmutableGraphIndex graph, final long epoch)
+      throws Exception {
+    final Field field = GraphSearcherPool.class.getDeclaredField("pooled");
+    field.setAccessible(true);
+    final Constructor<?> constructor = field.getType().getDeclaredConstructors()[0];
+    constructor.setAccessible(true);
+    field.set(pool, constructor.newInstance(graph, epoch));
+  }
+
+  private static ImmutableGraphIndex buildGraph(final long seed) throws Exception {
+    final Random random = new Random(seed);
+    final List<VectorFloat<?>> vectors = new ArrayList<>();
+    for (int i = 0; i < 16; i++) {
+      final float[] values = new float[DIMENSIONS];
+      for (int d = 0; d < DIMENSIONS; d++)
+        values[d] = random.nextFloat();
+      vectors.add(VTS.createFloatVector(values));
+    }
+
+    final ListRandomAccessVectorValues ravv = new ListRandomAccessVectorValues(vectors, DIMENSIONS);
+    try (final GraphIndexBuilder builder = new GraphIndexBuilder(ravv, VectorSimilarityFunction.COSINE, 8, 16, 1.2f, 1.2f,
+        false)) {
+      return builder.build(ravv);
+    }
+  }
+
+  private static void closeQuietly(final GraphSearcher searcher) {
+    try {
+      searcher.close();
+    } catch (final Exception ignored) {
+      // Nothing this test asserts depends on the view releasing cleanly.
+    }
+  }
+}


### PR DESCRIPTION
Closes #5648

`GraphSearcherPool` guarded reuse with two independent volatile fields and `borrow` drained the idle queue *before* publishing them, so a `release` running in that window still matched the outgoing pair and offered its searcher back after the drain had swept past. The next `borrow` matched the newly published pair and polled that searcher straight out, running a search over the new graph on a `GraphSearcher` whose `View` was captured from the old one - silently wrong neighbours, no exception. The queue carried no record of which identity an entry belonged to, so `borrow` could not tell a valid entry from a stale one, and draining is inherently racy against a concurrent `release`. The fix stamps every queued searcher with the identity it was pooled under and has `borrow` verify it on the way out; the published `(graph, epoch)` pair also becomes a single immutable record so it can no longer be read half-updated, and it is now published *before* the drain. The sweep and `release`'s check are kept purely as early reclamation.

## Test plan

- [x] New `GraphSearcherPoolStaleGraphTest` (5 tests) covers the graph-swap case, the stale-epoch case (live-builder path, same graph instance), full reclamation of every stale entry, publish-before-drain, and a guard that ordinary pooling still reuses searchers.
- [x] Proven to fail first: pointed at the unfixed `pooledGraph`/`pooledEpoch` fields, the three reproducers fail with `Expected not same: GraphSearcher@...` - the pool returning the searcher bound to the replaced graph. The two guard tests pass before and after.
- [x] `LSMVectorIndexSearcherPoolTest`, `LSMVectorIndexSearcherEpochTest`, `LSMVectorIndexConcurrentRebuildVisibilityTest`, `DeltaScanVectorSearchTest`, `LSMVectorIndexRebuildTest` - 24/24 pass.
- [x] Full `com.arcadedb.index.vector` package (benchmark/slow excluded) - 198/198 pass.

The exact interleaving is a two-instruction window that thread scheduling cannot reproduce reliably, so the tests assert the state it leaves behind (an entry pooled under one identity while the pool advertises another) and require the pool never to hand it out. That state is unreachable through the public API once the fix is in, so it is planted on the private identity field by reflection, mirroring `LSMVectorIndexSearcherEpochTest`.

Note: `searcherPoolEpoch()` was made strictly monotonic separately in #5621; this is about publication order and the trustworthiness of the queue's contents, not the epoch value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)