### PR TITLE
fix(test) #5630: harden three flaky ITs against loaded CI runners

### DIFF
--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
@@ -136,7 +136,8 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
       });
     }
     waitForAllServers();
-    awaitRoutedWriteOnEveryNode();
+    // The single CREATE above is the only write of this type in this test.
+    awaitTypeReplicatedOnEveryNode(1L);
 
     try (Session session = driver.session(SessionConfig.builder().withDatabase(getDatabaseName()).build())) {
       final long count = session.executeRead(tx ->
@@ -171,15 +172,18 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
   // --- replication settling helper -------------------------------------------
 
   /**
-   * Waits until every node holds the vertex type and its single record.
+   * Waits until every started node holds {@link #VERTEX_TYPE} with exactly {@code expectedRecords} records.
    * <p>
    * {@link #waitForAllServers()} tracks the Raft applied index, which advances before the applied schema
    * entry is visible through the database handle these assertions read. A routed read is answered by a
    * follower, so the read returned 0 against a node still one type behind, and the teardown's
    * byte-for-byte comparison then reported {@code DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5} on the
    * same run (issue #5630). Polling for the replicated state settles both.
+   *
+   * @param expectedRecords how many records the caller wrote - passed in rather than hardcoded so a second
+   *                        caller writing a different number does not silently wait for the wrong count
    */
-  private void awaitRoutedWriteOnEveryNode() {
+  private void awaitTypeReplicatedOnEveryNode(final long expectedRecords) {
     await().atMost(Duration.ofSeconds(60)).pollInterval(Duration.ofMillis(250)).untilAsserted(() -> {
       for (int i = 0; i < getServerCount(); i++) {
         if (getServer(i) == null || !getServer(i).isStarted())
@@ -188,7 +192,7 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
         assertThat(db.getSchema().existsType(VERTEX_TYPE))
             .as("server %d must have replicated type %s", i, VERTEX_TYPE).isTrue();
         assertThat(db.countType(VERTEX_TYPE, true))
-            .as("server %d must have replicated the routed write", i).isEqualTo(1L);
+            .as("server %d must have replicated the routed write", i).isEqualTo(expectedRecords);
       }
     });
   }

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
@@ -22,7 +22,6 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.bolt.message.BoltMessage;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
-import com.arcadedb.database.Database;
 import com.arcadedb.server.ha.raft.BaseRaftHATest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -39,13 +38,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.ByteBuffer;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 /**
  * Certifies that the Bolt ROUTE response reflects real HA topology: the true leader is advertised as the
@@ -136,8 +133,6 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
       });
     }
     waitForAllServers();
-    // The single CREATE above is the only write of this type in this test.
-    awaitTypeReplicatedOnEveryNode(1L);
 
     try (Session session = driver.session(SessionConfig.builder().withDatabase(getDatabaseName()).build())) {
       final long count = session.executeRead(tx ->
@@ -167,34 +162,6 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
     final String newLeaderBolt = "localhost:" + (BASE_BOLT_PORT + newLeader);
     final Map<String, Object> rt = awaitRoutingTable(BASE_BOLT_PORT + newLeader, newLeaderBolt);
     assertThat(BoltRouteTestSupport.addressesForRole(rt, "WRITE")).containsExactly(newLeaderBolt);
-  }
-
-  // --- replication settling helper -------------------------------------------
-
-  /**
-   * Waits until every started node holds {@link #VERTEX_TYPE} with exactly {@code expectedRecords} records.
-   * <p>
-   * {@link #waitForAllServers()} tracks the Raft applied index, which advances before the applied schema
-   * entry is visible through the database handle these assertions read. A routed read is answered by a
-   * follower, so the read returned 0 against a node still one type behind, and the teardown's
-   * byte-for-byte comparison then reported {@code DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5} on the
-   * same run (issue #5630). Polling for the replicated state settles both.
-   *
-   * @param expectedRecords how many records the caller wrote - passed in rather than hardcoded so a second
-   *                        caller writing a different number does not silently wait for the wrong count
-   */
-  private void awaitTypeReplicatedOnEveryNode(final long expectedRecords) {
-    await().atMost(Duration.ofSeconds(60)).pollInterval(Duration.ofMillis(250)).untilAsserted(() -> {
-      for (int i = 0; i < getServerCount(); i++) {
-        if (getServer(i) == null || !getServer(i).isStarted())
-          continue;
-        final Database db = getServerDatabase(i, getDatabaseName());
-        assertThat(db.getSchema().existsType(VERTEX_TYPE))
-            .as("server %d must have replicated type %s", i, VERTEX_TYPE).isTrue();
-        assertThat(db.countType(VERTEX_TYPE, true))
-            .as("server %d must have replicated the routed write", i).isEqualTo(expectedRecords);
-      }
-    });
   }
 
   // --- raw Bolt ROUTE helper -------------------------------------------------

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
@@ -22,6 +22,7 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.bolt.message.BoltMessage;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.database.Database;
 import com.arcadedb.server.ha.raft.BaseRaftHATest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -38,11 +39,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Certifies that the Bolt ROUTE response reflects real HA topology: the true leader is advertised as the
@@ -133,6 +136,7 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
       });
     }
     waitForAllServers();
