### PR TITLE
fix(python): use the supported 'similarity' METADATA key in the vector SQL test

### DIFF
--- a/bindings/python/tests/test_vector_sql.py
+++ b/bindings/python/tests/test_vector_sql.py
@@ -939,7 +939,7 @@ class TestVectorSQL:
         LSM_VECTOR
         METADATA {{
             "dimensions": 4,
-            "distanceFunction": "EUCLIDEAN"
+            "similarity": "EUCLIDEAN"
         }}
         """
         test_db.command("sql", sql_index)


### PR DESCRIPTION
One line. `main` is currently red for `test-python-bindings`, and has been since #5643 landed, but nothing has noticed because the workflow is path-filtered.

## What is broken

`bindings/python/tests/test_vector_sql.py::TestVectorSQL::test_document_vector_search_sql` creates its index with:

```sql
CREATE INDEX ON VecDocSearch (vector) LSM_VECTOR
METADATA { "dimensions": 4, "distanceFunction": "EUCLIDEAN" }
```

`distanceFunction` has never been a supported LSM_VECTOR key. Until #5643 an unrecognised METADATA key was **silently dropped**, so the clause appeared to work and the test passed - through the exact bug #5643 was written to fix. The index was actually built with the default metric, not EUCLIDEAN. #5643's own commit message makes the point: `{"dimensions": 384, "similarty": "EUCLIDEAN"}` built a COSINE index and reported success.

Now that an unknown key is a hard error reporting the accepted set, the test fails at `CREATE INDEX`:

```
CommandSQLParsingException: Invalid METADATA for LSM_VECTOR index:
Unsupported metadata key 'distanceFunction' for a LSM_VECTOR index.
Supported keys: [addHierarchy, ..., similarity, storeVectorsInGraph]
```

## The fix

`"distanceFunction"` → `"similarity"`, which is the key the engine accepts and the one the other five index-creating tests in this same file already use.

The test's assertions are unaffected. It ranks with `vectorL2Distance(...) ORDER BY dist ASC LIMIT 2`, a brute-force scan rather than an index lookup, so the metadata only has to parse for the test to mean what it says.

## Why main has been red without anyone seeing it

| When (UTC) | What |
|---|---|
| 2026-07-31 21:00 | `ed9a59af4` - last green `test-python-bindings` run on main |
| 2026-08-01 00:46 | `c0e50437d` (#5643) - unknown METADATA keys become a hard error |

`git merge-base --is-ancestor c0e50437d ed9a59af4` returns false, confirming the ordering. `test-python-bindings.yml` is path-filtered on `bindings/python/**`, and nothing on main has touched that path since, so the workflow has not run. It surfaces on the next PR that touches it, whatever that PR happens to be about.

## Verification

I could not run the python suite locally, since the package is not installed and building the wheel needs Docker. So I verified the contract at its source instead:

`engine/src/test/java/com/arcadedb/index/Issue5639IndexMetadataKeysTest` creates the identical clause at line 143 - `METADATA {"dimensions": 4, "similarity": "EUCLIDEAN"}` - and `unknownDenseVectorMetadataKeyIsReported` pins the rejection this test hit. Run on this commit:

```
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

CI on this PR runs the python suite for real, which is the gate that matters.

## Related

I swept for the same pattern: `distanceFunction` appears in exactly one other place, `test_import_database.py:271`, as `distanceFunction = cosine` inside an OrientDB-format import fixture rather than an ArcadeDB METADATA clause. That test passes and is untouched here.

Found while investigating a python CI failure on #5695, which is unrelated to this and only triggered the workflow because it edits `bindings/python/scripts/jar_exclusions.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
