### PR TITLE
ci(#5672): move run-scoped job-to-job transport off the Actions cache and onto artifacts

### DIFF
--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -49,17 +49,29 @@ jobs:
       - name: Save docker image
         run: docker save arcadedata/arcadedb:latest > /tmp/arcadedb-image.tar
 
-      - name: Cache Docker image
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # An artifact, not the cache: this moves the image to the jobs of THIS run and is never reusable by
+      # another one. The Actions cache is a fixed 10 GB per repository with LRU eviction, so a run-scoped
+      # entry could be evicted before the consuming job restored it (#5672).
+      - name: Upload docker image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: arcadedb-docker-image
           path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}
+          retention-days: 1
+          # Docker layers are already compressed; a second pass costs minutes and saves almost nothing.
+          compression-level: 0
 
-      - name: Cache Maven artifacts
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Only what this build produced: third-party dependencies come from the Maven cache the consuming
+      # job restores for itself, so shipping all of ~/.m2 duplicated ~1.9 GB to say nothing new.
+      - name: Package ArcadeDB Maven artifacts
+        run: tar -czf /tmp/arcadedb-m2.tgz -C ~/.m2/repository com/arcadedb
+
+      - name: Upload ArcadeDB Maven artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}
+          name: arcadedb-maven-artifacts
+          path: /tmp/arcadedb-m2.tgz
+          retention-days: 1
 
   bolt-nightly-java:
     needs: build-image
@@ -87,16 +99,20 @@ jobs:
           distribution: "temurin"
           java-version: 21
           cache: "maven"
-      - name: Restore Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+          name: arcadedb-maven-artifacts
+          path: /tmp
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}
+          name: arcadedb-docker-image
+          path: /tmp
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Set up Python
@@ -141,11 +157,11 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}
+          name: arcadedb-docker-image
+          path: /tmp
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Set up Python
@@ -198,11 +214,11 @@ jobs:
           python-version: "3.13.0"
       - name: Setup UV package manager
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}
+          name: arcadedb-docker-image
+          path: /tmp
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Run Bolt suite against pinned driver
@@ -244,11 +260,11 @@ jobs:
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0"
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}
+          name: arcadedb-docker-image
+          path: /tmp
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Set up Python
@@ -297,11 +313,11 @@ jobs:
         with:
           go-version-file: "e2e-go/go.mod"
           cache-dependency-path: "e2e-go/go.sum"
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}
+          name: arcadedb-docker-image
+          path: /tmp
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Set up Python

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -72,17 +72,33 @@ jobs:
       - name: Save docker image
         run: docker save arcadedata/arcadedb:latest > /tmp/arcadedb-image.tar
 
-      - name: Cache Docker image
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Artifacts, not the cache. Both of these move data from this job to the jobs that need it within
+      # THIS run - they are not reusable by any other run, because a later run rebuilds them. Keying them
+      # on github.run_id made that explicit and put them in the wrong store: the Actions cache is a fixed
+      # 10 GB per repository with LRU eviction, so a few concurrent runs evicted an entry minutes after it
+      # was written and every e2e job then died on `docker load` with "No such file or directory" (#5672).
+      # Artifacts are scoped to the run and are not evicted, which is the property this needs.
+      - name: Upload docker image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: arcadedb-docker-image
           path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          retention-days: 1
+          # Docker layers are already compressed; a second pass costs minutes and saves almost nothing.
+          compression-level: 0
 
-      - name: Cache Maven artifacts
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Only what this build produced, not the whole repository. Third-party dependencies come from the
+      # Maven cache that setup-java restores in each downstream job, so shipping all of ~/.m2 duplicated
+      # ~1.9 GB per run to say nothing the receiving job did not already have.
+      - name: Package ArcadeDB Maven artifacts
+        run: tar -czf /tmp/arcadedb-m2.tgz -C ~/.m2/repository com/arcadedb
+
+      - name: Upload ArcadeDB Maven artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-maven-artifacts
+          path: /tmp/arcadedb-m2.tgz
+          retention-days: 1
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -103,11 +119,16 @@ jobs:
           java-version: 21
           cache: "maven"
 
-      - name: Restore Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-maven-artifacts
+          path: /tmp
+
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
 
       - name: Run Unit Tests with Coverage
         # package phase runs surefire (test) and JaCoCo report (prepare-package) without reaching integration-test phase
@@ -177,11 +198,16 @@ jobs:
           java-version: 21
           cache: "maven"
 
-      - name: Restore Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-maven-artifacts
+          path: /tmp
+
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
 
       - name: Run Slow Unit Tests with Coverage
         run: ./mvnw package -Pcoverage --batch-mode --errors --fail-never --show-version -pl engine  -Dgroups=slow
@@ -226,11 +252,16 @@ jobs:
           java-version: 21
           cache: "maven"
 
-      - name: Restore Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-maven-artifacts
+          path: /tmp
+
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
 
       - name: Run Integration Tests with Coverage
         run: ./mvnw verify -DskipTests -Pintegration -Pcoverage  --batch-mode --errors --fail-never --show-version -pl !e2e,!load-tests,!e2e-ha,!ha-raft
@@ -277,11 +308,16 @@ jobs:
           java-version: 21
           cache: "maven"
 
