### PR TITLE
fix(engine) #5655: execute Cypher statements against the replicated database instance

### DIFF
--- a/docs/5655-opencypher-commits-on-inner-database.md
+++ b/docs/5655-opencypher-commits-on-inner-database.md
@@ -84,7 +84,8 @@ Not changed, and why:
 ## Test
 
 `Issue5655CypherCommitsOnInnerDatabaseIT`, a Cypher analogue of `Issue5492TruncateBatchNotReplicatedIT`:
-2-node cluster, one test per exposed path.
+2-node cluster, one test per exposed path, plus one that pins the entry-point decision
+(`PROFILE MATCH ... SET` through `query()`).
 
 Each asserts `ArcadeStateMachine.TEST_WAL_GAP_COUNTER` *before* querying the follower. A resync reinstalls
 the follower's database and a count issued after it throws `DatabaseIsClosed`, which reads like
@@ -120,7 +121,31 @@ auto-committed or an explicit `COMMIT` ran. Off HA nothing changes:
 
 - The rule is recorded in `ha-raft/CLAUDE.md` under "Anything that commits must hold the WRAPPED database
   instance, not the inner one". Two engines have now needed it. The remaining query engines (gremlin,
-  graphql, mongodbw) hold the same field shape and have not been audited against it.
+  graphql, mongodbw) hold the same field shape and have not been audited against it. **Not filed** - worth
+  an issue, since this is a class of bug that stays green under smoke tests.
 - The steps that call `begin()`/`commit()` directly rather than going through `transaction()` also forgo its
   MVCC retry loop, which `CreateStep` gets for free. That is a separate concern from replication and is not
   touched here.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5688
+
+### Review cycles
+
+**Cycle 1 - `2c6f4a4`.** `claude[bot]`: approve with one substantive finding. No inline comments; the review
+was posted as a PR issue comment.
+
+Both of the bot's claims were checked against the code before acting rather than taken on trust:
+
+| Finding | Verified | Action |
+|---|---|---|
+| The `isReadOnly()`-over-entry-point decision has no regression test, and `PROFILE MATCH ... SET` is exactly what a refactor back to entry-point switching would silently break | Confirmed: `LocalDatabase.query()` applies no idempotency gate of its own, and `RaftReplicatedDatabase.query()` on a leader delegates to `proxied.query()`, so the statement does reach the engine and write | Applied: third IT `profiledCypherWriteThroughQueryReachesFollowers` |
+| `executeTransaction()` still built `ResultInternal` from the raw `database` | Confirmed harmless: `ResultInternal(Database)` only stores the reference for `getDatabase()`. But the method otherwise reads as "everything here is `txDatabase`", and leaving one raw use is the inconsistency the fix exists to remove | Applied |
+| gremlin/graphql/mongodbw hold the same field shape and deserve an audit issue | Agreed, out of scope for this PR | Recorded above as an unfiled follow-up, for the developer to file |
+
+The new test was proven to fail before trusting it: with `executionDatabase()` temporarily stubbed to
+`return database`, `profiledCypherWriteThroughQueryReachesFollowers` fails at line 199 with
+`expected: 1L but was: 0L`. The stub was then reverted and the full set re-run green.
+
+No items were deferred.

--- a/docs/5655-opencypher-commits-on-inner-database.md
+++ b/docs/5655-opencypher-commits-on-inner-database.md
@@ -128,55 +128,39 @@ auto-committed or an explicit `COMMIT` ran. Off HA nothing changes:
 ## Follow-ups
 
 - The rule is recorded in `ha-raft/CLAUDE.md` under "Anything that commits must hold the WRAPPED database
-  instance, not the inner one". Two engines have now needed it. The remaining query engines (gremlin,
-  graphql, mongodbw) hold the same field shape and have not been audited against it. **Not filed** - worth
-  an issue, since this is a class of bug that stays green under smoke tests.
+  instance, not the inner one".
 - The steps that call `begin()`/`commit()` directly rather than going through `transaction()` also forgo its
   MVCC retry loop, which `CreateStep` gets for free. That is a separate concern from replication and is not
   touched here.
 
 ## PR
 
-https://github.com/ArcadeData/arcadedb/pull/5688
+https://github.com/ArcadeData/arcadedb/pull/5688 - four review cycles, all approving. Cycle-by-cycle
+process notes live in the PR thread; what follows is only the part that stayed relevant to the code.
 
-### Review cycles
+### Points settled during review
 
-**Cycle 1 - `2c6f4a4`.** `claude[bot]`: approve with one substantive finding. No inline comments; the review
-was posted as a PR issue comment.
+- **`PROFILE MATCH ... SET` is why the switch is on `isReadOnly()`.** Review asked for the design decision to
+  be pinned by a test rather than a comment, which is fair: it is the case a refactor back to entry-point
+  switching would silently break. `profiledCypherWriteThroughQueryReachesFollowers` covers it, and was
+  confirmed to fail with `executionDatabase()` stubbed to `return database`.
+- **Which read path actually carries the read-consistency barrier.** An early draft of the rationale listed
+  `lookupByRID`/`iterateType` alongside `query()`. Only `query(language, ...)` opens with
+  `waitForReadConsistency()` (`RaftReplicatedDatabase.java:1274`, `:1281`, `:1287`); the other three delegate
+  straight to the inner instance. Since `ExistsExpression`, `CountExpression` and `CollectExpression` all
+  evaluate their subqueries through `query()`, the conclusion holds - but on that one method, not on reads
+  generally.
+- **Mixed instances inside an explicit transaction are intentional.** After `START TRANSACTION` a read-only
+  `MATCH` runs on the raw instance and a write on the wrapper. Safe because the transaction lives in the
+  thread-local `DatabaseContext` keyed by database path, shared by both handles, and reads never commit.
+  Recorded in the `executionDatabase()` Javadoc.
+- **`ROLLBACK` has no dedicated replication test.** It commits nothing, so such a test could only assert an
+  absence. Deliberately skipped.
 
-Both of the bot's claims were checked against the code before acting rather than taken on trust:
+## Follow-up worth filing
 
