### PR TITLE
fix(engine) #5649: take the absolute value of a Duration on the whole, not its parts

### DIFF
--- a/docs/5649-sql-abs-duration-sign.md
+++ b/docs/5649-sql-abs-duration-sign.md
@@ -131,6 +131,32 @@ every other argument type are untouched.
 
 The Cypher-side `AbsFunction` is a separate class and does not have this branch, so it is unaffected.
 
+## Review
+
+PR: https://github.com/ArcadeData/arcadedb/pull/5654
+
+### Cycle 1 - `1586a4545`
+
+`claude[bot]` reviewed and recommended merging. Nothing blocking, and the two points raised under
+"minor / optional" both explicitly ask for no change, so no code moved this cycle. Nothing was deferred.
+
+**1. "The unit tests overlap somewhat with `fromQueryOverNegativeDuration`" - no action, and the review
+agrees it is desirable.** The overlap is deliberate: the unit tests pin the function's contract per
+defect class, the query test pins that the fix is actually reachable through the SQL engine rather than
+only through a direct call. For a silent-corruption regression with no prior coverage, losing either
+side would leave a real gap.
+
+**2. "The two `absExact` overloads carry different failure semantics - equality guard vs. try/catch" -
+no change, flagged for future readers only.** This is inherent to the types. A fixed-width integer has a
+single MIN_VALUE known statically, so an equality guard states the boundary exactly and costs nothing on
+the hot path. `Duration` has no such constant to compare against, and deriving the boundary by hand
+would restate `Duration`'s own normalization rules, which is precisely the reasoning the original bug
+got wrong. Letting `negated()` be the authority on what it cannot represent, and translating its
+exception, is the safer construction even though it reads less symmetrically.
+
+The review also noted it could not run Maven in its sandbox and relied on the reported suite results.
+Those were run locally and are recorded under "Test results" above, each with exit 0.
+
 ## Follow-ups
 
 None. Unlike #5647 there is no remaining silent-wrap path here: the one unrepresentable input now

