### PR TITLE
fix(engine) #5708: walk the script line chain iteratively when closing a batch plan

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptLineStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptLineStep.java
@@ -104,6 +104,8 @@ public class ScriptLineStep extends AbstractExecutionStep {
    * cascade in {@link AbstractExecutionStep#close()} is recursive, which overflows the stack on
    * large imports, hence the chain of script lines is walked iteratively here. A plan that fails to
    * close does not stop the walk: the first failure is rethrown once every line has been released.
+   * An {@link Error} is deliberately not caught and does abort the walk, unlike the previous
+   * try/finally: once the JVM reports one there is no value in releasing the remaining plans.
    */
   @Override
   public void close() {
@@ -121,9 +123,17 @@ public class ScriptLineStep extends AbstractExecutionStep {
       current = step.prev;
     }
 
-    // the chain can end on a step of another kind: from there it is bounded, so let it cascade
-    if (current != null)
-      current.close();
+    // Defensive, and unreachable today: chain() is the only place a script line gets a previous step
+    // and it always passes another script line, so the walk above ends on null. Should the chain ever
+    // end on a step of another kind, that tail is bounded and can cascade the usual way.
+    if (current != null) {
+      try {
+        current.close();
+      } catch (final RuntimeException e) {
+        if (error == null)
+          error = e;
+      }
+    }
 
     if (error != null)
       throw error;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptLineStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptLineStep.java
@@ -99,14 +99,38 @@ public class ScriptLineStep extends AbstractExecutionStep {
     return false;
   }
 
+  /**
+   * A batch script chains one step per statement, so the chain is as long as the script. The
+   * cascade in {@link AbstractExecutionStep#close()} is recursive, which overflows the stack on
+   * large imports, hence the chain of script lines is walked iteratively here. A plan that fails to
+   * close does not stop the walk: the first failure is rethrown once every line has been released.
+   */
   @Override
   public void close() {
-    try {
-      if (plan != null)
-        plan.close();
-    } finally {
-      super.close();
+    RuntimeException error = null;
+    ScriptLineStep step = this;
+    while (true) {
+      try {
+        if (step.plan != null)
+          step.plan.close();
+      } catch (final RuntimeException e) {
+        if (error == null)
+          error = e;
+      }
+
+      final ExecutionStepInternal previous = step.prev;
+      if (previous instanceof ScriptLineStep previousLine) {
+        step = previousLine;
+        continue;
+      }
+
+      if (previous != null)
+        previous.close();
+      break;
     }
+
+    if (error != null)
+      throw error;
   }
 
   public ExecutionStepInternal executeUntilReturn(final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptLineStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptLineStep.java
@@ -108,8 +108,9 @@ public class ScriptLineStep extends AbstractExecutionStep {
   @Override
   public void close() {
     RuntimeException error = null;
-    ScriptLineStep step = this;
-    while (true) {
+    ExecutionStepInternal current = this;
+
+    while (current instanceof ScriptLineStep step) {
       try {
         if (step.plan != null)
           step.plan.close();
@@ -117,17 +118,12 @@ public class ScriptLineStep extends AbstractExecutionStep {
         if (error == null)
           error = e;
       }
-
-      final ExecutionStepInternal previous = step.prev;
-      if (previous instanceof ScriptLineStep previousLine) {
-        step = previousLine;
-        continue;
-      }
-
-      if (previous != null)
-        previous.close();
-      break;
+      current = step.prev;
     }
+
+    // the chain can end on a step of another kind: from there it is bounded, so let it cascade
+    if (current != null)
+      current.close();
 
     if (error != null)
       throw error;

--- a/engine/src/test/java/com/arcadedb/query/sql/SQLScriptLargeBatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/SQLScriptLargeBatchTest.java
@@ -57,6 +57,9 @@ public class SQLScriptLargeBatchTest extends TestHelper {
     runner.join();
 
     assertThat(failure.get()).isNull();
-    assertThat(database.countType("ImportRow", false)).isEqualTo(STATEMENTS);
+    // count(@rid) scans: countType() would read the cached bucket counter instead of ground truth
+    try (final ResultSet counted = database.query("sql", "SELECT count(@rid) AS total FROM ImportRow")) {
+      assertThat(counted.next().<Long>getProperty("total")).isEqualTo(STATEMENTS);
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/SQLScriptLargeBatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/SQLScriptLargeBatchTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A batch script chains one execution step per statement, so releasing the plan must not walk the
+ * chain recursively: a large import would blow the stack.
+ */
+public class SQLScriptLargeBatchTest extends TestHelper {
+  private static final int STATEMENTS = 20_000;
+
+  @Test
+  void closingALargeBatchScriptDoesNotOverflowTheStack() throws InterruptedException {
+    database.command("sql", "CREATE DOCUMENT TYPE ImportRow");
+
+    final StringBuilder script = new StringBuilder("begin;\n");
+    for (int i = 0; i < STATEMENTS; i++)
+      script.append("INSERT INTO ImportRow SET id = ").append(i).append(";\n");
+    script.append("commit;\n");
+
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    // run on a thread with an explicit stack size so the outcome does not depend on the JVM default
+    final Thread runner = new Thread(null, () -> {
+      try (final ResultSet rs = database.command("sqlscript", script.toString())) {
+        while (rs.hasNext())
+          rs.next();
+      } catch (final Throwable t) {
+        failure.set(t);
+      }
+    }, "large-batch", 1024 * 1024);
+
+    runner.start();
+    runner.join();
+
+    assertThat(failure.get()).isNull();
+    assertThat(database.countType("ImportRow", false)).isEqualTo(STATEMENTS);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptLineStepCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptLineStepCloseTest.java
@@ -81,6 +81,37 @@ public class ScriptLineStepCloseTest {
   }
 
   /**
+   * A step of a kind other than a script line. {@link ScriptExecutionPlan#chain} never puts one behind a
+   * script line, but the chain is typed on {@link ExecutionStepInternal}, so the walk guards against it.
+   */
+  private static class ForeignStep extends AbstractExecutionStep {
+    private final List<String>     closed;
+    private final RuntimeException failure;
+
+    ForeignStep(final CommandContext context, final List<String> closed, final RuntimeException failure) {
+      super(context);
+      this.closed = closed;
+      this.failure = failure;
+    }
+
+    @Override
+    public ResultSet syncPull(final CommandContext context, final int nRecords) {
+      return new InternalResultSet();
+    }
+
+    @Override
+    public void close() {
+      closed.add("foreign");
+      try {
+        if (failure != null)
+          throw failure;
+      } finally {
+        super.close();
+      }
+    }
+  }
+
+  /**
    * Builds a chain of script lines in script order and returns the tail, which is what
    * {@link ScriptExecutionPlan#close()} closes.
    */
@@ -124,5 +155,48 @@ public class ScriptLineStepCloseTest {
     assertThatThrownBy(tail::close).isSameAs(firstFailure);
 
     assertThat(closed).containsExactly("line2", "line1", "line0");
+  }
+
+  /**
+   * The walk consumes the run of script lines and then hands whatever the chain ends on back to the ordinary
+   * cascade, so a step of another kind behind the lines is still released.
+   */
+  @Test
+  void aChainEndingOnAnotherKindOfStepStillReleasesThatStep() {
+    final CommandContext context = new BasicCommandContext();
+    final List<String> closed = new ArrayList<>();
+
+    final ScriptLineStep tail = chainOf(context, List.of(
+        new RecordingPlan("line0", closed, null),
+        new RecordingPlan("line1", closed, null)));
+    firstLineOf(tail).setPrevious(new ForeignStep(context, closed, null));
+
+    tail.close();
+
+    assertThat(closed).containsExactly("line1", "line0", "foreign");
+  }
+
+  @Test
+  void aFailureFromThatTrailingStepIsReportedToo() {
+    final CommandContext context = new BasicCommandContext();
+    final List<String> closed = new ArrayList<>();
+    final RuntimeException failure = new IllegalStateException("foreign failed");
+
+    final ScriptLineStep tail = chainOf(context, List.of(
+        new RecordingPlan("line0", closed, null),
+        new RecordingPlan("line1", closed, null)));
+    firstLineOf(tail).setPrevious(new ForeignStep(context, closed, failure));
+
+    assertThatThrownBy(tail::close).isSameAs(failure);
+
+    assertThat(closed).containsExactly("line1", "line0", "foreign");
+  }
+
+  /** Walks back to the head of the script line run so a foreign step can be hung behind it. */
+  private ScriptLineStep firstLineOf(final ScriptLineStep tail) {
+    ScriptLineStep step = tail;
+    while (step.getPrev() instanceof ScriptLineStep previous)
+      step = previous;
+    return step;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptLineStepCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptLineStepCloseTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers the contract of the iterative walk in {@link ScriptLineStep#close()}: every line is released, tail to
+ * head, and a plan that fails to close does not strand the ones behind it.
+ */
+public class ScriptLineStepCloseTest {
+  /** Minimal plan that records its own release and can be told to fail while doing so. */
+  private static class RecordingPlan implements InternalExecutionPlan {
+    private final String            name;
+    private final List<String>      closed;
+    private final RuntimeException  failure;
+
+    RecordingPlan(final String name, final List<String> closed, final RuntimeException failure) {
+      this.name = name;
+      this.closed = closed;
+      this.failure = failure;
+    }
+
+    @Override
+    public void close() {
+      closed.add(name);
+      if (failure != null)
+        throw failure;
+    }
+
+    @Override
+    public ResultSet fetchNext(final int n) {
+      return new InternalResultSet();
+    }
+
+    @Override
+    public void reset(final CommandContext context) {
+    }
+
+    @Override
+    public boolean canBeCached() {
+      return false;
+    }
+
+    @Override
+    public List<ExecutionStep> getSteps() {
+      return List.of();
+    }
+
+    @Override
+    public String prettyPrint(final int depth, final int indent) {
+      return name;
+    }
+
+    @Override
+    public Result toResult() {
+      return null;
+    }
+  }
+
+  /**
+   * Builds a chain of script lines in script order and returns the tail, which is what
+   * {@link ScriptExecutionPlan#close()} closes.
+   */
+  private ScriptLineStep chainOf(final CommandContext context, final List<InternalExecutionPlan> plans) {
+    ScriptLineStep previous = null;
+    for (final InternalExecutionPlan plan : plans) {
+      final ScriptLineStep step = new ScriptLineStep(plan, context);
+      if (previous != null)
+        step.setPrevious(previous);
+      previous = step;
+    }
+    return previous;
+  }
+
+  @Test
+  void closingTheTailReleasesEveryLineFromTailToHead() {
+    final CommandContext context = new BasicCommandContext();
+    final List<String> closed = new ArrayList<>();
+
+    chainOf(context, List.of(
+        new RecordingPlan("line0", closed, null),
+        new RecordingPlan("line1", closed, null),
+        new RecordingPlan("line2", closed, null))).close();
+
+    assertThat(closed).containsExactly("line2", "line1", "line0");
+  }
+
+  @Test
+  void aPlanThatFailsToCloseDoesNotStrandTheLinesBehindIt() {
+    final CommandContext context = new BasicCommandContext();
+    final List<String> closed = new ArrayList<>();
+    final RuntimeException firstFailure = new IllegalStateException("line2 failed");
+    final RuntimeException laterFailure = new IllegalStateException("line0 failed");
+
+    final ScriptLineStep tail = chainOf(context, List.of(
+        new RecordingPlan("line0", closed, laterFailure),
+        new RecordingPlan("line1", closed, null),
+        new RecordingPlan("line2", closed, firstFailure)));
+
+    // the tail-most failure is the one that surfaces, and it surfaces only after the whole chain is released
+    assertThatThrownBy(tail::close).isSameAs(firstFailure);
+
+    assertThat(closed).containsExactly("line2", "line1", "line0");
+  }
+}


### PR DESCRIPTION
Fixes #5708

## Problem

Importing data with a large SQL batch script fails with a `StackOverflowError` once the command finishes:

```
Error on command execution (PostCommandHandler)
java.lang.StackOverflowError
    at com.arcadedb.query.sql.executor.AbstractExecutionStep.close(AbstractExecutionStep.java:65)
    at com.arcadedb.query.sql.executor.ScriptLineStep.close(ScriptLineStep.java:108)
    at com.arcadedb.query.sql.executor.AbstractExecutionStep.close(AbstractExecutionStep.java:65)
    ...
```

## Root cause

`SQLScriptQueryEngine.executeInternal()` builds one `ScriptLineStep` per statement and links them into a
`prev` chain via `ScriptExecutionPlan.chain()`. Closing the plan closes the tail step, and the cascade is
recursive: `ScriptLineStep.close()` calls `super.close()`, and `AbstractExecutionStep.close()` calls
`prev.close()`. The chain is therefore unwound with about two stack frames per statement, and its length is
driven purely by the size of the user's batch.

Execution itself is iterative (`ScriptExecutionPlan.executeUntilReturn()` loops over the step list), which is
why the import runs to completion and only the cleanup blows up.

## Fix

`ScriptLineStep.close()` now walks the chain of script lines iteratively.

The cascade in `AbstractExecutionStep` is deliberately left alone: many of the step subclasses do not call
`super.close()`, so a generic iterative loop there would walk past them and change behavior. `ScriptLineStep`
is the only step type whose chain length is unbounded - `ForEachExecutionPlan` chains two steps and
`RetryExecutionPlan` chains one.

Nested script plans keep working: a nested `ScriptExecutionPlan` closed through `plan.close()` adds one frame
per nesting level, which is bounded by the script's block depth rather than by its statement count.

The previous `try`/`finally` intent is preserved and slightly strengthened: a plan that fails to close no
longer stops the walk, and the first failure is rethrown once every line has been released.

## Verification

- New regression test `SQLScriptLargeBatchTest`: a 20,000-statement `sqlscript` batch. It fails with the exact
  reported frames without the fix and passes with it. The batch runs on a thread with an explicit 1 MB stack
  so the outcome does not depend on the CI JVM's default `-Xss`.
- Checked by hand at 150,000 statements: closes in about 2s, confirming nothing else on the path recurses.
- `com.arcadedb.query.sql.**` on the full engine module: 2338 tests, 0 failures, 0 errors.

## Note, out of scope here

`AbstractExecutionStep.sendTimeout()` has the same recursive `prev` cascade. Today no caller propagates a
timeout across script lines (`TimeoutStep` and `AccumulatingTimeoutStep` only fire within a single select
plan), so the script chain never receives it. Worth remembering if timeout propagation is ever extended to
script plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
