### PR TITLE
fix(engine) #5647: SQL integer arithmetic fails on overflow instead of wrapping, and division by zero is a client error

### DIFF
--- a/docs/5647-sql-integer-arithmetic-overflow-div-zero.md
+++ b/docs/5647-sql-integer-arithmetic-overflow-div-zero.md
@@ -139,8 +139,45 @@ hardcoded `127.0.0.1:248X` assertions reach that other server instead of the tes
 the local environment, not of the test: the IT follows the same hardcoded-port pattern as the merged
 `Issue5545SqlArithmeticErrorHttpStatusIT` and ~117 other server ITs, all of which rely on CI having free ports.
 
-## Follow-up worth filing separately
+## Review cycles
 
+- **Cycle 1** (`a607aca0d`) - approved with observations. One was a real defect in code this PR had not
+  touched: the `Integer` overloads of `PLUS`/`MINUS` guarded on operand signs rather than on whether the answer
+  fits, so `Integer.MAX_VALUE - Integer.MIN_VALUE` returned `-1` and `Integer.MIN_VALUE + Integer.MIN_VALUE`
+  returned `0`. Verified, then fixed in `252bd7709` (defect 3 above) because the issue's premise that the
+  `Integer` path "already does the right thing" was provably false and this PR's headline claim depended on it.
+  Not applied: the lossy `double` fallback in `SLASH.apply(Long, Long)` (out of scope, see above); the
+  suggestion that the tracking doc may not belong in the tree (checked - `docs/<issue>-*.md` is the established
+  convention, 8+ prior examples including the merged #5545).
+- **Cycle 2** (`252bd7709`) - approved, no blocking items. Raised the `Type.increment` parallel path, recorded
+  as a follow-up below rather than fixed here.
+
+## Follow-ups worth filing separately
+
+### `Type.increment` has both of these defects, and it backs `sum()`
+
+Raised in review cycle 2 and confirmed empirically against the compiled class:
+
+```
+Type.increment(Long.MAX_VALUE, 1L)                    = -9223372036854775808
+Type.increment(Integer.MAX_VALUE, Integer.MIN_VALUE)  = -1
+Type.increment(Integer.MIN_VALUE, Integer.MIN_VALUE)  = 0
+```
+
+`engine/src/main/java/com/arcadedb/schema/Type.java:772` is a parallel arithmetic implementation: its
+`Long`+`Long` case is a bare `a.longValue() + b.longValue()`, and its `Integer`+`Integer` guard is the same
+one-directional sign check removed from `MathExpression` here. `SQLFunctionSum` and `SQLFunctionAverage` both
+route through it, so after this PR `select v * 2` fails cleanly on overflow while `select sum(v)` over the same
+values still wraps silently.
+
+Deliberately **not** fixed in this PR. `Type.increment` is a general-purpose utility with its own call graph,
+and making it throw changes aggregation semantics for every query language, which needs its own regression
+suite and its own release note. The existing `TypeTest.incrementIntegerOverflow` only asserts that
+`Integer.MAX_VALUE + 1` becomes a `Long`, so it does not pin the wrap and would not obstruct the fix.
+
+### HA command forwarding degrades a leader's 400 to a 500
+
+Lower confidence than the one above - this one still needs deliberate reproduction before being filed.
 While the local IT run was contending for those ports, a request landed on an unrelated multi-server cluster and
 exposed what looks like a distinct pre-existing defect on the HA command-forwarding path: when a replica forwards
 a command and the leader answers 400 with an `ArithmeticErrorException`, the replica re-wraps it as a

--- a/docs/5647-sql-integer-arithmetic-overflow-div-zero.md
+++ b/docs/5647-sql-integer-arithmetic-overflow-div-zero.md
@@ -42,6 +42,8 @@ inconsistency this issue is about.
 `engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java`, two new private helpers in the
 `Operator` enum plus six overload bodies rewired to them:
 
+Plus the two `Integer` overloads described in defect 3 below, rewritten to widen-then-narrow.
+
 - `exactIntegerArithmetic(op, left, right)` - `Math.addExact` / `subtractExact` / `multiplyExact` / `divideExact`,
   rethrowing the resulting `ArithmeticException` as `ArithmeticErrorException("long overflow")`. Wired into the
   `Long` overloads of `STAR`, `PLUS`, `MINUS` and `SLASH`.
@@ -57,12 +59,34 @@ correct `2147483648`, narrowing back to `Integer` whenever the answer fits. That
 `ArithmeticErrorException extends CommandExecutionException`, so embedded callers catching the broader type are
 unaffected and no HTTP or Bolt handler change was needed.
 
+### 3. The `Integer` overloads of `+` and `-` also wrapped (found in review, cycle 1)
+
+The issue states that "the `Integer` overload already does the right thing by widening to `long`". That premise
+is only half true, and the review of this PR caught it. `PLUS.apply(Integer, Integer)` guarded
+`sum < 0 && left > 0 && right > 0` and `MINUS.apply(Integer, Integer)` guarded
+`result > 0 && left < 0 && right > 0`: both test the **signs of the operands** rather than whether the answer
+fits, so each only ever detected overflow in one direction. Verified:
+
+```
+Integer.MAX_VALUE - Integer.MIN_VALUE  ->  -1   (should be  4294967295)
+Integer.MIN_VALUE + Integer.MIN_VALUE  ->   0   (should be -4294967296)
+```
+
+Both now widen first and narrow back when the answer fits, which is the idiom `STAR.apply(Integer, Integer)`
+already used a few lines above in the same enum. This is the same silent-wrap defect the PR is named for, in
+the same class, so fixing it here keeps the change honest rather than shipping "SQL integer arithmetic no longer
+wraps silently" with two counterexamples left in place. Unlike the `Long` overloads these have somewhere to
+widen to, so the result is a correct value rather than an error.
+
 ### Deliberately unchanged
 
 - Floating-point `/` and `%` keep IEEE 754 semantics (`±Infinity` / `NaN`). Only integer division has no
   representable answer for a zero divisor; this matches the decision taken on the Cypher side in #5163.
-- The `Integer` overloads of `PLUS`/`MINUS`/`STAR` keep their long-upgrade rather than gaining an exact-math
-  guard: they have a representable answer, and `MathExpressionTest:63-64` pins that upgrade.
+- The `Integer` overloads of `PLUS`/`MINUS`/`STAR` widen rather than gaining an exact-math guard: they have a
+  representable answer, and `MathExpressionTest:63-64` pins that upgrade.
+- `SLASH.apply(Long, Long)` keeps its lossy `(double) left / right` fallback for inexact division, raised in
+  review. It predates this issue and narrowing it would change division semantics for every SQL query, which
+  needs its own issue and its own regression suite.
 
 ### Known behavior change beyond the two reported defects
 
@@ -103,7 +127,11 @@ Connected suites re-run green (195 tests): `MathExpressionTest`, `Multiplication
 `CypherFollowUpsIssue5602Test`.
 
 The **full engine suite** was then run to confirm the blast radius, since these operators are shared by every
-SQL arithmetic expression in the product: **10556 tests, 0 failures, 0 errors**, BUILD SUCCESS.
+SQL arithmetic expression in the product: **10556 tests, 0 failures, 0 errors**, BUILD SUCCESS. Re-run after the
+review-cycle-1 `Integer` overload fix: **10557 tests, 0 failures, 0 errors**.
+
+The cycle-1 test was proven to fail first the same way, by stashing only the main-source change and re-running
+it: `expected: 4294967295L but was: -1`.
 
 The server IT was **not** verified locally and is left to CI. Port 2480 on the development machine is held
 permanently by a Homebrew-installed ArcadeDB service, so a `BaseGraphServerTest` server cannot bind it and the

--- a/docs/5647-sql-integer-arithmetic-overflow-div-zero.md
+++ b/docs/5647-sql-integer-arithmetic-overflow-div-zero.md
@@ -133,7 +133,20 @@ review-cycle-1 `Integer` overload fix: **10557 tests, 0 failures, 0 errors**.
 The cycle-1 test was proven to fail first the same way, by stashing only the main-source change and re-running
 it: `expected: 4294967295L but was: -1`.
 
-The server IT was **not** verified locally and is left to CI. Port 2480 on the development machine is held
+The server IT is **green in CI**, confirmed by class name in the `integration-tests` job log rather than by the
+check's colour:
+
+```
+[INFO] Running com.arcadedb.server.Issue5647SqlArithmeticHttpStatusIT
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- in com.arcadedb.server.Issue5647SqlArithmeticHttpStatusIT
+```
+
+That distinction matters here: `.github/workflows/mvn-test.yml` runs both `unit-tests` and `integration-tests`
+with `--fail-never`, so those checks go green even when tests fail - the failures surface only through the
+Tests Reporter step. `build-and-package` runs no ITs at all. The wider IT run reported zero failures and zero
+errors across every module, so this change introduces no IT regressions either.
+
+It was **not** verified locally. Port 2480 on the development machine is held
 permanently by a Homebrew-installed ArcadeDB service, so a `BaseGraphServerTest` server cannot bind it and the
 hardcoded `127.0.0.1:248X` assertions reach that other server instead of the test's own. This is a property of
 the local environment, not of the test: the IT follows the same hardcoded-port pattern as the merged
@@ -151,6 +164,8 @@ the local environment, not of the test: the IT follows the same hardcoded-port p
   convention, 8+ prior examples including the merged #5545).
 - **Cycle 2** (`252bd7709`) - approved, no blocking items. Raised the `Type.increment` parallel path, recorded
   as a follow-up below rather than fixed here.
+
+Final state: **clean approval**, 2 of 4 cycles used.
 
 ## Follow-ups worth filing separately
 

--- a/docs/5647-sql-integer-arithmetic-overflow-div-zero.md
+++ b/docs/5647-sql-integer-arithmetic-overflow-div-zero.md
@@ -1,0 +1,122 @@
+# 5647 - SQL integer arithmetic silently wraps on overflow, and SQL division by zero returns HTTP 500
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5647
+
+Split out of the review of #5631, which closed the last row of #5545 by converting `SQLFunctionAbsoluteValue`
+alone. Both defects below live in `MathExpression.Operator`, are pre-existing, and were out of scope for #5631.
+
+## Root cause
+
+Both are the SQL side of behavior the Cypher engine already has, so the two engines disagreed on the same
+caller mistake. `com.arcadedb.query.opencypher.ast.ArithmeticExpression` is the reference implementation
+(`integerArithmetic` / `checkIntegerDivisorNotZero`, issues #5163, #5164, #5602).
+
+### 1. 64-bit `+`, `-`, `*` wrapped around silently
+
+`MathExpression.Operator.STAR/PLUS/MINUS.apply(Long, Long)` were bare `left * right` / `left + right` /
+`left - right`. With `v` a stored `LONG` holding `Long.MAX_VALUE`, `select v*2` answered `-2` and `select v+1`
+answered `-9223372036854775808`, both with HTTP 200.
+
+The `Integer` overloads are fine: they widen to `long` on overflow, so they always have a representable answer.
+The `Long` overload has nowhere left to widen to. Because `UpdateItem` routes `UPDATE ... SET x *= v` through
+the same operators, the wrong number could be persisted, which makes this a silent data-corruption path rather
+than only a wrong display value.
+
+`SLASH.apply(Long, Long)` belongs to the same family for a less obvious reason: `Long.MIN_VALUE / -1` overflows
+without the JDK raising anything at all, because JLS 15.17.2 defines it to return the dividend.
+
+### 2. Integer `/` and `%` by zero raised a raw `java.lang.ArithmeticException`
+
+`SLASH`/`REM` computed `left % right` with no divisor guard, so `select 1/0` and `select 1%0` let the JDK
+exception escape uncaught. It is not an `ArithmeticErrorException`, so it missed the classification arms #5602
+added in `AbstractServerHttpHandler` and fell through to the generic `catch (Throwable)` arm: HTTP 500 plus a
+full stack trace in the server log, for a pure caller mistake.
+
+The `BigDecimal` overloads had the same defect, confirmed empirically rather than assumed: `BigDecimal.divide`
+and `BigDecimal.remainder` also raise a raw `java.lang.ArithmeticException` on a zero divisor. Leaving that one
+would have meant `v/0` answering 400 for a `LONG` column and 500 for a `DECIMAL` one - the same cross-path
+inconsistency this issue is about.
+
+## Changes
+
+`engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java`, two new private helpers in the
+`Operator` enum plus six overload bodies rewired to them:
+
+- `exactIntegerArithmetic(op, left, right)` - `Math.addExact` / `subtractExact` / `multiplyExact` / `divideExact`,
+  rethrowing the resulting `ArithmeticException` as `ArithmeticErrorException("long overflow")`. Wired into the
+  `Long` overloads of `STAR`, `PLUS`, `MINUS` and `SLASH`.
+- `checkDivisorNotZero(op, zero)` - raises `ArithmeticErrorException("/ by zero")` or `("% by zero")`. Wired into
+  the `Integer`, `Long` and `BigDecimal` overloads of `SLASH` and `REM`. The caller evaluates zero-ness in the
+  operand's own type (`right == 0` vs `right.signum() == 0`), so `BigDecimal` scale does not defeat the check.
+
+`SLASH.apply(Integer, Integer)` additionally widens through `long` so `Integer.MIN_VALUE / -1` returns the
+correct `2147483648`, narrowing back to `Integer` whenever the answer fits. That preserves the existing
+`MathExpressionTest.types()` contract that `1/1` is an `Integer`, and matches the widening idiom `STAR` and
+`PLUS` already used on their `Integer` overloads.
+
+`ArithmeticErrorException extends CommandExecutionException`, so embedded callers catching the broader type are
+unaffected and no HTTP or Bolt handler change was needed.
+
+### Deliberately unchanged
+
+- Floating-point `/` and `%` keep IEEE 754 semantics (`±Infinity` / `NaN`). Only integer division has no
+  representable answer for a zero divisor; this matches the decision taken on the Cypher side in #5163.
+- The `Integer` overloads of `PLUS`/`MINUS`/`STAR` keep their long-upgrade rather than gaining an exact-math
+  guard: they have a representable answer, and `MathExpressionTest:63-64` pins that upgrade.
+
+### Known behavior change beyond the two reported defects
+
+`PLUS`/`MINUS`.`apply(Object, Object)` convert date operands to timestamps and then call the `Long` overload, so
+nanosecond-precision date arithmetic that previously wrapped now raises `ArithmeticErrorException`. Reaching it
+requires summing two timestamps past year 2262; the previous answer was a garbage `Duration`, so failing is the
+better of the two. Noted here rather than special-cased, to avoid a branch with no test to justify it.
+
+Item 1 is a behavior change in the sense the issue calls out - queries that today return a silently wrapped
+number start failing - so it deserves a release note even though the current answer is simply wrong.
+
+## Tests
+
+Both are new files; no existing test was modified or deleted.
+
+- `engine/src/test/java/com/arcadedb/query/sql/parser/Issue5647SqlIntegerArithmeticTest.java` (11 tests) -
+  operator-level assertions for each overflow and each zero divisor, the `Integer` widening boundary, plus
+  end-to-end SQL through `TestHelper.executeInNewDatabase` for the read path, the `1/0` and `1%0` from the issue,
+  and an `UPDATE` that re-reads the record to prove no wrapped value was persisted. Three of the eleven are
+  regression guards that were green before the fix (IEEE semantics, null propagation, arithmetic without
+  overflow).
+- `server/src/test/java/com/arcadedb/server/Issue5647SqlArithmeticHttpStatusIT.java` (4 tests) - the HTTP status
+  codes, since the classification only exists at that boundary. Covers the read path, the auto-commit write path
+  (where the failure arrives wrapped in a `TransactionException`, the shape that historically degraded a client
+  error back to 500), and a non-overflow case that must still answer 200.
+
+### Verification
+
+Proven to fail first: 8 of the 11 engine tests failed against unmodified `main`, each reproducing the reported
+behavior exactly (`expected 2147483648L but was -2147483648`, `java.lang.ArithmeticException: / by zero` at
+`MathExpression$Operator$2.apply:140`, and "Expecting code to raise a throwable" for each silent wrap). The
+three that passed are the regression guards, which is the intended split.
+
+After the fix: 11/11 green.
+
+Connected suites re-run green (195 tests): `MathExpressionTest`, `MultiplicationOverflowTest`,
+`LetDivisionBugTest`, `SQLFunctionAbsoluteValueTest`, `TypeTest`, `Issue5163DivisionByZeroTest`,
+`CypherFollowUpsIssue5602Test`.
+
+The **full engine suite** was then run to confirm the blast radius, since these operators are shared by every
+SQL arithmetic expression in the product: **10556 tests, 0 failures, 0 errors**, BUILD SUCCESS.
+
+The server IT was **not** verified locally and is left to CI. Port 2480 on the development machine is held
+permanently by a Homebrew-installed ArcadeDB service, so a `BaseGraphServerTest` server cannot bind it and the
+hardcoded `127.0.0.1:248X` assertions reach that other server instead of the test's own. This is a property of
+the local environment, not of the test: the IT follows the same hardcoded-port pattern as the merged
+`Issue5545SqlArithmeticErrorHttpStatusIT` and ~117 other server ITs, all of which rely on CI having free ports.
+
+## Follow-up worth filing separately
+
+While the local IT run was contending for those ports, a request landed on an unrelated multi-server cluster and
+exposed what looks like a distinct pre-existing defect on the HA command-forwarding path: when a replica forwards
+a command and the leader answers 400 with an `ArithmeticErrorException`, the replica re-wraps it as a
+`TransactionException` and answers **500** - the same client-error-degraded-to-server-error shape #5545 was
+about, one layer further out. The reported detail also doubles the message (`long overflow -> long overflow`).
+This was observed by accident rather than by design, so it needs deliberate reproduction against a real cluster
+before being filed; it is out of scope here.

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -23,6 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.ArcadeDBException;
+import com.arcadedb.exception.ArithmeticErrorException;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.*;
 import com.arcadedb.utility.DateUtils;
@@ -109,7 +110,7 @@ public class MathExpression extends SimpleNode {
 
       @Override
       public Number apply(final Long left, final Long right) {
-        return left * right;
+        return exactIntegerArithmetic(this, left, right);
       }
 
       @Override
@@ -137,16 +138,24 @@ public class MathExpression extends SimpleNode {
     }, SLASH(10) {
       @Override
       public Number apply(final Integer left, final Integer right) {
-        if (left % right == 0)
-          return left / right;
+        checkDivisorNotZero(this, right == 0);
 
-        return ((double) left) / right;
+        if (left % right != 0)
+          return ((double) left) / right;
+
+        // widening keeps Integer.MIN_VALUE / -1 exact, then narrows back whenever the answer fits
+        final long result = ((long) left) / right;
+        if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE)
+          return (int) result;
+        return result;
       }
 
       @Override
       public Number apply(final Long left, final Long right) {
+        checkDivisorNotZero(this, right == 0);
+
         if (left % right == 0)
-          return left / right;
+          return exactIntegerArithmetic(this, left, right);
 
         return ((double) left) / right;
       }
@@ -163,6 +172,7 @@ public class MathExpression extends SimpleNode {
 
       @Override
       public Number apply(final BigDecimal left, final BigDecimal right) {
+        checkDivisorNotZero(this, right.signum() == 0);
         return left.divide(right, RoundingMode.HALF_UP);
       }
 
@@ -177,11 +187,13 @@ public class MathExpression extends SimpleNode {
     }, REM(10) {
       @Override
       public Number apply(final Integer left, final Integer right) {
+        checkDivisorNotZero(this, right == 0);
         return left % right;
       }
 
       @Override
       public Number apply(final Long left, final Long right) {
+        checkDivisorNotZero(this, right == 0);
         return left % right;
       }
 
@@ -197,6 +209,7 @@ public class MathExpression extends SimpleNode {
 
       @Override
       public Number apply(final BigDecimal left, final BigDecimal right) {
+        checkDivisorNotZero(this, right.signum() == 0);
         return left.remainder(right);
       }
 
@@ -219,7 +232,7 @@ public class MathExpression extends SimpleNode {
 
       @Override
       public Number apply(final Long left, final Long right) {
-        return left + right;
+        return exactIntegerArithmetic(this, left, right);
       }
 
       @Override
@@ -299,7 +312,7 @@ public class MathExpression extends SimpleNode {
 
       @Override
       public Number apply(final Long left, final Long right) {
-        return left - right;
+        return exactIntegerArithmetic(this, left, right);
       }
 
       @Override
@@ -703,6 +716,51 @@ public class MathExpression extends SimpleNode {
       throw new IllegalArgumentException(
           "Cannot increment value '" + a + "' (" + a.getClass() + ") with '" + b + "' (" + b.getClass() + ")");
 
+    }
+
+    /**
+     * Integer division and modulo by zero have no answer, and the JDK reports that as a raw
+     * {@code java.lang.ArithmeticException}. That is not something the HTTP and Bolt layers can classify, so it
+     * escaped as an internal fault (HTTP 500) even though the only thing wrong was the divisor the caller supplied.
+     * Raising an {@link ArithmeticErrorException} instead makes SQL answer 400, which is what the Cypher engine
+     * already did (issues #5163, #5602) and what Neo4j - the OpenCypher reference implementation - calls
+     * {@code Neo.ClientError.Statement.ArithmeticError}.
+     * <p>
+     * Floating-point division keeps IEEE 754 semantics ({@code ±Infinity} / {@code NaN}) and never reaches here,
+     * matching the same decision on the Cypher side.
+     *
+     * @param zero whether the divisor is zero, evaluated by the caller in the operand's own type
+     */
+    private static void checkDivisorNotZero(final Operator op, final boolean zero) {
+      if (zero)
+        throw new ArithmeticErrorException(op == REM ? "% by zero" : "/ by zero");
+    }
+
+    /**
+     * 64-bit {@code +}, {@code -}, {@code *} and {@code /} that fail on overflow instead of wrapping around with
+     * two's-complement semantics (issue #5647), mirroring what the Cypher engine has done since #5164.
+     * <p>
+     * This is deliberately confined to the {@code Long} overloads. The {@code Integer} ones widen to {@code long}
+     * on overflow and so always have a representable answer, but {@code long} has nowhere left to widen to: the
+     * wrapped value was returned as an ordinary result and an {@code UPDATE ... SET} would persist it, making this
+     * a silent data-corruption path rather than only a wrong display value.
+     * <p>
+     * {@code /} is included because {@code Long.MIN_VALUE / -1} overflows without the JDK raising anything at all -
+     * JLS 15.17.2 defines it to return the dividend. A zero divisor is rejected by
+     * {@link #checkDivisorNotZero} before this is reached, so it cannot be reported as an overflow.
+     */
+    private static long exactIntegerArithmetic(final Operator op, final long left, final long right) {
+      try {
+        return switch (op) {
+          case PLUS -> Math.addExact(left, right);
+          case MINUS -> Math.subtractExact(left, right);
+          case STAR -> Math.multiplyExact(left, right);
+          case SLASH -> Math.divideExact(left, right);
+          default -> throw new IllegalStateException("Operator " + op + " has no exact integer form");
+        };
+      } catch (final ArithmeticException e) {
+        throw new ArithmeticErrorException("long overflow", e);
+      }
     }
 
     public int getPriority() {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -223,11 +223,12 @@ public class MathExpression extends SimpleNode {
     }, PLUS(20) {
       @Override
       public Number apply(final Integer left, final Integer right) {
-        final int sum = left + right;
-        if (sum < 0 && left > 0 && right > 0)
-          // SPECIAL CASE: UPGRADE TO LONG
-          return left.longValue() + right;
-        return sum;
+        // widen first, then narrow back when the answer fits: the sign-based guard this replaced only detected
+        // overflow of two positives, so Integer.MIN_VALUE + Integer.MIN_VALUE silently wrapped to 0
+        final long result = ((long) left) + right;
+        if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE)
+          return (int) result;
+        return result;
       }
 
       @Override
@@ -302,11 +303,11 @@ public class MathExpression extends SimpleNode {
     MINUS(20) {
       @Override
       public Number apply(final Integer left, final Integer right) {
-        final int result = left - right;
-        if (result > 0 && left < 0 && right > 0)
-          // SPECIAL CASE: UPGRADE TO LONG
-          return left.longValue() - right;
-
+        // see PLUS: the guard this replaced never fired for a negative subtrahend, so
+        // Integer.MAX_VALUE - Integer.MIN_VALUE silently wrapped to -1
+        final long result = ((long) left) - right;
+        if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE)
+          return (int) result;
         return result;
       }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5647SqlIntegerArithmeticTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5647SqlIntegerArithmeticTest.java
@@ -85,6 +85,27 @@ class Issue5647SqlIntegerArithmeticTest {
   }
 
   /**
+   * The {@code Integer} overloads of {@code +} and {@code -} widened only for two positive operands, because their
+   * guards tested the sign of the operands rather than whether the answer fit. Overflow in the other direction was
+   * therefore returned silently - the same defect as the {@code Long} overloads, on the path the issue assumed was
+   * already correct. Unlike {@code long} these have somewhere to widen to, so the answer is a value, not an error.
+   */
+  @Test
+  void integerAdditionAndSubtractionWidenInBothDirections() {
+    assertThat(MathExpression.Operator.MINUS.apply(Integer.MAX_VALUE, Integer.MIN_VALUE)).isEqualTo(4294967295L);
+    assertThat(MathExpression.Operator.PLUS.apply(Integer.MIN_VALUE, Integer.MIN_VALUE)).isEqualTo(-4294967296L);
+
+    // the directions that already worked must keep working
+    assertThat(MathExpression.Operator.PLUS.apply(Integer.MAX_VALUE, Integer.MAX_VALUE)).isEqualTo(4294967294L);
+    assertThat(MathExpression.Operator.MINUS.apply(Integer.MIN_VALUE, Integer.MAX_VALUE)).isEqualTo(-4294967295L);
+
+    // and the ordinary case still narrows back to Integer rather than promoting everything to Long
+    assertThat(MathExpression.Operator.PLUS.apply(2, 3)).isEqualTo(5);
+    assertThat(MathExpression.Operator.PLUS.apply(2, 3).getClass()).isEqualTo(Integer.class);
+    assertThat(MathExpression.Operator.MINUS.apply(3, 2).getClass()).isEqualTo(Integer.class);
+  }
+
+  /**
    * The raw {@code java.lang.ArithmeticException} the JDK throws here is what reached the HTTP layer uncaught. It
    * has to become an {@link ArithmeticErrorException} on both overloads, since {@code 1/0} uses the {@code Integer}
    * one and a stored {@code LONG} column uses the other.

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5647SqlIntegerArithmeticTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5647SqlIntegerArithmeticTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.ArithmeticErrorException;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5647, covering the two arithmetic defects left in
+ * {@link MathExpression.Operator} after #5631 closed #5545 for {@code abs()} alone.
+ * <p>
+ * Both are the SQL side of behaviour the Cypher engine already has (#5163, #5164, #5602), so the two engines now
+ * answer the same way for the same caller mistake:
+ * <ol>
+ *   <li>64-bit {@code +}, {@code -} and {@code *} wrapped around silently. The {@code Integer} overload widens to
+ *       {@code long} on overflow, but the {@code Long} overload has nowhere left to widen to, so it returned a
+ *       mathematically wrong number that an {@code UPDATE ... SET} would then persist.</li>
+ *   <li>Integer {@code /} and {@code %} by zero escaped as a raw {@code java.lang.ArithmeticException}, which is not
+ *       an {@link ArithmeticErrorException} and so missed the classification the HTTP and Bolt layers apply - a
+ *       caller mistake was reported as an internal fault.</li>
+ * </ol>
+ */
+class Issue5647SqlIntegerArithmeticTest {
+
+  /**
+   * The wrap-around is only reachable on the {@code Long} overload: {@code Integer} operands widen to {@code long}
+   * instead, which is why the two overloads must not be given the same treatment.
+   */
+  @Test
+  void longAdditionSubtractionAndMultiplicationOverflowAreArithmeticErrors() {
+    assertThatThrownBy(() -> MathExpression.Operator.STAR.apply(Long.MAX_VALUE, 2L))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("long overflow");
+
+    assertThatThrownBy(() -> MathExpression.Operator.PLUS.apply(Long.MAX_VALUE, 1L))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("long overflow");
+
+    assertThatThrownBy(() -> MathExpression.Operator.MINUS.apply(Long.MIN_VALUE, 1L))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("long overflow");
+  }
+
+  /**
+   * {@code Long.MIN_VALUE / -1} has no {@code long} answer either, and unlike a zero divisor the JDK does not raise
+   * for it - {@code /} simply returns the dividend (JLS 15.17.2), which is the same silent wrap as the operators
+   * above.
+   */
+  @Test
+  void longDivisionOverflowIsAnArithmeticError() {
+    assertThatThrownBy(() -> MathExpression.Operator.SLASH.apply(Long.MIN_VALUE, -1L))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("long overflow");
+  }
+
+  /**
+   * The same division does have an answer in {@code Integer}, because there the operator can widen - so it must
+   * return the correct value rather than throw. This is the boundary that keeps the {@code Long} guard above from
+   * being over-applied.
+   */
+  @Test
+  void integerDivisionOverflowWidensInsteadOfWrapping() {
+    assertThat(MathExpression.Operator.SLASH.apply(Integer.MIN_VALUE, -1)).isEqualTo(2147483648L);
+  }
+
+  /**
+   * The raw {@code java.lang.ArithmeticException} the JDK throws here is what reached the HTTP layer uncaught. It
+   * has to become an {@link ArithmeticErrorException} on both overloads, since {@code 1/0} uses the {@code Integer}
+   * one and a stored {@code LONG} column uses the other.
+   */
+  @Test
+  void divisionAndModuloByZeroAreArithmeticErrors() {
+    assertThatThrownBy(() -> MathExpression.Operator.SLASH.apply(1, 0))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("/ by zero");
+
+    assertThatThrownBy(() -> MathExpression.Operator.SLASH.apply(1L, 0L))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("/ by zero");
+
+    assertThatThrownBy(() -> MathExpression.Operator.REM.apply(1, 0))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("% by zero");
+
+    assertThatThrownBy(() -> MathExpression.Operator.REM.apply(1L, 0L))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("% by zero");
+  }
+
+  /**
+   * Floating-point division keeps IEEE 754 semantics, matching what the Cypher engine settled on in #5163: only
+   * integer division has no representable answer for a zero divisor.
+   */
+  @Test
+  void floatingPointDivisionByZeroKeepsIeeeSemantics() {
+    assertThat(MathExpression.Operator.SLASH.apply(1d, 0d)).isEqualTo(Double.POSITIVE_INFINITY);
+    assertThat(MathExpression.Operator.SLASH.apply(0d, 0d).doubleValue()).isNaN();
+    assertThat(MathExpression.Operator.SLASH.apply(1f, 0f)).isEqualTo(Float.POSITIVE_INFINITY);
+  }
+
+  /**
+   * The null guard runs before the divisor check, so a null operand must still propagate as null rather than being
+   * reported as a division by zero.
+   */
+  @Test
+  void nullOperandsStillPropagateRatherThanFailing() {
+    assertThat(MathExpression.Operator.SLASH.apply((Object) 20, null)).isNull();
+    assertThat(MathExpression.Operator.REM.apply((Object) 20, null)).isNull();
+  }
+
+  /**
+   * Ordinary arithmetic must be untouched, including the {@code Integer} widening the file already did, so the new
+   * guards cannot turn valid data into a client error.
+   */
+  @Test
+  void arithmeticWithoutOverflowIsUnchanged() {
+    assertThat(MathExpression.Operator.STAR.apply(Long.MAX_VALUE, 1L)).isEqualTo(Long.MAX_VALUE);
+    assertThat(MathExpression.Operator.PLUS.apply(Long.MAX_VALUE - 1, 1L)).isEqualTo(Long.MAX_VALUE);
+    assertThat(MathExpression.Operator.MINUS.apply(Long.MIN_VALUE + 1, 1L)).isEqualTo(Long.MIN_VALUE);
+    assertThat(MathExpression.Operator.SLASH.apply(10L, 2L)).isEqualTo(5L);
+    assertThat(MathExpression.Operator.REM.apply(10L, 3L)).isEqualTo(1L);
+
+    // the Integer overloads still widen instead of wrapping, and still narrow back when the answer fits
+    assertThat(MathExpression.Operator.PLUS.apply(Integer.MAX_VALUE, 1)).isEqualTo(2147483648L);
+    assertThat(MathExpression.Operator.SLASH.apply(1, 1)).isEqualTo(1);
+    assertThat(MathExpression.Operator.SLASH.apply(1, 1).getClass()).isEqualTo(Integer.class);
+    assertThat(MathExpression.Operator.REM.apply(1, 1).getClass()).isEqualTo(Integer.class);
+  }
+
+  /**
+   * {@code BigDecimal} is arbitrary precision so it cannot overflow, but its zero divisor raises the same raw
+   * {@code java.lang.ArithmeticException} the integral overloads did, and reaches the wire layers the same way.
+   */
+  @Test
+  void bigDecimalDivisionAndModuloByZeroAreArithmeticErrors() {
+    assertThatThrownBy(() -> MathExpression.Operator.SLASH.apply(BigDecimal.ONE, BigDecimal.ZERO))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("/ by zero");
+
+    assertThatThrownBy(() -> MathExpression.Operator.REM.apply(BigDecimal.ONE, BigDecimal.ZERO))
+        .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("% by zero");
+  }
+
+  /**
+   * End to end through the SQL engine, which is where the defect was reported. {@code Long.MAX_VALUE} has to arrive
+   * as a stored property rather than a literal, matching how it would reach the operator in a real query.
+   */
+  @Test
+  void queryOverStoredLongMaxValueFailsInsteadOfWrapping() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testIssue5647Overflow", db -> {
+      db.getSchema().createDocumentType("Sample").createProperty("v", Type.LONG);
+      db.transaction(() -> db.newDocument("Sample").set("v", Long.MAX_VALUE).save());
+
+      for (final String expression : new String[] { "v * 2", "v + 1", "v - -1" }) {
+        assertThatThrownBy(() -> {
+          try (final ResultSet rs = db.query("sql", "select " + expression + " as r from Sample")) {
+            rs.next().getProperty("r");
+          }
+        }).as("'%s' must fail rather than wrap", expression)
+            .isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("long overflow");
+      }
+    });
+  }
+
+  /**
+   * The write path is what makes the silent wrap a data-corruption bug rather than a display wart: before the fix
+   * this stored {@code -2} without complaint. The record is re-read afterwards to prove nothing was persisted.
+   */
+  @Test
+  void updateDoesNotPersistAWrappedValue() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testIssue5647Update", db -> {
+      db.getSchema().createDocumentType("Sample").createProperty("v", Type.LONG);
+      db.transaction(() -> db.newDocument("Sample").set("v", Long.MAX_VALUE).save());
+
+      assertThatThrownBy(() -> db.command("sql", "update Sample set v = v * 2"))
+          .isInstanceOf(CommandExecutionException.class).hasMessageContaining("long overflow");
+
+      try (final ResultSet rs = db.query("sql", "select v from Sample")) {
+        assertThat(rs.next().<Long>getProperty("v")).isEqualTo(Long.MAX_VALUE);
+      }
+    });
+  }
+
+  /**
+   * The reported {@code select 1/0} and {@code select 1%0}, which answered HTTP 500 because a raw
+   * {@code java.lang.ArithmeticException} is not something the handler can classify.
+   */
+  @Test
+  void queryDividingByZeroIsAnArithmeticError() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testIssue5647DivZero", db -> {
+      db.getSchema().createDocumentType("Sample");
+      db.transaction(() -> db.newDocument("Sample").set("v", 1).save());
+
+      assertThatThrownBy(() -> {
+        try (final ResultSet rs = db.query("sql", "select 1/0 as r from Sample")) {
+          rs.next().getProperty("r");
+        }
+      }).isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("/ by zero");
+
+      assertThatThrownBy(() -> {
+        try (final ResultSet rs = db.query("sql", "select 1%0 as r from Sample")) {
+          rs.next().getProperty("r");
+        }
+      }).isInstanceOf(ArithmeticErrorException.class).hasMessageContaining("% by zero");
+    });
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/Issue5647SqlArithmeticHttpStatusIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5647SqlArithmeticHttpStatusIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.exception.ArithmeticErrorException;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5647, asserted over HTTP because the status code is the whole point: a raw
+ * {@code java.lang.ArithmeticException} - which is what SQL {@code 1/0} used to raise - is not an
+ * {@link ArithmeticErrorException}, so it missed the classification #5602 added and fell through to the generic
+ * {@code catch (Throwable)} arm as HTTP 500 with a stack trace in the server log, for what is only a caller mistake.
+ * <p>
+ * #5631 converted SQL {@code abs()} alone (issue #5545), so until now the same client error answered 400 in Cypher
+ * and 500 in SQL. The overflow half is covered too, since silently wrapping past {@code Long.MAX_VALUE} answered
+ * 200 with a wrong number rather than failing at all.
+ * <p>
+ * The {@code detail} assertions depend on the server not running in production mode:
+ * {@code AbstractServerHttpHandler.buildErrorBody} emits {@code detail} only when verbose, to avoid leaking the
+ * cause chain to a client probing endpoints. {@code SERVER_MODE} defaults to development, so it is present here.
+ * The status code and the {@code exception} field are asserted independently of that and are the actual subject of
+ * this test - {@code detail} only confirms which arithmetic error was reported.
+ */
+class Issue5647SqlArithmeticHttpStatusIT extends BaseGraphServerTest {
+
+  @Test
+  void sqlDivisionByZeroReturns400() throws Exception {
+    testEachServer(serverIndex -> {
+      executeSql(serverIndex, "CREATE DOCUMENT TYPE Issue5647Div", 200);
+      executeSql(serverIndex, "INSERT INTO Issue5647Div SET v = 1", 200);
+
+      final JSONObject divided = executeSql(serverIndex, "SELECT 1/0 AS r FROM Issue5647Div", 400);
+      assertThat(divided.getString("exception")).isEqualTo(ArithmeticErrorException.class.getName());
+      assertThat(divided.getString("detail")).contains("/ by zero");
+
+      final JSONObject remainder = executeSql(serverIndex, "SELECT 1%0 AS r FROM Issue5647Div", 400);
+      assertThat(remainder.getString("exception")).isEqualTo(ArithmeticErrorException.class.getName());
+      assertThat(remainder.getString("detail")).contains("% by zero");
+    });
+  }
+
+  /**
+   * The overflow arrives as a stored property because {@code Long.MAX_VALUE} arithmetic has to happen on the
+   * {@code Long} overload - an integer literal would widen to {@code long} instead of overflowing.
+   */
+  @Test
+  void sqlIntegerOverflowReturns400OnTheReadPath() throws Exception {
+    testEachServer(serverIndex -> {
+      createLongMaxValueRecord(serverIndex, "Issue5647Read");
+
+      for (final String expression : new String[] { "v * 2", "v + 1" }) {
+        final JSONObject json = executeSql(serverIndex, "SELECT " + expression + " AS r FROM Issue5647Read", 400);
+        assertThat(json.getString("exception")).isEqualTo(ArithmeticErrorException.class.getName());
+        assertThat(json.getString("detail")).contains("long overflow");
+      }
+    });
+  }
+
+  /**
+   * The write path is what made the silent wrap a data-corruption bug: this used to answer 200 and persist
+   * {@code -2}. It also exercises the auto-commit wrapper, which re-wraps the failure as a
+   * {@code TransactionException} - the shape that historically degraded a client error back to 500.
+   */
+  @Test
+  void sqlIntegerOverflowReturns400OnTheWritePath() throws Exception {
+    testEachServer(serverIndex -> {
+      createLongMaxValueRecord(serverIndex, "Issue5647Write");
+
+      final JSONObject json = executeSql(serverIndex, "UPDATE Issue5647Write SET v = v * 2", 400);
+      assertThat(json.getString("exception")).isEqualTo(ArithmeticErrorException.class.getName());
+      assertThat(json.getString("detail")).contains("long overflow");
+      assertThat(json.getString("error")).doesNotContain("Error on transaction commit");
+
+      // nothing was persisted: the wrapped -2 must not have reached storage
+      assertThat(executeSql(serverIndex, "SELECT v FROM Issue5647Write", 200).getJSONArray("result")
+          .getJSONObject(0).getLong("v")).isEqualTo(Long.MAX_VALUE);
+    });
+  }
+
+  /**
+   * Arithmetic that does have an answer must still answer 200, so the new guards cannot turn ordinary data into a
+   * client error. Division by a non-zero divisor and a product that stays in range are the two boundaries.
+   */
+  @Test
+  void sqlArithmeticWithoutOverflowStillReturns200() throws Exception {
+    testEachServer(serverIndex -> {
+      executeSql(serverIndex, "CREATE DOCUMENT TYPE Issue5647Ok", 200);
+      executeSql(serverIndex, "CREATE PROPERTY Issue5647Ok.v LONG", 200);
+      executeSql(serverIndex, "INSERT INTO Issue5647Ok SET v = 4611686018427387903", 200);
+
+      assertThat(executeSql(serverIndex, "SELECT v * 2 AS r FROM Issue5647Ok", 200).getJSONArray("result")
+          .getJSONObject(0).getLong("r")).isEqualTo(9223372036854775806L);
+
+      assertThat(executeSql(serverIndex, "SELECT 10/2 AS r FROM Issue5647Ok", 200).getJSONArray("result")
+          .getJSONObject(0).getLong("r")).isEqualTo(5L);
+    });
+  }
+
+  private void createLongMaxValueRecord(final int serverIndex, final String typeName) throws Exception {
+    executeSql(serverIndex, "CREATE DOCUMENT TYPE " + typeName, 200);
+    executeSql(serverIndex, "CREATE PROPERTY " + typeName + ".v LONG", 200);
+    executeSql(serverIndex, "INSERT INTO " + typeName + " SET v = 9223372036854775807", 200);
+  }
+
+  private JSONObject executeSql(final int serverIndex, final String command, final int expectedStatus) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/graph").openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    connection.setDoOutput(true);
+    try {
+      final JSONObject payload = new JSONObject().put("language", "sql").put("command", command);
+      try (final PrintWriter pw = new PrintWriter(new OutputStreamWriter(connection.getOutputStream()))) {
+        pw.write(payload.toString());
+      }
+
+      final int statusCode = connection.getResponseCode();
+      final String response = expectedStatus == 200 ? readResponse(connection) : readError(connection);
+
+      assertThat(statusCode)
+          .as("'%s' must return %d, got %d (body=%s)", command, expectedStatus, statusCode, response)
+          .isEqualTo(expectedStatus);
+
+      return new JSONObject(response);
+    } finally {
+      connection.disconnect();
+    }
+  }
+}


### PR DESCRIPTION
Closes #5647

Both defects live in `MathExpression.Operator`, are pre-existing, and are the SQL side of behavior the Cypher engine already had (#5163, #5164, #5602) - so until now the two engines disagreed on the identical caller mistake. #5631 closed #5545 by converting `SQLFunctionAbsoluteValue` alone.

**1. 64-bit `+`, `-`, `*` wrapped silently.** With `v` a stored `LONG` holding `Long.MAX_VALUE`, `select v*2` answered `-2` and `select v+1` answered `-9223372036854775808`, both HTTP 200. `UpdateItem` routes `UPDATE ... SET` through the same operators, so the wrong number could be persisted - silent data corruption, not just a wrong display value. The `Integer` overloads are fine because they widen to `long`; the `Long` overload has nowhere left to widen to.

**2. Integer `/` and `%` by zero raised a raw `java.lang.ArithmeticException`.** Not being an `ArithmeticErrorException`, it missed the classification arms #5602 added and fell through to the generic `catch (Throwable)` arm: HTTP 500 plus a stack trace in the server log, for a pure caller mistake.

Both are fixed by two helpers in the `Operator` enum. `exactIntegerArithmetic` uses `Math.addExact`/`subtractExact`/`multiplyExact`/`divideExact` and rethrows as `ArithmeticErrorException("long overflow")`; `checkDivisorNotZero` raises `"/ by zero"` / `"% by zero"`. `ArithmeticErrorException extends CommandExecutionException`, so embedded callers are unaffected and no HTTP or Bolt handler change was needed.

Two things found while probing that the issue did not list, both folded in because leaving them would have kept the same inconsistency alive on a neighbouring path:

- `Long.MIN_VALUE / -1` overflows with **no JDK exception at all** - JLS 15.17.2 defines it to return the dividend - so `divideExact` covers it.
- The `BigDecimal` overloads raise the same raw `java.lang.ArithmeticException` on a zero divisor. Without the guard, `v/0` would answer 400 for a `LONG` column and 500 for a `DECIMAL` one.

`SLASH.apply(Integer, Integer)` additionally widens through `long` so `Integer.MIN_VALUE / -1` returns the correct `2147483648`, narrowing back whenever the answer fits - preserving the existing `MathExpressionTest.types()` contract that `1/1` is an `Integer`.

**Deliberately unchanged:** floating-point `/` and `%` keep IEEE 754 semantics (`±Infinity` / `NaN`), matching the Cypher decision in #5163; the `Integer` overloads of `PLUS`/`MINUS`/`STAR` keep their long-upgrade rather than gaining an exact-math guard, since they always have a representable answer.

**Behavior change worth a release note:** as the issue anticipates, queries that today return a silently wrapped number now fail. There is also a narrower consequence documented in the tracking doc: `PLUS`/`MINUS` convert date operands to timestamps and call the `Long` overload, so nanosecond date arithmetic that previously wrapped now raises. Reaching it requires summing two timestamps past year 2262, where the previous answer was a garbage `Duration`.

## Test plan

- [x] `Issue5647SqlIntegerArithmeticTest` (11 new engine tests) - **proven to fail first**: 8 of 11 failed against unmodified code, each reproducing the reported behavior (`expected 2147483648L but was -2147483648`, `java.lang.ArithmeticException: / by zero` at `MathExpression$Operator$2.apply:140`, and "Expecting code to raise a throwable" per silent wrap). The 3 that passed are deliberate regression guards (IEEE semantics, null propagation, arithmetic without overflow). 11/11 green after the fix.
- [x] Connected suites green (195 tests): `MathExpressionTest`, `MultiplicationOverflowTest`, `LetDivisionBugTest`, `SQLFunctionAbsoluteValueTest`, `TypeTest`, `Issue5163DivisionByZeroTest`, `CypherFollowUpsIssue5602Test`.
- [x] **Full engine suite: 10556 tests, 0 failures, 0 errors.** Run because these operators back every SQL arithmetic expression in the product.
- [ ] `Issue5647SqlArithmeticHttpStatusIT` (4 new server ITs) - **left to CI, not verified locally.** Port 2480 on the dev machine is held permanently by a Homebrew ArcadeDB service, so a `BaseGraphServerTest` server cannot bind it and the hardcoded `127.0.0.1:248X` assertions reach that other server. The IT follows the same pattern as the merged `Issue5545SqlArithmeticErrorHttpStatusIT` and ~117 other server ITs. **Please confirm this one goes green in CI before merging.**

No existing test was modified or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)