-| Finding | Verified | Action |
-|---|---|---|
-| The `isReadOnly()`-over-entry-point decision has no regression test, and `PROFILE MATCH ... SET` is exactly what a refactor back to entry-point switching would silently break | Confirmed: `LocalDatabase.query()` applies no idempotency gate of its own, and `RaftReplicatedDatabase.query()` on a leader delegates to `proxied.query()`, so the statement does reach the engine and write | Applied: third IT `profiledCypherWriteThroughQueryReachesFollowers` |
-| `executeTransaction()` still built `ResultInternal` from the raw `database` | Confirmed harmless: `ResultInternal(Database)` only stores the reference for `getDatabase()`. But the method otherwise reads as "everything here is `txDatabase`", and leaving one raw use is the inconsistency the fix exists to remove | Applied |
-| gremlin/graphql/mongodbw hold the same field shape and deserve an audit issue | Agreed, out of scope for this PR | Recorded above as an unfiled follow-up, for the developer to file |
-
-The new test was proven to fail before trusting it: with `executionDatabase()` temporarily stubbed to
-`return database`, `profiledCypherWriteThroughQueryReachesFollowers` fails at line 199 with
-`expected: 1L but was: 0L`. The stub was then reverted and the full set re-run green.
-
-**Cycle 2 - `ee366ae`.** `claude[bot]`: approve, no blocking items.
-
-| Finding | Verified | Action |
-|---|---|---|
-| `executeDDL()` still holds the inner instance - "very likely fine", but worth closing the loop | Confirmed structurally: `LocalSchema` is built with `wrappedDatabaseInstance` at `LocalDatabase.java:2433` | Applied: added `cypherDDLReachesFollowers`. Reading a constructor is weaker than watching an index land on a follower, and the test costs one cluster start |
-| Local `executionDatabase` shadows the method name | Style only | Applied: renamed to `execDb` |
-| The "Review cycles" section will age oddly under `docs/` as a permanent file | Fair | **Not applied** - the orchestrating skill mandates this section. Kept, and raised at handoff so the developer can trim it at merge, which is the right place for that call |
-
-Note on the DDL test: it is a **guard, not a reproducer**. It passes with or without the fix, because the DDL
-path was never broken. It is here so that a future change moving DDL off the schema layer cannot do so
-silently.
-
-**Cycle 3 - `3d4e151`.** `claude[bot]`: approve, two non-blocking observations.
-
-| Finding | Verified | Action |
-|---|---|---|
-| The read-only rationale is overstated: the read-consistency barrier sits at the wrapper's top-level entry, not on the low-level reads the steps make | **Half right.** `lookupByRID`/`iterateType`/`lookupByKey` (`RaftReplicatedDatabase.java:1133-1155`) do delegate with no barrier - so naming them was wrong. But `query(language, ...)` (`:1274`, `:1281`, `:1287`) *does* open with `waitForReadConsistency()`, and `ExistsExpression`/`CountExpression`/`CollectExpression` evaluate their subqueries through exactly that call | Applied, but not as suggested. The bot proposed trimming the claim; the accurate repair was to narrow it to `query()` and say explicitly that the other three are indifferent. The conclusion stands on firmer ground than before |
-| `ROLLBACK` on the wrapper is only indirectly exercised | Correct, and self-limiting: `rollback()` commits nothing, so a replication test over it could only assert an absence | Skipped, rationale recorded. The bot rates it low risk for the same reason |
-| A tracking issue for the gremlin/graphql/mongodbw audit | Agreed | Still unfiled - the developer's call, surfaced at handoff |
-
-This is the one cycle where a bot claim did not survive checking as stated. Taking the suggested trim at face
-value would have removed a true statement about `query()` along with the false one about `lookupByRID`.
-
-No items were deferred.
+`gremlin`, `graphql` and `mongodbw` hold the same `private final DatabaseInternal database` field shape and
+have never been audited against the "anything that commits must hold the wrapped instance" rule. Two engines
+have now needed it (#5492 SQL, #5655 Cypher), and both hid the same way: nothing throws at the mistake, and
+the paths that happen to route through `database.transaction(...)` stay green and mask the ones that do not.
+Raised in review three times; not filed here because that is the maintainer's call.

--- a/docs/5655-opencypher-commits-on-inner-database.md
+++ b/docs/5655-opencypher-commits-on-inner-database.md
@@ -1,0 +1,126 @@
+# #5655 - OpenCypherQueryEngine commits on the inner LocalDatabase, bypassing Raft replication
+
+Cypher half of #5492. The SQL half shipped as #5652.
+
+## Root cause
+
+`OpenCypherQueryEngine` holds `private final DatabaseInternal database`, assigned in the constructor. On an
+HA leader that is the inner `LocalDatabase`: `RaftReplicatedDatabase.getQueryEngine()` delegates to
+`proxied.getQueryEngine()`, so the engine is built with the inner instance. The engine then handed that
+instance to everything it executed.
+
+`LocalDatabase.commit()` writes pages locally. `RaftReplicatedDatabase.commit()` proposes them to Raft and
+*then* writes. A commit on the inner instance succeeds, applies its pages on the leader, and replicates
+nothing. Nothing throws where the mistake is made.
+
+Two paths reach such a commit, and they fail independently:
+
+1. **The explicit `COMMIT` statement.** `executeTransaction()` ran `database.begin()` / `database.commit()` /
+   `database.rollback()` straight against the field. `commit()` is the only one of the three where the two
+   instances differ; `begin()` and `rollback()` delegate to the inner database on the wrapper too.
+
+2. **Auto-commit of a write step.** `CypherExecutionPlan` does `context.setDatabase(database)` with whatever
+   the engine handed it, and `SetStep`, `DeleteStep`, `MergeStep`, `RemoveStep`, `ForeachStep` and a writing
+   `CALL` subquery each call `begin()`/`commit()` **directly** on `context.getDatabase()` when no transaction
+   is already open.
+
+### Why a Cypher smoke test would have stayed green
+
+`CreateStep` is not affected. It wraps its work in `context.getDatabase().transaction(...)`, and
+`LocalDatabase.transaction()` drives `wrappedDatabaseInstance` internally rather than `this`
+(`LocalDatabase.java:1395-1403`). So a bare `CREATE` always replicated correctly while an equally ordinary
+`SET` in the same session did not. That asymmetry is the reason this survived alongside a passing Cypher HA
+suite, and it is worth remembering: "does it go through `transaction()` or call `commit()` directly?" is the
+question that separates the safe steps from the exposed ones.
+
+### Resolving the two items the issue left unverified
+
+The issue filed this as code-shape-matches, not reproduced. Both open questions are now answered:
+
+1. **Is an explicit Cypher transaction reachable across the wrapper on a leader?** Yes. `LocalDatabase.command()`
+   opens no transaction of its own, so `START TRANSACTION` / write / `COMMIT` issued as three commands on one
+   thread binds through the thread-local `DatabaseContext` and commits on the inner instance.
+2. **Are autocommit Cypher writes already covered by the wrapper's commit finalization?** No, and the
+   exposure is not uniform. It depends on which step runs: the `transaction()`-based steps were always safe,
+   the ones that call `commit()` directly were not.
+
+Both are reproduced by the new test, and the harness's own `DatabaseComparator` teardown independently
+reports the divergence as `Page PageId(graph/28/0) has different versions on databases. DB1 2 <> DB2 1`.
+
+## Fix
+
+Same resolution as #5652: resolve `getWrappedDatabaseInstance()` for anything that can commit. Off HA it
+returns the instance itself, so it is a no-op there.
+
+- New `executionDatabase(CypherStatement)` supplies the database the execution plan is built with, and
+  therefore what `CommandContext.getDatabase()` returns for every step in the tree, subqueries included -
+  all of it flows from that one argument.
+- `executeTransaction()` resolves the wrapper for `begin`/`commit`/`rollback`, so the statement never
+  straddles both instances.
+
+**The switch is on `statement.isReadOnly()`, not on the entry point.** A read-only statement cannot commit,
+so resolving the wrapper would change nothing about durability, while it *would* route the reads the steps
+issue (`query`, `lookupByRID`, `iterateType`) through `RaftReplicatedDatabase` and subject follower-local
+reads to the wrapper's read-consistency barriers. #5652 achieved the same separation by leaving `query()`
+alone, but that shortcut does not hold for Cypher: `PROFILE` bypasses the idempotency gate and executes, so
+`PROFILE MATCH ... SET ...` arrives through `query()` and does write. `isReadOnly()` is computed at parse
+time and already accounts for writes nested in a `CALL` subquery (`SimpleCypherStatement:152`), so it is the
+right authority.
+
+Not changed, and why:
+
+- `executeDDL()` goes through `database.getSchema()`; `LocalSchema` is constructed with
+  `wrappedDatabaseInstance`, so schema DDL already replicates.
+- `executeAdmin()` operates on the server security manager, not on database pages.
+- `executeSession()` only evaluates an expression to store a session parameter; it never commits.
+
+## Files
+
+| File | Change |
+|---|---|
+| `engine/.../query/opencypher/query/OpenCypherQueryEngine.java` | `executionDatabase()` helper; used in `execute()` and `executeTransaction()` |
+| `ha-raft/src/test/java/.../Issue5655CypherCommitsOnInnerDatabaseIT.java` | new regression test |
+
+## Test
+
+`Issue5655CypherCommitsOnInnerDatabaseIT`, a Cypher analogue of `Issue5492TruncateBatchNotReplicatedIT`:
+2-node cluster, one test per exposed path.
+
+Each asserts `ArcadeStateMachine.TEST_WAL_GAP_COUNTER` *before* querying the follower. A resync reinstalls
+the follower's database and a count issued after it throws `DatabaseIsClosed`, which reads like
+infrastructure noise rather than the divergence that caused it.
+
+Proven to fail before the fix:
+
+```
+[ERROR] Issue5655CypherCommitsOnInnerDatabaseIT.autocommitCypherWriteStepReachesFollowers:151
+        [the value written by the auto-committing SET step must reach the follower] expected: 1L but was: 0L
+[ERROR] Issue5655CypherCommitsOnInnerDatabaseIT.explicitCypherCommitReachesFollowers:102
+        [a write committed through the Cypher COMMIT statement must reach the follower] expected: 1L but was: 0L
+```
+
+## Verification
+
+| Suite | Result |
+|---|---|
+| `Issue5655CypherCommitsOnInnerDatabaseIT` | 2/2 pass (both failed before the fix) |
+| `engine` module, full | 7826 pass, 0 failures, 98 skipped |
+| `Issue5492*IT` (SQL half, cross-regression) | 3/3 pass |
+
+Server-module Cypher ITs (`Issue4141SessionManagementIT` and siblings, the transaction control over HTTP
+path) could not be run locally: port 2480 is held by a local service, so those ITs are CI-only here.
+
+## Impact
+
+Every HA deployment issuing Cypher writes through the `opencypher` engine was affected whenever a write step
+auto-committed or an explicit `COMMIT` ran. Off HA nothing changes:
+`LocalDatabase.getWrappedDatabaseInstance()` returns `this`.
+
+## Follow-ups
+
+- The rule is recorded in `ha-raft/CLAUDE.md` under "Anything that commits must hold the WRAPPED database
+  instance, not the inner one". Two engines have now needed it. The remaining query engines (gremlin,
+  graphql, mongodbw) hold the same field shape and have not been audited against it.
+- The steps that call `begin()`/`commit()` directly rather than going through `transaction()` also forgo its
+  MVCC retry loop, which `CreateStep` gets for free. That is a separate concern from replication and is not
+  touched here.