--- a/docs/5649-sql-abs-duration-sign.md
+++ b/docs/5649-sql-abs-duration-sign.md
@@ -1,0 +1,137 @@
+# #5649 - SQL `abs()` mishandles the sign of a `Duration`
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5649
+
+## Root cause
+
+`SQLFunctionAbsoluteValue.execute` handled the `Duration` branch by taking the duration apart into its
+`toSecondsPart()` / `toNanosPart()` components, testing each for negativity, then recombining the two
+magnitudes with `Duration.ofSeconds(Math.abs(seconds), Math.abs(nanos))`.
+
+Both halves are wrong, and for reasons that compound:
+
+- `toSecondsPart()` is the seconds component **within the minute** (`(int) (seconds % 60)`), not the
+  duration's total seconds. Recombining it with the nanos part therefore silently drops every whole
+  minute of the input.
+- `Duration` normalizes a negative value as a **negative seconds field plus a positive nanos
+  adjustment**. `toNanosPart()` is consequently never negative, so the `nanos > -1` half of the guard
+  is always true, and taking the two parts' magnitudes independently does not reconstruct the
+  magnitude of the whole.
+
+## Behaviour measured on `main` before the fix
+
+Probed directly against the pre-fix expression. `truth` is `d.isNegative() ? d.negated() : d`.
+
+| input | pre-fix result | correct | |
+|---|---|---|---|
+| `PT-0.5S` | `PT1.5S` | `PT0.5S` | wrong |
+| `PT-1M` (-60s) | `PT-1M` | `PT1M` | wrong - **returns a negative "absolute value"** |
+| `PT-2M` (-120s) | `PT-2M` | `PT2M` | wrong - **returns a negative "absolute value"** |
+| `PT-1M-29.5S` | `PT30.5S` | `PT1M29.5S` | wrong - whole minute dropped |
+| `PT-0.000000001S` | `PT1.999999999S` | `PT0.000000001S` | wrong |
+| `PT-5S` | `PT5S` | `PT5S` | ok |
+| `PT-1S` | `PT1S` | `PT1S` | ok |
+| `PT0S` | `PT0S` | `PT0S` | ok |
+| positive durations | unchanged | unchanged | ok |
+
+So the branch was correct only for negative durations whose magnitude is a whole number of seconds
+strictly under one minute. Everything else was either off by up to a minute or, for exact multiples of
+a minute, returned the input unchanged - a *negative* result from `abs()`.
+
+### Correction to the issue's own analysis
+
+The issue predicted that for `Duration.ofNanos(-500_000_000)` "the seconds part is `0`, so
+`seconds > -1` holds". Measured, `toSecondsPart()` is `-1` for that input, not `0`, so the guard
+does **not** hold and the else branch fires. The value is still wrong (`PT1.5S`), just by the
+recombination defect rather than the guard defect. The guard defect is real but bites on a different
+input class than the issue guessed: exact multiples of a minute (`-60s`, `-120s`), where both parts
+are `0` and the negative input is handed straight back.
+
+The issue also understated the blast radius: it framed this as an edge case in `(-1s, 0s)`, when in
+fact every negative duration of a minute or more is wrong too.
+
+## Fix
+
+Replace the whole branch with the direct expression of the intent, in a private `absExact(Duration)`
+overload sitting next to the existing integral one so both unrepresentable-magnitude cases read the same:
+
+```java
+private static Duration absExact(final Duration duration) {
+  if (!duration.isNegative())
+    return duration;
+
+  try {
+    return duration.negated();
+  } catch (final ArithmeticException e) {
+    throw new ArithmeticErrorException("duration overflow", e);
+  }
+}
+```
+
+`Duration.abs()` (Java 18+) would read slightly better than `negated()`, but `negated()` keeps the
+branch buildable on the `java17` branch and the two are equivalent.
+
+### Overflow boundary
+
+`Duration`'s range is *almost* symmetric: negating `Duration.ofSeconds(Long.MIN_VALUE, 0)` overflows,
+because the magnitude needs `Long.MAX_VALUE + 1` seconds. `negated()` signals that with a raw
+`java.lang.ArithmeticException("Exceeds capacity of Duration")`, which would escape the query as an
+HTTP 500 - the exact defect class #5545 and #5647 are about. The value is reachable from SQL via
+`duration('-9223372036854775808', 'second')`, so it is guarded and reported as
+`ArithmeticErrorException("duration overflow")`, matching how the four integral MIN_VALUEs are already
+handled in the same function and answering 400 instead of 500.
+
+Note this is exactly *one* input, not a range: `Duration.ofSeconds(Long.MIN_VALUE, 500_000_000)`
+negates fine, since the positive nanos adjustment pulls the magnitude back inside `Long`.
+
+## Changes
+
+- `engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java` - the `Duration`
+  branch now delegates to a private `absExact(Duration)` overload alongside the existing integral one.
+- `engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValueTest.java` - 8 new tests
+  appended. No existing test was modified or removed.
+
+## Test results
+
+The branch had zero coverage before this change, so the tests were written first and proven to fail
+against the unfixed code.
+
+**Before the fix** - `SQLFunctionAbsoluteValueTest`, 39 tests, **5 failures**, each reproducing a
+distinct class from the table above:
+
+| test | expected | actual before fix |
+|---|---|---|
+| `negativeSubSecondDurationDoesNotGainASecond` | `0.5S` | `1.5S` |
+| `negativeWholeMinuteDurationIsNotReturnedNegative` | `1M` | `-1M` |
+| `negativeDurationLongerThanAMinuteKeepsItsMinutes` | `1M29.5S` | `30.5S` |
+| `fromQueryOverNegativeDuration` | `1M30S` | `30S` |
+| `durationOverflowIsAnArithmeticError` | throws | no throw |
+
+The remaining 3 new tests (`positiveDurationIsReturnedUnchanged`,
+`negativeWholeSecondDurationUnderAMinuteStillWorks`, `zeroDuration`) pass both before and after by
+design - they pin the cases the old branch already handled, so the fix is demonstrably a strict
+improvement rather than a trade of one failure set for another.
+
+**After the fix**, all exit 0:
+
+| suite | result |
+|---|---|
+| `SQLFunctionAbsoluteValueTest` | 39/39 |
+| `com.arcadedb.function.**` | 1082/1082 |
+| `com.arcadedb.query.sql.**` | 2315/2315 (8 skipped) |
+| `com.arcadedb.query.opencypher.**` | 7785/7785 (98 skipped) |
+| `TypeConversionTest` | 12/12 |
+
+## Impact
+
+Any query calling `abs()` on a negative `Duration` could return a wrong magnitude, and for exact
+multiples of a minute a negative one. The result is a plain value that can be persisted by
+`UPDATE ... SET`, so this was silent data corruption rather than a display wart. Positive durations and
+every other argument type are untouched.
+
+The Cypher-side `AbsFunction` is a separate class and does not have this branch, so it is unaffected.
+
+## Follow-ups
+
+None. Unlike #5647 there is no remaining silent-wrap path here: the one unrepresentable input now
+fails the query.

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
@@ -36,6 +36,8 @@ import java.time.Duration;
  * Because the result keeps the argument's type, every fixed-width signed type
  * has exactly one input - its MIN_VALUE - whose magnitude it cannot represent;
  * those fail the query rather than returning a negative "absolute value".
