### PR TITLE
fix(engine) #5670: an unreadable edge-list chunk retries the delete instead of skipping it

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1245,6 +1245,9 @@ reference during a read still skip a momentarily unreadable chunk rather than fa
 The other side of that trade, taken deliberately: an endpoint edge list that is not transiently invisible but
 genuinely broken is indistinguishable from one at that moment, so deleting an edge attached to it now fails instead
 of completing and leaving the back-reference behind. `CHECK DATABASE` remains the repair path - it rebuilds a chain
-that cannot be loaded and drops the references into it.
+that cannot be loaded and drops the references into it. This reaches vertex deletion as well, because disconnecting
+an edge touches the vertex at the other end: deleting a healthy vertex whose *neighbour's* edge list cannot be read
+now reports a conflict rather than succeeding, since succeeding would delete the edge record while the neighbour
+keeps pointing at it - dangling a reference on a vertex nobody asked to touch.
 
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1298,4 +1298,15 @@ an edge touches the vertex at the other end: deleting a healthy vertex whose *ne
 now reports a conflict rather than succeeding, since succeeding would delete the edge record while the neighbour
 keeps pointing at it - dangling a reference on a vertex nobody asked to touch.
 
+**If you hit that, the recovery is `CHECK DATABASE ... FIX` and then retry the delete.** The symptom is a delete that
+keeps failing with `ConcurrentModificationException` on the same vertex however often it is retried, which is what
+tells a broken list apart from ordinary contention (that one succeeds on a retry). The repair is never blocked by the
+delete being blocked: `CHECK DATABASE` reads edge lists through the best-effort reader, so it can still walk, rebuild
+and re-link a chain that the delete path now refuses.
+
+Note also that on a hot super-node under heavy concurrent delete-and-append the transient window is now answered with
+a retry rather than passing silently, so those transactions retry slightly more often than before. That is the
+intended shift - from "quietly wrong" to "occasionally repeated" - and it lands on exactly the super-node shape the
+bug affected. `arcadedb.txRetryDelay` and `arcadedb.txRetries` are the tuning levers if a workload needs them.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1235,11 +1235,16 @@ direction, so there is genuinely nothing to remove. Tolerance for an endpoint **
 unchanged: there is nothing to disconnect from a vertex that is gone.
 
 Visible effect: an `edge.delete()` racing a concurrent write on the same endpoint can now raise a