--- a/docs/5655-opencypher-commits-on-inner-database.md
+++ b/docs/5655-opencypher-commits-on-inner-database.md
@@ -59,9 +59,13 @@ returns the instance itself, so it is a no-op there.
   straddles both instances.
 
 **The switch is on `statement.isReadOnly()`, not on the entry point.** A read-only statement cannot commit,
-so resolving the wrapper would change nothing about durability, while it *would* route the reads the steps
-issue (`query`, `lookupByRID`, `iterateType`) through `RaftReplicatedDatabase` and subject follower-local
-reads to the wrapper's read-consistency barriers. #5652 achieved the same separation by leaving `query()`
+so resolving the wrapper would change nothing about durability, while it *would* put the nested reads the
+steps issue on a different footing. Precisely which ones matters:
+`RaftReplicatedDatabase.lookupByRID`/`iterateType`/`lookupByKey` delegate straight to the inner instance and
+are indifferent, but its `query(language, ...)` overloads open with `waitForReadConsistency()`, and
+`ExistsExpression`, `CountExpression` and `CollectExpression` each evaluate their subquery through that call.
+Routing read-only statements through the wrapper would add a read barrier to every
+`EXISTS`/`COUNT`/`COLLECT` subquery, follower-local ones included. #5652 achieved the same separation by leaving `query()`
 alone, but that shortcut does not hold for Cypher: `PROFILE` bypasses the idempotency gate and executes, so
 `PROFILE MATCH ... SET ...` arrives through `query()` and does write. `isReadOnly()` is computed at parse
 time and already accounts for writes nested in a `CALL` subquery (`SimpleCypherStatement:152`), so it is the
@@ -163,5 +167,16 @@ The new test was proven to fail before trusting it: with `executionDatabase()` t
 Note on the DDL test: it is a **guard, not a reproducer**. It passes with or without the fix, because the DDL
 path was never broken. It is here so that a future change moving DDL off the schema layer cannot do so
 silently.
+
+**Cycle 3 - `3d4e151`.** `claude[bot]`: approve, two non-blocking observations.
+
+| Finding | Verified | Action |
+|---|---|---|
+| The read-only rationale is overstated: the read-consistency barrier sits at the wrapper's top-level entry, not on the low-level reads the steps make | **Half right.** `lookupByRID`/`iterateType`/`lookupByKey` (`RaftReplicatedDatabase.java:1133-1155`) do delegate with no barrier - so naming them was wrong. But `query(language, ...)` (`:1274`, `:1281`, `:1287`) *does* open with `waitForReadConsistency()`, and `ExistsExpression`/`CountExpression`/`CollectExpression` evaluate their subqueries through exactly that call | Applied, but not as suggested. The bot proposed trimming the claim; the accurate repair was to narrow it to `query()` and say explicitly that the other three are indifferent. The conclusion stands on firmer ground than before |
+| `ROLLBACK` on the wrapper is only indirectly exercised | Correct, and self-limiting: `rollback()` commits nothing, so a replication test over it could only assert an absence | Skipped, rationale recorded. The bot rates it low risk for the same reason |
+| A tracking issue for the gremlin/graphql/mongodbw audit | Agreed | Still unfiled - the developer's call, surfaced at handoff |
+
+This is the one cycle where a bot claim did not survive checking as stated. Taking the suggested trim at face
+value would have removed a true statement about `query()` along with the false one about `lookupByRID`.
 
 No items were deferred.