-      - name: Restore Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-maven-artifacts
+          path: /tmp
+
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
 
       - name: Run HA Integration Tests with Coverage
         run: ./mvnw verify -DskipTests -Pintegration -Pcoverage  --batch-mode --errors --fail-never --show-version -pl ha-raft
@@ -323,11 +359,16 @@ jobs:
           java-version: 21
           cache: "maven"
 
-      - name: Restore Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-maven-artifacts
+          path: /tmp
+
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
 
       - name: Build packages for Builder Tests
         run: ./mvnw clean package -DskipTests --batch-mode --errors  --show-version
@@ -354,17 +395,22 @@ jobs:
           java-version: 21
           cache: "maven"
 
-      - name: Restore Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-maven-artifacts
+          path: /tmp
 
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
+
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-docker-image
+          path: /tmp
 
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
@@ -403,11 +449,11 @@ jobs:
           cache: "npm"
           cache-dependency-path: "e2e-js/package-lock.json"
 
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-docker-image
+          path: /tmp
 
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
@@ -455,11 +501,11 @@ jobs:
           cache: "npm"
           cache-dependency-path: "e2e-studio/package-lock.json"
 
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-docker-image
+          path: /tmp
 
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
@@ -519,11 +565,11 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv --version
 
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-docker-image
+          path: /tmp
 
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
@@ -573,11 +619,11 @@ jobs:
           cache: true
           cache-dependency-path: "e2e-csharp/ArcadeDB.E2ETests/ArcadeDB.E2ETests.csproj"
 
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-docker-image
+          path: /tmp
 
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
@@ -630,11 +676,11 @@ jobs:
           go-version-file: "e2e-go/go.mod"
           cache-dependency-path: "e2e-go/go.sum"
 
-      - name: Restore Docker image
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          name: arcadedb-docker-image
+          path: /tmp
 
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar


### PR DESCRIPTION
Fixes #5672.

## The problem

`build-and-package` handed the Docker image and the Maven repository to downstream jobs through `actions/cache`, keyed on `github.run_id`. A key containing the run id can never match on another run, so these were not caches at all - they were intra-run transport, in a store that makes no promise to keep anything.

The Actions cache is a fixed **10 GB per repository with LRU eviction**, and these entries were most of it: **4.63 GB of 10 GB**, with **~2.37 GB added per run**, none of it ever reusable. So an entry could be evicted minutes after being written. On run [30674461475](https://github.com/ArcadeData/arcadedb/actions/runs/30674461475):

| 00:12:00 | `build-and-package` | `Cache saved with key: docker-image-30674461475-1` |
| 00:34:36 | `go-e2e-tests` | `Cache not found for input keys: docker-image-30674461475-1` |
| 00:34:36 | | `/tmp/arcadedb-image.tar: No such file or directory` |

All six e2e jobs died at `docker load`, **before running a single test**, on a PR whose only change was a Javadoc paragraph (#5659). The same churn evicted the cache that does its job - in that run the real `Linux-maven-<pomhash>` entry missed too, prefix fallback included, so the build re-downloaded its dependencies.

## The change

**1. Both move to artifacts.** Artifacts are scoped to the run and are not evicted, which is the property this needs. `actions/cache/save` → `upload-artifact`, `actions/cache/restore` → `download-artifact`, 4 producers and 18 consumers, using the SHA pins already present in this repo.

**2. Only the delta is shipped, not all of `~/.m2`.** Every consuming job already runs `setup-java` with `cache: "maven"`, so it restores third-party dependencies for itself - the 1.9 GB full-repository copy told it nothing it did not have. What it did not have is what this build produced, so only `com/arcadedb` is packaged:

```yaml
- run: tar -czf /tmp/arcadedb-m2.tgz -C ~/.m2/repository com/arcadedb
```

**3. A missing input now fails where it is missing.** `download-artifact` errors by naming the artifact it cannot find, instead of the miss being silent and surfacing several steps later as a Docker error. That was item 3 of the issue and it comes for free with the move - no `fail-on-cache-miss` needed, since the remaining `actions/cache` use is a real cache where a miss is legitimate.

**4. `bolt-nightly.yml` had the same construction** and is fixed the same way. Leaving it would have reproduced the bug on the nightly.

## What is deliberately untouched

The two genuine caches. `Linux-maven-${{ hashFiles('**/pom.xml') }}` with its `restore-keys` prefix, and `setup-java`'s `cache: "maven"` - both are keyed on content, hit across runs, and are the reason the build is fast. This PR gives them back ~4.6 GB of budget to live in.

## Verification

I cannot execute GitHub Actions locally, so the honest statement is that **this PR's own CI run is the test** - `pull_request` runs the workflow from the PR branch, so every job here exercises the changed transport end to end. What I did check statically:

- both files parse as YAML; job/step ordering verified programmatically (download precedes `docker load`, and the Maven install precedes every `mvnw` invocation)
- the accounting balances exactly: 4 `cache/save` → 4 `upload-artifact`, 18 `cache/restore` → 18 `download-artifact`
- no `github.run_id` remains in any cache key (the one surviving occurrence builds a run URL)
- the diff touches neither `hashFiles('**/pom.xml')` nor `cache: "maven"`
- pre-commit hygiene: no trailing whitespace, newline at EOF, ASCII/LF

**The signal to watch on this run:** every e2e job should reach its tests. If the artifact wiring is wrong they will fail at `Download docker image` with a named missing artifact, not at `docker load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8C35vrQkW1y1gaEvWzRPc