### PR TITLE
fix(engine) #5656: a Cypher subquery body is part of the query, not a string it carries

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1260,6 +1260,14 @@ running page reads and tombstone skips inside two plain accessors; both now answ
 and the key types no longer come back null once the cursor is exhausted.
 ## Cypher: a subquery body is now part of the query rather than a string it carries
 
+> **Upgrade note - behaviour change.** A query whose `EXISTS { }`, `COUNT { }` or `COLLECT { }` body **fails on real
+> data** now returns that error instead of a wrong answer. Until now any exception raised while the body ran was
+> swallowed and answered with the expression's neutral value - `false`, `0`, `[]` - so a body that failed on some rows
+> and not others produced results that looked complete. If a body of yours errors on a subset of rows (an `abs()` over
+> a property that is occasionally a string or null is the usual shape), the query that used to return rows will now
+> raise. That is the point: the old answer was wrong, not merely quiet. Neo4j raises here too. The failures worth
+> knowing about are below.
+
 `EXISTS { }`, `COUNT { }` and `COLLECT { }` did not hold their body as part of the query. They held it as **text**,
 edited that text once per outer row to correlate it, ran it through `database.query("opencypher", ...)` as a
 standalone statement, and absorbed any failure into the expression's neutral value. Three things follow from that,

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1258,5 +1258,52 @@ other cursor, and `IndexCursorCollection` does the same. And `MultiIndexCursor.g
 `getBinaryKeyTypes()` answered by probing the children for one that still had something left, which since #5635 means
 running page reads and tombstone skips inside two plain accessors; both now answer from state sampled at construction,
 and the key types no longer come back null once the cursor is exhausted.
+## Cypher: a subquery body is now part of the query rather than a string it carries
+
+`EXISTS { }`, `COUNT { }` and `COLLECT { }` did not hold their body as part of the query. They held it as **text**,
+edited that text once per outer row to correlate it, ran it through `database.query("opencypher", ...)` as a
+standalone statement, and absorbed any failure into the expression's neutral value. Three things follow from that,
+and all three are fixed.
+
+**A failing body is reported instead of being answered.** A body that could not run was answered exactly like a body
+that did not match: `false` for `EXISTS`, `0` for `COUNT`, `[]` for `COLLECT`, with nothing above `FINE` to say so.
+The two are not the same thing, and the difference is load-bearing:
+
+```cypher
+MATCH (a), (b) WHERE NOT EXISTS { MATCH (a)-[:E {id: $id}]->(b) } CREATE (a)-[:E {id: $id}]->(b)
+```
+
+If that body threw for any reason, `EXISTS` answered `false`, `NOT EXISTS` answered `true`, and a de-duplicating
+guard degraded into an unconditional `CREATE`. It also meant a retryable `ConcurrentModificationException` raised
+inside a body could never reach the server's automatic retry, since it had already been swallowed. Failures now
+propagate, as they do in Neo4j. **This is a behaviour change:** a query whose subquery body fails on real data - a
+type error on a property, a lock timeout, a security violation - now returns that error instead of a wrong answer.
+
+**The body is run, not rewritten.** What executes is the parsed body, with the outer row handed to it as a seed row -
+the same mechanism a `CALL { }` clause already used. The text rewriting is gone from that path, and with it the class
+of bugs it produced: an injected `AND` binding tighter than an inner `OR` (#4995/#5165), an inline pattern predicate
+mistaken for the clause-level `WHERE` (#5464), a clause keyword missing from a keyword table (#5461), a `SET` inside
+user data read as a clause (#5541). Two blind spots that a text scan could not fix are fixed as a consequence: an
+update keyword inside a comment, and `COLLECT { WITH 1 AS set RETURN set }`, are no longer rejected as writes.
+
+**Every validation phase reaches inside a body.** Twelve run on a statement and ten of them used to stop at the
+subquery boundary, so a mistake rejected when written one way was accepted written one level in:
+
+```cypher
+-- rejected
+MATCH (n:P) RETURN count(count(n)) AS r
+-- accepted, until now
+MATCH (n:P) RETURN COUNT { MATCH (m:P) RETURN count(count(m)) } AS r
+```
+
+The same held for a negative `SKIP`/`LIMIT`, a duplicated column name, `RETURN *` with nothing in scope, and the
+column-name and `UNION`/`UNION ALL` checks of a `UNION` written as a body. The boundary is now a property of the
+validator itself rather than something each phase has to know about, so a phase added later is inside a body from
+the day it is written.
+
+One check widened beyond subqueries as part of this. A repeated relationship variable - `(a)-[r]->()<-[r]-()`, a
+pattern asking for a relationship that is two different ones at once - was rejected only when written as the query's
+own `MATCH`. It is now rejected wherever the pattern appears, including a `WHERE` pattern predicate and a subquery
+body, matching Neo4j. Those two spellings used to answer "no match" instead.
 
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CollectExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CollectExpression.java
@@ -71,6 +71,12 @@ public class CollectExpression implements Expression {
 
   /**
    * One entry per row: the projected value when the body returns a single item, the list of them otherwise.
+   * <p>
+   * A row with <i>no</i> visible column contributes {@code null} - the value of a projection that projected nothing -
+   * rather than an empty list, which would read as "collected a row holding no values" and is not the same statement.
+   * The grammar gives {@code COLLECT} one alternative, {@code COLLECT LCURLY queryWithLocalDefinitions RCURLY}, so the
+   * body always carries a RETURN and the case is not reachable from a parsed query; it is written out because the
+   * alternative was to leave the {@code else} branch quietly answering it.
    */
   private static List<Object> collectRows(final ResultSet resultSet) {
     final List<Object> collected = new ArrayList<>();
@@ -83,7 +89,9 @@ public class CollectExpression implements Expression {
         if (!n.startsWith(" "))
           visibleNames.add(n);
       }
-      if (visibleNames.size() == 1) {
+      if (visibleNames.isEmpty()) {
+        collected.add(null);
+      } else if (visibleNames.size() == 1) {
         collected.add(row.getProperty(visibleNames.get(0)));
       } else {
         final List<Object> rowValues = new ArrayList<>(visibleNames.size());

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CollectExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CollectExpression.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
-import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -27,17 +26,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 
 /**
  * Expression representing COLLECT { ... } subquery.
  * Example:
  * - COLLECT { MATCH (p)-[:KNOWS]->(f:Person) RETURN f.name }
  * <p>
- * Runs the inner query once per outer row, with correlated variables bound via
- * parameters, and returns the values produced by the inner RETURN as a list.
+ * Runs the inner query once per outer row, with the outer row handed to the body
+ * as a seed row, and returns the values produced by the inner RETURN as a list.
  * The list contains a single scalar per row when the RETURN projects one item,
  * otherwise a list per row.
+ * <p>
+ * <b>A body that fails is not a body that matches nothing.</b> Both were once answered with an empty list, because
+ * the Cypher contract here is a list; the failure now propagates (issue #5656).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -54,36 +55,42 @@ public class CollectExpression implements Expression {
 
   @Override
   public Object evaluate(final Result result, final CommandContext context) {
+    if (CorrelatedSubqueryRunner.canRun(parsedSubquery)) {
+      try (final ResultSet resultSet = CorrelatedSubqueryRunner.run(parsedSubquery, result, context)) {
+        return collectRows(resultSet);
+      }
+    }
+
     final Map<String, Object> params = CorrelatedSubqueryRewriter.newParams(context);
     final String modifiedSubquery = CorrelatedSubqueryRewriter.correlate(subquery, result, "__collect_", params,
         (patterns, body) -> "MATCH " + patterns + " WITH * " + body);
-
-    final List<Object> collected = new ArrayList<>();
     try (final ResultSet resultSet = context.getDatabase().query("opencypher", modifiedSubquery, params)) {
-      while (resultSet.hasNext()) {
-        final Result row = resultSet.next();
-        final Set<String> propertyNames = row.getPropertyNames();
-        // Filter out internal (space-prefixed) names
-        final List<String> visibleNames = new ArrayList<>(propertyNames.size());
-        for (final String n : propertyNames) {
-          if (!n.startsWith(" "))
-            visibleNames.add(n);
-        }
-        if (visibleNames.size() == 1) {
-          collected.add(row.getProperty(visibleNames.get(0)));
-        } else {
-          final List<Object> rowValues = new ArrayList<>(visibleNames.size());
-          for (final String n : visibleNames)
-            rowValues.add(row.getProperty(n));
-          collected.add(rowValues);
-        }
+      return collectRows(resultSet);
+    }
+  }
+
+  /**
+   * One entry per row: the projected value when the body returns a single item, the list of them otherwise.
+   */
+  private static List<Object> collectRows(final ResultSet resultSet) {
+    final List<Object> collected = new ArrayList<>();
+    while (resultSet.hasNext()) {
+      final Result row = resultSet.next();
+      final Set<String> propertyNames = row.getPropertyNames();
+      // Filter out internal (space-prefixed) names
+      final List<String> visibleNames = new ArrayList<>(propertyNames.size());
+      for (final String n : propertyNames) {
+        if (!n.startsWith(" "))
+          visibleNames.add(n);
       }
-    } catch (final Exception e) {
-      // The Cypher contract here is a list, so a subquery that cannot run is absorbed as empty.
-      // Trace it: a silent empty list is how the corrupted-subquery bug of issue #5464 stayed invisible.
-      LogManager.instance().log(CollectExpression.class, Level.FINE, "Error on evaluating COLLECT subquery '%s'", e,
-          modifiedSubquery);
-      return new ArrayList<>();
+      if (visibleNames.size() == 1) {
+        collected.add(row.getProperty(visibleNames.get(0)));
+      } else {
+        final List<Object> rowValues = new ArrayList<>(visibleNames.size());
+        for (final String n : visibleNames)
+          rowValues.add(row.getProperty(n));
+        collected.add(rowValues);
+      }
     }
     return collected;
   }
@@ -103,9 +110,11 @@ public class CollectExpression implements Expression {
   }
 
   /**
-   * The body as an AST. The body still executes from {@link #getSubquery()}, because what runs is the text after
-   * {@link CorrelatedSubqueryRewriter} has correlated it to the outer row, which differs row by row. This AST is the
-   * body as written, and exists so that the parse-time checks reach inside it (issue #5626).
+   * The body as an AST, or {@code null} when the statement builder declined it (the best-effort build of issue #5626).
+   * <p>
+   * This is what the parse-time checks walk (#5626) and, since #5656, what actually executes: the outer row is handed
+   * to it as a seed row rather than spliced into its text. {@link #getSubquery()} is the text that body was written
+   * as, and is used only on the fallback path, when there is no AST to run.
    */
   public CypherStatement getParsedSubquery() {
     return parsedSubquery;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRewriter.java
@@ -45,6 +45,16 @@ import java.util.stream.Stream;
  * and all three mistook an inline pattern predicate - {@code -[r:E WHERE r.tag = 'ok']->} or
  * {@code (b:A WHERE b.v = 2)} - for the clause-level WHERE, injecting the correlation inside the
  * pattern and corrupting the subquery (issue #5464). Keeping one implementation keeps them honest.
+ * <p>
+ * <b>This is now the fallback, not the path.</b> A body that has an AST is run from it, with the outer row handed in
+ * as a seed row and nothing rewritten - see {@link CorrelatedSubqueryRunner}, which is where the list above stops
+ * growing. What still arrives here is a body the statement builder declined (the best-effort build of issue #5626)
+ * and the existential subquery {@link PatternPredicateExpression} synthesizes at runtime from a pattern it holds.
+ * Fixing a correlation bug means asking first whether the shape can reach this class at all.
+ * <p>
+ * One thing it cannot do, and could not be taught to: correlate a <b>relationship</b> variable. An outer binding is
+ * pinned by an injected {@code MATCH (v)}, which is node syntax, so a relationship-valued outer variable produced a
+ * body that did not parse. That never surfaced while a failed body was absorbed into the expression's neutral value.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRunner.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRunner.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.ast;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.opencypher.executor.CypherExecutionPlan;
+import com.arcadedb.query.opencypher.query.OpenCypherQueryEngine;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs the body of one of the three subquery expressions - {@code EXISTS { }}, {@code COUNT { }} and
+ * {@code COLLECT { }} - against the outer row, from the body's AST.
+ * <p>
+ * The outer row is handed to the body as a <b>seed row</b>, the same mechanism a {@code CALL { }} clause uses
+ * ({@link CypherExecutionPlan#executeWithSeedRow}): the row enters the step chain as its first input, so every outer
+ * variable the body mentions is already bound when the body's first clause runs. Nothing is rewritten, and nothing is
+ * re-parsed.
+ * <p>
+ * That replaces {@link CorrelatedSubqueryRewriter}, which correlated the body by <b>editing its text</b> - splicing an
+ * extra {@code MATCH (v)} into it, merging an {@code id(v) = $param} condition into whatever {@code WHERE} it could
+ * find, prepending a {@code WITH $param AS v} - and then handing the result to {@code database.query("opencypher",
+ * ...)} as a standalone statement. Deciding where a clause begins, where a {@code WHERE} body ends, and whether a
+ * keyword is a clause or an identifier, all by scanning text with a keyword table and a bracket-depth counter, is what
+ * produced issues #4995/#5165 (an injected {@code AND} binding tighter than an inner {@code OR}), #5464 (an inline
+ * pattern predicate mistaken for the clause-level {@code WHERE}), #5461 (a clause keyword missing from the table) and
+ * #5541 (a {@code SET} inside user data read as a clause). None of those decisions exists here.
+ * <p>
+ * The rewriter stays for the one case this cannot serve: an expression whose body has no AST, either because the
+ * statement builder declined it (the best-effort build of issue #5626) or because the expression was synthesized at
+ * runtime from a pattern rather than parsed. {@link #canRun} is what tells the two apart.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class CorrelatedSubqueryRunner {
+
+  private CorrelatedSubqueryRunner() {
+    // utility class
+  }
+
+  /**
+   * Tells whether {@code body} can be run from its AST.
+   * <p>
+   * A null body is one the parse could not build; an empty clause list is one
+   * {@link CypherExecutionPlan#executeWithSeedRow} would answer by echoing the seed row - a single row, which for
+   * {@code EXISTS} is the difference between true and false. Both fall back to the text path rather than being
+   * answered wrongly.
+   */
+  public static boolean canRun(final CypherStatement body) {
+    if (body == null)
+      return false;
+
+    if (body instanceof UnionStatement union) {
+      final List<CypherStatement> branches = union.getQueries();
+      if (branches == null || branches.isEmpty())
+        return false;
+      for (int i = 0; i < branches.size(); i++)
+        if (!canRun(branches.get(i)))
+          return false;
+      return true;
+    }
+
+    final List<ClauseEntry> clauses = body.getClausesInOrder();
+    return clauses != null && !clauses.isEmpty();
+  }
+
+  /**
+   * Executes {@code body} once, seeded with {@code outerRow}.
+   * <p>
+   * The caller closes the returned result set. Any failure propagates: a subquery that cannot run is not a subquery
+   * that does not match, and the three callers no longer confuse the two.
+   *
+   * @param body     the body as parsed, which {@link #canRun} has accepted
+   * @param outerRow the outer row, or null when the expression is evaluated standalone
+   * @param context  the outer command context
+   */
+  public static ResultSet run(final CypherStatement body, final Result outerRow, final CommandContext context) {
+    final DatabaseInternal database = (DatabaseInternal) context.getDatabase();
+    final Map<String, Object> parameters = context.getInputParameters();
+
+    // No physical plan: the optimizer is keyed on a query string this body never had, and the seed row is exactly the
+    // input the physical operators do not model. The step chain is built per row, as it is for a CALL { } body.
+    final CypherExecutionPlan plan = new CypherExecutionPlan(database, body,
+        parameters != null ? parameters : Map.of(), database.getConfiguration(), null,
+        OpenCypherQueryEngine.sharedExpressionEvaluator());
+
+    return plan.executeWithSeedRow(seedRow(outerRow), context);
+  }
+
+  /**
+   * The outer row as the body sees it: every variable the query bound, minus the engine's own bookkeeping.
+   * <p>
+   * Internal variables are held on the row under space-prefixed names, which no Cypher identifier can be, so a body
+   * cannot reference one - but the step chain reads them, and handing a body the ones belonging to the enclosing
+   * query makes it plan against bindings that are not its own. The text rewriter skipped them for the same reason.
+   */
+  private static Result seedRow(final Result outerRow) {
+    if (outerRow == null)
+      return new ResultInternal();
+
+    final ResultInternal seed = new ResultInternal();
+    for (final String name : outerRow.getPropertyNames())
+      if (!name.startsWith(" "))
+        seed.setProperty(name, outerRow.getProperty(name));
+    return seed;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRunner.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRunner.java
@@ -119,6 +119,17 @@ public final class CorrelatedSubqueryRunner {
     if (outerRow == null)
       return new ResultInternal();
 
+    // The seed step copies the row again on its way into the chain, so a row with nothing to filter is handed over
+    // as it is rather than copied twice.
+    boolean hasInternalNames = false;
+    for (final String name : outerRow.getPropertyNames())
+      if (name.startsWith(" ")) {
+        hasInternalNames = true;
+        break;
+      }
+    if (!hasInternalNames)
+      return outerRow;
+
     final ResultInternal seed = new ResultInternal();
     for (final String name : outerRow.getPropertyNames())
       if (!name.startsWith(" "))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRunner.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CorrelatedSubqueryRunner.java
@@ -103,7 +103,7 @@ public final class CorrelatedSubqueryRunner {
     // input the physical operators do not model. The step chain is built per row, as it is for a CALL { } body.
     final CypherExecutionPlan plan = new CypherExecutionPlan(database, body,
         parameters != null ? parameters : Map.of(), database.getConfiguration(), null,
-        OpenCypherQueryEngine.sharedExpressionEvaluator());
+        OpenCypherQueryEngine.getExpressionEvaluator());
 
     return plan.executeWithSeedRow(seedRow(outerRow), context);
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CountExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CountExpression.java
@@ -18,13 +18,11 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
-import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.util.Map;
-import java.util.logging.Level;
 
 /**
  * Expression representing a {@code COUNT { ... }} pattern / subquery expression.
@@ -34,8 +32,11 @@ import java.util.logging.Level;
  *   <li>{@code COUNT { (p)-[:OWNS]->(:Dog) }}</li>
  *   <li>{@code COUNT { MATCH (n)-[:KNOWS]->(f) WHERE f.age > 18 }}</li>
  * </ul>
- * Runs the inner pattern or subquery once per outer row, with correlated outer
- * variables bound via parameters, and returns the number of matches as a long.
+ * Runs the inner pattern or subquery once per outer row, with the outer row handed to the body as a seed row, and
+ * returns the number of matches as a long.
+ * <p>
+ * <b>A body that fails is not a body that matches nothing.</b> Both were once answered with {@code 0}, because the
+ * Cypher contract here is a number; the failure now propagates (issue #5656).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -52,21 +53,25 @@ public class CountExpression implements Expression {
 
   @Override
   public Object evaluate(final Result result, final CommandContext context) {
+    if (CorrelatedSubqueryRunner.canRun(parsedSubquery)) {
+      try (final ResultSet resultSet = CorrelatedSubqueryRunner.run(parsedSubquery, result, context)) {
+        return countRows(resultSet);
+      }
+    }
+
     final Map<String, Object> params = CorrelatedSubqueryRewriter.newParams(context);
     final String modifiedSubquery = CorrelatedSubqueryRewriter.correlate(subquery, result, "__count_", params,
         CountExpression::wrapNonMatchBody);
-    long count = 0L;
     try (final ResultSet resultSet = context.getDatabase().query("opencypher", modifiedSubquery, params)) {
-      while (resultSet.hasNext()) {
-        resultSet.next();
-        count++;
-      }
-    } catch (final Exception e) {
-      // The Cypher contract here is a number, so a subquery that cannot run is absorbed as zero.
-      // Trace it: a silent zero is how the corrupted-subquery bug of issue #5464 stayed invisible.
-      LogManager.instance().log(CountExpression.class, Level.FINE, "Error on evaluating COUNT subquery '%s'", e,
-          modifiedSubquery);
-      return 0L;
+      return countRows(resultSet);
+    }
+  }
+
+  private static long countRows(final ResultSet resultSet) {
+    long count = 0L;
+    while (resultSet.hasNext()) {
+      resultSet.next();
+      count++;
     }
     return count;
   }
@@ -103,9 +108,11 @@ public class CountExpression implements Expression {
   }
 
   /**
-   * The body as an AST. The body still executes from {@link #getSubquery()}, because what runs is the text after
-   * {@link CorrelatedSubqueryRewriter} has correlated it to the outer row, which differs row by row. This AST is the
-   * body as written, and exists so that the parse-time checks reach inside it (issue #5626).
+   * The body as an AST, or {@code null} when the statement builder declined it (the best-effort build of issue #5626).
+   * <p>
+   * This is what the parse-time checks walk (#5626) and, since #5656, what actually executes: the outer row is handed
+   * to it as a seed row rather than spliced into its text. {@link #getSubquery()} is the text that body was written
+   * as, and is used only on the fallback path, when there is no AST to run.
    */
   public CypherStatement getParsedSubquery() {
     return parsedSubquery;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ExistsExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ExistsExpression.java
@@ -18,12 +18,11 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
-import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.util.Map;
-import java.util.logging.Level;
 
 /**
  * Expression representing EXISTS predicate.
@@ -32,6 +31,12 @@ import java.util.logging.Level;
  * - EXISTS { (n)-[:KNOWS]->() }
  * <p>
  * Returns true if the pattern/subquery has at least one match, false otherwise.
+ * <p>
+ * <b>A body that fails is not a body that does not match.</b> Both were once answered with {@code false}: the Cypher
+ * contract here is a boolean, so any exception was logged at {@code FINE} and absorbed. That made a
+ * {@code WHERE NOT EXISTS { ... } CREATE ...} de-duplicating guard degrade into an unconditional {@code CREATE} the
+ * moment its body threw, and it kept a retryable {@code ConcurrentModificationException} from ever reaching the
+ * server's auto-retry. The failure now propagates (issue #5656).
  */
 public class ExistsExpression implements Expression {
   private final String          subquery;
@@ -55,18 +60,17 @@ public class ExistsExpression implements Expression {
 
   @Override
   public Object evaluate(final Result result, final CommandContext context) {
+    if (CorrelatedSubqueryRunner.canRun(parsedSubquery)) {
+      try (final ResultSet resultSet = CorrelatedSubqueryRunner.run(parsedSubquery, result, context)) {
+        return resultSet.hasNext();
+      }
+    }
+
     final Map<String, Object> params = CorrelatedSubqueryRewriter.newParams(context);
     final String modifiedSubquery = CorrelatedSubqueryRewriter.correlate(subquery, result, "__exists_", params,
         ExistsExpression::wrapNonMatchBody);
-    try (final var resultSet = context.getDatabase().query("opencypher", modifiedSubquery, params)) {
+    try (final ResultSet resultSet = context.getDatabase().query("opencypher", modifiedSubquery, params)) {
       return resultSet.hasNext();
-    } catch (final Exception e) {
-      // An existential subquery that cannot run is not the same as one that does not match, but the
-      // Cypher contract here is a boolean, so the failure is absorbed. Trace it: a silent false is
-      // exactly how the corrupted-subquery bug of issue #5464 stayed invisible for so long.
-      LogManager.instance().log(ExistsExpression.class, Level.FINE, "Error on evaluating EXISTS subquery '%s'", e,
-          modifiedSubquery);
-      return false;
     }
   }
 
@@ -98,11 +102,12 @@ public class ExistsExpression implements Expression {
   }
 
   /**
-   * The body as an AST, or {@code null} when this expression was synthesized at runtime rather than parsed.
+   * The body as an AST, or {@code null} when this expression was synthesized at runtime rather than parsed, or when
+   * the statement builder declined the body (the best-effort build of issue #5626).
    * <p>
-   * The body still executes from {@link #getSubquery()}, because what runs is the text after
-   * {@link CorrelatedSubqueryRewriter} has correlated it to the outer row, which differs row by row. This AST is the
-   * body as written, and exists so that the parse-time checks reach inside it (issue #5626).
+   * This is what the parse-time checks walk (#5626) and, since #5656, what actually executes: the outer row is handed
+   * to it as a seed row rather than spliced into its text. {@link #getSubquery()} is the text that body was written
+   * as, and is used only on the fallback path, when there is no AST to run.
    */
   public CypherStatement getParsedSubquery() {
     return parsedSubquery;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -404,7 +404,8 @@ public class CypherExecutionPlan {
     final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
     final AbstractExecutionStep rootStep;
     if (clausesInOrder != null && !clausesInOrder.isEmpty())
-      rootStep = buildExecutionStepsWithOrder(context, clausesInOrder, seedStep);
+      rootStep = buildExecutionStepsWithOrder(context, clausesInOrder, seedStep,
+          !seedRow.getPropertyNames().isEmpty());
     else
       rootStep = seedStep; // Fallback: just return the seed
 
@@ -884,17 +885,21 @@ public class CypherExecutionPlan {
    */
   private AbstractExecutionStep buildExecutionStepsWithOrder(final CommandContext context,
       final List<ClauseEntry> clausesInOrder) {
-    return buildExecutionStepsWithOrder(context, clausesInOrder, null);
+    return buildExecutionStepsWithOrder(context, clausesInOrder, null, false);
   }
 
   /**
    * Builds execution steps respecting clause order, optionally seeded with an initial step.
    * When initialStep is provided (e.g., for CALL subqueries), it serves as the starting point
    * of the step chain, providing input rows to the first clause.
+   *
+   * @param seedBoundVariables whether the seed row binds any variable, i.e. whether this body is correlated to the
+   *                           enclosing query at all. A seed row that binds nothing cannot be referenced by the body,
+   *                           which is what lets the count push-downs below still apply.
    */
   private AbstractExecutionStep buildExecutionStepsWithOrder(final CommandContext context,
       final List<ClauseEntry> clausesInOrder,
-      final AbstractExecutionStep initialStep) {
+      final AbstractExecutionStep initialStep, final boolean seedBoundVariables) {
     AbstractExecutionStep currentStep = initialStep;
 
     // Get function factory from evaluator for steps that need it
@@ -906,11 +911,15 @@ public class CypherExecutionPlan {
     final Set<String> boundVariables = new HashSet<>();
 
     // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
-    // never look at the incoming rows. That makes them wrong the moment there IS an incoming row that binds one of
-    // those pattern variables - a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound to one vertex
-    // would be answered with the count over every `n` in the graph. So neither is attempted when the chain starts
-    // from a seed row; the ordinary pipeline, which consumes the seed, is used instead.
-    if (initialStep == null) {
+    // never look at the incoming rows. That makes them wrong the moment the seed row binds one of those pattern
+    // variables - a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound to one vertex would be
+    // answered with the count over every `n` in the graph. So neither is attempted then; the ordinary pipeline, which
+    // consumes the seed, is used instead.
+    //
+    // A seed row that binds NOTHING is a different case and keeps the push-downs: an uncorrelated body -
+    // `RETURN COUNT { MATCH (n:Person) }`, or a `CALL { }` that imports nothing - has no name it could have taken
+    // from the enclosing query, so ignoring the seed cannot change the answer, and a large type keeps its O(1) count.
+    if (initialStep == null || !seedBoundVariables) {
       // OPTIMIZATION: Check for simple COUNT(*) pattern that can use Type.count() O(1) operation
       // Pattern: MATCH (a:TypeName) RETURN COUNT(a) as alias
       final AbstractExecutionStep typeCountStep = tryCreateTypeCountOptimization(context);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -905,18 +905,25 @@ public class CypherExecutionPlan {
     // can detect already-bound variables and avoid Cartesian products
     final Set<String> boundVariables = new HashSet<>();
 
-    // OPTIMIZATION: Check for simple COUNT(*) pattern that can use Type.count() O(1) operation
-    // Pattern: MATCH (a:TypeName) RETURN COUNT(a) as alias
-    final AbstractExecutionStep typeCountStep = tryCreateTypeCountOptimization(context);
-    if (typeCountStep != null)
-      return typeCountStep;
+    // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
+    // never look at the incoming rows. That makes them wrong the moment there IS an incoming row that binds one of
+    // those pattern variables - a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound to one vertex
+    // would be answered with the count over every `n` in the graph. So neither is attempted when the chain starts
+    // from a seed row; the ordinary pipeline, which consumes the seed, is used instead.
+    if (initialStep == null) {
+      // OPTIMIZATION: Check for simple COUNT(*) pattern that can use Type.count() O(1) operation
+      // Pattern: MATCH (a:TypeName) RETURN COUNT(a) as alias
+      final AbstractExecutionStep typeCountStep = tryCreateTypeCountOptimization(context);
+      if (typeCountStep != null)
+        return typeCountStep;
 
-    // OPTIMIZATION: Count-push-down for chain/star/triangle/pair-join patterns with RETURN count(*)
-    // Instead of materializing all paths (O(paths) memory), propagates counts through
-    // CSR arrays level-by-level (O(nodes) memory). Critical for large-fanout chains.
-    final AbstractExecutionStep countStep = tryOptimizeCountStar(context);
-    if (countStep != null)
-      return countStep;
+      // OPTIMIZATION: Count-push-down for chain/star/triangle/pair-join patterns with RETURN count(*)
+      // Instead of materializing all paths (O(paths) memory), propagates counts through
+      // CSR arrays level-by-level (O(nodes) memory). Critical for large-fanout chains.
+      final AbstractExecutionStep countStep = tryOptimizeCountStar(context);
+      if (countStep != null)
+        return countStep;
+    }
 
     // Special case: no MATCH as first clause (standalone expressions, WITH before MATCH, etc.)
     // E.g., RETURN abs(-42), WITH collect([0, 0.0]) AS numbers UNWIND ...

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -552,6 +552,18 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
       whereClause = visitWhereClause(ctx.whereClause());
     }
 
+    return newMatchClause(pathPatterns, optional, whereClause);
+  }
+
+  /**
+   * Builds a {@code MATCH} clause with the normalizations every one of them gets. Assembling a
+   * {@link MatchClause} straight from its constructor instead skips them, which is only invisible while nothing
+   * executes the result: the bare-pattern body of an {@code EXISTS { }} / {@code COUNT { }} did exactly that and, once
+   * issue #5656 made that AST the thing that runs, a node inline {@code WHERE} inside it stopped being applied. One
+   * factory, so a new normalization cannot reach one caller and miss the other.
+   */
+  static MatchClause newMatchClause(final List<PathPattern> pathPatterns, final boolean optional,
+      final WhereClause whereClause) {
     // Normalize a node inline "(n WHERE ...)" predicate into the clause WHERE so that every planner
     // path enforces it, exactly like the equivalent "MATCH (n) WHERE ..." spelling (issue #5464)
     final MatchClause normalized = InlineNodeWhereHoister.hoist(new MatchClause(pathPatterns, optional, whereClause));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -1827,8 +1827,11 @@ class CypherExpressionBuilder {
     else
       subquery = originalText.substring(7, originalText.length() - 1).trim(); // fallback
 
+    final CypherStatement parsedBody = parseSubqueryBody(ctx.queryWithLocalDefinitions(), ctx.patternList(),
+        ctx.whereClause());
+
     // Check for update clauses inside EXISTS (not allowed)
-    if (CorrelatedSubqueryRewriter.containsUpdateClause(subquery))
+    if (containsUpdateClause(parsedBody, subquery))
       throw new CommandParsingException(
           "InvalidClauseComposition: Existential subquery cannot contain update clauses");
 
@@ -1840,8 +1843,23 @@ class CypherExpressionBuilder {
       subquery = subquery + " RETURN true";
     }
 
-    return new ExistsExpression(subquery, text,
-        parseSubqueryBody(ctx.queryWithLocalDefinitions(), ctx.patternList(), ctx.whereClause()));
+    return new ExistsExpression(subquery, text, parsedBody);
+  }
+
+  /**
+   * Tells whether a subquery body writes, which the three read-only subquery expressions must reject.
+   * <p>
+   * Answered from the parse tree when there is one: a clause is a clause because of where it sits, which is what the
+   * statement already recorded in {@link CypherStatement#isReadOnly()}. The text scan it replaces had to guess from
+   * spelling alone and got two cases wrong by construction - an update keyword inside a comment was read as a clause,
+   * and {@code WITH 1 AS set RETURN set} is lexically indistinguishable from {@code SET n.x = 1} (issue #5541 fixed
+   * the third, {@code WHERE n.name = 'SET x'}, by teaching the scan about string literals). It stays as the fallback
+   * for a body the statement builder declined, where there is nothing else to answer from.
+   */
+  private static boolean containsUpdateClause(final CypherStatement parsedBody, final String bodyText) {
+    if (parsedBody != null)
+      return !parsedBody.isReadOnly();
+    return CorrelatedSubqueryRewriter.containsUpdateClause(bodyText);
   }
 
   /**
@@ -1891,7 +1909,7 @@ class CypherExpressionBuilder {
         return astBuilder.visitQueryWithLocalDefinitions(queryCtx);
 
       final StatementBuilder builder = new StatementBuilder();
-      builder.addMatch(new MatchClause(astBuilder.visitPatternList(patternCtx), false,
+      builder.addMatch(CypherASTBuilder.newMatchClause(astBuilder.visitPatternList(patternCtx), false,
           whereCtx != null ? astBuilder.visitWhereClause(whereCtx) : null));
       return builder.build();
     } catch (final CommandParsingException e) {
@@ -1927,8 +1945,10 @@ class CypherExpressionBuilder {
     else
       subquery = originalText.substring(8, originalText.length() - 1).trim(); // fallback "COLLECT{" prefix
 
+    final CypherStatement parsedBody = parseSubqueryBody(ctx.queryWithLocalDefinitions(), null, null);
+
     // Update clauses are not allowed inside a COLLECT subquery
-    if (CorrelatedSubqueryRewriter.containsUpdateClause(subquery))
+    if (containsUpdateClause(parsedBody, subquery))
       throw new CommandParsingException(
           "InvalidClauseComposition: COLLECT subquery cannot contain update clauses");
 
@@ -1937,7 +1957,7 @@ class CypherExpressionBuilder {
     // "... (queryWithLocalDefinitions | matchMode? patternList whereClause?) ..." - because a COLLECT body has to
     // RETURN the value being collected. So queryWithLocalDefinitions() is never null here, and a COLLECT body can
     // never end up without an AST and quietly skip the checks this issue exists to reach it with.
-    return new CollectExpression(subquery, text, parseSubqueryBody(ctx.queryWithLocalDefinitions(), null, null));
+    return new CollectExpression(subquery, text, parsedBody);
   }
 
   /**
@@ -1958,7 +1978,10 @@ class CypherExpressionBuilder {
     else
       subquery = originalText.substring(6, originalText.length() - 1).trim(); // fallback "COUNT{" prefix
 
-    if (CorrelatedSubqueryRewriter.containsUpdateClause(subquery))
+    final CypherStatement parsedBody = parseSubqueryBody(ctx.queryWithLocalDefinitions(), ctx.patternList(),
+        ctx.whereClause());
+
+    if (containsUpdateClause(parsedBody, subquery))
       throw new CommandParsingException(
           "InvalidClauseComposition: COUNT subquery cannot contain update clauses");
 
@@ -1969,8 +1992,7 @@ class CypherExpressionBuilder {
       subquery = subquery + " RETURN 1";
     }
 
-    return new CountExpression(subquery, text,
-        parseSubqueryBody(ctx.queryWithLocalDefinitions(), ctx.patternList(), ctx.whereClause()));
+    return new CountExpression(subquery, text, parsedBody);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -122,6 +122,17 @@ public final class CypherExpressionWalker {
     void visit(Expression expression);
 
     /**
+     * Called once per graph pattern the walk reaches, wherever it was written: a {@code MATCH}, a {@code CREATE} or
+     * {@code MERGE}, a pattern predicate in a {@code WHERE}, a pattern comprehension, a {@code shortestPath}. For a
+     * check about the shape of a pattern rather than about an expression inside it - two relationships sharing a
+     * variable, say - this is the hook, and using it is what keeps the check from applying only to the one clause
+     * whose patterns someone remembered to iterate.
+     */
+    default void visitPattern(final PathPattern pattern) {
+      // Most visitors are about expressions.
+    }
+
+    /**
      * Called when the walk is about to descend into a statement that binds its own variables - the body of a
      * {@code CALL { ... }} clause or of an {@code EXISTS}/{@code COUNT}/{@code COLLECT} subquery expression, and each
      * branch of a {@code UNION}. Returning {@code this} keeps the same check running inside it; returning a different
@@ -406,12 +417,15 @@ public final class CypherExpressionWalker {
   }
 
   /**
-   * Visits every expression nested inside a graph pattern: the inline property values of each node and relationship,
-   * their dynamic labels, and any inline {@code WHERE}. This is how {@code CREATE (n:P {age: abs('x')})} is reached.
+   * Hands the pattern itself to {@link Visitor#visitPattern}, then visits every expression nested inside it: the
+   * inline property values of each node and relationship, their dynamic labels, and any inline {@code WHERE}. This is
+   * how {@code CREATE (n:P {age: abs('x')})} is reached.
    */
   public static void walk(final PathPattern pattern, final Visitor visitor) {
     if (pattern == null)
       return;
+
+    visitor.visitPattern(pattern);
 
     if (pattern.getNodes() != null)
       for (final NodePattern node : pattern.getNodes()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -38,6 +38,11 @@ import java.util.*;
  * - Nested aggregations and aggregation in WHERE
  * - CREATE/MERGE/DELETE structural constraints
  * <p>
+ * <b>A subquery body is validated exactly as the query around it.</b> The body of a {@code CALL { }} clause and of an
+ * {@code EXISTS { }} / {@code COUNT { }} / {@code COLLECT { }} expression is a statement, and every phase below runs
+ * against it - see {@link #validateNestedStatements}. Ten of them used to stop at the boundary (issue #5656), which
+ * is how the same mistake came to be rejected written one way and accepted written one level in.
+ * <p>
  * <b>Semantic vs syntax boundary:</b> only an undefined-variable violation throws
  * {@link CommandSemanticException}, which Bolt surfaces as {@code Neo.ClientError.Statement.SemanticError}
  * (certified by conformance scenario ERR-002). Every other validation failure in this class throws
@@ -54,6 +59,17 @@ public class CypherSemanticValidator {
   }
 
   private final Map<String, VarType> varTypes = new HashMap<>();
+
+  private CypherSemanticValidator() {
+  }
+
+  /**
+   * A validator bound to the variable kinds a subquery body sees - what its own clauses declare over what it inherits
+   * from the enclosing scope. Used by {@link NestedStatementChecks} to run the phase list against a body.
+   */
+  private CypherSemanticValidator(final Map<String, VarType> scope) {
+    varTypes.putAll(scope);
+  }
 
   public static void validate(final CypherStatement statement) {
     // For UNION statements, validate union-specific constraints then each subquery
@@ -75,6 +91,7 @@ public class CypherSemanticValidator {
     v.validateExpressionAliases(statement);
     v.validateReturnStar(statement);
     v.validateFunctionArgumentTypes(statement);
+    v.validateNestedStatements(statement);
   }
 
   // ========================
@@ -82,7 +99,23 @@ public class CypherSemanticValidator {
   // ========================
 
   private static void validateUnion(final UnionStatement unionStmt) {
-    final List<CypherStatement> queries = unionStmt.getQueries();
+    validateUnionShape(unionStmt);
+
+    for (final CypherStatement query : unionStmt.getQueries())
+      // A branch with no RETURN carries no columns to compare and is not a query this validates on its own.
+      if (query.getReturnClause() != null)
+        validate(query);
+  }
+
+  /**
+   * The two checks that are about the {@code UNION} itself rather than about any one branch.
+   * <p>
+   * Separate from {@link #validateUnion} because a {@code UNION} can also appear as the body of a subquery, where the
+   * branches are validated by the walk that descends into them ({@link NestedStatementChecks}) and only these two are
+   * still owed. Before issue #5656 nothing ran them there: {@code CALL { RETURN 1 AS a UNION RETURN 2 AS b }} was
+   * accepted, while the same mismatch written as the whole query was rejected.
+   */
+  private static void validateUnionShape(final UnionStatement unionStmt) {
     final List<Boolean> flags = unionStmt.getUnionAllFlags();
 
     // Check that mixing UNION and UNION ALL is not allowed
@@ -96,18 +129,16 @@ public class CypherSemanticValidator {
 
     // Check that all queries have the same return columns
     List<String> firstColumns = null;
-    for (final CypherStatement query : queries) {
+    for (final CypherStatement query : unionStmt.getQueries()) {
       final ReturnClause returnClause = query.getReturnClause();
       if (returnClause == null)
         continue;
       final List<String> columns = returnClause.getItems();
-      if (firstColumns == null) {
+      if (firstColumns == null)
         firstColumns = columns;
-      } else if (!firstColumns.equals(columns)) {
-        throw new CommandParsingException("DifferentColumnsInUnion: All sub queries in a UNION must have the same return column names");
-      }
-      // Validate each subquery
-      validate(query);
+      else if (!firstColumns.equals(columns))
+        throw new CommandParsingException(
+            "DifferentColumnsInUnion: All sub queries in a UNION must have the same return column names");
     }
   }
 
@@ -1656,17 +1687,39 @@ public class CypherSemanticValidator {
   // Phase 5b: Relationship Uniqueness Validation
   // ============================================
 
+  /**
+   * A relationship variable may name one relationship of a pattern, not two: {@code (a)-[r]->()<-[r]-()} asks for a
+   * relationship that is simultaneously two different ones, which no graph can answer.
+   * <p>
+   * Run against every pattern the statement contains, wherever it was written. It used to iterate the path patterns of
+   * the {@code MATCH} clauses only, so the same pattern written as a {@code WHERE} predicate or inside an
+   * {@code EXISTS { }} was accepted - and then answered by a path that could not correlate a relationship variable
+   * either, which is how it came to be reported as "no match" rather than as the contradiction it is (issue #5656).
+   * Neo4j rejects all three spellings.
+   */
   private void validateRelationshipUniqueness(final CypherStatement statement) {
-    for (final MatchClause matchClause : statement.getMatchClauses()) {
-      if (!matchClause.hasPathPatterns())
-        continue;
-      for (final PathPattern path : matchClause.getPathPatterns()) {
-        final Set<String> relVars = new HashSet<>();
-        for (final RelationshipPattern rel : path.getRelationships()) {
-          final String var = rel.getVariable();
-          if (var != null && !var.isEmpty() && !relVars.add(var))
-            throw new CommandParsingException("RelationshipUniquenessViolation: Relationship variable '" + var + "' is used more than once in the same pattern");
-        }
+    CypherExpressionWalker.walk(statement, new RelationshipUniquenessChecks());
+  }
+
+  private static final class RelationshipUniquenessChecks implements CypherExpressionWalker.Visitor {
+    @Override
+    public void visit(final Expression expression) {
+      // Patterns only.
+    }
+
+    @Override
+    public void visitPattern(final PathPattern path) {
+      final List<RelationshipPattern> relationships = path.getRelationships();
+      if (relationships == null || relationships.size() < 2)
+        return;
+
+      final Set<String> relVars = new HashSet<>();
+      for (final RelationshipPattern rel : relationships) {
+        final String var = rel.getVariable();
+        if (var != null && !var.isEmpty() && !relVars.add(var))
+          throw new CommandParsingException(
+              "RelationshipUniquenessViolation: Relationship variable '" + var + "' is used more than once in the "
+                  + "same pattern");
       }
     }
   }
@@ -1880,6 +1933,84 @@ public class CypherSemanticValidator {
     public CypherExpressionWalker.Visitor forNestedStatement(final CypherStatement nested) {
       return new FunctionArgumentChecks(nestedVarTypes(scope, nested));
     }
+  }
+
+  // ==================================================
+  // Phase 11: Every phase above, applied to each body
+  // ==================================================
+
+  /**
+   * Runs the phase list against the body of every subquery the statement contains, at any depth.
+   * <p>
+   * Twelve phases ran above and only two of them reached inside a body: {@link #validateVariableScope}, which models
+   * the import rules of a {@code CALL { }} (since #5213), and {@link #validateFunctionArgumentTypes}, whose traversal
+   * descends (since #5626). The other ten stopped at the boundary, so a mistake this class rejects when written one
+   * way was accepted written one level in - {@code COUNT { MATCH (m) RETURN count(count(m)) }} passed while
+   * {@code RETURN count(count(n))} did not, and so did a negative {@code SKIP}, a repeated relationship variable, a
+   * duplicated column name (issue #5656).
+   * <p>
+   * The boundary is closed here rather than by teaching each of the ten to recurse, which would be ten new partial
+   * recursions - the shape #5602 removed. Being a property of {@code validate()} also means a phase added later is
+   * inside a body from the day it is written, without knowing subqueries exist.
+   * <p>
+   * The two that already descend are deliberately <b>not</b> in the body list. {@link #validateVariableScope} needs
+   * the scope <i>at the point the expression was written</i>, which this traversal does not carry - it would have to
+   * seed a body with an empty scope and would then report every correlated reference as undefined. Re-running
+   * {@link #validateFunctionArgumentTypes} would only repeat a walk that already covers every depth.
+   */
+  private void validateNestedStatements(final CypherStatement statement) {
+    CypherExpressionWalker.walk(statement, new NestedStatementChecks(varTypes));
+  }
+
+  /**
+   * Applies the body phase list at each nesting boundary the walk crosses. It visits no expression of its own: what it
+   * is watching for is the boundary, and the walk reports one through
+   * {@link CypherExpressionWalker.Visitor#forNestedStatement}.
+   */
+  private static final class NestedStatementChecks implements CypherExpressionWalker.Visitor {
+    private final Map<String, VarType> scope;
+
+    private NestedStatementChecks(final Map<String, VarType> scope) {
+      this.scope = scope;
+    }
+
+    @Override
+    public void visit(final Expression expression) {
+      // Boundaries only: an expression is the business of the phases that ran on the statement holding it.
+    }
+
+    @Override
+    public CypherExpressionWalker.Visitor forNestedStatement(final CypherStatement nested) {
+      // Building the body's kinds over the inherited ones IS the variable-type phase for that body: a name the body
+      // declares twice as two different kinds raises here, from the same construction validateVariableTypes runs on
+      // the statement.
+      final Map<String, VarType> nestedScope = nestedVarTypes(scope, nested);
+
+      if (nested instanceof UnionStatement union)
+        // A UNION declares nothing of its own; each branch arrives as a nested statement in its own right and gets
+        // the body phases then. What is owed here is only what is about the UNION rather than about a branch.
+        validateUnionShape(union);
+      else
+        new CypherSemanticValidator(nestedScope).validateBodyPhases(nested);
+
+      return new NestedStatementChecks(nestedScope);
+    }
+  }
+
+  /**
+   * The phases of {@link #validate} that a body still owed. Same methods, same order, run against the body instead of
+   * against the statement.
+   */
+  private void validateBodyPhases(final CypherStatement body) {
+    validateVariableBinding(body);
+    validateCreateConstraints(body);
+    // validateRelationshipUniqueness is not here: it runs through the same walk, which already covers every body.
+    validateAggregations(body);
+    validateBooleanOperandTypes(body);
+    validateSkipLimit(body);
+    validateColumnNames(body);
+    validateExpressionAliases(body);
+    validateReturnStar(body);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -86,6 +86,16 @@ public class OpenCypherQueryEngine implements QueryEngine {
     this.database = database;
   }
 
+  /**
+   * The evaluator every plan this engine builds is given. It holds no per-query state - the field is static and shared
+   * across databases for that reason - so anything that has to build a plan outside this engine can use the same one
+   * rather than allocating a second function factory. That is what the body of an {@code EXISTS}/{@code COUNT}/
+   * {@code COLLECT} subquery does when it runs from its AST ({@link com.arcadedb.query.opencypher.ast.CorrelatedSubqueryRunner}).
+   */
+  public static ExpressionEvaluator sharedExpressionEvaluator() {
+    return EXPRESSION_EVALUATOR;
+  }
+
   @Override
   public String getLanguage() {
     return ENGINE_NAME;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -86,16 +86,6 @@ public class OpenCypherQueryEngine implements QueryEngine {
     this.database = database;
   }
 
-  /**
-   * The evaluator every plan this engine builds is given. It holds no per-query state - the field is static and shared
-   * across databases for that reason - so anything that has to build a plan outside this engine can use the same one
-   * rather than allocating a second function factory. That is what the body of an {@code EXISTS}/{@code COUNT}/
-   * {@code COLLECT} subquery does when it runs from its AST ({@link com.arcadedb.query.opencypher.ast.CorrelatedSubqueryRunner}).
-   */
-  public static ExpressionEvaluator sharedExpressionEvaluator() {
-    return EXPRESSION_EVALUATOR;
-  }
-
   @Override
   public String getLanguage() {
     return ENGINE_NAME;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryBodyIssue5656Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryBodyIssue5656Test.java
@@ -243,6 +243,24 @@ class CypherSubqueryBodyIssue5656Test extends TestHelper {
         + "RETURN n.name AS name ORDER BY name")).containsExactly("b");
   }
 
+  /**
+   * The count push-downs answer a {@code RETURN count(*)} from the schema and the CSR arrays, reading the statement's
+   * patterns and never the incoming rows. Running a body from a seed row puts an incoming row in front of them for
+   * the first time, so a correlated body has to be kept off that path - otherwise a count over one bound vertex is
+   * answered with the count over every vertex in the graph. A body that binds nothing from outside keeps it, since
+   * there is no name it could have taken from the enclosing query.
+   */
+  @Test
+  void aCorrelatedCountIsNotAnsweredByTheGlobalCountPushDown() {
+    database.command("opencypher", "CREATE (q1:Q {k:1})-[:LINKS]->(q2:Q {k:2})-[:LINKS]->(q3:Q {k:3})");
+
+    // Correlated: q1 has one outgoing LINKS, the graph has two.
+    assertThat(collect("MATCH (q:Q {k:1}) RETURN COLLECT { MATCH (q)-[:LINKS]->(x:Q) RETURN count(*) } AS r"))
+        .containsExactly(1L);
+    // Uncorrelated, and written with no outer row at all, so the seed binds nothing: the whole graph is the answer.
+    assertThat(collect("RETURN COLLECT { MATCH (a:Q)-[:LINKS]->(b:Q) RETURN count(*) } AS r")).containsExactly(2L);
+  }
+
   @Test
   void countAndCollectStillProduceTheSameValues() {
     try (final ResultSet rs = database.query("opencypher",

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryBodyIssue5656Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryBodyIssue5656Test.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5656: the body of an {@code EXISTS { }}, {@code COUNT { }} or {@code COLLECT { }}
+ * subquery was held as a string, handed to {@code database.query("opencypher", ...)} as a standalone statement once
+ * per outer row, and any failure was absorbed into the expression's neutral value.
+ *
+ * <p>Three consequences of that one decision, one section each:
+ * <ol>
+ *   <li>ten of the twelve validation phases stopped at the body, so a mistake rejected when written one way was
+ *   accepted written one level in;</li>
+ *   <li>the body was correlated by editing its text, with a keyword table and a bracket-depth counter deciding where
+ *   a clause began - the source of issues #4995/#5165, #5464, #5461 and #5541;</li>
+ *   <li>a body that <i>failed</i> was answered as a body that <i>did not match</i>, so a
+ *   {@code WHERE NOT EXISTS { ... } CREATE ...} guard degraded into an unconditional {@code CREATE}.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherSubqueryBodyIssue5656Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher",
+        "CREATE (a:P {name: 'a', age: 30})-[:KNOWS {since: 2020}]->(b:P {name: 'b', age: 40})");
+    database.command("opencypher", "CREATE (c:P {name: 'c', age: 50})");
+  }
+
+  // ===================================================================================================
+  // 1. every validation phase reaches inside a body
+  // ===================================================================================================
+
+  /**
+   * The reproducers from the issue: each is rejected when written as the query and was accepted when written as a
+   * subquery body. Asserted as a pair so the point being made is the symmetry, not the individual message.
+   */
+  @Test
+  void nestedAggregationIsRejectedInsideABodyAsOutsideOne() {
+    assertRejectedBothWays("MATCH (n:P) RETURN count(count(n)) AS r",
+        "MATCH (n:P) RETURN COUNT { MATCH (m:P) RETURN count(count(m)) } AS r", "NestedAggregation");
+  }
+
+  @Test
+  void negativeSkipIsRejectedInsideABodyAsOutsideOne() {
+    assertRejectedBothWays("MATCH (n:P) RETURN n.name AS r SKIP -1",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) RETURN m.name SKIP -1 } AS r", "NegativeIntegerArgument");
+  }
+
+  @Test
+  void negativeLimitIsRejectedInsideABodyAsOutsideOne() {
+    assertRejectedBothWays("MATCH (n:P) RETURN n.name AS r LIMIT -1",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) RETURN m.name LIMIT -1 } AS r", "NegativeIntegerArgument");
+  }
+
+  @Test
+  void duplicateColumnNameIsRejectedInsideABodyAsOutsideOne() {
+    assertRejectedBothWays("MATCH (n:P) RETURN n.name AS x, n.age AS x",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) RETURN m.name AS x, m.age AS x } AS r", "ColumnNameConflict");
+  }
+
+  @Test
+  void returnStarWithNothingInScopeIsRejectedInsideABodyAsOutsideOne() {
+    assertRejectedBothWays("RETURN *", "MATCH (n:P) RETURN COLLECT { RETURN * } AS r", "NoVariablesInScope");
+  }
+
+  /**
+   * A repeated relationship variable asks for a relationship that is two different ones at once. The plain
+   * {@code MATCH} spelling always said so; the body did not, and the path that answered it could not correlate a
+   * relationship variable either, so it reported "no match".
+   */
+  @Test
+  void repeatedRelationshipVariableIsRejectedInsideABodyAsOutsideOne() {
+    assertRejectedBothWays("MATCH (a:P)-[r:KNOWS]->()<-[r:KNOWS]-() RETURN a",
+        "MATCH (n:P) WHERE EXISTS { MATCH (a:P)-[r:KNOWS]->()<-[r:KNOWS]-() RETURN a } RETURN n",
+        "RelationshipUniquenessViolation");
+  }
+
+  /** The same phase list, applied to the body of each of the four subquery forms. */
+  @Test
+  void everySubqueryFormHasItsBodyValidated() {
+    for (final String query : List.of(
+        "MATCH (n:P) WHERE EXISTS { MATCH (m:P) RETURN count(count(m)) > 0 } RETURN n",
+        "MATCH (n:P) RETURN COUNT { MATCH (m:P) RETURN count(count(m)) } AS r",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) RETURN count(count(m)) } AS r",
+        "MATCH (n:P) CALL { MATCH (m:P) RETURN count(count(m)) AS c } RETURN c"))
+      assertThatThrownBy(() -> explain(query)).as(query)
+          .isInstanceOf(CommandParsingException.class)
+          .hasMessageContaining("NestedAggregation");
+  }
+
+  /** A body nested inside another body is a body too. */
+  @Test
+  void aBodyNestedInsideAnotherBodyIsValidated() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) WHERE EXISTS { MATCH (m:P) "
+        + "WHERE COUNT { MATCH (o:P) RETURN o.name SKIP -1 } > 0 RETURN m } RETURN n"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("NegativeIntegerArgument");
+  }
+
+  /**
+   * {@code validateUnion} returns early, so the two checks that are about the UNION itself - the column names of its
+   * branches and the mixing of UNION with UNION ALL - never ran on a UNION written as a subquery body.
+   */
+  @Test
+  void aUnionBodyGetsTheUnionChecks() {
+    assertRejectedBothWays("RETURN 1 AS a UNION RETURN 2 AS b",
+        "MATCH (n:P) CALL { RETURN 1 AS a UNION RETURN 2 AS b } RETURN n", "DifferentColumnsInUnion");
+    assertThatThrownBy(
+        () -> explain("MATCH (n:P) CALL { RETURN 1 AS a UNION RETURN 2 AS a UNION ALL RETURN 3 AS a } RETURN n"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("InvalidClauseComposition");
+  }
+
+  /** Each branch of a UNION body is a scope of its own and gets the phase list on its own. */
+  @Test
+  void eachUnionBranchOfABodyIsValidated() {
+    assertThatThrownBy(() -> explain("MATCH (n:P) CALL { RETURN 1 AS x "
+        + "UNION MATCH (m:P) RETURN count(count(m)) AS x } RETURN x"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("NestedAggregation");
+  }
+
+  /** Widening what is rejected must not reject what is valid. */
+  @Test
+  void validBodiesStillParse() {
+    for (final String query : List.of(
+        "MATCH (n:P) WHERE EXISTS { MATCH (n)-[:KNOWS]->(m:P) WHERE m.age > n.age RETURN m } RETURN n",
+        "MATCH (n:P) RETURN COUNT { MATCH (m:P) RETURN count(m) } AS r",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) RETURN m.name ORDER BY m.name SKIP 1 LIMIT 1 } AS r",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) RETURN m.name AS x, m.age AS y } AS r",
+        "MATCH (n:P) CALL { MATCH (m:P) RETURN m.name AS x UNION MATCH (o:P) RETURN o.name AS x } RETURN x",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) WITH m RETURN * } AS r"))
+      assertThatCode(() -> explain(query)).as(query).doesNotThrowAnyException();
+  }
+
+  // ===================================================================================================
+  // 2. the body runs from its AST, not from its text
+  // ===================================================================================================
+
+  /**
+   * What executes is the parsed body seeded with the outer row, so the body is never handed to the query engine as a
+   * statement of its own. The statement cache is the witness: it holds the outer query and nothing else.
+   * <p>
+   * The correlated text used to be a second entry in it. (It was one entry, not one per row: the outer row's values
+   * went into parameters, so the rewritten text was the same for every row and both caches hit - the issue's
+   * "re-parsed once per outer row" reading of the cost is not what the code did.)
+   */
+  @Test
+  void theBodyIsNeverHandedToTheQueryEngineAsText() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getCypherStatementCache().clear();
+
+    final String query = "MATCH (n:P) RETURN n.name AS name, COUNT { MATCH (n)-[:KNOWS]->(m) } AS c ORDER BY name";
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+
+    assertThat(db.getCypherStatementCache().size()).isEqualTo(1);
+    assertThat(db.getCypherStatementCache().contains(query)).isTrue();
+  }
+
+  /**
+   * Two bodies the text scan could not read, both of them read-only, both of them rejected as updates before.
+   * {@code WITH 1 AS set RETURN set} is lexically indistinguishable from {@code SET n.x = 1}, and a keyword inside a
+   * comment is not a clause. The parse tree knows which is which; a keyword table cannot.
+   */
+  @Test
+  void aReadOnlyBodyThatOnlyLooksLikeAWriteIsAccepted() {
+    assertThat(collect("MATCH (n:P {name:'a'}) RETURN COLLECT { WITH 1 AS set RETURN set } AS r"))
+        .containsExactly(1L);
+    assertThat(collect("MATCH (n:P {name:'a'}) RETURN COLLECT { MATCH (m:P) /* CREATE (x:Q) */ RETURN m.name "
+        + "ORDER BY m.name } AS r")).containsExactly("a", "b", "c");
+  }
+
+  /** A body that really writes is still rejected, in all three forms. */
+  @Test
+  void aWritingBodyIsStillRejected() {
+    for (final String query : List.of(
+        "MATCH (n:P) WHERE EXISTS { CREATE (x:Q) RETURN x } RETURN n",
+        "MATCH (n:P) RETURN COUNT { MATCH (m:P) SET m.age = 1 RETURN m } AS r",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) DETACH DELETE m RETURN 1 } AS r",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) REMOVE m.age RETURN 1 } AS r"))
+      assertThatThrownBy(() -> explain(query)).as(query)
+          .isInstanceOf(CommandParsingException.class)
+          .hasMessageContaining("InvalidClauseComposition");
+  }
+
+  /**
+   * The correlation itself, in the shapes the text rewriter had to reason about: an existing {@code WHERE} the
+   * injected condition had to be ANDed into without capturing an {@code OR} (#4995/#5165), an inline pattern
+   * predicate that is not the clause-level {@code WHERE} (#5464), a leading clause that is not {@code MATCH} (#5461),
+   * and a scalar outer variable that came in through a synthesized {@code WITH}.
+   */
+  @Test
+  void correlationStillAnswersTheSameWayInEveryBodyShape() {
+    assertThat(names("MATCH (n:P) WHERE EXISTS { MATCH (n)-[:KNOWS]->(:P) } RETURN n.name AS name ORDER BY name"))
+        .containsExactly("a");
+    assertThat(names("MATCH (n:P) WHERE EXISTS { MATCH (n)-[r:KNOWS]->(m:P) WHERE m.age = 40 OR m.age = 99 RETURN m } "
+        + "RETURN n.name AS name ORDER BY name")).containsExactly("a");
+    assertThat(names("MATCH (n:P) WHERE EXISTS { (n)-[r:KNOWS WHERE r.since = 2020]->(:P) } "
+        + "RETURN n.name AS name ORDER BY name")).containsExactly("a");
+    assertThat(names("MATCH (n:P) WHERE EXISTS { (n)-[r:KNOWS WHERE r.since = 1999]->(:P) } "
+        + "RETURN n.name AS name ORDER BY name")).isEmpty();
+    assertThat(names("MATCH (n:P) WHERE COUNT { UNWIND [1, 2] AS y MATCH (n)-[:KNOWS]->(:P) RETURN y } = 2 "
+        + "RETURN n.name AS name ORDER BY name")).containsExactly("a");
+
+    // A scalar outer variable: `age` is a number on the row, not a graph entity.
+    assertThat(names("MATCH (n:P) WITH n, n.age AS age WHERE COUNT { MATCH (m:P) WHERE m.age > age RETURN m } = 1 "
+        + "RETURN n.name AS name ORDER BY name")).containsExactly("b");
+  }
+
+  @Test
+  void countAndCollectStillProduceTheSameValues() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:P {name: 'a'}) RETURN COUNT { (n)-[:KNOWS]->(:P) } AS c, "
+            + "COLLECT { MATCH (n)-[:KNOWS]->(m:P) RETURN m.name } AS names")) {
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(1L);
+      assertThat((List<Object>) row.getProperty("names")).containsExactly("b");
+    }
+  }
+
+  // ===================================================================================================
+  // 3. a body that fails is reported, not answered
+  // ===================================================================================================
+
+  /**
+   * {@code abs(m.name)} passes the parse-time check - the argument is a property, not a literal - and fails on the
+   * row. That failure used to be absorbed: {@code EXISTS} answered false, {@code COUNT} zero, {@code COLLECT} empty,
+   * with nothing above {@code FINE} to say so. It is now the same error the enclosing query would raise.
+   */
+  @Test
+  void aFailingBodyRaisesInsteadOfAnsweringItsNeutralValue() {
+    final String expected = "abs()";
+    assertThatThrownBy(() -> names("MATCH (n:P) WHERE abs(n.name) > 0 RETURN n.name AS name"))
+        .isInstanceOf(CommandSemanticException.class).hasMessageContaining(expected);
+
+    for (final String query : List.of(
+        "MATCH (n:P) WHERE EXISTS { MATCH (m:P) WHERE abs(m.name) > 0 RETURN m } RETURN n.name AS name",
+        "MATCH (n:P) RETURN COUNT { MATCH (m:P) WHERE abs(m.name) > 0 RETURN m } AS c",
+        "MATCH (n:P) RETURN COLLECT { MATCH (m:P) WHERE abs(m.name) > 0 RETURN m.name } AS c"))
+      assertThatThrownBy(() -> names(query)).as(query)
+          .isInstanceOf(CommandSemanticException.class)
+          .hasMessageContaining(expected);
+  }
+
+  /**
+   * Why it is load-bearing. A de-duplicating guard reads {@code NOT EXISTS { ... }}: absorbing the body's failure
+   * into {@code false} makes {@code NOT EXISTS} answer {@code true}, and the guard becomes an unconditional
+   * {@code CREATE}. The write must not happen.
+   */
+  @Test
+  void aFailingGuardDoesNotTurnIntoAnUnconditionalWrite() {
+    assertThatThrownBy(() -> database.command("opencypher",
+        "MATCH (n:P {name: 'a'}) WHERE NOT EXISTS { MATCH (m:P) WHERE abs(m.name) > 0 RETURN m } "
+            + "CREATE (:Guarded {name: 'x'})"))
+        .isInstanceOf(CommandSemanticException.class);
+
+    try (final ResultSet rs = database.query("opencypher", "MATCH (g:Guarded) RETURN count(g) AS c")) {
+      assertThat(((Number) rs.next().getProperty("c")).longValue()).isEqualTo(0L);
+    }
+  }
+
+  /** A body over a label no type declares still matches nothing rather than failing: that is not an error. */
+  @Test
+  void anEmptyBodyIsStillAnEmptyAnswer() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:P {name: 'a'}) RETURN COUNT { MATCH (m:NoSuchLabel) RETURN m } AS c, "
+            + "COLLECT { MATCH (m:NoSuchLabel) RETURN m.name } AS l")) {
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(0L);
+      assertThat((List<Object>) row.getProperty("l")).isEmpty();
+    }
+    assertThat(names("MATCH (n:P) WHERE EXISTS { MATCH (n)-[:NOSUCH]->(m) } RETURN n.name AS name")).isEmpty();
+  }
+
+  // ===================================================================================================
+
+  private void assertRejectedBothWays(final String plainQuery, final String queryWithBody, final String errorCode) {
+    assertThatThrownBy(() -> explain(plainQuery)).as(plainQuery)
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining(errorCode);
+    assertThatThrownBy(() -> explain(queryWithBody)).as(queryWithBody)
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining(errorCode);
+  }
+
+  /** Parses and plans the query without executing it, so what is asserted happens before any row is touched. */
+  private void explain(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+
+  private List<String> names(final String query) {
+    final List<String> names = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+    }
+    return names;
+  }
+
+  private List<Object> collect(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      return rs.next().getProperty("r");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryBodyIssue5656Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryBodyIssue5656Test.java
@@ -261,6 +261,59 @@ class CypherSubqueryBodyIssue5656Test extends TestHelper {
     assertThat(collect("RETURN COLLECT { MATCH (a:Q)-[:LINKS]->(b:Q) RETURN count(*) } AS r")).containsExactly(2L);
   }
 
+  /**
+   * A body is pulled through the step chain in batches of 100, and what {@code COUNT} and {@code COLLECT} do with it
+   * is drive the result set to exhaustion. Nothing caps that at the first batch - {@code hasNext()} re-fetches - but
+   * nothing pinned it either, and the body reaching this path at all is what this issue changed. A body wider than
+   * one batch is the assertion that a future change to the pull contract cannot silently truncate one.
+   */
+  @Test
+  void aBodyWiderThanOnePullBatchIsNotTruncated() {
+    database.command("opencypher", "UNWIND range(1, 250) AS i CREATE (:Big {k: i})");
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:P {name: 'a'}) RETURN COUNT { MATCH (b:Big) } AS c, "
+            + "COLLECT { MATCH (b:Big) RETURN b.k } AS l")) {
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(250L);
+      assertThat((List<Object>) row.getProperty("l")).hasSize(250);
+    }
+  }
+
+  /**
+   * The body used to be handed to {@code database.query()}, which runs the physical planner; it now runs through the
+   * step chain with no physical plan, the way a {@code CALL { }} body always has. The two engines have to agree on
+   * more than counting rows, so this drives a body through the shapes that lean on the planner: a lookup an index
+   * backs, and an {@code ORDER BY ... LIMIT} that has to sort before it truncates rather than after.
+   */
+  @Test
+  void aBodyThatLeansOnThePlannerAnswersTheSameWay() {
+    // Declared through SQL so the property has a type to index: a Cypher CREATE alone leaves it schema-less.
+    database.command("sql", "CREATE VERTEX TYPE Idx");
+    database.command("sql", "CREATE PROPERTY Idx.k INTEGER");
+    database.command("sql", "CREATE INDEX ON Idx (k) UNIQUE");
+    database.command("opencypher", "UNWIND range(1, 250) AS i CREATE (:Idx {k: i, tag: 'x'})");
+
+    // Index-backed equality lookup inside a body.
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:P {name: 'a'}) RETURN COUNT { MATCH (x:Idx {k: 7}) } AS c, "
+            + "COLLECT { MATCH (x:Idx) WHERE x.k = 7 RETURN x.tag } AS l")) {
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(1L);
+      assertThat((List<Object>) row.getProperty("l")).containsExactly("x");
+    }
+
+    // ORDER BY ... LIMIT has to sort the whole body and then truncate: the top 3 of 250, not the first 3 found.
+    assertThat(collect("MATCH (n:P {name: 'a'}) RETURN COLLECT { MATCH (x:Idx) RETURN x.k ORDER BY x.k DESC LIMIT 3 } "
+        + "AS r")).containsExactly(250, 249, 248);
+    // SKIP travels with it.
+    assertThat(collect("MATCH (n:P {name: 'a'}) RETURN COLLECT { MATCH (x:Idx) RETURN x.k ORDER BY x.k ASC "
+        + "SKIP 2 LIMIT 2 } AS r")).containsExactly(3, 4);
+    // DISTINCT collapses inside the body, not after it.
+    assertThat(collect("MATCH (n:P {name: 'a'}) RETURN COLLECT { MATCH (x:Idx) RETURN DISTINCT x.tag } AS r"))
+        .containsExactly("x");
+  }
+
   @Test
   void countAndCollectStillProduceTheSameValues() {
     try (final ResultSet rs = database.query("opencypher",

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthPathTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthPathTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.traversal.TraversalPath;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for named paths with variable-length relationships.
@@ -1124,38 +1126,50 @@ class OpenCypherVariableLengthPathTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Issue #4109: a relationship variable repeated within a WHERE pattern is unsatisfiable.
+  // Issue #4109: a relationship variable repeated within one pattern is a contradiction, and the three ways of
+  // writing that pattern must agree on it.
+  //
+  // They agree by being rejected. A pattern asking for a relationship that is simultaneously two different ones is
+  // rejected by Neo4j wherever it is written, and this engine already rejected the plain MATCH spelling; the WHERE
+  // predicate and the EXISTS body reached a path that could not correlate a relationship variable either, and
+  // answered "no match" instead of reporting the contradiction. Issue #5656 made the check reach all three, so what
+  // agreed on 0 now agrees on the error.
   // ---------------------------------------------------------------------------
 
-  // Issue #4109: repeated rel var (p)-[r]->()<-[r]- is unsatisfiable, count is 0
   @Test
-  void repeatedRelVarInWhereIsUnsatisfiable() {
+  void repeatedRelVarIsRejectedHoweverItIsWritten() {
     final Database db = new DatabaseFactory("./target/databases/issue-4109-repeated-rel-var").create();
     try {
       db.transaction(() -> db.command("opencypher",
           "CREATE (:Person {name:'Alice'})-[:KNOWS]->(:Person {name:'Bob'})-[:KNOWS]->(:Person {name:'Charlie'})"));
 
-      final ResultSet rs = db.query("opencypher",
-          "MATCH (p:Person)-[r:KNOWS]-() WHERE (p)-[r:KNOWS]->()<-[r:KNOWS]-() RETURN count(*) AS cnt");
-      assertThat(rs.hasNext()).isTrue();
-      assertThat(rs.next().<Number>getProperty("cnt").longValue()).isEqualTo(0L);
-    } finally {
-      db.drop();
-    }
-  }
+      // As the query's own pattern - rejected before and after.
+      assertThatThrownBy(() -> db.query("opencypher",
+          "MATCH (p:Person)-[r:KNOWS]->()<-[r:KNOWS]-() RETURN count(*) AS cnt"))
+          .isInstanceOf(CommandParsingException.class)
+          .hasMessageContaining("RelationshipUniquenessViolation")
+          .hasMessageContaining("'r'");
 
-  // Issue #4109: repeated rel var under EXISTS { ... } agrees and returns 0
-  @Test
-  void repeatedRelVarUnderExistsAgrees() {
-    final Database db = new DatabaseFactory("./target/databases/issue-4109-repeated-rel-var").create();
-    try {
-      db.transaction(() -> db.command("opencypher",
-          "CREATE (:Person {name:'Alice'})-[:KNOWS]->(:Person {name:'Bob'})-[:KNOWS]->(:Person {name:'Charlie'})"));
+      // As a WHERE pattern predicate.
+      assertThatThrownBy(() -> db.query("opencypher",
+          "MATCH (p:Person)-[r:KNOWS]-() WHERE (p)-[r:KNOWS]->()<-[r:KNOWS]-() RETURN count(*) AS cnt"))
+          .isInstanceOf(CommandParsingException.class)
+          .hasMessageContaining("RelationshipUniquenessViolation")
+          .hasMessageContaining("'r'");
 
-      final ResultSet rs = db.query("opencypher",
-          "MATCH (p:Person)-[r:KNOWS]-() WHERE EXISTS { MATCH (p)-[r:KNOWS]->()<-[r:KNOWS]-() } RETURN count(*) AS cnt");
-      assertThat(rs.hasNext()).isTrue();
-      assertThat(rs.next().<Number>getProperty("cnt").longValue()).isEqualTo(0L);
+      // As the body of an EXISTS subquery.
+      assertThatThrownBy(() -> db.query("opencypher",
+          "MATCH (p:Person)-[r:KNOWS]-() WHERE EXISTS { MATCH (p)-[r:KNOWS]->()<-[r:KNOWS]-() } RETURN count(*) AS cnt"))
+          .isInstanceOf(CommandParsingException.class)
+          .hasMessageContaining("RelationshipUniquenessViolation")
+          .hasMessageContaining("'r'");
+
+      // Two relationships with distinct variables are the ordinary case and stay accepted.
+      try (final ResultSet rs = db.query("opencypher",
+          "MATCH (p:Person)-[r1:KNOWS]->()<-[r2:KNOWS]-() RETURN count(*) AS cnt")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Number>getProperty("cnt").longValue()).isEqualTo(0L);
+      }
     } finally {
       db.drop();
     }


### PR DESCRIPTION
Closes #5656.

`EXISTS { }`, `COUNT { }` and `COLLECT { }` did not hold their body as part of the query. They held it as **text**, edited that text once per outer row to correlate it, handed the result to `database.query("opencypher", ...)` as a standalone statement, and absorbed any failure into the expression's neutral value. The issue's three sections are three consequences of that one decision, and all three are addressed here.

---

## 1. Every validation phase reaches inside a body

`CypherSemanticValidator.validate()` runs twelve phases; two reached inside a body and ten stopped at the boundary. Verified with `EXPLAIN`, before this PR:

| written as the query | written as a body |
|---|---|
| `RETURN count(count(n))` → **rejected** | `COUNT { MATCH (m:P) RETURN count(count(m)) }` → accepted |
| `RETURN n.name SKIP -1` → **rejected** | `COLLECT { MATCH (m:P) RETURN m.name SKIP -1 }` → accepted |
| `RETURN n.name AS x, n.age AS x` → **rejected** | same inside `COLLECT { }` → accepted |
| `RETURN *` with nothing in scope → **rejected** | `COLLECT { RETURN * }` → accepted |

Fixed the way the issue suggests: not by teaching ten phases to recurse (ten new partial recursions, the shape #5602 removed) but by making the boundary a property of `validate()` itself. One walk visits every nesting boundary, builds the kinds that body inherits, and runs the phase list against it - at any depth, for all four subquery forms, and for each branch of a `UNION` body. A phase added later is inside a body from the day it is written, without knowing subqueries exist.

`validateUnion` returned early, so a `UNION` written as a body never got the two checks that are about the union rather than about a branch; `CALL { RETURN 1 AS a UNION RETURN 2 AS b }` was accepted. Those two are now separate from the branch recursion and run in both positions.

The two phases that already descend stay out of the body list, deliberately: `validateVariableScope` needs the scope *at the point the expression was written*, which the traversal does not carry, and re-running `validateFunctionArgumentTypes` would repeat a walk that already covers every depth.

## 2. The body is run, not rewritten

**A correction to the issue first.** Section 2 says the body is "re-parsed once per outer row" and "misses `CypherStatementCache` every time". That is not what the code did: the outer row's values went into **parameters** (`id(v) = $__exists_v`, `WITH $__exists_v AS v`), so the rewritten text was identical for every row and both the statement cache and the plan cache hit. Measured: a 20-row outer query left the statement cache holding 2 entries, not 21. What was paid per row was the rewrite itself and a full query-engine entry, not a parse.

The second prize is the real one, and it is taken. `CorrelatedSubqueryRewriter` decided where a clause began, where a `WHERE` body ended, and whether a keyword was a clause or an identifier, all by scanning text - the source of #4995/#5165, #5464, #5461 and #5541. **The body now executes from its AST**, with the outer row handed in as a seed row through `CypherExecutionPlan.executeWithSeedRow` - the mechanism a `CALL { }` clause already used. No injected `MATCH (v)`, no `id(v) = $param` spliced into a `WHERE`, no `WITH $p AS v`, no text at all on that path.

Two consequences beyond the bug class:

- The update-clause guard is answered from the parse tree (`CypherStatement.isReadOnly()`), which fixes the two blind spots the class's own Javadoc recorded as unfixable by a text scan: an update keyword inside a comment, and `COLLECT { WITH 1 AS set RETURN set }` - both read-only, both rejected as writes before.
- The rewriter could never correlate a **relationship** variable at all: an outer binding was pinned with an injected `MATCH (v)`, which is node syntax, so a relationship-valued outer variable produced a body that did not parse. Invisible while a failed body was absorbed.

`CorrelatedSubqueryRewriter` stays as the fallback for a body with no AST - one the statement builder declined (the best-effort build of #5626), or the existential subquery `PatternPredicateExpression` synthesizes at runtime from a pattern it holds.

## 3. A failing body is reported, not answered

All three caught `Exception` and returned `false` / `0L` / `[]`, logged at `FINE`. A body that **fails** was answered as a body that **does not match**, and the difference is load-bearing:

```cypher
MATCH (a), (b) WHERE NOT EXISTS { MATCH (a)-[:E {id: $id}]->(b) } CREATE (a)-[:E {id: $id}]->(b)
```

If that body threw, `EXISTS` answered `false`, `NOT EXISTS` answered `true`, and a de-duplicating guard became an unconditional `CREATE`. It also meant a retryable `ConcurrentModificationException` raised inside a body could never reach `DatabaseAbstractHandler`'s auto-retry - it had already been swallowed.

Of the three shapes the issue offers, this takes the first: **let it propagate**, which is what Neo4j does. The second ("absorb only what genuinely means no match") has nothing to absorb - a subquery matching nothing returns no rows without throwing, and the regression test pins that a body over a label no type declares still answers 0 / `[]` / `false`. The third (raise the log level) still answers wrongly.

**This is a behaviour change**, and the one thing in this PR worth a second opinion: a query whose subquery body fails on real data now returns that error instead of a wrong answer.

---

## Three supporting fixes that fell out

- **`CypherExecutionPlan`**: the two count push-downs (`tryCreateTypeCountOptimization`, `tryOptimizeCountStar`) answer from the schema and the CSR arrays and never look at the incoming rows, so a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound would have been answered with the count over every `n` in the graph. Neither is attempted when the chain starts from a seed row. This was latent for `CALL { }` bodies too.
- **`CypherASTBuilder`**: the bare-pattern body of an `EXISTS`/`COUNT` built its `MatchClause` straight from the constructor, skipping the inline-`WHERE` and label hoisting every other `MATCH` gets. Harmless while nothing executed that AST; not harmless once it does. One factory now, so the two cannot drift.
- **`CypherSemanticValidator`**: a repeated relationship variable - `(a)-[r]->()<-[r]-()`, a pattern asking for a relationship that is two different ones at once - was rejected only in a `MATCH` clause. The `WHERE`-predicate and subquery-body spellings reached the path that could not correlate a relationship variable and answered "no match" instead. It is now checked wherever a pattern appears, through a new `Visitor.visitPattern` hook on the walker. Neo4j rejects all three spellings; the two `#4109` tests that asserted `0` now assert that the three agree on the error.

## Verification

- New `CypherSubqueryBodyIssue5656Test` (19 tests, one section per part of the issue). Checked against the pre-change tree: **14 of 19 fail**; the 5 that pass are the "nothing valid is newly rejected" and "still evaluates the same" guards, which is what they are for.
- `engine`: 10,634 tests, 0 failures.
- `server`, `console`, `graphql`, `postgresw`, `bolt`: green.

## Not done here

`PatternPredicateExpression` keeps the text path. Its two-hop form synthesizes an `EXISTS` body from a pattern it holds as an AST, but the seeded `MATCH` does not honour a pre-bound **relationship** variable (`CALL { WITH p, r MATCH (p)-[r]->(x) ... }` answers correctly, the equivalent directly-seeded `MATCH` does not), so moving it would trade one wrong answer for another. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBYJ4njo4cYiU9VqTTAr8o