--- a/docs/5655-opencypher-commits-on-inner-database.md
+++ b/docs/5655-opencypher-commits-on-inner-database.md
@@ -70,7 +70,11 @@ right authority.
 Not changed, and why:
 
 - `executeDDL()` goes through `database.getSchema()`; `LocalSchema` is constructed with
-  `wrappedDatabaseInstance`, so schema DDL already replicates.
+  `wrappedDatabaseInstance` (`LocalDatabase.java:2433`), so schema DDL already replicates regardless of which
+  instance the engine holds - which is also why SQL DDL replicated before #5492 was found. Since the whole
+  class of bug is "committed on the wrong instance", this one is pinned by a test
+  (`cypherDDLReachesFollowers`) rather than left as an argument from the constructor. That test is a guard,
+  not a reproducer: it passes with or without the fix, by design.
 - `executeAdmin()` operates on the server security manager, not on database pages.
 - `executeSession()` only evaluates an expression to store a session parameter; it never commits.
 
@@ -104,8 +108,8 @@ Proven to fail before the fix:
 
 | Suite | Result |
 |---|---|
-| `Issue5655CypherCommitsOnInnerDatabaseIT` | 2/2 pass (both failed before the fix) |
-| `engine` module, full | 7826 pass, 0 failures, 98 skipped |
+| `Issue5655CypherCommitsOnInnerDatabaseIT` | 4/4 pass; the 3 reproducers each proven to fail without the fix |
+| `engine` module, full | 10684 pass, 0 failures, 23 skipped |
 | `Issue5492*IT` (SQL half, cross-regression) | 3/3 pass |
 
 Server-module Cypher ITs (`Issue4141SessionManagementIT` and siblings, the transaction control over HTTP
@@ -147,5 +151,17 @@ Both of the bot's claims were checked against the code before acting rather than
 The new test was proven to fail before trusting it: with `executionDatabase()` temporarily stubbed to
 `return database`, `profiledCypherWriteThroughQueryReachesFollowers` fails at line 199 with
 `expected: 1L but was: 0L`. The stub was then reverted and the full set re-run green.
+
+**Cycle 2 - `ee366ae`.** `claude[bot]`: approve, no blocking items.
+
+| Finding | Verified | Action |
+|---|---|---|
+| `executeDDL()` still holds the inner instance - "very likely fine", but worth closing the loop | Confirmed structurally: `LocalSchema` is built with `wrappedDatabaseInstance` at `LocalDatabase.java:2433` | Applied: added `cypherDDLReachesFollowers`. Reading a constructor is weaker than watching an index land on a follower, and the test costs one cluster start |
+| Local `executionDatabase` shadows the method name | Style only | Applied: renamed to `execDb` |
+| The "Review cycles" section will age oddly under `docs/` as a permanent file | Fair | **Not applied** - the orchestrating skill mandates this section. Kept, and raised at handoff so the developer can trim it at merge, which is the right place for that call |
+
+Note on the DDL test: it is a **guard, not a reproducer**. It passes with or without the fix, because the DDL
+path was never broken. It is here so that a future change moving DDL off the schema layer cannot do so
+silently.
 
 No items were deferred.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -382,6 +382,12 @@ public class OpenCypherQueryEngine implements QueryEngine {
    * {@link #query} does not imply read-only here: {@code PROFILE} bypasses the idempotency gate and executes, so a
    * {@code PROFILE MATCH ... SET ...} reaches this method through {@code query()} and does write.
    *
+   * One consequence worth knowing before you touch this: inside an explicit transaction the two instances are
+   * deliberately mixed. {@code START TRANSACTION} opens on the wrapper, a read-only {@code MATCH} then runs against
+   * the raw instance and a write in the same transaction against the wrapper. That is safe because the transaction
+   * lives in the thread-local {@link DatabaseContext} keyed by database path, which both handles share, and because
+   * a read never commits - so both see one transaction and only one of them can end it.
+   *
    * @param statement the statement about to be planned, whose {@code isReadOnly()} already accounts for writes
    *                  nested in a {@code CALL} subquery
    */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -323,6 +323,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
       final Map<String, Object> parameters, final boolean explain, final boolean profile) {
     // Try to get cached physical plan first (saves optimization time: 200-500ms)
     final CypherExecutionPlan plan;
+    final DatabaseInternal executionDatabase = executionDatabase(statement);
 
     if (!explain && !profile) {
       // Only use plan cache for normal execution (not explain/profile)
@@ -330,10 +331,10 @@ public class OpenCypherQueryEngine implements QueryEngine {
       if (physicalPlan != null) {
         // Reuse cached physical plan (avoids expensive statistics collection and optimization)
         plan = new CypherExecutionPlan(
-            database, statement, parameters, configuration, physicalPlan, EXPRESSION_EVALUATOR);
+            executionDatabase, statement, parameters, configuration, physicalPlan, EXPRESSION_EVALUATOR);
       } else {
         // Create new plan from scratch and cache it
-        final CypherExecutionPlanner planner = new CypherExecutionPlanner(database, statement, parameters,
+        final CypherExecutionPlanner planner = new CypherExecutionPlanner(executionDatabase, statement, parameters,
             EXPRESSION_EVALUATOR);
         plan = planner.createExecutionPlan(configuration);
 
@@ -343,7 +344,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
       }
     } else {
       // explain/profile mode: always create new plan without caching
-      final CypherExecutionPlanner planner = new CypherExecutionPlanner(database, statement, parameters,
+      final CypherExecutionPlanner planner = new CypherExecutionPlanner(executionDatabase, statement, parameters,
           EXPRESSION_EVALUATOR);
       plan = planner.createExecutionPlan(configuration);
     }
@@ -353,6 +354,35 @@ public class OpenCypherQueryEngine implements QueryEngine {
     if (profile)
       return plan.profile();
     return plan.execute();
+  }
+
+  /**
+   * The database a Cypher plan executes against, and therefore the one {@code CommandContext.getDatabase()} returns.
+   * <p>
+   * The write steps auto-commit: {@code SetStep}, {@code DeleteStep}, {@code MergeStep}, {@code RemoveStep},
+   * {@code ForeachStep} and a writing {@code CALL} subquery each call {@code begin()}/{@code commit()} directly on
+   * {@code context.getDatabase()} when no transaction is already open. Handing them the raw instance sends those
+   * commits to {@code LocalDatabase.commit()}, which on an HA leader applies the pages locally and never proposes
+   * them to Raft: followers then trail by exactly those page versions and the next replicated entry touching one of
+   * them fails the version check (#5492, #5655). Off HA the wrapper is the instance itself, so this is a no-op there.
+   * <p>
+   * {@code CreateStep} would be safe either way - it wraps its work in {@code database.transaction(...)}, and
+   * {@code LocalDatabase.transaction()} drives {@code wrappedDatabaseInstance} internally rather than {@code this}.
+   * That is why a bare {@code CREATE} replicated correctly while an equally ordinary {@code SET} did not, and it is
+   * the kind of asymmetry that makes a smoke test look green.
+   * <p>
+   * A read-only statement keeps the raw instance. It cannot commit, so resolving the wrapper would change nothing
+   * about durability, while it would route the reads the steps issue ({@code query}, {@code lookupByRID},
+   * {@code iterateType}) through {@code RaftReplicatedDatabase} and subject follower-local reads to the wrapper's
+   * read-consistency barriers. The switch is on {@code isReadOnly()} rather than on the entry point because
+   * {@link #query} does not imply read-only here: {@code PROFILE} bypasses the idempotency gate and executes, so a
+   * {@code PROFILE MATCH ... SET ...} reaches this method through {@code query()} and does write.
+   *
+   * @param statement the statement about to be planned, whose {@code isReadOnly()} already accounts for writes
+   *                  nested in a {@code CALL} subquery
+   */
+  private DatabaseInternal executionDatabase(final CypherStatement statement) {
+    return statement.isReadOnly() ? database : database.getWrappedDatabaseInstance();
   }
 
   /**
@@ -668,6 +698,11 @@ public class OpenCypherQueryEngine implements QueryEngine {
     final InternalResultSet resultSet = new InternalResultSet();
     final ResultInternal result = new ResultInternal(database);
 
+    // The transaction this statement drives has to be the replicated one - see executionDatabase(). COMMIT is the
+    // only kind where the two instances differ (begin/rollback delegate to the inner database on the Raft wrapper
+    // too), but all three resolve it so the statement never straddles both.
+    final DatabaseInternal txDatabase = database.getWrappedDatabaseInstance();
+
     switch (txn.getKind()) {
     case BEGIN:
       final String isolationLevel = txn.getIsolationLevel();
@@ -682,20 +717,20 @@ public class OpenCypherQueryEngine implements QueryEngine {
           throw new CommandParsingException(
               "Invalid transaction isolation level '" + isolationLevel + "'. Valid values: " + validLevels);
         }
-        database.begin(level);
+        txDatabase.begin(level);
       } else
-        database.begin();
+        txDatabase.begin();
       result.setProperty("operation", "begin");
       break;
     case COMMIT:
-      if (!database.isTransactionActive())
+      if (!txDatabase.isTransactionActive())
         throw new CommandExecutionException("No active transaction to COMMIT (issue a START TRANSACTION first)");
-      database.commit();
+      txDatabase.commit();
       result.setProperty("operation", "commit");
       break;
     case ROLLBACK:
-      // database.rollback() is idempotent: with no active transaction it is a no-op, so ROLLBACK is lenient.
-      database.rollback();
+      // rollback() is idempotent: with no active transaction it is a no-op, so ROLLBACK is lenient.
+      txDatabase.rollback();
       result.setProperty("operation", "rollback");
       break;
     default:

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -372,9 +372,13 @@ public class OpenCypherQueryEngine implements QueryEngine {
    * the kind of asymmetry that makes a smoke test look green.
    * <p>
    * A read-only statement keeps the raw instance. It cannot commit, so resolving the wrapper would change nothing
-   * about durability, while it would route the reads the steps issue ({@code query}, {@code lookupByRID},
-   * {@code iterateType}) through {@code RaftReplicatedDatabase} and subject follower-local reads to the wrapper's
-   * read-consistency barriers. The switch is on {@code isReadOnly()} rather than on the entry point because
+   * about durability, while it would put the nested reads the steps issue on a different footing. Being precise
+   * about which ones: {@code RaftReplicatedDatabase.lookupByRID}/{@code iterateType}/{@code lookupByKey} delegate
+   * straight to the inner instance, so those are indifferent - but its {@code query(language, ...)} overloads open
+   * with {@code waitForReadConsistency()}, and {@code ExistsExpression}, {@code CountExpression} and
+   * {@code CollectExpression} all evaluate their subquery through exactly that call. Routing a read-only statement
+   * through the wrapper would therefore add a read barrier to every {@code EXISTS}/{@code COUNT}/{@code COLLECT}
+   * subquery, follower-local ones included. The switch is on {@code isReadOnly()} rather than on the entry point because
    * {@link #query} does not imply read-only here: {@code PROFILE} bypasses the idempotency gate and executes, so a
    * {@code PROFILE MATCH ... SET ...} reaches this method through {@code query()} and does write.
    *

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -323,7 +323,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
       final Map<String, Object> parameters, final boolean explain, final boolean profile) {
     // Try to get cached physical plan first (saves optimization time: 200-500ms)
     final CypherExecutionPlan plan;
-    final DatabaseInternal executionDatabase = executionDatabase(statement);
+    final DatabaseInternal execDb = executionDatabase(statement);
 
     if (!explain && !profile) {
       // Only use plan cache for normal execution (not explain/profile)
@@ -331,10 +331,10 @@ public class OpenCypherQueryEngine implements QueryEngine {
       if (physicalPlan != null) {
         // Reuse cached physical plan (avoids expensive statistics collection and optimization)
         plan = new CypherExecutionPlan(
-            executionDatabase, statement, parameters, configuration, physicalPlan, EXPRESSION_EVALUATOR);
+            execDb, statement, parameters, configuration, physicalPlan, EXPRESSION_EVALUATOR);
       } else {
         // Create new plan from scratch and cache it
-        final CypherExecutionPlanner planner = new CypherExecutionPlanner(executionDatabase, statement, parameters,
+        final CypherExecutionPlanner planner = new CypherExecutionPlanner(execDb, statement, parameters,
             EXPRESSION_EVALUATOR);
         plan = planner.createExecutionPlan(configuration);
 
@@ -344,7 +344,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
       }
     } else {
       // explain/profile mode: always create new plan without caching
-      final CypherExecutionPlanner planner = new CypherExecutionPlanner(executionDatabase, statement, parameters,
+      final CypherExecutionPlanner planner = new CypherExecutionPlanner(execDb, statement, parameters,
           EXPRESSION_EVALUATOR);
       plan = planner.createExecutionPlan(configuration);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -695,13 +695,13 @@ public class OpenCypherQueryEngine implements QueryEngine {
    * balance each START TRANSACTION with its own COMMIT/ROLLBACK.
    */
   private ResultSet executeTransaction(final CypherTransactionStatement txn) {
-    final InternalResultSet resultSet = new InternalResultSet();
-    final ResultInternal result = new ResultInternal(database);
-
     // The transaction this statement drives has to be the replicated one - see executionDatabase(). COMMIT is the
     // only kind where the two instances differ (begin/rollback delegate to the inner database on the Raft wrapper
     // too), but all three resolve it so the statement never straddles both.
     final DatabaseInternal txDatabase = database.getWrappedDatabaseInstance();
+
+    final InternalResultSet resultSet = new InternalResultSet();
+    final ResultInternal result = new ResultInternal(txDatabase);
 
     switch (txn.getKind()) {
     case BEGIN:

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
@@ -291,20 +291,30 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
     return await(expected, () -> markedCountOn(serverIndex, typeName));
   }
 
+  /**
+   * Polls until the count reaches {@code expected} or the deadline passes, then returns whatever was last read
+   * successfully.
+   * <p>
+   * On timeout it deliberately returns that last good reading rather than a sentinel, so the assertion reports the
+   * state the follower is actually stuck in - {@code but was: 0L}, the write never arrived - instead of a
+   * {@code -1L} that says only "the helper gave up" and hides which of the two happened. {@code -1} survives to the
+   * assertion only when every single attempt threw, which is itself the distinct diagnosis: the follower never
+   * became queryable at all.
+   */
   private long await(final long expected, final LongSupplier supplier) throws InterruptedException {
     final long deadline = System.currentTimeMillis() + 30_000;
-    long count = -1;
+    long lastRead = -1;
     while (System.currentTimeMillis() < deadline) {
       try {
-        count = supplier.getAsLong();
-        if (count == expected)
-          return count;
+        lastRead = supplier.getAsLong();
+        if (lastRead == expected)
+          return lastRead;
       } catch (final RuntimeException e) {
-        // Mid-resync the database is closed and being reinstalled; keep polling until the deadline.
-        count = -1;
+        // Mid-resync the database is closed and being reinstalled; keep polling until the deadline. The previous
+        // good reading is kept: it describes the follower better than the fact that one poll hit a resync window.
       }
       Thread.sleep(250);
     }
-    return count;
+    return lastRead;
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.Database;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5655, the Cypher half of #5492: {@code OpenCypherQueryEngine} held the inner
+ * {@code LocalDatabase} and handed it to everything it executed, so the commits that happen inside Cypher
+ * execution went to {@code LocalDatabase.commit()} on an HA leader - pages published locally, nothing
+ * proposed to Raft. Followers then trail by exactly those page versions and the next replicated entry
+ * touching one of them fails its version check with {@code WALVersionGapException}.
+ * <p>
+ * Two distinct paths reach that commit, and they fail independently, so each has its own test:
+ * <ul>
+ *   <li>the explicit {@code COMMIT} statement, which {@code executeTransaction()} runs straight against
+ *       the engine's field;</li>
+ *   <li>the auto-commit of a write step - {@code SetStep}, {@code DeleteStep}, {@code MergeStep},
+ *       {@code RemoveStep}, {@code ForeachStep} - which calls {@code begin()}/{@code commit()} directly on
+ *       {@code context.getDatabase()} when no transaction is already open.</li>
+ * </ul>
+ * {@code CreateStep} is deliberately not covered: it wraps its work in {@code database.transaction(...)},
+ * and {@code LocalDatabase.transaction()} drives {@code wrappedDatabaseInstance} internally, so a bare
+ * {@code CREATE} already replicated. That asymmetry is why a Cypher smoke test over CREATE alone stayed
+ * green while SET and the explicit COMMIT lost their writes.
+ * <p>
+ * Each test asserts the WAL gap counter <em>before</em> querying the follower: a resync reinstalls the
+ * follower's database, and a count issued after it throws {@code DatabaseIsClosed}, which reads like
+ * infrastructure noise rather than the divergence that caused it.
+ */
+@Tag("slow")
+class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
+
+  private static final String TYPE_EXPLICIT_TX = "CypherExplicitTxNode";
+  private static final String TYPE_AUTOCOMMIT  = "CypherAutocommitNode";
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  @AfterEach
+  void cleanupHooks() {
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = null;
+  }
+
+  /**
+   * {@code START TRANSACTION} / write / {@code COMMIT} issued through the Cypher engine. The COMMIT is the
+   * only one of the three that differs between the two instances: {@code begin()} and {@code rollback()}
+   * delegate to the inner database on the Raft wrapper too, {@code commit()} is where the proposal happens.
+   */
+  @Test
+  void explicitCypherCommitReachesFollowers() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = 1 - leaderIndex;
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.command("sql", "CREATE VERTEX TYPE " + TYPE_EXPLICIT_TX);
+    waitForAllServers();
+
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
+
+    leaderDb.command("cypher", "START TRANSACTION");
+    leaderDb.command("cypher", "CREATE (n:" + TYPE_EXPLICIT_TX + " {id: 1})");
+    leaderDb.command("cypher", "COMMIT");
+
+    assertThat(countOn(leaderIndex, TYPE_EXPLICIT_TX)).as("leader wrote the vertex").isEqualTo(1);
+
+    waitForAllServers();
+
+    assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
+        .as("follower must see no WAL version gap: the Cypher COMMIT has to be proposed to Raft")
+        .isZero();
+
+    assertThat(awaitCountOn(followerIndex, TYPE_EXPLICIT_TX, 1))
+        .as("a write committed through the Cypher COMMIT statement must reach the follower")
+        .isEqualTo(1);
+
+    // A page bumped on the leader but not on the follower does not fail until something touches it again,
+    // so an ordinary replicated write into the same bucket is what surfaces a gap that survived the above.
+    leaderDb.command("sql", "INSERT INTO " + TYPE_EXPLICIT_TX + " SET id = 2");
+    waitForAllServers();
+
+    assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
+        .as("no WAL version gap after a subsequent ordinary write into the same bucket")
+        .isZero();
+    assertThat(awaitCountOn(followerIndex, TYPE_EXPLICIT_TX, 2))
+        .as("follower converges with the leader after the subsequent ordinary write")
+        .isEqualTo(2);
+  }
+
+  /**
+   * Auto-commit {@code SET} with no transaction open. {@code SetStep} opens its own transaction and commits
+   * it on {@code context.getDatabase()}, which is whatever the engine handed the execution plan - so this
+   * fails even though the {@code CREATE} that seeded the vertex replicated correctly.
+   */
+  @Test
+  void autocommitCypherWriteStepReachesFollowers() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = 1 - leaderIndex;
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.command("sql", "CREATE VERTEX TYPE " + TYPE_AUTOCOMMIT);
+    leaderDb.command("cypher", "CREATE (n:" + TYPE_AUTOCOMMIT + " {id: 1, marked: 0})");
+
+    waitForAllServers();
+    assertThat(awaitCountOn(followerIndex, TYPE_AUTOCOMMIT, 1))
+        .as("baseline replicated before the SET: CREATE routes through database.transaction() and is unaffected")
+        .isEqualTo(1);
+
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
+
+    leaderDb.command("cypher", "MATCH (n:" + TYPE_AUTOCOMMIT + " {id: 1}) SET n.marked = 1");
+
+    assertThat(markedCountOn(leaderIndex)).as("leader applied the SET").isEqualTo(1);
+
+    waitForAllServers();
+
+    assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
+        .as("follower must see no WAL version gap: the write step's auto-commit has to be proposed to Raft")
+        .isZero();
+
+    assertThat(awaitMarkedCountOn(followerIndex, 1))
+        .as("the value written by the auto-committing SET step must reach the follower")
+        .isEqualTo(1);
+  }
+
+  /**
+   * Counts through a freshly resolved database handle. A snapshot resync reinstalls the follower's database, so a
+   * handle cached before it throws {@code DatabaseIsClosed} - which reads like an infrastructure failure rather than
+   * the divergence that caused it.
+   */
+  private long countOn(final int serverIndex, final String typeName) {
+    // count(id) rather than count(*): the latter reads a cached per-bucket counter, which is the wrong tool
+    // when the question is whether the pages themselves arrived.
+    final Database db = getServerDatabase(serverIndex, getDatabaseName());
+    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + typeName).next().getProperty("cnt"))
+        .longValue();
+  }
+
+  private long markedCountOn(final int serverIndex) {
+    final Database db = getServerDatabase(serverIndex, getDatabaseName());
+    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + TYPE_AUTOCOMMIT + " WHERE marked = 1")
+        .next().getProperty("cnt")).longValue();
+  }
+
+  private long awaitCountOn(final int serverIndex, final String typeName, final long expected)
+      throws InterruptedException {
+    return await(expected, () -> countOn(serverIndex, typeName));
+  }
+
+  private long awaitMarkedCountOn(final int serverIndex, final long expected) throws InterruptedException {
+    return await(expected, () -> markedCountOn(serverIndex));
+  }
+
+  private long await(final long expected, final LongSupplier supplier) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    long count = -1;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        count = supplier.getAsLong();
+        if (count == expected)
+          return count;
+      } catch (final RuntimeException e) {
+        // Mid-resync the database is closed and being reinstalled; keep polling until the deadline.
+        count = -1;
+      }
+      Thread.sleep(250);
+    }
+    return count;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.schema.Schema;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -62,6 +63,7 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
   private static final String TYPE_EXPLICIT_TX = "CypherExplicitTxNode";
   private static final String TYPE_AUTOCOMMIT  = "CypherAutocommitNode";
   private static final String TYPE_PROFILE     = "CypherProfileNode";
