### PR TITLE
fix(engine) #5627: report a procedure's wrong argument count the way a function's is

### DIFF
--- a/docs/5627-procedure-arity-unification.md
+++ b/docs/5627-procedure-arity-unification.md
@@ -72,6 +72,24 @@ Worth a follow-up in its own right - it is the same 500-for-a-client-mistake sha
 removed one case of - but it is a sweep over ~80 implementations' argument extraction rather than a change to
 the `Procedure` abstraction, so it is deliberately not bundled here.
 
+A second gap sits on the **function** side, which #5602 was meant to have closed: seven functions still hand-write
+their own count check and raise `CommandExecutionException` (a 500) with the pre-#5602 wording, bypassing
+`Function.checkArity` entirely.
+
+| File | Message |
+| --- | --- |
+| `function/coll/CollSort.java:57` | `coll.sort() requires exactly 1 argument` |
+| `function/coll/CollMin.java:56` | `coll.min() requires exactly 1 argument` |
+| `function/coll/CollMax.java:56` | `coll.max() requires exactly 1 argument` |
+| `function/coll/CollDistinct.java:58` | `coll.distinct() requires exactly 1 argument` |
+| `function/coll/CollIndexOf.java:55` | `coll.indexOf() requires exactly 2 arguments` |
+| `function/coll/CollInsert.java:56` | `coll.insert() requires exactly 3 arguments (list, index, value)` |
+| `function/sql/graph/SQLFunctionCypherRID.java:47` | `cypherRID() requires exactly one argument: the numeric Cypher id` |
+
+Each is a one-line replacement with `checkArity(args)` reading the bounds the function already declares, so it is
+a small and self-contained follow-up - but it is function-side work, and folding it in here would make this PR
+about something other than what #5627 asks.
+
 ### Why "Procedure", not "Function"
 
 `FunctionArity.message` hard-codes the word `Function`. Reusing it verbatim would tell a caller that

--- a/docs/5627-procedure-arity-unification.md
+++ b/docs/5627-procedure-arity-unification.md
@@ -1,5 +1,7 @@
 # #5627 - `Procedure.validateArgs()` reports a wrong argument count differently from functions
 
+PR: https://github.com/ArcadeData/arcadedb/pull/5698
+
 Follow-up from #5602 (PR #5612), which unified the function side and deliberately left the procedure side alone.
 
 ## Root cause
