### PR TITLE
fix(ci) #5701: coverage-report waits for the HA suite, and refuses to publish a partial merge

### DIFF
--- a/.github/scripts/check-workflow-artifact-deps.py
+++ b/.github/scripts/check-workflow-artifact-deps.py
@@ -24,6 +24,14 @@
 # `download-artifact` step it resolves which job uploads that artifact and asserts the producer is
 # in the consumer's transitive `needs` closure.
 #
+# Known boundary: it reads a job's `steps`, so a job that delegates to a reusable workflow
+# (`jobs.<id>.uses:`) is opaque - uploads and downloads inside the called workflow are neither
+# resolved nor checked. Because this check gates every other job, being wrong there would be
+# expensive, so a workflow containing such a job stops reporting "no job uploads this": the
+# producer may well be one of the steps it cannot see. Ordering violations it *can* see are still
+# reported. Following `uses:` into local workflows would lift the restriction; nothing in this
+# repository needs it yet.
+#
 # Usage:
 #   check-workflow-artifact-deps.py                 # check .github/workflows
 #   check-workflow-artifact-deps.py FILE|DIR ...    # check the given workflows
@@ -195,6 +203,10 @@ def check_workflow(path):
     produced = producers_of(jobs)
     violations = []
 
+    # A job that delegates to a reusable workflow has no steps to read, so an artifact this file
+    # never mentions may still be uploaded inside it. See the boundary note in the header.
+    opaque = any("uses" in job for job in jobs.values())
+
     for job_name, job in jobs.items():
         closure = None
         for step in steps_of(job):
@@ -231,10 +243,11 @@ def check_workflow(path):
 
             uploaders = matching_producers(produced, selector_names, selector_glob, is_pattern)
             if not uploaders:
-                violations.append(
-                    "%s: job '%s', step '%s' downloads '%s', which no job in this workflow uploads"
-                    % (path, job_name, step_name, selector)
-                )
+                if not opaque:
+                    violations.append(
+                        "%s: job '%s', step '%s' downloads '%s', which no job in this workflow "
+                        "uploads" % (path, job_name, step_name, selector)
+                    )
                 continue
 
             if closure is None:

--- a/.github/scripts/check-workflow-artifact-deps.py
+++ b/.github/scripts/check-workflow-artifact-deps.py
@@ -50,7 +50,8 @@ EXPRESSION = re.compile(r"\$\{\{.*?\}\}")
 
 
 def as_glob(value):
-    """Collapse a run-time expression into the glob of names it can produce.
+    """
+    Collapse a run-time expression into the glob of names it can produce.
 
     A matrix upload names its artifact `bolt-matrix-java-${{ matrix.version }}`; statically that is
     `bolt-matrix-java-*`. Keeping it as a glob is what lets the check still resolve the consumer
@@ -88,7 +89,7 @@ def needs_closure(jobs, name, seen=None):
 
 
 def producers_of(jobs):
-    """artifact glob -> the jobs that upload a name matching it."""
+    """Artifact glob -> the jobs that upload a name matching it."""
     produced = {}
     for job_name, job in jobs.items():
         for step in steps_of(job):
@@ -101,7 +102,8 @@ def producers_of(jobs):
 
 
 def matching_producers(produced, name, pattern):
-    """Resolve a download step's selector to the set of jobs it reads from.
+    """
+    Resolve a download step's selector to the set of jobs it reads from.
 
     `name` selects one artifact, `pattern` selects every artifact matching a glob, and neither
     means "download everything in the run" - which depends on every producing job. Both sides can