+  private static final String TYPE_DDL         = "CypherDDLNode";
 
   @Override
   protected int getServerCount() {
@@ -200,6 +202,41 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
   }
 
   /**
+   * Cypher DDL is the one write-shaped path this fix deliberately leaves on the raw instance, so it gets a test
+   * rather than an argument.
+   * <p>
+   * {@code executeDDL()} runs against {@code database.getSchema()}, and {@code LocalSchema} is constructed with
+   * {@code wrappedDatabaseInstance} (`LocalDatabase.java:2433`), so the schema layer replicates regardless of which
+   * instance the engine holds - which is also why SQL DDL replicated before #5492 was found. Given that the whole
+   * class of bug is "committed on the wrong instance", reading the constructor is weaker evidence than watching an
+   * index appear on a follower.
+   */
+  @Test
+  void cypherDDLReachesFollowers() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = 1 - leaderIndex;
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
+
+    leaderDb.command("cypher", "CREATE INDEX FOR (n:" + TYPE_DDL + ") ON (n.code)").close();
+
+    assertThat(indexedPropertyExistsOn(leaderIndex)).as("leader created the index").isTrue();
+
+    waitForAllServers();
+
+    assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
+        .as("no WAL version gap from Cypher DDL")
+        .isZero();
+
+    assertThat(awaitIndexOn(followerIndex))
+        .as("a Cypher CREATE INDEX must reach the follower: the schema layer holds the wrapped instance already")
+        .isTrue();
+  }
+
+  /**
    * Counts through a freshly resolved database handle. A snapshot resync reinstalls the follower's database, so a
    * handle cached before it throws {@code DatabaseIsClosed} - which reads like an infrastructure failure rather than
    * the divergence that caused it.
@@ -216,6 +253,32 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
     final Database db = getServerDatabase(serverIndex, getDatabaseName());
     return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + typeName + " WHERE marked = 1")
         .next().getProperty("cnt")).longValue();
+  }
+
+  /**
+   * True when the follower has both the type and an index covering {@code code}. Resolved through a fresh handle for
+   * the same reason as {@link #countOn}.
+   */
+  private boolean indexedPropertyExistsOn(final int serverIndex) {
+    final Database db = getServerDatabase(serverIndex, getDatabaseName());
+    final Schema schema = db.getSchema();
+    if (!schema.existsType(TYPE_DDL))
+      return false;
+    return schema.getType(TYPE_DDL).getIndexByProperties("code") != null;
+  }
+
+  private boolean awaitIndexOn(final int serverIndex) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        if (indexedPropertyExistsOn(serverIndex))
+          return true;
+      } catch (final RuntimeException e) {
+        // Mid-resync the database is closed and being reinstalled; keep polling until the deadline.
+      }
+      Thread.sleep(250);
+    }
+    return false;
   }
 
   private long awaitCountOn(final int serverIndex, final String typeName, final long expected)

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
@@ -43,6 +43,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       {@code RemoveStep}, {@code ForeachStep} - which calls {@code begin()}/{@code commit()} directly on
  *       {@code context.getDatabase()} when no transaction is already open.</li>
  * </ul>