@@ -160,3 +162,30 @@ checked with a repo-wide scan for `Error executing procedure`, `requires exactly
   anywhere. A client parsing either breaks; a client keying off the HTTP status gets a more accurate one.
 - `OPTIONAL CALL` no longer swallows a wrong argument count, matching what #5602 already did for functions.
 - No change to any procedure implementation, to `CallStep`, or to the function side.
+
+## Review cycles
+
+Four cycles against the `claude` bot on PR #5698. Every cycle was an approval; the changes below came from
+non-blocking observations, each verified against the code before being acted on.
+
+| # | Head | Change | Review outcome |
+| --- | --- | --- | --- |
+| 1 | `92a29ec9` | The fix itself: `Procedure.checkArity`, kind-aware `FunctionArity`, tests | Approved. 3 non-blocking notes. |
+| 2 | `acc02542` | Scoped the doc's claim to argument *count*, recorded the message-contract change | Approved. 3 non-blocking notes. |
+| 3 | `d5517a13` | Collapsed both `checkArity` bodies onto `FunctionArity.check`; dropped a misattributed `@author` | Approved. 3 non-blocking notes. |
+| 4 | `89ab2c9b` | Recorded the seven function-side hand-written arity checks as a follow-up | Approved, no actionable items. |
+
+Observations raised and deliberately not acted on:
+
+- **`validateArgs` is now a pure passthrough on both interfaces** (cycles 3 and 4). Kept: `validateArgs` is the
+  name `CallStep` and all ~80 `execute()` bodies call, and the split mirrors `Function`. Both reviews concluded
+  the symmetry is worth the hop.
+- **`docs/<issue>-<slug>.md` as a home for tracking docs** (cycle 2). Existing convention - 73 such files.
+- **The registry sweep assumes `validateArgs` is arity-only** (cycle 4). True today: no procedure overrides it.
+  A future override adding type checks could trip a different error on the sweep's array of nulls.
+- **`aCorrectArgumentCountIsStillAccepted` runs `algo.degree()` on an empty database** (cycle 3), so it leans on
+  that procedure tolerating an empty graph. Kept as a smoke check that the guard rejects counts, not calls.
+
+No deferred items - every actionable observation was resolved within its cycle.
+
+**Final state:** clean-approval.

--- a/docs/5627-procedure-arity-unification.md
+++ b/docs/5627-procedure-arity-unification.md
@@ -34,8 +34,12 @@ Two further defects came with the hand-written check:
 
 ## Fix
 
-- `FunctionArity` gains a kind-aware `message`/`mismatch` pair. The existing three-argument forms stay as the
-  function-flavoured shorthand, so no existing caller changes.
+- `FunctionArity` gains a kind-aware `message`/`mismatch` pair and a `check(kind, name, min, max, args)` holding
+  the guard body itself. The existing three-argument `message`/`mismatch` forms stay as the function-flavoured
+  shorthand, so no existing caller changes.
+- `Function.checkArity` and `Procedure.checkArity` are both one line over `FunctionArity.check`. The first draft
+  of this change left them as two byte-identical bodies differing only in the noun - which is exactly the shape
+  the two *messages* had before this issue, and how they came to disagree in the first place.
 - `Procedure` gains `checkArity(Object[])`, mirroring `Function.checkArity`: it reads the declared
   `getMinArgs()`/`getMaxArgs()`, resolves the maximum through `FunctionArity.effectiveMax()`, counts a null
   array as zero arguments, and raises `FunctionArity.mismatch("Procedure", ...)`. `validateArgs()` is kept as

--- a/docs/5627-procedure-arity-unification.md
+++ b/docs/5627-procedure-arity-unification.md
@@ -1,0 +1,118 @@
+# #5627 - `Procedure.validateArgs()` reports a wrong argument count differently from functions
+
+Follow-up from #5602 (PR #5612), which unified the function side and deliberately left the procedure side alone.
+
+## Root cause
+
+`Procedure` (`engine/src/main/java/com/arcadedb/function/procedure/Procedure.java`) declares its own
+`validateArgs()` default method that hand-writes the count check and raises `IllegalArgumentException` with
+wording of its own:
+
+```
+algo.dijkstra() requires exactly 4 argument(s), got 2
+algo.dijkstra() requires 4 to 5 arguments, got 2
+```
+
+`Function` has since been reduced to `checkArity()` phrased through `FunctionArity`, which raises
+`CommandSemanticException` (HTTP 400):
+
+```
+Function 'text.hammingDistance' expects 2 arguments but got 1
+```
+
+`CallStep.executeProcedure` rethrows `CommandParsingException` untouched and wraps everything else in
+`CommandExecutionException`, so the procedure's `IllegalArgumentException` was wrapped and surfaced as a 500
+while the identical mistake against a function surfaced as a 400.
+
+Two further defects came with the hand-written check:
+
+- it compares against the raw `getMaxArgs()`, so a procedure spelling "unbounded" the registry's way (`-1`)
+  would have had every call rejected - `FunctionArity.effectiveMax()` exists precisely to resolve that. No
+  procedure declares `-1` today, so this was latent rather than live.
+- it dereferences `args.length` without a null guard, so a null argument array raised `NullPointerException`
+  rather than the arity error. `Function.checkArity` counts `null` as zero arguments.
+
+## Fix
+
+- `FunctionArity` gains a kind-aware `message`/`mismatch` pair. The existing three-argument forms stay as the
+  function-flavoured shorthand, so no existing caller changes.
+- `Procedure` gains `checkArity(Object[])`, mirroring `Function.checkArity`: it reads the declared
+  `getMinArgs()`/`getMaxArgs()`, resolves the maximum through `FunctionArity.effectiveMax()`, counts a null
+  array as zero arguments, and raises `FunctionArity.mismatch("Procedure", ...)`. `validateArgs()` is kept as
+  the name `CallStep` calls and now delegates to it.
+- `Function.validateArgs`'s javadoc note recording why procedures were left out is replaced by a pointer to the
+  procedure-side `checkArity`.
+
+Resulting message, same sentence and same exception type as the function side:
+
+```
+Procedure 'algo.dijkstra' expects 4-5 arguments but got 2
+```
+
+### Why "Procedure", not "Function"
+
+`FunctionArity.message` hard-codes the word `Function`. Reusing it verbatim would tell a caller that
+`algo.dijkstra` is a function, which it is not - it has its own registry, its own `CALL` handling and its own
+interface. The sentence shape, the accepted-count phrasing and the exception type (and therefore the HTTP
+status) are what the issue asks to unify, and all three now match; only the noun distinguishes them, which is
+also what Neo4j does.
+
+### Why the ~80 in-`execute()` `validateArgs(args)` calls are kept
+
+The issue asks whether the hand-written `validateArgs(args)` at the top of each `execute()` can be dropped now
+that the base interface runs the guard. They are kept:
+
+- unlike the function-side duplication `Function.checkArity` replaced, these are not a second hand-written
+  count check that can drift - they call the same default method, reading the same declared bounds. Keeping
+  them cannot make two paths disagree.
+- `CallStep` is the only production caller that goes through `validateArgs()` first. `Procedure.execute()` is
+  a public interface method, and dropping the guard would leave any direct caller (tests, embedded usage) with
+  an `ArrayIndexOutOfBoundsException` instead of the client error.
+
+Dropping them would touch ~80 files to remove a guard, for no behavioural gain.
+
+## Tests
+
+- `ProcedureInterfaceTest` - the existing arity cases asserted the old `IllegalArgumentException` wording, so
+  they encode the behaviour this issue removes. Updated to the new contract (see "Existing tests" below), and
+  extended with the unbounded-maximum, null-array and identical-to-the-function-side cases.
+- `ProcedureArityIssue5627Test` (new, `engine/src/test/java/com/arcadedb/query/opencypher/`) - the end-to-end
+  `CALL` path: the error reaches the client as `CommandSemanticException` rather than wrapped in
+  `CommandExecutionException`, survives `OPTIONAL CALL`, and reads with the same sentence a function gets.
+  Includes a sweep over the whole procedure registry so a procedure added later cannot reintroduce a
+  divergent wording.
+
+### Existing tests
+
+Per `CLAUDE.md`, existing tests are not modified. `ProcedureInterfaceTest`'s five arity cases are the
+exception, surfaced here deliberately: they assert `IllegalArgumentException` and the literal strings
+`"exactly 2"` / `"2 to 4"`, which *are* the behaviour #5627 asks to replace. They were testing the correct
+thing (the arity guard fires, with the right numbers) against the wording of the day, so the assertions are
+retargeted at the new wording rather than deleted or loosened to accept both.
+
+### Results
+
+Before the fix, 7 of the 8 cases in `ProcedureArityIssue5627Test` failed (the eighth asserts a correct call still
+runs, and passed on both sides). After it:
+
+```
+ProcedureArityIssue5627Test   8 tests, 0 failures
+ProcedureInterfaceTest       10 tests, 0 failures
+ProcedureRegistryTest        15 tests, 0 failures
+FunctionInterfaceTest        13 tests, 0 failures
+
+mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**,com.arcadedb.function.**'
+  Tests run: 8918, Failures: 0, Errors: 0, Skipped: 98
+```
+
+The full reactor compiles (`mvn -DskipTests compile`). No source outside these tests referenced the old wording -
+checked with a repo-wide scan for `Error executing procedure`, `requires exactly N argument(s)` and
+`requires N to M arguments, got`.
+
+## Impact
+
+- Behavioural change visible to clients: a wrong argument count on a `CALL` of a registered procedure now
+  returns HTTP 400 with `Procedure 'x' expects N arguments but got M` instead of HTTP 500 with
+  `Error executing procedure: x`. This is the point of the issue.
+- `OPTIONAL CALL` no longer swallows a wrong argument count, matching what #5602 already did for functions.
+- No change to any procedure implementation, to `CallStep`, or to the function side.

--- a/docs/5627-procedure-arity-unification.md
+++ b/docs/5627-procedure-arity-unification.md
@@ -39,7 +39,10 @@ Two further defects came with the hand-written check:
 - `Procedure` gains `checkArity(Object[])`, mirroring `Function.checkArity`: it reads the declared
   `getMinArgs()`/`getMaxArgs()`, resolves the maximum through `FunctionArity.effectiveMax()`, counts a null
   array as zero arguments, and raises `FunctionArity.mismatch("Procedure", ...)`. `validateArgs()` is kept as
-  the name `CallStep` calls and now delegates to it.
+  the name `CallStep` and every implementation call, and now delegates to it. Nothing on the procedure side
+  calls `checkArity` independently yet, so the split is currently symmetry with `Function` rather than
+  necessity - it is the shape the issue asks for, and it is the seam a caller that wants the check without the
+  `validateArgs` name would use.
 - `Function.validateArgs`'s javadoc note recording why procedures were left out is replaced by a pointer to the
   procedure-side `checkArity`.
 
@@ -48,6 +51,22 @@ Resulting message, same sentence and same exception type as the function side:
 ```
 Procedure 'algo.dijkstra' expects 4-5 arguments but got 2
 ```
+
+### What this does *not* unify
+
+Argument **count** only, which is what #5627 asks for. Argument **value** validation on the procedure side is
+untouched and still diverges: `MergeRelationship.extractVertex`/`extractString` and the `AbstractPathProcedure`
+helpers raise a plain `IllegalArgumentException` for a null or wrongly-typed argument, which is not a
+`CommandParsingException`, so `CallStep.executeProcedure` still wraps it and the client still gets a 500.
+
+```
+CALL merge.relationship(null, ...)  -> 500  Error executing procedure: merge.relationship
+CALL merge.relationship(1, 2)       -> 400  Procedure 'merge.relationship' expects 5 arguments but got 2
+```
+
+Worth a follow-up in its own right - it is the same 500-for-a-client-mistake shape #5602 and this issue each
+removed one case of - but it is a sweep over ~80 implementations' argument extraction rather than a change to
+the `Procedure` abstraction, so it is deliberately not bundled here.
 
 ### Why "Procedure", not "Function"
 
@@ -114,5 +133,8 @@ checked with a repo-wide scan for `Error executing procedure`, `requires exactly
 - Behavioural change visible to clients: a wrong argument count on a `CALL` of a registered procedure now
   returns HTTP 400 with `Procedure 'x' expects N arguments but got M` instead of HTTP 500 with
   `Error executing procedure: x`. This is the point of the issue.
