### PR TITLE
perf(engine) #5660: filter a bound-target expansion on the segment's neighbour pointer

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/EdgeIterator.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeIterator.java
@@ -56,6 +56,13 @@ public class EdgeIterator extends ResettableIteratorBase<Edge> {
         nextEdgeRID = currentContainer.getRID(currentPosition);
         nextVertexRID = currentContainer.getRID(currentPosition);
 
+        if (!matchesNeighborFilter(nextVertexRID)) {
+          // FILTER IT OUT ON THE POINTER READ FROM THE SEGMENT, BEFORE ANY RECORD IS TOUCHED
+          nextEdgeRID = null;
+          nextVertexRID = null;
+          continue;
+        }
+
         // VALIDATE A NON-LIGHTWEIGHT EDGE HERE SO A DANGLING POINTER (edge record removed but the link still in
         // the segment) IS SKIPPED WHILE PEEKING, KEEPING hasNext()/next() CONSISTENT WITH THE Iterator CONTRACT.
         // OTHERWISE next() WOULD SKIP THE RECORD AND THROW NoSuchElementException WHEN THE SEGMENT ENDS - WHICH

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -69,6 +69,24 @@ public class EdgeLinkedList {
     return new EdgeIteratorFilter((DatabaseInternal) vertex.getDatabase(), vertex, direction, lastSegment, edgeTypes);
   }
 
+  /**
+   * Same as {@link #edgeIterator(String...)} but yielding only the edges that reach the given
+   * neighbour vertex.
+   * <p>
+   * The filter is applied to the neighbour pointer stored beside each edge pointer in the segment,
+   * so a non-matching edge is discarded without its record being loaded. Use this instead of
+   * iterating every edge and comparing endpoints whenever the far end is already known.
+   */
+  public Iterator<Edge> edgeIteratorConnectedTo(final RID neighbor, final String... edgeTypes) {
+    final ResettableIteratorBase<Edge> iterator;
+    if (edgeTypes == null || edgeTypes.length == 0)
+      iterator = new EdgeIterator(lastSegment, vertex.getIdentity(), direction);
+    else
+      iterator = new EdgeIteratorFilter((DatabaseInternal) vertex.getDatabase(), vertex, direction, lastSegment, edgeTypes);
+    iterator.setNeighborVertexFilter(neighbor);
+    return iterator;
+  }
+
   public Iterator<Vertex> vertexIterator(final String... edgeTypes) {
     if (edgeTypes == null || edgeTypes.length == 0)
       return new VertexIterator((DatabaseInternal) vertex.getDatabase(), lastSegment);

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -794,6 +794,9 @@ public class GraphEngine {
 
     switch (direction) {
       case BOTH: {
+        // No countEntries override here, unlike the BOTH branch of getEdges: that one delegates to
+        // EdgeLinkedList.count, which filters by edge type only. There is no neighbour-keyed count, so an
+        // override could do nothing cheaper than the walk MultiIterator already falls back to.
         final MultiIterator<Edge> result = new MultiIterator<>();
         final EdgeLinkedList outEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.OUT);
         if (outEdges != null)

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -765,6 +765,68 @@ public class GraphEngine {
   }
 
   /**
+   * Returns the edges between two known vertices, without materialising the ones that do not reach the target.
+   * <p>
+   * This is the iterating counterpart of {@link #isVertexConnectedTo(VertexInternal, Identifiable, Vertex.DIRECTION, String)}:
+   * use it when the far end of the pattern is already pinned and the edges still have to be inspected - typically to
+   * apply a filter on the edge's own properties. Compared to walking {@link #getEdges(VertexInternal, Vertex.DIRECTION,
+   * String...)} and comparing endpoints afterwards, the rejection happens on the pointers held in the edge segment, so
+   * the cost per non-matching edge drops from a record load plus a property deserialization to two integer comparisons.
+   * On a super-node that is the difference between the probe being unusable and being free.
+   *
+   * @param target the vertex the returned edges must reach; must not be null
+   */
+  public Iterator<Edge> getEdgesConnectedTo(final VertexInternal vertex, final Vertex.DIRECTION direction,
+                                            final Identifiable target, final String... edgeTypes) {
+    if (direction == null)
+      throw new IllegalArgumentException("Direction is null");
+    if (target == null)
+      throw new IllegalArgumentException("Target vertex is null");
+
+    final RID targetRID = target.getIdentity();
+    // The edge-list head pointers live in the vertex record, so they have to be read from the instance the
+    // running transaction has, not from whatever snapshot the caller happens to hold: a vertex loaded before
+    // an edge was appended still points at the previous head and would hide the newest edges. The public
+    // Vertex.getEdges() does this resolution for its callers; a caller reaching the engine directly does not.
+    final VertexInternal source = getMostUpdatedVertex(vertex);
+
+    switch (direction) {
+      case BOTH: {
+        final MultiIterator<Edge> result = new MultiIterator<>();
+        final EdgeLinkedList outEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.OUT);
+        if (outEdges != null)
+          result.addIterator(outEdges.edgeIteratorConnectedTo(targetRID, edgeTypes));
+        final EdgeLinkedList inEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.IN);
+        if (inEdges != null)
+          result.addIterator(inEdges.edgeIteratorConnectedTo(targetRID, edgeTypes));
+        return result;
+      }
+
+      case OUT: {
+        final EdgeLinkedList outEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.OUT);
+        return outEdges != null ? outEdges.edgeIteratorConnectedTo(targetRID, edgeTypes) : Collections.emptyIterator();
+      }
+
+      case IN: {
+        final EdgeLinkedList inEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.IN);
+        return inEdges != null ? inEdges.edgeIteratorConnectedTo(targetRID, edgeTypes) : Collections.emptyIterator();
+      }
+
+      default:
+        throw new IllegalArgumentException("Invalid direction " + direction);
+    }
+  }
+
+  /** Returns the instance of the vertex the running transaction has already loaded, or the given one. */
+  private VertexInternal getMostUpdatedVertex(final VertexInternal vertex) {
+    if (!database.isTransactionActive())
+      return vertex;
+    return database.getTransaction().getRecordFromCache(vertex.getIdentity()) instanceof VertexInternal cached ?
+        cached :
+        vertex;
+  }
+
+  /**
    * Returns all the connected vertices, both directions, any edge type.
    *
    * @return An iterator of PVertex instances

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -819,7 +819,14 @@ public class GraphEngine {
     }
   }
 
-  /** Returns the instance of the vertex the running transaction has already loaded, or the given one. */
+  /**
+   * Returns the instance of the vertex the running transaction has already loaded, or the given one.
+   * <p>
+   * The cache is keyed by RID over every record shape, so the entry can legitimately be absent (the vertex was never
+   * touched in this transaction) or not a vertex at all (a record loaded through a path that did not resolve its
+   * type). Neither is an error: the caller's own handle is then the best available, and it is what the pre-existing
+   * behaviour used anyway.
+   */
   private VertexInternal getMostUpdatedVertex(final VertexInternal vertex) {
     if (!database.isTransactionActive())
       return vertex;

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -786,8 +786,10 @@ public class GraphEngine {
     final RID targetRID = target.getIdentity();
     // The edge-list head pointers live in the vertex record, so they have to be read from the instance the
     // running transaction has, not from whatever snapshot the caller happens to hold: a vertex loaded before
-    // an edge was appended still points at the previous head and would hide the newest edges. The public
-    // Vertex.getEdges() does this resolution for its callers; a caller reaching the engine directly does not.
+    // an edge was appended still points at the previous head and would hide the newest edges. The Vertex-level
+    // accessors reach the engine already holding that instance - ImmutableVertex resolves it explicitly and a
+    // MutableVertex is one - but a caller reaching this method directly hands over whatever it has, so the
+    // resolution belongs here.
     final VertexInternal source = getMostUpdatedVertex(vertex);
 
     switch (direction) {
@@ -1013,6 +1015,16 @@ public class GraphEngine {
     return null;
   }
 
+  /**
+   * Tells whether the two vertices are joined, rejecting on the neighbour pointer held in the edge segment so no
+   * edge record is loaded. {@link #getEdgesConnectedTo(VertexInternal, Vertex.DIRECTION, Identifiable, String...)}
+   * is the iterating counterpart, for when the matching edges themselves have to be inspected.
+   * <p>
+   * Unlike that method this one reads the edge-list head from the vertex handle it is given, so the caller must pass
+   * the instance the running transaction holds. Every {@link Vertex} accessor does (ImmutableVertex resolves it, a
+   * MutableVertex is one); a caller reaching the engine directly with an older snapshot would miss the edges appended
+   * since that snapshot was taken.
+   */
   public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -775,6 +775,10 @@ public class GraphEngine {
    * itself is not free - the segment still yields an RID per entry, as it always did - but on a super-node dropping
    * the per-edge record load is the difference between the probe being unusable and being cheap.
    *
+   * Under {@link Vertex.DIRECTION#BOTH} a self-loop is returned twice, once from each list, exactly as
+   * {@link #getEdges(VertexInternal, Vertex.DIRECTION, String...)} does. A caller that cares must de-duplicate by
+   * edge identity, as the Cypher expansion does.
+   *
    * @param target the vertex the returned edges must reach; must not be null
    */
   public Iterator<Edge> getEdgesConnectedTo(final VertexInternal vertex, final Vertex.DIRECTION direction,
@@ -985,29 +989,29 @@ public class GraphEngine {
     return Collections.emptyList();
   }
 
-  public RID getFirstEdgeConnectedToVertex(VertexInternal vertex, final Identifiable toVertex,
+  public RID getFirstEdgeConnectedToVertex(final VertexInternal vertex, final Identifiable toVertex,
                                            final int[] edgeBucketFilter) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
 
     // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
-    vertex = getMostUpdatedVertex(vertex);
+    final VertexInternal source = getMostUpdatedVertex(vertex);
 
-    final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+    final EdgeLinkedList outEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.OUT);
     if (outEdges != null) {
       final RID edgeRID = outEdges.getFirstEdgeConnectedToVertex(toVertex.getIdentity(), edgeBucketFilter);
       if (edgeRID != null)
         return edgeRID;
     }
 
-    final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+    final EdgeLinkedList inEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.IN);
     if (inEdges != null)
       return inEdges.getFirstEdgeConnectedToVertex(toVertex.getIdentity(), edgeBucketFilter);
 
     return null;
   }
 
-  public RID getFirstEdgeConnectedToVertex(VertexInternal vertex, final Identifiable toVertex,
+  public RID getFirstEdgeConnectedToVertex(final VertexInternal vertex, final Identifiable toVertex,
                                            final Vertex.DIRECTION direction, final int[] edgeBucketFilter) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
@@ -1016,10 +1020,10 @@ public class GraphEngine {
       throw new IllegalArgumentException("Direction is null");
 
     // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
-    vertex = getMostUpdatedVertex(vertex);
+    final VertexInternal source = getMostUpdatedVertex(vertex);
 
     if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.OUT);
       if (outEdges != null) {
         final RID edgeRID = outEdges.getFirstEdgeConnectedToVertex(toVertex.getIdentity(), edgeBucketFilter);
         if (edgeRID != null)
@@ -1028,7 +1032,7 @@ public class GraphEngine {
     }
 
     if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.IN);
       if (inEdges != null)
         return inEdges.getFirstEdgeConnectedToVertex(toVertex.getIdentity(), edgeBucketFilter);
     }
@@ -1044,22 +1048,22 @@ public class GraphEngine {
    * Like that method, and like every other probe here that walks an edge list, it resolves the vertex to the instance
    * the running transaction holds before reading the head pointer - see {@link #getMostUpdatedVertex}.
    */
-  public boolean isVertexConnectedTo(VertexInternal vertex, final Identifiable toVertex) {
+  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
 
     // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
-    vertex = getMostUpdatedVertex(vertex);
+    final VertexInternal source = getMostUpdatedVertex(vertex);
 
-    final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+    final EdgeLinkedList outEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.OUT);
     if (outEdges != null && outEdges.containsVertex(toVertex.getIdentity(), null))
       return true;
 
-    final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+    final EdgeLinkedList inEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.IN);
     return inEdges != null && inEdges.containsVertex(toVertex.getIdentity(), null);
   }
 
-  public boolean isVertexConnectedTo(VertexInternal vertex, final Identifiable toVertex,
+  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex,
                                      final Vertex.DIRECTION direction) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
@@ -1068,23 +1072,23 @@ public class GraphEngine {
       throw new IllegalArgumentException("Direction is null");
 
     // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
-    vertex = getMostUpdatedVertex(vertex);
+    final VertexInternal source = getMostUpdatedVertex(vertex);
 
     if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.OUT);
       if (outEdges != null && outEdges.containsVertex(toVertex.getIdentity(), null))
         return true;
     }
 
     if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.IN);
       return inEdges != null && inEdges.containsVertex(toVertex.getIdentity(), null);
     }
 
     return false;
   }
 
-  public boolean isVertexConnectedTo(VertexInternal vertex, final Identifiable toVertex,
+  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex,
                                      final Vertex.DIRECTION direction,
                                      final String edgeType) {
     if (toVertex == null)
@@ -1097,19 +1101,19 @@ public class GraphEngine {
       throw new IllegalArgumentException("Edge type is null");
 
     // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
-    vertex = getMostUpdatedVertex(vertex);
+    final VertexInternal source = getMostUpdatedVertex(vertex);
 
-    final int[] bucketFilter = vertex.getDatabase().getSchema().getType(edgeType).getBuckets(true).stream()
+    final int[] bucketFilter = source.getDatabase().getSchema().getType(edgeType).getBuckets(true).stream()
         .mapToInt(x -> x.getFileId()).toArray();
 
     if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.OUT);
       if (outEdges != null && outEdges.containsVertex(toVertex.getIdentity(), bucketFilter))
         return true;
     }
 
     if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(source, Vertex.DIRECTION.IN);
       return inEdges != null && inEdges.containsVertex(toVertex.getIdentity(), bucketFilter);
     }
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -771,8 +771,9 @@ public class GraphEngine {
    * use it when the far end of the pattern is already pinned and the edges still have to be inspected - typically to
    * apply a filter on the edge's own properties. Compared to walking {@link #getEdges(VertexInternal, Vertex.DIRECTION,
    * String...)} and comparing endpoints afterwards, the rejection happens on the pointers held in the edge segment, so
