### PR TITLE
docs(engine) #5626: say what bounds the parse-time subquery body build

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -1853,9 +1853,14 @@ class CypherExpressionBuilder {
    * builds the body <i>as written</i> alongside it, off the existing sub-tree rather than by re-lexing the text.
    * <p>
    * What that costs is a full statement build over an existing sub-tree, not a bare tree walk: the visit goes through
-   * the same {@link CypherASTBuilder} pipeline any statement does, rewriters included. It is bounded by the size of
-   * the body, it is paid once per distinct query text since the plan is cached, and it buys the checks a body they
-   * can walk - but a reader sizing it should read it as "one more statement built", not "one traversal".
+   * the same {@link CypherASTBuilder} pipeline any statement does, rewriters included. A reader sizing it should read
+   * it as "one more statement built", not "one traversal".
+   * <p>
+   * Two things bound it. It is paid once per distinct query text, because {@code CypherStatementCache} keys the whole
+   * parse - this AST included, since it hangs off the statement - on the query string itself. And nesting adds rather
+   * than multiplies: a body reached from here is built by its own visit, and the enclosing statement holds the
+   * subquery only as an expression, so a subquery inside a subquery is built once as part of its parent's body, not
+   * again for every level above it. The total is linear in the text.
    * <p>
    * A body written as a bare pattern - {@code EXISTS { (n)-[:KNOWS]->(m) }} - has no {@code queryWithLocalDefinitions}
    * of its own and is wrapped into the {@code MATCH} the executor synthesizes for it anyway.


### PR DESCRIPTION
Follow-up to #5642, which merged before this last review point was answered.

The `parseSubqueryBody` Javadoc said the body AST is "paid once per distinct query text" without saying what makes that true, and said nothing about what nesting does to the cost. A reviewer on #5642 asked for a confirmation on both, since the cost compounds with depth if the answer is the wrong one. It is not:

- **Once per distinct query text** holds because `CypherStatementCache` is a `Map<String, ParsedQuery>` keyed on the query string itself, and this AST hangs off the statement inside `ParsedQuery` - so it rides that cache rather than needing one of its own.
- **Nesting adds rather than multiplies.** A body reached from `parseSubqueryBody` is built by its own visit, and the enclosing statement holds the subquery only as an expression - it never descends into the body a second time. So `EXISTS { ... EXISTS { ... } }` builds the inner body once, as part of its parent's build, not again for every level above it. Total work is linear in the text, not exponential in depth.

Javadoc only, no behaviour change. A claim about a cache belongs next to the code that relies on it rather than only in a review thread, which is why this is a commit and not a reply.

Closes the last open point from the #5642 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8C35vrQkW1y1gaEvWzRPc