+- The message text is an external contract for anyone matching on it. The two old phrasings,
+  `x() requires exactly N argument(s), got M` and `x() requires N to M arguments, got K`, no longer appear
+  anywhere. A client parsing either breaks; a client keying off the HTTP status gets a more accurate one.
 - `OPTIONAL CALL` no longer swallows a wrong argument count, matching what #5602 already did for functions.
 - No change to any procedure implementation, to `CallStep`, or to the function side.

--- a/engine/src/main/java/com/arcadedb/function/Function.java
+++ b/engine/src/main/java/com/arcadedb/function/Function.java
@@ -91,11 +91,7 @@ public interface Function {
    *             declaring {@code getMinArgs() == 0} is handed it unchanged and must still tolerate it.
    */
   default void checkArity(final Object[] args) {
-    final int actualArgs = args == null ? 0 : args.length;
-    // effectiveMax(), not getMaxArgs(), so an implementation that spells "unbounded" the registry's way (-1) is not
-    // read as "at most -1 arguments" - which would reject every call while the message still said "at least N".
-    if (actualArgs < getMinArgs() || actualArgs > FunctionArity.effectiveMax(getMaxArgs()))
-      throw FunctionArity.mismatch(getName(), FunctionArity.describe(getMinArgs(), getMaxArgs()), actualArgs);
+    FunctionArity.check("Function", getName(), getMinArgs(), getMaxArgs(), args);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/Function.java
+++ b/engine/src/main/java/com/arcadedb/function/Function.java
@@ -154,9 +154,10 @@ public interface Function {
    * read one way through an expression and another through {@code CALL} - and, because {@code CallStep} wraps what
    * it catches, surfaced over HTTP as 500 rather than the 400 the expression path gave (issue #5602).
    * <p>
-   * Note that {@code Procedure} declares a separate {@code validateArgs} of its own. Procedures are not functions -
-   * they have their own registry, their own {@code CALL} handling and around eighty implementations - so unifying
-   * the two is a change to the procedure abstraction rather than to this one, and is deliberately not done here.
+   * Note that {@code Procedure} declares a separate {@code validateArgs} of its own, over its own
+   * {@code checkArity}: procedures are not functions - they have their own registry and their own {@code CALL}
+   * handling - so the two guards stay separate. What they share is {@link FunctionArity}, so the same mistake reads
+   * the same way and carries the same status whichever kind the name resolved to (#5627).
    *
    * @param args the arguments to validate
    * @throws CommandSemanticException if the argument count is outside the declared bounds

--- a/engine/src/main/java/com/arcadedb/function/FunctionArity.java
+++ b/engine/src/main/java/com/arcadedb/function/FunctionArity.java
@@ -96,6 +96,32 @@ public final class FunctionArity {
   }
 
   /**
+   * Rejects a call whose argument count falls outside {@code minArgs}..{@code maxArgs}.
+   * <p>
+   * The body behind both runtime guards - {@link Function#checkArity} and {@code Procedure.checkArity}. They were
+   * byte-identical but for the noun, which is the shape the two <em>messages</em> had before #5627 and is how they
+   * came to disagree; keeping the check itself in one place is what stops that recurring.
+   *
+   * @param kind         see {@link #message(String, String, String, int)}
+   * @param callableName the name without parentheses, used in the message
+   * @param minArgs      fewest arguments accepted
+   * @param maxArgs      most arguments accepted; {@code -1} and {@link Integer#MAX_VALUE} both mean "no limit"
+   * @param args         the arguments the call carried, {@code null} counting as none - a couple of executors used
+   *                     to defend against a null array by hand, and folding that in here keeps the count check in
+   *                     one place. Note that this only rejects the null array for a callable that requires at least
+   *                     one argument: one declaring {@code minArgs == 0} is handed it unchanged and must still
+   *                     tolerate it.
+   */
+  public static void check(final String kind, final String callableName, final int minArgs, final int maxArgs,
+      final Object[] args) {
+    final int actualArgs = args == null ? 0 : args.length;
+    // effectiveMax(), not maxArgs, so an implementation that spells "unbounded" the registry's way (-1) is not read
+    // as "at most -1 arguments" - which would reject every call while the message still said "at least N".
+    if (actualArgs < minArgs || actualArgs > effectiveMax(maxArgs))
+      throw mismatch(kind, callableName, describe(minArgs, maxArgs), actualArgs);
+  }
+
+  /**
    * The exception form of {@link #message(String, String, int)}: a wrong argument count is the caller's mistake, so
    * it is a client error (HTTP 400) rather than an internal failure.
    */

--- a/engine/src/main/java/com/arcadedb/function/FunctionArity.java
+++ b/engine/src/main/java/com/arcadedb/function/FunctionArity.java
@@ -22,9 +22,9 @@ import com.arcadedb.exception.CommandSemanticException;
 
 /**
  * The one wording for "wrong number of arguments", shared by every path that can detect it: the functions' own
- * runtime guard ({@link Function#checkArity}) and the Cypher parser's declaration gate
- * ({@code FunctionValidator}). A client is told the same thing whichever caught the mistake - the point of issue
- * #5484, extended to the runtime side in #5602.
+ * runtime guard ({@link Function#checkArity}), the procedures' ({@code Procedure.checkArity}) and the Cypher
+ * parser's declaration gate ({@code FunctionValidator}). A client is told the same thing whichever caught the
+ * mistake - the point of issue #5484, extended to the runtime side in #5602 and to procedures in #5627.
  * <p>
  * It lives beside {@link Function} rather than in the Cypher helper it started in, because nothing about counting
  * arguments is language-specific and {@link Function} is the query-language-neutral abstraction: having the base
@@ -68,6 +68,8 @@ public final class FunctionArity {
   }
 
   /**
+   * The function-flavoured shorthand for {@link #message(String, String, String, int)}.
+   *
    * @param functionName function name without parentheses, e.g. {@code "abs"}
    * @param expectedArgs the accepted count, phrased for the message, e.g. {@code "1 argument"} - usually from
    *                     {@link #describe}, but spelled out by the few functions whose accepted counts are not a
@@ -75,15 +77,38 @@ public final class FunctionArity {
    * @param actualArgs   how many arguments the call actually carried
    */
   public static String message(final String functionName, final String expectedArgs, final int actualArgs) {
-    return "Function '" + functionName + "' expects " + expectedArgs + " but got " + actualArgs;
+    return message("Function", functionName, expectedArgs, actualArgs);
   }
 
   /**
-   * The exception form of {@link #message}: a wrong argument count is the caller's mistake, so it is a client error
-   * (HTTP 400) rather than an internal failure.
+   * @param kind         what the name denotes, capitalised because it opens the sentence: {@code "Function"} or
+   *                     {@code "Procedure"}. Procedures are a separate abstraction - their own interface, their own
+   *                     registry, their own {@code CALL} handling - so telling a caller that {@code algo.dijkstra}
+   *                     is a function would be wrong. Everything after the noun is shared, which is what makes the
+   *                     same mistake read the same way whichever kind the name resolved to (#5627).
+   * @param callableName the name without parentheses, e.g. {@code "abs"} or {@code "algo.dijkstra"}
+   * @param expectedArgs the accepted count, phrased for the message, e.g. {@code "1 argument"}
+   * @param actualArgs   how many arguments the call actually carried
+   */
+  public static String message(final String kind, final String callableName, final String expectedArgs,
+      final int actualArgs) {
+    return kind + " '" + callableName + "' expects " + expectedArgs + " but got " + actualArgs;
+  }
+
+  /**
+   * The exception form of {@link #message(String, String, int)}: a wrong argument count is the caller's mistake, so
+   * it is a client error (HTTP 400) rather than an internal failure.
    */
   public static CommandSemanticException mismatch(final String functionName, final String expectedArgs,
       final int actualArgs) {
     return new CommandSemanticException(message(functionName, expectedArgs, actualArgs));
+  }
+
+  /**
+   * The exception form of {@link #message(String, String, String, int)}.
+   */
+  public static CommandSemanticException mismatch(final String kind, final String callableName,
+      final String expectedArgs, final int actualArgs) {
+    return new CommandSemanticException(message(kind, callableName, expectedArgs, actualArgs));
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/procedure/Procedure.java
+++ b/engine/src/main/java/com/arcadedb/function/procedure/Procedure.java
@@ -104,11 +104,11 @@ public interface Procedure {
   /**
    * Rejects a call whose argument count falls outside {@link #getMinArgs()}..{@link #getMaxArgs()}.
    * <p>
-   * The counterpart of {@code Function.checkArity}, phrased through the same {@link FunctionArity}: a wrong argument
+   * The counterpart of {@code Function.checkArity}, over the same {@link FunctionArity#check} body: a wrong argument
    * count is the same mistake whether the name resolved to a function or to a procedure, so it reads the same way
-   * and carries the same status. It used to raise an {@link IllegalArgumentException} with wording of its own, which
-   * {@code CallStep.executeProcedure} then wrapped - surfacing over HTTP as 500 where the function path already gave
-   * 400 (issue #5627).
+   * and carries the same status, differing only in the noun. It used to raise an {@link IllegalArgumentException}
+   * with wording of its own, which {@code CallStep.executeProcedure} then wrapped - surfacing over HTTP as 500 where
+   * the function path already gave 400 (issue #5627).
    * <p>
    * A wrong argument count is the caller's mistake, so this is a {@link CommandSemanticException} (HTTP 400) rather
    * than an internal failure. {@code CallStep} rethrows {@code CommandParsingException}, which this extends,
@@ -119,12 +119,7 @@ public interface Procedure {
    * @throws CommandSemanticException if the argument count is outside the declared bounds
    */
   default void checkArity(final Object[] args) {
-    final int actualArgs = args == null ? 0 : args.length;
-    // effectiveMax(), not getMaxArgs(), so an implementation that spells "unbounded" the registry's way (-1) is not
-    // read as "at most -1 arguments" - which would reject every call while the message still said "at least N".
-    if (actualArgs < getMinArgs() || actualArgs > FunctionArity.effectiveMax(getMaxArgs()))
-      throw FunctionArity.mismatch("Procedure", getName(), FunctionArity.describe(getMinArgs(), getMaxArgs()),
-          actualArgs);
+    FunctionArity.check("Procedure", getName(), getMinArgs(), getMaxArgs(), args);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/procedure/Procedure.java
+++ b/engine/src/main/java/com/arcadedb/function/procedure/Procedure.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.function.procedure;
 
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.function.FunctionArity;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 
@@ -100,22 +102,47 @@ public interface Procedure {
   Stream<Result> execute(Object[] args, Result inputRow, CommandContext context);
 
   /**
-   * Validates the arguments before execution.
-   * Default implementation checks argument count.
+   * Rejects a call whose argument count falls outside {@link #getMinArgs()}..{@link #getMaxArgs()}.
+   * <p>
+   * The counterpart of {@code Function.checkArity}, phrased through the same {@link FunctionArity}: a wrong argument
+   * count is the same mistake whether the name resolved to a function or to a procedure, so it reads the same way
+   * and carries the same status. It used to raise an {@link IllegalArgumentException} with wording of its own, which
+   * {@code CallStep.executeProcedure} then wrapped - surfacing over HTTP as 500 where the function path already gave
+   * 400 (issue #5627).
+   * <p>
+   * A wrong argument count is the caller's mistake, so this is a {@link CommandSemanticException} (HTTP 400) rather
+   * than an internal failure. {@code CallStep} rethrows {@code CommandParsingException}, which this extends,
+   * untouched.
+   *
+   * @param args the arguments the call carried, {@code null} counting as none
+   *
+   * @throws CommandSemanticException if the argument count is outside the declared bounds
+   */
+  default void checkArity(final Object[] args) {
+    final int actualArgs = args == null ? 0 : args.length;
+    // effectiveMax(), not getMaxArgs(), so an implementation that spells "unbounded" the registry's way (-1) is not
+    // read as "at most -1 arguments" - which would reject every call while the message still said "at least N".
+    if (actualArgs < getMinArgs() || actualArgs > FunctionArity.effectiveMax(getMaxArgs()))
+      throw FunctionArity.mismatch("Procedure", getName(), FunctionArity.describe(getMinArgs(), getMaxArgs()),
+          actualArgs);
+  }
+
+  /**
+   * Validates the arguments before execution. Kept as the name the {@code CALL} path calls
+   * ({@code CallStep.executeProcedure}) and the name each implementation calls at the top of its {@code execute()};
+   * the check itself is {@link #checkArity}.
+   * <p>
+   * The per-implementation calls are deliberately kept rather than folded into the {@code CALL} path alone: they are
+   * not a second hand-written count check that can drift from the declared bounds - they run this very method - and
+   * {@link #execute} is public, so a direct caller would otherwise index past the end of the array instead of being
+   * told what it got wrong.
    *
    * @param args the arguments to validate
-   * @throws IllegalArgumentException if arguments are invalid
+   *
+   * @throws CommandSemanticException if the argument count is outside the declared bounds
    */
   default void validateArgs(final Object[] args) {
-    if (args.length < getMinArgs() || args.length > getMaxArgs()) {
-      if (getMinArgs() == getMaxArgs()) {
-        throw new IllegalArgumentException(
-            getName() + "() requires exactly " + getMinArgs() + " argument(s), got " + args.length);
-      } else {
-        throw new IllegalArgumentException(
-            getName() + "() requires " + getMinArgs() + " to " + getMaxArgs() + " arguments, got " + args.length);
-      }
-    }
+    checkArity(args);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/function/procedure/ProcedureInterfaceTest.java
+++ b/engine/src/test/java/com/arcadedb/function/procedure/ProcedureInterfaceTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.procedure;
 
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import org.junit.jupiter.api.Test;
@@ -44,10 +45,8 @@ class ProcedureInterfaceTest {
     final Procedure proc = createProcedure("exactProc", 2, 2);
 
     assertThatThrownBy(() -> proc.validateArgs(new Object[]{"a"}))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("exactProc")
-        .hasMessageContaining("exactly 2")
-        .hasMessageContaining("got 1");
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessage("Procedure 'exactProc' expects 2 arguments but got 1");
   }
 
   @Test
@@ -55,10 +54,8 @@ class ProcedureInterfaceTest {
     final Procedure proc = createProcedure("exactProc", 2, 2);
 
     assertThatThrownBy(() -> proc.validateArgs(new Object[]{"a", "b", "c"}))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("exactProc")
-        .hasMessageContaining("exactly 2")
-        .hasMessageContaining("got 3");
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessage("Procedure 'exactProc' expects 2 arguments but got 3");
   }
 
   @Test
@@ -76,10 +73,8 @@ class ProcedureInterfaceTest {
     final Procedure proc = createProcedure("rangeProc", 2, 4);
 
     assertThatThrownBy(() -> proc.validateArgs(new Object[]{"a"}))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("rangeProc")
-        .hasMessageContaining("2 to 4")
-        .hasMessageContaining("got 1");
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessage("Procedure 'rangeProc' expects 2-4 arguments but got 1");
   }
 
   @Test
@@ -87,10 +82,36 @@ class ProcedureInterfaceTest {
     final Procedure proc = createProcedure("rangeProc", 1, 3);
 
     assertThatThrownBy(() -> proc.validateArgs(new Object[]{"a", "b", "c", "d"}))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("rangeProc")
-        .hasMessageContaining("1 to 3")
-        .hasMessageContaining("got 4");
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessage("Procedure 'rangeProc' expects 1-3 arguments but got 4");
+  }
+
+  @Test
+  void anUnboundedMaximumIsNotReadAsAnUpperLimit() {
+    // The two spellings of "no limit": the registry writes -1, Function.getMaxArgs defaults to Integer.MAX_VALUE.
+    // A raw `count > getMaxArgs()` against -1 rejects every call, since any count exceeds -1 (issue #5627).
+    for (final int unbounded : new int[] { -1, Integer.MAX_VALUE }) {
+      final Procedure proc = createProcedure("variadicProc", 1, unbounded);
+
+      proc.validateArgs(new Object[]{"a"});
+      proc.validateArgs(new Object[]{"a", "b", "c", "d"});
+
+      assertThatThrownBy(() -> proc.validateArgs(new Object[0]))
+          .as("maxArgs=%d", unbounded)
+          .isInstanceOf(CommandSemanticException.class)
+          .hasMessage("Procedure 'variadicProc' expects at least 1 argument but got 0");
+    }
+  }
+
+  @Test
+  void aNullArgumentArrayCountsAsNoArguments() {
+    // args.length on a null array raised NullPointerException, which the CALL path wraps as an internal failure.
+    assertThatThrownBy(() -> createProcedure("exactProc", 2, 2).validateArgs(null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessage("Procedure 'exactProc' expects 2 arguments but got 0");
+
+    // A procedure accepting no arguments is handed the null array unchanged, as functions are.
+    createProcedure("zeroArgProc", 0, 0).validateArgs(null);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/ProcedureArityIssue5627Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/ProcedureArityIssue5627Test.java
@@ -41,8 +41,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * and raised as a {@code CommandSemanticException} (400). {@code Procedure} kept a hand-written check of its own
  * raising {@code IllegalArgumentException}, which {@code CallStep.executeProcedure} then wrapped in a
  * {@code CommandExecutionException} - a 500 for what is entirely the caller's mistake.
- *
- * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class ProcedureArityIssue5627Test extends TestHelper {
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/ProcedureArityIssue5627Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/ProcedureArityIssue5627Test.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.function.procedure.Procedure;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5627: a wrong argument count on a procedure read differently from the same mistake on a
+ * function, and reached the client with a different HTTP status.
+ * <p>
+ * #5602 reduced {@code Function.validateArgs} to {@code Function.checkArity}, phrased through {@code FunctionArity}
+ * and raised as a {@code CommandSemanticException} (400). {@code Procedure} kept a hand-written check of its own
+ * raising {@code IllegalArgumentException}, which {@code CallStep.executeProcedure} then wrapped in a
+ * {@code CommandExecutionException} - a 500 for what is entirely the caller's mistake.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ProcedureArityIssue5627Test extends TestHelper {
+
+  /** The one sentence both callable kinds use, differing only in the noun. */
+  private static final Pattern CANONICAL = Pattern.compile("^(Function|Procedure) '[^']+' expects .+ but got \\d+$");
+
+  @Test
+  void aWrongArgumentCountOnAProcedureIsAClientError() {
+    // algo.sameCommunity declares 3 arguments exactly. Before the fix this arrived as CommandExecutionException
+    // ("Error executing procedure: algo.sameCommunity") wrapping an IllegalArgumentException, i.e. a 500.
+    assertThatThrownBy(() -> consume("CALL algo.sameCommunity(1)"))
+        .isInstanceOf(CommandSemanticException.class)
+        .isNotInstanceOf(CommandExecutionException.class)
+        .hasMessage("Procedure 'algo.sameCommunity' expects 3 arguments but got 1");
+  }
+
+  @Test
+  void aProcedureWithARangeOfAcceptedCountsPhrasesItAsARange() {
+    // algo.dijkstra accepts 4 or 5. "4-5 arguments" is what FunctionArity.describe() produces, the same phrasing a
+    // function with a range gets.
+    assertThatThrownBy(() -> consume("CALL algo.dijkstra(1, 2)"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessage("Procedure 'algo.dijkstra' expects 4-5 arguments but got 2");
+  }
+
+  @Test
+  void tooManyArgumentsIsRejectedTheSameWayTooFewIs() {
+    assertThatThrownBy(() -> consume("CALL algo.dijkstra(1, 2, 3, 4, 5, 6)"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessage("Procedure 'algo.dijkstra' expects 4-5 arguments but got 6");
+  }
+
+  @Test
+  void aProcedureAndAFunctionDescribeTheMistakeTheSameWay() {
+    // The point of the issue: one sentence, one exception type, whichever kind of callable the name resolved to.
+    final Throwable onAProcedure = catchFrom("CALL algo.sameCommunity(1)");
+    final Throwable onAFunction = catchFrom("CALL text.hammingDistance('a')");
+
+    assertThat(onAProcedure).isInstanceOf(CommandSemanticException.class);
+    assertThat(onAFunction).isInstanceOf(CommandSemanticException.class);
+    assertThat(onAProcedure.getMessage()).matches(CANONICAL);
+    assertThat(onAFunction.getMessage()).matches(CANONICAL);
+  }
+
+  @Test
+  void optionalCallDoesNotSwallowAWrongArgumentCount() {
+    // OPTIONAL suppresses "no rows", not "your call is malformed" - the rule #5602 settled for functions, which the
+    // procedure path only honours once the arity error is a CommandParsingException.
+    assertThatThrownBy(() -> consume("OPTIONAL CALL algo.sameCommunity(1)"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("algo.sameCommunity");
+  }
+
+  @Test
+  void aCorrectArgumentCountIsStillAccepted() {
+    // The guard must reject counts, not calls: algo.degree accepts 0-2, so a no-argument CALL has to run.
+    consume("CALL algo.degree()");
+  }
+
+  /**
+   * Every registered procedure, not only the two called above: a procedure added later cannot reintroduce a wording
+   * of its own without failing here.
+   */
+  @Test
+  void everyRegisteredProcedureReportsTheCanonicalSentence() {
+    final Collection<CypherProcedure> procedures = CypherProcedureRegistry.getAllProcedures();
+    assertThat(procedures).as("the procedure registry is empty, so this sweep proves nothing").isNotEmpty();
+
+    for (final Procedure procedure : procedures) {
+      if (procedure.getMinArgs() > 0)
+        assertRejects(procedure, procedure.getMinArgs() - 1);
+      if (procedure.getMaxArgs() >= 0 && procedure.getMaxArgs() < Integer.MAX_VALUE)
+        assertRejects(procedure, procedure.getMaxArgs() + 1);
+    }
+  }
+
+  @Test
+  void aNullArgumentArrayCountsAsNoArguments() {
+    // args.length on a null array raised NullPointerException, which CallStep would have wrapped as a 500 too.
+    final Procedure procedure = CypherProcedureRegistry.get("algo.sameCommunity");
+    assertThat(procedure).isNotNull();
+    assertThatThrownBy(() -> procedure.validateArgs(null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessage("Procedure 'algo.sameCommunity' expects 3 arguments but got 0");
+  }
+
+  private void assertRejects(final Procedure procedure, final int argCount) {
+    assertThatThrownBy(() -> procedure.validateArgs(new Object[argCount])).as("%s with %d arguments",
+            procedure.getName(), argCount)
+        .isInstanceOf(CommandSemanticException.class)
+        .satisfies(e -> assertThat(e.getMessage()).matches(CANONICAL));
+  }
+
+  private Throwable catchFrom(final String query) {
+    try {
+      consume(query);
+    } catch (final Exception e) {
+      return e;
+    }
+    throw new AssertionError(query + " did not fail");
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}


### PR DESCRIPTION
Closes #5627

Follow-up from #5602 (PR #5612), which unified the function side and deliberately left the procedure side alone. `Procedure` declared a `validateArgs()` of its own that hand-wrote the count check and raised `IllegalArgumentException` with older wording, so `CallStep.executeProcedure` wrapped it in a `CommandExecutionException` - a 500 for what is entirely the caller's mistake, while the identical mistake against a function had returned 400 with `Function 'x' expects N arguments but got M` since #5602. `Procedure` now has a `checkArity()` reading its declared `getMinArgs()`/`getMaxArgs()` and phrased through the shared `FunctionArity`, so a wrong argument count reads with the same sentence and carries the same status whichever kind the name resolved to: `Procedure 'algo.dijkstra' expects 4-5 arguments but got 2`. The move also picks up the two guards the hand-written check lacked - `FunctionArity.effectiveMax()`, so a procedure spelling "unbounded" the registry's way (`-1`) is not read as "at most -1 arguments", and a null argument array counted as zero arguments instead of dereferenced.

The word stays `Procedure` rather than `Function`: reusing `FunctionArity.message` verbatim would tell a caller that `algo.dijkstra` is a function, which it is not. The sentence shape, the accepted-count phrasing and the exception type are what the issue asks to unify, and all three now match.

The ~80 hand-written `validateArgs(args)` calls at the top of each `execute()` are **kept**, and the issue's question about dropping them is answered in the tracking doc: unlike the function-side duplication `Function.checkArity` replaced, these are not a second hand-written count check that can drift - they call the same default method reading the same declared bounds - and `Procedure.execute()` is public, so dropping the guard would leave a direct caller with an `ArrayIndexOutOfBoundsException` instead of the client error.

**Note on existing tests.** `ProcedureInterfaceTest`'s five arity cases asserted `IllegalArgumentException` and the literal strings `"exactly 2"` / `"2 to 4"` - which *are* the behaviour this issue asks to replace. They were testing the correct thing (the guard fires, with the right numbers) against the wording of the day, so the assertions are retargeted at the new contract rather than deleted or loosened to accept both. This is a deliberate exception to the "never modify existing tests" rule, flagged here for review.

## Test plan

- [ ] `mvn -pl engine test -Dtest=ProcedureArityIssue5627Test` - 8 cases, all new. 7 of them fail on `main` (the eighth asserts a correct call still runs). Covers: the `CALL` path raising `CommandSemanticException` rather than a wrapped `CommandExecutionException`; exact-count and range phrasings; too many as well as too few; `OPTIONAL CALL` no longer swallowing it; a null argument array; a sweep over every registered procedure asserting the canonical sentence, so a procedure added later cannot reintroduce a wording of its own.
- [ ] `mvn -pl engine test -Dtest=ProcedureInterfaceTest` - 10 cases, including the new unbounded-maximum (`-1` and `Integer.MAX_VALUE`) and null-array coverage.
- [ ] `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**,com.arcadedb.function.**'` - 8918 tests, 0 failures, 98 skipped.
- [ ] `mvn -DskipTests compile` - full reactor.
- [ ] Repo-wide scan for the old wording (`Error executing procedure`, `requires exactly N argument(s)`, `requires N to M arguments, got`) finds no other dependant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)