-   * the cost per non-matching edge drops from a record load plus a property deserialization to two integer comparisons.
-   * On a super-node that is the difference between the probe being unusable and being free.
+   * a non-matching edge costs a pointer comparison instead of a record load and a property deserialization. The walk
+   * itself is not free - the segment still yields an RID per entry, as it always did - but on a super-node dropping
+   * the per-edge record load is the difference between the probe being unusable and being cheap.
    *
    * @param target the vertex the returned edges must reach; must not be null
    */
@@ -825,12 +826,16 @@ public class GraphEngine {
   /**
    * Returns the instance of the vertex the running transaction has already loaded, or the given one.
    * <p>
+   * Every read of an edge-list head has to go through this: the head is a pointer inside the vertex record, so a
+   * handle obtained before an edge was appended still points at the previous head and would hide the newest edges.
+   * The {@link Vertex} accessors call it before reaching the engine; a caller reaching the engine directly gets it
+   * from the entry point it uses.
+   * <p>
    * The cache is keyed by RID over every record shape, so the entry can legitimately be absent (the vertex was never
    * touched in this transaction) or not a vertex at all (a record loaded through a path that did not resolve its
-   * type). Neither is an error: the caller's own handle is then the best available, and it is what the pre-existing
-   * behaviour used anyway.
+   * type). Neither is an error: the caller's own handle is then the best available.
    */
-  private VertexInternal getMostUpdatedVertex(final VertexInternal vertex) {
+  VertexInternal getMostUpdatedVertex(final VertexInternal vertex) {
     if (!database.isTransactionActive())
       return vertex;
     return database.getTransaction().getRecordFromCache(vertex.getIdentity()) instanceof VertexInternal cached ?
@@ -980,10 +985,13 @@ public class GraphEngine {
     return Collections.emptyList();
   }
 
-  public RID getFirstEdgeConnectedToVertex(final VertexInternal vertex, final Identifiable toVertex,
+  public RID getFirstEdgeConnectedToVertex(VertexInternal vertex, final Identifiable toVertex,
                                            final int[] edgeBucketFilter) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
+
+    // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
+    vertex = getMostUpdatedVertex(vertex);
 
     final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
     if (outEdges != null) {
@@ -999,13 +1007,16 @@ public class GraphEngine {
     return null;
   }
 
-  public RID getFirstEdgeConnectedToVertex(final VertexInternal vertex, final Identifiable toVertex,
+  public RID getFirstEdgeConnectedToVertex(VertexInternal vertex, final Identifiable toVertex,
                                            final Vertex.DIRECTION direction, final int[] edgeBucketFilter) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
 
     if (direction == null)
       throw new IllegalArgumentException("Direction is null");
+
+    // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
+    vertex = getMostUpdatedVertex(vertex);
 
     if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
       final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
@@ -1030,14 +1041,15 @@ public class GraphEngine {
    * edge record is loaded. {@link #getEdgesConnectedTo(VertexInternal, Vertex.DIRECTION, Identifiable, String...)}
    * is the iterating counterpart, for when the matching edges themselves have to be inspected.
    * <p>
-   * Unlike that method this one reads the edge-list head from the vertex handle it is given, so the caller must pass
-   * the instance the running transaction holds. Every {@link Vertex} accessor does (ImmutableVertex resolves it, a
-   * MutableVertex is one); a caller reaching the engine directly with an older snapshot would miss the edges appended
-   * since that snapshot was taken.
+   * Like that method, and like every other probe here that walks an edge list, it resolves the vertex to the instance
+   * the running transaction holds before reading the head pointer - see {@link #getMostUpdatedVertex}.
    */
-  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex) {
+  public boolean isVertexConnectedTo(VertexInternal vertex, final Identifiable toVertex) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
+
+    // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
+    vertex = getMostUpdatedVertex(vertex);
 
     final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
     if (outEdges != null && outEdges.containsVertex(toVertex.getIdentity(), null))
@@ -1047,13 +1059,16 @@ public class GraphEngine {
     return inEdges != null && inEdges.containsVertex(toVertex.getIdentity(), null);
   }
 
-  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex,
+  public boolean isVertexConnectedTo(VertexInternal vertex, final Identifiable toVertex,
                                      final Vertex.DIRECTION direction) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
 
     if (direction == null)
       throw new IllegalArgumentException("Direction is null");
+
+    // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
+    vertex = getMostUpdatedVertex(vertex);
 
     if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
       final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
@@ -1069,7 +1084,7 @@ public class GraphEngine {
     return false;
   }
 
-  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex,
+  public boolean isVertexConnectedTo(VertexInternal vertex, final Identifiable toVertex,
                                      final Vertex.DIRECTION direction,
                                      final String edgeType) {
     if (toVertex == null)
@@ -1080,6 +1095,9 @@ public class GraphEngine {
 
     if (edgeType == null)
       throw new IllegalArgumentException("Edge type is null");
+
+    // Read the edge-list head from the instance this transaction holds; see getMostUpdatedVertex.
+    vertex = getMostUpdatedVertex(vertex);
 
     final int[] bucketFilter = vertex.getDatabase().getSchema().getType(edgeType).getBuckets(true).stream()
         .mapToInt(x -> x.getFileId()).toArray();

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
@@ -256,12 +256,6 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
   }
 
   private VertexInternal getMostUpdatedVertex(final VertexInternal vertex) {
-    if (!database.isTransactionActive())
-      return vertex;
-
-    VertexInternal mostUpdated = (VertexInternal) database.getTransaction().getRecordFromCache(vertex.getIdentity());
-    if (mostUpdated == null)
-      mostUpdated = vertex;
-    return mostUpdated;
+    return database.getGraphEngine().getMostUpdatedVertex(vertex);
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/IteratorFilterBase.java
+++ b/engine/src/main/java/com/arcadedb/graph/IteratorFilterBase.java
@@ -66,8 +66,8 @@ public abstract class IteratorFilterBase<T> extends ResettableIteratorBase<T> {
         nextEdge = currentContainer.getRID(currentPosition);
         nextVertex = currentContainer.getRID(currentPosition);
 
-        if (!validBuckets.contains(nextEdge.getBucketId())) {
-          // FILTER IT OUT
+        if (!validBuckets.contains(nextEdge.getBucketId()) || !matchesNeighborFilter(nextVertex)) {
+          // FILTER IT OUT. BOTH CHECKS RUN ON THE POINTERS READ FROM THE SEGMENT, BEFORE ANY RECORD IS TOUCHED
           nextEdge = null;
           nextVertex = null;
           next = null;

--- a/engine/src/main/java/com/arcadedb/graph/IteratorFilterBase.java
+++ b/engine/src/main/java/com/arcadedb/graph/IteratorFilterBase.java
@@ -66,6 +66,9 @@ public abstract class IteratorFilterBase<T> extends ResettableIteratorBase<T> {
         nextEdge = currentContainer.getRID(currentPosition);
         nextVertex = currentContainer.getRID(currentPosition);
 
+        // THE NEIGHBOUR CHECK IS SHARED WITH THE VERTEX ITERATOR BELOW (edge == false). NO CALLER ARMS THE FILTER
+        // ON A VERTEX ITERATOR TODAY, SO IT IS INERT THERE; IT IS LEFT SHARED BECAUSE THE ENTRY IT FILTERS ON IS
+        // THE SAME PAIR EITHER WAY, SO A FUTURE "VERTICES CONNECTED TO X" WOULD BEHAVE IDENTICALLY
         if (!validBuckets.contains(nextEdge.getBucketId()) || !matchesNeighborFilter(nextVertex)) {
           // FILTER IT OUT. BOTH CHECKS RUN ON THE POINTERS READ FROM THE SEGMENT, BEFORE ANY RECORD IS TOUCHED
           nextEdge = null;

--- a/engine/src/main/java/com/arcadedb/graph/ResettableIteratorBase.java
+++ b/engine/src/main/java/com/arcadedb/graph/ResettableIteratorBase.java
@@ -19,6 +19,7 @@
 package com.arcadedb.graph;
 
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
 import com.arcadedb.utility.ResettableIterator;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,6 +30,9 @@ public abstract class ResettableIteratorBase<T> implements ResettableIterator<T>
   protected       EdgeSegment      currentContainer;
   protected final AtomicInteger    currentPosition = new AtomicInteger(MutableEdgeSegment.CONTENT_START_POSITION);
   protected       int              browsed         = 0;
+  private         int              neighborBucketId = -1;
+  private         long             neighborPosition = -1;
+  private         boolean          neighborFiltered = false;
 
   protected ResettableIteratorBase(final DatabaseInternal database, final EdgeSegment current) {
     if (current == null)
@@ -36,6 +40,29 @@ public abstract class ResettableIteratorBase<T> implements ResettableIterator<T>
     this.database = database;
     this.initialContainer = current;
     this.currentContainer = current;
+  }
+
+  /**
+   * Restricts the iteration to the entries whose neighbour vertex is the given one.
+   * <p>
+   * Both the edge pointer and the neighbour pointer are stored inline in the segment, so the
+   * neighbour is already in hand when an entry is examined. Rejecting on it costs two primitive
+   * comparisons and, crucially, happens <b>before</b> the edge record is materialised. That is what
+   * makes an "is A connected to B" probe over a super-node cost a scan of the edge list rather than
+   * one record load - plus one property deserialization - per edge in it.
+   *
+   * @param neighbor the only neighbour vertex to accept, or {@code null} to iterate everything
+   */
+  public void setNeighborVertexFilter(final RID neighbor) {
+    this.neighborFiltered = neighbor != null;
+    this.neighborBucketId = neighbor != null ? neighbor.getBucketId() : -1;
+    this.neighborPosition = neighbor != null ? neighbor.getPosition() : -1;
+  }
+
+  /** Tells whether the entry just read out of the segment survives the neighbour filter. */
+  protected final boolean matchesNeighborFilter(final RID neighbor) {
+    return !neighborFiltered
+        || (neighbor != null && neighbor.getBucketId() == neighborBucketId && neighbor.getPosition() == neighborPosition);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/graph/ResettableIteratorBase.java
+++ b/engine/src/main/java/com/arcadedb/graph/ResettableIteratorBase.java
@@ -49,7 +49,8 @@ public abstract class ResettableIteratorBase<T> implements ResettableIterator<T>
    * neighbour is already in hand when an entry is examined. Rejecting on it costs two primitive
    * comparisons and, crucially, happens <b>before</b> the edge record is materialised. That is what
    * makes an "is A connected to B" probe over a super-node cost a scan of the edge list rather than
-   * one record load - plus one property deserialization - per edge in it.
+   * one record load - plus one property deserialization - per edge in it. The scan itself is
+   * unchanged: the segment still yields an RID per entry whether or not the filter is set.
    *
    * @param neighbor the only neighbour vertex to accept, or {@code null} to iterate everything
    */

--- a/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
+++ b/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
@@ -329,6 +329,14 @@ public class StripedEdgeList extends EdgeLinkedList {
   }
 
   @Override
+  public Iterator<Edge> edgeIteratorConnectedTo(final RID neighbor, final String... edgeTypes) {
+    final MultiIterator<Edge> iterator = new MultiIterator<>();
+    for (final EdgeLinkedList chain : allChains(false))
+      iterator.addIterator(chain.edgeIteratorConnectedTo(neighbor, edgeTypes));
+    return iterator;
+  }
+
+  @Override
   public Iterator<Vertex> vertexIterator(final String... edgeTypes) {
     final MultiIterator<Vertex> iterator = new MultiIterator<>();
     for (final EdgeLinkedList chain : allChains(false))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -18,11 +18,13 @@
  */
 package com.arcadedb.query.opencypher.executor.operators;
 
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.VertexInternal;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -30,6 +32,7 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
@@ -131,7 +134,8 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
        */
       private boolean isConnectedOLTP(final Vertex source, final Vertex target) {
         final Vertex.DIRECTION arcadeDirection = direction.toArcadeDirection();
-        for (final Edge edge : source.getEdges(arcadeDirection, edgeTypes)) {
+        for (final Iterator<Edge> edges = candidateEdges(source, target, arcadeDirection); edges.hasNext(); ) {
+          final Edge edge = edges.next();
           try {
             if (arcadeDirection == Vertex.DIRECTION.BOTH) {
               // source can be either endpoint, so check both sides
@@ -147,6 +151,20 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
           }
         }
         return false;
+      }
+
+      /**
+       * Narrows the fallback to the edges that actually reach the target, using the neighbour pointer
+       * stored in the edge segment. The endpoint check below still runs and still reports ghosts, but
+       * it now runs on the handful of candidate edges instead of on the source's whole edge list -
+       * which is what keeps this fallback usable when the source is a super-node.
+       */
+      private Iterator<Edge> candidateEdges(final Vertex source, final Vertex target, final Vertex.DIRECTION arcadeDirection) {
+        if (source instanceof VertexInternal internalSource)
+          return ((DatabaseInternal) source.getDatabase()).getGraphEngine()
+              .getEdgesConnectedTo(internalSource, arcadeDirection, target.getIdentity(),
+                  edgeTypes == null ? new String[0] : edgeTypes);
+        return source.getEdges(arcadeDirection, edgeTypes).iterator();
       }
 
       @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -158,6 +158,11 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
        * stored in the edge segment. The endpoint check below still runs and still reports ghosts, but
        * it now runs on the handful of candidate edges instead of on the source's whole edge list -
        * which is what keeps this fallback usable when the source is a super-node.
+       * <p>
+       * That narrows what the probe incidentally reports: a ghost edge reaching the target is still
+       * loaded and reported, but one pointing elsewhere in the source's list is no longer visited, so
+       * it goes unnoticed here. This is a connectivity probe, not a ghost scanner - CHECK DATABASE is
+       * what sweeps a whole edge list.
        */
       private Iterator<Edge> candidateEdges(final Vertex source, final Vertex target, final Vertex.DIRECTION arcadeDirection) {
         if (source instanceof VertexInternal internalSource)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -162,8 +162,7 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
       private Iterator<Edge> candidateEdges(final Vertex source, final Vertex target, final Vertex.DIRECTION arcadeDirection) {
         if (source instanceof VertexInternal internalSource)
           return ((DatabaseInternal) source.getDatabase()).getGraphEngine()
-              .getEdgesConnectedTo(internalSource, arcadeDirection, target.getIdentity(),
-                  edgeTypes == null ? new String[0] : edgeTypes);
+              .getEdgesConnectedTo(internalSource, arcadeDirection, target.getIdentity(), edgeTypes);
         return source.getEdges(arcadeDirection, edgeTypes).iterator();
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
@@ -28,6 +29,7 @@ import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.VertexInternal;
 import com.arcadedb.query.opencypher.InlineProperties;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.NodePattern;
@@ -336,7 +338,7 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
                   // Standard path: load edges (needs full Vertex)
                   if (sourceVertex == null)
                     sourceVertex = (Vertex) sourceObj;
-                  currentEdges = getEdges(sourceVertex);
+                  currentEdges = getEdges(sourceVertex, lastResult);
                   currentVertices = null;
                   currentGavNeighborIds = null;
                   seenEdges = getEffectiveDirection() == Direction.BOTH ? new RidHashSet() : null;
@@ -711,17 +713,41 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
   /**
    * Gets edges from a vertex based on the relationship pattern.
    */
-  private Iterator<Edge> getEdges(final Vertex vertex) {
+  private Iterator<Edge> getEdges(final Vertex vertex, final Result lastResult) {
     final Direction direction = getEffectiveDirection();
     final String[] types = pattern.hasTypes() ?
         pattern.getTypes().toArray(new String[0]) :
         null;
+
+    // When the far end of the hop is already pinned - the shape every "is A linked to B" guard has,
+    // for instance the NOT EXISTS a loader wraps around each insert - the edge list can be filtered on
+    // the neighbour pointer held in the segment. Without this the step materialises every edge of the
+    // source and only rejects it at the bound-target check below, which on a super-node means hundreds
+    // of thousands of record loads to answer a question about one edge.
+    final RID boundTarget = getBoundTargetRID(lastResult);
+    if (boundTarget != null && vertex instanceof VertexInternal internalVertex)
+      return ((DatabaseInternal) context.getDatabase()).getGraphEngine()
+          .getEdgesConnectedTo(internalVertex, direction.toArcadeDirection(), boundTarget,
+              types == null ? new String[0] : types);
 
     if (types == null || types.length == 0) {
       return vertex.getEdges(direction.toArcadeDirection()).iterator();
     } else {
       return vertex.getEdges(direction.toArcadeDirection(), types).iterator();
     }
+  }
+
+  /**
+   * Returns the RID the target variable is already pinned to, or {@code null} when it is still free.
+   * <p>
+   * Deliberately accepts exactly what the bound-target identity check in {@code processStandardPath}
+   * accepts, so pre-filtering the edge list can never drop a row that check would have kept.
+   */
+  private RID getBoundTargetRID(final Result lastResult) {
+    if (lastResult == null || boundVariableNames == null || !boundVariableNames.contains(targetVariable))
+      return null;
+    final Object boundValue = lastResult.getProperty(targetVariable);
+    return boundValue instanceof Vertex boundVertex ? boundVertex.getIdentity() : null;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
@@ -727,8 +727,7 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
     final RID boundTarget = getBoundTargetRID(lastResult);
     if (boundTarget != null && vertex instanceof VertexInternal internalVertex)
       return ((DatabaseInternal) context.getDatabase()).getGraphEngine()
-          .getEdgesConnectedTo(internalVertex, direction.toArcadeDirection(), boundTarget,
-              types == null ? new String[0] : types);
+          .getEdgesConnectedTo(internalVertex, direction.toArcadeDirection(), boundTarget, types);
 
     if (types == null || types.length == 0) {
       return vertex.getEdges(direction.toArcadeDirection()).iterator();

--- a/engine/src/test/java/com/arcadedb/graph/EdgesConnectedToTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgesConnectedToTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.graph;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
@@ -260,6 +261,50 @@ class EdgesConnectedToTest {
 
       assertThat(ridsOf(connectedTo(staleHandle[0], Vertex.DIRECTION.OUT, target, "Knows"))).containsExactly(appended);
     });
+  }
+
+  /**
+   * The striped super-node layout (#5156) spreads a hot vertex's edges over several chains, so it overrides the
+   * iterator factory and has to narrow every one of them. This is the layout the optimisation exists for, so it
+   * cannot be the one branch left un-asserted.
+   */
+  @Test
+  void narrowsEveryChainOfAPromotedSuperNode() {
+    final int savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(256);
+    try {
+      database.transaction(() -> {
+        final MutableVertex hub = newNode("hub");
+        final List<Vertex> leaves = new ArrayList<>();
+        for (int i = 0; i < 2_000; i++) {
+          final MutableVertex leaf = newNode("leaf" + i);
+          leaves.add(leaf);
+          hub.newEdge("Knows", leaf, "seq", i).save();
+        }
+
+        final EdgeLinkedList outEdges = ((DatabaseInternal) database).getGraphEngine()
+            .getEdgeHeadChunk((VertexInternal) hub, Vertex.DIRECTION.OUT);
+        // the precondition: without promotion this would exercise the plain chain again and prove nothing
+        assertThat(outEdges).isInstanceOf(StripedEdgeList.class);
+
+        // one leaf per stripe generation: first, last and a few in between
+        for (final int i : new int[] { 0, 1, 700, 1_300, 1_999 }) {
+          final Vertex leaf = leaves.get(i);
+          final List<RID> expected = new ArrayList<>();
+          for (final Edge edge : hub.getEdges(Vertex.DIRECTION.OUT, "Knows"))
+            if (edge.getIn().equals(leaf.getIdentity()))
+              expected.add(edge.getIdentity());
+
+          assertThat(expected).hasSize(1);
+          assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, leaf, "Knows")))
+              .containsExactlyInAnyOrderElementsOf(expected);
+        }
+
+        assertThat(connectedTo(hub, Vertex.DIRECTION.OUT, newNode("stranger"), "Knows").hasNext()).isFalse();
+      });
+    } finally {
+      GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/graph/EdgesConnectedToTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgesConnectedToTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers {@link GraphEngine#getEdgesConnectedTo}, which yields only the edges reaching a known
+ * neighbour by filtering on the neighbour pointer held in the edge segment, so the edges that do not
+ * reach it are never materialised.
+ * <p>
+ * Every case is asserted against the unfiltered {@code getEdges} walk, because the filter is only
+ * worth having if it is indistinguishable from iterating everything and comparing endpoints
+ * afterwards - that is precisely what callers replace with it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class EdgesConnectedToTest {
+  private static final String DB_PATH = "./target/databases/edgesConnectedTo";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node");
+      database.getSchema().createEdgeType("Knows");
+      database.getSchema().createEdgeType("Owns");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  @Test
+  void returnsOnlyTheEdgesReachingTheGivenNeighbour() {
+    database.transaction(() -> {
+      final MutableVertex hub = newNode("hub");
+      final MutableVertex wanted = newNode("wanted");
+      final MutableVertex other = newNode("other");
+
+      final RID wantedEdge = hub.newEdge("Knows", wanted, "tag", "keep").save().getIdentity();
+      hub.newEdge("Knows", other, "tag", "drop").save();
+      hub.newEdge("Knows", other, "tag", "drop").save();
+
+      assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, wanted))).containsExactly(wantedEdge);
+      // the precondition the filter is supposed to improve on: the unfiltered walk sees all three
+      assertThat(ridsOf(hub.getEdges(Vertex.DIRECTION.OUT, "Knows").iterator())).hasSize(3);
+    });
+  }
+
+  @Test
+  void returnsEveryParallelEdgeBetweenThePair() {
+    database.transaction(() -> {
+      final MutableVertex hub = newNode("hub");
+      final MutableVertex wanted = newNode("wanted");
+
+      final RID first = hub.newEdge("Knows", wanted, "seq", 1).save().getIdentity();
+      final RID second = hub.newEdge("Knows", wanted, "seq", 2).save().getIdentity();
+      hub.newEdge("Knows", newNode("other"), "seq", 3).save();
+
+      // a duplicate check has to see every parallel edge, not just the first one
+      assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, wanted))).containsExactlyInAnyOrder(first, second);
+    });
+  }
+
+  @Test
+  void honoursTheEdgeTypeFilter() {
+    database.transaction(() -> {
+      final MutableVertex hub = newNode("hub");
+      final MutableVertex wanted = newNode("wanted");
+
+      final RID knows = hub.newEdge("Knows", wanted).save().getIdentity();
+      final RID owns = hub.newEdge("Owns", wanted).save().getIdentity();
+
+      assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, wanted, "Knows"))).containsExactly(knows);
+      assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, wanted, "Owns"))).containsExactly(owns);
+      // no type filter at all takes the untyped iterator, which must filter on the neighbour just the same
+      assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, wanted))).containsExactlyInAnyOrder(knows, owns);
+    });
+  }
+
+  @Test
+  void honoursTheDirection() {
+    database.transaction(() -> {
+      final MutableVertex middle = newNode("middle");
+      final MutableVertex peer = newNode("peer");
+
+      final RID outgoing = middle.newEdge("Knows", peer).save().getIdentity();
+      final RID incoming = peer.newEdge("Knows", middle).save().getIdentity();
+
+      assertThat(ridsOf(connectedTo(middle, Vertex.DIRECTION.OUT, peer))).containsExactly(outgoing);
+      assertThat(ridsOf(connectedTo(middle, Vertex.DIRECTION.IN, peer))).containsExactly(incoming);
+      assertThat(ridsOf(connectedTo(middle, Vertex.DIRECTION.BOTH, peer))).containsExactlyInAnyOrder(outgoing, incoming);
+    });
+  }
+
+  @Test
+  void findsSelfLoops() {
+    database.transaction(() -> {
+      final MutableVertex node = newNode("self");
+      final RID loop = node.newEdge("Knows", node).save().getIdentity();
+      node.newEdge("Knows", newNode("other")).save();
+
+      assertThat(ridsOf(connectedTo(node, Vertex.DIRECTION.OUT, node))).containsExactly(loop);
+      assertThat(ridsOf(connectedTo(node, Vertex.DIRECTION.IN, node))).containsExactly(loop);
+      // BOTH walks the OUT and the IN list, and a self-loop sits in each of them
+      assertThat(ridsOf(connectedTo(node, Vertex.DIRECTION.BOTH, node))).containsExactly(loop, loop);
+    });
+  }
+
+  @Test
+  void returnsNothingWhenThePairIsNotConnected() {
+    database.transaction(() -> {
+      final MutableVertex hub = newNode("hub");
+      final MutableVertex stranger = newNode("stranger");
+      for (int i = 0; i < 50; i++)
+        hub.newEdge("Knows", newNode("n" + i)).save();
+
+      assertThat(connectedTo(hub, Vertex.DIRECTION.OUT, stranger).hasNext()).isFalse();
+      // and the answer agrees with the primitive that never materialises anything
+      assertThat(hub.isConnectedTo(stranger, Vertex.DIRECTION.OUT)).isFalse();
+    });
+  }
+
+  @Test
+  void worksOnAVertexWithNoEdgesAtAll() {
+    database.transaction(() -> {
+      final MutableVertex lonely = newNode("lonely");
+      final MutableVertex other = newNode("other");
+      assertThat(connectedTo(lonely, Vertex.DIRECTION.BOTH, other).hasNext()).isFalse();
+    });
+  }
+
+  @Test
+  void spansEveryChunkOfALongEdgeList() {
+    // The edge list of a vertex is a chain of segments; the filter must keep walking past the head,
+    // otherwise it would silently miss the older edges - and the oldest are exactly the ones a
+    // long-running loader keeps re-checking.
+    final int degree = 5_000;
+    database.transaction(() -> {
+      final MutableVertex hub = newNode("hub");
+      RID firstEdge = null;
+      RID lastEdge = null;
+      for (int i = 0; i < degree; i++) {
+        final MutableVertex leaf = newNode("leaf" + i);
+        final RID edge = hub.newEdge("Knows", leaf, "seq", i).save().getIdentity();
+        if (i == 0)
+          firstEdge = edge;
+        lastEdge = edge;
+      }
+
+      // the neighbour of the very first edge lives in the deepest segment of the chain
+      final Vertex firstLeaf = database.lookupByRID(firstEdge, true).asEdge().getInVertex();
+      assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, firstLeaf))).containsExactly(firstEdge);
+
+      final Vertex lastLeaf = database.lookupByRID(lastEdge, true).asEdge().getInVertex();
+      assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, lastLeaf))).containsExactly(lastEdge);
+    });
+  }
+
+  @Test
+  void agreesWithTheUnfilteredWalkOnEveryNeighbour() {
+    database.transaction(() -> {
+      final MutableVertex hub = newNode("hub");
+      final List<Vertex> leaves = new ArrayList<>();
+      for (int i = 0; i < 40; i++) {
+        final MutableVertex leaf = newNode("leaf" + i);
+        leaves.add(leaf);
+        // a variable number of parallel edges per leaf, so the comparison is not trivially one-to-one
+        for (int e = 0; e <= i % 3; e++)
+          hub.newEdge("Knows", leaf, "seq", e).save();
+      }
+
+      for (final Vertex leaf : leaves) {
+        final List<RID> expected = new ArrayList<>();
+        for (final Edge edge : hub.getEdges(Vertex.DIRECTION.OUT, "Knows"))
+          if (edge.getIn().equals(leaf.getIdentity()))
+            expected.add(edge.getIdentity());
+
+        assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, leaf, "Knows")))
+            .containsExactlyInAnyOrderElementsOf(expected);
+      }
+    });
+  }
+
+  @Test
+  void findsParallelEdgesThatSitBehindALongTailOfOtherNeighbours() {
+    // The pair's edges are the newest entries of a list long enough to span several segments, and the
+    // pair is also joined by an edge of another type and by an edge in the opposite direction.
+    database.transaction(() -> {
+      final MutableVertex hub = newNode("hub");
+      for (int i = 0; i < 200; i++)
+        hub.newEdge("Knows", newNode("leaf" + i), "seq", i).save();
+
+      final MutableVertex shared = newNode("shared");
+      final RID first = hub.newEdge("Knows", shared, "kind", "payment").save().getIdentity();
+      final RID second = hub.newEdge("Knows", shared, "kind", "refund").save().getIdentity();
+      hub.newEdge("Owns", shared).save();
+      shared.newEdge("Knows", hub, "kind", "reversed").save();
+
+      assertThat(ridsOf(connectedTo(hub, Vertex.DIRECTION.OUT, shared, "Knows")))
+          .containsExactlyInAnyOrder(first, second);
+    });
+  }
+
+  @Test
+  void readsTheEdgeListFromTheInstanceTheTransactionHas() {
+    // The head of the edge list is a pointer inside the vertex record, so a vertex handle held from
+    // before an edge was appended still points at the previous head. Callers reaching the engine
+    // directly hand over whatever handle they hold, so the resolution has to happen in the engine -
+    // otherwise the newest edges, which are exactly the ones a duplicate check asks about, go missing.
+    final RID[] hubRid = new RID[1];
+    final RID[] targetRid = new RID[1];
+    final Vertex[] staleHandle = new Vertex[1];
+
+    database.transaction(() -> {
+      hubRid[0] = newNode("hub").getIdentity();
+      targetRid[0] = newNode("target").getIdentity();
+      staleHandle[0] = (Vertex) database.lookupByRID(hubRid[0], true);
+    });
+
+    database.transaction(() -> {
+      final MutableVertex fresh = ((Vertex) database.lookupByRID(hubRid[0], true)).modify();
+      final Vertex target = (Vertex) database.lookupByRID(targetRid[0], true);
+      final RID appended = fresh.newEdge("Knows", target).save().getIdentity();
+
+      assertThat(ridsOf(connectedTo(staleHandle[0], Vertex.DIRECTION.OUT, target, "Knows"))).containsExactly(appended);
+    });
+  }
+
+  @Test
+  void rejectsAMissingTarget() {
+    database.transaction(() -> {
+      final MutableVertex hub = newNode("hub");
+      assertThatThrownBy(() -> connectedTo(hub, Vertex.DIRECTION.OUT, null))
+          .isInstanceOf(IllegalArgumentException.class);
+    });
+  }
+
+  private MutableVertex newNode(final String name) {
+    return database.newVertex("Node").set("name", name).save();
+  }
+
+  private Iterator<Edge> connectedTo(final Vertex source, final Vertex.DIRECTION direction, final Vertex target,
+      final String... edgeTypes) {
+    return ((DatabaseInternal) database).getGraphEngine()
+        .getEdgesConnectedTo((VertexInternal) source, direction, target, edgeTypes);
+  }
+
+  private static List<RID> ridsOf(final Iterator<Edge> edges) {
+    final List<RID> rids = new ArrayList<>();
+    while (edges.hasNext())
+      rids.add(edges.next().getIdentity());
+    return rids;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/EdgesConnectedToTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgesConnectedToTest.java
@@ -52,7 +52,11 @@ class EdgesConnectedToTest {
 
   @BeforeEach
   void setUp() {
-    database = new DatabaseFactory(DB_PATH).create();
+    // a run killed mid-test leaves the directory behind, and create() would then throw on every later run
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
     database.transaction(() -> {
       database.getSchema().createVertexType("Node");
       database.getSchema().createEdgeType("Knows");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBoundTargetExpansionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBoundTargetExpansionTest.java
@@ -158,7 +158,7 @@ class CypherBoundTargetExpansionTest {
    * The row count is deliberately not asserted. A cycle whose first hop has two parallel edges reports one row
    * per closing edge rather than one per (first, closing) pair, which is a pre-existing planner discrepancy
    * unrelated to this narrowing - it reproduces with the narrowing reverted. Asserting the count here would
-   * pin a bug rather than this behaviour; it is tracked separately.
+   * pin a bug rather than this behaviour; it is tracked by issue #5663.
    */
   @Test
   void narrowingHandlesACyclePatternWhereTheLastHopReturnsToABoundVariable() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBoundTargetExpansionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBoundTargetExpansionTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * When a relationship pattern's target is already pinned to a vertex, the step narrows the source's
+ * edge list to the edges that reach it, filtering on the neighbour pointer in the edge segment rather
+ * than materialising every edge and rejecting it afterwards. Without that, a guard such as
+ * {@code NOT EXISTS { (a)-[:E {...}]->(t) }} costs one record load per edge of {@code a}, which on a
+ * hub vertex is hundreds of thousands of random reads to answer a question about a single edge.
+ * <p>
+ * These cases pin the value of the optimisation to the thing that must not change: the answer. Each
+ * one is a shape where a pre-filter applied too eagerly - before the type, property, direction or
+ * uniqueness rules - would silently drop a row.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherBoundTargetExpansionTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypherboundtarget");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      database.getSchema().createVertexType("Txn");
+      database.getSchema().createEdgeType("INITIATED");
+      database.getSchema().createEdgeType("SETTLED");
+
+      final MutableVertex hub = database.newVertex("Account").set("code", "HUB").save();
+      final MutableVertex other = database.newVertex("Account").set("code", "OTHER").save();
+
+      // The hub reaches many leaves, so a guard about one of them has to ignore all the others.
+      for (int i = 0; i < 200; i++) {
+        final MutableVertex txn = database.newVertex("Txn").set("ref", "T" + i).save();
+        hub.newEdge("INITIATED", txn, "ref", "T" + i, "kind", "payment").save();
+      }
+
+      // A leaf reached twice by different edge types and different properties.
+      final MutableVertex shared = database.newVertex("Txn").set("ref", "SHARED").save();
+      hub.newEdge("INITIATED", shared, "ref", "SHARED", "kind", "payment").save();
+      hub.newEdge("INITIATED", shared, "ref", "SHARED", "kind", "refund").save();
+      hub.newEdge("SETTLED", shared, "ref", "SHARED").save();
+
+      // An edge in the opposite direction, and one from a different source.
+      shared.newEdge("INITIATED", hub, "ref", "REVERSED").save();
+      other.newEdge("INITIATED", shared, "ref", "FROM_OTHER").save();
+
+      // A never-linked leaf: the case a loader's guard hits on every insert.
+      database.newVertex("Txn").set("ref", "UNLINKED").save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void existsGuardAnswersTheSameOnLinkedAndUnlinkedLeaves() {
+    // SHARED is reached by a payment edge and a refund edge, so both guards see the edge...
+    assertThat(guardSaysAbsent("SHARED", "payment")).isFalse();
+    assertThat(guardSaysAbsent("SHARED", "refund")).isFalse();
+    // ...but a kind that no edge of that pair carries is still reported absent, so narrowing the edge
+    // list did not weaken the property filter into a plain connectivity check
+    assertThat(guardSaysAbsent("SHARED", "chargeback")).isTrue();
+    assertThat(guardSaysAbsent("T0", "payment")).isFalse();
+    assertThat(guardSaysAbsent("UNLINKED", "payment")).isTrue();
+  }
+
+  private boolean guardSaysAbsent(final String ref, final String kind) {
+    final String cypher = "MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: $ref}) "
+        + "WHERE NOT EXISTS { (a)-[:INITIATED {ref: $ref, kind: $kind}]->(t) } RETURN a";
+    try (final ResultSet rs = database.query("opencypher", cypher, "ref", ref, "kind", kind)) {
+      return rs.hasNext();
+    }
+  }
+
+  @Test
+  void narrowingKeepsEveryParallelEdgeBetweenThePair() {
+    // Two INITIATED edges reach SHARED; a filter that stopped at the first would lose one.
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "MATCH (a)-[r:INITIATED]->(t) RETURN r.kind AS v"))
+        .containsExactlyInAnyOrder("payment", "refund");
+  }
+
+  @Test
+  void narrowingRespectsTheEdgeType() {
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "MATCH (a)-[r:SETTLED]->(t) RETURN r.ref AS v")).containsExactly("SHARED");
+  }
+
+  @Test
+  void narrowingRespectsTheDirection() {
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "MATCH (a)<-[r:INITIATED]-(t) RETURN r.ref AS v")).containsExactly("REVERSED");
+
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "MATCH (a)-[r:INITIATED]-(t) RETURN r.ref AS v"))
+        .containsExactlyInAnyOrder("SHARED", "SHARED", "REVERSED");
+  }
+
+  @Test
+  void narrowingRespectsAnInlineWhereOnTheRelationship() {
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "MATCH (a)-[r:INITIATED WHERE r.kind = 'refund']->(t) RETURN r.kind AS v"))
+        .containsExactly("refund");
+  }
+
+  @Test
+  void narrowingDoesNotLeakEdgesFromAnotherSource() {
+    // OTHER also points at SHARED; pinning the target must not pull that edge into the HUB's expansion.
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "MATCH (a)-[r:INITIATED]->(t) RETURN r.ref AS v"))
+        .doesNotContain("FROM_OTHER");
+  }
+
+  @Test
+  void narrowingHandlesACyclePatternWhereTheLastHopReturnsToABoundVariable() {
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'})-[:INITIATED]->(t:Txn {ref: 'SHARED'})-[r:INITIATED]->(a) "
+        + "RETURN r.ref AS v")).containsExactly("REVERSED", "REVERSED");
+  }
+
+  @Test
+  void unpinnedTargetStillSeesTheWholeEdgeList() {
+    // The narrowing must not engage when the target is free, or the hub's 200 leaves would vanish.
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Account {code: 'HUB'})-[:INITIATED]->(t:Txn) RETURN count(t) AS c")) {
+      assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(202);
+    }
+  }
+
+  private List<String> refsOf(final String cypher) {
+    final List<String> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", cypher)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        values.add(row.getProperty("v") != null ? row.getProperty("v").toString() : null);
+      }
+    }
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBoundTargetExpansionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBoundTargetExpansionTest.java
@@ -150,10 +150,29 @@ class CypherBoundTargetExpansionTest {
         .doesNotContain("FROM_OTHER");
   }
 