+ * A third test pins the entry point rather than the commit site: a write can reach execution through
+ * {@code query()} via {@code PROFILE}, which is why the fix keys off {@code isReadOnly()} instead of off
+ * {@code command()}-vs-{@code query()} as the SQL fix could.
+ * <p>
  * {@code CreateStep} is deliberately not covered: it wraps its work in {@code database.transaction(...)},
  * and {@code LocalDatabase.transaction()} drives {@code wrappedDatabaseInstance} internally, so a bare
  * {@code CREATE} already replicated. That asymmetry is why a Cypher smoke test over CREATE alone stayed
@@ -57,6 +61,7 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
 
   private static final String TYPE_EXPLICIT_TX = "CypherExplicitTxNode";
   private static final String TYPE_AUTOCOMMIT  = "CypherAutocommitNode";
+  private static final String TYPE_PROFILE     = "CypherProfileNode";
 
   @Override
   protected int getServerCount() {
@@ -138,7 +143,7 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
 
     leaderDb.command("cypher", "MATCH (n:" + TYPE_AUTOCOMMIT + " {id: 1}) SET n.marked = 1");
 
-    assertThat(markedCountOn(leaderIndex)).as("leader applied the SET").isEqualTo(1);
+    assertThat(markedCountOn(leaderIndex, TYPE_AUTOCOMMIT)).as("leader applied the SET").isEqualTo(1);
 
     waitForAllServers();
 
@@ -146,8 +151,51 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
         .as("follower must see no WAL version gap: the write step's auto-commit has to be proposed to Raft")
         .isZero();
 
-    assertThat(awaitMarkedCountOn(followerIndex, 1))
+    assertThat(awaitMarkedCountOn(followerIndex, TYPE_AUTOCOMMIT, 1))
         .as("the value written by the auto-committing SET step must reach the follower")
+        .isEqualTo(1);
+  }
+
+  /**
+   * The reason {@code executionDatabase()} switches on {@code isReadOnly()} rather than on the entry point, which is
+   * how the SQL fix (#5652) drew the same line.
+   * <p>
+   * {@code query()} does not imply read-only on this engine: {@code PROFILE} deliberately bypasses the idempotency
+   * gate so a plan can be inspected under execution, so {@code PROFILE MATCH ... SET ...} arrives through
+   * {@code query()} and writes. Switching on the entry point would leave exactly this statement committing on the
+   * inner instance, and nothing else in the suite would notice - which is what makes it worth its own test rather
+   * than a comment. It also covers the uncached branch of {@code execute()}, since profile mode never uses the plan
+   * cache.
+   */
+  @Test
+  void profiledCypherWriteThroughQueryReachesFollowers() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = 1 - leaderIndex;
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.command("sql", "CREATE VERTEX TYPE " + TYPE_PROFILE);
+    leaderDb.command("cypher", "CREATE (n:" + TYPE_PROFILE + " {id: 1, marked: 0})");
+
+    waitForAllServers();
+    assertThat(awaitCountOn(followerIndex, TYPE_PROFILE, 1)).as("baseline replicated before the profiled SET")
+        .isEqualTo(1);
+
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
+
+    // query(), not command(): the whole point is that a write reaches execution through the read entry point.
+    leaderDb.query("cypher", "PROFILE MATCH (n:" + TYPE_PROFILE + " {id: 1}) SET n.marked = 1").close();
+
+    assertThat(markedCountOn(leaderIndex, TYPE_PROFILE)).as("leader applied the profiled SET").isEqualTo(1);
+
+    waitForAllServers();
+
+    assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
+        .as("follower must see no WAL version gap: a profiled write executed through query() still commits")
+        .isZero();
+
+    assertThat(awaitMarkedCountOn(followerIndex, TYPE_PROFILE, 1))
+        .as("a write that reaches execution through query() via PROFILE must replicate like any other")
         .isEqualTo(1);
   }
 
