### PR TITLE
fix(engine) #5663: a hop onto a bound vertex counts every relationship joining the pair

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1226,6 +1226,13 @@ and still reports it once. The CSR-backed variant reads the multiplicity off the
 stopping at the first hit, and now steps aside for the edge-list walk when the hop has to tell one relationship
 from another - which adjacency ids cannot do.
 
+A graph analytical view keeps its pending deletions per `(source, target)` pair, because the CSR holds adjacency
+ids and has no edge identity to key on, so deleting one of several parallel edges masks all of them. That is why
+`isConnectedTo` can report a pair as gone while two of its edges remain. A boolean can absorb that; a row count
+cannot. A masked pair is therefore reported as "cannot say", and the hop falls back to the edge list, which is
+exact - so a `SYNCHRONOUS` view that has seen such a delete answers the pattern with the right number of rows
+rather than none.
+
 One related source of confusion is gone with it: two equally cheap hops were tie-broken by a `HashSet` iteration
 order over identity hash codes, so the same query could be planned differently from run to run. Ties now fall to
 the order the hops are written in.

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1191,6 +1191,13 @@ that the `METADATA`-clause reader has to reject as typos.
 
 ## Cypher: a hop onto an already-bound vertex counts every relationship joining the pair
 
+> **Upgrading? Row counts can go up, and that is the fix.** A pattern with a hop onto an already-bound vertex - most
+> commonly a cycle, whose closing hop always has both endpoints bound - was returning fewer rows than it should
+> wherever parallel edges join the same pair. It returns them all now, so `count(*)`, `collect()` and `sum()` over
+> such a pattern report larger numbers than they did in 26.7.2. The old numbers were under-counts, not a different
+> convention: a saved report, a golden-file test or a threshold calibrated against them is the thing to re-check. A
+> graph with at most one edge per pair per type is unaffected in every respect - there was nothing to under-count.
+
 A pattern relationship matches once per relationship. Two parallel edges between the same two vertices are two
 matches, whether or not the pattern names them - `MATCH (a)-[:R]->(b)` over a pair joined twice returns two rows,
 the same as Neo4j. The optimizer's operator for the hop whose far end is already bound did not: built as a

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1189,6 +1189,47 @@ Finally, restoring a vector index from an exported definition (`IMPORT DATABASE`
 distinct entry point: an exported definition legitimately carries structural keys - `type`, `bucket`, `version`, ... -
 that the `METADATA`-clause reader has to reject as typos.
 
+## Cypher: a hop onto an already-bound vertex counts every relationship joining the pair
+
+A pattern relationship matches once per relationship. Two parallel edges between the same two vertices are two
+matches, whether or not the pattern names them - `MATCH (a)-[:R]->(b)` over a pair joined twice returns two rows,
+the same as Neo4j. The optimizer's operator for the hop whose far end is already bound did not: built as a
+semi-join ("is this pair connected?"), it answered once per input row and threw the rest of the pair away
+([#5663](https://github.com/ArcadeData/arcadedb/issues/5663)).
+
+The shape where it shows is a cycle, because the hop that closes one always has both endpoints bound:
+
+```cypher
+CREATE (a:Account {code: 'HUB'})
+CREATE (t:Txn {ref: 'SHARED'})
+CREATE (a)-[:INITIATED {kind: 'payment'}]->(t)
+CREATE (a)-[:INITIATED {kind: 'refund'}]->(t)
+CREATE (t)-[:INITIATED {ref: 'REVERSED'}]->(a)
+
+MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a)
+RETURN r1.kind
+```
+
+The cycle can be walked two ways, one per first-hop edge, each closing through the single returning edge -
+relationship uniqueness is satisfied because `r1` and `r2` bind different edges in both walks. The answer was one
+row. Anything aggregating over such a pattern (`count(*)`, `collect(r1)`, `sum`) silently under-reported wherever
+parallel edges exist between a pair, which is normal in transaction and payment graphs. The step-by-step executor
+had always got this right, so the same query could answer differently depending on which plan was chosen.
+
+The operator is an expansion now: it walks the relationships joining the pair and emits one row per relationship,
+binding the relationship variable and enforcing relationship uniqueness against the hops that precede it in the
+same `MATCH` clause - including when the hop is anonymous, whose edge a later hop in the clause must still not
+reuse. It keeps what made it fast: the source's edge list is filtered on the neighbour pointer held in the edge
+segment, so an edge that does not reach the target costs a pointer comparison rather than a record load, and only
+the edges that do reach it are ever materialised. An undirected hop reaches a self-loop from both adjacency lists
+and still reports it once. The CSR-backed variant reads the multiplicity off the sorted adjacency array instead of
+stopping at the first hit, and now steps aside for the edge-list walk when the hop has to tell one relationship
+from another - which adjacency ids cannot do.
+
+One related source of confusion is gone with it: two equally cheap hops were tie-broken by a `HashSet` iteration
+order over identity hash codes, so the same query could be planned differently from run to run. Ties now fall to
+the order the hops are written in.
+
 ## `.github/dependency-review-config.yml` expresses the policy the action actually reads
 
 The file was organised into `security:`, `licensing:`, `packages:`, `changes:`, `exemptions:`, `notifications:`,

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -112,6 +112,12 @@ public interface GraphTraversalProvider {
    * The default implementation counts occurrences in {@link #getNeighborIds} and never answers
    * unknown; a CSR-backed provider overrides it with an equal-range scan on the sorted adjacency
    * array.
+   * <p>
+   * <b>The default halves the count of a {@link Vertex.DIRECTION#BOTH} self-loop</b>, because
+   * {@link #getNeighborIds} is specified to return the raw adjacency entries and a self-loop
+   * contributes one to each of the two lists - which is why the callers of that method de-duplicate
+   * it themselves (see {@code SelfLoops.deduplicate}). A provider whose {@code getNeighborIds}
+   * already de-duplicates would halve a count that was never doubled, and must override this method.
    */
   default long countEdgesBetween(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
       final String... edgeTypes) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -103,8 +103,15 @@ public interface GraphTraversalProvider {
    * {@link Vertex.DIRECTION#BOTH} a self-loop counts once, matching how the OLTP expansion
    * de-duplicates the relationship it reaches from both adjacency lists.
    * <p>
-   * The default implementation counts occurrences in {@link #getNeighborIds}; a CSR-backed provider
-   * overrides it with an equal-range scan on the sorted adjacency array.
+   * <b>A negative result means the provider cannot answer exactly</b> and the caller must fall back
+   * to the edge list. A count is a stronger claim than a boolean, and a provider that tracks its
+   * pending changes at a coarser granularity than the individual edge can hold the boolean while
+   * losing the count - saying "unknown" is then the only honest answer. The caller has the two
+   * vertices in hand and can always walk the edges itself.
+   * <p>
+   * The default implementation counts occurrences in {@link #getNeighborIds} and never answers
+   * unknown; a CSR-backed provider overrides it with an equal-range scan on the sorted adjacency
+   * array.
    */
   default long countEdgesBetween(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
       final String... edgeTypes) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -96,6 +96,29 @@ public interface GraphTraversalProvider {
   boolean isConnectedTo(int nodeA, int nodeB, Vertex.DIRECTION direction, String... edgeTypes);
 
   /**
+   * Counts the edges joining nodeA to nodeB in the given direction and of the given edge types.
+   * <p>
+   * This is the multiplicity {@link #isConnectedTo} collapses to a boolean: a pattern relationship
+   * matches once per edge, so a pair joined by parallel edges contributes one row per edge. Under
+   * {@link Vertex.DIRECTION#BOTH} a self-loop counts once, matching how the OLTP expansion
+   * de-duplicates the relationship it reaches from both adjacency lists.
+   * <p>
+   * The default implementation counts occurrences in {@link #getNeighborIds}; a CSR-backed provider
+   * overrides it with an equal-range scan on the sorted adjacency array.
+   */
+  default long countEdgesBetween(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+      final String... edgeTypes) {
+    long count = 0;
+    for (final int neighbor : getNeighborIds(nodeA, direction, edgeTypes))
+      if (neighbor == nodeB)
+        ++count;
+    // A self-loop contributes one entry to each adjacency list, so a BOTH walk sees every one of them twice
+    if (direction == Vertex.DIRECTION.BOTH && nodeA == nodeB)
+      count /= 2;
+    return count;
+  }
+
+  /**
    * Returns a property value from columnar storage, or null if not materialized.
    */
   Object getProperty(int nodeId, String propertyName);

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -200,6 +200,11 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   private DeltaCollector         deltaCollector;
   public static final int        DEFAULT_COMPACTION_THRESHOLD = 10_000;
   private static final int       MAX_PENDING_DELTAS           = 100_000;
+  /**
+   * Returned by {@link #countEdgesBetween} when the overlay makes the multiplicity unknowable, which
+   * the {@link com.arcadedb.graph.GraphTraversalProvider} contract spells as any negative value.
+   */
+  private static final long      MULTIPLICITY_UNKNOWN         = -1L;
   private volatile int           compactionThreshold = DEFAULT_COMPACTION_THRESHOLD;
   private final AtomicBoolean    compacting = new AtomicBoolean(false);
   private final AtomicBoolean    buildQueued = new AtomicBoolean(false);
@@ -1814,12 +1819,6 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   private static final int[] EMPTY_INT = new int[0];
-
-  /**
-   * Returned by {@link #countEdgesBetween} when the overlay makes the multiplicity unknowable, which
-   * the {@link com.arcadedb.graph.GraphTraversalProvider} contract spells as any negative value.
-   */
-  private static final long MULTIPLICITY_UNKNOWN = -1L;
 
   /**
    * Checks the view is built and returns a consistent snapshot for the caller to use.

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -85,6 +85,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   /** Maximum number of concurrent CSR builds/compactions across all databases. */
   private static final int MAX_CONCURRENT_BUILDS = Math.max(2, Runtime.getRuntime().availableProcessors());
 
+  /**
+   * Returned by {@link #countEdgesBetween} when the overlay makes the multiplicity unknowable, which
+   * the {@link com.arcadedb.graph.GraphTraversalProvider} contract spells as any negative value.
+   */
+  private static final long MULTIPLICITY_UNKNOWN = -1L;
+
   /** Semaphore bounding concurrent CPU-intensive build operations. */
   private static final Semaphore BUILD_PERMITS = new Semaphore(MAX_CONCURRENT_BUILDS);
 
@@ -200,11 +206,6 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   private DeltaCollector         deltaCollector;
   public static final int        DEFAULT_COMPACTION_THRESHOLD = 10_000;
   private static final int       MAX_PENDING_DELTAS           = 100_000;
-  /**
-   * Returned by {@link #countEdgesBetween} when the overlay makes the multiplicity unknowable, which
-   * the {@link com.arcadedb.graph.GraphTraversalProvider} contract spells as any negative value.
-   */
-  private static final long      MULTIPLICITY_UNKNOWN         = -1L;
   private volatile int           compactionThreshold = DEFAULT_COMPACTION_THRESHOLD;
   private final AtomicBoolean    compacting = new AtomicBoolean(false);
   private final AtomicBoolean    buildQueued = new AtomicBoolean(false);

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -868,6 +868,29 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
+   * Counts the edges joining nodeA to nodeB, optionally filtered by edge type.
+   * <p>
+   * This is the multiplicity {@link #isConnectedTo} collapses to a boolean, and a pattern
+   * relationship matches once per edge, so a Cypher hop between two pinned vertices needs it rather
+   * than the boolean. Parallel edges sit next to each other in the sorted adjacency array, so the
+   * equal range around the binary search hit gives the count in O(log(degree) + multiplicity).
+   */
+  @Override
+  public long countEdgesBetween(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+      final String... edgeTypes) {
+    final Snapshot snap = checkBuilt();
+    long total = 0;
+    if (edgeTypes != null && edgeTypes.length > 0) {
+      for (final String edgeType : edgeTypes)
+        total += countBetweenForType(snap, nodeA, nodeB, direction, edgeType);
+    } else {
+      for (final String edgeType : snap.csrPerType.keySet())
+        total += countBetweenForType(snap, nodeA, nodeB, direction, edgeType);
+    }
+    return total;
+  }
+
+  /**
    * Counts common neighbors between two nodes, optionally filtered by edge types.
    */
   public int countCommonNeighbors(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
@@ -1539,6 +1562,65 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       }
     }
     return false;
+  }
+
+  /**
+   * Counts the edges of one type joining nodeA to nodeB, mirroring {@link #isConnectedForType} entry
+   * by entry so the two never disagree on whether an edge is there.
+   * <p>
+   * A self-loop is held by both adjacency lists of its vertex, so a BOTH walk would see it twice; the
+   * backward side is skipped when the two nodes are the same, which is what the OLTP expansion
+   * achieves by de-duplicating on edge identity.
+   */
+  private long countBetweenForType(final Snapshot snap, final int nodeA, final int nodeB,
+      final Vertex.DIRECTION direction, final String edgeType) {
+    final CSRAdjacencyIndex csr = snap.csrPerType.get(edgeType);
+    final DeltaOverlay ov = snap.overlay;
+    final boolean nodeAInBase = nodeA < snap.nodeMapping.size();
+    final boolean selfLoop = nodeA == nodeB;
+    final boolean walkForward = direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH;
+    final boolean walkBackward = (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH)
+        && !(direction == Vertex.DIRECTION.BOTH && selfLoop);
+
+    long count = 0;
+
+    if (csr != null && nodeAInBase) {
+      if (walkForward && (ov == null || !ov.isEdgeDeleted(edgeType, nodeA, nodeB)))
+        count += equalRangeCount(csr.getForwardNeighbors(), csr.getForwardOffsets()[nodeA],
+            csr.getForwardOffsets()[nodeA + 1], nodeB);
+      if (walkBackward && (ov == null || !ov.isEdgeDeleted(edgeType, nodeB, nodeA)))
+        count += equalRangeCount(csr.getBackwardNeighbors(), csr.getBackwardOffsets()[nodeA],
+            csr.getBackwardOffsets()[nodeA + 1], nodeB);
+    }
+
+    if (ov != null) {
+      if (walkForward)
+        for (final int neighbor : ov.getAddedOutNeighbors(nodeA, edgeType))
+          if (neighbor == nodeB)
+            ++count;
+      if (walkBackward)
+        for (final int neighbor : ov.getAddedInNeighbors(nodeA, edgeType))
+          if (neighbor == nodeB)
+            ++count;
+    }
+
+    return count;
+  }
+
+  /**
+   * Returns how many times {@code value} occurs in the sorted range {@code [from, to)}.
+   */
+  private static int equalRangeCount(final int[] sorted, final int from, final int to, final int value) {
+    final int hit = Arrays.binarySearch(sorted, from, to, value);
+    if (hit < 0)
+      return 0;
+    int start = hit;
+    while (start > from && sorted[start - 1] == value)
+      --start;
+    int end = hit + 1;
+    while (end < to && sorted[end] == value)
+      ++end;
+    return end - start;
   }
 
   private int countCommonForType(final Snapshot snap, final int nodeA, final int nodeB,

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -868,7 +868,8 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
-   * Counts the edges joining nodeA to nodeB, optionally filtered by edge type.
+   * Counts the edges joining nodeA to nodeB, optionally filtered by edge type, or a negative value
+   * when the delta overlay makes the count unknowable (see {@link #countBetweenForType}).
    * <p>
    * This is the multiplicity {@link #isConnectedTo} collapses to a boolean, and a pattern
    * relationship matches once per edge, so a Cypher hop between two pinned vertices needs it rather
@@ -880,12 +881,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       final String... edgeTypes) {
     final Snapshot snap = checkBuilt();
     long total = 0;
-    if (edgeTypes != null && edgeTypes.length > 0) {
-      for (final String edgeType : edgeTypes)
-        total += countBetweenForType(snap, nodeA, nodeB, direction, edgeType);
-    } else {
-      for (final String edgeType : snap.csrPerType.keySet())
-        total += countBetweenForType(snap, nodeA, nodeB, direction, edgeType);
+    final Iterable<String> types = edgeTypes != null && edgeTypes.length > 0 ?
+        Arrays.asList(edgeTypes) : snap.csrPerType.keySet();
+    for (final String edgeType : types) {
+      final long forType = countBetweenForType(snap, nodeA, nodeB, direction, edgeType);
+      if (forType < 0)
+        return MULTIPLICITY_UNKNOWN; // one unknown type makes the whole count unknown
+      total += forType;
     }
     return total;
   }
@@ -1565,12 +1567,23 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
-   * Counts the edges of one type joining nodeA to nodeB, mirroring {@link #isConnectedForType} entry
-   * by entry so the two never disagree on whether an edge is there.
+   * Counts the edges of one type joining nodeA to nodeB, or {@link #MULTIPLICITY_UNKNOWN} when the
+   * overlay cannot say how many of them survive.
    * <p>
    * A self-loop is held by both adjacency lists of its vertex, so a BOTH walk would see it twice; the
    * backward side is skipped when the two nodes are the same, which is what the OLTP expansion
    * achieves by de-duplicating on edge identity.
+   * <p>
+   * <b>Why a deleted pair is answered "unknown" rather than zero.</b> {@link DeltaOverlay} keys its
+   * pending deletions on the {@code (source, target)} pair, not on the edge, because the CSR holds
+   * adjacency ids and has no edge identity to key on. Deleting one of three parallel edges therefore
+   * marks the whole pair, and every read that consults the mask drops all three - which is what
+   * {@link #isConnectedTo} and {@link #getNeighborIds} do, and it is why they report a pair as gone
+   * while two of its edges remain. A boolean can absorb that; a count cannot, because the caller
+   * turns it directly into rows. So a masked pair is reported unknown and the caller walks the edge
+   * list, which is exact. Resolving it here instead would take per-edge identity in the CSR, and a
+   * per-pair counter cannot substitute: the overlay absorbs a deletion replayed across merges by
+   * set semantics (issue #4587), which a counter would double-count.
    */
   private long countBetweenForType(final Snapshot snap, final int nodeA, final int nodeB,
       final Vertex.DIRECTION direction, final String edgeType) {
@@ -1582,13 +1595,18 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     final boolean walkBackward = (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH)
         && !(direction == Vertex.DIRECTION.BOTH && selfLoop);
 
+    if (ov != null
+        && ((walkForward && ov.isEdgeDeleted(edgeType, nodeA, nodeB))
+        || (walkBackward && ov.isEdgeDeleted(edgeType, nodeB, nodeA))))
+      return MULTIPLICITY_UNKNOWN;
+
     long count = 0;
 
     if (csr != null && nodeAInBase) {
-      if (walkForward && (ov == null || !ov.isEdgeDeleted(edgeType, nodeA, nodeB)))
+      if (walkForward)
         count += equalRangeCount(csr.getForwardNeighbors(), csr.getForwardOffsets()[nodeA],
             csr.getForwardOffsets()[nodeA + 1], nodeB);
-      if (walkBackward && (ov == null || !ov.isEdgeDeleted(edgeType, nodeB, nodeA)))
+      if (walkBackward)
         count += equalRangeCount(csr.getBackwardNeighbors(), csr.getBackwardOffsets()[nodeA],
             csr.getBackwardOffsets()[nodeA + 1], nodeB);
     }
@@ -1796,6 +1814,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   private static final int[] EMPTY_INT = new int[0];
+
+  /**
+   * Returned by {@link #countEdgesBetween} when the overlay makes the multiplicity unknowable, which
+   * the {@link com.arcadedb.graph.GraphTraversalProvider} contract spells as any negative value.
+   */
+  private static final long MULTIPLICITY_UNKNOWN = -1L;
 
   /**
    * Checks the view is built and returns a consistent snapshot for the caller to use.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandInto.java
@@ -32,7 +32,6 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -193,9 +192,15 @@ public class ExpandInto extends AbstractPhysicalOperator {
    * pattern's types, each one exactly once.
    * <p>
    * The engine walks the source's edge segments rejecting on the neighbour pointer, so only the edges
-   * that actually reach the target are materialised. The generic {@link Vertex#getEdges} fallback is
-   * for a source handle that is not a {@link VertexInternal}; it loads every edge and compares the far
-   * endpoint, which is what this operator exists to avoid.
+   * that actually reach the target are materialised.
+   * <p>
+   * The {@link Vertex#getEdges} branch is for a source handle that is not a {@link VertexInternal},
+   * which the plan does not produce today - every vertex an operator binds comes from a scan, a seek
+   * or an expansion, and all three yield engine vertices - so it exists to keep the operator total
+   * against a handle arriving from elsewhere rather than to serve a known caller. It has to compare
+   * the far endpoint of each edge, which is the work the neighbour-pointer filter avoids, so it
+   * filters lazily: the operator's batching is what bounds how much of a super-node's edge list is
+   * ever walked, and collecting into a list first would take that bound away.
    * <p>
    * An undirected hop walks both adjacency lists of the source, which reaches a self-loop twice - the
    * same relationship, not two of them - so the result is de-duplicated by edge identity.
@@ -207,18 +212,47 @@ public class ExpandInto extends AbstractPhysicalOperator {
     if (source instanceof VertexInternal internalSource)
       connecting = ((DatabaseInternal) source.getDatabase()).getGraphEngine()
           .getEdgesConnectedTo(internalSource, arcadeDirection, target.getIdentity(), edgeTypes);
-    else {
-      final RID targetRid = target.getIdentity();
-      final List<Edge> reaching = new ArrayList<>();
-      for (final Edge edge : source.getEdges(arcadeDirection, edgeTypes))
-        if (arcadeDirection == Vertex.DIRECTION.BOTH ?
-            edge.getOut().equals(targetRid) || edge.getIn().equals(targetRid) :
-            (arcadeDirection == Vertex.DIRECTION.OUT ? edge.getIn() : edge.getOut()).equals(targetRid))
-          reaching.add(edge);
-      connecting = reaching.isEmpty() ? Collections.emptyIterator() : reaching.iterator();
-    }
+    else
+      connecting = reachingTarget(source.getEdges(arcadeDirection, edgeTypes).iterator(),
+          target.getIdentity(), arcadeDirection);
 
     return arcadeDirection == Vertex.DIRECTION.BOTH ? SelfLoops.deduplicatingEdges(connecting) : connecting;
+  }
+
+  /**
+   * Lazily keeps the edges whose far endpoint is {@code target}, one at a time.
+   */
+  private static Iterator<Edge> reachingTarget(final Iterator<Edge> edges, final RID target,
+      final Vertex.DIRECTION direction) {
+    return new Iterator<>() {
+      private Edge nextEdge = null;
+
+      @Override
+      public boolean hasNext() {
+        if (nextEdge != null)
+          return true;
+        while (edges.hasNext()) {
+          final Edge candidate = edges.next();
+          final boolean reaches = direction == Vertex.DIRECTION.BOTH ?
+              candidate.getOut().equals(target) || candidate.getIn().equals(target) :
+              (direction == Vertex.DIRECTION.OUT ? candidate.getIn() : candidate.getOut()).equals(target);
+          if (reaches) {
+            nextEdge = candidate;
+            return true;
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public Edge next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        final Edge result = nextEdge;
+        nextEdge = null;
+        return result;
+      }
+    };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandInto.java
@@ -24,36 +24,42 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.VertexInternal;
 import com.arcadedb.query.opencypher.ast.Direction;
+import com.arcadedb.query.opencypher.executor.SelfLoops;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
- * Physical operator that checks for the existence of a relationship between two known vertices.
- * This is a semi-join optimization that is much more efficient than ExpandAll when both
- * the source and target vertices are already bound.
+ * Physical operator that walks the relationships between two vertices the plan has already bound.
  * <p>
- * KEY OPTIMIZATION: Uses Vertex.isConnectedTo() for O(m) RID-level existence checks
- * instead of loading and iterating through all edges. This provides 5-10x speedup
- * compared to ExpandAll for bounded patterns.
+ * KEY OPTIMIZATION: the edge list of the source is filtered on the neighbour pointer stored beside
+ * each edge pointer in the segment ({@code GraphEngine.getEdgesConnectedTo}), so an edge that does
+ * not reach the target is rejected by two primitive comparisons instead of a record load. On a hub
+ * vertex that is the difference between answering a question about one edge and reading its whole
+ * edge list.
  * <p>
  * Example query:
  * MATCH (a:Person {id: 1}), (b:Person {id: 2})
  * MATCH (a)-[r:KNOWS]->(b)
  * RETURN r
  * <p>
- * Instead of expanding all KNOWS edges from 'a' and filtering, we directly check
- * if there's a connection between 'a' and 'b'.
+ * This is an expansion, not an existence check: a pattern relationship matches once per relationship,
+ * so two parallel KNOWS edges between the pair yield two rows - whether or not the pattern names the
+ * relationship. Answering it once per input row under-counts every cycle and every multigraph pattern
+ * (issue #5663).
  * <p>
- * Cost: O(M) where M is input rows (much cheaper than ExpandAll)
- * Cardinality: Subset of input rows where connection exists
+ * Cost: O(degree(source)) pointer comparisons plus one record load per emitted row
+ * Cardinality: input rows * the number of relationships joining the pair
  */
 public class ExpandInto extends AbstractPhysicalOperator {
   private final String    sourceVariable;
@@ -64,6 +70,9 @@ public class ExpandInto extends AbstractPhysicalOperator {
   // Same-MATCH-clause relationship variable names that were bound before this hop.
   // See ExpandAll for the rationale.
   private Set<String>     sameClausePrecedingRelVars;
+  // Synthetic row property name under which to stash this hop's edge when edgeVariable is null but
+  // the edge is still needed by later same-clause hops for the uniqueness check.
+  private String          edgeTrackingVar;
 
   public ExpandInto(final PhysicalOperator child, final String sourceVariable,
                     final String targetVariable, final String edgeVariable,
@@ -85,24 +94,31 @@ public class ExpandInto extends AbstractPhysicalOperator {
     this.sameClausePrecedingRelVars = sameClausePrecedingRelVars;
   }
 
+  public void setEdgeTrackingVar(final String edgeTrackingVar) {
+    this.edgeTrackingVar = edgeTrackingVar;
+  }
+
   @Override
   public ResultSet execute(final CommandContext context, final int nRecords) {
     final ResultSet inputResults = child.execute(context, nRecords);
 
     return new ResultSet() {
-      private final List<Result> buffer      = new ArrayList<>();
-      private       int          bufferIndex = 0;
-      private       boolean      finished    = false;
+      private       Result         currentInputResult       = null;
+      private       Iterator<Edge> edgeIterator             = null;
+      // Edge RIDs already bound by same-clause preceding rel vars in the current input row.
+      // Computed once per input row, queried per edge.
+      private       RidHashSet     currentInputUsedEdgeRids = null;
+      private final List<Result>   buffer                   = new ArrayList<>();
+      private       int            bufferIndex              = 0;
+      private       boolean        finished                 = false;
 
       @Override
       public boolean hasNext() {
-        if (bufferIndex < buffer.size()) {
+        if (bufferIndex < buffer.size())
           return true;
-        }
 
-        if (finished) {
+        if (finished)
           return false;
-        }
 
         fetchMore(nRecords > 0 ? nRecords : 100);
         return bufferIndex < buffer.size();
@@ -110,9 +126,8 @@ public class ExpandInto extends AbstractPhysicalOperator {
 
       @Override
       public Result next() {
-        if (!hasNext()) {
+        if (!hasNext())
           throw new NoSuchElementException();
-        }
         return buffer.get(bufferIndex++);
       }
 
@@ -120,107 +135,50 @@ public class ExpandInto extends AbstractPhysicalOperator {
         buffer.clear();
         bufferIndex = 0;
 
-        // Process input rows and check for connections
-        while (buffer.size() < n && inputResults.hasNext()) {
-          final Result inputResult = inputResults.next();
+        while (buffer.size() < n) {
+          // Move to the next input row once the current pair has no relationship left to yield
+          if (edgeIterator == null || !edgeIterator.hasNext()) {
+            if (!inputResults.hasNext()) {
+              finished = true;
+              break;
+            }
 
-          final Vertex sourceVertex = inputResult.getProperty(sourceVariable);
-          final Vertex targetVertex = inputResult.getProperty(targetVariable);
+            currentInputResult = inputResults.next();
 
-          // Skip if either vertex is null (OPTIONAL MATCH case)
-          if (sourceVertex == null || targetVertex == null) {
+            final Vertex sourceVertex = currentInputResult.getProperty(sourceVariable);
+            final Vertex targetVertex = currentInputResult.getProperty(targetVariable);
+
+            // Skip if either vertex is null (OPTIONAL MATCH case)
+            if (sourceVertex == null || targetVertex == null) {
+              edgeIterator = null;
+              continue;
+            }
+
+            edgeIterator = connectingEdges(sourceVertex, targetVertex);
+            currentInputUsedEdgeRids = collectUsedEdgeRids(currentInputResult);
             continue;
           }
 
-          // Check if there's a connection between source and target
-          final Vertex.DIRECTION arcadeDirection = direction.toArcadeDirection();
+          final Edge edge = edgeIterator.next();
 
-          // Get the edge type - if multiple types, check each
-          boolean connected = false;
-          Edge connectedEdge = null;
+          // Cypher path isomorphism: each relationship of a MATCH pattern must be a distinct edge.
+          // The set is null when no same-clause rel var is bound, so the check is free.
+          if (currentInputUsedEdgeRids != null && currentInputUsedEdgeRids.contains(edge.getIdentity()))
+            continue;
 
-          if (edgeTypes == null || edgeTypes.length == 0) {
-            // No type restriction - check for any connection
-            connected = sourceVertex.isConnectedTo(targetVertex, arcadeDirection);
-            if (connected && edgeVariable != null) {
-              // Need to get the actual edge for binding
-              connectedEdge = findEdge(sourceVertex, targetVertex, arcadeDirection, null);
-            }
-          } else {
-            // Check for specific edge types
-            for (final String edgeType : edgeTypes) {
-              connected = sourceVertex.isConnectedTo(targetVertex, arcadeDirection, edgeType);
-              if (connected) {
-                if (edgeVariable != null) {
-                  connectedEdge = findEdge(sourceVertex, targetVertex, arcadeDirection, edgeType);
-                }
-                break;
-              }
-            }
-          }
+          final ResultInternal result = new ResultInternal();
 
-          // If connected, produce output row
-          if (connected) {
-            // Cypher path isomorphism: drop rows where the discovered edge is the same
-            // as one already bound to a same-clause preceding rel var. We only resolve
-            // the connecting edge for the check when the bound set is non-empty.
-            if (connectedEdge == null && ExpandInto.this.hasUsedRels(inputResult)) {
-              connectedEdge = ExpandInto.this.findEdgeForCheck(sourceVertex, targetVertex, arcadeDirection);
-            }
-            if (connectedEdge != null && ExpandInto.this.isSameClauseEdgeReuse(inputResult, connectedEdge.getIdentity()))
-              continue;
+          // Copy all properties from input
+          for (final String prop : currentInputResult.getPropertyNames())
+            result.setProperty(prop, currentInputResult.getProperty(prop));
 
-            final ResultInternal result = new ResultInternal();
+          if (edgeVariable != null)
+            result.setProperty(edgeVariable, edge);
+          else if (edgeTrackingVar != null)
+            result.setProperty(edgeTrackingVar, edge);
 
-            // Copy all properties from input
-            for (final String prop : inputResult.getPropertyNames()) {
-              result.setProperty(prop, inputResult.getProperty(prop));
-            }
-
-            // Add edge if variable is specified
-            if (edgeVariable != null && connectedEdge != null) {
-              result.setProperty(edgeVariable, connectedEdge);
-            }
-
-            buffer.add(result);
-          }
+          buffer.add(result);
         }
-
-        if (!inputResults.hasNext()) {
-          finished = true;
-        }
-      }
-
-      /**
-       * Helper method to find the actual edge between two vertices.
-       * Only called when edge variable binding is required.
-       *
-       * Optimization: Uses GraphEngine.getFirstEdgeConnectedToVertex() which operates
-       * at the EdgeSegment level for maximum performance.
-       */
-      private Edge findEdge(final Vertex source, final Vertex target,
-                            final Vertex.DIRECTION direction, final String edgeType) {
-        final DatabaseInternal database = (DatabaseInternal) source.getDatabase();
-        final VertexInternal sourceInternal = (VertexInternal) source;
-
-        // Build edge bucket filter if edge type is specified
-        final int[] edgeBucketFilter;
-        if (edgeType != null) {
-          edgeBucketFilter = database.getSchema().getType(edgeType).getBuckets(true).stream()
-              .mapToInt(b -> b.getFileId()).toArray();
-        } else {
-          edgeBucketFilter = null;
-        }
-
-        // Use GraphEngine API for optimal performance
-        final RID edgeRID = database.getGraphEngine()
-            .getFirstEdgeConnectedToVertex(sourceInternal, target, direction, edgeBucketFilter);
-
-        if (edgeRID != null) {
-          return database.lookupByRID(edgeRID, true).asEdge();
-        }
-
-        return null;
       }
 
       @Override
@@ -231,67 +189,56 @@ public class ExpandInto extends AbstractPhysicalOperator {
   }
 
   /**
-   * True iff at least one same-clause preceding rel var holds an Edge in this row.
-   * Used as a cheap gate before falling back to a full {@code findEdge} for the check.
+   * Returns the relationships joining the two bound vertices, in the pattern's direction and of the
+   * pattern's types, each one exactly once.
+   * <p>
+   * The engine walks the source's edge segments rejecting on the neighbour pointer, so only the edges
+   * that actually reach the target are materialised. The generic {@link Vertex#getEdges} fallback is
+   * for a source handle that is not a {@link VertexInternal}; it loads every edge and compares the far
+   * endpoint, which is what this operator exists to avoid.
+   * <p>
+   * An undirected hop walks both adjacency lists of the source, which reaches a self-loop twice - the
+   * same relationship, not two of them - so the result is de-duplicated by edge identity.
    */
-  private boolean hasUsedRels(final Result row) {
-    if (sameClausePrecedingRelVars == null)
-      return false;
-    for (final String relVar : sameClausePrecedingRelVars) {
-      if (row.getProperty(relVar) instanceof Edge)
-        return true;
+  private Iterator<Edge> connectingEdges(final Vertex source, final Vertex target) {
+    final Vertex.DIRECTION arcadeDirection = direction.toArcadeDirection();
+    final Iterator<Edge> connecting;
+
+    if (source instanceof VertexInternal internalSource)
+      connecting = ((DatabaseInternal) source.getDatabase()).getGraphEngine()
+          .getEdgesConnectedTo(internalSource, arcadeDirection, target.getIdentity(), edgeTypes);
+    else {
+      final RID targetRid = target.getIdentity();
+      final List<Edge> reaching = new ArrayList<>();
+      for (final Edge edge : source.getEdges(arcadeDirection, edgeTypes))
+        if (arcadeDirection == Vertex.DIRECTION.BOTH ?
+            edge.getOut().equals(targetRid) || edge.getIn().equals(targetRid) :
+            (arcadeDirection == Vertex.DIRECTION.OUT ? edge.getIn() : edge.getOut()).equals(targetRid))
+          reaching.add(edge);
+      connecting = reaching.isEmpty() ? Collections.emptyIterator() : reaching.iterator();
     }
-    return false;
+
+    return arcadeDirection == Vertex.DIRECTION.BOTH ? SelfLoops.deduplicatingEdges(connecting) : connecting;
   }
 
   /**
-   * True iff {@code edgeRid} matches the RID of any edge currently bound to a
-   * same-clause preceding rel var in {@code row}.
+   * Collects the RIDs of the edges already bound to same-clause preceding relationship variables in
+   * the input row. Returns null when no relevant binding is present, so the per-edge check stays free
+   * in the common single-hop case.
    */
-  private boolean isSameClauseEdgeReuse(final Result row, final RID edgeRid) {
+  private RidHashSet collectUsedEdgeRids(final Result row) {
     if (sameClausePrecedingRelVars == null || sameClausePrecedingRelVars.isEmpty())
-      return false;
+      return null;
+    RidHashSet used = null;
     for (final String relVar : sameClausePrecedingRelVars) {
       final Object val = row.getProperty(relVar);
-      if (val instanceof Edge && ((Edge) val).getIdentity().equals(edgeRid))
-        return true;
+      if (val instanceof Edge edge) {
+        if (used == null)
+          used = new RidHashSet();
+        used.add(edge.getIdentity());
+      }
     }
-    return false;
-  }
-
-  /**
-   * Loads the connecting edge purely to perform the isomorphism check. Only invoked
-   * when {@code edgeVariable} is null (no binding required) but a same-clause check
-   * is needed and the input row has at least one edge bound.
-   */
-  private Edge findEdgeForCheck(final Vertex source, final Vertex target,
-                                final Vertex.DIRECTION direction) {
-    if (edgeTypes == null || edgeTypes.length == 0)
-      return findEdgeRaw(source, target, direction, null);
-    for (final String edgeType : edgeTypes) {
-      final Edge e = findEdgeRaw(source, target, direction, edgeType);
-      if (e != null)
-        return e;
-    }
-    return null;
-  }
-
-  private Edge findEdgeRaw(final Vertex source, final Vertex target,
-                           final Vertex.DIRECTION direction, final String edgeType) {
-    final DatabaseInternal database = (DatabaseInternal) source.getDatabase();
-    final VertexInternal sourceInternal = (VertexInternal) source;
-    final int[] edgeBucketFilter;
-    if (edgeType != null) {
-      edgeBucketFilter = database.getSchema().getType(edgeType).getBuckets(true).stream()
-          .mapToInt(b -> b.getFileId()).toArray();
-    } else {
-      edgeBucketFilter = null;
-    }
-    final RID edgeRID = database.getGraphEngine()
-        .getFirstEdgeConnectedToVertex(sourceInternal, target, direction, edgeBucketFilter);
-    if (edgeRID != null)
-      return database.lookupByRID(edgeRID, true).asEdge();
-    return null;
+    return used;
   }
 
   @Override
@@ -318,7 +265,7 @@ public class ExpandInto extends AbstractPhysicalOperator {
     sb.append("(").append(targetVariable).append(")");
     sb.append(" [cost=").append(String.format(Locale.US, "%.2f", estimatedCost));
     sb.append(", rows=").append(estimatedCardinality);
-    sb.append("] ⭐ SEMI-JOIN\n");
+    sb.append("] ⭐ BOUND-TARGET\n");
 
     if (child != null) {
       sb.append(child.explain(depth + 1));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -141,7 +141,15 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
 
       /**
        * OLTP fallback: counts the relationships joining the pair by iterating edges, for when one or
-       * both vertices are not present in the GAV mapping (created after the last build).
+       * both vertices are not present in the GAV mapping (created after the last build), or when the
+       * view cannot state the multiplicity exactly.
+       * <p>
+       * It counts every connecting edge without checking any against the relationship variables an
+       * earlier hop of the same MATCH clause bound - which is correct only because
+       * {@code CypherOptimizer.createExpandIntoOperator} selects this operator solely for a hop that
+       * has no such variable to check against and no edge to track. That gate is what makes the
+       * question moot here; widen it and this count has to start asking it, which it cannot do,
+       * because the operator never binds the edges it counts.
        */
       private long countConnectingOLTP(final Vertex source, final Vertex target) {
         final Vertex.DIRECTION arcadeDirection = direction.toArcadeDirection();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -113,12 +113,12 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
           final int srcId = provider.getNodeId(sourceVertex.getIdentity());
           final int tgtId = provider.getNodeId(targetVertex.getIdentity());
 
-          final long connectingEdges;
-          if (srcId < 0 || tgtId < 0)
-            // One or both vertices not in GAV mapping — fall back to the OLTP edge list
+          // One or both vertices not in the GAV mapping, or a provider that cannot state the
+          // multiplicity exactly (a negative answer) — fall back to the OLTP edge list
+          long connectingEdges = srcId < 0 || tgtId < 0 ?
+              -1 : provider.countEdgesBetween(srcId, tgtId, direction.toArcadeDirection(), edgeTypes);
+          if (connectingEdges < 0)
             connectingEdges = countConnectingOLTP(sourceVertex, targetVertex);
-          else
-            connectingEdges = provider.countEdgesBetween(srcId, tgtId, direction.toArcadeDirection(), edgeTypes);
 
           // One row per relationship joining the pair: a pattern hop is an expansion, not a
           // connectivity test, so parallel edges each contribute a walk

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * CSR-backed ExpandInto that uses binary search on sorted CSR arrays for O(log(degree))
@@ -121,12 +122,16 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
             connectingEdges = countConnectingOLTP(sourceVertex, targetVertex);
 
           // One row per relationship joining the pair: a pattern hop is an expansion, not a
-          // connectivity test, so parallel edges each contribute a walk
-          for (long i = 0; i < connectingEdges; i++) {
-            final ResultInternal result = new ResultInternal();
-            for (final String prop : inputResult.getPropertyNames())
-              result.setProperty(prop, inputResult.getProperty(prop));
-            buffer.add(result);
+          // connectivity test, so parallel edges each contribute a walk. The row's property names
+          // do not change between the copies, so the set is walked once however many rows it feeds.
+          if (connectingEdges > 0) {
+            final Set<String> properties = inputResult.getPropertyNames();
+            for (long i = 0; i < connectingEdges; i++) {
+              final ResultInternal result = new ResultInternal();
+              for (final String prop : properties)
+                result.setProperty(prop, inputResult.getProperty(prop));
+              buffer.add(result);
+            }
           }
         }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -26,6 +26,7 @@ import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.VertexInternal;
 import com.arcadedb.query.opencypher.ast.Direction;
+import com.arcadedb.query.opencypher.executor.SelfLoops;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
@@ -39,10 +40,15 @@ import java.util.NoSuchElementException;
 
 /**
  * CSR-backed ExpandInto that uses binary search on sorted CSR arrays for O(log(degree))
- * connectivity checks, without loading any edge objects or traversing linked lists.
+ * lookups, without loading any edge objects or traversing linked lists.
  * <p>
- * Selected when both source and target are bound, the edge variable is not captured,
- * and a matching {@link GraphTraversalProvider} is available.
+ * A pattern relationship matches once per relationship, so the pair's row is repeated once per edge
+ * joining it - the CSR holds one adjacency entry per edge, so the equal range around the search hit
+ * gives that multiplicity without materialising anything (issue #5663).
+ * <p>
+ * Selected when both source and target are bound, no edge object is needed - neither captured by the
+ * query nor required to enforce relationship uniqueness against another hop of the same MATCH clause,
+ * which adjacency ids cannot answer - and a matching {@link GraphTraversalProvider} is available.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -103,20 +109,20 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
           if (sourceVertex == null || targetVertex == null)
             continue;
 
-          // CSR connectivity check: O(log(degree)) binary search
+          // CSR multiplicity lookup: O(log(degree)) binary search plus the equal range
           final int srcId = provider.getNodeId(sourceVertex.getIdentity());
           final int tgtId = provider.getNodeId(targetVertex.getIdentity());
 
-          boolean connected;
-          if (srcId < 0 || tgtId < 0) {
-            // One or both vertices not in GAV mapping — fall back to OLTP edge check
-            connected = isConnectedOLTP(sourceVertex, targetVertex);
-          } else {
-            final Vertex.DIRECTION arcadeDirection = direction.toArcadeDirection();
-            connected = provider.isConnectedTo(srcId, tgtId, arcadeDirection, edgeTypes);
-          }
+          final long connectingEdges;
+          if (srcId < 0 || tgtId < 0)
+            // One or both vertices not in GAV mapping — fall back to the OLTP edge list
+            connectingEdges = countConnectingOLTP(sourceVertex, targetVertex);
+          else
+            connectingEdges = provider.countEdgesBetween(srcId, tgtId, direction.toArcadeDirection(), edgeTypes);
 
-          if (connected) {
+          // One row per relationship joining the pair: a pattern hop is an expansion, not a
+          // connectivity test, so parallel edges each contribute a walk
+          for (long i = 0; i < connectingEdges; i++) {
             final ResultInternal result = new ResultInternal();
             for (final String prop : inputResult.getPropertyNames())
               result.setProperty(prop, inputResult.getProperty(prop));
@@ -129,28 +135,35 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
       }
 
       /**
-       * OLTP fallback: checks connectivity by iterating edges when one or both vertices
-       * are not present in the GAV mapping (created after last build).
+       * OLTP fallback: counts the relationships joining the pair by iterating edges, for when one or
+       * both vertices are not present in the GAV mapping (created after the last build).
        */
-      private boolean isConnectedOLTP(final Vertex source, final Vertex target) {
+      private long countConnectingOLTP(final Vertex source, final Vertex target) {
         final Vertex.DIRECTION arcadeDirection = direction.toArcadeDirection();
-        for (final Iterator<Edge> edges = candidateEdges(source, target, arcadeDirection); edges.hasNext(); ) {
+        Iterator<Edge> edges = candidateEdges(source, target, arcadeDirection);
+        if (arcadeDirection == Vertex.DIRECTION.BOTH)
+          // both adjacency lists are walked, and a self-loop sits in each of them
+          edges = SelfLoops.deduplicatingEdges(edges);
+
+        long count = 0;
+        while (edges.hasNext()) {
           final Edge edge = edges.next();
           try {
             if (arcadeDirection == Vertex.DIRECTION.BOTH) {
               // source can be either endpoint, so check both sides
-              if (edge.getOutVertex().getIdentity().equals(target.getIdentity()) || edge.getInVertex().getIdentity().equals(target.getIdentity()))
-                return true;
+              if (edge.getOutVertex().getIdentity().equals(target.getIdentity())
+                  || edge.getInVertex().getIdentity().equals(target.getIdentity()))
+                ++count;
             } else {
               final Vertex other = arcadeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
               if (other.getIdentity().equals(target.getIdentity()))
-                return true;
+                ++count;
             }
           } catch (final RecordNotFoundException e) {
             GhostEdgeReporter.reportSkipped(e);
           }
         }
-        return false;
+        return count;
       }
 
       /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandIntoStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandIntoStep.java
@@ -32,10 +32,12 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * Execution step wrapper for ExpandInto physical operator (semi-join optimization).
- * Checks for existence of relationships between two already-bound vertices.
+ * Execution step wrapper for the ExpandInto physical operator.
+ * Walks the relationships between two already-bound vertices, one row per relationship.
  * <p>
- * This is 5-10x faster than ExpandAll when both endpoints are known.
+ * This is much faster than ExpandAll when both endpoints are known: the source's edge list is
+ * filtered on the neighbour pointer held in the segment, so an edge that does not reach the target
+ * costs a pointer comparison instead of a record load.
  * <p>
  * Example:
  * <pre>
@@ -43,9 +45,6 @@ import java.util.NoSuchElementException;
  * MATCH (a)-[r:KNOWS]->(b)
  * RETURN r
  * </pre>
- * <p>
- * Uses Vertex.isConnectedTo() for O(m) RID-level existence checks instead of
- * loading and iterating through all edges.
  */
 public class ExpandIntoStep extends AbstractExecutionStep {
   private final String sourceVariable;
@@ -221,7 +220,7 @@ public class ExpandIntoStep extends AbstractExecutionStep {
     builder.append("(").append(targetVariable).append(")");
     builder.append(" [cost=").append(String.format("%.2f", estimatedCost));
     builder.append(", rows=").append(estimatedCardinality);
-    builder.append("] ⭐ SEMI-JOIN");
+    builder.append("] ⭐ BOUND-TARGET");
     if (context.isProfiling()) {
       builder.append(" (").append(getCostFormatted()).append(")");
       if (rowCount > 0)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -468,7 +468,19 @@ public class CypherOptimizer {
       // Check if we should use ExpandInto (both endpoints bound)
       if (expandIntoRule.shouldUseExpandInto(rel, boundVariables)) {
         // Use ExpandInto for bounded patterns
-        currentOp = createExpandIntoOperator(rel, currentOp, sameClausePreceding);
+        currentOp = createExpandIntoOperator(rel, currentOp, sameClausePreceding, needsEdgeTracking.contains(rel));
+
+        // An anonymous hop still binds a relationship, and a later same-clause hop must not reuse it.
+        // Must run before anything wraps currentOp.
+        if ((rel.getVariable() == null || rel.getVariable().isEmpty())
+            && needsEdgeTracking.contains(rel)
+            && currentOp instanceof ExpandInto expandInto) {
+          final String synVar = "  anon_e_" + (syntheticEdgeVarCounter++);
+          expandInto.setEdgeTrackingVar(synVar);
+          relVarsPerClause
+              .computeIfAbsent(rel.getClauseIndex(), k -> new HashSet<>())
+              .add(synVar);
+        }
       } else {
         // A relationship variable nobody reads is as good as anonymous: the hop can be walked
         // through the CSR adjacency view, which never materializes an edge object. The step-based
@@ -625,7 +637,8 @@ public class CypherOptimizer {
   private PhysicalOperator createExpandIntoOperator(
       final LogicalRelationship relationship,
       final PhysicalOperator input,
-      final Set<String> sameClausePrecedingRelVars) {
+      final Set<String> sameClausePrecedingRelVars,
+      final boolean needsEdgeTracking) {
     // Extract parameters from relationship
     final String sourceVariable = relationship.getSourceVariable();
     final String targetVariable = relationship.getTargetVariable();
@@ -634,14 +647,19 @@ public class CypherOptimizer {
     final String[] edgeTypes = relationship.getTypes().toArray(new String[0]);
 
     // Estimate cost and cardinality for ExpandInto
-    // ExpandInto is much cheaper than ExpandAll because it's just an existence check
+    // ExpandInto is much cheaper than ExpandAll because the edge list is filtered on the neighbour
+    // pointer, so only the edges reaching the pinned target are ever materialised
     final long inputCardinality = input.getEstimatedCardinality();
     final long outputCardinality = (long) (inputCardinality * DEFAULT_EXPAND_INTO_SELECTIVITY);
-    final double expandIntoCost = inputCardinality * 1.0; // O(1) per input row for existence check
+    final double expandIntoCost = inputCardinality * 1.0; // pointer comparisons per input row, no record load
     final double totalCost = input.getEstimatedCost() + expandIntoCost;
 
-    // Check for GAV provider: use CSR-backed expand-into when edge variable is not captured
-    if (edgeVariable == null) {
+    // Check for GAV provider: use CSR-backed expand-into when no edge object is needed. The CSR holds
+    // adjacency ids, not edge identities, so it can count the relationships joining the pair but
+    // cannot tell one of them from an edge a preceding same-clause hop already bound. A hop that has
+    // to answer that question walks the edge list instead.
+    if (edgeVariable == null && !needsEdgeTracking
+        && (sameClausePrecedingRelVars == null || sameClausePrecedingRelVars.isEmpty())) {
       final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(database, edgeTypes);
       if (provider != null) {
         // GAV expand-into: binary search on CSR arrays, no edge loading

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/rules/JoinOrderRule.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/rules/JoinOrderRule.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.opencypher.optimizer.statistics.TypeStatistics;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -114,7 +115,10 @@ public class JoinOrderRule implements OptimizationRule {
 
     final List<LogicalRelationship> ordered = new ArrayList<>();
     final Set<String> bound = new HashSet<>(boundVariables);
-    final Set<LogicalRelationship> remaining = new HashSet<>(relationships);
+    // Insertion-ordered: LogicalRelationship inherits identity hashing, so a plain HashSet made the
+    // tie-break between two equally cheap hops depend on the addresses the JVM happened to hand out,
+    // and the same query planned differently from run to run. Ties now fall to pattern order.
+    final Set<LogicalRelationship> remaining = new LinkedHashSet<>(relationships);
 
     // Build expansion plan greedily
     while (!remaining.isEmpty()) {

--- a/engine/src/test/java/com/arcadedb/graph/GraphTraversalProviderCountEdgesBetweenTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphTraversalProviderCountEdgesBetweenTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.database.RID;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link GraphAnalyticalView} overrides {@code countEdgesBetween}, so the SPI's default implementation is
+ * the one a future provider inherits and the one nothing in the tree exercises. It carries a load-bearing
+ * assumption - that {@link GraphTraversalProvider#getNeighborIds} returns the raw adjacency entries, so an
+ * undirected self-loop appears once per list and has to be halved - and an assumption only a test can hold.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphTraversalProviderCountEdgesBetweenTest {
+
+  /**
+   * The minimum provider the default needs: adjacency ids per direction, raw, exactly as the contract
+   * spells them. Node 0 is joined to node 1 by three edges out and one back, and carries two self-loops.
+   */
+  private static final class RawAdjacencyProvider implements GraphTraversalProvider {
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      if (nodeId != 0)
+        return new int[0];
+      // three 0->1 edges, plus two self-loops on 0, held once in each list as the engine stores them
+      return switch (direction) {
+        case OUT -> new int[] { 0, 0, 1, 1, 1 };
+        case IN -> new int[] { 0, 0, 1 };
+        case BOTH -> new int[] { 0, 0, 0, 0, 1, 1, 1, 1 };
+      };
+    }
+
+    @Override
+    public int getNodeCount() {
+      return 2;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "raw-adjacency";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return -1;
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return null;
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return getNeighborIds(nodeId, direction, edgeTypes).length;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+        final String... edgeTypes) {
+      for (final int neighbor : getNeighborIds(nodeA, direction, edgeTypes))
+        if (neighbor == nodeB)
+          return true;
+      return false;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+  }
+
+  @Test
+  void theDefaultCountsEveryParallelEdgeAndEachSelfLoopOnce() {
+    final GraphTraversalProvider provider = new RawAdjacencyProvider();
+
+    // a pair joined several times contributes one per edge, in each direction and in both
+    assertThat(provider.countEdgesBetween(0, 1, Vertex.DIRECTION.OUT)).isEqualTo(3);
+    assertThat(provider.countEdgesBetween(0, 1, Vertex.DIRECTION.IN)).isEqualTo(1);
+    assertThat(provider.countEdgesBetween(0, 1, Vertex.DIRECTION.BOTH)).isEqualTo(4);
+
+    // a self-loop is held by both lists, so an undirected walk sees each of the two twice and must not
+    // report four relationships where there are two
+    assertThat(provider.countEdgesBetween(0, 0, Vertex.DIRECTION.OUT)).isEqualTo(2);
+    assertThat(provider.countEdgesBetween(0, 0, Vertex.DIRECTION.IN)).isEqualTo(2);
+    assertThat(provider.countEdgesBetween(0, 0, Vertex.DIRECTION.BOTH)).isEqualTo(2);
+
+    // and a pair nothing joins is zero, never negative: the default always knows the answer
+    assertThat(provider.countEdgesBetween(1, 0, Vertex.DIRECTION.OUT)).isZero();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -4102,6 +4102,60 @@ class GraphAnalyticalViewTest extends TestHelper {
     final int[] bothNeighbors = gav.getNeighborIds(nodeId, Vertex.DIRECTION.BOTH, "SELF_REL");
     assertThat(bothNeighbors).contains(nodeId);
 
+    // ...but counting the relationships joining the pair reports the one self-loop once, however many
+    // adjacency lists it is held by
+    assertThat(gav.countEdgesBetween(nodeId, nodeId, Vertex.DIRECTION.OUT, "SELF_REL")).isEqualTo(1);
+    assertThat(gav.countEdgesBetween(nodeId, nodeId, Vertex.DIRECTION.IN, "SELF_REL")).isEqualTo(1);
+    assertThat(gav.countEdgesBetween(nodeId, nodeId, Vertex.DIRECTION.BOTH, "SELF_REL")).isEqualTo(1);
+
+    gav.drop();
+  }
+
+  /**
+   * {@code isConnectedTo} collapses a multigraph pair to a boolean, which is the wrong answer for a Cypher
+   * hop onto a pinned target: the pattern matches once per relationship. The count has to survive parallel
+   * edges, edge-type filtering and direction (issue #5663).
+   */
+  @Test
+  void countEdgesBetweenReportsEveryParallelEdge() {
+    database.getSchema().createVertexType("Party");
+    database.getSchema().createEdgeType("PAID");
+    database.getSchema().createEdgeType("REFUNDED");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Party").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Party").set("name", "B").save();
+    final MutableVertex c = database.newVertex("Party").set("name", "C").save();
+    a.newEdge("PAID", b);
+    a.newEdge("PAID", b);
+    a.newEdge("PAID", b);
+    b.newEdge("PAID", a);
+    a.newEdge("REFUNDED", b);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("parallelEdgesView")
+        .withVertexTypes("Party")
+        .withEdgeTypes("PAID", "REFUNDED")
+        .build();
+
+    final int idA = gav.getNodeId(a.getIdentity());
+    final int idB = gav.getNodeId(b.getIdentity());
+    final int idC = gav.getNodeId(c.getIdentity());
+
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(3);
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.IN, "PAID")).isEqualTo(1);
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.BOTH, "PAID")).isEqualTo(4);
+
+    // the type filter still applies, and every type is counted when none is given
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "REFUNDED")).isEqualTo(1);
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT)).isEqualTo(4);
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID", "REFUNDED")).isEqualTo(4);
+
+    // a pair nothing joins counts zero, in agreement with the boolean it replaces
+    assertThat(gav.countEdgesBetween(idA, idC, Vertex.DIRECTION.BOTH, "PAID")).isZero();
+    assertThat(gav.isConnectedTo(idA, idC, Vertex.DIRECTION.BOTH, "PAID")).isFalse();
+
     gav.drop();
   }
 

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -4159,6 +4159,60 @@ class GraphAnalyticalViewTest extends TestHelper {
     gav.drop();
   }
 
+  /**
+   * The overlay keys a pending deletion on the (source, target) pair, so deleting one of several parallel
+   * edges masks all of them: {@code isConnectedTo} and {@code getNeighborIds} then report the pair as gone
+   * while the others remain. A count cannot absorb that the way a boolean can, because the caller turns it
+   * into rows, so the count says "unknown" and leaves the caller to walk the edge list (issue #5663).
+   */
+  @Test
+  void countEdgesBetweenAnswersUnknownWhenTheOverlayMasksAPair() {
+    database.getSchema().createVertexType("Party");
+    database.getSchema().createEdgeType("PAID");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Party").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Party").set("name", "B").save();
+    final MutableVertex c = database.newVertex("Party").set("name", "C").save();
+    a.newEdge("PAID", b, "seq", 1);
+    a.newEdge("PAID", b, "seq", 2);
+    a.newEdge("PAID", b, "seq", 3);
+    a.newEdge("PAID", c, "seq", 4);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("maskedPairView")
+        .withVertexTypes("Party")
+        .withEdgeTypes("PAID")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+
+    final int idA = gav.getNodeId(a.getIdentity());
+    final int idB = gav.getNodeId(b.getIdentity());
+    final int idC = gav.getNodeId(c.getIdentity());
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(3);
+
+    // Delete one of the three A->B edges
+    database.begin();
+    for (final var edge : a.getIdentity().asVertex().getEdges(Vertex.DIRECTION.OUT, "PAID"))
+      if (Integer.valueOf(1).equals(edge.get("seq"))) {
+        edge.delete();
+        break;
+      }
+    database.commit();
+
+    // The pair is masked, so the view cannot say how many survive and says so...
+    assertThat(gav.countEdgesBetween(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isNegative();
+    // ...which is the honest form of what the boolean and the neighbour list already report
+    assertThat(gav.isConnectedTo(idA, idB, Vertex.DIRECTION.OUT, "PAID")).isFalse();
+    assertThat(gav.getNeighborIds(idA, Vertex.DIRECTION.OUT, "PAID")).doesNotContain(idB);
+
+    // a pair the deletion did not touch still answers exactly
+    assertThat(gav.countEdgesBetween(idA, idC, Vertex.DIRECTION.OUT, "PAID")).isEqualTo(1);
+
+    gav.drop();
+  }
+
   // ── ASYNCHRONOUS update mode tests ──────────────────────────────────────
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBoundTargetExpansionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBoundTargetExpansionTest.java
@@ -155,20 +155,19 @@ class CypherBoundTargetExpansionTest {
    * pinned - the narrowing engages on a source the same statement has been traversing, and must still find the
    * one edge that closes the cycle.
    * <p>
-   * The row count is deliberately not asserted. A cycle whose first hop has two parallel edges reports one row
-   * per closing edge rather than one per (first, closing) pair, which is a pre-existing planner discrepancy
-   * unrelated to this narrowing - it reproduces with the narrowing reverted. Asserting the count here would
-   * pin a bug rather than this behaviour; it is tracked by issue #5663.
+   * The pair is joined by two parallel INITIATED edges going out and one coming back, so the cycle can be walked
+   * two ways, one per first-hop edge. The closing hop is an expansion like any other, not a "is the cycle closed?"
+   * question asked once for the pair - answering it once under-counted every such walk (issue #5663).
    */
   @Test
   void narrowingHandlesACyclePatternWhereTheLastHopReturnsToABoundVariable() {
-    // the closing hop resolves, and resolves to the only edge that can close the cycle
+    // the closing hop resolves to the only edge that can close the cycle, once per walk that reaches it
     assertThat(refsOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a) "
-        + "RETURN r2.ref AS v")).isNotEmpty().containsOnly("REVERSED");
+        + "RETURN r2.ref AS v")).containsExactly("REVERSED", "REVERSED");
 
-    // and the first hop still only ever binds an edge of the HUB->SHARED pair
+    // and the first hop binds each edge of the HUB->SHARED pair exactly once
     assertThat(refsOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a) "
-        + "RETURN r1.kind AS v")).isNotEmpty().isSubsetOf("payment", "refund");
+        + "RETURN r1.kind AS v")).containsExactlyInAnyOrder("payment", "refund");
 
     // a cycle that cannot close returns nothing, so the narrowing is not answering "connected" for any target
     assertThat(refsOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'T0'})-[r2:INITIATED]->(a) "

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCycleCardinalityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCycleCardinalityTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A hop whose far end is already bound is still an expansion: it matches once per relationship joining the
+ * pair, not once per pair. Answering it once collapsed every walk of a cycle over a multigraph into a single
+ * row, so anything aggregating over the cycle silently under-reported (issue #5663).
+ * <p>
+ * The fixture is the smallest graph where the two readings differ: two parallel edges out of {@code hub} and
+ * one coming back, so the cycle can be walked twice - each walk binds a different first edge and closes
+ * through the same returning edge, which relationship uniqueness allows because the two are distinct edges.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherCycleCardinalityTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cyphercyclecardinality");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      database.getSchema().createVertexType("Txn");
+      database.getSchema().createEdgeType("INITIATED");
+      database.getSchema().createEdgeType("SETTLED");
+
+      final MutableVertex hub = database.newVertex("Account").set("code", "HUB").save();
+      final MutableVertex shared = database.newVertex("Txn").set("ref", "SHARED").save();
+
+      hub.newEdge("INITIATED", shared, "kind", "payment").save();
+      hub.newEdge("INITIATED", shared, "kind", "refund").save();
+      shared.newEdge("INITIATED", hub, "ref", "REVERSED").save();
+
+      // A leaf the cycle cannot close through, so a hop that answered "connected" would still be caught.
+      final MutableVertex lonely = database.newVertex("Txn").set("ref", "LONELY").save();
+      hub.newEdge("INITIATED", lonely, "kind", "payment").save();
+
+      // A pair of accounts joined by two edges each way, for the undirected and self-loop shapes.
+      final MutableVertex peer = database.newVertex("Account").set("code", "PEER").save();
+      hub.newEdge("SETTLED", peer, "seq", 1).save();
+      hub.newEdge("SETTLED", peer, "seq", 2).save();
+      peer.newEdge("SETTLED", hub, "seq", 3).save();
+      peer.newEdge("SETTLED", peer, "seq", 4).save();
+      peer.newEdge("SETTLED", peer, "seq", 5).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void aCycleReportsOneRowPerFirstHopEdge() {
+    assertThat(valuesOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a) "
+        + "RETURN r1.kind AS v")).containsExactlyInAnyOrder("payment", "refund");
+  }
+
+  @Test
+  void aCycleReportsTheClosingEdgeOncePerFirstHopEdge() {
+    assertThat(valuesOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a) "
+        + "RETURN r2.ref AS v")).containsExactly("REVERSED", "REVERSED");
+  }
+
+  @Test
+  void aCycleCountsEveryWalk() {
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a) "
+        + "RETURN count(*) AS c")).isEqualTo(2);
+  }
+
+  @Test
+  void anAnonymousCycleCountsEveryWalk() {
+    // An unnamed relationship is still a relationship: the pattern matches once per edge either way.
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'})-[:INITIATED]->(t:Txn {ref: 'SHARED'})-[:INITIATED]->(a) "
+        + "RETURN count(*) AS c")).isEqualTo(2);
+  }
+
+  @Test
+  void aCycleThatCannotCloseReturnsNothing() {
+    assertThat(valuesOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'LONELY'})-[r2:INITIATED]->(a) "
+        + "RETURN r2.ref AS v")).isEmpty();
+  }
+
+  @Test
+  void aClosingHopStillRefusesToReuseTheEdgeTheFirstHopBound() {
+    // Undirected, so either of the three INITIATED edges joining the pair can open the cycle and any other
+    // one can close it: 3 x 3 assignments minus the 3 where the closing hop would reuse the edge the first
+    // hop bound, which Cypher forbids.
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]-(t:Txn {ref: 'SHARED'})-[r2:INITIATED]-(a) "
+        + "RETURN count(*) AS c")).isEqualTo(6);
+
+    // and the same when neither relationship is named, which is where the edge has to be tracked implicitly
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'})-[:INITIATED]-(t:Txn {ref: 'SHARED'})-[:INITIATED]-(a) "
+        + "RETURN count(*) AS c")).isEqualTo(6);
+  }
+
+  @Test
+  void anUndirectedClosingHopCountsEveryRelationshipJoiningThePair() {
+    // HUB->PEER twice and PEER->HUB once: three relationships join the pair, so the undirected hop that
+    // closes onto the bound PEER yields three rows for each of the two directed first hops.
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'})-[r1:SETTLED]->(p:Account {code: 'PEER'}) "
+        + "RETURN count(*) AS c")).isEqualTo(2);
+    assertThat(valuesOf("MATCH (a:Account {code: 'HUB'})-[r1:SETTLED]->(p:Account {code: 'PEER'})-[r2:SETTLED]-(a) "
+        + "RETURN r2.seq AS v")).containsExactlyInAnyOrder("2", "3", "1", "3");
+  }
+
+  @Test
+  void aSelfLoopClosingOnItsOwnVertexIsCountedOnce() {
+    // PEER carries two self-loops. An undirected hop reaches each of them from both adjacency lists, but a
+    // relationship reached twice is still one relationship.
+    assertThat(valuesOf("MATCH (p:Account {code: 'PEER'})-[r:SETTLED]-(p) RETURN r.seq AS v"))
+        .containsExactlyInAnyOrder("4", "5");
+    assertThat(valuesOf("MATCH (p:Account {code: 'PEER'})-[r:SETTLED]->(p) RETURN r.seq AS v"))
+        .containsExactlyInAnyOrder("4", "5");
+  }
+
+  private long countOf(final String cypher) {
+    try (final ResultSet rs = database.query("opencypher", cypher)) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private List<String> valuesOf(final String cypher) {
+    final List<String> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", cypher)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        values.add(row.getProperty("v") != null ? row.getProperty("v").toString() : null);
+      }
+    }
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCycleCardinalityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCycleCardinalityTest.java
@@ -133,7 +133,8 @@ class CypherCycleCardinalityTest {
   @Test
   void anUndirectedClosingHopCountsEveryRelationshipJoiningThePair() {
     // HUB->PEER twice and PEER->HUB once: three relationships join the pair, so the undirected hop that
-    // closes onto the bound PEER yields three rows for each of the two directed first hops.
+    // closes onto the bound PEER sees all three and keeps the two that are not the edge the first hop
+    // bound - twice over, once per directed first hop.
     assertThat(countOf("MATCH (a:Account {code: 'HUB'})-[r1:SETTLED]->(p:Account {code: 'PEER'}) "
         + "RETURN count(*) AS c")).isEqualTo(2);
     assertThat(valuesOf("MATCH (a:Account {code: 'HUB'})-[r1:SETTLED]->(p:Account {code: 'PEER'})-[r2:SETTLED]-(a) "

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCycleCardinalityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCycleCardinalityTest.java
@@ -151,6 +151,28 @@ class CypherCycleCardinalityTest {
         .containsExactlyInAnyOrder("4", "5");
   }
 
+  /**
+   * A pattern is an expansion where it appears in MATCH and a question where it appears as a predicate.
+   * The two must not be confused now that the bound-target hop multiplies rows: an existence test over a
+   * pair joined twice answers once, or every guard over a multigraph would over-report.
+   */
+  @Test
+  void anExistencePredicateOverAPairJoinedTwiceStillAnswersOnce() {
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "WHERE (a)-[:INITIATED]->(t) RETURN count(*) AS c")).isEqualTo(1);
+
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "WHERE EXISTS { (a)-[:INITIATED]->(t) } RETURN count(*) AS c")).isEqualTo(1);
+
+    // and the negation of the same question still admits a pair nothing joins, exactly once
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "WHERE NOT EXISTS { (t)-[:SETTLED]->(a) } RETURN count(*) AS c")).isEqualTo(1);
+
+    // ...while the same pattern written in MATCH is an expansion and reports both edges
+    assertThat(countOf("MATCH (a:Account {code: 'HUB'}), (t:Txn {ref: 'SHARED'}) "
+        + "MATCH (a)-[:INITIATED]->(t) RETURN count(*) AS c")).isEqualTo(2);
+  }
+
   private long countOf(final String cypher) {
     try (final ResultSet rs = database.query("opencypher", cypher)) {
       return ((Number) rs.next().getProperty("c")).longValue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherExistsSuperNodeBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherExistsSuperNodeBenchmark.java
@@ -104,7 +104,8 @@ class CypherExistsSuperNodeBenchmark {
     final long fromHub = timeGuard(HUB_ANCHORED, probeRid, true);
     final long fromLeaf = timeGuard(LEAF_ANCHORED, probeRid, true);
 
-    LogManager.instance().log(this, Level.INFO, "degree=%d anchored on hub: %d ms, anchored on leaf: %d ms", DEGREE, fromHub, fromLeaf);
+    LogManager.instance().log(this, Level.INFO, "degree=%d anchored on hub: %.3f ms, anchored on leaf: %.3f ms",
+        DEGREE, fromHub / 1_000_000d, fromLeaf / 1_000_000d);
 
     assertThat(fromLeaf).isLessThan(fromHub);
   }
@@ -139,6 +140,12 @@ class CypherExistsSuperNodeBenchmark {
     return params;
   }
 
+  /**
+   * Returns the mean time per run in <b>nanoseconds</b>. Milliseconds used to be the unit, but the
+   * neighbour-pointer narrowing brought both shapes under a millisecond at this degree, so integer
+   * millisecond truncation reported them as 0 and 0 - and the comparison this test exists to make
+   * became a coin flip between "leaf is faster" and "they tie".
+   */
   private long timeGuard(final String cypher, final String target, final boolean expected) {
     final Map<String, Object> params = params(target);
 
@@ -153,6 +160,6 @@ class CypherExistsSuperNodeBenchmark {
       try (final ResultSet rs = database.query("opencypher", cypher, params)) {
         assertThat(rs.hasNext()).isEqualTo(expected);
       }
-    return (System.nanoTime() - begin) / REPEATS / 1_000_000;
+    return (System.nanoTime() - begin) / REPEATS;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherGAVBoundTargetCardinalityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherGAVBoundTargetCardinalityTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The CSR-backed hop onto a pinned target answers with adjacency ids instead of edge records, so it has to
+ * derive the multiplicity of the pair from the adjacency array rather than collapsing it to "connected"
+ * (issue #5663). It must agree, row for row, with the same query planned without the view.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherGAVBoundTargetCardinalityTest {
+  private static final String CYCLE = "MATCH (a:Account {code: 'HUB'})-[:INITIATED]->(t:Txn {ref: 'SHARED'})-[:SETTLED]->(a) "
+      + "RETURN count(*) AS c";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cyphergavboundtarget");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      database.getSchema().createVertexType("Txn");
+      database.getSchema().createEdgeType("INITIATED");
+      database.getSchema().createEdgeType("SETTLED");
+
+      final MutableVertex hub = database.newVertex("Account").set("code", "HUB").save();
+      final MutableVertex shared = database.newVertex("Txn").set("ref", "SHARED").save();
+
+      // Two ways out and two ways back, so the cycle can be walked four times
+      hub.newEdge("INITIATED", shared, "kind", "payment").save();
+      hub.newEdge("INITIATED", shared, "kind", "refund").save();
+      shared.newEdge("SETTLED", hub, "seq", 1).save();
+      shared.newEdge("SETTLED", hub, "seq", 2).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void theViewCountsEveryWalkOfTheCycle() {
+    // The hops carry disjoint edge types and bind nothing, so no edge object is needed and the closing
+    // hop is free to run off the view.
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("cycle-view")
+        .withVertexTypes("Account", "Txn")
+        .withEdgeTypes("INITIATED", "SETTLED")
+        .build();
+    try {
+      assertThat(planOf(CYCLE)).contains("GAVExpandInto");
+      assertThat(countOf(CYCLE)).isEqualTo(4);
+    } finally {
+      view.drop();
+    }
+
+    assertThat(countOf(CYCLE)).isEqualTo(4);
+  }
+
+  @Test
+  void theViewAgreesWhenNoEdgeClosesTheCycle() {
+    final String unclosable = "MATCH (a:Account {code: 'HUB'})-[:SETTLED]->(t:Txn {ref: 'SHARED'})-[:INITIATED]->(a) "
+        + "RETURN count(*) AS c";
+    assertThat(countOf(unclosable)).isZero();
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("cycle-view")
+        .withVertexTypes("Account", "Txn")
+        .withEdgeTypes("INITIATED", "SETTLED")
+        .build();
+    try {
+      assertThat(countOf(unclosable)).isZero();
+    } finally {
+      view.drop();
+    }
+  }
+
+  private long countOf(final String cypher) {
+    try (final ResultSet rs = database.query("opencypher", cypher)) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private String planOf(final String cypher) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + cypher)) {
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherGAVBoundTargetCardinalityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherGAVBoundTargetCardinalityTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -104,6 +105,38 @@ class CypherGAVBoundTargetCardinalityTest {
         .build();
     try {
       assertThat(countOf(unclosable)).isZero();
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * The view's overlay masks a pending deletion per (source, target) pair, so deleting one of the two
+   * SETTLED edges hides both from the CSR. The count it can no longer state exactly must not become the
+   * number of rows: the operator falls back to the edge list, which still holds the surviving edge.
+   */
+  @Test
+  void theViewFallsBackToTheEdgeListWhenADeletionMasksThePair() {
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("cycle-view-sync")
+        .withVertexTypes("Account", "Txn")
+        .withEdgeTypes("INITIATED", "SETTLED")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+    try {
+      assertThat(planOf(CYCLE)).contains("GAVExpandInto");
+      assertThat(countOf(CYCLE)).isEqualTo(4);
+
+      // Drop one of the two SETTLED edges closing the cycle: 2 first hops x 1 remaining closing edge
+      database.transaction(() -> {
+        for (final Edge edge : database.query("opencypher", "MATCH (t:Txn {ref: 'SHARED'})-[r:SETTLED]->(:Account) RETURN r")
+            .stream().map(r -> (Edge) r.getProperty("r")).toList()) {
+          edge.delete();
+          break;
+        }
+      });
+
+      assertThat(countOf(CYCLE)).isEqualTo(2);
     } finally {
       view.drop();
     }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/GAVEligibilityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/GAVEligibilityTest.java
@@ -131,7 +131,7 @@ class GAVEligibilityTest {
       result.next();
 
     final String planString = result.getExecutionPlan().get().prettyPrint(0, 2);
-    // The optimizer now handles overlapping edge types correctly via ExpandInto/SEMI-JOIN
+    // The optimizer now handles overlapping edge types correctly via the bound-target ExpandInto
     assertThat(planString).contains("Cost-Based");
     result.close();
   }
@@ -179,7 +179,7 @@ class GAVEligibilityTest {
       result.next();
 
     final String planString = result.getExecutionPlan().get().prettyPrint(0, 2);
-    // Optimizer handles overlapping edge types via ExpandInto/SEMI-JOIN
+    // Optimizer handles overlapping edge types via the bound-target ExpandInto
     assertThat(planString).contains("Cost-Based");
     result.close();
   }
@@ -387,7 +387,7 @@ class GAVEligibilityTest {
 
   @Test
   void triangleCountUsesOptimizer() {
-    // Q3-like: triangle in country — optimizer handles via ExpandInto/SEMI-JOIN
+    // Q3-like: triangle in country - optimizer handles via the bound-target ExpandInto
     final ResultSet result = database.query("opencypher",
         "PROFILE MATCH (co:Country) MATCH (p1:Person)-[:IS_LOCATED_IN]->(:City)-[:IS_PART_OF]->(co) MATCH (p2:Person)-[:IS_LOCATED_IN]->(:City)-[:IS_PART_OF]->(co) MATCH (p3:Person)-[:IS_LOCATED_IN]->(:City)-[:IS_PART_OF]->(co) MATCH (p1)-[:KNOWS]-(p2)-[:KNOWS]-(p3)-[:KNOWS]-(p1) RETURN count(*) AS count");
 
@@ -478,7 +478,7 @@ class GAVEligibilityTest {
 
   @Test
   void starJoinQ4PatternUsesOptimizer() {
-    // Q4-like: star join with central node m:Message — optimizer handles via SEMI-JOIN
+    // Q4-like: star join with central node m:Message - optimizer handles via the bound-target ExpandInto
     final ResultSet result = database.query("opencypher",
         "PROFILE MATCH (:Tag)<-[:HAS_TAG]-(m:Message)-[:HAS_CREATOR]->(:Person), (m)<-[:LIKES]-(:Person), (m)<-[:REPLY_OF]-(:Comment) RETURN count(*) AS count");
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/PhysicalOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/PhysicalOperatorTest.java
@@ -357,7 +357,7 @@ class PhysicalOperatorTest {
       );
       final String expandIntoExplain = expandInto.explain(0);
       assertThat(expandIntoExplain.contains("ExpandInto")).as("Explain should contain operator type").isTrue();
-      assertThat(expandIntoExplain.contains("SEMI-JOIN")).as("Explain should indicate semi-join").isTrue();
+      assertThat(expandIntoExplain.contains("BOUND-TARGET")).as("Explain should indicate the target is pinned").isTrue();
       assertThat(expandIntoExplain.contains("a")).as("Explain should contain source variable").isTrue();
       assertThat(expandIntoExplain.contains("b")).as("Explain should contain target variable").isTrue();
     });


### PR DESCRIPTION
Closes #5663.

## The issue is real, and Neo4j answers the other way

A pattern relationship matches **once per relationship**, whether or not the pattern names it. So over

```cypher
CREATE (a:Account {code: 'HUB'})
CREATE (t:Txn {ref: 'SHARED'})
CREATE (a)-[:INITIATED {kind: 'payment'}]->(t)
CREATE (a)-[:INITIATED {kind: 'refund'}]->(t)
CREATE (t)-[:INITIATED {ref: 'REVERSED'}]->(a)

MATCH (a:Account {code: 'HUB'})-[r1:INITIATED]->(t:Txn {ref: 'SHARED'})-[r2:INITIATED]->(a)
RETURN r1.kind
```

the cycle can be walked two ways, one per first-hop edge, each closing through the single returning edge. Relationship uniqueness is satisfied in both: `r1` and `r2` bind different edges. Expected `["payment", "refund"]`, actual `["payment"]`.

## Root cause

`ExpandInto` - the operator the optimizer picks for a hop whose far end is already bound - was written as a semi-join: `isConnectedTo()` plus, when a variable had to be bound, one `findEdge()` for the *first* connecting edge. One row per input row, the rest of the pair discarded. `GAVExpandInto`, its CSR-backed twin, had the identical defect (`isConnectedTo` collapsed to a boolean).

The step-by-step executor (`MatchRelationshipStep`) had always got this right - it iterates the narrowed edge list - which is why the same query could answer differently depending on which plan won. That plan choice was itself unstable: `JoinOrderRule` kept its candidate hops in a `HashSet` of objects with identity hashing, so two equally cheap hops were tie-broken by whatever addresses the JVM handed out.

## The fix

**`ExpandInto` is an expansion, not a probe.** It walks the relationships joining the pair with `GraphEngine.getEdgesConnectedTo` and emits one row per relationship. It keeps exactly what made it fast: the source's edge list is filtered on the neighbour pointer held beside each edge pointer in the segment, so an edge that does not reach the target costs two primitive comparisons rather than a record load, and only the edges that do reach it are materialised. For the common single-edge pair this is now *one* narrowed scan where the old code did two (`isConnectedTo`, then `findEdge`).

It also gained what `ExpandAll` already had and it lacked:
- relationship uniqueness against the preceding hops of its own MATCH clause is applied per edge;
- an **anonymous** hop can now carry a synthetic edge-tracking variable, so a later same-clause hop cannot reuse the relationship it bound. Previously an anonymous bound-target hop was invisible to the uniqueness check;
- an undirected hop reaches a self-loop from both adjacency lists and reports it once (`SelfLoops.deduplicatingEdges`, the helper the other executors already share).

**`GAVExpandInto` reads the multiplicity off the CSR** instead of stopping at the first hit. New SPI method `GraphTraversalProvider.countEdgesBetween` - default implementation counts occurrences in `getNeighborIds`, `GraphAnalyticalView` overrides it with an equal-range scan around the binary-search hit, O(log(degree) + multiplicity), mirroring `isConnectedForType` entry by entry (overlay deletions and additions included) so the two never disagree about whether an edge is there.

**The planner stops sending hops to the CSR that it cannot answer.** Adjacency ids carry no edge identity, so `GAVExpandInto` cannot tell one relationship from another. It is now selected only when the hop needs no edge object at all: no variable captured, no edge tracking, and no preceding same-clause relationship variable to check against. That closes a pre-existing hole where an anonymous bound-target hop planned onto a view skipped relationship uniqueness entirely.

**Plan choice is deterministic.** `JoinOrderRule` uses a `LinkedHashSet`, so ties fall to the order the hops are written in.

### Considered and rejected

Special-casing the cycle shape, or keeping the semi-join and multiplying the row by a separate count, would leave two code paths disagreeing about what a hop means - which is the class of bug this is. Making the operator an expansion is the smaller and more honest change, and it is what Neo4j's `Expand(Into)` does.

There is one deliberate trade: the old code could stop at the first matching edge, the new one must walk the source's whole (narrowed) edge list to know the multiplicity. That is inherent to answering correctly, it is pointer comparisons rather than record loads, and record loads are unchanged (one per emitted row).

## Tests

- `CypherCycleCardinalityTest` (new): the issue's repro named and anonymous; `count(*)` over the cycle; a cycle that cannot close; the undirected closing hop, where relationship uniqueness has to survive the new multiplicity; parallel edges both ways; self-loops counted once under an undirected hop.
- `CypherGAVBoundTargetCardinalityTest` (new): the same cycle planned onto a `GraphAnalyticalView`, asserting from `EXPLAIN` that `GAVExpandInto` is the operator under test, and that it agrees with the plan without the view.
- `GraphAnalyticalViewTest.countEdgesBetweenReportsEveryParallelEdge` (new): the CSR count directly - parallel edges, direction, edge-type filter, untyped, and a pair nothing joins; the existing self-loop test now also pins the count.
- `CypherBoundTargetExpansionTest.narrowingHandlesACyclePatternWhereTheLastHopReturnsToABoundVariable` asserted no row count and said why, pointing at this issue. It asserts it now.
- Full `com.arcadedb.query.opencypher.**` + `com.arcadedb.graph.**` (8176 tests, includes the OpenCypher TCK suite) and `com.arcadedb.query.sql.**` (2659) green.

The `⭐ SEMI-JOIN` marker in `EXPLAIN` output reads `⭐ BOUND-TARGET` now, since the operator is no longer a semi-join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8C35vrQkW1y1gaEvWzRPc