+  /**
+   * A cycle closes on a variable bound by an earlier hop, so the closing hop expands with its target already
+   * pinned - the narrowing engages on a source the same statement has been traversing, and must still find the
+   * one edge that closes the cycle.
+   * <p>
+   * The row count is deliberately not asserted. A cycle whose first hop has two parallel edges reports one row
+   * per closing edge rather than one per (first, closing) pair, which is a pre-existing planner discrepancy
+   * unrelated to this narrowing - it reproduces with the narrowing reverted. Asserting the count here would
+   * pin a bug rather than this behaviour; it is tracked separately.
+   */
   @Test
   void narrowingHandlesACyclePatternWhereTheLastHopReturnsToABoundVariable() {
-    assertThat(refsOf("MATCH (a:Account {code: 'HUB'})-[:INITIATED]->(t:Txn {ref: 'SHARED'})-[r:INITIATED]->(a) "
-        + "RETURN r.ref AS v")).containsExactly("REVERSED", "REVERSED");
+    // the closing hop resolves, and resolves to the only edge that can close the cycle
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a) "
+        + "RETURN r2.ref AS v")).isNotEmpty().containsOnly("REVERSED");
+
+    // and the first hop still only ever binds an edge of the HUB->SHARED pair
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a) "
+        + "RETURN r1.kind AS v")).isNotEmpty().isSubsetOf("payment", "refund");
+
+    // a cycle that cannot close returns nothing, so the narrowing is not answering "connected" for any target
+    assertThat(refsOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'T0'})-[r2:INITIATED]->(a) "
+        + "RETURN r2.ref AS v")).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherExistsSuperNodeBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherExistsSuperNodeBenchmark.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -102,7 +104,7 @@ class CypherExistsSuperNodeBenchmark {
     final long fromHub = timeGuard(HUB_ANCHORED, probeRid, true);
     final long fromLeaf = timeGuard(LEAF_ANCHORED, probeRid, true);
 
-    System.out.println("degree=" + DEGREE + " anchored on hub: " + fromHub + " ms, anchored on leaf: " + fromLeaf + " ms");
+    LogManager.instance().log(this, Level.INFO, "degree=%d anchored on hub: %d ms, anchored on leaf: %d ms", DEGREE, fromHub, fromLeaf);
 
     assertThat(fromLeaf).isLessThan(fromHub);
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherExistsSuperNodeBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherExistsSuperNodeBenchmark.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces the ingest slowdown reported on a transaction graph where a handful of hub accounts
+ * accumulate hundreds of thousands of edges: the loader guards every insert with
+ * {@code NOT EXISTS((a)-[:INITIATED {...}]->(t))}, and that guard is evaluated by expanding the
+ * whole edge list of whichever endpoint the pattern is written from.
+ * <p>
+ * The two measurements differ only in that endpoint. Anchoring on the hub walks its full degree and
+ * materialises every edge record on the way; anchoring on the leaf walks one edge.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class CypherExistsSuperNodeBenchmark {
+  private static final int DEGREE  = Integer.parseInt(System.getProperty("supernode.degree", "50000"));
+  private static final int REPEATS = 5;
+
+  /** The loader's guard, written from the hub: expands the hub's whole OUT list. */
+  private static final String HUB_ANCHORED  = "MATCH (a:Account), (t:Txn) WHERE id(a) = $a AND id(t) = $t "
+      + "AND NOT EXISTS { (a)-[:INITIATED {ref: 'PROBE'}]->(t) } RETURN a";
+  /** The same guard written from the leaf: expands the leaf's IN list, which holds one edge. */
+  private static final String LEAF_ANCHORED = "MATCH (a:Account), (t:Txn) WHERE id(a) = $a AND id(t) = $t "
+      + "AND NOT EXISTS { (t)<-[:INITIATED {ref: 'PROBE'}]-(a) } RETURN a";
+
+  /** Same two shapes, but matching on the property an already-linked leaf actually carries. */
+  private static final String HUB_ANCHORED_EXISTING  = "MATCH (a:Account), (t:Txn) WHERE id(a) = $a AND id(t) = $t "
+      + "AND NOT EXISTS { (a)-[:INITIATED]->(t) } RETURN a";
+  private static final String LEAF_ANCHORED_EXISTING = "MATCH (a:Account), (t:Txn) WHERE id(a) = $a AND id(t) = $t "
+      + "AND NOT EXISTS { (t)<-[:INITIATED]-(a) } RETURN a";
+
+  private Database database;
+  private String   hubRid;
+  private String   probeRid;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypherexistssupernode");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      database.getSchema().createVertexType("Txn");
+      database.getSchema().createEdgeType("INITIATED");
+    });
+
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account").set("code", "HUB").save();
+      hubRid = hub.getIdentity().toString();
+      for (int i = 0; i < DEGREE; i++) {
+        final MutableVertex txn = database.newVertex("Txn").set("ref", "T" + i).save();
+        hub.newEdge("INITIATED", txn, "ref", "T" + i).save();
+      }
+      // The leaf the guard is asked about: never linked, so the guard must walk to the very end
+      // before it can answer "no match" - exactly the loader's common case.
+      probeRid = database.newVertex("Txn").set("ref", "PROBE").save().getIdentity().toString();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void anchoringOnTheLeafAvoidsTheSuperNodeScan() {
+    final long fromHub = timeGuard(HUB_ANCHORED, probeRid, true);
+    final long fromLeaf = timeGuard(LEAF_ANCHORED, probeRid, true);
+
+    System.out.println("degree=" + DEGREE + " anchored on hub: " + fromHub + " ms, anchored on leaf: " + fromLeaf + " ms");
+
+    assertThat(fromLeaf).isLessThan(fromHub);
+  }
+
+  /**
+   * The flip is only a usable workaround if it answers identically. Asked about a leaf that IS
+   * linked, both forms must report the edge as existing, so the guard suppresses the row.
+   */
+  @Test
+  void bothAnchorsAgreeWhenTheEdgeExists() {
+    final String linkedRid = database.query("opencypher", "MATCH (t:Txn {ref: 'T7'}) RETURN id(t) AS r").next()
+        .getProperty("r").toString();
+
+    assertThat(guardPasses(HUB_ANCHORED_EXISTING, linkedRid)).isFalse();
+    assertThat(guardPasses(LEAF_ANCHORED_EXISTING, linkedRid)).isFalse();
+
+    // ...and both still admit a leaf that is not linked
+    assertThat(guardPasses(HUB_ANCHORED_EXISTING, probeRid)).isTrue();
+    assertThat(guardPasses(LEAF_ANCHORED_EXISTING, probeRid)).isTrue();
+  }
+
+  private boolean guardPasses(final String cypher, final String target) {
+    try (final ResultSet rs = database.query("opencypher", cypher, params(target))) {
+      return rs.hasNext();
+    }
+  }
+
+  private Map<String, Object> params(final String target) {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("a", hubRid);
+    params.put("t", target);
+    return params;
+  }
+
+  private long timeGuard(final String cypher, final String target, final boolean expected) {
+    final Map<String, Object> params = params(target);
+
+    // warm the statement cache and the page cache
+    for (int i = 0; i < 2; i++)
+      try (final ResultSet rs = database.query("opencypher", cypher, params)) {
+        assertThat(rs.hasNext()).isEqualTo(expected);
+      }
+
+    final long begin = System.nanoTime();
+    for (int i = 0; i < REPEATS; i++)
+      try (final ResultSet rs = database.query("opencypher", cypher, params)) {
+        assertThat(rs.hasNext()).isEqualTo(expected);
+      }
+    return (System.nanoTime() - begin) / REPEATS / 1_000_000;
+  }
+}