+ * Duration has the same single unrepresentable input at Long.MIN_VALUE seconds
+ * with no nanos, and is treated the same way.
  *
  * @author Michael MacFadden
  */
@@ -69,13 +71,7 @@ public class SQLFunctionAbsoluteValue extends SQLFunctionMathAbstract {
     } else if (inputValue instanceof Float float1) {
       result = Math.abs(float1);
     } else if (inputValue instanceof Duration duration) {
-      final int seconds = duration.toSecondsPart();
-      final long nanos = duration.toNanosPart();
-      if (seconds > -1 && nanos > -1)
-        result = inputValue;
-      else {
-        result = Duration.ofSeconds(Math.abs(seconds), Math.abs(nanos));
-      }
+      result = absExact(duration);
     } else {
       throw new IllegalArgumentException("Argument to absolute value must be a number");
     }
@@ -102,6 +98,28 @@ public class SQLFunctionAbsoluteValue extends SQLFunctionMathAbstract {
     if (value == minValue)
       throw new ArithmeticErrorException(typeName + " overflow");
     return Math.abs(value);
+  }
+
+  /**
+   * A {@code Duration} carries its sign on the whole, not on its components: it is normalized as a possibly
+   * negative seconds field plus an always non-negative nanos adjustment, and {@code toSecondsPart()} reports
+   * the seconds within the minute rather than the total. Neither part is therefore a usable signal on its own,
+   * and taking the two magnitudes independently does not reconstruct the magnitude of the whole.
+   * <p>
+   * The range is symmetric apart from a single value: negating a duration of exactly {@code Long.MIN_VALUE}
+   * seconds and no nanos would need {@code Long.MAX_VALUE + 1} seconds. That is the same unrepresentable
+   * magnitude the integral types have at their MIN_VALUE, so it is reported the same way rather than being
+   * allowed to escape as a raw {@link ArithmeticException}.
+   */
+  private static Duration absExact(final Duration duration) {
+    if (!duration.isNegative())
+      return duration;
+
+    try {
+      return duration.negated();
+    } catch (final ArithmeticException e) {
+      throw new ArithmeticErrorException("duration overflow", e);
+    }
   }
 
   public boolean aggregateResults() {

--- a/engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValueTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValueTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -356,6 +357,118 @@ class SQLFunctionAbsoluteValueTest {
           rs.next().getProperty("abs");
         }
       }).isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("long overflow");