--- a/.github/scripts/check-workflow-artifact-deps.py
+++ b/.github/scripts/check-workflow-artifact-deps.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+#
+# Fails when a workflow job downloads an artifact it does not wait for.
+#
+# `actions/download-artifact` reads the artifact store of the *current run*. It has no
+# happens-before relationship with the job that uploads: if the producer has not finished by the
+# time the consumer runs, the artifact simply is not there yet. GitHub expresses that ordering
+# only through `needs`, and nothing in the actions themselves checks it - a consumer with the
+# wrong `needs` is valid YAML that runs green and silently reads an incomplete input.
+#
+# That is how #5701 happened. `coverage-report` downloaded `ha-integration-coverage-reports` but
+# listed only `[unit-tests, integration-tests, slow-unit-tests]` in `needs`, so it started ~14
+# minutes before `ha-integration-tests` finished. The download failed, `continue-on-error: true`
+# swallowed it, and the merged report went to Codecov without the ha-raft module - which Codecov
+# read as 1,110 covered lines vanishing, and reported as a coverage regression on a PR that had
+# touched 29 lines somewhere else entirely. Every symptom pointed at the diff; the cause was a
+# missing entry in a `needs` list.
+#
+# Worse, it was a race, not a constant: when the other three jobs happened to finish late the
+# artifact was there and the report was complete. So the check flipped between correct and wrong
+# on identical config, which is exactly the shape of bug that survives code review.
+#
+# This script makes the ordering an enforced invariant instead of a convention: for every
+# `download-artifact` step it resolves which job uploads that artifact and asserts the producer is
+# in the consumer's transitive `needs` closure.
+#
+# Usage:
+#   check-workflow-artifact-deps.py                 # check .github/workflows
+#   check-workflow-artifact-deps.py FILE|DIR ...    # check the given workflows
+#
+# @author Luca Garulli (l.garulli@arcadedata.com)
+
+import fnmatch
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - the workflow installs it explicitly
+    sys.exit("check-workflow-artifact-deps: PyYAML is required (pip install pyyaml)")
+
+UPLOAD_ACTION = "actions/upload-artifact"
+DOWNLOAD_ACTION = "actions/download-artifact"
+
+# upload-artifact's documented default when `name` is omitted.
+DEFAULT_ARTIFACT_NAME = "artifact"
+
+EXPRESSION = re.compile(r"\$\{\{.*?\}\}")
+
+
+def as_glob(value):
+    """Collapse a run-time expression into the glob of names it can produce.
+
+    A matrix upload names its artifact `bolt-matrix-java-${{ matrix.version }}`; statically that is
+    `bolt-matrix-java-*`. Keeping it as a glob is what lets the check still resolve the consumer
+    that picks the whole family up with `pattern: bolt-matrix-*`, instead of reporting a family of
+    artifacts nobody uploads.
+    """
+    return EXPRESSION.sub("*", value)
+
+
+def action_of(step):
+    uses = step.get("uses")
+    return uses.split("@", 1)[0].strip() if isinstance(uses, str) else ""
+
+
+def steps_of(job):
+    steps = job.get("steps")
+    return [s for s in steps if isinstance(s, dict)] if isinstance(steps, list) else []
+
+
+def needs_of(job):
+    needs = job.get("needs")
+    if isinstance(needs, str):
+        return [needs]
+    return [n for n in needs if isinstance(n, str)] if isinstance(needs, list) else []
+
+
+def needs_closure(jobs, name, seen=None):
+    """Every job that must finish before `name` starts, directly or transitively."""
+    seen = set() if seen is None else seen
+    for parent in needs_of(jobs.get(name) or {}):
+        if parent not in seen:
+            seen.add(parent)
+            needs_closure(jobs, parent, seen)
+    return seen
+
+
+def producers_of(jobs):
+    """artifact glob -> the jobs that upload a name matching it."""
+    produced = {}
+    for job_name, job in jobs.items():
+        for step in steps_of(job):
+            if action_of(step) != UPLOAD_ACTION:
+                continue
+            with_ = step.get("with") or {}
+            name = str(with_.get("name", DEFAULT_ARTIFACT_NAME))
+            produced.setdefault(as_glob(name), set()).add(job_name)
+    return produced
+
+
+def matching_producers(produced, name, pattern):
+    """Resolve a download step's selector to the set of jobs it reads from.
+
+    `name` selects one artifact, `pattern` selects every artifact matching a glob, and neither
+    means "download everything in the run" - which depends on every producing job. Both sides can
+    be globs (a matrix uploader against a family-wide consumer), so they are matched in either
+    direction: overlap in the names they can denote is enough to create the ordering requirement.
+    """
+    if name is None and pattern is None:
+        return {job for jobs in produced.values() for job in jobs}
+
+    selector = name if name is not None else pattern
+    matched = set()
+    for artifact, jobs in produced.items():
+        if fnmatch.fnmatch(artifact, selector) or fnmatch.fnmatch(selector, artifact):
+            matched |= jobs
+    return matched
+
+
+def check_workflow(path):
+    """Return the list of violation strings found in one workflow file."""
+    try:
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as error:
+        return ["%s: cannot parse: %s" % (path, error)]
+
+    if not isinstance(document, dict):
+        return []
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+    jobs = {name: job for name, job in jobs.items() if isinstance(job, dict)}
+
+    produced = producers_of(jobs)
+    violations = []
+
+    for job_name, job in jobs.items():
+        closure = None
+        for step in steps_of(job):
+            if action_of(step) != DOWNLOAD_ACTION:
+                continue
+            with_ = step.get("with") or {}
+
+            # A cross-run download reads another run's store, so this run's ordering says nothing.
+            if with_.get("run-id") is not None:
+                continue
+
+            # A selector is matched as the glob of names it can denote, so a matrix-interpolated
+            # one still resolves. One that collapses to a bare "*" denotes nothing in particular,
+            # and demanding every producer on the strength of it would be a guess, not a finding.
+            name = as_glob(str(with_["name"])) if with_.get("name") is not None else None
+            pattern = as_glob(str(with_["pattern"])) if with_.get("pattern") is not None else None
+            if name == "*" or pattern == "*":
+                continue
+
+            selector = (
+                "name: %s" % name
+                if name is not None
+                else "pattern: %s" % pattern if pattern is not None else "every artifact in the run"
+            )
+            step_name = step.get("name") or selector
+
+            uploaders = matching_producers(produced, name, pattern)
+            if not uploaders:
+                violations.append(
+                    "%s: job '%s', step '%s' downloads '%s', which no job in this workflow uploads"
+                    % (path, job_name, step_name, selector)
+                )
+                continue
+
+            if closure is None:
+                closure = needs_closure(jobs, job_name)
+            # A job reading back its own upload is ordered by step order, not by `needs`.
+            missing = sorted(uploaders - closure - {job_name})
+            if missing:
+                violations.append(
+                    "%s: job '%s', step '%s' downloads '%s' produced by %s, "
+                    "but %s %s not in its 'needs' closure %s\n"
+                    "    -> the download races the upload: add %s to '%s.needs'"
+                    % (
+                        path,
+                        job_name,
+                        step_name,
+                        selector,
+                        sorted(uploaders),
+                        missing,
+                        "is" if len(missing) == 1 else "are",
+                        sorted(closure) or "[]",
+                        missing,
+                        job_name,
+                    )
+                )
+
+    return violations
+
+
+def workflow_files(arguments):
+    default = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+    targets = [Path(a) for a in arguments] or [default]
+    files = []
+    for target in targets:
+        if target.is_dir():
+            files += sorted(p for p in target.iterdir() if p.suffix in (".yml", ".yaml"))
+        elif target.exists():
+            files.append(target)
+        else:
+            sys.exit("check-workflow-artifact-deps: no such file or directory: %s" % target)
+    return files
+
+
+def main(arguments):
+    files = workflow_files(arguments)
+    violations = [v for path in files for v in check_workflow(path)]
+
+    if violations:
+        print("Artifact downloads that are not ordered after their upload:\n", file=sys.stderr)
+        for violation in violations:
+            print("  %s\n" % violation, file=sys.stderr)
+        print(
+            "A job only waits for what its 'needs' lists. Downloading an artifact from a job that\n"
+            "is not in that list is a race: it usually resolves one way on a fast run and the other\n"
+            "way on a slow one, so the job goes green on incomplete input.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("check-workflow-artifact-deps: %d workflow(s) checked, no unordered downloads" % len(files))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/check-workflow-artifact-deps.py
+++ b/.github/scripts/check-workflow-artifact-deps.py
@@ -49,15 +49,12 @@ DEFAULT_ARTIFACT_NAME = "artifact"
 EXPRESSION = re.compile(r"\$\{\{.*?\}\}")
 
 
+# A matrix upload names its artifact `bolt-matrix-java-${{ matrix.version }}`; statically that is
+# `bolt-matrix-java-*`. Keeping it as a glob is what lets the check still resolve the consumer that
+# picks the whole family up with `pattern: bolt-matrix-*`, instead of reporting a family of
+# artifacts nobody uploads.
 def as_glob(value):
-    """
-    Collapse a run-time expression into the glob of names it can produce.
-
-    A matrix upload names its artifact `bolt-matrix-java-${{ matrix.version }}`; statically that is
-    `bolt-matrix-java-*`. Keeping it as a glob is what lets the check still resolve the consumer
-    that picks the whole family up with `pattern: bolt-matrix-*`, instead of reporting a family of
-    artifacts nobody uploads.
-    """
+    """Collapse a run-time expression into the glob of names it can produce."""
     return EXPRESSION.sub("*", value)
 
 
@@ -101,15 +98,12 @@ def producers_of(jobs):
     return produced
 
 
+# `name` selects one artifact, `pattern` selects every artifact matching a glob, and neither means
+# "download everything in the run" - which depends on every producing job. Both sides can be globs
+# (a matrix uploader against a family-wide consumer), so they are matched in either direction:
+# overlap in the names they can denote is enough to create the ordering requirement.
 def matching_producers(produced, name, pattern):
-    """
-    Resolve a download step's selector to the set of jobs it reads from.
-
-    `name` selects one artifact, `pattern` selects every artifact matching a glob, and neither
-    means "download everything in the run" - which depends on every producing job. Both sides can
-    be globs (a matrix uploader against a family-wide consumer), so they are matched in either
-    direction: overlap in the names they can denote is enough to create the ordering requirement.
-    """
+    """Resolve a download step's selector to the set of jobs it reads from."""
     if name is None and pattern is None:
         return {job for jobs in produced.values() for job in jobs}
 

--- a/.github/scripts/check-workflow-artifact-deps.py
+++ b/.github/scripts/check-workflow-artifact-deps.py
@@ -307,8 +307,8 @@ def workflow_files(arguments):
 def main(arguments):
     files = workflow_files(arguments)
     results = [check_workflow(path) for path in files]
-    violations = [v for found, _ in results for v in found]
-    notes = [n for _, found in results for n in found]
+    violations = [violation for found, _ in results for violation in found]
+    notes = [note for _, suppressed in results for note in suppressed]
 
     for note in notes:
         print("check-workflow-artifact-deps: %s" % note)

--- a/.github/scripts/check-workflow-artifact-deps.py
+++ b/.github/scripts/check-workflow-artifact-deps.py
@@ -187,21 +187,22 @@ def matching_producers(produced, selector_names, selector_glob, is_pattern):
 
 
 def check_workflow(path):
-    """Return the list of violation strings found in one workflow file."""
+    """Return the (violations, notes) found in one workflow file."""
     try:
         document = yaml.safe_load(path.read_text(encoding="utf-8"))
     except yaml.YAMLError as error:
-        return ["%s: cannot parse: %s" % (path, error)]
+        return ["%s: cannot parse: %s" % (path, error)], []
 
     if not isinstance(document, dict):
-        return []
+        return [], []
     jobs = document.get("jobs")
     if not isinstance(jobs, dict):
-        return []
+        return [], []
     jobs = {name: job for name, job in jobs.items() if isinstance(job, dict)}
 
     produced = producers_of(jobs)
     violations = []
+    suppressed = []
 
     # A job that delegates to a reusable workflow has no steps to read, so an artifact this file
     # never mentions may still be uploaded inside it. See the boundary note in the header.
@@ -243,11 +244,15 @@ def check_workflow(path):
 
             uploaders = matching_producers(produced, selector_names, selector_glob, is_pattern)
             if not uploaders:
-                if not opaque:
-                    violations.append(
-                        "%s: job '%s', step '%s' downloads '%s', which no job in this workflow "
-                        "uploads" % (path, job_name, step_name, selector)
-                    )
+                message = (
+                    "%s: job '%s', step '%s' downloads '%s', which no job in this workflow uploads"
+                    % (path, job_name, step_name, selector)
+                )
+                # Suppressed, not dropped. A typo in an artifact name looks exactly like an
+                # artifact a reusable workflow uploads, and this check gates every other job, so
+                # the benefit of the doubt goes to the workflow - but silently discarding the
+                # finding is how #5701 stayed invisible in the first place.
+                (suppressed if opaque else violations).append(message)
                 continue
 
             if closure is None:
@@ -273,7 +278,16 @@ def check_workflow(path):
                     )
                 )
 