+    awaitRoutedWriteOnEveryNode();
 
     try (Session session = driver.session(SessionConfig.builder().withDatabase(getDatabaseName()).build())) {
       final long count = session.executeRead(tx ->
@@ -162,6 +166,31 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
     final String newLeaderBolt = "localhost:" + (BASE_BOLT_PORT + newLeader);
     final Map<String, Object> rt = awaitRoutingTable(BASE_BOLT_PORT + newLeader, newLeaderBolt);
     assertThat(BoltRouteTestSupport.addressesForRole(rt, "WRITE")).containsExactly(newLeaderBolt);
+  }
+
+  // --- replication settling helper -------------------------------------------
+
+  /**
+   * Waits until every node holds the vertex type and its single record.
+   * <p>
+   * {@link #waitForAllServers()} tracks the Raft applied index, which advances before the applied schema
+   * entry is visible through the database handle these assertions read. A routed read is answered by a
+   * follower, so the read returned 0 against a node still one type behind, and the teardown's
+   * byte-for-byte comparison then reported {@code DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5} on the
+   * same run (issue #5630). Polling for the replicated state settles both.
+   */
+  private void awaitRoutedWriteOnEveryNode() {
+    await().atMost(Duration.ofSeconds(60)).pollInterval(Duration.ofMillis(250)).untilAsserted(() -> {
+      for (int i = 0; i < getServerCount(); i++) {
+        if (getServer(i) == null || !getServer(i).isStarted())
+          continue;
+        final Database db = getServerDatabase(i, getDatabaseName());
+        assertThat(db.getSchema().existsType(VERTEX_TYPE))
+            .as("server %d must have replicated type %s", i, VERTEX_TYPE).isTrue();
+        assertThat(db.countType(VERTEX_TYPE, true))
+            .as("server %d must have replicated the routed write", i).isEqualTo(1L);
+      }
+    });
   }
 
   // --- raw Bolt ROUTE helper -------------------------------------------------

--- a/docs/5630-flaky-ci-test-hardening.md
+++ b/docs/5630-flaky-ci-test-hardening.md
@@ -121,17 +121,55 @@ When reading that CI run, note what the issue itself records about this repo: th
 **reporter** (`IT Tests Reporter` / `HA IT Tests Reporter`), not the test step. Maven runs with test
 failures ignored, so `Run Integration Tests with Coverage: success` does **not** mean the tests passed.
 
-### Open item: proving the hardened assertions can still fail
+### Proof that the rewritten assertion can still fail - DONE
 
-A hardening change is only worth anything if the assertion it leaves behind still detects the
-regression it guards, and a green CI run does not establish that - a test that can no longer fail is
-also green. Two checks are worth running before this is trusted, neither of which CI performs:
+A green CI run does not establish this: a test that can no longer fail is also green. The largest
+rewrite in this change is the completion-gap assertion, and it was verified directly.
 
-1. `Issue3122AsyncParallelCommandsIT` - force `setParallelLevel(1)` so execution is sequential. The
-   completion-gap assertion must fail, with a reported gap of at least `SLEEP_DURATION`. This is the
-   important one: it is the assertion that was rewritten most substantially.
-2. `HttpRedMetricsIT` - the polls are wrapped around assertions that were already there and are
-   unchanged in substance, so the risk is lower, but a run with the path-collapsing behaviour reverted
-   should still fail on `rawUnmatchedMeters`.
+`databaseAsyncCommandsRunInParallel` drives `database.async()`, which lives in the engine and needs no
+server, so the occupied port was not an obstacle. A throwaway harness ran the exact assertion logic
+against a real embedded database at both parallel levels:
 
-Recorded as an explicit gap rather than left implied.
+| `parallelLevel` | measured gap | `gap < SLEEP_DURATION` |
+|---|---|---|
+| 1 (sequential) | 2001 ms | **fails** - correct |
+| 2 (parallel) | 0 ms | passes - correct |
+
+The sequential result is not merely empirical. With one worker the second command's 2000 ms sleep
+cannot begin until the first has completed, so the gap has a hard floor of `SLEEP_DURATION`; the
+assertion is `isLessThan(SLEEP_DURATION)`, which fails at the boundary as well as above it. The
+parallel side has the whole of `SLEEP_DURATION` as margin. The assertion discriminates.
+
+The harness was deleted after the run; it is not part of this branch.
+
+### Remaining verification gap
+
+`HttpRedMetricsIT`, `Issue5470BatchStreamStallIT` and `Bolt5002RoutingTableIT` were not exercised
+against their failure modes. Their assertions are unchanged in substance - the polls wrap conditions
+that were already being asserted, and the timeout constants were scaled without altering the ordering
+under test - so the risk is materially lower than for the Issue3122 rewrite. CI green plus the review
+spot-check is the evidence for those three.
+
+## Review cycle 1 (`ec04ad3fe`)
+
+Bot review raised five points. Outcomes:
+
+1. **Accepted - `Issue5470` client `soTimeout` equalled the streaming budget.** The comment claimed the
+   client timeout outlives the budget so that a server which wrongly waits is caught by the elapsed-time
+   assertion, but the value was set *equal* to it, making the two race. Introduced
+   `CLIENT_SO_TIMEOUT_MS = STREAMING_BUDGET_MS + 30_000` so the assertion, not a `SocketTimeoutException`,
+   is what reports the failure. Correct catch.
+2. **Declined - widening `SEQUENTIAL_COST_FRACTION` from 1.5 to 1.6-1.7.** The suggestion treats the
+   threshold as trading only against false failures, but the sequential ratio is
+   `(2*SLEEP + o) / (SLEEP + o)` for per-request overhead `o`, which *decreases* toward 1.0 as `o` grows -
+   it is 2.0 only when overhead is negligible and already 1.5 once overhead reaches one SLEEP. Raising the
+   constant therefore buys false-failure margin by surrendering false-pass margin, and a regression guard
+   that silently passes is the worse failure. Kept at 1.5, with the reasoning recorded in the constant's
+   javadoc so it is not re-litigated.
+   **However**, the review was pointing at something real next to it: the ratio is meaningless if the
+   baseline is degenerate. Added an assertion that `singleMs >= SLEEP_DURATION`, which closes the case
+   where `waitCompletion` returns before the command is picked up and the threshold collapses to the HTTP
+   round trip. That is the cheaper protection for the property the suggestion was reaching for.
+3. **Point 5 (treat the negative check as blocking, not a follow-up)** - agreed and discharged; see the
+   proof table above.
+4. Points 3 and 4 were confirmations of existing reasoning; no change needed.

--- a/docs/5630-flaky-ci-test-hardening.md
+++ b/docs/5630-flaky-ci-test-hardening.md
@@ -56,7 +56,9 @@ machine, so the budget was already tighter than an unloaded local run.
 - `httpAsyncCommandsRunInParallel` has no completion callback, so it measures a **single-command
   baseline back to back with the concurrent pair** on the same server, and asserts the pair costs less
   than 1.5x the baseline. Sequential execution costs ~2x the baseline, parallel ~1x; the threshold sits
-  midway and load inflates both measurements together.
+  midway. What makes the ratio hold where an absolute budget does not is that the dominant term in both
+  measurements is the same server-side SLEEP, a wall-clock wait rather than CPU work and so largely
+  load-independent - not that load inflates the two measurements proportionally.
 - The `latch.await` / `future.get` / `waitCompletion` timeouts were raised to liveness-guard values
   (120 s / 60 s) and are documented as such. They exist so a wedged executor fails rather than hangs;
   they are not performance assertions.
@@ -203,3 +205,20 @@ No blocking points. Outcomes:
    over `**/failsafe-reports/TEST*.xml`). All four classes land in that job - it excludes only
    `e2e,load-tests,e2e-ha,ha-raft`, and `Bolt5002RoutingTableIT` runs in the `bolt` module despite extending
    `BaseRaftHATest`. Do not read this PR as verified until that reporter is green.
+
+## Review cycle 3 (`615206dd7`)
+
+1. **Declined - "trim or drop this doc; I don't see an existing `docs/NNNN-*.md` per-issue convention".**
+   The premise is factually wrong, and cycle 2's review asserted the opposite about the same file, so it
+   was checked against the repository rather than split the difference: `git ls-files docs` matches **68**
+   files of the form `docs/NNNN-*.md`, and **31** of those carry review-cycle sections of exactly the kind
+   this one has. Both the file and its cycle notes are house style. Keeping them.
+2. **Accepted - the stated reason the HTTP ratio is robust was imprecise.** The doc and the class javadoc
+   said the ratio survives because "load inflates both measurements together". That is not the mechanism:
+   the dominant term in both is the server-side `SLEEP`, a wall-clock wait rather than CPU work, so it is
+   largely load-*independent*, and it is that shared constant dominating both measurements that pins the
+   parallel ratio near 1.0. Corrected in both places. The 1.5 threshold is unaffected - and note this
+   sharpens rather than contradicts the cycle-1 argument for not raising it, which turned on the *overhead*
+   term growing.
+3. Points 2, 3 and 5 (runtime cost, residual differential-starvation flake, the Bolt helper) were
+   confirmations of decisions already recorded above; no change.

