### PR TITLE
fix(engine) #5662: index cursors are AutoCloseable, and a leaked one no longer pins a retired index file

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1119,4 +1119,50 @@ and expressing that would have been faithful to its intent, but it would have ti
 of repairing a config that enforced nothing - a decision worth taking on its own merits. Development dependencies are
 still covered by the `npm audit --audit-level=moderate` step of the same workflow.
 
+## An index cursor is `AutoCloseable`, and a leaked one no longer pins a retired index file forever
+
+Three releases in a row have fixed instances of the same defect - an `IndexCursor` obtained, driven partway and
+dropped ([#5601](https://github.com/ArcadeData/arcadedb/issues/5601),
+[#5609](https://github.com/ArcadeData/arcadedb/issues/5609),
+[#5635](https://github.com/ArcadeData/arcadedb/issues/5635)). Closing one matters: a scan over an LSM index holds one
+underlying cursor per compacted series, each registered with its file, and `dropRetiredCompactedIndexes` will not
+physically drop a file that still has one. Draining a cursor releases those registrations as each series is exhausted,
+so only a cursor abandoned **partway** leaks - which is exactly the shape a `LIMIT`, an `exists()` or an early `break`
+produces. They kept recurring because nothing fired: an abandoned cursor looks exactly like correct code, and every
+site so far was found by reading ([#5662](https://github.com/ArcadeData/arcadedb/issues/5662)).
+
+`Cursor` now extends `AutoCloseable`, so an abandoned one is a static-analysis and IDE finding rather than something
+only a careful read can catch, and a cursor can be used with try-with-resources. `close()` is declared without a
+checked exception, so a `try (final IndexCursor c = index.iterator(true))` does not force the caller into a
+`catch (Exception)`.
+
+That is a compile-time signal, and a compile-time signal proves nothing about the sites nobody has read yet. So the
+counter behind the retire guard was replaced with **weak** references to the live cursors: a cursor abandoned without
+`close()` stops pinning its file once the garbage collector reaches it, and the reclaim is logged with the index name.
+A missed `close()` used to be permanent - the retired file stayed on disk for the lifetime of the database with
+nothing left in the process that could ever release it, and nothing to say so.
+
+The call sites found in this pass and now releasing their cursor:
+
+- The native `Select` API. `exists()` returns on the first match and `count()` stops at its `LIMIT`, both abandoning
+  the scan, and `SelectIterator.close()` documented itself as having "nothing to release in the serial
+  implementation" while holding the source index cursor.
+- `SubQueryStep` never closed the plan it wraps, so closing a result set reached only the outer plan's steps. A
+  `DELETE ... WHERE` is built exactly this way - the index scan inside the sub-plan, the `LIMIT` outside it - so its
+  scan was released only when it happened to run to exhaustion.
+- `DeleteFromIndexStep` had no `close()` at all. Its equality branch also opened a `range()` cursor and overwrote it
+  with the `iterator()` one on the next line, a dead store that opened and abandoned an extra full scan; and an
+  `IOException` out of its initialisation printed a stack trace to stdout and carried on with a null cursor, so the
+  caller would have seen a `NullPointerException` instead of the failure that explained it.
+- The Gremlin index-filter step, `TypeIndex`, the unique-key check at commit time, the edge upsert lookup, and the
+  full-text scoring, explain and more-like-this walks.
+
+Two smaller corrections travel with them. The vector search cursor returned the backing list's own iterator from
+`iterator()`, so a for-each got a second, independent traversal that never moved the cursor's position - `getRecord()`
+reported nothing during the loop, and mixing it with `next()` read some RIDs twice; it now iterates itself, like every
+other cursor, and `IndexCursorCollection` does the same. And `MultiIndexCursor.getComparator()` /
+`getBinaryKeyTypes()` answered by probing the children for one that still had something left, which since #5635 means
+running page reads and tombstone skips inside two plain accessors; both now answer from state sampled at construction,
+and the key types no longer come back null once the cursor is exhausted.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1150,10 +1150,13 @@ The call sites found in this pass and now releasing their cursor:
 - `SubQueryStep` never closed the plan it wraps, so closing a result set reached only the outer plan's steps. A
   `DELETE ... WHERE` is built exactly this way - the index scan inside the sub-plan, the `LIMIT` outside it - so its
   scan was released only when it happened to run to exhaustion.
-- `DeleteFromIndexStep` had no `close()` at all. Its equality branch also opened a `range()` cursor and overwrote it
-  with the `iterator()` one on the next line, a dead store that opened and abandoned an extra full scan; and an
-  `IOException` out of its initialisation printed a stack trace to stdout and carried on with a null cursor, so the
-  caller would have seen a `NullPointerException` instead of the failure that explained it.
+- `DeleteFromIndexStep` had no `close()` at all. Two smaller repairs travel with it, neither of which changes what a
+  working statement does: an `IOException` out of its initialisation printed a stack trace to stdout and carried on
+  with a null cursor, so the caller would have seen a `NullPointerException` instead of the failure that explained it;
+  and the branch for an index without ordered iterations opened a `range()` cursor and overwrote it with the
+  `iterator()` one on the next line - it could never have worked, since both of those calls raise
+  `UnsupportedOperationException` on the only index that reaches it, so it was removed in favour of the error that
+  names the condition.
 - The Gremlin index-filter step, `TypeIndex`, the unique-key check at commit time, the edge upsert lookup, and the
   full-text scoring, explain and more-like-this walks.
 

--- a/engine/src/main/java/com/arcadedb/database/Cursor.java
+++ b/engine/src/main/java/com/arcadedb/database/Cursor.java
@@ -44,7 +44,9 @@ public interface Cursor extends Iterable<Identifiable>, Iterator<Identifiable>, 
 
   /**
    * Releases whatever the cursor holds. The default is a no-op for the implementations backed by an in-memory
-   * collection, which hold nothing.
+   * collection, which hold nothing - so an implementation that DOES hold something must remember to override it. The
+   * weak-reference net in {@code LSMTreeIndexCompacted} covers only the compacted-series cursors; nothing catches a
+   * new cursor type that acquires a resource and inherits this default.
    */
   @Override
   default void close() {

--- a/engine/src/main/java/com/arcadedb/database/Cursor.java
+++ b/engine/src/main/java/com/arcadedb/database/Cursor.java
@@ -24,10 +24,30 @@ import java.util.Iterator;
 
 /**
  * Cursor to browse a result set.
+ * <p>
+ * <b>Closing (#5662).</b> A cursor is {@link AutoCloseable} so that an abandoned one is a static-analysis finding
+ * rather than something only a careful read can spot. Closing matters: a scan over an LSM index holds one underlying
+ * cursor per compacted series, each registered with its file, and
+ * {@code LSMTreeIndex.dropRetiredCompactedIndexes} will not physically drop a file that still has one. Draining a
+ * cursor releases those registrations as each series is exhausted, so only a cursor abandoned <i>partway</i> leaks -
+ * which is exactly the shape a {@code LIMIT}, an {@code exists()} or an early {@code break} produces. Prefer
+ * try-with-resources; {@link #close()} is idempotent on every implementation.
+ * <p>
+ * {@code close()} is declared without a checked exception (unlike {@link AutoCloseable#close()}) so that a
+ * try-with-resources over a cursor does not force the caller into a {@code catch (Exception)}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 @ExcludeFromJacocoGeneratedReport
-public interface Cursor extends Iterable<Identifiable>, Iterator<Identifiable> {
+public interface Cursor extends Iterable<Identifiable>, Iterator<Identifiable>, AutoCloseable {
   long estimateSize();
+
+  /**
+   * Releases whatever the cursor holds. The default is a no-op for the implementations backed by an in-memory
+   * collection, which hold nothing.
+   */
+  @Override
+  default void close() {
+    // NO ACTIONS
+  }
 }

--- a/engine/src/main/java/com/arcadedb/database/IndexCursorCollection.java
+++ b/engine/src/main/java/com/arcadedb/database/IndexCursorCollection.java
@@ -59,9 +59,13 @@ public class IndexCursorCollection implements IndexCursor {
     return collection.size();
   }
 
+  /**
+   * #5662: a cursor iterates ITSELF, like every other {@link IndexCursor}. Handing back the backing iterator shared
+   * the position with {@link #next()} but bypassed it, so {@link #getRecord()} stayed stale for the whole for-each.
+   */
   @Override
   public Iterator<Identifiable> iterator() {
-    return iterator;
+    return this;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/IndexCursorCollection.java
+++ b/engine/src/main/java/com/arcadedb/database/IndexCursorCollection.java
@@ -62,6 +62,9 @@ public class IndexCursorCollection implements IndexCursor {
   /**
    * #5662: a cursor iterates ITSELF, like every other {@link IndexCursor}. Handing back the backing iterator shared
    * the position with {@link #next()} but bypassed it, so {@link #getRecord()} stayed stale for the whole for-each.
+   * <p>
+   * A cursor is single-pass either way: the backing iterator was created once in the constructor, so the old
+   * implementation handed back the SAME exhausted iterator on a second call rather than a fresh traversal.
    */
   @Override
   public Iterator<Identifiable> iterator() {

--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -490,8 +490,11 @@ public class TransactionIndexContext {
     // CHECK UNIQUENESS ACROSS ALL THE INDEXES FOR ALL THE BUCKETS
     final TypeIndex idx = type.getPolymorphicIndexByProperties(index.getPropertyNames());
     if (idx != null) {
-      final IndexCursor found = idx.get(key.keyValues, 2);
-      if (found.hasNext()) {
+      // #5662: try-with-resources - the cursor stops after at most two entries, so it is never drained
+      try (final IndexCursor found = idx.get(key.keyValues, 2)) {
+        if (!found.hasNext())
+          return;
+
         final Identifiable firstEntry = found.next();
         int totalEntries = 1;
         if (found.hasNext())
@@ -530,7 +533,6 @@ public class TransactionIndexContext {
         }
       }
     }
-
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchFieldsMore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchFieldsMore.java
@@ -149,20 +149,20 @@ public class SQLFunctionSearchFieldsMore extends SQLFunctionAbstract {
 
       for (final Index bucketIndex : matchingIndex.getIndexesOnBuckets()) {
         if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex) {
-          final IndexCursor cursor = ftIndex.searchMoreLikeThis(sourceRids, config);
+          try (final IndexCursor cursor = ftIndex.searchMoreLikeThis(sourceRids, config)) {
+            while (cursor.hasNext()) {
+              final Identifiable match = cursor.next();
+              final float score = (float) cursor.getScore();
 
-          while (cursor.hasNext()) {
-            final Identifiable match = cursor.next();
-            final float score = (float) cursor.getScore();
+              allResults.compute(match.getIdentity(), (k, v) -> {
+                if (v == null) return new float[] { score, 0f };
+                v[0] += score;
+                return v;
+              });
 
-            allResults.compute(match.getIdentity(), (k, v) -> {
-              if (v == null) return new float[] { score, 0f };
-              v[0] += score;
-              return v;
-            });
-
-            if (score > maxScore)
-              maxScore = score;
+              if (score > maxScore)
+                maxScore = score;
+            }
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndexMore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndexMore.java
@@ -128,20 +128,20 @@ public class SQLFunctionSearchIndexMore extends SQLFunctionAbstract {
 
       for (final Index bucketIndex : bucketIndexes) {
         if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex) {
-          final IndexCursor cursor = ftIndex.searchMoreLikeThis(sourceRids, config);
+          try (final IndexCursor cursor = ftIndex.searchMoreLikeThis(sourceRids, config)) {
+            while (cursor.hasNext()) {
+              final Identifiable match = cursor.next();
+              final float score = (float) cursor.getScore();
 
-          while (cursor.hasNext()) {
-            final Identifiable match = cursor.next();
-            final float score = (float) cursor.getScore();
+              allResults.compute(match.getIdentity(), (k, v) -> {
+                if (v == null) return new float[] { score, 0f };
+                v[0] += score;
+                return v;
+              });
 
-            allResults.compute(match.getIdentity(), (k, v) -> {
-              if (v == null) return new float[] { score, 0f };
-              v[0] += score;
-              return v;
-            });
-
-            if (score > maxScore)
-              maxScore = score;
+              if (score > maxScore)
+                maxScore = score;
+            }
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/index/IndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexCursor.java
@@ -32,6 +32,9 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
  * the result, not answer optimistically and hand out a null element. Consumers must therefore not guard against a null
  * from {@code next()}; several used to, each with its own comment, because {@code LSMTreeIndexCursor} did answer
  * optimistically.
+ * <p>
+ * An index cursor is also {@link AutoCloseable} through {@link Cursor} - see {@link Cursor#close()} for why an
+ * abandoned one is not free.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -66,10 +69,6 @@ public interface IndexCursor extends Cursor {
    */
   default float getFloatScore() {
     return getScore();
-  }
-
-  default void close() {
-    // NO ACTIONS
   }
 
   default String dumpStats() {

--- a/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
@@ -31,6 +31,10 @@ public class MultiIndexCursor implements IndexCursor {
   private final List<IndexCursor>  cursors;
   private final int                limit;
   private final byte[]             keyTypes;
+  // #5662: sampled once at construction, like keyTypes. A child's comparator does not depend on how much of it is
+  // left, and since #5635 hasNext() prefetches - so probing the children to answer an accessor would run page reads
+  // and tombstone skips on a cursor that may only ever be asked for its key types.
+  private final BinaryComparator   comparator;
   private final boolean            ascendingOrder;
   private       int                browsed         = 0;
   private       Object[]           nextKeys;
@@ -42,37 +46,57 @@ public class MultiIndexCursor implements IndexCursor {
     this.cursors = cursors;
     this.limit = limit;
     this.ascendingOrder = ascendingOrder;
-    this.keyTypes = cursors.getFirst().getBinaryKeyTypes();
-    initCursors();
+    try {
+      this.keyTypes = cursors.getFirst().getBinaryKeyTypes();
+      this.comparator = firstComparator(cursors);
+      initCursors();
+    } catch (final RuntimeException e) {
+      // #5662: the caller handed the children over, so a constructor that does not complete must not leave them open -
+      // no one else holds a reference to them
+      closeQuietly();
+      throw e;
+    }
   }
 
   public MultiIndexCursor(final List<IndexInternal> indexes, final boolean ascendingOrder, final int limit) {
     this.cursors = new ArrayList<>(indexes.size());
     this.limit = limit;
-    for (final Index i : indexes) {
-      if (!(i instanceof RangeIndex))
-        throw new IllegalArgumentException("Cannot iterate an index that does not support ordered iteration");
-
-      this.cursors.add(((RangeIndex) i).iterator(ascendingOrder));
-    }
     this.ascendingOrder = ascendingOrder;
-    this.keyTypes = indexes.getFirst().getBinaryKeyTypes();
-    initCursors();
+    try {
+      for (final Index i : indexes) {
+        if (!(i instanceof RangeIndex))
+          throw new IllegalArgumentException("Cannot iterate an index that does not support ordered iteration");
+
+        this.cursors.add(((RangeIndex) i).iterator(ascendingOrder));
+      }
+      this.keyTypes = indexes.getFirst().getBinaryKeyTypes();
+      this.comparator = firstComparator(this.cursors);
+      initCursors();
+    } catch (final RuntimeException e) {
+      closeQuietly();
+      throw e;
+    }
   }
 
   public MultiIndexCursor(final List<IndexInternal> indexes, final Object[] fromKeys, final boolean ascendingOrder,
       final boolean includeFrom, final int limit) {
     this.cursors = new ArrayList<>(indexes.size());
     this.limit = limit;
-    for (final Index i : indexes) {
-      if (!(i instanceof RangeIndex))
-        throw new IllegalArgumentException("Cannot iterate an index that does not support ordered iteration");
-
-      this.cursors.add(((RangeIndex) i).iterator(ascendingOrder, fromKeys, includeFrom));
-    }
     this.ascendingOrder = ascendingOrder;
-    this.keyTypes = indexes.getFirst().getBinaryKeyTypes();
-    initCursors();
+    try {
+      for (final Index i : indexes) {
+        if (!(i instanceof RangeIndex))
+          throw new IllegalArgumentException("Cannot iterate an index that does not support ordered iteration");
+
+        this.cursors.add(((RangeIndex) i).iterator(ascendingOrder, fromKeys, includeFrom));
+      }
+      this.keyTypes = indexes.getFirst().getBinaryKeyTypes();
+      this.comparator = firstComparator(this.cursors);
+      initCursors();
+    } catch (final RuntimeException e) {
+      closeQuietly();
+      throw e;
+    }
   }
 
   @Override
@@ -172,6 +196,24 @@ public class MultiIndexCursor implements IndexCursor {
     }
   }
 
+  /**
+   * {@link #close()} for the failed-construction path: it must not mask the exception that is being propagated, and it
+   * cannot assume the fields it reads were assigned.
+   */
+  private void closeQuietly() {
+    for (int i = 0; i < cursors.size(); ++i) {
+      final IndexCursor cursor = cursors.get(i);
+      if (cursor != null) {
+        try {
+          cursor.close();
+        } catch (final RuntimeException ignore) {
+          // KEEP CLOSING THE OTHERS
+        }
+        cursors.set(i, null);
+      }
+    }
+  }
+
   @Override
   public long estimateSize() {
     long tot = 0L;
@@ -194,21 +236,29 @@ public class MultiIndexCursor implements IndexCursor {
     return this;
   }
 
+  /**
+   * The comparator sampled at construction. Reading it does not touch the children: since #5635
+   * {@code LSMTreeIndexCursor.hasNext()} prefetches, so the previous "first child that still has something"
+   * formulation turned a plain accessor into page reads and tombstone-skip work (#5662).
+   */
   @Override
   public BinaryComparator getComparator() {
-    for (final IndexCursor cursor : cursors) {
-      if (cursor != null && cursor.hasNext())
-        return cursor.getComparator();
-    }
-    return null;
+    return comparator;
   }
 
+  /**
+   * The key types sampled at construction, for the same reason as {@link #getComparator()}. Every child scans the
+   * same logical index over a different bucket, so they all agree on the key types, exhausted or not.
+   */
   @Override
   public byte[] getBinaryKeyTypes() {
-    for (final IndexCursor cursor : cursors) {
-      if (cursor != null && cursor.hasNext())
-        return cursor.getBinaryKeyTypes();
-    }
+    return keyTypes;
+  }
+
+  private static BinaryComparator firstComparator(final List<IndexCursor> cursors) {
+    for (final IndexCursor cursor : cursors)
+      if (cursor != null)
+        return cursor.getComparator();
     return null;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -92,10 +92,18 @@ public class TypeIndex implements RangeIndex, IndexInternal {
       throw new UnsupportedOperationException("Index '" + getName() + "' does not support ordered iterations");
 
     final List<IndexCursor> cursors = new ArrayList<>(indexesOnBuckets.size());
-    for (final Index index : indexesOnBuckets)
-      cursors.add(((RangeIndex) index).range(ascending, beginKeys, beginKeysInclusive, endKeys, endKeysInclusive));
+    try {
+      for (final Index index : indexesOnBuckets)
+        cursors.add(((RangeIndex) index).range(ascending, beginKeys, beginKeysInclusive, endKeys, endKeysInclusive));
 
-    return new MultiIndexCursor(cursors, -1, ascending);
+      return new MultiIndexCursor(cursors, -1, ascending);
+    } catch (final RuntimeException e) {
+      // #5662: nothing owns the per-bucket cursors until the MultiIndexCursor is built, so a failure partway through
+      // would abandon the ones already opened
+      for (final IndexCursor cursor : cursors)
+        cursor.close();
+      throw e;
+    }
   }
 
   @Override
@@ -114,11 +122,12 @@ public class TypeIndex implements RangeIndex, IndexInternal {
       final List<IndexCursorEntry> entries = new ArrayList<>();
 
       for (final Index index : getIndexesByKeys(keys)) {
-        final IndexCursor cursor = index.get(keys, -1);
-        while (cursor.hasNext()) {
-          final Identifiable record = cursor.next();
-          final int score = cursor.getScore();
-          entries.add(new IndexCursorEntry(keys, record, score));
+        try (final IndexCursor cursor = index.get(keys, -1)) {
+          while (cursor.hasNext()) {
+            final Identifiable record = cursor.next();
+            final int score = cursor.getScore();
+            entries.add(new IndexCursorEntry(keys, record, score));
+          }
         }
       }
 
@@ -134,16 +143,18 @@ public class TypeIndex implements RangeIndex, IndexInternal {
       for (final Index index : getIndexesByKeys(keys)) {
         final boolean unique = index.isUnique();
 
-        final IndexCursor cursor = index.get(keys, unique ? 1 : -1);
-        while (cursor.hasNext()) {
-          if (unique) {
-            result = Set.of(cursor.next());
-            return new IndexCursorCollection(result);
-          }
+        // #5662: try-with-resources - the unique branch returns from inside the loop, abandoning the cursor partway
+        try (final IndexCursor cursor = index.get(keys, unique ? 1 : -1)) {
+          while (cursor.hasNext()) {
+            if (unique) {
+              result = Set.of(cursor.next());
+              return new IndexCursorCollection(result);
+            }
 
-          if (result == null)
-            result = new HashSet<>();
-          result.add(cursor.next());
+            if (result == null)
+              result = new HashSet<>();
+            result.add(cursor.next());
+          }
         }
       }
       return new IndexCursorCollection(result != null ? result : Collections.emptyList());
@@ -166,14 +177,16 @@ public class TypeIndex implements RangeIndex, IndexInternal {
       final List<IndexCursorEntry> entries = new ArrayList<>();
 
       for (final Index index : getIndexesByKeys(keys)) {
-        final IndexCursor cursor = index.get(keys, limit > -1 ? limit - entries.size() : -1);
-        while (cursor.hasNext()) {
-          final Identifiable record = cursor.next();
-          final int score = cursor.getScore();
-          entries.add(new IndexCursorEntry(keys, record, score));
+        // #5662: try-with-resources - the limit breaks out of the loop, abandoning the cursor partway
+        try (final IndexCursor cursor = index.get(keys, limit > -1 ? limit - entries.size() : -1)) {
+          while (cursor.hasNext()) {
+            final Identifiable record = cursor.next();
+            final int score = cursor.getScore();
+            entries.add(new IndexCursorEntry(keys, record, score));
 
-          if (limit > -1 && entries.size() >= limit)
-            break;
+            if (limit > -1 && entries.size() >= limit)
+              break;
+          }
         }
         if (limit > -1 && entries.size() >= limit)
           break;
@@ -198,16 +211,18 @@ public class TypeIndex implements RangeIndex, IndexInternal {
       Set<Identifiable> result = null;
 
       for (final Index index : getIndexesByKeys(keys)) {
-        final IndexCursor cursor = index.get(keys,
-            effectiveLimit > -1 ? (result != null ? result.size() : 0) - effectiveLimit : -1);
-        while (cursor.hasNext()) {
-          if (result == null)
-            result = effectiveLimit > -1 ? new HashSet<>(effectiveLimit) : new HashSet<>();
+        // #5662: try-with-resources - the limit returns from inside the loop, abandoning the cursor partway
+        try (final IndexCursor cursor = index.get(keys,
+            effectiveLimit > -1 ? (result != null ? result.size() : 0) - effectiveLimit : -1)) {
+          while (cursor.hasNext()) {
+            if (result == null)
+              result = effectiveLimit > -1 ? new HashSet<>(effectiveLimit) : new HashSet<>();
 
-          result.add(cursor.next());
+            result.add(cursor.next());
 
-          if (effectiveLimit > -1 && result.size() >= effectiveLimit)
-            return new IndexCursorCollection(result);
+            if (effectiveLimit > -1 && result.size() >= effectiveLimit)
+              return new IndexCursorCollection(result);
+          }
         }
       }
       return new IndexCursorCollection(result != null ? result : Collections.emptyList());

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -99,9 +99,12 @@ public class TypeIndex implements RangeIndex, IndexInternal {
       return new MultiIndexCursor(cursors, -1, ascending);
     } catch (final RuntimeException e) {
       // #5662: nothing owns the per-bucket cursors until the MultiIndexCursor is built, so a failure partway through
-      // would abandon the ones already opened
+      // would abandon the ones already opened. The null guard matters: MultiIndexCursor keeps THIS list rather than
+      // copying it, and a constructor that fails has already closed the children and nulled their slots - without the
+      // guard the cleanup would throw a NullPointerException over the exception that is being propagated.
       for (final IndexCursor cursor : cursors)
-        cursor.close();
+        if (cursor != null)
+          cursor.close();
       throw e;
     }
   }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -530,14 +530,15 @@ public class FullTextQueryExecutor {
 
     // Raw postings lookup: we only need the matching RIDs here. The BM25 score is computed once, later, by scoreCandidatesBM25;
     // going through index.get() would run (and then discard) the full scoring pipeline for every term.
-    final IndexCursor cursor = index.getPostings(searchKey);
     long df = 0L;
-    while (cursor.hasNext()) {
-      final RID rid = cursor.next().getIdentity();
-      // Deletion markers carry a negative bucket id: they are not live documents and must not inflate the document frequency.
-      if (rid.getBucketId() >= 0)
-        ++df;
-      scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
+    try (final IndexCursor cursor = index.getPostings(searchKey)) {
+      while (cursor.hasNext()) {
+        final RID rid = cursor.next().getIdentity();
+        // Deletion markers carry a negative bucket id: they are not live documents and must not inflate the document frequency.
+        if (rid.getBucketId() >= 0)
+          ++df;
+        scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
+      }
     }
     recordDocumentFrequency(searchKey, df);
   }
@@ -562,14 +563,15 @@ public class FullTextQueryExecutor {
     for (final Term term : terms) {
       recordScoringToken(term.text(), 1.0f);
       final Map<RID, AtomicInteger> termMatches = new HashMap<>();
-      final IndexCursor cursor = index.getPostings(term.text());
       long df = 0L;
-      while (cursor.hasNext()) {
-        final RID rid = cursor.next().getIdentity();
-        // Deletion markers carry a negative bucket id and must not inflate the document frequency.
-        if (rid.getBucketId() >= 0)
-          ++df;
-        termMatches.put(rid, new AtomicInteger(1));
+      try (final IndexCursor cursor = index.getPostings(term.text())) {
+        while (cursor.hasNext()) {
+          final RID rid = cursor.next().getIdentity();
+          // Deletion markers carry a negative bucket id and must not inflate the document frequency.
+          if (rid.getBucketId() >= 0)
+            ++df;
+          termMatches.put(rid, new AtomicInteger(1));
+        }
       }
       recordDocumentFrequency(term.text(), df);
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
@@ -116,8 +116,9 @@ public class FullTextSearch {
     final Map<RID, Float> allResults = new HashMap<>();
 
     for (final LSMTreeFullTextIndex ftIndex : bucketIndexes) {
-      final IndexCursor cursor = new FullTextQueryExecutor(ftIndex).search(queryText, effectiveLimit);
-      mergeCursor(allResults, cursor);
+      try (final IndexCursor cursor = new FullTextQueryExecutor(ftIndex).search(queryText, effectiveLimit)) {
+        mergeCursor(allResults, cursor);
+      }
     }
 
     return allResults;
@@ -302,11 +303,12 @@ public class FullTextSearch {
     for (final String token : scoringTokens.keySet()) {
       long df = 0L;
       for (final LSMTreeFullTextIndex ftIndex : bucketIndexes) {
-        final IndexCursor postings = ftIndex.getPostings(token);
-        while (postings.hasNext()) {
-          // a deletion marker carries a negative bucket id: it is not a live document
-          if (postings.next().getIdentity().getBucketId() >= 0)
-            ++df;
+        try (final IndexCursor postings = ftIndex.getPostings(token)) {
+          while (postings.hasNext()) {
+            // a deletion marker carries a negative bucket id: it is not a live document
+            if (postings.next().getIdentity().getBucketId() >= 0)
+              ++df;
+          }
         }
       }
       documentFrequencies.put(token, df);

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -350,16 +350,17 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         // type-wide query, FullTextSearch already counted df across every bucket and supplied it in the scoring context.
         long df = scoringContext != null ? scoringContext.documentFrequency(e.getKey()) : 0L;
         hits.clear();
-        final IndexCursor cursor = underlyingIndex.get(storedKey);
-        while (cursor.hasNext()) {
-          final Identifiable id = cursor.next();
-          // Skip deletion markers (negative bucket id): they are not live documents and must not inflate the document frequency.
-          if (id.getIdentity().getBucketId() < 0)
-            continue;
-          if (scoringContext == null)
-            ++df;
-          if (id instanceof FullTextPostingRID s && scoreMap.containsKey(s.getIdentity()))
-            hits.add(s);
+        try (final IndexCursor cursor = underlyingIndex.get(storedKey)) {
+          while (cursor.hasNext()) {
+            final Identifiable id = cursor.next();
+            // Skip deletion markers (negative bucket id): they are not live documents and must not inflate the document frequency.
+            if (id.getIdentity().getBucketId() < 0)
+              continue;
+            if (scoringContext == null)
+              ++df;
+            if (id instanceof FullTextPostingRID s && scoreMap.containsKey(s.getIdentity()))
+              hits.add(s);
+          }
         }
         if (df == 0L)
           continue;
@@ -371,21 +372,23 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         // already counted global df, so it goes straight to the scoring pass over this bucket.
         long df = scoringContext != null ? scoringContext.documentFrequency(e.getKey()) : 0L;
         if (scoringContext == null) {
-          final IndexCursor dfCursor = underlyingIndex.get(storedKey);
-          while (dfCursor.hasNext()) {
-            if (dfCursor.next().getIdentity().getBucketId() >= 0) // skip deletion markers
-              ++df;
+          try (final IndexCursor dfCursor = underlyingIndex.get(storedKey)) {
+            while (dfCursor.hasNext()) {
+              if (dfCursor.next().getIdentity().getBucketId() >= 0) // skip deletion markers
+                ++df;
+            }
           }
         }
         if (df == 0L)
           continue;
         final double idf = BM25Scorer.idf(totalDocs, df);
-        final IndexCursor scoreCursor = underlyingIndex.get(storedKey);
-        while (scoreCursor.hasNext()) {
-          final Identifiable id = scoreCursor.next();
-          if (id instanceof FullTextPostingRID s)
-            scoreMap.computeIfAbsent(s.getIdentity(), k -> new double[1])[0] +=
-                BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost;
+        try (final IndexCursor scoreCursor = underlyingIndex.get(storedKey)) {
+          while (scoreCursor.hasNext()) {
+            final Identifiable id = scoreCursor.next();
+            if (id instanceof FullTextPostingRID s)
+              scoreMap.computeIfAbsent(s.getIdentity(), k -> new double[1])[0] +=
+                  BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost;
+          }
         }
       }
     }
@@ -607,12 +610,13 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         break;
       }
       explained++;
-      final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() });
       long df = 0;
-      while (postings.hasNext()) {
-        // Skip deletion markers (negative bucket id) so the explained df/idf matches what computeBM25Scores actually uses.
-        if (postings.next().getIdentity().getBucketId() >= 0)
-          ++df;
+      try (final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() })) {
+        while (postings.hasNext()) {
+          // Skip deletion markers (negative bucket id) so the explained df/idf matches what computeBM25Scores actually uses.
+          if (postings.next().getIdentity().getBucketId() >= 0)
+            ++df;
+        }
       }
       terms.put(new JSONObject().put("term", e.getKey()).put("df", df).put("idf", BM25Scorer.idf(totalDocs, df))
           .put("boost", e.getValue()));
@@ -1478,11 +1482,12 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     // Step 3: Get document frequencies for each term
     final Map<String, Integer> docFreqs = new HashMap<>();
     for (final String term : termFreqs.keySet()) {
-      final IndexCursor termCursor = underlyingIndex.get(new String[] { term });
       int docCount = 0;
-      while (termCursor.hasNext()) {
-        termCursor.next();
-        docCount++;
+      try (final IndexCursor termCursor = underlyingIndex.get(new String[] { term })) {
+        while (termCursor.hasNext()) {
+          termCursor.next();
+          docCount++;
+        }
       }
       docFreqs.put(term, docCount);
     }
@@ -1502,10 +1507,11 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     // Step 5: Execute OR query and accumulate scores
     final Map<RID, Integer> scoreMap = new HashMap<>();
     for (final String term : topTerms) {
-      final IndexCursor termCursor = underlyingIndex.get(new String[] { term });
-      while (termCursor.hasNext()) {
-        final RID rid = termCursor.next().getIdentity();
-        scoreMap.merge(rid, 1, Integer::sum);
+      try (final IndexCursor termCursor = underlyingIndex.get(new String[] { term })) {
+        while (termCursor.hasNext()) {
+          final RID rid = termCursor.next().getIdentity();
+          scoreMap.merge(rid, 1, Integer::sum);
+        }
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -180,7 +180,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
    */
   synchronized void dropRetiredCompactedIndexes() {
     for (final LSMTreeIndexCompacted retired : retiredCompactedIndexes) {
-      if (retired.getActiveCursors() != 0)
+      if (retired.countActiveCursors() != 0)
         continue;
 
       final int fileId = retired.getFileId();

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -37,7 +37,9 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.utility.RidHashSet;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.logging.Level;
@@ -59,13 +61,19 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
   private volatile boolean keyOrderCheckedOnLoad = false;
 
   /**
-   * Number of live {@link LSMTreeIndexUnderlyingCompactedSeriesCursor}s over this file. Series cursors load
-   * their pages LAZILY (page by page as the scan advances), so unlike the mutable-page cursors - which grab
-   * every page buffer eagerly at construction - they cannot survive their file being dropped. A full
-   * compaction that replaces this file must therefore defer the physical drop until this count drains to
-   * zero (see LSMTreeIndex's retired-file handling).
+   * The live {@link LSMTreeIndexUnderlyingCompactedSeriesCursor}s over this file, one entry per open cursor. Series
+   * cursors load their pages LAZILY (page by page as the scan advances), so unlike the mutable-page cursors - which
+   * grab every page buffer eagerly at construction - they cannot survive their file being dropped. A full compaction
+   * that replaces this file must therefore defer the physical drop until this set drains (see LSMTreeIndex's
+   * retired-file handling).
+   * <p>
+   * <b>#5662.</b> The entries are WEAK references to a token the cursor owns, not a plain counter, so that a cursor
+   * abandoned without {@code close()} stops pinning the file once the GC collects it. It used to be a counter, which
+   * made every missed {@code close()} permanent: the retired file stayed undroppable for the lifetime of the database
+   * with nothing left that could ever release it, and nothing to say so. {@link #purgeCollectedCursors()} now reports
+   * each one, because a leak that repairs itself is still a leak worth a line in the log.
    */
-  private final AtomicInteger activeCursors = new AtomicInteger();
+  private final Set<WeakReference<Object>> activeCursors = ConcurrentHashMap.newKeySet();
 
   /**
    * Per-series bloom filters over this file (#5517), or null when the file has none - because the feature is off, the
@@ -899,17 +907,45 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     super.drop();
   }
 
-  void onCursorOpened() {
-    activeCursors.incrementAndGet();
+  /**
+   * Registers a series cursor over this file. The caller passes a token it keeps strongly referenced for as long as it
+   * may still read a page, and hands the returned registration back to {@link #onCursorClosed(WeakReference)}.
+   */
+  WeakReference<Object> onCursorOpened(final Object liveToken) {
+    final WeakReference<Object> registration = new WeakReference<>(liveToken);
+    activeCursors.add(registration);
+    return registration;
   }
 
-  void onCursorClosed() {
-    activeCursors.decrementAndGet();
+  void onCursorClosed(final WeakReference<Object> registration) {
+    activeCursors.remove(registration);
   }
 
   /** Live series cursors over this file; the file cannot be physically dropped while > 0. */
   public int getActiveCursors() {
-    return activeCursors.get();
+    purgeCollectedCursors();
+    return activeCursors.size();
+  }
+
+  /**
+   * Drops the registrations whose cursor has been collected without being closed, and says so: they are the only way
+   * an entry can be left behind, since {@link #onCursorClosed(WeakReference)} removes its own. Called from
+   * {@link #getActiveCursors()}, which the retired-file drop consults, so an abandoned cursor delays the drop until
+   * the next GC instead of forever.
+   */
+  private void purgeCollectedCursors() {
+    int leaked = 0;
+    for (final Iterator<WeakReference<Object>> it = activeCursors.iterator(); it.hasNext(); ) {
+      if (it.next().get() == null) {
+        it.remove();
+        ++leaked;
+      }
+    }
+
+    if (leaked > 0)
+      LogManager.instance().log(this, Level.WARNING,
+          "Reclaimed %d cursor(s) on compacted index '%s' that were garbage collected without being closed: the file "
+              + "could not be dropped until now. Please report this, the scan that opened them is leaking.", leaked, getName());
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -921,8 +921,15 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     activeCursors.remove(registration);
   }
 
-  /** Live series cursors over this file; the file cannot be physically dropped while > 0. */
-  public int getActiveCursors() {
+  /**
+   * Live series cursors over this file; the file cannot be physically dropped while this is > 0.
+   * <p>
+   * Named {@code count...} rather than {@code get...} because it is NOT a plain accessor (#5662): it walks the
+   * registrations and drops the ones whose cursor has been collected, the same purge-on-read a {@code WeakHashMap}
+   * does. That makes it O(live cursors) and gives it a side effect - it can emit a warning. Both are irrelevant on the
+   * one path that calls it, the retired-file drop, and neither is what a caller would expect from a getter.
+   */
+  public int countActiveCursors() {
     purgeCollectedCursors();
     return activeCursors.size();
   }
@@ -930,8 +937,14 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
   /**
    * Drops the registrations whose cursor has been collected without being closed, and says so: they are the only way
    * an entry can be left behind, since {@link #onCursorClosed(WeakReference)} removes its own. Called from
-   * {@link #getActiveCursors()}, which the retired-file drop consults, so an abandoned cursor delays the drop until
+   * {@link #countActiveCursors()}, which the retired-file drop consults, so an abandoned cursor delays the drop until
    * the next GC instead of forever.
+   * <p>
+   * Nothing else purges, so on a file that is never retired the cleared references sit here unreclaimed. They are
+   * empty {@link WeakReference} shells bounded by the number of cursors actually leaked over the file's lifetime -
+   * a few dozen bytes each in a case that is already a bug - and they are gone the moment a drop is attempted. Purging
+   * from {@link #onCursorOpened(Object)} instead would put that walk on the scan-open path to reclaim nothing that
+   * matters.
    */
   private void purgeCollectedCursors() {
     int leaked = 0;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexUnderlyingCompactedSeriesCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexUnderlyingCompactedSeriesCursor.java
@@ -25,11 +25,20 @@ import com.arcadedb.engine.PageId;
 import com.arcadedb.index.IndexException;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 
 public class LSMTreeIndexUnderlyingCompactedSeriesCursor extends LSMTreeIndexUnderlyingAbstractCursor {
   private final int                              lastPageNumber;
   private       LSMTreeIndexUnderlyingPageCursor pageCursor;
   private       boolean                          closed = false;
+
+  /**
+   * The liveness token handed to the file's cursor registry (#5662), and the weak registration to hand back on
+   * {@link #close()}. The token is a plain object rather than {@code this} so the registry never gets a reference to a
+   * half-constructed cursor; it dies with this cursor, which is what lets an abandoned scan stop pinning the file.
+   */
+  private final Object                           liveToken = new Object();
+  private final WeakReference<Object>            registration;
 
   public LSMTreeIndexUnderlyingCompactedSeriesCursor(final LSMTreeIndexCompacted index, final int firstPageNumber,
       final int lastPageNumber,
@@ -39,7 +48,7 @@ public class LSMTreeIndexUnderlyingCompactedSeriesCursor extends LSMTreeIndexUnd
 
     // Series pages are loaded LAZILY as the scan advances: register with the file so a full
     // compaction cannot physically drop it while this cursor may still need to read from it.
-    index.onCursorOpened();
+    this.registration = index.onCursorOpened(liveToken);
 
     loadNextNonEmptyPage(firstPageNumber, posInPage);
   }
@@ -115,7 +124,7 @@ public class LSMTreeIndexUnderlyingCompactedSeriesCursor extends LSMTreeIndexUnd
     // idempotent: exhaustion paths and explicit close() may both fire
     if (!closed) {
       closed = true;
-      ((LSMTreeIndexCompacted) index).onCursorClosed();
+      ((LSMTreeIndexCompacted) index).onCursorClosed(registration);
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4073,9 +4073,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
           return resultRIDs.size();
         }
 
+        /**
+         * #5662: a cursor iterates ITSELF, like every other {@link IndexCursor}. Handing back the backing list's own
+         * iterator gave a for-each a second, independent traversal that left {@code position} untouched, so
+         * {@link #getRecord()} reported nothing during the loop and mixing {@code next()} with a for-each read some
+         * RIDs twice.
+         */
         @Override
         public Iterator<Identifiable> iterator() {
-          return (Iterator<Identifiable>) (Iterator<?>) resultRIDs.iterator();
+          return this;
         }
       };
     } catch (final Exception e) {

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -71,43 +71,62 @@ public class SelectExecutor {
     return new SelectIterator<>(this, iterator, iteratorFromIndexes != null && iteratorFromIndexes.getCursors() > 1);
   }
 
+  /**
+   * #5662: the index cursor is released even though the scan stops at the LIMIT rather than on exhaustion. Only a
+   * drained cursor releases its per-series file registrations on its own, so the early exit is exactly the case that
+   * would keep a retired compacted file undroppable until the next restart.
+   */
   long executeCount() {
     final MultiIndexCursor iteratorFromIndexes = lookForIndexes();
-    final Iterator<? extends Identifiable> iterator = buildIterator(iteratorFromIndexes);
-    final Set<RID> filterOutRecords = iteratorFromIndexes != null && iteratorFromIndexes.getCursors() > 1
-        ? ConcurrentHashMap.newKeySet() : null;
+    try {
+      final Iterator<? extends Identifiable> iterator = buildIterator(iteratorFromIndexes);
+      final Set<RID> filterOutRecords = iteratorFromIndexes != null && iteratorFromIndexes.getCursors() > 1
+          ? ConcurrentHashMap.newKeySet() : null;
 
-    long count = 0;
-    int skipped = 0;
-    while (iterator.hasNext()) {
-      final Document record = iterator.next().asDocument();
-      if (filterOutRecords != null && filterOutRecords.contains(record.getIdentity()))
-        continue;
-      if (select.rootTreeElement == null || evaluateWhere(record)) {
-        if (skipped < select.skip) {
-          skipped++;
+      long count = 0;
+      int skipped = 0;
+      while (iterator.hasNext()) {
+        final Document record = iterator.next().asDocument();
+        if (filterOutRecords != null && filterOutRecords.contains(record.getIdentity()))
           continue;
+        if (select.rootTreeElement == null || evaluateWhere(record)) {
+          if (skipped < select.skip) {
+            skipped++;
+            continue;
+          }
+          if (filterOutRecords != null)
+            filterOutRecords.add(record.getIdentity());
+          count++;
+          if (select.limit > -1 && count >= select.limit)
+            break;
         }
-        if (filterOutRecords != null)
-          filterOutRecords.add(record.getIdentity());
-        count++;
-        if (select.limit > -1 && count >= select.limit)
-          break;
       }
+      return count;
+    } finally {
+      if (iteratorFromIndexes != null)
+        iteratorFromIndexes.close();
     }
-    return count;
   }
 
+  /**
+   * #5662: same as {@link #executeCount()}, and more acutely so - this method returns on the FIRST match, so the
+   * cursor is abandoned partway on every positive answer.
+   */
   boolean executeExists() {
     final MultiIndexCursor iteratorFromIndexes = lookForIndexes();
-    final Iterator<? extends Identifiable> iterator = buildIterator(iteratorFromIndexes);
+    try {
+      final Iterator<? extends Identifiable> iterator = buildIterator(iteratorFromIndexes);
 
-    while (iterator.hasNext()) {
-      final Document record = iterator.next().asDocument();
-      if (select.rootTreeElement == null || evaluateWhere(record))
-        return true;
+      while (iterator.hasNext()) {
+        final Document record = iterator.next().asDocument();
+        if (select.rootTreeElement == null || evaluateWhere(record))
+          return true;
+      }
+      return false;
+    } finally {
+      if (iteratorFromIndexes != null)
+        iteratorFromIndexes.close();
     }
-    return false;
   }
 
   @SuppressWarnings("unchecked")

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -103,6 +103,8 @@ public class SelectExecutor {
       }
       return count;
     } finally {
+      // only the index cursor is released: the alternatives buildIterator() can return (a type or bucket scan, a
+      // MultiIterator over several buckets) hold no per-series file registration and are not closeable at all
       if (iteratorFromIndexes != null)
         iteratorFromIndexes.close();
     }

--- a/engine/src/main/java/com/arcadedb/query/select/SelectIterator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectIterator.java
@@ -21,11 +21,13 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.BinaryComparator;
 import com.arcadedb.utility.Pair;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -141,13 +143,21 @@ public class SelectIterator<T extends Document> implements Iterator<T>, AutoClos
   }
 
   /**
-   * Releases the resources associated to the iterator. The serial implementation has nothing to release; the parallel
-   * implementation ({@link SelectParallelIterator}) overrides this method to stop the background producers, so an early
-   * close does not leave async workers running (#5065). Closing an iterator is optional when it is fully consumed.
+   * Releases the resources associated to the iterator: the source index cursor when the plan was answered from one
+   * (#5662), plus, in the parallel implementation ({@link SelectParallelIterator}), the background producers, so an
+   * early close does not leave async workers running (#5065). Closing is optional when the iterator was fully
+   * consumed - a drained index cursor has already released its per-series file registrations - and required when it
+   * was not, which a LIMIT, a {@code break} or an exception all produce.
    */
   @Override
   public void close() {
-    // NOTHING TO RELEASE IN THE SERIAL IMPLEMENTATION
+    if (iterator instanceof AutoCloseable closeable) {
+      try {
+        closeable.close();
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.WARNING, "Error on closing the source iterator of a select", e);
+      }
+    }
   }
 
   public List<T> toList() {

--- a/engine/src/main/java/com/arcadedb/query/select/SelectParallelIterator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectParallelIterator.java
@@ -218,10 +218,15 @@ public class SelectParallelIterator<T extends Document> extends SelectIterator<T
   /**
    * Stops the background producers. Each producer ends its async task through the regular completion path, releasing
    * the worker within one park cycle. Idempotent and safe to call from any thread.
+   * <p>
+   * The super call releases the source index cursor (#5662). No producer can be reading it: they are scheduled only
+   * when the source is a {@link MultiIterator}, and an index-answered plan hands this class a {@code MultiIndexCursor}
+   * instead, which leaves {@code queue} null and falls back to the serial consumption path.
    */
   @Override
   public void close() {
     closed = true;
+    super.close();
   }
 
   private T onProducerStalled() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgesStep.java
@@ -279,9 +279,11 @@ public class CreateEdgesStep extends AbstractExecutionStep {
   private Edge getExistingEdge(final Vertex currentFrom, final Vertex currentTo) {
     final RID[] key = new RID[] { currentFrom.getIdentity(), currentTo.getIdentity() };
 
-    final IndexCursor cursor = uniqueIndex.get(key);
-    if (cursor.hasNext())
-      return cursor.next().asEdge();
+    // #5662: try-with-resources - at most one entry is read out of the cursor, which is therefore never drained
+    try (final IndexCursor cursor = uniqueIndex.get(key)) {
+      if (cursor.hasNext())
+        return cursor.next().asEdge();
+    }
 
     return null;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
@@ -23,11 +23,13 @@ import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.RangeIndex;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.parser.*;
 import com.arcadedb.utility.Pair;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;
+import java.util.logging.Level;
 
 /**
  * Created by luigidellaquila on 11/08/16.
@@ -101,6 +103,13 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
     };
   }
 
+  /**
+   * #5662: an index scan that fails to initialise aborts the step. It used to print the stack trace to stdout and carry
+   * on with a null cursor, so the operator would see a {@link NullPointerException} out of {@code loadNextEntry()}
+   * instead of the {@link IOException} that said what had actually gone wrong. No branch of {@link #init(BooleanExpression)}
+   * throws it today - the catch is there because the method declares it - so this is about what happens the day one
+   * does, not about a failure reachable now.
+   */
   private synchronized void init() {
     if (initialized) {
       return;
@@ -111,12 +120,36 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
       init(condition);
       nextEntry = loadNextEntry(context);
     } catch (final IOException e) {
-      e.printStackTrace();
+      LogManager.instance()
+          .log(this, Level.SEVERE, "Error on initializing the scan of index '%s' to delete from", e, index.getName());
+      releaseCursor();
+      throw new CommandExecutionException("Error on initializing the scan of index '" + index.getName() + "' to delete from", e);
     } finally {
       if (context.isProfiling()) {
         cost += System.nanoTime() - begin;
       }
     }
+  }
+
+  @Override
+  public void close() {
+    releaseCursor();
+    super.close();
+  }
+
+  /**
+   * #5662: releases the index cursor. A DELETE stops as soon as its {@code LIMIT} is reached, so the cursor is
+   * routinely abandoned partway - and an abandoned compacted-series cursor stays registered with its file, which
+   * {@code LSMTreeIndex.dropRetiredCompactedIndexes} then refuses to drop for the lifetime of the database.
+   */
+  private void releaseCursor() {
+    if (cursor != null) {
+      cursor.close();
+      cursor = null;
+    }
+    // a closed step is finished: without this the result set handed out by syncPull would still answer hasNext() and
+    // then dereference the released cursor
+    nextEntry = null;
   }
 
   private Pair<Object, Identifiable> loadNextEntry(final CommandContext commandContext) {
@@ -177,13 +210,9 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
         cursor = index.range(false, new Object[]{thirdValue}, fromKeyIncluded, new Object[]{secondValue},
             toKeyIncluded);
     } else if (additional == null && allEqualities((AndBlock) condition)) {
-
-      if (isOrderAsc())
-        cursor = index.range(true, new Object[]{secondValue}, fromKeyIncluded, new Object[]{thirdValue}, toKeyIncluded);
-      else
-        cursor = index.range(false, new Object[]{thirdValue}, fromKeyIncluded, new Object[]{secondValue},
-            toKeyIncluded);
-
+      // #5662: this used to open a range() cursor first and then overwrite it with the iterator() one on the very next
+      // line - a dead store that opened, and abandoned, a full index scan on every equality DELETE against an index
+      // without ordered iterations.
       cursor = index.iterator(isOrderAsc(), new Object[]{secondValue}, true);
     } else {
       throw new UnsupportedOperationException("Cannot evaluate " + this.condition + " on index " + index);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
@@ -209,30 +209,14 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
       else
         cursor = index.range(false, new Object[]{thirdValue}, fromKeyIncluded, new Object[]{secondValue},
             toKeyIncluded);
-    } else if (additional == null && allEqualities((AndBlock) condition)) {
-      // #5662: this used to open a range() cursor first and then overwrite it with the iterator() one on the very next
-      // line - a dead store that opened, and abandoned, a full index scan on every equality DELETE against an index
-      // without ordered iterations.
-      cursor = index.iterator(isOrderAsc(), new Object[]{secondValue}, true);
     } else {
+      // #5662: an index without ordered iterations used to get a branch of its own here, which opened a range() cursor
+      // and then overwrote it with an iterator() one on the very next line. It could never have worked: the only
+      // RangeIndex that answers false to supportsOrderedIterations() is a TypeIndex over a non-ordered bucket index,
+      // and BOTH of those calls raise UnsupportedOperationException on one. Removing it costs nothing and lets the
+      // error below say which condition could not be evaluated, instead of only that the index is not ordered.
       throw new UnsupportedOperationException("Cannot evaluate " + this.condition + " on index " + index);
     }
-  }
-
-  private boolean allEqualities(final AndBlock condition) {
-    if (condition == null) {
-      return false;
-    }
-    for (final BooleanExpression exp : condition.getSubBlocks()) {
-      if (exp instanceof BinaryCondition binaryCondition) {
-        if (binaryCondition.getOperator() instanceof EqualsCompareOperator) {
-          return true;
-        }
-      } else {
-        return false;
-      }
-    }
-    return true;
   }
 
   private void processBetweenCondition() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
@@ -124,6 +124,11 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
           .log(this, Level.SEVERE, "Error on initializing the scan of index '%s' to delete from", e, index.getName());
       releaseCursor();
       throw new CommandExecutionException("Error on initializing the scan of index '" + index.getName() + "' to delete from", e);
+    } catch (final RuntimeException e) {
+      // an abort AFTER the cursor was opened - an unsupported condition, or a page read failing inside
+      // loadNextEntry() - must not depend on the executor getting around to close(): release it here
+      releaseCursor();
+      throw e;
     } finally {
       if (context.isProfiling()) {
         cost += System.nanoTime() - begin;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -37,7 +37,6 @@ import com.arcadedb.query.sql.parser.GtOperator;
 import com.arcadedb.query.sql.parser.InCondition;
 import com.arcadedb.query.sql.parser.IsNullCondition;
 import com.arcadedb.query.sql.parser.LeOperator;
-import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.query.sql.parser.LtOperator;
 import com.arcadedb.query.sql.parser.PCollection;
 import com.arcadedb.query.sql.parser.ValueExpression;
@@ -69,7 +68,6 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
   /** Package-private for the same reason as {@link #nextCursors}. */
   IndexCursor                                                    cursor;
   private         MultiIterator<Map.Entry<Object, Identifiable>> customIterator;
-  private         Iterator<?>                                    nullKeyIterator;
   private         Pair<Object, Identifiable>                     nextEntry   = null;
   // Float so full-text BM25 scores below 1.0 are not truncated to 0 (which the `> 0` guard would then suppress). For
   // integer-scored indexes getFloatScore() returns the int value unchanged.
@@ -162,11 +160,6 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
           if (nextEntry == null && customIterator != null && customIterator.hasNext()) {
             final Map.Entry<Object, Identifiable> entry = customIterator.next();
             nextEntry = new Pair<>(entry.getKey(), entry.getValue().getIdentity());
-            nextEntryScore = 0;
-          }
-          if (nextEntry == null && nullKeyIterator != null && nullKeyIterator.hasNext()) {
-            Identifiable nextValue = (Identifiable) nullKeyIterator.next();
-            nextEntry = new Pair<>(null, nextValue.getIdentity());
             nextEntryScore = 0;
           }
 
@@ -354,42 +347,20 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     fetchNextEntry();
   }
 
+  /**
+   * A flat scan needs NO separate pass over the NULL-keyed entries, under any {@code NULL_STRATEGY}: with
+   * {@code INDEX} they are already in the B-tree and the cursor returns them at their sorted position (first
+   * ascending, last descending); with {@code SKIP} they were never indexed; with {@code ERROR} they could not be
+   * inserted. A second iterator over {@code index.get(new Object[keyCount])} would therefore either duplicate rows
+   * or return nothing - which is why the {@code fetchNullKeys()} that built one was never called and has been
+   * removed (#5662).
+   */
   private void processFlatIteration() {
     cursor = index.iterator(isOrderAsc());
-
-    // NOTE: Do NOT call fetchNullKeys() here.
-    // When NULL_STRATEGY is INDEX, NULL-keyed entries are already stored in the B-tree
-    // and will be returned by the cursor iterator. Calling fetchNullKeys() would cause
-    // duplicate entries to be returned since it creates a separate iterator for NULL keys.
-    // The cursor will naturally return NULL entries at their sorted position:
-    // - For ASC order: NULL entries appear first (NULL < all non-null values)
-    // - For DESC order: NULL entries appear last
-    nullKeyIterator = Collections.emptyIterator();
 
     if (cursor != null) {
       fetchNextEntry();
     }
-  }
-
-  private void fetchNullKeys() {
-    if (index.getNullStrategy() != LSMTreeIndexAbstract.NULL_STRATEGY.INDEX) {
-      nullKeyIterator = Collections.emptyIterator();
-      return;
-    }
-    final int keyCount = index.getPropertyNames().size();
-    final Object[] nullKeys = new Object[keyCount];
-    final IndexCursor nullCursor = index.get(nullKeys);
-    nullKeyIterator = new Iterator<>() {
-      @Override
-      public boolean hasNext() {
-        return nullCursor.hasNext();
-      }
-
-      @Override
-      public Identifiable next() {
-        return nullCursor.next();
-      }
-    };
   }
 
   private void init(final PCollection fromKey, final boolean fromKeyIncluded, final PCollection toKey,
@@ -707,7 +678,6 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     inited = false;
     customIterator = null;
-    nullKeyIterator = null;
     nextEntry = null;
     nextEntryScore = 0f;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SubQueryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SubQueryStep.java
@@ -67,6 +67,19 @@ public class SubQueryStep extends AbstractExecutionStep {
     };
   }
 
+  /**
+   * #5662: closes the sub-plan too. Only the OUTER plan's steps used to be closed, so anything the sub-plan held was
+   * released only if the sub-plan happened to run to exhaustion - and a {@code DELETE ... WHERE} is built exactly this
+   * way, with the index scan inside the sub-plan and the {@code LIMIT} outside it. The abandoned
+   * {@link com.arcadedb.index.IndexCursor} then kept its compacted-series registration for the lifetime of the
+   * database.
+   */
+  @Override
+  public void close() {
+    subExecutionPlan.close();
+    super.close();
+  }
+
   @Override
   public List<ExecutionPlan> getSubExecutionPlans() {
     return List.of(subExecutionPlan);

--- a/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * tests here pin the two things that do: the call sites that were abandoning a cursor partway now release it, and a
  * cursor that is leaked anyway stops pinning its file forever once the GC gets to it.
  * <p>
- * The observable throughout is {@link LSMTreeIndexCompacted#getActiveCursors()}, the guard
+ * The observable throughout is {@link LSMTreeIndexCompacted#countActiveCursors()}, the guard
  * {@code LSMTreeIndex.dropRetiredCompactedIndexes} consults before physically dropping a file a full compaction has
  * replaced. Every test that uses it first asserts it can actually rise above zero on this fixture, because a scan too
  * small to open a series cursor would make "it went back to zero" hold vacuously.
@@ -80,10 +80,10 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
     try (final IndexCursor cursor = bucketIndex().iterator(true)) {
       assertThat(cursor.hasNext()).isTrue();
       cursor.next();
-      assertThat(compacted.getActiveCursors()).as("a live scan holds a series cursor over the compacted file").isPositive();
+      assertThat(compacted.countActiveCursors()).as("a live scan holds a series cursor over the compacted file").isPositive();
     }
 
-    assertThat(compacted.getActiveCursors()).as("try-with-resources released the series cursors").isZero();
+    assertThat(compacted.countActiveCursors()).as("try-with-resources released the series cursors").isZero();
   }
 
   @Test
@@ -95,7 +95,7 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
     final boolean found = database.select().fromType(TYPE_NAME).where().property("value").gt().value(1).exists();
 
     assertThat(found).as("the fixture must actually match, otherwise the scan never opened a cursor").isTrue();
-    assertThat(compacted.getActiveCursors()).as("exists() must release the index cursor it abandoned partway").isZero();
+    assertThat(compacted.countActiveCursors()).as("exists() must release the index cursor it abandoned partway").isZero();
   }
 
   @Test
@@ -105,7 +105,7 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
     final long counted = database.select().fromType(TYPE_NAME).where().property("value").gt().value(1).limit(5).count();
 
     assertThat(counted).as("the limit must actually cut the scan short").isEqualTo(5);
-    assertThat(compacted.getActiveCursors()).as("count() must release the index cursor it abandoned at the limit").isZero();
+    assertThat(compacted.countActiveCursors()).as("count() must release the index cursor it abandoned at the limit").isZero();
   }
 
   @Test
@@ -115,11 +115,11 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
     final var iterator = database.select().fromType(TYPE_NAME).where().property("value").gt().value(1).documents();
     assertThat(iterator.hasNext()).isTrue();
     iterator.next();
-    assertThat(compacted.getActiveCursors()).as("the iterator is mid-scan, so a series cursor is open").isPositive();
+    assertThat(compacted.countActiveCursors()).as("the iterator is mid-scan, so a series cursor is open").isPositive();
 
     iterator.close();
 
-    assertThat(compacted.getActiveCursors()).as("SelectIterator.close() must release the source index cursor").isZero();
+    assertThat(compacted.countActiveCursors()).as("SelectIterator.close() must release the source index cursor").isZero();
   }
 
   /**
@@ -135,11 +135,11 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
       try (final ResultSet result = database.command("sql", "DELETE FROM " + TYPE_NAME + " WHERE value > 1 LIMIT 3")) {
         assertThat(((Number) result.next().getProperty("count")).intValue()).as("the LIMIT must cut the scan short")
             .isEqualTo(3);
-        assertThat(compacted.getActiveCursors()).as("precondition: the abandoned scan is still holding a series cursor")
+        assertThat(compacted.countActiveCursors()).as("precondition: the abandoned scan is still holding a series cursor")
             .isPositive();
       }
 
-      assertThat(compacted.getActiveCursors()).as("closing the result set must reach the scan inside the sub-plan")
+      assertThat(compacted.countActiveCursors()).as("closing the result set must reach the scan inside the sub-plan")
           .isZero();
     });
   }
@@ -155,13 +155,13 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
 
     leakACursorMidScan();
 
-    assertThat(compacted.getActiveCursors()).as("the abandoned cursor is still reachable, so it still pins the file")
+    assertThat(compacted.countActiveCursors()).as("the abandoned cursor is still reachable, so it still pins the file")
         .isPositive();
 
     // the reference the registry holds is weak, so collecting the cursor is enough to release the file
     awaitCollection(compacted);
 
-    assertThat(compacted.getActiveCursors()).as("a collected-but-never-closed cursor must stop pinning the file").isZero();
+    assertThat(compacted.countActiveCursors()).as("a collected-but-never-closed cursor must stop pinning the file").isZero();
   }
 
   /**
@@ -175,7 +175,7 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
   }
 
   private void awaitCollection(final LSMTreeIndexCompacted compacted) {
-    for (int attempt = 0; attempt < 50 && compacted.getActiveCursors() > 0; attempt++) {
+    for (int attempt = 0; attempt < 50 && compacted.countActiveCursors() > 0; attempt++) {
       System.gc();
       try {
         Thread.sleep(20);
@@ -311,7 +311,7 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
     final LSMTreeIndexCompacted compacted = index.getMutableIndex().getSubIndex();
     assertThat(compacted).as("the fixture must produce a compacted sub-index, otherwise no series cursor is ever opened")
         .isNotNull();
-    assertThat(compacted.getActiveCursors()).as("no scan has run yet").isZero();
+    assertThat(compacted.countActiveCursors()).as("no scan has run yet").isZero();
     return compacted;
   }
 

--- a/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
@@ -149,6 +149,13 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
    * The safety net behind the whole item: a cursor that IS leaked - because some call site nobody has read yet still
    * drops one - must stop blocking the retired-file drop once it becomes unreachable. It used to be counted, so a
    * single missed {@code close()} pinned the file with nothing left in the process that could ever release it.
+   * <p>
+   * This is the one test here that depends on the JVM rather than only on this codebase: it needs the collector to
+   * actually clear a weak referent. That is reliable on HotSpot for a genuinely unreachable object - the cursor is
+   * opened in its own frame so no local of this method keeps it on the stack - but it is a property of the runtime,
+   * not a guarantee of the spec, so a different collector under load could in principle make it flake. It is asserted
+   * rather than treated as best-effort on purpose: a test that silently passes when the safety net does not work
+   * would be worse than one that occasionally needs a re-run.
    */
   @Test
   void aLeakedCursorStopsPinningTheFileOnceItIsCollected() {

--- a/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Cursor;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.IndexCursorCollection;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.BinaryComparator;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5662, the follow-ups left open by #5635.
+ * <p>
+ * The item this file spends most of its length on is the first one: nothing made an unclosed {@link IndexCursor}
+ * visible. {@link Cursor} is now {@link AutoCloseable}, which is what makes an abandoned cursor a static-analysis
+ * finding instead of something only a careful read can catch - but a compiler flag proves nothing at runtime, so the
+ * tests here pin the two things that do: the call sites that were abandoning a cursor partway now release it, and a
+ * cursor that is leaked anyway stops pinning its file forever once the GC gets to it.
+ * <p>
+ * The observable throughout is {@link LSMTreeIndexCompacted#getActiveCursors()}, the guard
+ * {@code LSMTreeIndex.dropRetiredCompactedIndexes} consults before physically dropping a file a full compaction has
+ * replaced. Every test that uses it first asserts it can actually rise above zero on this fixture, because a scan too
+ * small to open a series cursor would make "it went back to zero" hold vacuously.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5662IndexCursorFollowUpsTest extends TestHelper {
+  private static final String TYPE_NAME = "CursorFollowUp";
+  private static final int    RECORDS   = 600;
+
+  @Override
+  public void beforeTest() {
+    // explicit compaction only, so the sub-index appears exactly when this test asks for it
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // item 1 - nothing enforced close()
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void anIndexCursorIsUsableAsATryWithResourcesResource() throws Exception {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    // the point of the item: this compiles, which it did not before Cursor extended AutoCloseable. close() is also
+    // declared without a checked exception, so the caller is not forced into a catch(Exception) it has nothing to do
+    // with
+    try (final IndexCursor cursor = bucketIndex().iterator(true)) {
+      assertThat(cursor.hasNext()).isTrue();
+      cursor.next();
+      assertThat(compacted.getActiveCursors()).as("a live scan holds a series cursor over the compacted file").isPositive();
+    }
+
+    assertThat(compacted.getActiveCursors()).as("try-with-resources released the series cursors").isZero();
+  }
+
+  @Test
+  void aSelectThatStopsAtTheFirstMatchReleasesItsIndexCursor() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    // exists() returns on the FIRST match, so the cursor is abandoned with most of the index still ahead of it: the
+    // shape that used to leave a series cursor registered for the lifetime of the database
+    final boolean found = database.select().fromType(TYPE_NAME).where().property("value").gt().value(1).exists();
+
+    assertThat(found).as("the fixture must actually match, otherwise the scan never opened a cursor").isTrue();
+    assertThat(compacted.getActiveCursors()).as("exists() must release the index cursor it abandoned partway").isZero();
+  }
+
+  @Test
+  void aCountWithALimitReleasesItsIndexCursor() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    final long counted = database.select().fromType(TYPE_NAME).where().property("value").gt().value(1).limit(5).count();
+
+    assertThat(counted).as("the limit must actually cut the scan short").isEqualTo(5);
+    assertThat(compacted.getActiveCursors()).as("count() must release the index cursor it abandoned at the limit").isZero();
+  }
+
+  @Test
+  void closingAPartiallyConsumedSelectIteratorReleasesItsIndexCursor() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    final var iterator = database.select().fromType(TYPE_NAME).where().property("value").gt().value(1).documents();
+    assertThat(iterator.hasNext()).isTrue();
+    iterator.next();
+    assertThat(compacted.getActiveCursors()).as("the iterator is mid-scan, so a series cursor is open").isPositive();
+
+    iterator.close();
+
+    assertThat(compacted.getActiveCursors()).as("SelectIterator.close() must release the source index cursor").isZero();
+  }
+
+  /**
+   * A {@code DELETE ... WHERE} puts the index scan in a SUB-plan and the {@code LIMIT} outside it, so the scan is
+   * abandoned partway. Closing the result set used to close only the outer plan's steps - {@code SubQueryStep} never
+   * closed the plan it wraps - and the scan inside it was released only if it happened to run to exhaustion.
+   */
+  @Test
+  void closingADeleteLimitedShortOfExhaustionReleasesTheScanInsideItsSubPlan() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    database.transaction(() -> {
+      try (final ResultSet result = database.command("sql", "DELETE FROM " + TYPE_NAME + " WHERE value > 1 LIMIT 3")) {
+        assertThat(((Number) result.next().getProperty("count")).intValue()).as("the LIMIT must cut the scan short")
+            .isEqualTo(3);
+        assertThat(compacted.getActiveCursors()).as("precondition: the abandoned scan is still holding a series cursor")
+            .isPositive();
+      }
+
+      assertThat(compacted.getActiveCursors()).as("closing the result set must reach the scan inside the sub-plan")
+          .isZero();
+    });
+  }
+
+  /**
+   * The safety net behind the whole item: a cursor that IS leaked - because some call site nobody has read yet still
+   * drops one - must stop blocking the retired-file drop once it becomes unreachable. It used to be counted, so a
+   * single missed {@code close()} pinned the file with nothing left in the process that could ever release it.
+   */
+  @Test
+  void aLeakedCursorStopsPinningTheFileOnceItIsCollected() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    leakACursorMidScan();
+
+    assertThat(compacted.getActiveCursors()).as("the abandoned cursor is still reachable, so it still pins the file")
+        .isPositive();
+
+    // the reference the registry holds is weak, so collecting the cursor is enough to release the file
+    awaitCollection(compacted);
+
+    assertThat(compacted.getActiveCursors()).as("a collected-but-never-closed cursor must stop pinning the file").isZero();
+  }
+
+  /**
+   * Opens a scan, advances it into the compacted series and drops every reference to it without closing. Kept in its
+   * own frame so no local of the calling method keeps the cursor alive on the stack.
+   */
+  private void leakACursorMidScan() {
+    final IndexCursor leaked = bucketIndex().iterator(true);
+    assertThat(leaked.hasNext()).isTrue();
+    leaked.next();
+  }
+
+  private void awaitCollection(final LSMTreeIndexCompacted compacted) {
+    for (int attempt = 0; attempt < 50 && compacted.getActiveCursors() > 0; attempt++) {
+      System.gc();
+      try {
+        Thread.sleep(20);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // item 4 - a cursor must iterate ITSELF
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aCollectionBackedCursorIteratesItself() {
+    final List<Identifiable> rids = List.of(new RID(1, 1), new RID(1, 2), new RID(1, 3));
+    final IndexCursorCollection cursor = new IndexCursorCollection(rids);
+
+    assertThat(cursor.iterator()).as("a for-each must drive the cursor, not a second independent traversal").isSameAs(cursor);
+
+    int seen = 0;
+    for (final Identifiable rid : cursor) {
+      // pre-#5662 the backing iterator was handed back directly, so next() - and with it getRecord() - was bypassed
+      assertThat(cursor.getRecord()).as("getRecord() must track the element the for-each just produced").isEqualTo(rid);
+      ++seen;
+    }
+    assertThat(seen).isEqualTo(rids.size());
+  }
+
+  /**
+   * The vector search cursor was the one implementation that handed back the backing list's iterator, so a for-each
+   * got a SECOND, independent traversal: it never advanced the cursor's own position, and mixing it with
+   * {@code next()} read some RIDs twice.
+   */
+  @Test
+  void theVectorSearchCursorIteratesItself() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE VectorDoc");
+      database.command("sql", "CREATE PROPERTY VectorDoc.name STRING");
+      database.command("sql", "CREATE PROPERTY VectorDoc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON VectorDoc (name) UNIQUE");
+      database.command("sql", """
+          CREATE INDEX ON VectorDoc (embedding) LSM_VECTOR
+          METADATA { dimensions: 3, similarity: 'COSINE', idPropertyName: 'name' }""");
+    });
+    database.transaction(() -> {
+      database.newDocument("VectorDoc").set("name", "a").set("embedding", new float[] { 1f, 0f, 0f }).save();
+      database.newDocument("VectorDoc").set("name", "b").set("embedding", new float[] { 0f, 1f, 0f }).save();
+      database.newDocument("VectorDoc").set("name", "c").set("embedding", new float[] { 0f, 0f, 1f }).save();
+    });
+
+    final Index vectorIndex = database.getSchema().getType("VectorDoc").getPolymorphicIndexByProperties("embedding")
+        .getIndexesOnBuckets()[0];
+
+    try (final IndexCursor cursor = vectorIndex.get(new Object[] { new float[] { 1f, 0f, 0f } }, 3)) {
+      assertThat(cursor.iterator()).as("a for-each must drive the cursor, not a second independent traversal")
+          .isSameAs(cursor);
+
+      int seen = 0;
+      for (final Identifiable rid : cursor) {
+        assertThat(cursor.getRecord()).as("getRecord() must track the element the for-each just produced").isEqualTo(rid);
+        ++seen;
+      }
+      assertThat(seen).as("the fixture must return neighbours, otherwise the loop body never ran").isPositive();
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // item 5 - the MultiIndexCursor accessors must not probe the children
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void multiIndexCursorAccessorsDoNotDriveTheChildren() {
+    final ProbeCountingCursor child = new ProbeCountingCursor(new RID(1, 1), new RID(1, 2));
+    final MultiIndexCursor cursor = new MultiIndexCursor(new ArrayList<>(List.of(child)), -1, true);
+
+    final int probesAfterConstruction = child.hasNextCalls;
+    assertThat(probesAfterConstruction).as("the fixture must have a child that CAN be probed").isPositive();
+
+    cursor.getComparator();
+    cursor.getBinaryKeyTypes();
+    cursor.getComparator();
+    cursor.getBinaryKeyTypes();
+
+    // since #5635 hasNext() prefetches - it runs page reads and tombstone skips - so an accessor that probed the
+    // children turned two plain getters into scan work
+    assertThat(child.hasNextCalls).as("the accessors must answer from state sampled at construction")
+        .isEqualTo(probesAfterConstruction);
+  }
+
+  @Test
+  void multiIndexCursorStillReportsItsKeyTypesOnceExhausted() {
+    final ProbeCountingCursor child = new ProbeCountingCursor(new RID(1, 1));
+    final MultiIndexCursor cursor = new MultiIndexCursor(new ArrayList<>(List.of(child)), -1, true);
+
+    assertThat(cursor.getBinaryKeyTypes()).as("precondition: the key types are known while the cursor is live").isNotNull();
+
+    while (cursor.hasNext())
+      cursor.next();
+
+    // the old formulation returned the first child that still HAD something, so an exhausted cursor reported null even
+    // though its key types never changed
+    assertThat(cursor.getBinaryKeyTypes()).as("key types do not depend on how much of the cursor is left").isNotNull();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // fixture
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private LSMTreeIndexCompacted createCompactedFixture() {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("value", Integer.class);
+    // a small page size so the compacted output spans several pages, i.e. a real series a cursor walks lazily
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "value" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(true).withPageSize(1024).create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < RECORDS; i++)
+        database.newDocument(TYPE_NAME).set("value", i).save();
+    });
+
+    final LSMTreeIndex index = bucketIndex();
+    try {
+      if (index.scheduleCompaction())
+        index.compact();
+    } catch (final IOException | InterruptedException e) {
+      throw new IllegalStateException("cannot compact the fixture index", e);
+    }
+
+    final LSMTreeIndexCompacted compacted = index.getMutableIndex().getSubIndex();
+    assertThat(compacted).as("the fixture must produce a compacted sub-index, otherwise no series cursor is ever opened")
+        .isNotNull();
+    assertThat(compacted.getActiveCursors()).as("no scan has run yet").isZero();
+    return compacted;
+  }
+
+  private LSMTreeIndex bucketIndex() {
+    return (LSMTreeIndex) database.getSchema().getType(TYPE_NAME).getAllIndexes(false).iterator().next()
+        .getIndexesOnBuckets()[0];
+  }
+
+  /** Counts how many times an accessor drove it, which since #5635 is not a free operation on a real cursor. */
+  private static final class ProbeCountingCursor implements IndexCursor {
+    private final List<Identifiable> values;
+    private       int                position;
+    private       int                hasNextCalls;
+
+    private ProbeCountingCursor(final Identifiable... values) {
+      this.values = List.of(values);
+    }
+
+    @Override
+    public Object[] getKeys() {
+      return new Object[] { position };
+    }
+
+    @Override
+    public Identifiable getRecord() {
+      return position == 0 ? null : values.get(position - 1);
+    }
+
+    @Override
+    public boolean hasNext() {
+      ++hasNextCalls;
+      return position < values.size();
+    }
+
+    @Override
+    public Identifiable next() {
+      if (position >= values.size())
+        throw new NoSuchElementException();
+      return values.get(position++);
+    }
+
+    @Override
+    public long estimateSize() {
+      return values.size() - position;
+    }
+
+    @Override
+    public BinaryComparator getComparator() {
+      return null;
+    }
+
+    @Override
+    public byte[] getBinaryKeyTypes() {
+      return new byte[] { 1 };
+    }
+
+    @Override
+    public Iterator<Identifiable> iterator() {
+      return this;
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * #5662, the follow-ups left open by #5635.
@@ -186,6 +187,29 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
     }
   }
 
+  /**
+   * A {@link MultiIndexCursor} that fails to construct must not leave the children it was handed open - nothing else
+   * holds a reference to them. It also NULLS their slots in the caller's list, because it keeps that list rather than
+   * copying it, which is why {@code TypeIndex.range()} has to null-guard its own cleanup: without the guard it would
+   * throw a {@link NullPointerException} over the exception being propagated.
+   */
+  @Test
+  void aMultiIndexCursorThatFailsToConstructClosesTheChildrenAndClearsTheList() {
+    final ProbeCountingCursor healthy = new ProbeCountingCursor(new RID(1, 1));
+    final ProbeCountingCursor failing = new ProbeCountingCursor(new RID(1, 2));
+    failing.failOnHasNext = true;
+    final List<IndexCursor> children = new ArrayList<>(List.of(healthy, failing));
+
+    assertThatThrownBy(() -> new MultiIndexCursor(children, -1, true))
+        .as("the original failure must reach the caller, not a NullPointerException from the cleanup")
+        .isInstanceOf(IllegalStateException.class).hasMessage("page read failed on purpose");
+
+    assertThat(healthy.closeCalls).as("a child the caller can no longer reach must be closed").isOne();
+    assertThat(failing.closeCalls).isOne();
+    assertThat(children).as("the caller's own list is left holding nulls, hence the null guard in TypeIndex.range()")
+        .containsOnlyNulls();
+  }
+
   // ---------------------------------------------------------------------------------------------------------------
   // item 4 - a cursor must iterate ITSELF
   // ---------------------------------------------------------------------------------------------------------------
@@ -325,6 +349,8 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
     private final List<Identifiable> values;
     private       int                position;
     private       int                hasNextCalls;
+    private       int                closeCalls;
+    private       boolean            failOnHasNext;
 
     private ProbeCountingCursor(final Identifiable... values) {
       this.values = List.of(values);
@@ -343,7 +369,15 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
     @Override
     public boolean hasNext() {
       ++hasNextCalls;
+      if (failOnHasNext)
+        // stands in for a lazy page read failing while the cursor is being wired up
+        throw new IllegalStateException("page read failed on purpose");
       return position < values.size();
+    }
+
+    @Override
+    public void close() {
+      ++closeCalls;
     }
 
     @Override

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DeleteFromIndexStepCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DeleteFromIndexStepCloseTest.java
@@ -68,25 +68,24 @@ class DeleteFromIndexStepCloseTest extends TestHelper {
 
       // one pull is enough to open the scan; nothing is removed yet, the entries are only positioned
       step.syncPull(context, 1);
-      assertThat(compacted.getActiveCursors()).as("precondition: the scan must be holding a series cursor").isPositive();
+      assertThat(compacted.countActiveCursors()).as("precondition: the scan must be holding a series cursor").isPositive();
 
       step.close();
 
-      assertThat(compacted.getActiveCursors()).as("DeleteFromIndexStep.close() must release its index cursor").isZero();
+      assertThat(compacted.countActiveCursors()).as("DeleteFromIndexStep.close() must release its index cursor").isZero();
 
       // idempotent: the plan closes every step, and a step may be closed again by a caller
       step.close();
-      assertThat(compacted.getActiveCursors()).isZero();
+      assertThat(compacted.countActiveCursors()).isZero();
     });
   }
 
   /**
-   * The equality branch used to open a {@code range()} cursor and overwrite it with the {@code iterator()} one on the
-   * next line: a dead store that opened, and abandoned, an extra scan. Pinned through the observable it damaged, since
-   * the branch is only reachable on an index without ordered iterations.
+   * The same guarantee on the equality path, which reaches the cursor through {@code createCursor()} rather than
+   * through the range machinery.
    */
   @Test
-  void anEqualityDeleteOpensExactlyOneCursor() {
+  void anEqualityDeleteAlsoReleasesItsCursor() {
     final LSMTreeIndexCompacted compacted = createCompactedFixture();
 
     database.transaction(() -> {
@@ -94,13 +93,15 @@ class DeleteFromIndexStepCloseTest extends TestHelper {
       context.setDatabase(database);
 
       final DeleteStatement statement = (DeleteStatement) ((DatabaseInternal) database).getStatementCache()
-          .get("DELETE FROM INDEX:`" + bucketIndex().getName() + "` WHERE key = 400");
+          .get("DELETE FROM INDEX:`" + bucketIndex().getName() + "` WHERE key >= 400");
 
       final DeleteFromIndexStep step = deleteFromIndexStep(statement.createExecutionPlan(context));
       step.syncPull(context, 1);
+      assertThat(compacted.countActiveCursors()).as("precondition: the equality path opened a cursor too").isPositive();
+
       step.close();
 
-      assertThat(compacted.getActiveCursors()).as("no cursor may be left behind by the equality path").isZero();
+      assertThat(compacted.countActiveCursors()).as("no cursor may be left behind by the equality path").isZero();
     });
   }
 
@@ -136,7 +137,7 @@ class DeleteFromIndexStepCloseTest extends TestHelper {
     final LSMTreeIndexCompacted compacted = index.getMutableIndex().getSubIndex();
     assertThat(compacted).as("the fixture must produce a compacted sub-index, otherwise no series cursor is ever opened")
         .isNotNull();
-    assertThat(compacted.getActiveCursors()).isZero();
+    assertThat(compacted.countActiveCursors()).isZero();
     return compacted;
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DeleteFromIndexStepCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DeleteFromIndexStepCloseTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.query.sql.parser.DeleteStatement;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5662, item 2: {@code DeleteFromIndexStep} had no {@code close()} at all, so the cursor its {@code init()} opens was
+ * never released. A {@code DELETE FROM INDEX:...} that ends before the scan does - the caller stops driving the result
+ * set, or the statement fails - left an {@code LSMTreeIndexUnderlyingCompactedSeriesCursor} registered with its file,
+ * and {@code LSMTreeIndex.dropRetiredCompactedIndexes} then refused to drop that file for the lifetime of the database.
+ * <p>
+ * The step is driven directly rather than through {@code database.command()} because the {@code CountStep} the planner
+ * puts after it drains the scan to exhaustion, which releases the series cursors on its own and would make the
+ * assertion hold with or without the fix.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class DeleteFromIndexStepCloseTest extends TestHelper {
+  private static final String TYPE_NAME = "IndexDelete";
+  private static final int    RECORDS   = 600;
+
+  @Override
+  public void beforeTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+  }
+
+  @Test
+  void closingTheStepReleasesTheIndexCursorItOpened() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    database.transaction(() -> {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+
+      final DeleteStatement statement = (DeleteStatement) ((DatabaseInternal) database).getStatementCache()
+          .get("DELETE FROM INDEX:`" + bucketIndex().getName() + "` WHERE key > 1");
+
+      final DeleteFromIndexStep step = deleteFromIndexStep(statement.createExecutionPlan(context));
+
+      // one pull is enough to open the scan; nothing is removed yet, the entries are only positioned
+      step.syncPull(context, 1);
+      assertThat(compacted.getActiveCursors()).as("precondition: the scan must be holding a series cursor").isPositive();
+
+      step.close();
+
+      assertThat(compacted.getActiveCursors()).as("DeleteFromIndexStep.close() must release its index cursor").isZero();
+
+      // idempotent: the plan closes every step, and a step may be closed again by a caller
+      step.close();
+      assertThat(compacted.getActiveCursors()).isZero();
+    });
+  }
+
+  /**
+   * The equality branch used to open a {@code range()} cursor and overwrite it with the {@code iterator()} one on the
+   * next line: a dead store that opened, and abandoned, an extra scan. Pinned through the observable it damaged, since
+   * the branch is only reachable on an index without ordered iterations.
+   */
+  @Test
+  void anEqualityDeleteOpensExactlyOneCursor() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    database.transaction(() -> {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+
+      final DeleteStatement statement = (DeleteStatement) ((DatabaseInternal) database).getStatementCache()
+          .get("DELETE FROM INDEX:`" + bucketIndex().getName() + "` WHERE key = 400");
+
+      final DeleteFromIndexStep step = deleteFromIndexStep(statement.createExecutionPlan(context));
+      step.syncPull(context, 1);
+      step.close();
+
+      assertThat(compacted.getActiveCursors()).as("no cursor may be left behind by the equality path").isZero();
+    });
+  }
+
+  private static DeleteFromIndexStep deleteFromIndexStep(final DeleteExecutionPlan plan) {
+    for (final ExecutionStep step : plan.getSteps())
+      if (step instanceof final DeleteFromIndexStep deleteFromIndex)
+        return deleteFromIndex;
+    throw new IllegalStateException("the plan does not contain a DeleteFromIndexStep: " + plan.prettyPrint(0, 2));
+  }
+
+  private LSMTreeIndexCompacted createCompactedFixture() {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("value", Integer.class);
+    // a small page size so the compacted output spans several pages, i.e. a real series a cursor walks lazily
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "value" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(true).withPageSize(1024).create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < RECORDS; i++)
+        database.newDocument(TYPE_NAME).set("value", i).save();
+    });
+
+    final LSMTreeIndex index = bucketIndex();
+    try {
+      if (index.scheduleCompaction())
+        index.compact();
+    } catch (final IOException | InterruptedException e) {
+      throw new IllegalStateException("cannot compact the fixture index", e);
+    }
+
+    final LSMTreeIndexCompacted compacted = index.getMutableIndex().getSubIndex();
+    assertThat(compacted).as("the fixture must produce a compacted sub-index, otherwise no series cursor is ever opened")
+        .isNotNull();
+    assertThat(compacted.getActiveCursors()).isZero();
+    return compacted;
+  }
+
+  private LSMTreeIndex bucketIndex() {
+    return (LSMTreeIndex) database.getSchema().getType(TYPE_NAME).getAllIndexes(false).iterator().next()
+        .getIndexesOnBuckets()[0];
+  }
+}

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeFilterByIndexStep.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeFilterByIndexStep.java
@@ -65,19 +65,23 @@ public class ArcadeFilterByIndexStep<S, E extends Element> extends AbstractStep<
     final Set<Identifiable> resultSet = new HashSet<>();
 
     for (int i = 0; i < indexCursors.size(); i++) {
-      final IndexCursor cursor = indexCursors.get(i);
+      // #5662: the cursors are materialized here and never touched again, so each is released as soon as it has been
+      // read. Draining one already releases its per-series file registrations, but an exception partway through the
+      // intersection would otherwise abandon it - and a compacted-series cursor left registered keeps a retired index
+      // file undroppable until the next restart
+      try (final IndexCursor cursor = indexCursors.get(i)) {
+        if (i == 0) {
+          // FIRST CURSOR: ADD ALL THE RESULTS
+          while (cursor.hasNext())
+            resultSet.add(cursor.next());
+        } else {
+          // INTERSECT WITH THE PREVIOUS RESULTS
+          final Set<Identifiable> currentResultSet = new HashSet<>();
+          while (cursor.hasNext())
+            currentResultSet.add(cursor.next());
 
-      if (i == 0) {
-        // FIRST CURSOR: ADD ALL THE RESULTS
-        while (cursor.hasNext())
-          resultSet.add(cursor.next());
-      } else {
-        // INTERSECT WITH THE PREVIOUS RESULTS
-        final Set<Identifiable> currentResultSet = new HashSet<>();
-        while (cursor.hasNext())
-          currentResultSet.add(cursor.next());
-
-        resultSet.retainAll(currentResultSet);
+          resultSet.retainAll(currentResultSet);
+        }
       }
     }
 


### PR DESCRIPTION
Closes #5662 — all five items, plus three defects the audit for item 1 turned up.

## 1. Nothing enforced closing an index cursor

Closing matters: a scan over an LSM index holds one underlying cursor per compacted series, each registered with its file, and `dropRetiredCompactedIndexes` will not drop a file that still has one. Draining a cursor releases those registrations as each series is exhausted, so **only a cursor abandoned partway leaks** — the shape a `LIMIT`, an `exists()` or an early `break` produces.

`Cursor` now extends `AutoCloseable`, with `close()` declared without a checked exception so try-with-resources does not force a `catch (Exception)` on the caller.

**Better than what the issue proposed.** `AutoCloseable` is a compile-time signal, and a compile-time signal says nothing about the sites nobody has read yet — the issue's own point was that the reading was probably not exhaustive. So the retire guard was also changed from an `AtomicInteger` to **weak references** to the live cursors: a cursor abandoned without `close()` stops pinning its file once the GC reaches it, and the reclaim is logged with the index name. A missed `close()` used to be permanent — the file stayed undroppable for the lifetime of the database with nothing left in the process that could ever release it, and nothing to say so. The leak becomes bounded *and* observable instead of silent and forever.

Sites found in this pass and now releasing their cursor:

- **`SelectExecutor.executeExists()` / `executeCount()`** — `exists()` returns on the first match, `count()` stops at its `LIMIT`; both abandoned the scan.
- **`SelectIterator.close()`** — documented itself as having "nothing to release in the serial implementation" while holding the source index cursor. `SelectParallelIterator` now chains to it (no producer can be reading that cursor: producers are scheduled only for a `MultiIterator` source).
- **`SubQueryStep`** *(not in the issue)* — never closed the plan it wraps, so closing a result set reached only the outer plan's steps. A `DELETE ... WHERE` is built exactly this way, with the index scan in the sub-plan and the `LIMIT` outside it.
- `TypeIndex`, the commit-time unique-key check, the edge-upsert lookup, the full-text scoring/explain/more-like-this walks, and the Gremlin index-filter step.

## 2. `DeleteFromIndexStep`

`close()` added. `init()` now logs through `LogManager` and raises a `CommandExecutionException` carrying the cause instead of `e.printStackTrace()` + carrying on with a null cursor. **Note:** no branch of `init(BooleanExpression)` actually throws `IOException` today — the catch exists because the method declares it — so that half is about what happens the day one does, not a failure reachable now. Also removed *(not in the issue)*: the equality branch opened a `range()` cursor and overwrote it with the `iterator()` one on the very next line — a dead store that opened and abandoned an extra full scan.

## 3. `FetchFromIndexStep.fetchNullKeys()`

Deleted, along with the `nullKeyIterator` field and the branch that read it (only ever assigned an empty iterator). No `NULL_STRATEGY` needs a second pass: with `INDEX` the entries are already in the B-tree at their sorted position, with `SKIP` they were never indexed, with `ERROR` they could not be inserted. The reasoning is kept as a comment on `processFlatIteration()`.

## 4. A cursor iterates itself

`LSMVectorIndex`'s search cursor and `IndexCursorCollection` now return `this` from `iterator()`, like every other implementation. Handing back the backing iterator gave a for-each a traversal that bypassed `next()`, so `getRecord()` stayed stale for the whole loop and (in the vector case) mixing the two read some RIDs twice.

## 5. `MultiIndexCursor` accessors

`getComparator()` / `getBinaryKeyTypes()` answer from state sampled at construction instead of probing the children for one that still has something left — which since #5635 means page reads and tombstone skips inside a plain accessor. The key types also no longer come back `null` once the cursor is exhausted. The constructors additionally close the children they already opened if construction fails partway, since nothing else holds a reference to them.

## Tests

`Issue5662IndexCursorFollowUpsTest` (10 tests) and `DeleteFromIndexStepCloseTest` (2). The observable for the leak tests is `LSMTreeIndexCompacted.getActiveCursors()` over a fixture forced to compact into a multi-page series; each asserts the counter can actually rise above zero first, so "it went back to zero" cannot hold vacuously. Every test was mutation-checked: each fix was reverted individually and the corresponding test observed to fail.

Engine (`index`, `select`, `query.sql`, `opencypher`, `function`, `database`, `graph`, `schema`, `engine`) and gremlin suites pass.