-    return violations
+    notes = (
+        [
+            "%s: %d missing-producer finding(s) not reported, because a job in this workflow "
+            "delegates to a reusable workflow whose steps cannot be read:\n%s"
+            % (path, len(suppressed), "\n".join("      %s" % s for s in suppressed))
+        ]
+        if suppressed
+        else []
+    )
+    return violations, notes
 
 
 def workflow_files(arguments):
@@ -292,7 +306,12 @@ def workflow_files(arguments):
 
 def main(arguments):
     files = workflow_files(arguments)
-    violations = [v for path in files for v in check_workflow(path)]
+    results = [check_workflow(path) for path in files]
+    violations = [v for found, _ in results for v in found]
+    notes = [n for _, found in results for n in found]
+
+    for note in notes:
+        print("check-workflow-artifact-deps: %s" % note)
 
     if violations:
         print("Artifact downloads that are not ordered after their upload:\n", file=sys.stderr)

--- a/.github/scripts/check-workflow-artifact-deps.py
+++ b/.github/scripts/check-workflow-artifact-deps.py
@@ -47,15 +47,61 @@ DOWNLOAD_ACTION = "actions/download-artifact"
 DEFAULT_ARTIFACT_NAME = "artifact"
 
 EXPRESSION = re.compile(r"\$\{\{.*?\}\}")
+MATRIX_REFERENCE = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_.-]+)\s*\}\}")
 
 
 # A matrix upload names its artifact `bolt-matrix-java-${{ matrix.version }}`; statically that is
 # `bolt-matrix-java-*`. Keeping it as a glob is what lets the check still resolve the consumer that
 # picks the whole family up with `pattern: bolt-matrix-*`, instead of reporting a family of
-# artifacts nobody uploads.
+# artifacts nobody uploads. It is only the fallback: a glob denotes more names than the step can
+# actually produce, so `names_of` below resolves the matrix outright wherever it can.
 def as_glob(value):
     """Collapse a run-time expression into the glob of names it can produce."""
     return EXPRESSION.sub("*", value)
+
+
+def matrix_values(job, key):
+    """The literal values `matrix.<key>` can take in this job, or None if they are not literal."""
+    matrix = (job.get("strategy") or {}).get("matrix")
+    if not isinstance(matrix, dict):
+        return None
+
+    values = set()
+    candidates = matrix.get(key)
+    candidates = list(candidates) if isinstance(candidates, list) else []
+    # `include` entries contribute values of their own, and are the only source for a key that the
+    # base matrix does not declare at all - which is how most of this repository's matrices read.
+    include = matrix.get("include")
+    if isinstance(include, list):
+        candidates += [entry[key] for entry in include if isinstance(entry, dict) and key in entry]
+
+    for value in candidates:
+        if not isinstance(value, (str, int, float, bool)):
+            return None
+        values.add(str(value))
+    return values or None
+
+
+# Resolving the matrix matters because a glob denotes names the step cannot produce. `build-*`
+# covers `build-logs`, so an unrelated job uploading that literal would be reported as something
+# every consumer of it has to wait for - a false violation, in a check that gates the whole build.
+# Expanding `${{ matrix.os }}` to exactly {ubuntu, macos} removes the guesswork.
+#
+# Independent keys are expanded as a cartesian product, which over-approximates an `include`-only
+# matrix whose keys are correlated. That errs the safe way: it can only ask for an ordering that is
+# already implied, never drop one that is missing.
+def names_of(job, value):
+    """The exact artifact names `value` can take, or None when it cannot be resolved."""
+    names = {value}
+    for token, key in {m.group(0): m.group(1) for m in MATRIX_REFERENCE.finditer(value)}.items():
+        values = matrix_values(job, key)
+        if values is None:
+            return None
+        names = {name.replace(token, resolved) for name in names for resolved in values}
+
+    # Anything left is an expression over something no static read can resolve: an input, a
+    # `fromJSON` matrix, a step output.
+    return None if any("${{" in name for name in names) else names
 
 
 def action_of(step):
@@ -86,33 +132,50 @@ def needs_closure(jobs, name, seen=None):
 
 
 def producers_of(jobs):
-    """Artifact glob -> the jobs that upload a name matching it."""
-    produced = {}
+    """The (names, glob, job) an upload step can produce, one entry per step."""
+    produced = []
     for job_name, job in jobs.items():
         for step in steps_of(job):
             if action_of(step) != UPLOAD_ACTION:
                 continue
             with_ = step.get("with") or {}
             name = str(with_.get("name", DEFAULT_ARTIFACT_NAME))
-            produced.setdefault(as_glob(name), set()).add(job_name)
+            produced.append((names_of(job, name), as_glob(name), job_name))
     return produced
 
 
-# `name` selects one artifact, `pattern` selects every artifact matching a glob, and neither means
-# "download everything in the run" - which depends on every producing job. Both sides can be globs
-# (a matrix uploader against a family-wide consumer), so they are matched in either direction:
-# overlap in the names they can denote is enough to create the ordering requirement.
-def matching_producers(produced, name, pattern):
-    """Resolve a download step's selector to the set of jobs it reads from."""
-    if name is None and pattern is None:
-        return {job for jobs in produced.values() for job in jobs}
+# Two selectors require an ordering when they can denote the same artifact. Whenever a side is
+# resolved to exact names, that side is compared by name and the answer is exact. Only when both
+# are globs does this fall back to matching them against each other in either direction, which
+# over-matches - the conservative end, since a spurious `needs` entry costs a wait and a missing
+# one costs a silently incomplete download.
+def overlaps(selector_names, selector_glob, is_pattern, producer_names, producer_glob):
+    """True when a download selector and an upload can name the same artifact."""
+    if producer_names is not None:
+        if selector_names is not None and not is_pattern:
+            return bool(selector_names & producer_names)
+        return any(fnmatch.fnmatch(name, selector_glob) for name in producer_names)
 
