### PR TITLE
fix(engine) #5677: store a LINK hash-index key compressed, and refuse an unencodable key type at creation

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1259,4 +1259,42 @@ other cursor, and `IndexCursorCollection` does the same. And `MultiIndexCursor.g
 running page reads and tombstone skips inside two plain accessors; both now answer from state sampled at construction,
 and the key types no longer come back null once the cursor is exhausted.
 
+## A `HASH` index can key on a `LINK`, and an unsupported key type is refused at creation
+
+`CREATE INDEX ON INITIATED (`@out`, `@in`) UNIQUE_HASH` - the structural way to enforce edge de-duplication - was
+accepted, and then every insert failed:
+
+```
+com.arcadedb.index.IndexException: Unsupported key type for hash index 'INITIATED_0_...' (fileId=5): 14 (0x0E) while
+parsing entry at content offset 11. Loaded key types=[14(0x0E)=INVALID, 14(0x0E)=INVALID]. This means the index
+metadata or a bucket page is corrupted; rebuild the index (DROP and recreate it).
+```
+
+A `LINK` (and therefore an edge type's `@out`/`@in`) encodes as `TYPE_RID`, which the hash bucket's key-size, compare
+and validation paths did not recognise: only `TYPE_COMPRESSED_RID` was handled, so every key-length computation over
+such an entry fell through to the "corrupted" branch. Endpoint-keyed de-duplication was therefore `LSM_TREE`-only, and
+the failure said nothing about it.
+
+`LINK` keys are now stored the same way the bucket already stores its entry values - as varint-compressed RIDs. That
+was the cheaper of the two fixes to make correct: the fixed 4+8 byte `TYPE_RID` form costs 12 bytes per key column,
+against 2-7 for the varint form, so on the composite `(@out, @in)` key that motivates such an index it is roughly half
+the key bytes, and half the pages. Both encodings are deterministic and injective, so hashing and key comparison are
+unaffected. The metadata page keeps recording the schema type, so the on-disk format is unchanged and
+`getKeyTypes()`/`getBinaryKeyTypes()` still report `LINK`/`TYPE_RID` - the compression is internal to the bucket.
+
+The second half of the report was the message itself. Nothing was corrupt: the index had never been able to hold that
+key type, so "rebuild the index (DROP and recreate it)" pointed at a remedy that could not work and implied data loss
+that had not happened. A key type a hash index cannot encode is now refused when the index is created, before any file
+exists, naming the type and the supported ones:
+
+```
+Cannot create index 'Doc_0_...' of type HASH because the key type LIST cannot be used as a HASH index key.
+Supported key types are: BOOLEAN, INTEGER, SHORT, LONG, FLOAT, DOUBLE, DATETIME, STRING, BINARY, LINK, BYTE, DATE,
+DECIMAL, DATETIME_MICROS, DATETIME_NANOS, DATETIME_SECOND. Create the index as LSM_TREE instead
+```
+
+The runtime error that remains - reachable only from a damaged metadata page, or an index created before that check -
+now names the key column, states that no record data is lost, and distinguishes the two causes instead of asserting
+corruption.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1297,4 +1297,11 @@ The runtime error that remains - reachable only from a damaged metadata page, or
 now names the key column, states that no record data is lost, and distinguishes the two causes instead of asserting
 corruption.
 
+**Downgrade note.** Nothing needs migrating on upgrade: the metadata page records the same byte it always did, and a
+`LINK` HASH index created before this release cannot hold data anyway - it failed on the first insert - so an existing
+one simply starts working. The compatibility runs one way only, though. A `LINK` HASH index created *with* this
+release is not readable by an earlier build: the old loader does not recognise `TYPE_RID` as a key type and flags the
+metadata page as corrupt. The database still opens and every other index is unaffected, but that one index has to be
+dropped before going back. `LSM_TREE` indexes on the same properties are unaffected in both directions.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -83,6 +83,10 @@ public class HashIndex implements IndexInternal {
   public static class HashIndexFactoryHandler implements IndexFactoryHandler {
     @Override
     public IndexInternal create(final IndexBuilder<?> builder) {
+      // Refuse a key type the bucket cannot encode BEFORE any file is created, so the failure names the type instead
+      // of surfacing on the first insert as an unsupported-key-type error (issue #5677).
+      HashIndexBucket.checkSupportedKeyTypes(builder.getIndexName(), builder.getKeyTypes());
+
       // Use 64KB default page size for hash indexes (vs 256KB for LSM)
       final int pageSize = builder.getPageSize() == LSMTreeIndexAbstract.DEF_PAGE_SIZE ?
           HashIndexBucket.DEF_PAGE_SIZE : builder.getPageSize();
@@ -512,7 +516,9 @@ public class HashIndex implements IndexInternal {
 
   @Override
   public byte[] getBinaryKeyTypes() {
-    return bucket.binaryKeyTypes;
+    // The types declared by the schema, not the ones the bucket writes on the page: callers compare these against
+    // other indexes' key types and use them to coerce user-supplied values.
+    return bucket.declaredKeyTypes;
   }
 
   @Override
@@ -624,7 +630,7 @@ public class HashIndex implements IndexInternal {
 
   private Object[] convertKeys(final Object[] keys) {
     if (keys != null) {
-      final byte[] keyTypes = bucket.binaryKeyTypes;
+      final byte[] keyTypes = bucket.declaredKeyTypes;
       final Object[] convertedKeys = new Object[keys.length];
       for (int i = 0; i < keys.length; ++i) {
         if (keys[i] == null)

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -99,6 +99,11 @@ public class HashIndexBucket extends PaginatedComponent {
   final boolean unique;
 
   Type[]  keyTypes;
+  // Binary type declared by the schema for each key column: this is what is persisted on the metadata page and
+  // what diagnostics report. Use binaryKeyTypes (below) for anything that touches the on-page encoding.
+  byte[]  declaredKeyTypes;
+  // Binary type actually used to encode each key column on the page. It only differs from the declared one for
+  // LINK keys: see storageKeyType().
   byte[]  binaryKeyTypes;
   LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy;
 
@@ -127,9 +132,12 @@ public class HashIndexBucket extends PaginatedComponent {
     this.comparator = serializer.getComparator();
     this.unique = unique;
     this.keyTypes = keyTypes;
+    this.declaredKeyTypes = new byte[keyTypes.length];
     this.binaryKeyTypes = new byte[keyTypes.length];
-    for (int i = 0; i < keyTypes.length; i++)
-      this.binaryKeyTypes[i] = keyTypes[i].getBinaryType();
+    for (int i = 0; i < keyTypes.length; i++) {
+      this.declaredKeyTypes[i] = keyTypes[i].getBinaryType();
+      this.binaryKeyTypes[i] = storageKeyType(this.declaredKeyTypes[i]);
+    }
     this.nullStrategy = nullStrategy;
 
     // Initialize the file: metadata page + 1 directory page + 1 initial bucket
@@ -728,7 +736,7 @@ public class HashIndexBucket extends PaginatedComponent {
   // ─── INITIALIZATION ──────────────────────────────────────
 
   private void initializeNewIndex() throws IOException {
-    this.metaTailOffset = META_KEY_TYPES_START + binaryKeyTypes.length + 2 * Binary.BYTE_SERIALIZED_SIZE;
+    this.metaTailOffset = META_KEY_TYPES_START + declaredKeyTypes.length + 2 * Binary.BYTE_SERIALIZED_SIZE;
 
     // Page 0: metadata
     final MutablePage metaPage = database.getTransaction().addPage(new PageId(database, fileId, 0), pageSize);
@@ -739,10 +747,12 @@ public class HashIndexBucket extends PaginatedComponent {
     pos += Binary.INT_SERIALIZED_SIZE;
     metaPage.writeInt(pos, 0);                           // totalEntries = 0
     pos += Binary.INT_SERIALIZED_SIZE;
-    metaPage.writeByte(pos, (byte) binaryKeyTypes.length); // numberOfKeys
+    metaPage.writeByte(pos, (byte) declaredKeyTypes.length); // numberOfKeys
     pos += Binary.BYTE_SERIALIZED_SIZE;
-    for (final byte binaryKeyType : binaryKeyTypes) {
-      metaPage.writeByte(pos, binaryKeyType);
+    // Persist the SCHEMA type, not the storage type, so the metadata page keeps describing the index the same way
+    // the schema does and the storage encoding stays an internal detail of this class.
+    for (final byte declaredKeyType : declaredKeyTypes) {
+      metaPage.writeByte(pos, declaredKeyType);
       pos += Binary.BYTE_SERIALIZED_SIZE;
     }
     metaPage.writeByte(pos, (byte) nullStrategy.ordinal());
@@ -796,12 +806,14 @@ public class HashIndexBucket extends PaginatedComponent {
     boolean metadataCorrupt = numKeysCorrupt;
 
     int pos = META_KEY_TYPES_START;
+    declaredKeyTypes = new byte[numKeys];
     binaryKeyTypes = new byte[numKeys];
     keyTypes = new Type[numKeys];
     for (int i = 0; i < numKeys; i++) {
-      binaryKeyTypes[i] = metaPage.readByte(pos);
-      keyTypes[i] = Type.getByBinaryType(binaryKeyTypes[i]);
-      if (!isSupportedKeyType(binaryKeyTypes[i]))
+      declaredKeyTypes[i] = metaPage.readByte(pos);
+      binaryKeyTypes[i] = storageKeyType(declaredKeyTypes[i]);
+      keyTypes[i] = Type.getByBinaryType(declaredKeyTypes[i]);
+      if (!isSupportedKeyType(declaredKeyTypes[i]))
         metadataCorrupt = true;
       pos += Binary.BYTE_SERIALIZED_SIZE;
     }
@@ -830,9 +842,12 @@ public class HashIndexBucket extends PaginatedComponent {
   }
 
   /**
-   * Returns true if the given binary type is one this hash index can serialize/deserialize as a key
-   * component. Mirrors the supported cases in {@link #getSerializedValueSize}; used to validate the key
-   * types loaded from the metadata page so corruption is detected up front instead of deep in a search.
+   * Returns true if the given SCHEMA binary type is one this hash index can serialize/deserialize as a key
+   * component. Used to refuse an unsupported type at creation ({@link #checkSupportedKeyTypes}) and to validate the
+   * key types loaded from the metadata page, so corruption is detected up front instead of deep in a search.
+   * <p>
+   * The cases mirror those of {@link #getSerializedValueSize} after {@link #storageKeyType} has been applied, which
+   * is why {@code TYPE_RID} is accepted here but absent there: it is stored as {@code TYPE_COMPRESSED_RID}.
    */
   static boolean isSupportedKeyType(final byte type) {
     switch (type) {
@@ -851,12 +866,56 @@ public class HashIndexBucket extends PaginatedComponent {
     case BinaryTypes.TYPE_STRING:
     case BinaryTypes.TYPE_BINARY:
     case BinaryTypes.TYPE_COMPRESSED_RID:
+    case BinaryTypes.TYPE_RID:
     case BinaryTypes.TYPE_DECIMAL:
     case BinaryTypes.TYPE_UUID:
       return true;
     default:
       return false;
     }
+  }
+
+  /**
+   * Maps a schema binary type to the binary type this index actually writes on the page.
+   * <p>
+   * The only remapping is {@link BinaryTypes#TYPE_RID} (the encoding of {@link Type#LINK}, and therefore of an edge
+   * type's {@code @out}/{@code @in} endpoints) to {@link BinaryTypes#TYPE_COMPRESSED_RID}: both encodings are
+   * deterministic and injective, so hashing and byte comparison are unaffected, but the fixed 4+8 byte form costs 12
+   * bytes per column against the 2-7 of the varint form the bucket already uses for entry values. On the composite
+   * {@code (@out,@in)} key that is the point of an endpoint-keyed unique index, that is roughly half the key bytes -
+   * and hence half the pages - for free. See issue #5677.
+   */
+  static byte storageKeyType(final byte declaredBinaryType) {
+    return declaredBinaryType == BinaryTypes.TYPE_RID ? BinaryTypes.TYPE_COMPRESSED_RID : declaredBinaryType;
+  }
+
+  /**
+   * Validates the key types a hash index is about to be created with, so an unsupported one is refused up front with
+   * a message naming it, instead of surfacing as an "unsupported key type" deep inside the first insert (#5677).
+   */
+  static void checkSupportedKeyTypes(final String indexName, final Type[] keyTypes) {
+    if (keyTypes == null)
+      return;
+    for (final Type keyType : keyTypes)
+      if (keyType == null || !isSupportedKeyType(keyType.getBinaryType()))
+        throw new IndexException(
+            "Cannot create index '" + indexName + "' of type HASH because the key type " + keyType
+                + " cannot be used as a HASH index key. Supported key types are: " + supportedKeyTypeNames()
+                + ". Create the index as LSM_TREE instead");
+  }
+
+  /**
+   * Comma-separated list of the schema types usable as a hash index key, for the creation-time error message.
+   */
+  private static String supportedKeyTypeNames() {
+    final StringBuilder buffer = new StringBuilder(128);
+    for (final Type type : Type.values())
+      if (isSupportedKeyType(type.getBinaryType())) {
+        if (!buffer.isEmpty())
+          buffer.append(", ");
+        buffer.append(type.name());
+      }
+    return buffer.toString();
   }
 
   /**
@@ -874,12 +933,12 @@ public class HashIndexBucket extends PaginatedComponent {
    * Formats the loaded key types as signed value + hex, flagging any that are not valid hash index key types.
    */
   private String formatKeyTypes() {
-    final StringBuilder buffer = new StringBuilder(2 + binaryKeyTypes.length * 12);
+    final StringBuilder buffer = new StringBuilder(2 + declaredKeyTypes.length * 12);
     buffer.append('[');
-    for (int i = 0; i < binaryKeyTypes.length; i++) {
+    for (int i = 0; i < declaredKeyTypes.length; i++) {
       if (i > 0)
         buffer.append(", ");
-      final byte type = binaryKeyTypes[i];
+      final byte type = declaredKeyTypes[i];
       buffer.append(type).append("(0x").append(String.format("%02X", type & 0xFF)).append(')');
       if (!isSupportedKeyType(type))
         buffer.append("=INVALID");
@@ -903,16 +962,23 @@ public class HashIndexBucket extends PaginatedComponent {
   }
 
   /**
-   * Builds a rich, actionable exception for an unrecognized key type encountered while parsing an entry.
-   * The bare type value (e.g. -108) is meaningless on its own; this adds the index identity, the loaded
-   * key types, the page/offset being parsed, and the remediation step.
+   * Builds a rich, actionable exception for a key column whose type this index cannot encode.
+   * <p>
+   * The offending type is the one loaded from the metadata page for that column, NOT a byte read out of the entry
+   * being walked, so this is never evidence that entry's bytes are damaged. Since {@link #checkSupportedKeyTypes}
+   * refuses an unsupported type at creation, reaching this point means the metadata page itself no longer describes
+   * a valid index - either it is corrupted, or the index predates that check. Both are fixed by recreating the index,
+   * so the message says so without claiming the stored records are damaged. The bare type value (e.g. -108) is
+   * meaningless on its own; the index identity, the column, the loaded types and the parse position are added.
    */
-  private IndexException unsupportedKeyType(final byte type, final int offset) {
+  private IndexException unsupportedKeyType(final byte type, final int column, final int offset) {
     return new IndexException(
-        "Unsupported key type for hash index '" + getName() + "' (fileId=" + fileId + "): " + type + " (0x"
-            + String.format("%02X", type & 0xFF) + ") while parsing entry at content offset " + offset
-            + ". Loaded key types=" + formatKeyTypes()
-            + ". This means the index metadata or a bucket page is corrupted; rebuild the index (DROP and recreate it).");
+        "Key column " + column + " of hash index '" + getName() + "' (fileId=" + fileId + ") has type " + type + " (0x"
+            + String.format("%02X", type & 0xFF) + "), which a hash index cannot encode (hit while parsing an entry at "
+            + "content offset " + offset + "). Declared key types=" + formatKeyTypes()
+            + ". No record data is lost: either the index metadata page is damaged, or the index was created on a "
+            + "property type HASH does not support. Drop it and recreate it, as LSM_TREE if the key type is not in: "
+            + supportedKeyTypeNames());
   }
 
   /**
@@ -1016,13 +1082,13 @@ public class HashIndexBucket extends PaginatedComponent {
   public List<String> checkMetadataIntegrity() {
     final List<String> problems = new ArrayList<>();
 
-    if (binaryKeyTypes == null || binaryKeyTypes.length == 0)
+    if (declaredKeyTypes == null || declaredKeyTypes.length == 0)
       problems.add("no key types loaded (the metadata page reports an invalid key count)");
     else
-      for (int i = 0; i < binaryKeyTypes.length; i++)
-        if (!isSupportedKeyType(binaryKeyTypes[i]))
-          problems.add("invalid key type at column " + i + ": " + binaryKeyTypes[i] + " (0x"
-              + String.format("%02X", binaryKeyTypes[i] & 0xFF) + ")");
+      for (int i = 0; i < declaredKeyTypes.length; i++)
+        if (!isSupportedKeyType(declaredKeyTypes[i]))
+          problems.add("invalid key type at column " + i + ": " + declaredKeyTypes[i] + " (0x"
+              + String.format("%02X", declaredKeyTypes[i] & 0xFF) + ")");
 
     try {
       final int globalDepth = readGlobalDepth();
@@ -1678,7 +1744,7 @@ public class HashIndexBucket extends PaginatedComponent {
       final byte nullMarker = page.readByte(offset);
       offset += Binary.BYTE_SERIALIZED_SIZE;
       if (nullMarker != 0)
-        offset += getSerializedValueSize(page, offset, binaryKeyTypes[i]);
+        offset += getSerializedValueSize(page, offset, i);
     }
     return offset - startOffset;
   }
@@ -1689,7 +1755,7 @@ public class HashIndexBucket extends PaginatedComponent {
       final byte nullMarker = data[offset];
       offset += 1;
       if (nullMarker != 0)
-        offset += getSerializedValueSizeFromBytes(data, offset, binaryKeyTypes[i]);
+        offset += getSerializedValueSizeFromBytes(data, offset, i);
     }
     return offset - startOffset;
   }
@@ -1699,9 +1765,12 @@ public class HashIndexBucket extends PaginatedComponent {
   }
 
   /**
-   * Computes how many bytes a serialized value occupies in the page.
+   * Computes how many bytes the value of the given key column occupies in the page. The column is passed rather than
+   * its type so the storage encoding is read from {@link #binaryKeyTypes} while a failure can still report the
+   * schema type from {@link #declaredKeyTypes}.
    */
-  private int getSerializedValueSize(final BasePage page, final int offset, final byte type) {
+  private int getSerializedValueSize(final BasePage page, final int offset, final int column) {
+    final byte type = binaryKeyTypes[column];
     switch (type) {
     case BinaryTypes.TYPE_BOOLEAN:
     case BinaryTypes.TYPE_BYTE:
@@ -1734,11 +1803,12 @@ public class HashIndexBucket extends PaginatedComponent {
     case BinaryTypes.TYPE_UUID:
       return 16; // Two longs
     default:
-      throw unsupportedKeyType(type, offset);
+      throw unsupportedKeyType(declaredKeyTypes[column], column, offset);
     }
   }
 
-  private int getSerializedValueSizeFromBytes(final byte[] data, final int offset, final byte type) {
+  private int getSerializedValueSizeFromBytes(final byte[] data, final int offset, final int column) {
+    final byte type = binaryKeyTypes[column];
     switch (type) {
     case BinaryTypes.TYPE_BOOLEAN:
     case BinaryTypes.TYPE_BYTE:
@@ -1769,7 +1839,7 @@ public class HashIndexBucket extends PaginatedComponent {
     case BinaryTypes.TYPE_UUID:
       return 16;
     default:
-      throw unsupportedKeyType(type, offset);
+      throw unsupportedKeyType(declaredKeyTypes[column], column, offset);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -848,6 +848,11 @@ public class HashIndexBucket extends PaginatedComponent {
    * <p>
    * The cases mirror those of {@link #getSerializedValueSize} after {@link #storageKeyType} has been applied, which
    * is why {@code TYPE_RID} is accepted here but absent there: it is stored as {@code TYPE_COMPRESSED_RID}.
+   * <p>
+   * Two of the accepted types have no {@link Type} constant that maps to them, so they cannot be declared through the
+   * schema and never appear in {@link #supportedKeyTypeNames}: {@code TYPE_COMPRESSED_RID}, which only reaches this
+   * method as a storage type, and {@code TYPE_UUID}. They stay accepted so a metadata page carrying one is not
+   * mistaken for corruption.
    */
   static boolean isSupportedKeyType(final byte type) {
     switch (type) {
@@ -899,8 +904,9 @@ public class HashIndexBucket extends PaginatedComponent {
     for (final Type keyType : keyTypes)
       if (keyType == null || !isSupportedKeyType(keyType.getBinaryType()))
         throw new IndexException(
-            "Cannot create index '" + indexName + "' of type HASH because the key type " + keyType
-                + " cannot be used as a HASH index key. Supported key types are: " + supportedKeyTypeNames()
+            "Cannot create index '" + indexName + "' of type HASH because "
+                + (keyType == null ? "a key column has no type" : "the key type " + keyType + " cannot be used")
+                + " as a HASH index key. Supported key types are: " + supportedKeyTypeNames()
                 + ". Create the index as LSM_TREE instead");
   }
 

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -914,7 +914,9 @@ public class HashIndexBucket extends PaginatedComponent {
       if (keyType == null || !isSupportedKeyType(keyType.getBinaryType()))
         throw new IndexException(
             "Cannot create index '" + indexName + "' of type HASH because "
-                + (keyType == null ? "a key column has no type" : "the key type " + keyType + " cannot be used")
+                // name(), not toString(): the supported set below is built from name(), and an implicit dependency on
+                // Type not overriding toString() would silently report the two in different spellings.
+                + (keyType == null ? "a key column has no type" : "the key type " + keyType.name() + " cannot be used")
                 + " as a HASH index key. Supported key types are: " + SUPPORTED_KEY_TYPE_NAMES
                 + ". Create the index as LSM_TREE instead");
   }

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -81,6 +81,9 @@ public class HashIndexBucket extends PaginatedComponent {
   // huge list (the first problems are enough to know it must be rebuilt).
   static final int MAX_REPORTED_PROBLEMS = 20;
 
+  // The schema types usable as a hash index key, listed in the creation-time refusal. Fixed for the life of the JVM.
+  private static final String SUPPORTED_KEY_TYPE_NAMES = supportedKeyTypeNames();
+
   // Bucket page header offsets (relative to PAGE_HEADER_SIZE)
   static final int BUCKET_LOCAL_DEPTH     = 0;                       // short (2)
   static final int BUCKET_ENTRY_COUNT     = 2;                       // short (2)
@@ -897,6 +900,12 @@ public class HashIndexBucket extends PaginatedComponent {
   /**
    * Validates the key types a hash index is about to be created with, so an unsupported one is refused up front with
    * a message naming it, instead of surfacing as an "unsupported key type" deep inside the first insert (#5677).
+   * <p>
+   * This is called from {@code HashIndexFactoryHandler.create()}, which is the only path that reaches the creation
+   * constructor of {@link HashIndex} (and through it the creation constructor of this class) - every hash index is
+   * built by {@code IndexFactory.createIndex()}. A new construction path must call this too, or it can write a file
+   * whose declared key type the bucket cannot encode; the {@link #loadMetadata} check would then only catch it on the
+   * next open.
    */
   static void checkSupportedKeyTypes(final String indexName, final Type[] keyTypes) {
     if (keyTypes == null)
@@ -906,12 +915,13 @@ public class HashIndexBucket extends PaginatedComponent {
         throw new IndexException(
             "Cannot create index '" + indexName + "' of type HASH because "
                 + (keyType == null ? "a key column has no type" : "the key type " + keyType + " cannot be used")
-                + " as a HASH index key. Supported key types are: " + supportedKeyTypeNames()
+                + " as a HASH index key. Supported key types are: " + SUPPORTED_KEY_TYPE_NAMES
                 + ". Create the index as LSM_TREE instead");
   }
 
   /**
-   * Comma-separated list of the schema types usable as a hash index key, for the creation-time error message.
+   * Comma-separated list of the schema types usable as a hash index key, for the creation-time error message. The set
+   * is fixed at class-load time, so it is built once rather than on every refusal.
    */
   private static String supportedKeyTypeNames() {
     final StringBuilder buffer = new StringBuilder(128);
@@ -984,7 +994,7 @@ public class HashIndexBucket extends PaginatedComponent {
             + "content offset " + offset + "). Declared key types=" + formatKeyTypes()
             + ". No record data is lost: either the index metadata page is damaged, or the index was created on a "
             + "property type HASH does not support. Drop it and recreate it, as LSM_TREE if the key type is not in: "
-            + supportedKeyTypeNames());
+            + SUPPORTED_KEY_TYPE_NAMES);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/hash/HashIndexMetadataCorruptionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/HashIndexMetadataCorruptionTest.java
@@ -108,7 +108,7 @@ class HashIndexMetadataCorruptionTest extends TestHelper {
         .hasMessageContaining(TYPE_NAME)        // names the affected index (the underlying hash bucket of the Account type)
         .hasMessageContaining("-108")           // still reports the offending byte
         .hasMessageContaining("0x94")           // and its hex form
-        .hasMessageContaining("rebuild"));      // tells the operator how to recover
+        .hasMessageContaining("recreate"));     // tells the operator how to recover
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5677HashIndexLinkKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5677HashIndexLinkKeyTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.hash;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.EdgeType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import com.arcadedb.serializer.BinaryTypes;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression for issue #5677: a HASH index whose key is a LINK (a plain {@code LINK} property, or the
+ * {@code @out}/{@code @in} endpoints of an edge type) was accepted at creation and then blew up on the first
+ * insert with "Unsupported key type ... the index metadata or a bucket page is corrupted".
+ *
+ * <p>{@code Type.LINK} serializes as {@code BinaryTypes.TYPE_RID} (14), which the hash bucket's key-size,
+ * compare and validation paths did not know about - only {@code TYPE_COMPRESSED_RID} (13) was handled - so
+ * every key-length computation over such an entry fell through to the "corrupted" branch.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5677HashIndexLinkKeyTest extends TestHelper {
+
+  @Test
+  void uniqueHashIndexOnEdgeEndpointsDeduplicatesEdges() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      final EdgeType edgeType = database.getSchema().createEdgeType("INITIATED");
+      database.getSchema().buildTypeIndex("INITIATED", new String[] { "@out", "@in" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+      assertThat(edgeType.getAllIndexes(false)).hasSize(1);
+    });
+
+    final RID[] endpoints = new RID[2];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account").set("id", 0).save();
+      final MutableVertex leaf = database.newVertex("Account").set("id", 1).save();
+      hub.newEdge("INITIATED", leaf).save();
+      endpoints[0] = hub.getIdentity();
+      endpoints[1] = leaf.getIdentity();
+    });
+
+    // THE SAME PAIR MUST BE REJECTED BY THE UNIQUE CONSTRAINT
+    assertThatThrownBy(() -> database.transaction(() -> {
+      final MutableVertex hub = database.lookupByRID(endpoints[0], true).asVertex().modify();
+      hub.newEdge("INITIATED", database.lookupByRID(endpoints[1], true).asVertex()).save();
+    })).isInstanceOf(DuplicatedKeyException.class);
+
+    // AND THE INDEX MUST ANSWER A LOOKUP ON THE ENDPOINT PAIR
+    database.transaction(() -> {
+      final Index index = database.getSchema().getIndexByName("INITIATED[@out,@in]");
+
+      final IndexCursor found = index.get(new Object[] { endpoints[0], endpoints[1] });
+      assertThat(found.hasNext()).isTrue();
+      found.next();
+      assertThat(found.hasNext()).isFalse();
+
+      // THE REVERSED PAIR IS A DIFFERENT KEY
+      assertThat(index.get(new Object[] { endpoints[1], endpoints[0] }).hasNext()).isFalse();
+
+      assertThat(database.countType("INITIATED", false)).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void uniqueHashIndexOnEdgeEndpointsSurvivesManyDistinctPairs() {
+    final int vertices = 500;
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      database.getSchema().createEdgeType("INITIATED");
+      database.getSchema().buildTypeIndex("INITIATED", new String[] { "@out", "@in" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+    });
+
+    final RID[] rids = new RID[vertices];
+    database.transaction(() -> {
+      for (int i = 0; i < vertices; i++)
+        rids[i] = database.newVertex("Account").set("id", i).save().getIdentity();
+    });
+
+    // FAN OUT FROM VERTEX 0: ENOUGH ENTRIES TO FORCE SEVERAL DIRECTORY DOUBLINGS AND BUCKET SPLITS
+    database.transaction(() -> {
+      final MutableVertex hub = database.lookupByRID(rids[0], true).asVertex().modify();
+      for (int i = 1; i < vertices; i++)
+        hub.newEdge("INITIATED", database.lookupByRID(rids[i], true).asVertex()).save();
+    });
+
+    database.transaction(() -> {
+      final Index index = database.getSchema().getIndexByName("INITIATED[@out,@in]");
+      for (int i = 1; i < vertices; i++)
+        assertThat(index.get(new Object[] { rids[0], rids[i] }).hasNext())//
+            .as("missing entry for pair (0,%d)", i).isTrue();
+
+      assertThat(index.countEntries()).isEqualTo(vertices - 1L);
+    });
+  }
+
+  @Test
+  void uniqueHashIndexOnLinkPropertyEnforcesUniqueness() {
+    database.transaction(() -> {
+      final VertexType library = database.getSchema().createVertexType("Library");
+      final VertexType book = database.getSchema().createVertexType("Book");
+      book.createProperty("library", Type.LINK);
+      database.getSchema().buildTypeIndex("Book", new String[] { "library" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+      assertThat(library.getName()).isEqualTo("Library");
+    });
+
+    final RID[] libraries = new RID[2];
+    database.transaction(() -> {
+      libraries[0] = database.newVertex("Library").set("name", "a").save().getIdentity();
+      libraries[1] = database.newVertex("Library").set("name", "b").save().getIdentity();
+      database.newVertex("Book").set("library", libraries[0]).save();
+      database.newVertex("Book").set("library", libraries[1]).save();
+    });
+
+    assertThatThrownBy(() -> database.transaction(//
+        () -> database.newVertex("Book").set("library", libraries[0]).save()))//
+        .isInstanceOf(DuplicatedKeyException.class);
+
+    database.transaction(() -> {
+      final Index index = database.getSchema().getIndexByName("Book[library]");
+      assertThat(index.get(new Object[] { libraries[1] }).hasNext()).isTrue();
+      // A VERTEX PASSED INSTEAD OF ITS RID MUST RESOLVE TO THE SAME KEY
+      assertThat(index.get(new Object[] { database.lookupByRID(libraries[0], true) }).hasNext()).isTrue();
+    });
+  }
+
+  @Test
+  void nonUniqueHashIndexOnLinkPropertyGroupsRecords() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Library");
+      database.getSchema().createVertexType("Book").createProperty("library", Type.LINK);
+      database.getSchema().buildTypeIndex("Book", new String[] { "library" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(false).create();
+    });
+
+    final RID[] libraries = new RID[2];
+    database.transaction(() -> {
+      libraries[0] = database.newVertex("Library").set("name", "a").save().getIdentity();
+      libraries[1] = database.newVertex("Library").set("name", "b").save().getIdentity();
+      for (int i = 0; i < 10; i++)
+        database.newVertex("Book").set("library", libraries[i % 2]).set("id", i).save();
+    });
+
+    database.transaction(() -> {
+      final Index index = database.getSchema().getIndexByName("Book[library]");
+      for (final RID library : libraries) {
+        int found = 0;
+        final IndexCursor cursor = index.get(new Object[] { library });
+        while (cursor.hasNext()) {
+          cursor.next();
+          ++found;
+        }
+        assertThat(found).isEqualTo(5);
+      }
+    });
+  }
+
+  @Test
+  void deletingAnEdgeRemovesItsEndpointKeyFromTheHashIndex() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      database.getSchema().createEdgeType("INITIATED");
+      database.getSchema().buildTypeIndex("INITIATED", new String[] { "@out", "@in" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+    });
+
+    final RID[] endpoints = new RID[2];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account").set("id", 0).save();
+      final MutableVertex leaf = database.newVertex("Account").set("id", 1).save();
+      hub.newEdge("INITIATED", leaf).save();
+      endpoints[0] = hub.getIdentity();
+      endpoints[1] = leaf.getIdentity();
+    });
+
+    database.transaction(() -> database.command("sql", "DELETE FROM INITIATED"));
+
+    database.transaction(() -> {
+      final Index index = database.getSchema().getIndexByName("INITIATED[@out,@in]");
+      assertThat(index.get(new Object[] { endpoints[0], endpoints[1] }).hasNext()).isFalse();
+
+      // AND THE PAIR CAN BE RE-CREATED
+      final MutableVertex hub = database.lookupByRID(endpoints[0], true).asVertex().modify();
+      hub.newEdge("INITIATED", database.lookupByRID(endpoints[1], true).asVertex()).save();
+    });
+  }
+
+  @Test
+  void linkKeysSurviveAReopen() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Library");
+      database.getSchema().createVertexType("Book").createProperty("library", Type.LINK);
+      database.getSchema().buildTypeIndex("Book", new String[] { "library" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(false).create();
+    });
+
+    final RID[] libraries = new RID[2];
+    database.transaction(() -> {
+      libraries[0] = database.newVertex("Library").set("name", "a").save().getIdentity();
+      libraries[1] = database.newVertex("Library").set("name", "b").save().getIdentity();
+      for (int i = 0; i < 20; i++)
+        database.newVertex("Book").set("library", libraries[i % 2]).set("id", i).save();
+    });
+
+    reopenDatabase();
+
+    database.transaction(() -> {
+      final IndexInternal index = (IndexInternal) database.getSchema().getIndexByName("Book[library]");
+      // THE SCHEMA TYPE MUST BE REPORTED, NOT THE INTERNAL STORAGE ENCODING
+      assertThat(index.getKeyTypes()).containsExactly(Type.LINK);
+      assertThat(index.getBinaryKeyTypes()).containsExactly(BinaryTypes.TYPE_RID);
+      assertThat(index.countEntries()).isEqualTo(20L);
+
+      int found = 0;
+      final IndexCursor cursor = index.get(new Object[] { libraries[0] });
+      while (cursor.hasNext()) {
+        cursor.next();
+        ++found;
+      }
+      assertThat(found).isEqualTo(10);
+    });
+  }
+
+  @Test
+  void sqlEqualityOnALinkPropertyUsesTheHashIndex() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Library");
+      database.getSchema().createVertexType("Book").createProperty("library", Type.LINK);
+      database.getSchema().buildTypeIndex("Book", new String[] { "library" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(false).create();
+    });
+
+    final RID[] libraries = new RID[1];
+    database.transaction(() -> {
+      libraries[0] = database.newVertex("Library").set("name", "a").save().getIdentity();
+      for (int i = 0; i < 5; i++)
+        database.newVertex("Book").set("library", libraries[0]).set("id", i).save();
+    });
+
+    database.transaction(() -> {
+      // THE PLANNER MUST PICK THE HASH INDEX, OTHERWISE THE KEY COERCION BELOW WOULD NEVER BE EXERCISED
+      assertThat(database.query("sql", "EXPLAIN SELECT FROM Book WHERE library = \"" + libraries[0] + "\"")//
+          .next().<Object>getProperty("executionPlan").toString()).contains("FETCH FROM INDEX");
+
+      // A RID PASSED AS A QUOTED STRING MUST BE COERCED TO THE DECLARED LINK KEY TYPE BEFORE THE LOOKUP
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Book WHERE library = \"" + libraries[0] + "\"")) {
+        assertThat(rs.stream().count()).isEqualTo(5);
+      }
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Book WHERE library = " + libraries[0])) {
+        assertThat(rs.stream().count()).isEqualTo(5);
+      }
+    });
+  }
+
+  @Test
+  void sqlCreatedEdgeEndpointHashIndexCanBeRebuilt() {
+    database.command("sql", "CREATE VERTEX TYPE Account");
+    database.command("sql", "CREATE EDGE TYPE INITIATED");
+    database.command("sql", "CREATE INDEX ON INITIATED (`@out`, `@in`) UNIQUE_HASH");
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX Account SET id = 1");
+      database.command("sql", "CREATE VERTEX Account SET id = 2");
+      database.command("sql", "CREATE EDGE INITIATED FROM (SELECT FROM Account WHERE id = 1) "
+          + "TO (SELECT FROM Account WHERE id = 2)");
+    });
+
+    // THE REBUILD REPOPULATES THE HASH BUCKET FROM THE STORED EDGES, EXERCISING THE KEY ENCODING AGAIN
+    database.command("sql", "REBUILD INDEX *");
+
+    database.transaction(() -> {
+      final Index index = database.getSchema().getIndexByName("INITIATED[@out,@in]");
+      assertThat(index.countEntries()).isEqualTo(1L);
+    });
+
+    assertThatThrownBy(() -> database.transaction(//
+        () -> database.command("sql", "CREATE EDGE INITIATED FROM (SELECT FROM Account WHERE id = 1) "
+            + "TO (SELECT FROM Account WHERE id = 2)")))//
+        .isInstanceOf(DuplicatedKeyException.class);
+  }
+
+  @Test
+  void hashIndexRejectsAnUnsupportedKeyTypeAtCreationTime() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("tags", Type.LIST);
+
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex("Doc", new String[] { "tags" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(false).create())//
+          .hasMessageContaining("LIST")//
+          .hasMessageContaining("HASH")//
+          .hasMessageNotContainingAny("corrupt", "rebuild");
+
+      assertThat(database.getSchema().getType("Doc").getAllIndexes(false)).isEmpty();
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5677HashIndexLinkKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5677HashIndexLinkKeyTest.java
@@ -163,6 +163,76 @@ class Issue5677HashIndexLinkKeyTest extends TestHelper {
     });
   }
 
+  /**
+   * A composite key where only SOME columns remap to a different storage encoding. The variable-width compressed RID
+   * sits next to a variable-width STRING, in both orders, so a column whose declared and storage encodings disagree
+   * has to be measured with the storage one for the following column to start at the right offset.
+   */
+  @Test
+  void compositeKeyMixingALinkWithAStringIsReadBackAtTheRightOffsets() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Library");
+
+      final VertexType book = database.getSchema().createVertexType("Book");
+      book.createProperty("library", Type.LINK);
+      book.createProperty("title", Type.STRING);
+      database.getSchema().buildTypeIndex("Book", new String[] { "library", "title" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+
+      // AND THE MIRROR ORDER, SO THE REMAPPED COLUMN IS THE TRAILING ONE TOO
+      final VertexType loan = database.getSchema().createVertexType("Loan");
+      loan.createProperty("borrower", Type.STRING);
+      loan.createProperty("library", Type.LINK);
+      database.getSchema().buildTypeIndex("Loan", new String[] { "borrower", "library" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+    });
+
+    final RID[] libraries = new RID[2];
+    // TITLES OF DELIBERATELY DIFFERENT LENGTHS: A MIS-MEASURED PRECEDING COLUMN WOULD MISALIGN THE STRING THAT FOLLOWS
+    final String[] titles = { "a", "a much longer title than the first one", "" };
+
+    database.transaction(() -> {
+      libraries[0] = database.newVertex("Library").set("name", "a").save().getIdentity();
+      libraries[1] = database.newVertex("Library").set("name", "b").save().getIdentity();
+
+      for (final RID library : libraries)
+        for (final String title : titles) {
+          database.newVertex("Book").set("library", library).set("title", title).save();
+          database.newVertex("Loan").set("borrower", title).set("library", library).save();
+        }
+    });
+
+    database.transaction(() -> {
+      final Index books = database.getSchema().getIndexByName("Book[library,title]");
+      final Index loans = database.getSchema().getIndexByName("Loan[borrower,library]");
+
+      for (final RID library : libraries)
+        for (final String title : titles) {
+          try (final IndexCursor cursor = books.get(new Object[] { library, title })) {
+            assertThat(cursor.hasNext()).as("Book(%s, '%s')", library, title).isTrue();
+            assertThat(cursor.next().asVertex().getString("title")).isEqualTo(title);
+          }
+          try (final IndexCursor cursor = loans.get(new Object[] { title, library })) {
+            assertThat(cursor.hasNext()).as("Loan('%s', %s)", title, library).isTrue();
+            assertThat(cursor.next().asVertex().<RID>get("library")).isEqualTo(library);
+          }
+        }
+
+      assertThat(books.countEntries()).isEqualTo((long) libraries.length * titles.length);
+      assertThat(loans.countEntries()).isEqualTo((long) libraries.length * titles.length);
+
+      // SAME LINK, DIFFERENT STRING MUST NOT COLLIDE, AND NEITHER MUST THE REVERSE
+      try (final IndexCursor cursor = books.get(new Object[] { libraries[0], "not indexed" })) {
+        assertThat(cursor.hasNext()).isFalse();
+      }
+    });
+
+    // AND THE UNIQUE CONSTRAINT STILL DISCRIMINATES ON THE LINK COLUMN ALONE
+    assertThatThrownBy(() -> database.transaction(//
+        () -> database.newVertex("Book").set("library", libraries[0]).set("title", titles[1]).save()))//
+        .isInstanceOf(DuplicatedKeyException.class);
+  }
+
   @Test
   void nonUniqueHashIndexOnLinkPropertyGroupsRecords() {
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5677HashIndexLinkKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5677HashIndexLinkKeyTest.java
@@ -78,13 +78,16 @@ class Issue5677HashIndexLinkKeyTest extends TestHelper {
     database.transaction(() -> {
       final Index index = database.getSchema().getIndexByName("INITIATED[@out,@in]");
 
-      final IndexCursor found = index.get(new Object[] { endpoints[0], endpoints[1] });
-      assertThat(found.hasNext()).isTrue();
-      found.next();
-      assertThat(found.hasNext()).isFalse();
+      try (final IndexCursor found = index.get(new Object[] { endpoints[0], endpoints[1] })) {
+        assertThat(found.hasNext()).isTrue();
+        found.next();
+        assertThat(found.hasNext()).isFalse();
+      }
 
       // THE REVERSED PAIR IS A DIFFERENT KEY
-      assertThat(index.get(new Object[] { endpoints[1], endpoints[0] }).hasNext()).isFalse();
+      try (final IndexCursor reversed = index.get(new Object[] { endpoints[1], endpoints[0] })) {
+        assertThat(reversed.hasNext()).isFalse();
+      }
 
       assertThat(database.countType("INITIATED", false)).isEqualTo(1);
     });
@@ -117,8 +120,9 @@ class Issue5677HashIndexLinkKeyTest extends TestHelper {
     database.transaction(() -> {
       final Index index = database.getSchema().getIndexByName("INITIATED[@out,@in]");
       for (int i = 1; i < vertices; i++)
-        assertThat(index.get(new Object[] { rids[0], rids[i] }).hasNext())//
-            .as("missing entry for pair (0,%d)", i).isTrue();
+        try (final IndexCursor cursor = index.get(new Object[] { rids[0], rids[i] })) {
+          assertThat(cursor.hasNext()).as("missing entry for pair (0,%d)", i).isTrue();
+        }
 
       assertThat(index.countEntries()).isEqualTo(vertices - 1L);
     });
@@ -149,9 +153,13 @@ class Issue5677HashIndexLinkKeyTest extends TestHelper {
 
     database.transaction(() -> {
       final Index index = database.getSchema().getIndexByName("Book[library]");
-      assertThat(index.get(new Object[] { libraries[1] }).hasNext()).isTrue();
+      try (final IndexCursor cursor = index.get(new Object[] { libraries[1] })) {
+        assertThat(cursor.hasNext()).isTrue();
+      }
       // A VERTEX PASSED INSTEAD OF ITS RID MUST RESOLVE TO THE SAME KEY
-      assertThat(index.get(new Object[] { database.lookupByRID(libraries[0], true) }).hasNext()).isTrue();
+      try (final IndexCursor cursor = index.get(new Object[] { database.lookupByRID(libraries[0], true) })) {
+        assertThat(cursor.hasNext()).isTrue();
+      }
     });
   }
 
@@ -176,10 +184,11 @@ class Issue5677HashIndexLinkKeyTest extends TestHelper {
       final Index index = database.getSchema().getIndexByName("Book[library]");
       for (final RID library : libraries) {
         int found = 0;
-        final IndexCursor cursor = index.get(new Object[] { library });
-        while (cursor.hasNext()) {
-          cursor.next();
-          ++found;
+        try (final IndexCursor cursor = index.get(new Object[] { library })) {
+          while (cursor.hasNext()) {
+            cursor.next();
+            ++found;
+          }
         }
         assertThat(found).isEqualTo(5);
       }
@@ -208,7 +217,9 @@ class Issue5677HashIndexLinkKeyTest extends TestHelper {
 
     database.transaction(() -> {
       final Index index = database.getSchema().getIndexByName("INITIATED[@out,@in]");
-      assertThat(index.get(new Object[] { endpoints[0], endpoints[1] }).hasNext()).isFalse();
+      try (final IndexCursor cursor = index.get(new Object[] { endpoints[0], endpoints[1] })) {
+        assertThat(cursor.hasNext()).isFalse();
+      }
 
       // AND THE PAIR CAN BE RE-CREATED
       final MutableVertex hub = database.lookupByRID(endpoints[0], true).asVertex().modify();
@@ -243,10 +254,11 @@ class Issue5677HashIndexLinkKeyTest extends TestHelper {
       assertThat(index.countEntries()).isEqualTo(20L);
 
       int found = 0;
-      final IndexCursor cursor = index.get(new Object[] { libraries[0] });
-      while (cursor.hasNext()) {
-        cursor.next();
-        ++found;
+      try (final IndexCursor cursor = index.get(new Object[] { libraries[0] })) {
+        while (cursor.hasNext()) {
+          cursor.next();
+          ++found;
+        }
       }
       assertThat(found).isEqualTo(10);
     });


### PR DESCRIPTION
Fixes #5677.

## The report

`CREATE INDEX ON INITIATED (\`@out\`, \`@in\`) UNIQUE_HASH` was accepted, then every insert failed:

```
com.arcadedb.index.IndexException: Unsupported key type for hash index 'INITIATED_0_...' (fileId=5): 14 (0x0E)
while parsing entry at content offset 11. Loaded key types=[14(0x0E)=INVALID, 14(0x0E)=INVALID]. This means the
index metadata or a bucket page is corrupted; rebuild the index (DROP and recreate it).
```

`Type.LINK` encodes as `BinaryTypes.TYPE_RID` (14), which the hash bucket's key-size, compare and validation paths
did not recognise - only `TYPE_COMPRESSED_RID` (13) was handled - so every key-length computation over such an entry
fell through to the corruption branch. The same index as `LSM_TREE` works, so endpoint-keyed de-duplication was
LSM-only and nothing said so.

Both defects in the report are real and both are fixed.

## Defect 1: the key type

The issue offered two options: handle `TYPE_RID` alongside `TYPE_COMPRESSED_RID`, or refuse the combination.
**This PR takes a third one that is strictly better than either.**

Adding a `TYPE_RID` case would work, but it bakes in the fixed 4+8 byte encoding: 12 bytes per key column. Instead,
`LINK` keys are now *stored* as `TYPE_COMPRESSED_RID` - the varint form the bucket already uses for every entry
value, at 2-7 bytes. On the composite `(@out, @in)` key that is the whole point of an endpoint-keyed unique index,
that is roughly half the key bytes and therefore half the pages. Both encodings are deterministic and injective, so
hashing and byte comparison are unaffected, and **no new page-format case is introduced at all** - the change reuses
a path that every hash entry already exercises for its value RID.

The metadata page still persists the *schema* type, so the on-disk format is unchanged and
`getKeyTypes()`/`getBinaryKeyTypes()` still report `LINK`/`TYPE_RID`. The compression is internal to the bucket:
`declaredKeyTypes` is what the schema said, `binaryKeyTypes` is what goes on the page.

That split is not cosmetic. `HashIndex.convertKeys()` coerces user-supplied values against the reported types, so
reporting the storage type there would silently stop `WHERE library = "#150:5"` from resolving the string to a RID
and throw a `ClassCastException`. `sqlEqualityOnALinkPropertyUsesTheHashIndex` covers exactly that, and it was
confirmed non-vacuous by reverting the line and watching it fail.

## Defect 2: the message

Nothing was corrupt. The index had never been able to hold that key type, so "rebuild the index (DROP and recreate
it)" pointed at a remedy that could not work and implied data loss that had not occurred.