--- a/docs/5630-flaky-ci-test-hardening.md
+++ b/docs/5630-flaky-ci-test-hardening.md
@@ -1,0 +1,137 @@
+# Issue #5630 - Flaky CI tests: wall-clock budgets, short read timeouts, and unsettled counters
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5630
+
+## Problem
+
+Six ITs failed across CI runs of #5612. Every one passed when re-run in isolation on the same commit,
+and none of them touches anything that PR changed. The issue groups them into three shapes, each with
+its own fix:
+
+| test | how it failed | shape |
+|---|---|---|
+| `Issue3122AsyncParallelCommandsIT.databaseAsyncCommandsRunInParallel` | 26831 ms against a 3000 ms budget | wall-clock budget |
+| `Issue5470BatchStreamStallIT` | `Read timed out after 2000 milliseconds` | short read timeout |
+| `HttpRedMetricsIT.unmatchedUrisCollapseToBoundedPathTag` | counter read `49`, wanted `>= 50` | unsettled counter |
+| `Bolt5002RoutingTableIT.neo4jSchemeRoutesReadsAndWrites` | expected `1` got `0`, plus `DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5` | unsettled replication |
+| `Issue5410AbandonedTicketReleaseIT` | HA raft, 44 s | not addressed - see below |
+| `Issue5569SlotMergeDeleteRaftIT` | HA raft, 13 s, also fails on main | not addressed - see below |
+
+None of these is a product defect. In every case the assertion encodes an assumption about *timing*
+that holds on an unloaded developer machine and does not hold on a shared CI runner. The fix is to
+assert the property actually under test rather than a wall-clock proxy for it, without weakening what
+the test detects.
+
+## Root cause per test
+
+### `HttpRedMetricsIT` - the meter is recorded after the response is sent
+
+`AbstractServerHttpHandler.handleRequest` captures `httpStartNanos` at entry and records the
+`arcadedb.http.requests` timer in its `finally` block, which runs after the exchange has been
+completed. A client that has already read the response code is therefore racing the meter update.
+With 50 sequential requests the last one had not been recorded when the sum was read: 49, not 50.
+
+**Fix:** the positive meter assertions in all three test methods are wrapped in an Awaitility
+`untilAsserted` poll (30 s ceiling, 100 ms interval). The negative assertions are deliberately left
+outside the poll and moved *after* it:
+
+- `rawUnmatchedMeters` must be zero - polling a negative assertion would pass on the first tick before
+  any request was recorded, so it is checked once, after the poll has proven all 50 landed. This is
+  strictly stronger than the original ordering, not weaker.
+- `rawPathTimer` must be null - same reasoning.
+
+### `Issue3122AsyncParallelCommandsIT` - a wall-clock budget is not a parallelism assertion
+
+All three test methods asserted `totalTime < SLEEP_DURATION * 1.5`, i.e. under 3000 ms. The reported
+run took 26831 ms while running perfectly in parallel; the same test takes ~7 s alone on a developer
+machine, so the budget was already tighter than an unloaded local run.
+
+**Fix:** no assertion compares elapsed time to a constant any more.
+
+- The two callback-driven tests (`databaseAsyncCommandsRunInParallel`, `simpleSqlAsyncCommandsRunInParallel`)
+  now record the instant each command signals completion and assert the two completions are **less than
+  one SLEEP apart**. Run sequentially the second command cannot start until the first finishes, so its
+  completion is at least `SLEEP_DURATION` later regardless of machine load. The gap is invariant under
+  a uniform slowdown; total elapsed time is not.
+- `httpAsyncCommandsRunInParallel` has no completion callback, so it measures a **single-command
+  baseline back to back with the concurrent pair** on the same server, and asserts the pair costs less
+  than 1.5x the baseline. Sequential execution costs ~2x the baseline, parallel ~1x; the threshold sits
+  midway and load inflates both measurements together.
+- The `latch.await` / `future.get` / `waitCompletion` timeouts were raised to liveness-guard values
+  (120 s / 60 s) and are documented as such. They exist so a wedged executor fails rather than hangs;
+  they are not performance assertions.
+
+Timestamps are written to an `AtomicLongArray` before `latch.countDown()`, so `await()` happens-after
+every write.
+
+### `Issue5470BatchStreamStallIT` - the socket timeout was shorter than CI scheduling noise
+
+The scenario needs the ordering `socket read timeout < injected stall < streaming budget`, so that the
+relaxed streaming budget is proven to govern a server-side stall. The absolute values did not matter,
+but at 2 s the socket timeout was also shorter than the pauses a loaded runner puts between the
+client's writes of the 1.7 MB body, so the server timed the upload out mid-body.
+
+**Fix:** the three values are scaled together, preserving the ordering under test and widening the
+margin against runner scheduling by 5x:
+
+| constant | before | after |
+|---|---|---|
+| `READ_TIMEOUT_MS` (`NETWORK_SOCKET_TIMEOUT`) | 2 000 | 10 000 |
+| `STALL_MS` | 5 000 | 20 000 |
+| streaming budget (`SERVER_HTTP_STREAMING_READ_TIMEOUT`) | 60 000 | 120 000 |
+
+The client-side `setSoTimeout` in the two raw-socket tests and the `elapsedMs` bound in
+`stalledClientIsCutOffAndAnswered` were tied to `STREAMING_BUDGET_MS` rather than left at a bare
+`60_000`. This keeps the assertion, not the client socket, as the thing that fails when the server
+wrongly waits for the streaming budget.
+
+### `Bolt5002RoutingTableIT` - a routed read hits a follower that has not applied the schema entry
+
+`waitForAllServers()` tracks the Raft applied index, which advances before the applied schema entry is
+visible through the database handle the test reads. `executeRead` is routed to a follower, so it saw
+zero records. The `DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5` suppressed in the same run is the
+same lag surfacing in teardown: a follower still missing the `Bolt5002Route` type.
+
+**Fix:** `awaitRoutedWriteOnEveryNode()` polls every started node until it holds both the type and its
+single record before the routed read runs. This settles the teardown comparison as well.
+
+## Not addressed here
+
+`Issue5410AbandonedTicketReleaseIT` and `Issue5569SlotMergeDeleteRaftIT` are left untouched.
+
+Neither matches the three shapes above. The issue records only a duration for each, with no assertion
+message identifying what actually failed, and notes that `Issue5569SlotMergeDeleteRaftIT` **also fails
+on main** (run 30592955402). That makes it a candidate real defect in the HA/raft area rather than a
+test-hardening target - "is this failure mine?" cannot be answered from the recorded evidence. Widening
+a timeout in either would risk masking a genuine bug. They need their own investigation with a captured
+failure, and should be tracked separately.
+
+## Verification
+
+- `mvn -o -pl server -DskipTests test-compile` - BUILD SUCCESS
+- `mvn -o -pl bolt -DskipTests test-compile` - BUILD SUCCESS (also confirms Awaitility is on the test
+  classpath in `bolt`; it is declared in the root POM's `<dependencies>`, not `<dependencyManagement>`,
+  so every module inherits it and no new dependency was added)
+
+**The four IT classes were not run locally.** Ports 2480/2481 were held for the duration of this work
+by an ArcadeDB server running under the developer's IntelliJ debugger, which `BaseGraphServerTest`
+needs to bind. CI is the verification gate for this change, by the developer's decision.
+
+When reading that CI run, note what the issue itself records about this repo: the failing step is the
+**reporter** (`IT Tests Reporter` / `HA IT Tests Reporter`), not the test step. Maven runs with test
+failures ignored, so `Run Integration Tests with Coverage: success` does **not** mean the tests passed.
+
+### Open item: proving the hardened assertions can still fail
+
+A hardening change is only worth anything if the assertion it leaves behind still detects the
+regression it guards, and a green CI run does not establish that - a test that can no longer fail is
+also green. Two checks are worth running before this is trusted, neither of which CI performs:
+
+1. `Issue3122AsyncParallelCommandsIT` - force `setParallelLevel(1)` so execution is sequential. The
+   completion-gap assertion must fail, with a reported gap of at least `SLEEP_DURATION`. This is the
+   important one: it is the assertion that was rewritten most substantially.
+2. `HttpRedMetricsIT` - the polls are wrapped around assertions that were already there and are
+   unchanged in substance, so the risk is lower, but a run with the path-collapsing behaviour reverted
+   should still fail on `rawUnmatchedMeters`.
+
+Recorded as an explicit gap rather than left implied.

--- a/docs/5630-flaky-ci-test-hardening.md
+++ b/docs/5630-flaky-ci-test-hardening.md
@@ -173,3 +173,33 @@ Bot review raised five points. Outcomes:
 3. **Point 5 (treat the negative check as blocking, not a follow-up)** - agreed and discharged; see the
    proof table above.
 4. Points 3 and 4 were confirmations of existing reasoning; no change needed.
+
+## Review cycle 2 (`3ff6ba5f5`)
+
+No blocking points. Outcomes:
+
+1. **No change - residual flakiness in `assertCommandsOverlapped`.** Correctly observed: if a runner starves
+   the second worker for a whole SLEEP, two genuinely parallel commands can still complete `>= SLEEP` apart.
+   The reviewer recommends keeping it anyway and that is right - the old assertion failed under *any* uniform
+   slowdown, this one fails only under differential starvation of one worker. Strict improvement, residual
+   risk accepted knowingly.
+2. **Confirmed and documented - the baseline guard's dependency on enqueue-before-202.** The review flagged
+   that `singleMs >= SLEEP_DURATION` is only sound if the command is enqueued before the 202 the client
+   observes, otherwise the guard added in cycle 1 would produce *false failures*. Verified in the source
+   rather than assumed: `PostCommandHandler` line 214-217 calls `executeCommandAsync(...)` - which enqueues
+   synchronously via `database.async().command(...)` - and only then constructs the 202. The ordering holds;
+   a comment now records it at the assertion.
+3. **Accepted for `Issue3122` only - `@Tag("slow")`.** This class now waits out two SLEEPs in the HTTP test
+   where it previously waited one, so the change itself made it slower and the tag is earned under the
+   CLAUDE.md convention for multi-second regression tests. Declined for `HttpRedMetricsIT`, which issues 50
+   local HTTP requests and is sub-second unless it fails.
+   Worth recording: `excludedGroups` is **commented out** in the root POM (line 216), so no tag filtering is
+   currently active. Tagging changes nothing about what CI runs today - it is classification, which is also
+   why it carries no risk of silencing the very test being de-flaked. If tag filtering is ever re-enabled,
+   `slow` must stay inside the IT job or this and the two already-tagged classes would stop running.
+4. **Answered - which CI signal is authoritative.** Verified against `.github/workflows/mvn-test.yml`: the
+   integration job runs `./mvnw verify ... --fail-never`, so `Run Integration Tests with Coverage: success`
+   is unconditional and carries no information. The gate is the `IT Tests Reporter` step (dorny/test-reporter
+   over `**/failsafe-reports/TEST*.xml`). All four classes land in that job - it excludes only
+   `e2e,load-tests,e2e-ha,ha-raft`, and `Bolt5002RoutingTableIT` runs in the `bolt` module despite extending
+   `BaseRaftHATest`. Do not read this PR as verified until that reporter is green.