-    selector = name if name is not None else pattern
-    matched = set()
-    for artifact, jobs in produced.items():
-        if fnmatch.fnmatch(artifact, selector) or fnmatch.fnmatch(selector, artifact):
-            matched |= jobs
-    return matched
+    if selector_names is not None and not is_pattern:
+        return any(fnmatch.fnmatch(name, producer_glob) for name in selector_names)
+
+    return fnmatch.fnmatch(producer_glob, selector_glob) or fnmatch.fnmatch(
+        selector_glob, producer_glob
+    )
+
+
+# `name` selects one artifact, `pattern` selects every artifact matching a glob, and neither means
+# "download everything in the run" - which depends on every producing job.
+def matching_producers(produced, selector_names, selector_glob, is_pattern):
+    """Resolve a download step's selector to the set of jobs it reads from."""
+    if selector_glob is None:
+        return {job for _, _, job in produced}
+
+    return {
+        job
+        for producer_names, producer_glob, job in produced
+        if overlaps(selector_names, selector_glob, is_pattern, producer_names, producer_glob)
+    }
 
 
 def check_workflow(path):
@@ -139,26 +202,34 @@ def check_workflow(path):
                 continue
             with_ = step.get("with") or {}
 
-            # A cross-run download reads another run's store, so this run's ordering says nothing.
-            if with_.get("run-id") is not None:
+            # A cross-run download reads another run's store, so this run's ordering says nothing
+            # about it. `run-id: ${{ github.run_id }}` is the exception: it names this run, so the
+            # step is an ordinary consumer and skipping it would quietly disable the check.
+            run_id = with_.get("run-id")
+            if run_id is not None and "github.run_id" not in str(run_id):
                 continue
 
-            # A selector is matched as the glob of names it can denote, so a matrix-interpolated
-            # one still resolves. One that collapses to a bare "*" denotes nothing in particular,
-            # and demanding every producer on the strength of it would be a guess, not a finding.
-            name = as_glob(str(with_["name"])) if with_.get("name") is not None else None
-            pattern = as_glob(str(with_["pattern"])) if with_.get("pattern") is not None else None
-            if name == "*" or pattern == "*":
-                continue
+            # A selector resolves to the exact names it can denote where the matrix allows, and to
+            # the glob of them otherwise. One that collapses to a bare "*" denotes nothing in
+            # particular, and demanding every producer on the strength of it would be a guess.
+            raw = with_.get("name") if with_.get("name") is not None else with_.get("pattern")
+            is_pattern = with_.get("name") is None and with_.get("pattern") is not None
+
+            selector_names = selector_glob = None
+            if raw is not None:
+                selector_glob = as_glob(str(raw))
+                if selector_glob == "*":
+                    continue
+                selector_names = names_of(job, str(raw))
 
             selector = (
-                "name: %s" % name
-                if name is not None
-                else "pattern: %s" % pattern if pattern is not None else "every artifact in the run"
+                "%s: %s" % ("pattern" if is_pattern else "name", selector_glob)
+                if selector_glob is not None
+                else "every artifact in the run"
             )
             step_name = step.get("name") or selector
 