### PR DESCRIPTION
Fixes #5660.

## Problem

A relationship pattern whose target is already pinned - the shape of every "is A linked to B" guard,
such as the `NOT EXISTS` a loader wraps around each insert - expanded the source's **whole** edge
list. For each edge, before any filter ran, `MatchRelationshipStep.processStandardPath` took a read
lock and allocated a record shell, then called `getTargetVertex` -> `getInVertex()` which forces a
full record load, then deserialized the edge's properties. The bound-target identity check ran last.

On a hub vertex that is one random record read per edge to answer a question about a single edge, so
the guard's cost grows with the hub's degree and an ingest slows down as it runs. A thread dump from
the reporting user had all six loader threads there and none in the write path; their commits took
1-2 ms while the gaps between transactions were 1.6-3.2 s.

## Change

The neighbour vertex RID is stored inline beside the edge RID in the edge segment, and
`IteratorFilterBase` already reads it for every entry before deciding anything. This adds an optional
neighbour filter to the segment iterators, applied exactly there - before any `lookupByRID` - and
exposes it as `GraphEngine.getEdgesConnectedTo`.

- `ResettableIteratorBase`: the filter, held as primitives so the comparison allocates nothing.
- `IteratorFilterBase.hasNext` (typed) and `EdgeIterator.hasNext` (untyped): apply it where the
  `(edgeRID, neighbourRID)` pair is read.