--- a/docs/5630-flaky-ci-test-hardening.md
+++ b/docs/5630-flaky-ci-test-hardening.md
@@ -13,7 +13,7 @@ its own fix:
 | `Issue3122AsyncParallelCommandsIT.databaseAsyncCommandsRunInParallel` | 26831 ms against a 3000 ms budget | wall-clock budget |
 | `Issue5470BatchStreamStallIT` | `Read timed out after 2000 milliseconds` | short read timeout |
 | `HttpRedMetricsIT.unmatchedUrisCollapseToBoundedPathTag` | counter read `49`, wanted `>= 50` | unsettled counter |
-| `Bolt5002RoutingTableIT.neo4jSchemeRoutesReadsAndWrites` | expected `1` got `0`, plus `DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5` | unsettled replication |
+| `Bolt5002RoutingTableIT.neo4jSchemeRoutesReadsAndWrites` | expected `1` got `0`, plus `DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5` | **not a flake - real divergence, reverted** |
 | `Issue5410AbandonedTicketReleaseIT` | HA raft, 44 s | not addressed - see below |
 | `Issue5569SlotMergeDeleteRaftIT` | HA raft, 13 s, also fails on main | not addressed - see below |
 
@@ -87,15 +87,36 @@ The client-side `setSoTimeout` in the two raw-socket tests and the `elapsedMs` b
 `60_000`. This keeps the assertion, not the client socket, as the thing that fails when the server
 wrongly waits for the streaming budget.
 
-### `Bolt5002RoutingTableIT` - a routed read hits a follower that has not applied the schema entry
+### `Bolt5002RoutingTableIT` - NOT a flake. Reverted from this change.
 
-`waitForAllServers()` tracks the Raft applied index, which advances before the applied schema entry is
-visible through the database handle the test reads. `executeRead` is routed to a follower, so it saw
-zero records. The `DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5` suppressed in the same run is the
-same lag surfacing in teardown: a follower still missing the `Bolt5002Route` type.
+This test was attacked as an "unsettled replication" case, on the theory that `waitForAllServers()`
+returns before the applied schema entry is visible and a bounded poll would settle it. **That diagnosis
+was wrong, and the issue's classification of this test is wrong too.**
 
-**Fix:** `awaitRoutedWriteOnEveryNode()` polls every started node until it holds both the type and its
-single record before the routed read runs. This settles the teardown comparison as well.
+A poll was added over every started node, waiting up to 60 s for the `Bolt5002Route` type and its single
+record. CI answered unambiguously:
+
+```
+org.awaitility.core.ConditionTimeoutException:
+  [server 1 must have replicated type Bolt5002Route]
+  Expecting value to be true but was false within 1 minutes
+  Suppressed: DatabaseComparator$DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5
+```
+
+Server 1 never received the type at all - not within 60 s, and the teardown comparison independently
+reported the same divergence the original issue recorded as a suppressed error. State that does not
+settle in 60 s is not lag, and no amount of polling fixes it. There is a real replication defect behind
+this test.
+
+The change was therefore **reverted**; the file is byte-identical to `main` on this branch. The remaining
+value of the experiment is diagnostic: it converts "expected 1 got 0" into evidence that a specific node
+never receives a schema entry written through the Cypher-over-Bolt path.
+
+**Follow-up:** needs its own issue and investigation. A plausible starting point - unverified, stated as a
+hypothesis only - is the `#5492`/`#5655` family: code that commits while holding the inner `LocalDatabase`
+rather than the wrapped replicated instance applies locally and replicates nothing. The Bolt write path
+should be checked against `getWrappedDatabaseInstance()`. Do not treat that as a diagnosis; it is only
+where to look first.
 
 ## Not addressed here
 
@@ -115,13 +136,26 @@ failure, and should be tracked separately.
   classpath in `bolt`; it is declared in the root POM's `<dependencies>`, not `<dependencyManagement>`,
   so every module inherits it and no new dependency was added)
 
-**The four IT classes were not run locally.** Ports 2480/2481 were held for the duration of this work
-by an ArcadeDB server running under the developer's IntelliJ debugger, which `BaseGraphServerTest`
-needs to bind. CI is the verification gate for this change, by the developer's decision.
+**The IT classes were not run locally.** Ports 2480/2481 were held for the duration of this work by an
+ArcadeDB server running under the developer's IntelliJ debugger, which `BaseGraphServerTest` needs to
+bind. CI was the verification gate, by the developer's decision.
 
-When reading that CI run, note what the issue itself records about this repo: the failing step is the
-**reporter** (`IT Tests Reporter` / `HA IT Tests Reporter`), not the test step. Maven runs with test
-failures ignored, so `Run Integration Tests with Coverage: success` does **not** mean the tests passed.
+### CI result (run 30706875826, commit `037e32702`)
+
+The `integration-tests` job reported `Run Integration Tests with Coverage: success` and
+`IT Tests Reporter: failure` - exactly the trap the issue documents. The Maven step runs with
+`--fail-never`, so its success is unconditional and carries no information; the reporter is the gate.
+
+| class | result | elapsed |
+|---|---|---|
+| `Issue3122AsyncParallelCommandsIT` | 3/3 pass | 8.1 s |
+| `HttpRedMetricsIT` | 3/3 pass | 0.5 s |
+| `Issue5470BatchStreamStallIT` | 3/3 pass | 31.0 s |
+| `Bolt5002RoutingTableIT` | 1 error - real defect, reverted | 110.6 s |
+
+The three hardening fixes are confirmed by the authoritative signal. Two incidental confirmations: the
+0.5 s on `HttpRedMetricsIT` supports having declined `@Tag("slow")` for it, and the 31 s on `Issue5470`
+is the runtime cost the reviews flagged.
 
 ### Proof that the rewritten assertion can still fail - DONE
 

--- a/server/src/test/java/com/arcadedb/server/Issue3122AsyncParallelCommandsIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue3122AsyncParallelCommandsIT.java
@@ -33,6 +33,8 @@ import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.IntFunction;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,11 +42,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Test for GitHub Issue #3122: Async commands should run in parallel.
  * https://github.com/ArcadeData/arcadedb/issues/3122