-            uploaders = matching_producers(produced, name, pattern)
+            uploaders = matching_producers(produced, selector_names, selector_glob, is_pattern)
             if not uploaders:
                 violations.append(
                     "%s: job '%s', step '%s' downloads '%s', which no job in this workflow uploads"

--- a/.github/scripts/collect-coverage-reports.sh
+++ b/.github/scripts/collect-coverage-reports.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Collects the JaCoCo reports of every test suite, and refuses to hand over a partial set.
+#
+# Coverage is produced by four jobs that each upload their own JaCoCo XML, and merged by a fifth
+# that downloads all four and uploads the union. The merge is only meaningful if all four are
+# present: a suite that is missing does not read as "unknown", it reads as "nothing in that module
+# was covered". In #5701 the ha-raft reports were absent and Codecov reported 1,110 covered lines
+# disappearing - as a coverage regression, on a PR that had not touched the module.
+#
+# The absence used to be invisible. Each download carried `continue-on-error: true`, and the file
+# list came from a bare `find`, so "the suite is missing" and "the suite is there" produced the
+# same green step with a different number of files. This script makes that difference loud: it
+# names the suites it expects, verifies each one actually contributed a report, and fails before
+# anything is uploaded rather than publishing a merge that is quietly missing a module.
+#
+# Failing here is the point. A partial upload is worse than no upload: it does not just mislabel
+# its own commit, it becomes the base every later PR is compared against, so one incomplete run
+# produces a phantom coverage drop and then a phantom coverage recovery on whoever comes next.
+#
+# Usage:
+#   collect-coverage-reports.sh <suite>=<dir> [<suite>=<dir> ...]
+#
+# Writes COVERAGE_FILES (a comma-separated list) to $GITHUB_OUTPUT when set, a per-suite table to
+# $GITHUB_STEP_SUMMARY when set, and the list to stdout either way.
+#
+# @author Luca Garulli (l.garulli@arcadedata.com)
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: $(basename "$0") <suite>=<dir> [<suite>=<dir> ...]" >&2
+    exit 2
+fi
+
+files=()
+missing=()
+summary=()
+
+for argument in "$@"; do
+    if [[ $argument != *=* ]]; then
+        echo "$(basename "$0"): expected <suite>=<dir>, got '$argument'" >&2
+        exit 2
+    fi
+    suite="${argument%%=*}"
+    directory="${argument#*=}"
+
+    # A suite whose job never ran leaves no directory at all, one whose job produced no coverage
+    # leaves an empty one. Both are the same failure - the merge would silently drop that suite.
+    found=()
+    if [[ -d $directory ]]; then
+        while IFS= read -r report; do
+            found+=("$report")
+        done < <(find "$directory" -type f -name 'jacoco*.xml' | sort)
+    fi
+
+    if [[ ${#found[@]} -eq 0 ]]; then
+        missing+=("$suite")
+        summary+=("| $suite | \`$directory\` | 0 | :x: missing |")
+    else
+        files+=("${found[@]}")
+        summary+=("| $suite | \`$directory\` | ${#found[@]} | :white_check_mark: |")
+    fi
+done
+
+if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
+    {
+        echo "### Coverage reports collected"
+        echo
+        echo "| Suite | Artifact | Reports | Status |"
+        echo "|---|---|---:|---|"
+        printf '%s\n' "${summary[@]}"
+    } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+printf '%s\n' "${summary[@]}"
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo >&2
+    echo "No coverage report from: ${missing[*]}" >&2
+    echo >&2
+    echo "Not uploading a partial merge. Every module those suites cover would be reported as" >&2
+    echo "uncovered, which reads as a coverage regression on a diff that never touched it - and" >&2
+    echo "then becomes the base the next pull request is compared against." >&2
+    echo >&2
+    echo "Check whether the producing job was cancelled or failed before writing its JaCoCo XML." >&2
+    exit 1
+fi
+
+list="$(
+    IFS=,
+    echo "${files[*]}"
+)"
+
+echo "Collected ${#files[@]} JaCoCo report(s)"
+
+if [[ -n ${GITHUB_OUTPUT:-} ]]; then
+    echo "COVERAGE_FILES=$list" >>"$GITHUB_OUTPUT"
+fi
+
+echo "$list"

--- a/.github/scripts/collect-coverage-reports.sh
+++ b/.github/scripts/collect-coverage-reports.sh
@@ -37,6 +37,12 @@ files=()
 missing=()
 summary=()
 
+# `find` runs into a file rather than straight into the read loop: a process substitution is not
+# part of the pipeline, so `pipefail` never sees its exit status and an unreadable directory would
+# look exactly like an empty one. Given this script exists to tell those two apart, it checks.
+scratch="$(mktemp)"
+trap 'rm -f "$scratch"' EXIT
+
 for argument in "$@"; do
     if [[ $argument != *=* ]]; then
         echo "$(basename "$0"): expected <suite>=<dir>, got '$argument'" >&2
@@ -49,9 +55,13 @@ for argument in "$@"; do
     # leaves an empty one. Both are the same failure - the merge would silently drop that suite.
     found=()
     if [[ -d $directory ]]; then
+        if ! find "$directory" -type f -name 'jacoco*.xml' >"$scratch"; then
+            echo "$(basename "$0"): cannot read '$directory' for suite '$suite'" >&2
+            exit 1
+        fi
         while IFS= read -r report; do
             found+=("$report")
-        done < <(find "$directory" -type f -name 'jacoco*.xml' | sort)
+        done < <(sort "$scratch")
     fi
 
     if [[ ${#found[@]} -eq 0 ]]; then

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -190,6 +190,131 @@ YAML
 expect "rejects a matrix-named download that does not wait for the matrix" 1 "cell" \
     "$DEPS" "$work/matrix-name"
 
+# A literal artifact that falls under a matrix family's glob is not produced by that family:
+# `build-*` covers `build-logs`, but `matrix.os` only ever yields `build-ubuntu` / `build-macos`.
+# Reporting the matrix job here would be a false violation in a check that gates the whole build.
+mkdir -p "$work/prefix-collision"
+cat >"$work/prefix-collision/ci.yml" <<'YAML'
+name: prefix-collision
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu, macos ]
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: build-${{ matrix.os }}
+  logs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: build-logs
+  consume:
+    runs-on: ubuntu-latest
+    needs: logs
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: build-logs
+YAML
+expect "does not demand a matrix job whose glob merely covers another artifact" 0 "" \
+    "$DEPS" "$work/prefix-collision"
+
+# The same shape, with the download actually naming one of the matrix's values.
+mkdir -p "$work/matrix-value"
+sed 's/name: build-logs$/name: build-macos/' "$work/prefix-collision/ci.yml" \
+    >"$work/matrix-value/ci.yml"
+expect "still demands the matrix job when the name is one it produces" 1 "build" \
+    "$DEPS" "$work/matrix-value"
+
+# An `include`-only matrix is the shape most of this repository's matrices use.
+mkdir -p "$work/matrix-include"
+cat >"$work/matrix-include/ci.yml" <<'YAML'
+name: matrix-include
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: linux
+            runs-on: ubuntu-latest
+          - platform: darwin
+            runs-on: macos-15
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheel-${{ matrix.platform }}
+  consume:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: wheel-darwin
+YAML
+expect "resolves a value contributed only by a matrix include" 1 "build" \
+    "$DEPS" "$work/matrix-include"
+
+# A matrix built at run time cannot be resolved, so the glob fallback applies rather than a crash.
+mkdir -p "$work/matrix-dynamic"
+cat >"$work/matrix-dynamic/ci.yml" <<'YAML'
+name: matrix-dynamic
+on: [ push ]
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - id: gen
+        run: echo matrix=[] >> "$GITHUB_OUTPUT"
+  build:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: image-${{ matrix.arch }}
+  consume:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: image-amd64
+YAML
+expect "falls back to the glob when the matrix is built at run time" 1 "build" \
+    "$DEPS" "$work/matrix-dynamic"
+
+# `run-id` pointing at the current run is an ordinary consumer, not a cross-run read.
+mkdir -p "$work/same-run-id"
+cat >"$work/same-run-id/ci.yml" <<'YAML'
+name: same-run-id
+on: [ push ]
+jobs:
+  producer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: report
+  consume:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: report
+          run-id: ${{ github.run_id }}
+YAML
+expect "still checks a download pinned to the current run-id" 1 "producer" \
+    "$DEPS" "$work/same-run-id"
+
 # A selector that collapses to a bare "*" names nothing in particular: no finding can be drawn.
 mkdir -p "$work/opaque"
 cat >"$work/opaque/ci.yml" <<'YAML'

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+#
+# Self-test for the CI scripts in .github/scripts.
+#
+# These scripts guard the build, so a regression in one of them is silent by construction: it does
+# not break anything visible, it just stops catching what it was written to catch. The cases below
+# pin both directions - what must fail, and what must not - against fixtures rather than against
+# the live workflows, so they keep testing the same thing as the workflows change.
+#
+# The #5701 fixtures are the regression test for this issue: a `coverage-report` job that
+# downloads HA coverage without waiting for it, and a merge that is missing one suite's reports.
+#
+# Usage:
+#   test-ci-scripts.sh
+#
+# @author Luca Garulli (l.garulli@arcadedata.com)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../.."
+
+SCRIPTS=".github/scripts"
+DEPS="$SCRIPTS/check-workflow-artifact-deps.py"
+COLLECT="$SCRIPTS/collect-coverage-reports.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+checks=0
+
+pass() {
+    checks=$((checks + 1))
+    echo "  ok   - $1"
+}
+
+fail() {
+    checks=$((checks + 1))
+    failures=$((failures + 1))
+    echo "  FAIL - $1"
+    if [[ -n ${2:-} ]]; then
+        echo "$2" | sed 's/^/         /'
+    fi
+}
+
+# Runs a command, then asserts its exit status and, optionally, that its output mentions a string.
+expect() {
+    local description="$1" expected_status="$2" needle="$3"
+    shift 3
+    local output status=0
+    output="$("$@" 2>&1)" || status=$?
+
+    if [[ $status -ne $expected_status ]]; then
+        fail "$description (expected exit $expected_status, got $status)" "$output"
+    elif [[ -n $needle && $output != *"$needle"* ]]; then
+        fail "$description (output does not mention '$needle')" "$output"
+    else
+        pass "$description"
+    fi
+}
+
+echo "check-workflow-artifact-deps.py"
+
+# The #5701 shape: coverage-report consumes an artifact from a job it does not wait for.
+mkdir -p "$work/unordered"
+cat >"$work/unordered/ci.yml" <<'YAML'
+name: unordered
+on: [ push ]
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: unit-coverage-reports
+  ha-integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ha-integration-coverage-reports
+  coverage-report:
+    runs-on: ubuntu-latest
+    needs: [ unit-tests ]
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: unit-coverage-reports
+      - uses: actions/download-artifact@v8
+        with:
+          name: ha-integration-coverage-reports
+YAML
+expect "rejects a download whose producer is not in needs" 1 "ha-integration-tests" \
+    "$DEPS" "$work/unordered"
+
+# Same workflow with the missing dependency added: the only change that should matter.
+mkdir -p "$work/ordered"
+sed 's/needs: \[ unit-tests \]/needs: [ unit-tests, ha-integration-tests ]/' \
+    "$work/unordered/ci.yml" >"$work/ordered/ci.yml"
+expect "accepts the same workflow once needs lists the producer" 0 "" \
+    "$DEPS" "$work/ordered"
+
+# needs is transitive: waiting for a job that waits for the producer is enough.
+mkdir -p "$work/transitive"
+cat >"$work/transitive/ci.yml" <<'YAML'
+name: transitive
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: jars
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+  report:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: jars
+YAML
+expect "accepts a producer reached transitively through needs" 0 "" \
+    "$DEPS" "$work/transitive"
+
+# A matrix uploader names its artifact with an expression; a consumer picks the family up with a
+# pattern. That pair must resolve, or every matrix workflow reports a false violation.
+mkdir -p "$work/matrix"
+cat >"$work/matrix/ci.yml" <<'YAML'
+name: matrix
+on: [ push ]
+jobs:
+  cell:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ 1, 2 ]
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bolt-matrix-java-${{ matrix.version }}
+  merge:
+    runs-on: ubuntu-latest
+    needs: cell
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: bolt-matrix-*
+          merge-multiple: true
+YAML
+expect "resolves a matrix-named upload against a pattern download" 0 "" \
+    "$DEPS" "$work/matrix"
+
+# The same pattern download without the dependency is still a race.
+mkdir -p "$work/matrix-unordered"
+sed '/needs: cell/d' "$work/matrix/ci.yml" >"$work/matrix-unordered/ci.yml"
+expect "rejects a pattern download that does not wait for the matrix" 1 "cell" \
+    "$DEPS" "$work/matrix-unordered"
+
+# A matrix consumer downloading its own cell's artifact resolves to the matrix producer.
+mkdir -p "$work/matrix-name"
+cat >"$work/matrix-name/ci.yml" <<'YAML'
+name: matrix-name
+on: [ push ]
+jobs:
+  cell:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ 1, 2 ]
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: report-${{ matrix.version }}
+  consume:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ 1, 2 ]
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: report-${{ matrix.version }}
+YAML
+expect "rejects a matrix-named download that does not wait for the matrix" 1 "cell" \
+    "$DEPS" "$work/matrix-name"
+
+# A selector that collapses to a bare "*" names nothing in particular: no finding can be drawn.
+mkdir -p "$work/opaque"
+cat >"$work/opaque/ci.yml" <<'YAML'
+name: opaque
+on:
+  workflow_dispatch:
+    inputs:
+      artifact:
+        type: string
+jobs:
+  producer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: something
+  consume:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact }}
+YAML
+expect "does not guess at a fully interpolated selector" 0 "" \
+    "$DEPS" "$work/opaque"
+
+# A download with no selector takes every artifact in the run, so it depends on every producer.
+mkdir -p "$work/download-all"
+cat >"$work/download-all/ci.yml" <<'YAML'
+name: download-all
+on: [ push ]
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: one
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: two
+  all:
+    runs-on: ubuntu-latest
+    needs: a
+    steps:
+      - uses: actions/download-artifact@v8
+YAML
+expect "rejects an unselective download that misses a producer" 1 "'b'" \
+    "$DEPS" "$work/download-all"
+
+# A cross-run download reads another run's artifact store, so this run's ordering cannot apply.
+mkdir -p "$work/cross-run"
+cat >"$work/cross-run/ci.yml" <<'YAML'
+name: cross-run
+on: [ push ]
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: from-another-workflow
+          run-id: 12345
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+YAML
+expect "ignores a download from another workflow run" 0 "" \
+    "$DEPS" "$work/cross-run"
+
+# The invariant on the workflows this repository actually ships.
+expect "the repository's own workflows are ordered" 0 "" "$DEPS"
+
+echo
+echo "collect-coverage-reports.sh"
+
+for suite in unit slow integration ha; do
+    mkdir -p "$work/coverage/$suite/module/target/site/jacoco"
+    echo '<report/>' >"$work/coverage/$suite/module/target/site/jacoco/jacoco.xml"
+done
+
+expect "collects a report from every suite" 0 "$work/coverage/ha/module/target/site/jacoco/jacoco.xml" \
+    "$COLLECT" \
+    "unit-tests=$work/coverage/unit" \
+    "slow-unit-tests=$work/coverage/slow" \
+    "integration-tests=$work/coverage/integration" \
+    "ha-integration-tests=$work/coverage/ha"
+
+# #5701 itself: the HA job has not uploaded yet, so its artifact never downloaded.
+expect "refuses to publish when a suite's artifact is missing" 1 "ha-integration-tests" \
+    "$COLLECT" \
+    "unit-tests=$work/coverage/unit" \
+    "slow-unit-tests=$work/coverage/slow" \
+    "integration-tests=$work/coverage/integration" \
+    "ha-integration-tests=$work/coverage/absent"
+
+# A job that ran but produced no coverage leaves the directory behind and is just as wrong.
+mkdir -p "$work/coverage/empty"
+expect "refuses to publish when a suite produced no report" 1 "ha-integration-tests" \
+    "$COLLECT" \
+    "unit-tests=$work/coverage/unit" \
+    "ha-integration-tests=$work/coverage/empty"
+
+# The collected list is what the upload steps consume, so its shape is part of the contract.
+list="$("$COLLECT" "unit-tests=$work/coverage/unit" "ha-integration-tests=$work/coverage/ha" | tail -1)"
+if [[ $list == *",,"* || $list == *, || $list == ,* ]]; then
+    fail "the file list has no empty entries" "$list"
+elif [[ $(tr ',' '\n' <<<"$list" | wc -l) -ne 2 ]]; then
+    fail "the file list has one entry per report" "$list"
+else
+    pass "the file list is comma-separated with no empty entries"
+fi
+
+expect "rejects an argument that is not <suite>=<dir>" 2 "expected <suite>=<dir>" \
+    "$COLLECT" "not-a-pair"
+
+echo
+if [[ $failures -gt 0 ]]; then
+    echo "$failures of $checks checks failed"
+    exit 1
+fi
+echo "$checks checks passed"

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -406,6 +406,11 @@ YAML
 expect "does not report an artifact a reusable workflow may upload" 0 "" \
     "$DEPS" "$work/reusable"
 