+    });
+  }
+
+  /**
+   * Issue #5649. A positive duration has to come back untouched whatever its magnitude. The
+   * one-minute-and-over cases matter because the old implementation reasoned about
+   * {@code toSecondsPart()}, which is the seconds component within the minute rather than the whole.
+   */
+  @Test
+  void positiveDurationIsReturnedUnchanged() {
+    final Duration[] positives = { Duration.ofSeconds(5), Duration.ofSeconds(90), Duration.ofNanos(500_000_000L),
+        Duration.ofSeconds(90, 500_000_000L), Duration.ofHours(3) };
+
+    for (final Duration positive : positives) {
+      function.execute(null, null, null, new Object[] { positive }, null);
+      assertThat(function.getResult()).isInstanceOf(Duration.class).isEqualTo(positive);
+    }
+  }
+
+  /**
+   * Issue #5649, the headline case: a negative duration whose magnitude is under a second. The old
+   * implementation recombined {@code Math.abs(toSecondsPart())} with {@code Math.abs(toNanosPart())},
+   * and because {@code Duration} normalizes a negative value as negative seconds plus a *positive*
+   * nanos adjustment, {@code PT-0.5S} is stored as (-1s, +500000000ns) and came back as {@code PT1.5S}.
+   */
+  @Test
+  void negativeSubSecondDurationDoesNotGainASecond() {
+    function.execute(null, null, null, new Object[] { Duration.ofNanos(-500_000_000L) }, null);
+    assertThat(function.getResult()).isEqualTo(Duration.ofNanos(500_000_000L));
+
+    function.execute(null, null, null, new Object[] { Duration.ofNanos(-1) }, null);
+    assertThat(function.getResult()).isEqualTo(Duration.ofNanos(1));
+  }
+
+  /**
+   * Issue #5649, the worst class. For an exact multiple of a minute both components are zero, so the
+   * old {@code seconds > -1 && nanos > -1} guard held for a negative input and handed it straight back:
+   * {@code abs()} returned a negative duration.
+   */
+  @Test
+  void negativeWholeMinuteDurationIsNotReturnedNegative() {
+    final Duration[] negatives = { Duration.ofSeconds(-60), Duration.ofSeconds(-120), Duration.ofHours(-2) };
+
+    for (final Duration negative : negatives) {
+      function.execute(null, null, null, new Object[] { negative }, null);
+      assertThat(function.getResult()).isEqualTo(negative.negated());
+      assertThat(((Duration) function.getResult()).isNegative()).isFalse();
+    }
+  }
+
+  /**
+   * Issue #5649. Recombining the two parts drops every whole minute of the input, so {@code PT-1M-29.5S}
+   * used to come back as {@code PT30.5S} - a magnitude a full minute short of the truth.
+   */
+  @Test
+  void negativeDurationLongerThanAMinuteKeepsItsMinutes() {
+    function.execute(null, null, null, new Object[] { Duration.ofSeconds(-90, 500_000_000L) }, null);
+    assertThat(function.getResult()).isEqualTo(Duration.ofSeconds(89, 500_000_000L));
+  }
+
+  /**
+   * Issue #5649. The cases the old branch already got right, kept so the fix is pinned as a strict
+   * improvement rather than a swap of one set of failures for another.
+   */
+  @Test
+  void negativeWholeSecondDurationUnderAMinuteStillWorks() {
+    function.execute(null, null, null, new Object[] { Duration.ofSeconds(-5) }, null);
+    assertThat(function.getResult()).isEqualTo(Duration.ofSeconds(5));
+
+    function.execute(null, null, null, new Object[] { Duration.ofSeconds(-1) }, null);
+    assertThat(function.getResult()).isEqualTo(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void zeroDuration() {
+    function.execute(null, null, null, new Object[] { Duration.ZERO }, null);
+    assertThat(function.getResult()).isEqualTo(Duration.ZERO);
+  }
+
+  /**
+   * Issue #5649. {@code Duration}'s range is symmetric except for this single value: negating
+   * {@code Duration.ofSeconds(Long.MIN_VALUE, 0)} needs {@code Long.MAX_VALUE + 1} seconds, which
+   * {@code Duration} cannot hold. Left unguarded it escapes as a raw {@code java.lang.ArithmeticException}
+   * and answers HTTP 500; it has to be the same {@link ArithmeticErrorException} the four integral
+   * MIN_VALUEs already raise. Note the boundary is exactly one value - a positive nanos adjustment pulls
+   * the magnitude back inside range, which the second half of this test pins.
+   */
+  @Test
+  void durationOverflowIsAnArithmeticError() {
+    assertThatThrownBy(() -> function.execute(null, null, null, new Object[] { Duration.ofSeconds(Long.MIN_VALUE) }, null))
+        .isInstanceOf(ArithmeticErrorException.class)
+        .hasMessageContaining("duration overflow");
+
+    final Duration representable = Duration.ofSeconds(Long.MIN_VALUE, 500_000_000L);
+    function.execute(null, null, null, new Object[] { representable }, null);
+    assertThat(function.getResult()).isEqualTo(representable.negated());
+  }
+
+  /**
+   * Issue #5649 end to end through the SQL engine, where the duration is built by {@code duration()}
+   * rather than handed to the function directly.
+   */
+  @Test
+  void fromQueryOverNegativeDuration() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testAbsFunctionDuration", db -> {
+      try (final ResultSet rs = db.query("sql", "select abs(duration(-90, 'second')) as abs")) {
+        assertThat(rs.next().<Duration>getProperty("abs")).isEqualTo(Duration.ofSeconds(90));
+      }
+
+      try (final ResultSet rs = db.query("sql", "select abs(duration(-500, 'millisecond')) as abs")) {
+        assertThat(rs.next().<Duration>getProperty("abs")).isEqualTo(Duration.ofMillis(500));
+      }
     });
   }
 }