+ * <p>
+ * None of the assertions below compares elapsed time against a fixed constant. Doing so made the class a
+ * CI flake (issue #5630): a run that takes 7 s alone on a developer machine took 26.8 s on a loaded shared
+ * runner, nine times over a 3 s budget, while running perfectly in parallel the whole time. What separates
+ * parallel from sequential execution is not how long the work took but how the two commands were spaced,
+ * so that is what is asserted:
+ * <ul>
+ *   <li>with a completion callback, the two commands must finish <em>less than one SLEEP apart</em> - run
+ *       sequentially the second cannot even start until the first is done, so its completion is at least
+ *       {@code SLEEP_DURATION} later no matter how loaded the machine is;</li>
+ *   <li>without one (the HTTP route), a single-command baseline is measured back to back with the
+ *       concurrent pair, and the pair must cost well under twice the baseline. Load inflates both
+ *       measurements together, so the ratio survives what an absolute budget cannot.</li>
+ * </ul>
  */
 class Issue3122AsyncParallelCommandsIT extends BaseGraphServerTest {
 
   private static final String DATABASE_NAME  = "Issue3122AsyncParallelCommands";
   private static final int    SLEEP_DURATION = 2000; // 2 seconds per sleep command
+
+  /**
+   * Liveness guards only, never performance assertions: they exist so a wedged async executor fails the
+   * test instead of hanging it. Deliberately far above any plausible loaded-CI duration.
+   */
+  private static final long COMPLETION_TIMEOUT_MS      = 120_000;
+  private static final long HTTP_RESPONSE_TIMEOUT_SECS = 60;
+
+  /**
+   * A pair of commands executed sequentially costs about twice the single-command baseline; executed in
+   * parallel it costs about the baseline. The threshold sits midway, far from both outcomes.
+   */
+  private static final double SEQUENTIAL_COST_FRACTION = 1.5;
 
   @Override
   protected String getDatabaseName() {
@@ -53,8 +82,6 @@ class Issue3122AsyncParallelCommandsIT extends BaseGraphServerTest {
 
   /**
    * Test that two async commands sent via HTTP run in parallel, not sequentially.
-   * If they run in parallel, total time should be ~SLEEP_DURATION.
-   * If they run sequentially, total time would be ~2*SLEEP_DURATION.
    */
   @Test
   void httpAsyncCommandsRunInParallel() throws Exception {
@@ -67,13 +94,128 @@ class Issue3122AsyncParallelCommandsIT extends BaseGraphServerTest {
           .as("Server should have at least 2 async worker threads by default")
           .isGreaterThanOrEqualTo(2);
 
-      final long startTime = System.currentTimeMillis();
+      // Baseline first, on the same server and under the same load as the pair it is compared against.
+      final long singleMs = timeHttpAsyncSleepCommands(serverIndex, database, 1);
+      final long pairMs = timeHttpAsyncSleepCommands(serverIndex, database, 2);
 
-      // Send two async SLEEP commands concurrently
-      final ExecutorService executor = Executors.newFixedThreadPool(2);
+      LogManager.instance().log(this, Level.INFO,
+          "One async SLEEP command (%d ms each): %d ms; two concurrently: %d ms", SLEEP_DURATION, singleMs, pairMs);
+
+      assertThat(pairMs)
+          .as("Two concurrent async commands must cost far less than two sequential ones "
+              + "(one command: %d ms, two commands: %d ms)", singleMs, pairMs)
+          .isLessThan((long) (singleMs * SEQUENTIAL_COST_FRACTION));
+    });
+  }
+
+  /**
+   * Test that two async commands via the database.async() API run in parallel.
+   */
+  @Test
+  void databaseAsyncCommandsRunInParallel() throws Exception {
+    final Database database = getServer(0).getDatabase(getDatabaseName());
+
+    // Ensure we have at least 2 async worker threads
+    final int originalParallelLevel = database.async().getParallelLevel();
+    if (originalParallelLevel < 2)
+      database.async().setParallelLevel(2);
+
+    try {
+      assertCommandsOverlapped("database.async()", awaitAsyncSleepCompletions(database, "sqlscript",
+          cmdNum -> "SLEEP " + SLEEP_DURATION + "; CONSOLE.log 'Database async command " + cmdNum + " completed'"));
+    } finally {
+      database.async().setParallelLevel(originalParallelLevel);
+    }
+  }
+
+  /**
+   * Test that simple SQL SLEEP commands (not sqlscript) also run in parallel.
+   */
+  @Test
+  void simpleSqlAsyncCommandsRunInParallel() throws Exception {
+    final Database database = getServer(0).getDatabase(getDatabaseName());
+
+    // Ensure we have at least 2 async worker threads
+    final int originalParallelLevel = database.async().getParallelLevel();
+    if (originalParallelLevel < 2)
+      database.async().setParallelLevel(2);
+
+    try {
+      assertCommandsOverlapped("SQL", awaitAsyncSleepCompletions(database, "sql",
+          cmdNum -> "SLEEP " + SLEEP_DURATION));
+    } finally {
+      database.async().setParallelLevel(originalParallelLevel);
+    }
+  }
+
+  /**
+   * Submits two async SLEEP commands and returns the instant at which each one reported completion.
+   */
+  private long[] awaitAsyncSleepCompletions(final Database database, final String language,
+      final IntFunction<String> commandForIndex) throws InterruptedException {
+    final int commands = 2;
+    final AtomicLongArray completedAt = new AtomicLongArray(commands);
+    final AtomicInteger completedCount = new AtomicInteger();
+    final CountDownLatch latch = new CountDownLatch(commands);
+
+    for (int i = 0; i < commands; i++) {
+      final int cmdNum = i + 1;
+      final int slot = i;
+      database.async().command(language, commandForIndex.apply(cmdNum), new AsyncResultsetCallback() {
+        @Override
+        public void onComplete(final ResultSet resultset) {
+          // Written before countDown() so the await() below happens-after every timestamp.
+          completedAt.set(slot, System.currentTimeMillis());
+          completedCount.incrementAndGet();
+          latch.countDown();
+          LogManager.instance().log(this, Level.INFO, "Async %s command %d completed", language, cmdNum);
+        }
+
+        @Override
+        public void onError(final Exception exception) {
+          latch.countDown();
+          LogManager.instance().log(this, Level.SEVERE, "Async %s command %d failed", exception, language, cmdNum);
+        }
+      });
+    }
+
+    assertThat(latch.await(COMPLETION_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        .as("Both async commands should complete within %d ms", COMPLETION_TIMEOUT_MS).isTrue();
+    assertThat(completedCount.get()).isEqualTo(commands);
+
+    return new long[] { completedAt.get(0), completedAt.get(1) };
+  }
+
+  /**
+   * Asserts the two commands were in flight at the same time. Sequential execution puts at least one whole
+   * SLEEP between the two completions, because the second command cannot start before the first has
+   * finished; parallel execution puts them within scheduling noise of each other. The gap is independent
+   * of how loaded the machine is, which a total-elapsed-time budget is not.
+   */
+  private void assertCommandsOverlapped(final String label, final long[] completions) {
+    final long completionGap = Math.abs(completions[1] - completions[0]);
+
+    LogManager.instance().log(this, Level.INFO,
+        "Completion gap for 2 %s SLEEP commands (%d ms each): %d ms", label, SLEEP_DURATION, completionGap);
+
+    assertThat(completionGap)
+        .as("%s async commands must run in parallel: run sequentially their completions would be at least "
+            + "one SLEEP (%d ms) apart, they were %d ms apart", label, SLEEP_DURATION, completionGap)
+        .isLessThan((long) SLEEP_DURATION);
+  }
+
+  /**
+   * Fires {@code count} async SLEEP commands over HTTP and returns the wall-clock time until all of them
+   * have finished executing on the server.
+   */
+  private long timeHttpAsyncSleepCommands(final int serverIndex, final Database database, final int count)
+      throws Exception {
+    final ExecutorService executor = Executors.newFixedThreadPool(count);
+    try {
+      final long startTime = System.currentTimeMillis();
       final List<Future<Integer>> futures = new ArrayList<>();
 
-      for (int i = 0; i < 2; i++) {
+      for (int i = 0; i < count; i++) {
         final int cmdNum = i + 1;
         futures.add(executor.submit(() -> {
           final HttpURLConnection connection = (HttpURLConnection) new URL(
@@ -100,157 +242,16 @@ class Issue3122AsyncParallelCommandsIT extends BaseGraphServerTest {
         }));
       }
 
-      // Wait for both HTTP requests to return (they should return immediately with 202)
-      for (Future<Integer> future : futures) {
-        final int responseCode = future.get(5, TimeUnit.SECONDS);
-        assertThat(responseCode).isEqualTo(202);
-      }
+      // The HTTP requests themselves return immediately with 202; the work continues on the async executor.
+      for (final Future<Integer> future : futures)
+        assertThat(future.get(HTTP_RESPONSE_TIMEOUT_SECS, TimeUnit.SECONDS)).isEqualTo(202);
 
+      assertThat(database.async().waitCompletion(COMPLETION_TIMEOUT_MS))
+          .as("The %d async command(s) must finish within %d ms", count, COMPLETION_TIMEOUT_MS).isTrue();
+
+      return System.currentTimeMillis() - startTime;
+    } finally {
       executor.shutdown();
-
-      // Now wait for the async commands to actually complete
-      database.async().waitCompletion(SLEEP_DURATION * 3);
-
-      final long endTime = System.currentTimeMillis();
-      final long totalTime = endTime - startTime;
-
-      LogManager.instance().log(this, Level.INFO,
-          "Total time for 2 async SLEEP commands (%d ms each): %d ms", SLEEP_DURATION, totalTime);
-
-      // If running in parallel, total time should be close to SLEEP_DURATION
-      // If running sequentially, total time would be close to 2*SLEEP_DURATION
-      // We use 1.5x as the threshold - parallel should be well under this
-      final long maxExpectedParallelTime = (long) (SLEEP_DURATION * 1.5);
-
-      assertThat(totalTime)
-          .as("Async commands should run in parallel. Total time: %d ms, expected max: %d ms", totalTime, maxExpectedParallelTime)
-          .isLessThan(maxExpectedParallelTime);
-    });
-  }
-
-  /**
-   * Test that two async commands via the database.async() API run in parallel.
-   */
-  @Test
-  void databaseAsyncCommandsRunInParallel() throws Exception {
-    final Database database = getServer(0).getDatabase(getDatabaseName());
-
-    // Ensure we have at least 2 async worker threads
-    final int originalParallelLevel = database.async().getParallelLevel();
-    if (originalParallelLevel < 2) {
-      database.async().setParallelLevel(2);
-    }
-
-    try {
-      final long startTime = System.currentTimeMillis();
-      final AtomicInteger completedCount = new AtomicInteger(0);
-      final CountDownLatch latch = new CountDownLatch(2);
-
-      // Send two async SLEEP commands
-      for (int i = 0; i < 2; i++) {
-        final int cmdNum = i + 1;
-        database.async().command("sqlscript",
-            "SLEEP " + SLEEP_DURATION + "; CONSOLE.log 'Database async command " + cmdNum + " completed'",
-            new AsyncResultsetCallback() {
-              @Override
-              public void onComplete(final ResultSet resultset) {
-                completedCount.incrementAndGet();
-                latch.countDown();
-                LogManager.instance().log(this, Level.INFO, "Database async command %d completed", cmdNum);
-              }
-
-              @Override
-              public void onError(final Exception exception) {
-                latch.countDown();
-                LogManager.instance().log(this, Level.SEVERE, "Database async command %d failed", exception, cmdNum);
-              }
-            });
-      }
-
-      // Wait for both commands to complete
-      final boolean completed = latch.await(SLEEP_DURATION * 3, TimeUnit.MILLISECONDS);
-      assertThat(completed).as("Both async commands should complete within timeout").isTrue();
-      assertThat(completedCount.get()).isEqualTo(2);
-
-      final long endTime = System.currentTimeMillis();
-      final long totalTime = endTime - startTime;
-
-      LogManager.instance().log(this, Level.INFO,
-          "Total time for 2 database.async() SLEEP commands (%d ms each): %d ms", SLEEP_DURATION, totalTime);
-
-      // If running in parallel, total time should be close to SLEEP_DURATION
-      final long maxExpectedParallelTime = (long) (SLEEP_DURATION * 1.5);
-
-      assertThat(totalTime)
-          .as("Database async commands should run in parallel. Total time: %d ms, expected max: %d ms", totalTime,
-              maxExpectedParallelTime)
-          .isLessThan(maxExpectedParallelTime);
-
-    } finally {
-      database.async().setParallelLevel(originalParallelLevel);
-    }
-  }
-
-  /**
-   * Test that simple SQL SLEEP commands (not sqlscript) also run in parallel.
-   */
-  @Test
-  void simpleSqlAsyncCommandsRunInParallel() throws Exception {
-    final Database database = getServer(0).getDatabase(getDatabaseName());
-
-    // Ensure we have at least 2 async worker threads
-    final int originalParallelLevel = database.async().getParallelLevel();
-    if (originalParallelLevel < 2) {
-      database.async().setParallelLevel(2);
-    }
-
-    try {
-      final long startTime = System.currentTimeMillis();
-      final AtomicInteger completedCount = new AtomicInteger(0);
-      final CountDownLatch latch = new CountDownLatch(2);
-
-      // Send two async SLEEP commands using plain SQL
-      for (int i = 0; i < 2; i++) {
-        final int cmdNum = i + 1;
-        database.async().command("sql",
-            "SLEEP " + SLEEP_DURATION,
-            new AsyncResultsetCallback() {
-              @Override
-              public void onComplete(final ResultSet resultset) {
-                completedCount.incrementAndGet();
-                latch.countDown();
-                LogManager.instance().log(this, Level.INFO, "SQL async command %d completed", cmdNum);
-              }
-
-              @Override
-              public void onError(final Exception exception) {
-                latch.countDown();
-                LogManager.instance().log(this, Level.SEVERE, "SQL async command %d failed", exception, cmdNum);
-              }
-            });
-      }
-
-      // Wait for both commands to complete
-      final boolean completed = latch.await(SLEEP_DURATION * 3, TimeUnit.MILLISECONDS);
-      assertThat(completed).as("Both SQL async commands should complete within timeout").isTrue();
-      assertThat(completedCount.get()).isEqualTo(2);
-
-      final long endTime = System.currentTimeMillis();
-      final long totalTime = endTime - startTime;
-
-      LogManager.instance().log(this, Level.INFO,
-          "Total time for 2 SQL async SLEEP commands (%d ms each): %d ms", SLEEP_DURATION, totalTime);
-
-      // If running in parallel, total time should be close to SLEEP_DURATION
-      final long maxExpectedParallelTime = (long) (SLEEP_DURATION * 1.5);
-
-      assertThat(totalTime)
-          .as("SQL async commands should run in parallel. Total time: %d ms, expected max: %d ms", totalTime,
-              maxExpectedParallelTime)
-          .isLessThan(maxExpectedParallelTime);
-
-    } finally {
-      database.async().setParallelLevel(originalParallelLevel);
     }
   }
 

--- a/server/src/test/java/com/arcadedb/server/Issue3122AsyncParallelCommandsIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue3122AsyncParallelCommandsIT.java
@@ -72,6 +72,13 @@ class Issue3122AsyncParallelCommandsIT extends BaseGraphServerTest {
   /**
    * A pair of commands executed sequentially costs about twice the single-command baseline; executed in
    * parallel it costs about the baseline. The threshold sits midway, far from both outcomes.
+   * <p>
+   * Do not raise it to buy margin against a stray pause. Writing {@code o} for the fixed per-request
+   * overhead, the sequential ratio is {@code (2*SLEEP + o) / (SLEEP + o)}, which <em>falls</em> toward 1.0
+   * as {@code o} grows: it is 2.0 only when the overhead is negligible, and already 1.5 once the overhead
+   * reaches a whole SLEEP. Every increase of this constant therefore buys false-failure margin by giving
+   * up false-pass margin, and a regression guard that silently passes is the worse of the two. The
+   * baseline-validity assertion below is the cheaper way to protect the same property.
    */
   private static final double SEQUENTIAL_COST_FRACTION = 1.5;
 
@@ -100,6 +107,14 @@ class Issue3122AsyncParallelCommandsIT extends BaseGraphServerTest {
 
       LogManager.instance().log(this, Level.INFO,
           "One async SLEEP command (%d ms each): %d ms; two concurrently: %d ms", SLEEP_DURATION, singleMs, pairMs);
+
+      // The threshold below is only meaningful if the baseline actually waited out its SLEEP. Were
+      // waitCompletion to return before the command was picked up, singleMs would collapse to the HTTP
+      // round trip and the comparison would silently stop testing anything.
+      assertThat(singleMs)
+          .as("The single-command baseline must have waited out its SLEEP, otherwise the ratio below is "
+              + "measured against nothing (baseline: %d ms, SLEEP: %d ms)", singleMs, SLEEP_DURATION)
+          .isGreaterThanOrEqualTo(SLEEP_DURATION);
 
       assertThat(pairMs)
           .as("Two concurrent async commands must cost far less than two sequential ones "

--- a/server/src/test/java/com/arcadedb/server/Issue3122AsyncParallelCommandsIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue3122AsyncParallelCommandsIT.java
@@ -24,6 +24,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.serializer.json.JSONObject;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
@@ -56,7 +57,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       concurrent pair, and the pair must cost well under twice the baseline. Load inflates both
  *       measurements together, so the ratio survives what an absolute budget cannot.</li>
  * </ul>
+ * <p>
+ * Every method here waits out at least one real 2 s SLEEP, and the HTTP one waits out two (baseline then
+ * pair), so the class is tagged slow per the repository convention for multi-second regression tests.
  */
+@Tag("slow")
 class Issue3122AsyncParallelCommandsIT extends BaseGraphServerTest {
 
   private static final String DATABASE_NAME  = "Issue3122AsyncParallelCommands";
@@ -111,6 +116,10 @@ class Issue3122AsyncParallelCommandsIT extends BaseGraphServerTest {
       // The threshold below is only meaningful if the baseline actually waited out its SLEEP. Were
       // waitCompletion to return before the command was picked up, singleMs would collapse to the HTTP
       // round trip and the comparison would silently stop testing anything.
+      // This is safe to assert rather than merely hope for: on the awaitResponse=false path
+      // PostCommandHandler calls executeCommandAsync - which enqueues via database.async().command() -
+      // before it builds the 202, so by the time the future below has observed the response the command
+      // is already on the queue that waitCompletion drains.
       assertThat(singleMs)
           .as("The single-command baseline must have waited out its SLEEP, otherwise the ratio below is "
               + "measured against nothing (baseline: %d ms, SLEEP: %d ms)", singleMs, SLEEP_DURATION)

--- a/server/src/test/java/com/arcadedb/server/Issue3122AsyncParallelCommandsIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue3122AsyncParallelCommandsIT.java
@@ -54,8 +54,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       sequentially the second cannot even start until the first is done, so its completion is at least
  *       {@code SLEEP_DURATION} later no matter how loaded the machine is;</li>
  *   <li>without one (the HTTP route), a single-command baseline is measured back to back with the
- *       concurrent pair, and the pair must cost well under twice the baseline. Load inflates both
- *       measurements together, so the ratio survives what an absolute budget cannot.</li>
+ *       concurrent pair, and the pair must cost well under twice the baseline. What makes the ratio hold
+ *       where an absolute budget does not is that the dominant term in both measurements is the same
+ *       server-side SLEEP - a wall-clock wait, so largely load-independent - leaving the parallel ratio
+ *       near 1.0 and the sequential one near 2.0 whatever the runner is doing.</li>
  * </ul>
  * <p>
  * Every method here waits out at least one real 2 s SLEEP, and the HTTP one waits out two (baseline then

--- a/server/src/test/java/com/arcadedb/server/Issue5470BatchStreamStallIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5470BatchStreamStallIT.java
@@ -54,8 +54,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("slow")
 class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
 
-  private static final int READ_TIMEOUT_MS  = 2_000;
-  private static final int STALL_MS         = 5_000;
+  /**
+   * What the scenario needs is the ordering {@code READ_TIMEOUT_MS < STALL_MS < streaming budget}, not any
+   * particular absolute value. At 2 s the socket timeout was also shorter than the pauses a loaded CI runner
+   * puts between the client's writes of the 1.7 MB body, so the server timed the upload out mid-body and the
+   * class failed with "Read timed out after 2000 milliseconds" (issue #5630). The three values are scaled
+   * together here: the ordering under test is unchanged, the margin against runner scheduling is five times
+   * wider.
+   */
+  private static final int READ_TIMEOUT_MS      = 10_000;
+  private static final int STALL_MS             = 20_000;
+  private static final int STREAMING_BUDGET_MS  = 120_000;
   /** More than one server-side vertex batch (PostBatchHandler flushes every 10,000 vertices). */
   private static final int TOTAL_VERTICES   = 25_000;
 
@@ -65,7 +74,7 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
     GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(READ_TIMEOUT_MS);
     // Keep the streaming budget well above the stall injected below: setting it to 0 (the pre-fix behaviour)
     // makes serverSideStallDoesNotTruncateTheBatch fail with a connection reset.
-    GlobalConfiguration.SERVER_HTTP_STREAMING_READ_TIMEOUT.setValue(60_000);
+    GlobalConfiguration.SERVER_HTTP_STREAMING_READ_TIMEOUT.setValue(STREAMING_BUDGET_MS);
   }
 
   @AfterEach
@@ -137,7 +146,9 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
     final String auth = Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
 
     try (final Socket socket = new Socket("127.0.0.1", 2480)) {
-      socket.setSoTimeout(60_000);
+      // Outlive the streaming budget, so that a server which did wait for it is caught by the elapsed-time
+      // assertion below rather than by a read timeout on this socket.
+      socket.setSoTimeout(STREAMING_BUDGET_MS);
 
       final OutputStream out = socket.getOutputStream();
       // Announce far more bytes than are ever sent, then go silent.
@@ -157,7 +168,7 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
 
       // Either the server answers (preferred: 408 with the counters) or it closes the connection, but it must
       // never wait for the relaxed streaming budget before reacting.
-      assertThat(elapsedMs).isLessThan(60_000L);
+      assertThat(elapsedMs).isLessThan((long) STREAMING_BUDGET_MS);
       if (statusLine != null)
         assertThat(statusLine).contains("408");
     }
@@ -185,7 +196,7 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
     final String auth = Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
 
     try (final Socket socket = new Socket("127.0.0.1", 2480)) {
-      socket.setSoTimeout(60_000);
+      socket.setSoTimeout(STREAMING_BUDGET_MS);
 
       final OutputStream out = socket.getOutputStream();
       // vertexBatchSize=1 commits every record, so the reported counts are exactly what reached the database.

--- a/server/src/test/java/com/arcadedb/server/Issue5470BatchStreamStallIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5470BatchStreamStallIT.java
@@ -65,6 +65,12 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
   private static final int READ_TIMEOUT_MS      = 10_000;
   private static final int STALL_MS             = 20_000;
   private static final int STREAMING_BUDGET_MS  = 120_000;
+  /**
+   * Strictly greater than the streaming budget. A server that wrongly waits out the whole budget must be
+   * caught by an elapsed-time assertion, not by the client's own read timeout firing first: at equal
+   * values the two race and the failure surfaces as a SocketTimeoutException instead.
+   */
+  private static final int CLIENT_SO_TIMEOUT_MS = STREAMING_BUDGET_MS + 30_000;
   /** More than one server-side vertex batch (PostBatchHandler flushes every 10,000 vertices). */
   private static final int TOTAL_VERTICES   = 25_000;
 
@@ -146,9 +152,7 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
     final String auth = Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
 
     try (final Socket socket = new Socket("127.0.0.1", 2480)) {
-      // Outlive the streaming budget, so that a server which did wait for it is caught by the elapsed-time
-      // assertion below rather than by a read timeout on this socket.
-      socket.setSoTimeout(STREAMING_BUDGET_MS);
+      socket.setSoTimeout(CLIENT_SO_TIMEOUT_MS);
 
       final OutputStream out = socket.getOutputStream();
       // Announce far more bytes than are ever sent, then go silent.
@@ -196,7 +200,7 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
     final String auth = Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
 
     try (final Socket socket = new Socket("127.0.0.1", 2480)) {
-      socket.setSoTimeout(STREAMING_BUDGET_MS);
+      socket.setSoTimeout(CLIENT_SO_TIMEOUT_MS);
 
       final OutputStream out = socket.getOutputStream();
       // vertexBatchSize=1 commits every record, so the reported counts are exactly what reached the database.

--- a/server/src/test/java/com/arcadedb/server/monitor/HttpRedMetricsIT.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/HttpRedMetricsIT.java
@@ -26,15 +26,26 @@ import org.junit.jupiter.api.Test;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Base64;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Verifies the always-on HTTP RED timer {@code arcadedb.http.requests} records every request
  * served by the universal handler entry, with a bounded path-template tag (never the raw URI).
  */
 class HttpRedMetricsIT extends BaseGraphServerTest {
+
+  /**
+   * The RED timer is recorded in the handler's finally block, which runs after the response has been
+   * written, so every meter read here races the request that produced it. The assertions are polled for
+   * that window rather than widened, which would stop them detecting a request that is never recorded.
+   */
+  private static final Duration SETTLE_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration POLL_INTERVAL  = Duration.ofMillis(100);
 
   @Override
   protected int getServerCount() {
@@ -48,18 +59,21 @@ class HttpRedMetricsIT extends BaseGraphServerTest {
     issueReady();
     issueQuery();
 
-    final Timer anyTimer = Metrics.globalRegistry.find("arcadedb.http.requests").timer();
-    assertThat(anyTimer).isNotNull();
-
     // The query route must be tagged with the template, not the concrete database name "graph".
     // Every tag of the tuple this test drove is pinned: the ITs share one reused fork, so meters from
     // earlier test classes are still registered under this name and a path-only lookup returns an
     // arbitrary one of them. Those stale meters record nothing for this test, so asserting a count on
     // one is a false failure that depends purely on test ordering.
-    final Timer queryTimer = Metrics.globalRegistry.find("arcadedb.http.requests")
-        .tag("path", "/query/{database}").tag("db", "graph").tag("method", "POST").tag("status", "200").timer();
-    assertThat(queryTimer).isNotNull();
-    assertThat(queryTimer.count()).isGreaterThanOrEqualTo(1L);
+    // Polled: the handler records the timer in a finally block that runs after the response is sent, so
+    // a client that already read the response code can still observe the meter unregistered or short.
+    await().atMost(SETTLE_TIMEOUT).pollInterval(POLL_INTERVAL).untilAsserted(() -> {
+      assertThat(Metrics.globalRegistry.find("arcadedb.http.requests").timer()).isNotNull();
+
+      final Timer queryTimer = Metrics.globalRegistry.find("arcadedb.http.requests")
+          .tag("path", "/query/{database}").tag("db", "graph").tag("method", "POST").tag("status", "200").timer();
+      assertThat(queryTimer).isNotNull();
+      assertThat(queryTimer.count()).isGreaterThanOrEqualTo(1L);
+    });
 
     // Cardinality guard: no timer should carry the raw database name in its path tag.
     final Timer rawPathTimer = Metrics.globalRegistry.find("arcadedb.http.requests").tag("path", "/query/graph").timer();
@@ -78,11 +92,14 @@ class HttpRedMetricsIT extends BaseGraphServerTest {
     assertThat(c.getResponseCode()).isEqualTo(401);
     c.disconnect();
 
-    // RED metrics must record errors too, tagged with the failing status code.
-    final Timer errorTimer = Metrics.globalRegistry.find("arcadedb.http.requests")
-        .tag("path", "/command/{database}").tag("status", "401").timer();
-    assertThat(errorTimer).isNotNull();
-    assertThat(errorTimer.count()).isGreaterThanOrEqualTo(1L);
+    // RED metrics must record errors too, tagged with the failing status code. Polled for the same
+    // reason as above: the record happens after the 401 has already reached the client.
+    await().atMost(SETTLE_TIMEOUT).pollInterval(POLL_INTERVAL).untilAsserted(() -> {
+      final Timer errorTimer = Metrics.globalRegistry.find("arcadedb.http.requests")
+          .tag("path", "/command/{database}").tag("status", "401").timer();
+      assertThat(errorTimer).isNotNull();
+      assertThat(errorTimer.count()).isGreaterThanOrEqualTo(1L);
+    });
   }
 
   @Test
@@ -93,21 +110,26 @@ class HttpRedMetricsIT extends BaseGraphServerTest {
     for (int i = 0; i < 50; i++)
       hitGet("/unmatched/" + i);
 
-    // No timer may carry a raw client URI in its path tag.
+    // All unmatched traffic collapses onto a single bounded path tag. The 50 requests above may split
+    // across status or method tags, and earlier test classes in the reused fork leave their own
+    // "unmatched" meters behind, so the count is summed over every meter carrying the tag rather than
+    // read off whichever single one the lookup happens to return.
+    // Polled: the last request's timer is recorded after its response was read, so an immediate sum
+    // legitimately lands one short of 50.
+    await().atMost(SETTLE_TIMEOUT).pollInterval(POLL_INTERVAL).untilAsserted(() -> {
+      final Collection<Timer> collapsed = Metrics.globalRegistry.find("arcadedb.http.requests")
+          .tag("path", "unmatched").timers();
+      assertThat(collapsed).isNotEmpty();
+      assertThat(collapsed.stream().mapToLong(Timer::count).sum()).isGreaterThanOrEqualTo(50L);
+    });
+
+    // No timer may carry a raw client URI in its path tag. Checked after the poll above, so every one
+    // of the 50 requests has been recorded by the time the cardinality guard reads the registry.
     final long rawUnmatchedMeters = Metrics.globalRegistry.find("arcadedb.http.requests").timers().stream()
         .map(t -> t.getId().getTag("path"))
         .filter(p -> p != null && p.startsWith("/unmatched"))
         .count();
     assertThat(rawUnmatchedMeters).isZero();
-
-    // All unmatched traffic collapses onto a single bounded path tag. The 50 requests above may split
-    // across status or method tags, and earlier test classes in the reused fork leave their own
-    // "unmatched" meters behind, so the count is summed over every meter carrying the tag rather than
-    // read off whichever single one the lookup happens to return.
-    final java.util.Collection<Timer> collapsed = Metrics.globalRegistry.find("arcadedb.http.requests")
-        .tag("path", "unmatched").timers();
-    assertThat(collapsed).isNotEmpty();
-    assertThat(collapsed.stream().mapToLong(Timer::count).sum()).isGreaterThanOrEqualTo(50L);
   }
 
   private void hitGet(final String path) throws Exception {


### PR DESCRIPTION
Refs #5630 (does not close it - see below)

Three of the six ITs recorded in the issue asserted something about *timing* that holds on an unloaded developer machine and does not hold on a shared CI runner. Each assertion is replaced with one on the property actually under test, chosen so it stays sensitive to the regression it guards rather than merely widened until it stops failing.

**All three are confirmed fixed by CI**, read from `IT Tests Reporter` - the authoritative gate, since the Maven step runs `--fail-never` and its success is unconditional:

| class | result | elapsed |
|---|---|---|
| `Issue3122AsyncParallelCommandsIT` | 3/3 pass | 8.1 s |
| `HttpRedMetricsIT` | 3/3 pass | 0.5 s |
| `Issue5470BatchStreamStallIT` | 3/3 pass | 31.0 s |

### What changed

- **`Issue3122AsyncParallelCommandsIT`** (26831 ms against a 3000 ms budget). No assertion compares elapsed time to a constant any more. The callback-driven tests record when each command signals completion and assert the two are **less than one SLEEP apart**: run sequentially the second command cannot start until the first finishes, so its completion is at least `SLEEP_DURATION` later at any load. `httpAsyncCommandsRunInParallel` has no callback, so it measures a single-command baseline back to back with the concurrent pair and requires the pair to cost under 1.5x the baseline, guarded by an assertion that the baseline actually waited out its SLEEP.
- **`HttpRedMetricsIT`** (counter read 49, wanted >= 50). `AbstractServerHttpHandler` records the RED timer in a `finally` block that runs *after* the response is sent, so a client that read the response races the meter. Positive assertions are polled; the negative cardinality guards stay outside the poll and move *after* it, which is strictly stronger than the original ordering.
- **`Issue5470BatchStreamStallIT`** (`Read timed out after 2000 milliseconds`). The scenario needs the ordering `socket timeout < injected stall < streaming budget`; the absolute values are incidental. The three values scale together (2/5/60 s to 10/20/120 s), and the client `soTimeout` is set strictly above the budget so the elapsed-time assertion, not a `SocketTimeoutException`, reports a server that wrongly waits.

**The rewritten gap assertion was proven still able to fail**, which is the check a hardening PR most often skips: at `parallelLevel=1` it produces a 2001 ms gap and fails; at `parallelLevel=2`, 0 ms and passes. The sequential side has a structural floor, not just a measured margin.

No new dependency: Awaitility is in the root POM `<dependencies>`, inherited by all modules.

### Not fixed here - and why this does not close #5630

**`Bolt5002RoutingTableIT` was attempted and reverted.** It is not a flake. A poll over every node waited the full 60 s and server 1 never received the `Bolt5002Route` type:

```
ConditionTimeoutException: [server 1 must have replicated type Bolt5002Route]
  Expecting value to be true but was false within 1 minutes
  Suppressed: DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5
```

State that does not settle in 60 s is not lag, and the teardown comparison independently reported the same divergence the issue recorded as a suppressed error. There is a real replication defect behind this test, so the issue's "unsettled replication, wants a bounded poll" classification is wrong. The file is restored byte-identical to `main`; the evidence and a starting point for investigation are in the tracking doc.

**`Issue5410AbandonedTicketReleaseIT` and `Issue5569SlotMergeDeleteRaftIT`** remain untouched. Neither matches the flake shapes, the issue records only a duration for each, and #5569 also fails on main.

So #5630 should stay open for those three.

## Test plan

- [x] `IT Tests Reporter` green for the three hardened classes (run 30706875826)
- [x] Gap assertion proven falsifiable at `parallelLevel=1`
- [ ] Re-run after the revert to confirm `integration-tests` is green end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)