+# Suppressed is not the same as discarded: a typo in an artifact name looks identical to one the
+# called workflow uploads, so the finding still has to be visible somewhere.
+expect "says which findings it suppressed and why" 0 "not reported" \
+    "$DEPS" "$work/reusable"
+
 # The blind spot must not suppress a violation that is still visible in this file.
 mkdir -p "$work/reusable-unordered"
 cat >"$work/reusable-unordered/ci.yml" <<'YAML'
@@ -475,6 +480,16 @@ fi
 
 expect "rejects an argument that is not <suite>=<dir>" 2 "expected <suite>=<dir>" \
     "$COLLECT" "not-a-pair"
+
+# An unreadable directory is not an empty one, and telling those apart is the whole job. Skipped
+# for root, which can read it regardless.
+if [[ $(id -u) -ne 0 ]]; then
+    mkdir -p "$work/coverage/unreadable"
+    chmod 000 "$work/coverage/unreadable"
+    expect "fails when a suite's directory cannot be read" 1 "cannot read" \
+        "$COLLECT" "ha-integration-tests=$work/coverage/unreadable"
+    chmod 755 "$work/coverage/unreadable"
+fi
 
 echo
 if [[ $failures -gt 0 ]]; then

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -386,6 +386,50 @@ YAML
 expect "ignores a download from another workflow run" 0 "" \
     "$DEPS" "$work/cross-run"
 