- `EdgeLinkedList.edgeIteratorConnectedTo` plus a `StripedEdgeList` override, so super-nodes on the
  striped path are covered too.
- `MatchRelationshipStep.getEdges` uses it when `getBoundTargetRID` finds the target pinned;
  `GAVExpandInto.candidateEdges` uses it for the OLTP fallback.

**Every existing per-edge check is left in place and still decides the result.** `getBoundTargetRID`
deliberately accepts exactly what the bound-target identity check accepts, so the pre-filter can only
avoid building rows that check would have thrown away.

`getEdgesConnectedTo` resolves the vertex to the instance the running transaction holds, the way the
public `Vertex` edge accessors do. The edge-list head is a pointer inside the vertex record, so
reading it from a handle loaded before an edge was appended would miss the newest edges.

## Result

One hub, a guard about a leaf that is not linked (the loader's common case), warm page cache, single
thread:

| degree | 50k | 100k | 200k | 350k |
|---|---|---|---|---|
| before | 25 ms | 55 ms | 93 ms | 139 ms |
| after | 1 ms | 2 ms | 4 ms | 5 ms |

The reporting user should gain more than this ~28x: these numbers are warm-cache, and what the change
removes is precisely the random record reads, which is where their much larger per-edge constant is.

## Tests

- `EdgesConnectedToTest` - 12 tests on the new engine primitive: parallel edges between a pair, edge
  type filter, direction, self-loops, disconnected pairs, a vertex with no edges, a list long enough
  to span several segments, and agreement with the unfiltered walk on every neighbour. Every case is
  asserted against the plain `getEdges` walk, since the filter is only worth having if it is
  indistinguishable from it.
- `CypherBoundTargetExpansionTest` - 8 tests pinning the Cypher answers: the `NOT EXISTS` guard on
  linked and unlinked leaves, parallel edges, edge type, direction, inline `WHERE` on the
  relationship, no leakage from another source, a cycle pattern whose last hop returns to a bound
  variable, and an unpinned target still seeing the whole edge list.
- `CypherExistsSuperNodeBenchmark` - `@Tag("benchmark")` so it stays out of CI, degree via
  `-Dsupernode.degree`.

Mutation-checked rather than assumed: disabling the neighbour filter kills 6 of the engine tests, and
reverting the transaction-instance resolution kills both the stale-handle test and the cycle-pattern
test.

Full `engine` module: 10,515 tests green.