### PR DESCRIPTION
Closes #5649

`SQLFunctionAbsoluteValue` took a `Duration` apart into `toSecondsPart()` / `toNanosPart()`, tested each component for negativity, then recombined the two magnitudes with `Duration.ofSeconds(Math.abs(seconds), Math.abs(nanos))`. Both halves are wrong: `toSecondsPart()` is the seconds *within the minute*, so recombining drops every whole minute of the input, and `Duration` normalizes a negative value as negative seconds plus an always-positive nanos adjustment, so `toNanosPart()` is never negative and the two magnitudes taken independently do not reconstruct the magnitude of the whole. The branch is replaced with `duration.isNegative() ? duration.negated() : duration`, guarded for the single unrepresentable input.

Measured on `main` before the fix, the branch was correct only for negative durations whose magnitude is a whole number of seconds strictly under one minute:

| input | before | correct |
|---|---|---|
| `PT-0.5S` | `PT1.5S` | `PT0.5S` |
| `PT-1M` | `PT-1M` (negative!) | `PT1M` |
| `PT-2M` | `PT-2M` (negative!) | `PT2M` |
| `PT-1M-29.5S` | `PT30.5S` | `PT1M29.5S` |
| `PT-0.000000001S` | `PT1.999999999S` | `PT0.000000001S` |

The exact-multiple-of-a-minute rows are the worst class: both components are `0`, so the old `seconds > -1 && nanos > -1` guard held for a negative input and handed it straight back, i.e. `abs()` returned a negative duration. The result is a plain value that `UPDATE ... SET` will persist, so this was silent data corruption rather than a display wart.

Two notes on scope, both wider than the issue text predicted. The issue guessed `toSecondsPart()` would be `0` for `Duration.ofNanos(-500_000_000)`; measured it is `-1`, so that input fails via the recombination defect rather than the guard defect. And the issue framed the blast radius as `(-1s, 0s)`, when in fact every negative duration of a minute or more is wrong too.

The one boundary that does need a guard: negating a duration of exactly `Long.MIN_VALUE` seconds with no nanos overflows and `negated()` raises a raw `java.lang.ArithmeticException`, which would escape as an HTTP 500 - the defect class of #5545 / #5647. It is reachable from SQL via `duration('-9223372036854775808', 'second')`, so it now raises `ArithmeticErrorException("duration overflow")` exactly as the four integral MIN_VALUEs in the same function already do. That is a single input, not a range: a positive nanos adjustment pulls the magnitude back inside `Long`, and a test pins that.

The branch had zero test coverage before this change. `AbsFunction` on the Cypher side is a separate class without this branch and is unaffected.

## Test plan

- [x] 8 tests appended to `SQLFunctionAbsoluteValueTest`; no existing test modified or deleted
- [x] Proven to fail first against the unfixed code: 5 of the 8 fail, one per defect class (`0.5S`→`1.5S`, `1M`→`-1M`, `1M29.5S`→`30.5S`, query `1M30S`→`30S`, overflow does not throw)
- [x] The other 3 (`positiveDurationIsReturnedUnchanged`, `negativeWholeSecondDurationUnderAMinuteStillWorks`, `zeroDuration`) pass before and after by design, pinning the cases the old branch already handled so the fix is a strict improvement
- [x] End-to-end through the SQL engine via `abs(duration(-90, 'second'))`, not just the function in isolation
- [x] `SQLFunctionAbsoluteValueTest` 39/39, exit 0
- [x] `com.arcadedb.function.**` 1082/1082, exit 0
- [x] `com.arcadedb.query.sql.**` 2315/2315, exit 0
- [x] `com.arcadedb.query.opencypher.**` 7785/7785, exit 0
- [x] `TypeConversionTest` 12/12, exit 0