+# A job delegating to a reusable workflow has no steps to read, so its uploads are invisible. The
+# check must not turn that blind spot into a hard failure on a workflow that is actually correct.
+mkdir -p "$work/reusable"
+cat >"$work/reusable/ci.yml" <<'YAML'
+name: reusable
+on: [ push ]
+jobs:
+  called:
+    uses: ./.github/workflows/build.yml
+  consume:
+    runs-on: ubuntu-latest
+    needs: called
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: built-by-the-called-workflow
+YAML
+expect "does not report an artifact a reusable workflow may upload" 0 "" \
+    "$DEPS" "$work/reusable"
+
+# The blind spot must not suppress a violation that is still visible in this file.
+mkdir -p "$work/reusable-unordered"
+cat >"$work/reusable-unordered/ci.yml" <<'YAML'
+name: reusable-unordered
+on: [ push ]
+jobs:
+  called:
+    uses: ./.github/workflows/build.yml
+  producer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v7
+        with:
+          name: visible
+  consume:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: visible
+YAML
+expect "still reports a visible violation alongside a reusable workflow" 1 "producer" \
+    "$DEPS" "$work/reusable-unordered"
+
 # The invariant on the workflows this repository actually ships.
 expect "the repository's own workflows are ordered" 0 "" "$DEPS"
 

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -33,8 +33,10 @@ jobs:
           python-version: "3.13.0"
           cache: "pip"
       - name: Check workflow artifact dependencies
+        # Pinned for the same reason the actions above are pinned to a SHA: this step gates every
+        # other job, so what it installs should not change under it between runs.
         run: |
-          python3 -m pip install --quiet pyyaml
+          python3 -m pip install --quiet pyyaml==6.0.3
           ./.github/scripts/check-workflow-artifact-deps.py
       - name: Check CI scripts
         run: ./.github/scripts/tests/test-ci-scripts.sh
@@ -742,10 +744,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ unit-tests, integration-tests, slow-unit-tests, ha-integration-tests ]
     # Coverage is still worth publishing when a suite reported failing tests: the suites run with