-`ConcurrentModificationException` where it previously "succeeded". That is a `NeedRetryException`, so the standard
-retry loop (`database.transaction(...)`, and the server's auto-retry for single-request commands) absorbs it. A
-client-managed explicit transaction spanning several requests sees it and should retry the transaction, which is the
-same contract concurrent updates have always had. Best-effort callers are unaffected: iteration, counting and the
-opportunistic pruning of an already-dangling reference during a read still skip a momentarily unreadable chunk
-rather than failing.
+`ConcurrentModificationException` where it previously "succeeded" - and so can moving an edge, which disconnects it
+the same way. That is a `NeedRetryException`, so the standard retry loop (`database.transaction(...)`, and the
+server's auto-retry for single-request commands) absorbs it. A client-managed explicit transaction spanning several
+requests sees it and should retry the transaction, which is the same contract concurrent updates have always had.
+Best-effort callers are unaffected: iteration, counting and the opportunistic pruning of an already-dangling
+reference during a read still skip a momentarily unreadable chunk rather than failing.
+
+The other side of that trade, taken deliberately: an endpoint edge list that is not transiently invisible but
+genuinely broken is indistinguishable from one at that moment, so deleting an edge attached to it now fails instead
+of completing and leaving the back-reference behind. `CHECK DATABASE` remains the repair path - it rebuilds a chain
+that cannot be loaded and drops the references into it.
 
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1282,21 +1282,28 @@ half-done one. `null` from the write-side head lookup now means one thing only -
 direction, so there is genuinely nothing to remove. Tolerance for an endpoint **vertex** that no longer exists is
 unchanged: there is nothing to disconnect from a vertex that is gone.
 
-Visible effect: an `edge.delete()` racing a concurrent write on the same endpoint can now raise a
-`ConcurrentModificationException` where it previously "succeeded" - and so can moving an edge, which disconnects it
-the same way. That is a `NeedRetryException`, so the standard retry loop (`database.transaction(...)`, and the
+**Visible effect, and it is not limited to deleting an edge.** Three operations disconnect an edge and therefore
+share the new contract:
+
+- `edge.delete()` / `DELETE EDGE`,
+- moving an edge, which disconnects it the same way,
+- **`vertex.delete()` / `DELETE VERTEX`** - the widest reach of the three. Deleting a vertex disconnects each of its
+  edges from the vertex at the *other* end, so the strict read lands on a **neighbour's** edge list. A vertex that is
+  itself perfectly healthy can now fail to delete because a neighbour's list could not be read at that moment.
+
+Any of them racing a concurrent write can now raise a `ConcurrentModificationException` where it previously
+"succeeded". That is a `NeedRetryException`, so the standard retry loop (`database.transaction(...)`, and the
 server's auto-retry for single-request commands) absorbs it. A client-managed explicit transaction spanning several
 requests sees it and should retry the transaction, which is the same contract concurrent updates have always had.
 Best-effort callers are unaffected: iteration, counting and the opportunistic pruning of an already-dangling
 reference during a read still skip a momentarily unreadable chunk rather than failing.
 
-The other side of that trade, taken deliberately: an endpoint edge list that is not transiently invisible but
-genuinely broken is indistinguishable from one at that moment, so deleting an edge attached to it now fails instead
-of completing and leaving the back-reference behind. `CHECK DATABASE` remains the repair path - it rebuilds a chain
-that cannot be loaded and drops the references into it. This reaches vertex deletion as well, because disconnecting
-an edge touches the vertex at the other end: deleting a healthy vertex whose *neighbour's* edge list cannot be read
-now reports a conflict rather than succeeding, since succeeding would delete the edge record while the neighbour
-keeps pointing at it - dangling a reference on a vertex nobody asked to touch.
+The other side of that trade, taken deliberately: an edge list that is not transiently invisible but genuinely
+broken is indistinguishable from one at that moment, so the operations above now fail instead of completing and
+leaving the back-reference behind. For `DELETE VERTEX` that means a healthy vertex next to a corrupted one is not
+deletable by the normal path until the corruption is repaired - succeeding would delete the edge record while the
+neighbour keeps pointing at it, dangling a reference on a vertex nobody asked to touch. `CHECK DATABASE` remains the
+repair path: it rebuilds a chain that cannot be loaded and drops the references into it.
 
 **If you hit that, the recovery is `CHECK DATABASE ... FIX` and then retry the delete.** The symptom is a delete that
 keeps failing with `ConcurrentModificationException` on the same vertex however often it is retried, which is what

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1210,4 +1210,36 @@ and expressing that would have been faithful to its intent, but it would have ti
 of repairing a config that enforced nothing - a decision worth taking on its own merits. Development dependencies are
 still covered by the `npm audit --audit-level=moderate` step of the same workflow.
 
+## Deleting an edge no longer leaves its back-reference behind under concurrency
+
+Removing an edge disconnects it from both endpoints and then deletes the edge record. The disconnection walked the
+endpoint's edge-list chain with best-effort reads: the head chunk came from a helper that answers `null` when it
+cannot be loaded, the chain hops used a plain lookup, and `deleteEdge` wrapped the lot in a
+`catch (RecordNotFoundException)`. All three read "chunk unreadable" as "nothing to remove here" - and then the edge
+record was deleted anyway.
+
+Under concurrency a chunk is regularly unreadable for reasons that say nothing about the graph. A commit publishes
+its pages one at a time and a reader takes no commit lock, so a vertex page can expose a new edge-list head RID a
+moment before that head's own page becomes visible; and a chunk emptied by another transaction is relinked out of
+the chain while a walker is still following a pointer to it. Hitting either window ended the removal without having
+removed anything, so the back-reference outlived its edge: the endpoint reported one edge too many
+(`countEdges`, `both()`, `in()`/`out()`) and `check database` reported one broken link. On a hot vertex - the
+super-node shape this happens on - the window is narrow, which is why it surfaced as a rare, unexplained off-by-one
+rather than as a reproducible failure.
+
+The append path already answered exactly this window with a retryable `ConcurrentModificationException`. The removal
+path now does the same: a head chunk that is present but unreadable, and a chain hop that cannot be read, are
+retryable conflicts, so the transaction re-reads a consistent view and completes the removal instead of committing a
+half-done one. `null` from the write-side head lookup now means one thing only - the vertex has no edge list in that
+direction, so there is genuinely nothing to remove. Tolerance for an endpoint **vertex** that no longer exists is
+unchanged: there is nothing to disconnect from a vertex that is gone.
+
+Visible effect: an `edge.delete()` racing a concurrent write on the same endpoint can now raise a
+`ConcurrentModificationException` where it previously "succeeded". That is a `NeedRetryException`, so the standard
+retry loop (`database.transaction(...)`, and the server's auto-retry for single-request commands) absorbs it. A
+client-managed explicit transaction spanning several requests sees it and should retry the transaction, which is the
+same contract concurrent updates have always had. Best-effort callers are unaffected: iteration, counting and the
+opportunistic pruning of an already-dangling reference during a read still skip a momentarily unreadable chunk
+rather than failing.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/graph/EdgeIteratorFilter.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeIteratorFilter.java
@@ -21,6 +21,7 @@ package com.arcadedb.graph;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.log.LogManager;
@@ -100,12 +101,22 @@ public class EdgeIteratorFilter extends IteratorFilterBase<Edge> {
         LogManager.instance().log(this, Level.WARNING, "Error on loading edge %s %s. Fixing it. Error: %s", edge,
             vertex != null ? "vertex " + vertex : "", e.getMessage());
 
-      database.transaction(() -> {
-        final EdgeLinkedList outEdges = database.getGraphEngine().getEdgeHeadChunk((VertexInternal) this.vertex, direction);
-        if (outEdges != null)
-          outEdges.removeEdgeRID(edge);
+      try {
+        database.transaction(() -> {
+          final EdgeLinkedList outEdges = database.getGraphEngine().getEdgeHeadChunk((VertexInternal) this.vertex, direction);
+          if (outEdges != null)
+            outEdges.removeEdgeRID(edge);
 
-      }, true);
+        }, true);
+      } catch (final NeedRetryException retryLater) {
+        // #5670: the removal walk now reports an unreadable chunk as a retryable conflict, because a caller that
+        // is DELETING an edge must not conclude there was nothing to remove. This caller is not deleting anything:
+        // it is opportunistically pruning a reference whose edge is already gone, from inside a READ. A concurrent
+        // commit reshaping the chain therefore costs the ghost one more pass, not the iteration.
+        LogManager.instance()
+            .log(this, Level.FINE, "Cannot prune dangling edge %s from vertex %s now (concurrent change): %s", edge,
+                vertex, retryLater.getMessage());
+      }
 
     } else {
       if (fullStackTracePrinted < 10) {

--- a/engine/src/main/java/com/arcadedb/graph/EdgeIteratorFilter.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeIteratorFilter.java
@@ -113,6 +113,12 @@ public class EdgeIteratorFilter extends IteratorFilterBase<Edge> {
         // is DELETING an edge must not conclude there was nothing to remove. This caller is not deleting anything:
         // it is opportunistically pruning a reference whose edge is already gone, from inside a READ. A concurrent
         // commit reshaping the chain therefore costs the ghost one more pass, not the iteration.
+        //
+        // NeedRetryException, deliberately wider than the ConcurrentModificationException this change introduces:
+        // the condition being absorbed is "retry later", not one specific cause. Its sibling LockTimeoutException
+        // says the same thing about this prune - come back for it - and letting THAT escape would fail a read
+        // because an optional repair could not get a lock, which is precisely the outcome this catch exists to
+        // prevent. Narrowing it to the CME would re-open that door for the sake of matching a comment.
         LogManager.instance()
             .log(this, Level.FINE, "Cannot prune dangling edge %s from vertex %s now (concurrent change): %s", edge,
                 vertex, retryLater.getMessage());

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -28,6 +28,7 @@ import com.arcadedb.database.TransactionContext;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DatabaseOperationException;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.serializer.json.JSONArray;
@@ -373,6 +374,13 @@ public class EdgeLinkedList {
    * updateRecord captures the page only later, at the newer version if a concurrent transaction modified the
    * same chunk in between. The commit-time MVCC check would then compare matching versions, miss the conflict,
    * and let the stale chunk buffer silently overwrite the concurrent change (a lost update / dropped edge).
+   * <p>
+   * A chunk that is not readable at all maps to a retryable {@link ConcurrentModificationException}: the directory
+   * page and the chunk page of a concurrent commit are published one page at a time (readers take no commit lock),
+   * so a freshly-read head RID can momentarily point to a record whose page is not visible yet. That is transient
+   * by construction - surfacing it as a conflict lets the transaction retry loop re-read a consistent view instead
+   * of raising a "record not found" that reads like a fact about the graph, and that a caller further up was
+   * entitled to take for "there was nothing here to remove" (#5670).
    */
   protected EdgeSegment loadChunkForWrite(final RID chunkRID) {
     final DatabaseInternal database = (DatabaseInternal) vertex.getDatabase();
@@ -384,13 +392,17 @@ public class EdgeLinkedList {
     final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(chunkRID.getBucketId());
     try {
       bucket.fetchPageInTransaction(chunkRID);
+      // Read THROUGH the anchored page, bypassing the record cache: a cached copy read before the anchor can be
+      // one version older than the page just anchored - writing that stale buffer back at commit would pass the
+      // MVCC check (the version matches) and silently erase a concurrent append.
+      return new MutableEdgeSegment(database, chunkRID, bucket.getRecord(chunkRID).copyOfContent());
     } catch (final IOException e) {
       throw new DatabaseOperationException("Error on loading edge chunk page " + chunkRID, e);
+    } catch (final RecordNotFoundException e) {
+      throw new ConcurrentModificationException(
+          "Edge list " + direction + " chunk " + chunkRID + " of vertex " + vertex.getIdentity()
+              + " not visible yet (concurrent commit in flight)");
     }
-    // Read THROUGH the anchored page, bypassing the record cache: a cached copy read before the anchor can be
-    // one version older than the page just anchored - writing that stale buffer back at commit would pass the
-    // MVCC check (the version matches) and silently erase a concurrent append.
-    return new MutableEdgeSegment(database, chunkRID, bucket.getRecord(chunkRID).copyOfContent());
   }
 
   /**
@@ -486,9 +498,22 @@ public class EdgeLinkedList {
    * #5155: reads an edge-list chunk for a read-only walk hop, WITHOUT anchoring its page in the transaction.
    * Used while scanning the chain for the chunk to modify; the modified chunk (and, on an empty-chunk relink,
    * the previous-browsed chunk) is re-loaded through {@link #loadChunkForWrite} before being mutated.
+   * <p>
+   * #5670: called ONLY from the three removal walks, so a chunk that cannot be read is a retryable conflict, never
+   * a reason to stop walking. The hop pointer this transaction is following was read before the walk reached it,
+   * and a concurrent commit can have relinked that chunk out of the chain (an emptied chunk is deleted, see
+   * {@link #updateSegment}) or not published its page yet. Abandoning the walk there would end the removal without
+   * having removed anything, while the caller goes on to delete the edge record - leaving a back-reference to a
+   * record that no longer exists. Retrying re-reads the chain from the vertex's current head instead.
    */
   private EdgeSegment readChunk(final RID chunkRID) {
-    return (EdgeSegment) ((DatabaseInternal) vertex.getDatabase()).lookupByRID(chunkRID, true);
+    try {
+      return (EdgeSegment) ((DatabaseInternal) vertex.getDatabase()).lookupByRID(chunkRID, true);
+    } catch (final RecordNotFoundException e) {
+      throw new ConcurrentModificationException(
+          "Edge list " + direction + " chunk " + chunkRID + " of vertex " + vertex.getIdentity()
+              + " is no longer readable (concurrent commit in flight)");
+    }
   }
 
   private int computeBestSize() {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -545,6 +545,11 @@ public class GraphEngine {
   private VertexInternal resolveEndpointToDisconnect(final Edge edge, final Vertex.DIRECTION direction) {
     final RID endpointRID = direction == Vertex.DIRECTION.OUT ? edge.getOut() : edge.getIn();
     try {
+      // NOT redundant with the resolution below, however much it looks it: Edge.getOutVertex/getInVertex load with
+      // loadContent=false, which hands back a LAZY handle without touching the bucket. A deleted endpoint therefore
+      // does not surface here at all - it surfaces later, inside getEdgeHeadChunkForWrite, which maps it to a
+      // retryable conflict. This check is what keeps the two apart: vertex gone = nothing to disconnect (tolerated),
+      // vertex present but its list unreadable = a conflict to retry. Removing it turns the first into the second.
       if (!edge.getDatabase().existsRecord(endpointRID))
         return null;
       final Vertex endpoint = direction == Vertex.DIRECTION.OUT ? edge.getOutVertex() : edge.getInVertex();

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1103,6 +1103,12 @@ public class GraphEngine {
    * from one here, so it now fails the removal on every attempt instead of completing it best-effort and leaving the
    * back-reference. Repair belongs to {@code CHECK DATABASE}, which rebuilds an unloadable chain and drops the
    * references into it; see issue #5680 for how this couples to the tolerance {@link #deleteVertex} keeps.
+   * <p>
+   * That price reaches {@link #deleteVertex} too, since disconnecting an edge touches the vertex at the OTHER end:
+   * deleting a healthy vertex whose NEIGHBOUR's list cannot be read now reports a conflict. Also deliberate -
+   * succeeding there would delete the edge record while the neighbour keeps pointing at it, dangling a reference on
+   * a vertex nobody asked to touch. Pinned by
+   * {@code Issue5670EdgeDeleteDanglingBackRefTest.deletingAVertexWhoseNeighbourListIsUnreadableReportsAConflictRatherThanDanglingTheReference}.
    */
   public EdgeLinkedList getEdgeHeadChunkForWrite(final VertexInternal vertex, final Vertex.DIRECTION direction) {
     if (direction != Vertex.DIRECTION.OUT && direction != Vertex.DIRECTION.IN)

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -547,6 +547,12 @@ public class GraphEngine {
    */
   private VertexInternal resolveEndpointToDisconnect(final Edge edge, final Vertex.DIRECTION direction) {
     final RID endpointRID = direction == Vertex.DIRECTION.OUT ? edge.getOut() : edge.getIn();
+    if (endpointRID == null)
+      // No endpoint recorded on this side: nothing to disconnect, same answer as a vertex that is gone. An edge
+      // always carries both, so this is a guard rather than a case - but existsRecord raises IllegalArgumentException
+      // on a null RID, which the catch below does not cover and which is not retryable, so it would escape as a hard
+      // failure from the one method whose job is to decide what is tolerable.
+      return null;
     try {
       // NOT redundant with the resolution below, however much it looks it: Edge.getOutVertex/getInVertex load with
       // loadContent=false, which hands back a LAZY handle without touching the bucket. A deleted endpoint therefore

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -527,8 +527,11 @@ public class GraphEngine {
     if (edgeRID != null && !(edge instanceof LightEdge))
       // DELETE EDGE RECORD TOO
       try {
-        // Use the database's delete method to ensure proper index cleanup
-        // instead of directly calling bucket.deleteRecord()
+        // The physical removal only: index cleanup has already happened. This method is reached through
+        // LocalDatabase.deleteRecordNoLock, which cleans the record's index entries and fires the delete events
+        // BEFORE dispatching an Edge here - so going back through the database would repeat that work, not add it.
+        // (The comment previously here said the opposite of what the line below does; verified by deleting an edge
+        // carrying an indexed property and watching the index drop from 1 entry to 0.)
         final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(edge.getIdentity().getBucketId());
         bucket.deleteRecord(edge.getIdentity());
       } catch (final RecordNotFoundException e) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -493,37 +493,34 @@ public class GraphEngine {
     return total;
   }
 
+  /**
+   * Disconnects an edge from both its endpoints and deletes the edge record.
+   * <p>
+   * #5670: the two endpoint blocks tolerate a VANISHED ENDPOINT VERTEX (nothing left to disconnect) but NOT a
+   * vanished piece of a still-existing vertex's edge list. Resolving the vertex and walking its chain used to sit
+   * inside one {@code catch (SchemaException | RecordNotFoundException)}, so a chunk that was merely not visible
+   * YET - a concurrent commit publishes the vertex page carrying the new head RID before the head chunk's own page,
+   * the exact transient {@link #getOrCreateEdgeList} already turns into a retryable conflict on the append path -
+   * silently skipped the removal while the edge record below was deleted anyway. The back-reference survived its
+   * edge: one edge too many in the endpoint's degree and one integrity error, under concurrency only. Splitting the
+   * resolution from the mutation, and reading the head through the strict {@link #getEdgeHeadChunkForWrite}, makes
+   * that window a retry instead.
+   */
   public void deleteEdge(final Edge edge) {
     final Database database = edge.getDatabase();
 
-    try {
-      if (database.existsRecord(edge.getOut())) {
-        final VertexInternal vOut = (VertexInternal) edge.getOutVertex();
-        if (vOut != null) {
-          final EdgeLinkedList outEdges = getEdgeHeadChunk(vOut, Vertex.DIRECTION.OUT);
-          if (outEdges != null)
-            outEdges.removeEdge(edge);
-        }
-      }
-    } catch (final SchemaException | RecordNotFoundException e) {
-      LogManager.instance()
-          .log(this, Level.FINE, "Error on loading outgoing vertex %s from edge %s", e, edge.getOut(),
-              edge.getIdentity());
+    final VertexInternal vOut = resolveEndpointToDisconnect(edge, Vertex.DIRECTION.OUT);
+    if (vOut != null) {
+      final EdgeLinkedList outEdges = getEdgeHeadChunkForWrite(vOut, Vertex.DIRECTION.OUT);
+      if (outEdges != null)
+        outEdges.removeEdge(edge);
     }
 
-    try {
-      if (database.existsRecord(edge.getIn())) {
-        final VertexInternal vIn = (VertexInternal) edge.getInVertex();
-        if (vIn != null) {
-          final EdgeLinkedList inEdges = getEdgeHeadChunk(vIn, Vertex.DIRECTION.IN);
-          if (inEdges != null)
-            inEdges.removeEdge(edge);
-        }
-      }
-    } catch (final SchemaException | RecordNotFoundException e) {
-      LogManager.instance()
-          .log(this, Level.FINE, "Error on loading incoming vertex %s from edge %s", e, edge.getIn(),
-              edge.getIdentity());
+    final VertexInternal vIn = resolveEndpointToDisconnect(edge, Vertex.DIRECTION.IN);
+    if (vIn != null) {
+      final EdgeLinkedList inEdges = getEdgeHeadChunkForWrite(vIn, Vertex.DIRECTION.IN);
+      if (inEdges != null)
+        inEdges.removeEdge(edge);
     }
 
     final RID edgeRID = edge.getIdentity();
@@ -537,6 +534,29 @@ public class GraphEngine {
       } catch (final RecordNotFoundException e) {
         // ALREADY DELETED: IGNORE IT
       }
+  }
+
+  /**
+   * The endpoint vertex of {@code edge} in {@code direction} whose edge list still has to be disconnected, or null
+   * when there is nothing to disconnect because the vertex itself is gone (deleted concurrently, or never existed -
+   * a dangling endpoint reference). ONLY the vertex resolution is tolerated here: every failure further in, on the
+   * edge list of a vertex that does exist, must reach the caller (see {@link #deleteEdge}).
+   */
+  private VertexInternal resolveEndpointToDisconnect(final Edge edge, final Vertex.DIRECTION direction) {
+    final RID endpointRID = direction == Vertex.DIRECTION.OUT ? edge.getOut() : edge.getIn();
+    try {
+      if (!edge.getDatabase().existsRecord(endpointRID))
+        return null;
+      final Vertex endpoint = direction == Vertex.DIRECTION.OUT ? edge.getOutVertex() : edge.getInVertex();
+      // asVertexInternal, not a direct cast: a cached vertex arrives wrapped in a SynchronizedVertex, which is a
+      // Vertex but not a VertexInternal.
+      return endpoint == null ? null : asVertexInternal(endpoint);
+    } catch (final SchemaException | RecordNotFoundException e) {
+      LogManager.instance()
+          .log(this, Level.FINE, "Error on loading %s vertex %s from edge %s", e, direction, endpointRID,
+              edge.getIdentity());
+      return null;
+    }
   }
 
   public void moveEdge(final MutableEdge edge, final Vertex.DIRECTION direction, final RID newVertexRID) {
@@ -1040,6 +1060,11 @@ public class GraphEngine {
       }
   }
 
+  /**
+   * READ-side edge list of a vertex: best-effort, so a head chunk that cannot be loaded costs the caller the list
+   * (null) rather than an exception. Callers that are about to MUTATE the list must use
+   * {@link #getEdgeHeadChunkForWrite} instead - see the contract stated there.
+   */
   public EdgeLinkedList getEdgeHeadChunk(final VertexInternal vertex, final Vertex.DIRECTION direction) {
     if (direction != Vertex.DIRECTION.OUT && direction != Vertex.DIRECTION.IN)
       return null;
@@ -1047,13 +1072,8 @@ public class GraphEngine {
     RID rid = null;
     try {
       rid = direction == Vertex.DIRECTION.OUT ? vertex.getOutEdgesHeadChunk() : vertex.getInEdgesHeadChunk();
-      if (rid != null) {
-        final Record head = vertex.getDatabase().lookupByRID(rid, true);
-        if (head instanceof StripeDirectory directory)
-          // SUPER-NODE PROMOTED VERTEX (#5156): THE EDGE LIST IS STRIPED OVER MULTIPLE CHAINS
-          return new StripedEdgeList(vertex, direction, directory);
-        return new EdgeLinkedList(vertex, direction, (EdgeSegment) head);
-      }
+      if (rid != null)
+        return buildEdgeList(vertex, direction, rid);
     } catch (final RecordNotFoundException e) {
       // rid == null: the vertex itself was deleted concurrently (stale reference from a
       //   prior traversal step). Expected under concurrent writes — log at FINE.
@@ -1065,6 +1085,44 @@ public class GraphEngine {
     }
 
     return null;
+  }
+
+  /**
+   * WRITE-side edge list of a vertex, for a caller about to remove entries from it (#5670). Identical to
+   * {@link #getEdgeHeadChunk} except that a head RID which is present but cannot be READ raises a retryable
+   * {@link ConcurrentModificationException} instead of answering null.
+   * <p>
+   * Null means one thing only here: the vertex has NO edge list in this direction, so there is genuinely nothing
+   * to remove. Anything else is not a fact about the graph, it is a fact about timing - a concurrent commit
+   * publishes its pages one at a time and this reader holds no commit lock, so the vertex page can expose a head
+   * RID a moment before that head's own page becomes visible. Answering null there let the caller "successfully"
+   * skip a removal it had to perform. {@link #getOrCreateEdgeList} draws the same line on the append path, and
+   * {@link StripedEdgeList#addChain} on the per-stripe chains.
+   */
+  public EdgeLinkedList getEdgeHeadChunkForWrite(final VertexInternal vertex, final Vertex.DIRECTION direction) {
+    if (direction != Vertex.DIRECTION.OUT && direction != Vertex.DIRECTION.IN)
+      return null;
+
+    final RID rid = direction == Vertex.DIRECTION.OUT ? vertex.getOutEdgesHeadChunk() : vertex.getInEdgesHeadChunk();
+    if (rid == null)
+      return null;
+
+    try {
+      return buildEdgeList(vertex, direction, rid);
+    } catch (final RecordNotFoundException e) {
+      throw new ConcurrentModificationException(
+          "Edge list " + direction + " head chunk " + rid + " of vertex " + vertex.getIdentity()
+              + " not visible yet (concurrent commit in flight)");
+    }
+  }
+
+  /** Wraps the head record of an edge list in the view matching its layout: striped (#5156) or classic. */
+  private EdgeLinkedList buildEdgeList(final VertexInternal vertex, final Vertex.DIRECTION direction, final RID headRID) {
+    final Record head = vertex.getDatabase().lookupByRID(headRID, true);
+    if (head instanceof StripeDirectory directory)
+      // SUPER-NODE PROMOTED VERTEX (#5156): THE EDGE LIST IS STRIPED OVER MULTIPLE CHAINS
+      return new StripedEdgeList(vertex, direction, directory);
+    return new EdgeLinkedList(vertex, direction, (EdgeSegment) head);
   }
 
   // -------------------------------------------------------------------------

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1098,21 +1098,29 @@ public class GraphEngine {
    * RID a moment before that head's own page becomes visible. Answering null there let the caller "successfully"
    * skip a removal it had to perform. {@link #getOrCreateEdgeList} draws the same line on the append path, and
    * {@link StripedEdgeList#addChain} on the per-stripe chains.
+   * <p>
+   * The price, taken deliberately: a chunk that is not transiently invisible but GENUINELY lost is indistinguishable
+   * from one here, so it now fails the removal on every attempt instead of completing it best-effort and leaving the
+   * back-reference. Repair belongs to {@code CHECK DATABASE}, which rebuilds an unloadable chain and drops the
+   * references into it; see issue #5680 for how this couples to the tolerance {@link #deleteVertex} keeps.
    */
   public EdgeLinkedList getEdgeHeadChunkForWrite(final VertexInternal vertex, final Vertex.DIRECTION direction) {
     if (direction != Vertex.DIRECTION.OUT && direction != Vertex.DIRECTION.IN)
       return null;
 
-    final RID rid = direction == Vertex.DIRECTION.OUT ? vertex.getOutEdgesHeadChunk() : vertex.getInEdgesHeadChunk();
-    if (rid == null)
-      return null;
-
+    // The head-RID read stays INSIDE the try: on a not-yet-materialised ImmutableVertex it lazy-loads the record,
+    // so a vertex deleted since the caller resolved it raises RecordNotFoundException here rather than at the chunk
+    // lookup. That is the same transient this method exists to convert - letting it escape raw would fail the
+    // transaction with an exception that is NOT retryable.
     try {
+      final RID rid = direction == Vertex.DIRECTION.OUT ? vertex.getOutEdgesHeadChunk() : vertex.getInEdgesHeadChunk();
+      if (rid == null)
+        return null;
       return buildEdgeList(vertex, direction, rid);
     } catch (final RecordNotFoundException e) {
       throw new ConcurrentModificationException(
-          "Edge list " + direction + " head chunk " + rid + " of vertex " + vertex.getIdentity()
-              + " not visible yet (concurrent commit in flight)");
+          "Edge list " + direction + " of vertex " + vertex.getIdentity()
+              + " is not fully visible yet (concurrent commit in flight): " + e.getMessage());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
+++ b/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
@@ -71,8 +71,8 @@ public class StripedEdgeList extends EdgeLinkedList {
   /** Millis of the last skipped-chain WARNING (see addChain): a hot super-node under the transient cross-file
    * publication window could otherwise flood the log with one line per read. Reads are deliberately
    * BEST-EFFORT - unlike the write path (which surfaces the same condition as a retryable conflict, see
-   * loadStripeHead), a read skips the momentarily unresolvable chain, so counts/iterations during a concurrent
-   * commit can transiently under-report instead of failing. */
+   * EdgeLinkedList.loadChunkForWrite), a read skips the momentarily unresolvable chain, so counts/iterations
+   * during a concurrent commit can transiently under-report instead of failing. */
   private static final AtomicLong                      LAST_SKIPPED_CHAIN_WARN = new AtomicLong();
 
   private final DatabaseInternal database;
@@ -238,7 +238,9 @@ public class StripedEdgeList extends EdgeLinkedList {
     EdgeSegment head = null;
     final RID headRID = directory.getHead(generation, slot);
     if (headRID != null) {
-      head = loadStripeHead(headRID);
+      // loadChunkForWrite maps a head that is not visible yet - the directory and chunk pages of a concurrent
+      // commit are published one at a time - to a retryable conflict rather than a spurious "record not found".
+      head = loadChunkForWrite(headRID);
       if (append(head, edgeRID, vertexRID))
         return;
     }
@@ -261,7 +263,7 @@ public class StripedEdgeList extends EdgeLinkedList {
 
     if (!freshHeadRID.equals(headRID)) {
       // A CONCURRENT TRANSACTION ALREADY REPLACED THE HEAD: APPEND INTO THE CURRENT ONE
-      head = loadStripeHead(freshHeadRID);
+      head = loadChunkForWrite(freshHeadRID);
       if (append(head, edgeRID, vertexRID))
         return;
     }
@@ -274,22 +276,6 @@ public class StripedEdgeList extends EdgeLinkedList {
     newChunk.setPrevious(head);
     database.createRecord(newChunk, database.getSchema().getBucketById(head.getIdentity().getBucketId()).getName());
     updateSlot(fresh, generation, slot, newChunk.getIdentity());
-  }
-
-  /**
-   * Loads a stripe head chunk for write, mapping a transient miss to a retryable conflict: the directory page
-   * and the stripe chunk page of a concurrent commit are published one page at a time (readers take no commit
-   * lock), so a freshly-read head RID can momentarily point to a record whose page is not visible yet. That is
-   * transient by construction - surfacing it as {@link ConcurrentModificationException} lets the transaction
-   * retry loop re-read a consistent view instead of failing with a spurious "record not found".
-   */
-  private EdgeSegment loadStripeHead(final RID headRID) {
-    try {
-      return loadChunkForWrite(headRID);
-    } catch (final RecordNotFoundException e) {
-      throw new ConcurrentModificationException(
-          "Stripe head chunk " + headRID + " not visible yet (concurrent commit in flight on vertex " + vertex.getIdentity() + ")");
-    }
   }
 
   /** In-place append + merge tracking; false if the chunk is full. */
@@ -460,7 +446,7 @@ public class StripedEdgeList extends EdgeLinkedList {
       if (strict)
         // MUTATING (or dedup-feeding) caller: skipping the chain would silently commit an incomplete operation
         // (e.g. a removal leaving a stale back-reference). The miss is transient by construction (cross-file
-        // commit publication) - surface it as a retryable conflict, symmetric with loadStripeHead.
+        // commit publication) - surface it as a retryable conflict, symmetric with loadChunkForWrite.
         throw new ConcurrentModificationException(
             "Stripe chain " + headRID + " of vertex " + vertex.getIdentity() + " not visible yet (concurrent commit in flight)");
       final long now = System.currentTimeMillis();

--- a/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
@@ -20,8 +20,10 @@ package com.arcadedb.graph;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -120,6 +122,33 @@ class Issue5670EdgeDeleteDanglingBackRefTest extends TestHelper {
   }
 
   /**
+   * The head RID is read off the vertex INSIDE the strict lookup's try, because on a handle that has not loaded its
+   * record yet that read lazy-loads it - so an endpoint deleted since the caller resolved it surfaces here rather
+   * than at the chunk lookup. Escaping raw, that is a plain {@code RecordNotFoundException}: not a
+   * {@code NeedRetryException}, so it would fail the transaction outright instead of retrying it.
+   */
+  @Test
+  void headChunkForWriteRaisesRetryableConflictWhenTheVertexItselfVanishes() {
+    createSchema();
+    final RID hubRID = createHub();
+    createEdges(hubRID, 20);
+
+    database.begin();
+    try {
+      // A handle that has NOT materialised its record (loadContent=false): reading its head RID lazy-loads it.
+      final VertexInternal lazyHub = (VertexInternal) database.lookupByRID(hubRID, false);
+      database.getSchema().getBucketById(hubRID.getBucketId()).deleteRecord(hubRID);
+
+      assertThatThrownBy(
+          () -> ((DatabaseInternal) database).getGraphEngine().getEdgeHeadChunkForWrite(lazyHub, Vertex.DIRECTION.IN))
+          .isInstanceOf(ConcurrentModificationException.class)
+          .isInstanceOf(NeedRetryException.class);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
    * The reported shape (#5670): concurrent transactions that each delete one pre-existing edge of a hub and append
    * one new edge. Net degree is invariant, so the hub's IN-degree must stay at the pool size and the integrity
    * check must be clean. Before the fix this reported one edge too many - the surplus being an edge whose record
@@ -165,6 +194,9 @@ class Issue5670EdgeDeleteDanglingBackRefTest extends TestHelper {
                   src.newEdge("LINK", hubRID);
                 }, false, 10_000);
               } catch (final Exception e) {
+                // Nothing here is expected to surface: the retry budget above is far beyond what this contention
+                // needs, so ANY exception reaching this point is the bug, not a tolerated retry. Counted rather
+                // than rethrown only so the assertions below run on a fully drained pool.
                 failures.incrementAndGet();
               }
             }

--- a/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
@@ -149,6 +149,41 @@ class Issue5670EdgeDeleteDanglingBackRefTest extends TestHelper {
   }
 
   /**
+   * The second-order effect of the strict removal, locked in deliberately: deleting a vertex disconnects its edges
+   * from the vertices on the OTHER end too, so a healthy vertex whose NEIGHBOUR's edge list cannot be read now
+   * reports a retryable conflict instead of succeeding.
+   * <p>
+   * That is the intended answer, not an oversight. Succeeding here means deleting the edge record while the
+   * neighbour keeps pointing at it - creating exactly the dangling back-reference this issue is about, on a vertex
+   * nobody asked to touch. Under the concurrency this fix targets the retry resolves it; on a genuinely broken
+   * neighbour list the delete fails and {@code CHECK DATABASE} is the repair path. See issue #5680, which tracks
+   * whether vertex deletion should keep a tolerant escape hatch for that case.
+   */
+  @Test
+  void deletingAVertexWhoseNeighbourListIsUnreadableReportsAConflictRatherThanDanglingTheReference() {
+    createSchema();
+    final RID hubRID = createHub();
+    final List<RID> edges = createEdges(hubRID, 20);
+
+    // The SOURCE of the last edge: a perfectly healthy vertex, whose only edge points at the hub.
+    final RID[] srcHolder = new RID[1];
+    database.transaction(() -> srcHolder[0] = edges.get(edges.size() - 1).asEdge().getOut());
+
+    // Break the HUB's IN list - the neighbour of the vertex we are about to delete - leaving the hub record intact.
+    final RID[] headHolder = new RID[1];
+    database.transaction(() -> headHolder[0] = ((VertexInternal) hubRID.asVertex()).getInEdgesHeadChunk());
+    assertPrecondition(hubRID, edges.get(0), edges.size());
+    deleteRecord(headHolder[0]);
+
+    assertThatThrownBy(() -> database.transaction(() -> srcHolder[0].asVertex().delete(), false, 1))
+        .isInstanceOf(ConcurrentModificationException.class)
+        .isInstanceOf(NeedRetryException.class);
+
+    // Rolled back whole: the source vertex is still there, so a retry can complete it properly.
+    database.transaction(() -> assertThat(database.existsRecord(srcHolder[0])).isTrue());
+  }
+
+  /**
    * The reported shape (#5670): concurrent transactions that each delete one pre-existing edge of a hub and append
    * one new edge. Net degree is invariant, so the hub's IN-degree must stay at the pool size and the integrity
    * check must be clean. Before the fix this reported one edge too many - the surplus being an edge whose record

--- a/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * #5670: deleting an edge must never leave its back-reference behind.
+ * <p>
+ * The removal walk over an endpoint's edge list used to treat an unreadable chunk as "nothing to remove": the head
+ * chunk was read through the best-effort {@code getEdgeHeadChunk} (null on a miss) and the chain hops through a
+ * plain lookup, while {@code deleteEdge} wrapped both in a {@code catch (RecordNotFoundException)}. Under
+ * concurrency a chunk is regularly unreadable for reasons that have nothing to do with the graph: a commit
+ * publishes its pages one at a time and the reader takes no commit lock, so a vertex page can expose a head RID
+ * before that head's own page is visible, and an emptied chunk is relinked out of the chain under a walker's feet.
+ * The removal was then skipped while the edge record was deleted anyway - one edge too many in the endpoint's
+ * degree, plus one integrity error. The append path already answered the same window with a retryable conflict;
+ * these tests pin that the removal path now does too.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5670EdgeDeleteDanglingBackRefTest extends TestHelper {
+
+  /** These tests deliberately corrupt an edge-list chain, so the blanket end-of-test check would always fire. */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  /**
+   * The transient window as observed in the field: the hub's IN head chunk RID is readable on the vertex but the
+   * chunk itself is not. Simulated by removing the head chunk record. The edge delete must raise a retryable
+   * conflict, leaving the edge (and its back-reference) intact for the retry - not commit a delete that strips the
+   * record while the back-reference survives.
+   */
+  @Test
+  void edgeDeleteRaisesRetryableConflictWhenTheEndpointHeadChunkIsUnreadable() {
+    createSchema();
+    final RID hubRID = createHub();
+    final List<RID> edges = createEdges(hubRID, 200);
+
+    final List<RID> chain = inChunkChain(hubRID);
+    assertThat(chain).as("the hub's IN list must span several chunks").hasSizeGreaterThan(3);
+
+    final RID victim = edges.get(0);
+    assertPrecondition(hubRID, victim, edges.size());
+
+    final RID headChunk = chain.get(0);
+    deleteRecord(headChunk);
+
+    assertThatThrownBy(() -> database.transaction(() -> victim.asEdge().delete(), false, 1))
+        .isInstanceOf(ConcurrentModificationException.class)
+        .hasMessageContaining(headChunk.toString());
+
+    // The whole delete was rolled back: the edge record is still there, so a retry can complete it properly.
+    database.transaction(() -> assertThat(database.existsRecord(victim)).isTrue());
+  }
+
+  /**
+   * Same contract one hop further in: a chunk in the MIDDLE of the chain is gone (what a concurrent commit does
+   * when it empties a chunk and relinks the chain past it), and the edge to remove lives behind it. Abandoning the
+   * walk there is what left the back-reference dangling.
+   */
+  @Test
+  void edgeDeleteRaisesRetryableConflictWhenAMidChainChunkIsUnreadable() {
+    createSchema();
+    final RID hubRID = createHub();
+    final List<RID> edges = createEdges(hubRID, 200);
+
+    final List<RID> chain = inChunkChain(hubRID);
+    assertThat(chain).as("the hub's IN list must span several chunks").hasSizeGreaterThan(3);
+
+    // The oldest chunk is the chain's tail, so the first edge created is the one furthest from the head.
+    final RID victim = edges.get(0);
+    final RID midChunk = chain.get(1);
+    assertThat(chunkHolding(victim, chain)).as("the victim must sit BEHIND the chunk about to vanish")
+        .isGreaterThan(chain.indexOf(midChunk));
+    assertPrecondition(hubRID, victim, edges.size());
+
+    deleteRecord(midChunk);
+
+    assertThatThrownBy(() -> database.transaction(() -> victim.asEdge().delete(), false, 1))
+        .isInstanceOf(ConcurrentModificationException.class)
+        .hasMessageContaining(midChunk.toString());
+
+    database.transaction(() -> assertThat(database.existsRecord(victim)).isTrue());
+  }
+
+  /**
+   * The reported shape (#5670): concurrent transactions that each delete one pre-existing edge of a hub and append
+   * one new edge. Net degree is invariant, so the hub's IN-degree must stay at the pool size and the integrity
+   * check must be clean. Before the fix this reported one edge too many - the surplus being an edge whose record
+   * was deleted while its back-reference stayed in the hub's list.
+   */
+  @Test
+  @Tag("slow")
+  void concurrentDeleteAndAppendNeverLeaveADanglingBackReference() throws InterruptedException {
+    final int rounds = 40;
+    final int threads = 8;
+    final int perThread = 60;
+    final int pool = threads * perThread; // exactly one removal per iteration drains the pool
+
+    final int savedRetryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(1);
+    try {
+      createSchema();
+
+      for (int round = 0; round < rounds; round++) {
+        final RID hubRID = createHub();
+        final ConcurrentLinkedQueue<RID> removable = new ConcurrentLinkedQueue<>(createEdges(hubRID, pool));
+
+        final AtomicLong failures = new AtomicLong();
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(threads);
+        for (int t = 0; t < threads; t++) {
+          new Thread(() -> {
+            try {
+              start.await();
+            } catch (final InterruptedException e) {
+              Thread.currentThread().interrupt();
+              done.countDown();
+              return;
+            }
+            for (int i = 0; i < perThread; i++) {
+              final RID toRemove = removable.poll();
+              try {
+                database.transaction(() -> {
+                  if (toRemove != null)
+                    toRemove.asEdge().delete();
+                  final MutableVertex src = database.newVertex("Src");
+                  src.save();
+                  src.newEdge("LINK", hubRID);
+                }, false, 10_000);
+              } catch (final Exception e) {
+                failures.incrementAndGet();
+              }
+            }
+            done.countDown();
+          }).start();
+        }
+        start.countDown();
+        done.await();
+
+        assertThat(failures.get()).as("round " + round).isEqualTo(0);
+
+        final long[] inDegree = new long[1];
+        database.transaction(() -> inDegree[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
+        assertThat(inDegree[0]).as("round " + round + ": hub IN-degree").isEqualTo(pool);
+      }
+
+      assertIntegrityClean();
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
+    }
+  }
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Hub", 1);
+      database.getSchema().createVertexType("Src", 16);
+      database.getSchema().createEdgeType("LINK", 16);
+    });
+  }
+
+  private RID createHub() {
+    final MutableVertex[] holder = new MutableVertex[1];
+    database.transaction(() -> {
+      holder[0] = database.newVertex("Hub");
+      holder[0].save();
+    });
+    return holder[0].getIdentity();
+  }
+
+  /** One edge per transaction, so the hub's IN chain grows chunk by chunk exactly as it does in production. */
+  private List<RID> createEdges(final RID hubRID, final int count) {
+    final List<RID> edges = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      final RID[] holder = new RID[1];
+      database.transaction(() -> {
+        final MutableVertex src = database.newVertex("Src");
+        src.save();
+        holder[0] = src.newEdge("LINK", hubRID).getIdentity();
+      });
+      edges.add(holder[0]);
+    }
+    return edges;
+  }
+
+  /** The hub's IN chunk chain, head first (newest chunk) to tail (the chunk created with the first edge). */
+  private List<RID> inChunkChain(final RID hubRID) {
+    final List<RID> chain = new ArrayList<>();
+    database.transaction(() -> {
+      RID rid = ((VertexInternal) hubRID.asVertex()).getInEdgesHeadChunk();
+      while (rid != null) {
+        chain.add(rid);
+        rid = ((EdgeSegment) database.lookupByRID(rid, true)).getPreviousRID();
+      }
+    });
+    return chain;
+  }
+
+  /** Index in {@code chain} of the chunk holding {@code edgeRID}, or -1. */
+  private int chunkHolding(final RID edgeRID, final List<RID> chain) {
+    final int[] found = new int[] { -1 };
+    database.transaction(() -> {
+      for (int i = 0; i < chain.size(); i++)
+        if (((EdgeSegment) database.lookupByRID(chain.get(i), true)).containsEdge(edgeRID)) {
+          found[0] = i;
+          break;
+        }
+    });
+    return found[0];
+  }
+
+  /** The graph is intact and the edge under test is really reachable from the hub before the chain is broken. */
+  private void assertPrecondition(final RID hubRID, final RID edgeRID, final int expectedDegree) {
+    database.transaction(() -> {
+      assertThat(hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK")).isEqualTo(expectedDegree);
+      assertThat(database.existsRecord(edgeRID)).isTrue();
+    });
+  }
+
+  private void deleteRecord(final RID rid) {
+    database.transaction(() -> database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid));
+    database.transaction(() -> assertThat(database.existsRecord(rid)).isFalse());
+  }
+
+  private void assertIntegrityClean() {
+    try (final ResultSet rs = database.command("sql", "check database")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        assertThat(longProperty(row, "autoFix")).as("check database autoFix: " + row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "totalErrors")).as("check database totalErrors: " + row.toJSON()).isEqualTo(0L);
+      }
+    }
+  }
+
+  /** Null-tolerant read of a numeric check-database property, so a missing field fails clearly instead of NPE. */
+  private static long longProperty(final Result row, final String name) {
+    final Object value = row.getProperty(name);
+    return value == null ? 0L : ((Number) value).longValue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -228,10 +229,11 @@ class Issue5670EdgeDeleteDanglingBackRefTest extends TestHelper {
                   src.save();
                   src.newEdge("LINK", hubRID);
                 }, false, 10_000);
-              } catch (final Exception e) {
+              } catch (final Throwable unexpected) {
                 // Nothing here is expected to surface: the retry budget above is far beyond what this contention
-                // needs, so ANY exception reaching this point is the bug, not a tolerated retry. Counted rather
-                // than rethrown only so the assertions below run on a fully drained pool.
+                // needs, so ANY throwable reaching this point is the bug, not a tolerated retry. Counted rather
+                // than rethrown only so the assertions below run on a fully drained pool - and Throwable, not
+                // Exception, so an Error cannot skip the countDown below and hang the run instead of failing it.
                 failures.incrementAndGet();
               }
             }
@@ -239,7 +241,9 @@ class Issue5670EdgeDeleteDanglingBackRefTest extends TestHelper {
           }).start();
         }
         start.countDown();
-        done.await();
+        // Bounded: a future regression that wedges a worker should fail this test, not hang CI until the job times
+        // out. The whole round is seconds of work, so minutes of headroom cannot fire on a merely slow machine.
+        assertThat(done.await(5, TimeUnit.MINUTES)).as("round " + round + ": all workers finished").isTrue();
 
         assertThat(failures.get()).as("round " + round).isEqualTo(0);
 


### PR DESCRIPTION
Fixes #5670.

## The issue is real, and it reproduces

The reported `ConcurrentEdgeAppendMergeTest` failure - `expected: 3000L but was: 3001L` with one
`checkDatabaseIntegrity` error alongside - is not a test-side race. A tightened version of the same
workload (8 threads x 60 delete+append iterations on a hub, 40 rounds) fails in ~2 of 3 runs with the
identical signature:

```
[round 8 in-degree] expected: 480L but was: 481L
  Suppressed: AssertionFailedError: expected: 0 but was: 1  (checkDatabaseIntegrity)
```

## Root cause

Instrumenting the swallow points caught it exactly:

```
IN rid=#3:14336 vertex=#1:17 ex=Record #3:14336 not found
```

`GraphEngine.deleteEdge` disconnects the edge from both endpoints and then deletes the edge record.
The disconnection read the endpoint's chain best-effort in three places at once:

- `getEdgeHeadChunk` answers `null` when the head chunk cannot be loaded,
- the chain hops (`EdgeLinkedList.readChunk`) used a plain lookup,
- and `deleteEdge` wrapped the lot in `catch (SchemaException | RecordNotFoundException)`.

All three read "chunk unreadable" as "nothing to remove here" - and the edge record below was
deleted anyway.

Under concurrency a chunk is regularly unreadable for reasons that say nothing about the graph. A
commit publishes its pages one at a time and a reader takes no commit lock, so a vertex page can
expose a new edge-list head RID a moment before that head's own page becomes visible; and a chunk
emptied by another transaction is relinked out of the chain while a walker is still following a
pointer to it. Hitting either window ended the removal having removed nothing, so the back-reference
outlived its edge: **one edge too many in the endpoint's degree, and one broken link**. On a hot
vertex the window is narrow, which is why it surfaced as a rare, unexplained off-by-one.

## The fix

The issue suggested capturing the integrity-check detail so the *next* occurrence would say which
RID is surplus. That is a better failure report, not a fix - and the surplus turned out to be
explainable without it. The alternative implemented here is to close the window itself, using the
line the codebase already draws elsewhere: **the append path (`getOrCreateEdgeList`) answers exactly
this transient with a retryable `ConcurrentModificationException`**, as does
`StripedEdgeList.addChain` for the per-stripe chains. The removal path never got the same treatment.

- **`GraphEngine.getEdgeHeadChunkForWrite`** - strict counterpart of `getEdgeHeadChunk`. `null` now
  means one thing only: the vertex has no edge list in that direction, so there is genuinely nothing
  to remove. A head RID that is present but unreadable is a retryable conflict.
- **`GraphEngine.deleteEdge`** - endpoint resolution split from chain mutation
  (`resolveEndpointToDisconnect`), so only a vanished endpoint *vertex* is tolerated: there is
  nothing to disconnect from a vertex that is gone.
- **`EdgeLinkedList.readChunk` / `loadChunkForWrite`** - an unreadable chunk on a removal walk is a
  retryable conflict. This subsumes `StripedEdgeList.loadStripeHead`, which is **removed** rather
  than left behind as dead code.
- **`EdgeIteratorFilter`** - the opportunistic pruning of an already-dangling reference runs inside a
  READ, so it stays best-effort: it absorbs the new retryable conflict and leaves the ghost for a
  later pass instead of failing the iteration.

Read paths are unchanged. Iteration and counting still skip a momentarily unreadable chunk rather
than failing, which is the documented best-effort contract for reads.

### Visible behaviour change

An `edge.delete()` racing a concurrent write on the same endpoint can now raise
`ConcurrentModificationException` where it previously "succeeded". That is a `NeedRetryException`, so
`database.transaction(...)` and the server's auto-retry for single-request commands absorb it. A
client-managed explicit transaction spanning several requests sees it and should retry - the same
contract concurrent updates have always had. Noted in the release notes.

## Tests

`Issue5670EdgeDeleteDanglingBackRefTest` - **all three fail on the current code, all three pass with
the fix**:

| Test | Shape |
|---|---|
| `edgeDeleteRaisesRetryableConflictWhenTheEndpointHeadChunkIsUnreadable` | deterministic; the field-observed window |
| `edgeDeleteRaisesRetryableConflictWhenAMidChainChunkIsUnreadable` | deterministic; the relinked-out-from-under-the-walker window |
| `concurrentDeleteAndAppendNeverLeaveADanglingBackReference` | `@Tag("slow")`; the reported shape |

The deterministic pair asserts its preconditions (the chain really spans several chunks, the victim
really sits behind the hole, the degree is right before the corruption) and matches the offending
chunk RID in the exception message, so it cannot pass on an unrelated throw.

## Verification

Full `engine` suite, three runs. `ExplicitLockingTransactionTest.errorOnExplicitLock` failed on the
first run, so it was chased down rather than retried away: it **passed** on a run with this branch's
test class but the main-code fix reverted, and **passed** again on a second run with the fix. It is a
pre-existing load-sensitive assertion - `explicitLock` throws only when `immutablePages` is non-empty,
and under `REPEATABLE_READ` a page is retained only when `pageNumber < file.getTotalPages()`, which is
the **on-disk** file size; a just-committed page whose flush is still queued reads as "new" and is not
retained. Unrelated to edge handling; filed as #5679.

- baseline at HEAD: 10625 tests, 0 failures
- with fix: 10587 tests, 0 failures

## Left out, deliberately

`deleteVertex` keeps its documented best-effort edge disconnection (`Issue4420TolerantDeleteTest`,
`Issue4432CorruptVertexDeleteTest` pin that a structurally broken vertex stays deletable). It is
exposed to the same transient window when *collecting* its edges, but making it strict would trade
repairability for strictness - a decision worth taking on its own merits, not as a side effect here.
Filed as #5680. Note that it does get the fix transitively where it matters: each edge it
deletes goes through `deleteEdge`, so a neighbour's back-reference is no longer left dangling.