A key type a hash index cannot encode is now refused **before any file is created**, naming it and the supported set:

```
Cannot create index 'Doc_0_...' of type HASH because the key type LIST cannot be used as a HASH index key.
Supported key types are: BOOLEAN, INTEGER, SHORT, LONG, FLOAT, DOUBLE, DATETIME, STRING, BINARY, LINK, BYTE,
DATE, DECIMAL, DATETIME_MICROS, DATETIME_NANOS, DATETIME_SECOND. Create the index as LSM_TREE instead
```

The runtime error that remains is reachable only from a damaged metadata page or an index created before that
check. It now names the key column, states that no record data is lost, and distinguishes the two causes instead of
asserting corruption. The offending type is read from the metadata, never from the entry being walked, so the old
wording pointed at the wrong artefact as well as the wrong remedy.

## Verification

`Issue5677HashIndexLinkKeyTest` - 9 tests, written first, all failing on the pre-fix tree:

- unique `(@out, @in)`: de-duplicates, rejects the reverse pair as a different key, answers the endpoint lookup
- 499 distinct pairs from one hub, enough to force several directory doublings and bucket splits
- unique and non-unique `LINK` property indexes, including a vertex passed where a RID is expected
- edge delete removes the endpoint key, and the pair can be re-created
- reopen: key types, `countEntries()` and lookups all survive
- SQL equality on a `LINK`, asserting the planner actually picks the index first
- SQL-created `UNIQUE_HASH` on `(@out, @in)` survives `REBUILD INDEX *`
- an unsupported key type is refused at creation, with no index left behind

`HashIndexMetadataCorruptionTest` asserted the literal word "rebuild"; it now asserts "recreate", matching the
reworded message. Its intent - that the error tells the operator how to recover - is unchanged.

Sweep: `*Index*`, `*Schema*`, `*Edge*` over the engine module, 1089 tests. One failure,
`LSMVectorIndexSearcherPoolTest.concurrentSearchesNeverShareASearcher`, a load-sensitive assertion on vector
searcher-pool sizing that passes in isolation and shares no code with this change.