-    # --fail-never, so JaCoCo writes its report and the job records the failure afterwards. Only a
-    # cancelled run has nothing to say - and it is also the one case where the artifacts a
-    # cancelled job would have uploaded are genuinely absent rather than late.
-    if: ${{ !cancelled() }}
+    # --fail-never, so JaCoCo writes its report and the job records the failure afterwards.
+    #
+    # A suite that was *skipped* is different. It produced no report because it never ran - build
+    # and-package failed, most likely - so there is nothing to merge, and reporting that as a
+    # missing artifact would only add a second red check to an already-red build. Skipping keeps
+    # the collector's failure meaning what it says: a suite that should have uploaded, and did not.
+    if: >-
+      ${{ !cancelled()
+      && needs.unit-tests.result != 'skipped'
+      && needs.slow-unit-tests.result != 'skipped'
+      && needs.integration-tests.result != 'skipped'
+      && needs.ha-integration-tests.result != 'skipped' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           python-version: "3.13.0"
           cache: "pip"
+      - name: Check workflow artifact dependencies
+        run: |
+          python3 -m pip install --quiet pyyaml
+          ./.github/scripts/check-workflow-artifact-deps.py
+      - name: Check CI scripts
+        run: ./.github/scripts/tests/test-ci-scripts.sh
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   build-and-package:
@@ -724,13 +730,27 @@ jobs:
           path: e2e-go/reports/go-junit.xml
           retention-days: 7
 
+  # Merges the JaCoCo reports of every test suite and publishes the union.
+  #
+  # `needs` must list every job whose coverage is downloaded below. It is not an optimisation: a
+  # download only sees artifacts already uploaded, so a producer missing from this list is a race
+  # the merge loses whenever that job is the slow one. ha-integration-tests was missing here and
+  # takes ~55 minutes - the longest job in the workflow - so its reports were usually absent and
+  # the whole ha-raft module was published as uncovered (#5701). check-workflow-artifact-deps.py
+  # in the setup job now enforces the rule for every workflow.
   coverage-report:
     runs-on: ubuntu-latest
-    needs: [ unit-tests, integration-tests, slow-unit-tests ]
-    if: success() || failure()
+    needs: [ unit-tests, integration-tests, slow-unit-tests, ha-integration-tests ]
+    # Coverage is still worth publishing when a suite reported failing tests: the suites run with
+    # --fail-never, so JaCoCo writes its report and the job records the failure afterwards. Only a
+    # cancelled run has nothing to say - and it is also the one case where the artifacts a
+    # cancelled job would have uploaded are genuinely absent rather than late.
+    if: ${{ !cancelled() }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # continue-on-error keeps a missing artifact from failing the step with a bare "Artifact not
+      # found", so the collector below can report which suite is missing and why it matters.
       - name: Download unit test coverage reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
@@ -761,14 +781,19 @@ jobs:
           name: ha-integration-coverage-reports
           path: ha-integration-coverage
 
+      # Fails when a suite contributed no report, so nothing downstream publishes a merge that is
+      # missing a module. The steps below deliberately carry no `if`, so they are skipped on failure.
       - name: Get coverage files
         id: coverage-files-generator
-        if: success() || failure()
-        run: echo "COVERAGE_FILES=$(find . -path **/jacoco*.xml -printf '%p,')" >> "$GITHUB_OUTPUT"
+        run: |
+          ./.github/scripts/collect-coverage-reports.sh \
+            unit-tests=unit-coverage \
+            slow-unit-tests=slow-unit-coverage \
+            integration-tests=integration-coverage \
+            ha-integration-tests=ha-integration-coverage
 
       - name: Codacy coverage reporter
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
-        if: success() || failure()
         with:
           language: java
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -776,7 +801,6 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: success() || failure()
         with:
           fail_ci_if_error: false
           disable_search: true

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -752,6 +752,11 @@ jobs:
     # most likely build-and-package failed - so there is nothing to merge, and reporting that as a
     # missing artifact would only add a second red check to an already-red build. Skipping keeps
     # the collector's failure meaning what it says: a suite that should have uploaded, and did not.
+    #
+    # This reads any one skipped suite as "none of them ran", which holds because all four hang off
+    # build-and-package and so skip together. Give one of them a path filter or a condition of its
+    # own and that stops being true: the other three would still have coverage worth publishing,
+    # and this condition would drop it. Revisit here if a suite ever gains its own gate.
     if: >-
       ${{ !cancelled()
       && needs.unit-tests.result != 'skipped'

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -32,12 +32,14 @@ jobs:
         with:
           python-version: "3.13.0"
           cache: "pip"
+      # Both steps below need PyYAML, so it gets its own step rather than hiding inside the first
+      # one that happens to run - reordering those would otherwise break the second confusingly.
+      # Pinned for the same reason the actions here are pinned to a SHA: this job gates every other
+      # one, so what it installs should not change under it between runs.
+      - name: Install workflow linting dependencies
+        run: python3 -m pip install --quiet pyyaml==6.0.3
       - name: Check workflow artifact dependencies
-        # Pinned for the same reason the actions above are pinned to a SHA: this step gates every
-        # other job, so what it installs should not change under it between runs.
-        run: |
-          python3 -m pip install --quiet pyyaml==6.0.3
-          ./.github/scripts/check-workflow-artifact-deps.py
+        run: ./.github/scripts/check-workflow-artifact-deps.py
       - name: Check CI scripts
         run: ./.github/scripts/tests/test-ci-scripts.sh
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
@@ -746,8 +748,8 @@ jobs:
     # Coverage is still worth publishing when a suite reported failing tests: the suites run with
     # --fail-never, so JaCoCo writes its report and the job records the failure afterwards.
     #
-    # A suite that was *skipped* is different. It produced no report because it never ran - build
-    # and-package failed, most likely - so there is nothing to merge, and reporting that as a
+    # A suite that was *skipped* is different. It produced no report because it never ran at all -
+    # most likely build-and-package failed - so there is nothing to merge, and reporting that as a
     # missing artifact would only add a second red check to an already-red build. Skipping keeps
     # the collector's failure meaning what it says: a suite that should have uploaded, and did not.
     if: >-


### PR DESCRIPTION
Fixes #5701.

## The bug

`coverage-report` downloads `ha-integration-coverage-reports` but its `needs` listed only
`[unit-tests, integration-tests, slow-unit-tests]`. `actions/download-artifact` reads the artifact
store of the current run and has no happens-before relationship with the uploader - that ordering
exists only through `needs`. `ha-integration-tests` takes ~55 minutes, by far the longest job in
the workflow, so `coverage-report` usually started well before it finished.

The download then failed, `continue-on-error: true` swallowed the failure, and the merged report
went to Codecov with the whole `ha-raft` module absent. Codecov does not read an absent module as
"unknown" - it reads it as uncovered, which is how a 29-line change to
`engine/src/main/java/com/arcadedb/index/hash/` produced `Hits 101236 -> 100126 (-1110)` on #5685.

## Confirmed on the real runs

| run | coverage-report started | ha-integration-tests finished | HA artifact |
|---|---|---|---|
| 30691056907 | 08:53:51 | 09:08:18 | `Artifact not found for name: ha-integration-coverage-reports` |
| 30691165476 | 08:59:57 | 09:12:02 | missing |
| 30693081526 | 10:08:14 | 10:08:03 | present (finished 11s earlier) |

So it was a race, not a constant. That is the part that made it hard to see: identical config
produced a complete report on a slow run and an incomplete one on a fast run, and the incomplete
runs also became the base every later pull request was compared against - one bad run yields a
phantom drop and then a phantom recovery on whoever comes next.

## What changed

**1. The ordering.** `ha-integration-tests` added to `coverage-report.needs`. The job condition
becomes `!cancelled()` rather than `success() || failure()`, so a suite that reported failing tests
still publishes what JaCoCo wrote (the suites run with `--fail-never`), while a cancelled run - the
one case where an artifact is genuinely absent rather than merely late - still skips.

**2. No more silent partial merges.** The issue notes that `continue-on-error: true` hides exactly
this class of bug, and suggests failing or at least logging. This goes with failing.
`.github/scripts/collect-coverage-reports.sh` replaces the bare
`find . -path **/jacoco*.xml -printf '%p,'`: it takes the suites it expects as `<suite>=<dir>`
pairs, verifies each contributed at least one report, writes a per-suite table to the step summary,
and exits non-zero naming the missing suites. The Codacy and Codecov steps lose their
`if: success() || failure()` so they are skipped when it fails. A partial upload is worse than no
upload, and a red `coverage-report` naming the missing suite is a far better signal than a green
one reporting a fabricated regression.

**3. The generalisation - suggested in place of just adding the `needs` entry.** Adding one entry
fixes today's instance and leaves the class open: nothing about a `download-artifact` step tells
you which job must precede it, so the next one is equally invisible.
`.github/scripts/check-workflow-artifact-deps.py` makes it an enforced invariant - for every
download step it resolves the producing job and asserts it is in the consumer's transitive `needs`
closure, across every workflow. It handles transitive `needs`, matrix-interpolated artifact names
matched as globs against `pattern:` consumers, selector-less downloads (which depend on every
producer), and cross-run downloads (which this run's ordering cannot constrain). Run against the
unfixed workflow it reports this bug and nothing else; across the other 17 workflows it is clean.
Wired into the `setup` job.

## Verification

`.github/scripts/tests/test-ci-scripts.sh` (also wired into `setup`) - 15 checks, both directions,
against fixtures rather than the live workflows:

```
check-workflow-artifact-deps.py
  ok   - rejects a download whose producer is not in needs
  ok   - accepts the same workflow once needs lists the producer
  ok   - accepts a producer reached transitively through needs
  ok   - resolves a matrix-named upload against a pattern download
  ok   - rejects a pattern download that does not wait for the matrix
  ok   - rejects a matrix-named download that does not wait for the matrix
  ok   - does not guess at a fully interpolated selector
  ok   - rejects an unselective download that misses a producer
  ok   - ignores a download from another workflow run
  ok   - the repository's own workflows are ordered

collect-coverage-reports.sh
  ok   - collects a report from every suite
  ok   - refuses to publish when a suite's artifact is missing
  ok   - refuses to publish when a suite produced no report
  ok   - the file list is comma-separated with no empty entries
  ok   - rejects an argument that is not <suite>=<dir>

15 checks passed
```

Mutation-checked: reverting only the `needs` line and re-running turns
`the repository's own workflows are ordered` red with the exact #5701 diagnostic, and nothing else
changes. The two `collect-coverage-reports.sh` refusal cases are the #5701 shape directly - the HA
artifact never downloaded, and the HA job ran but wrote no report.

## Trade-off worth stating

`coverage-report` now waits for the slowest job, so the Codecov and Codacy checks land roughly 10
minutes later than they do today. That is the cost of the signal being true; there is no ordering
that produces a complete merge sooner.

## On #5702

Independent of it. `ha-integration-tests` runs with `--fail-never` and uploads with
`if: success() || failure()`, so its coverage artifact exists whether or not tests pass. The issue
notes this fix will surface partial HA coverage from partially-failed runs - it will, and that is
the correct behaviour: coverage genuinely lost because tests did not run is a real signal, unlike a
module vanishing entirely. Only a cancelled HA job produces no artifact, and that now fails loudly
by name instead of silently.

## Behavior change worth knowing about

`coverage-report` can now go red where it previously went green. Two paths:

1. A suite that ran but never uploaded - a runner death or a job timeout, *not* a test failure,
   which `--fail-never` already covers - leaves its artifact missing and the collector fails the
   job by name. Given #5702, the HA suite is the likely one.
2. Any suite reporting `skipped` skips `coverage-report` entirely rather than publishing three of
   four.

Both are deliberate. The alternative to (1) is publishing a merge without `ha-raft`, which is
#5701 itself; a red check naming the suite is the honest version of the same event. If it proves
noisy, the remedy is fixing #5702 rather than re-enabling silent partial merges.

Neither can block a merge today: `main` has no branch protection (`GET /branches/main/protection`
returns 404), no rulesets, and Mergify's only rule targets Dependabot. No status check is required.