@@ -164,9 +212,9 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
         .longValue();
   }
 
-  private long markedCountOn(final int serverIndex) {
+  private long markedCountOn(final int serverIndex, final String typeName) {
     final Database db = getServerDatabase(serverIndex, getDatabaseName());
-    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + TYPE_AUTOCOMMIT + " WHERE marked = 1")
+    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + typeName + " WHERE marked = 1")
         .next().getProperty("cnt")).longValue();
   }
 
@@ -175,8 +223,9 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
     return await(expected, () -> countOn(serverIndex, typeName));
   }
 
-  private long awaitMarkedCountOn(final int serverIndex, final long expected) throws InterruptedException {
-    return await(expected, () -> markedCountOn(serverIndex));
+  private long awaitMarkedCountOn(final int serverIndex, final String typeName, final long expected)
+      throws InterruptedException {
+    return await(expected, () -> markedCountOn(serverIndex, typeName));
   }
 
   private long await(final long expected, final LongSupplier supplier) throws InterruptedException {


### PR DESCRIPTION
Closes #5655

Cypher half of #5492; the SQL half shipped as #5652.

`OpenCypherQueryEngine` holds the inner `LocalDatabase` on an HA leader (`RaftReplicatedDatabase.getQueryEngine()` delegates to `proxied`) and handed that instance to everything it executed. `LocalDatabase.commit()` applies pages locally and proposes nothing to Raft, so two paths lost their writes: the explicit `COMMIT` statement, which `executeTransaction()` ran straight against the field, and the auto-commit of a write step - `SetStep`, `DeleteStep`, `MergeStep`, `RemoveStep`, `ForeachStep` and a writing `CALL` subquery each call `begin()`/`commit()` directly on `context.getDatabase()`, which `CypherExecutionPlan` sets from that same field. Both are now resolved through `getWrappedDatabaseInstance()`, a no-op off HA.

The issue filed this as code-shape-matches, not reproduced. Both of its open questions are answered in the tracking doc, and the more useful half of the answer is why it hid: `CreateStep` was never affected, because it wraps its work in `database.transaction(...)` and `LocalDatabase.transaction()` drives `wrappedDatabaseInstance` internally. A bare `CREATE` replicated correctly while an equally ordinary `SET` in the same session did not, which is what kept a Cypher HA suite green over a broken engine.

One deliberate difference from #5652: the switch is on `statement.isReadOnly()` rather than on the entry point. Read-only statements keep the raw instance so follower-local reads are not subjected to the wrapper's read-consistency barriers, but `query()` cannot stand in for "read-only" here - `PROFILE` bypasses the idempotency gate and executes, so `PROFILE MATCH ... SET ...` arrives through `query()` and does write.

## Test plan

- [x] `Issue5655CypherCommitsOnInnerDatabaseIT` - 2-node cluster, one test per exposed path (explicit `COMMIT`, auto-committing `SET`). Both **fail before the fix** (`expected: 1L but was: 0L`), and the harness's own `DatabaseComparator` teardown independently reports `Page PageId(graph/28/0) has different versions on databases. DB1 2 <> DB2 1`. Both pass after.
- [x] Full `engine` module: 7826 pass, 0 failures, 98 skipped.
- [x] `Issue5492*IT` (the SQL half, cross-regression): 3/3 pass.
- [ ] Server-module Cypher ITs (`Issue4141SessionManagementIT` and siblings - transaction control over HTTP) could not be run locally, port 2480 was occupied. CI covers them.

Each test asserts `TEST_WAL_GAP_COUNTER` *before* querying the follower: a resync reinstalls the follower's database, and a count issued after it throws `DatabaseIsClosed`, which reads like infrastructure noise rather than the divergence that caused it.