### PR TITLE
fix(server) #5711: an HTTP query no longer silently truncates at the serializer limit

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1498,7 +1498,9 @@ did not.
 `truncated` is true only when the cap stopped the serialization with at least one row still pending, so a result
 that ends exactly at the cap is not flagged. The server also logs a warning naming the database, the cap and the
 query - but only when the *default* did the cutting, since truncation against a `limit` the caller asked for is
-the expected outcome. The `POST /timeseries/{db}/query` endpoint reports `limit` and `truncated` the same way.
+the expected outcome. `POST /timeseries/{db}/query` reports `limit` and `truncated` the same way, reads the same
+setting instead of its own hardcoded 20,000, and no longer answers a non-positive `limit` with zero rows (it used
+to compute `min(rows, -1)`, so `limit: -1` returned nothing at all).
 
 The cap is now configurable with **`arcadedb.server.httpQueryDefaultLimit`** (default 20000, `-1` for unlimited);
 it applies only to callers that state no limit of their own.

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1471,4 +1471,50 @@ release is not readable by an earlier build: the old loader does not recognise `
 metadata page as corrupt. The database still opens and every other index is unaffected, but that one index has to be
 dropped before going back. `LSM_TREE` indexes on the same properties are unaffected in both directions.
 
+## HTTP: a truncated query response is no longer indistinguishable from a complete one
+
+The HTTP query and command endpoints serialize at most a fixed number of rows into a response, 20,000 by default.
+The cap was applied after the engine had produced the rows and was reported nowhere: same `200`, same body shape,
+no flag and no count. A caller that paged by writing `LIMIT` into its own SQL - the obvious thing to do - got
+20,000 rows for any page larger than that and nothing in the answer said so
+([#5711](https://github.com/ArcadeData/arcadedb/issues/5711)).
+
+Two things were wrong, and both are fixed.
+
+**A limit the caller stated is now honored as written.** The row cap is the `limit` field of the request when
+there is one; otherwise it is the server default, raised to the LIMIT the query itself carries. So
+`SELECT i FROM R LIMIT 30000` now returns 30,000 rows over HTTP exactly as it does embedded, while a query
+stating no limit at all is still capped. The query's LIMIT only ever raises the cap: a smaller LIMIT is already
+enforced by the engine, so the serializer has nothing to add. This also removes an asymmetry between the two
+surfaces: `GET /query` already read the LIMIT back from the execution plan, `POST /query` and `POST /command`
+did not.
+
+**When the default cap does bite, the response says so.** The query and command endpoints now always report:
+
+```json
+{ "result": [ ... ], "limit": 20000, "returned": 20000, "truncated": true }
+```
+
+`truncated` is true only when the cap stopped the serialization with at least one row still pending, so a result
+that ends exactly at the cap is not flagged. The server also logs a warning naming the database, the cap and the
+query - but only when the *default* did the cutting, since truncation against a `limit` the caller asked for is
+the expected outcome. The `POST /timeseries/{db}/query` endpoint reports `limit` and `truncated` the same way.
+
+The cap is now configurable with **`arcadedb.server.httpQueryDefaultLimit`** (default 20000, `-1` for unlimited);
+it applies only to callers that state no limit of their own.
+
+**Java remote driver.** `RemoteDatabase` warns when the server reports a truncated result instead of handing back
+a partial `ResultSet` that looks complete, and `setMaxResultRows(Integer)` sets the cap for that connection -
+`-1` removes it, so a query with no LIMIT of its own returns every row like the embedded API does. Beware that
+removing the cap makes the server materialize the whole result set in memory before answering.
+
+**Studio** marks the row count with `(truncated)` when the result it is showing was cut short.
+
+Three smaller behaviour changes come with this. A serializer name other than `graph`, `studio` or `record` used
+to emit one row *above* the cap; it now emits exactly the cap, like the others. On `GET /query`, an explicit
+`limit` query parameter now wins over the LIMIT in the query text (it used to be the other way round), which is
+what the POST endpoints have always done. And `"limit": 0` now means unlimited everywhere, as it already did in
+the serializer: it used to be pushed down as a literal `LIMIT 0` and return no row at all for a query that
+carried no LIMIT of its own, while returning every row for a query that did.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1513,6 +1513,11 @@ non-positive `limit` with zero rows (it used to compute `min(rows, -1)`, so `lim
 The cap is now configurable with **`arcadedb.server.httpQueryDefaultLimit`** (default 20000, `-1` for unlimited);
 it applies only to callers that state no limit of their own.
 
+One gap is worth knowing about: a query's LIMIT raises the cap only for a language that exposes it on the
+execution plan. SQL does; Cypher on the non-EXPLAIN path builds no plan, so `MATCH ... RETURN n LIMIT 30000` is
+still cut at the default - now with `truncated: true` and a warning rather than silently. Send `limit` in the
+request for those languages.
+
 **Java remote driver.** `RemoteDatabase` warns when the server reports a truncated result instead of handing back
 a partial `ResultSet` that looks complete, and `setMaxResultRows(Integer)` sets the cap for that connection -
 `-1` removes it, so a query with no LIMIT of its own returns every row like the embedded API does. Beware that

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1498,9 +1498,17 @@ did not.
 `truncated` is true only when the cap stopped the serialization with at least one row still pending, so a result
 that ends exactly at the cap is not flagged. The server also logs a warning naming the database, the cap and the
 query - but only when the *default* did the cutting, since truncation against a `limit` the caller asked for is
-the expected outcome. `POST /timeseries/{db}/query` reports `limit` and `truncated` the same way, reads the same
-setting instead of its own hardcoded 20,000, and no longer answers a non-positive `limit` with zero rows (it used
-to compute `min(rows, -1)`, so `limit: -1` returned nothing at all).
+the expected outcome.
+
+The flag is exact for the row-oriented serializers (`record`, `studio` and the default one), where `returned` also
+never exceeds `limit`. With `serializer: "graph"` the cap counts graph *elements* instead of rows, so two things
+differ: `returned` can come back above `limit`, because the row that reaches the cap is expanded whole; and since
+the same vertex reached twice is serialized once, `truncated` is best-effort there - a result whose rows dedup
+down to fewer elements than the cap can read `false`. A paging client should use a row-oriented serializer.
+
+`POST /timeseries/{db}/query` reports `limit` and `truncated` the same way, logs the same warning when its own
+default did the cutting, reads the same setting instead of its own hardcoded 20,000, and no longer answers a
+non-positive `limit` with zero rows (it used to compute `min(rows, -1)`, so `limit: -1` returned nothing at all).
 
 The cap is now configurable with **`arcadedb.server.httpQueryDefaultLimit`** (default 20000, `-1` for unlimited);
 it applies only to callers that state no limit of their own.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -941,6 +941,16 @@ public enum GlobalConfiguration {
       "Maximum size in bytes for HTTP request body content. Set to -1 for unlimited size (WARNING: removes DoS protection). Default is 100MB",
       Long.class, 100L * 1024 * 1024), // 100MB DEFAULT
 
+  SERVER_HTTP_QUERY_DEFAULT_LIMIT("arcadedb.server.httpQueryDefaultLimit", SCOPE.SERVER,
+      """
+      Default maximum number of rows the HTTP query/command endpoints serialize into a single response when \
+      the caller states no limit of its own. A request that carries a `limit` field, and a query that carries \
+      its own LIMIT clause, are both honored as written and are never capped by this value. When this default \
+      does cut a result short the response reports `"truncated": true` next to `returned` and `limit`, and the \
+      server logs a warning: the truncation is never silent (issue #5711). Set to -1 or 0 for unlimited \
+      (WARNING: removes the protection against materializing an unbounded result set in memory). Default is 20000""",
+      Integer.class, 20_000),
+
   SERVER_HTTP_STREAMING_READ_TIMEOUT("arcadedb.server.httpStreamingReadTimeout", SCOPE.SERVER,
       """
       Budget in milliseconds granted to endpoints that consume the request body while working (today only \

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -752,10 +752,12 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
   protected ResultSet createResultSet(final JSONObject response) {
     final ResultSet resultSet = new InternalResultSet();
 
-    if (response.getBoolean("truncated", false))
+    if (getMaxResultRows() == null && response.getBoolean("truncated", false))
       // The server dropped rows this driver never asked to drop: without this the caller would receive a
       // partial ResultSet indistinguishable from a complete one, and would silently disagree with the same
-      // query executed on the embedded API (issue #5711).
+      // query executed on the embedded API (issue #5711). An application that set its own cap with
+      // setMaxResultRows() asked for the truncation, so it is not warned about it - the same rule the server
+      // applies to a request carrying its own 'limit', and what keeps a paging application out of the log.
       LogManager.instance().log(this, Level.WARNING,
           "The server truncated the result set to %d rows (its limit is %d): the returned result is incomplete. Add an explicit "
               + "LIMIT to the query, or raise the cap with RemoteDatabase.setMaxResultRows().",

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -752,6 +752,15 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
   protected ResultSet createResultSet(final JSONObject response) {
     final ResultSet resultSet = new InternalResultSet();
 
+    if (response.getBoolean("truncated", false))
+      // The server dropped rows this driver never asked to drop: without this the caller would receive a
+      // partial ResultSet indistinguishable from a complete one, and would silently disagree with the same
+      // query executed on the embedded API (issue #5711).
+      LogManager.instance().log(this, Level.WARNING,
+          "The server truncated the result set to %d rows (its limit is %d): the returned result is incomplete. Add an explicit "
+              + "LIMIT to the query, or raise the cap with RemoteDatabase.setMaxResultRows().",
+          response.getInt("returned", -1), response.getInt("limit", -1));
+
     final JSONArray resultArray = response.getJSONArray("result");
     for (int i = 0; i < resultArray.length(); ++i) {
       final JSONObject result = resultArray.getJSONObject(i);

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -85,7 +85,9 @@ public class RemoteHttpComponent extends RWLockContext {
   protected        String                      currentServer;
   protected        int                         currentPort;
   private         Pair<String, Integer>       stickyTransactionServer;
-  private         Integer                     maxResultRows;
+  // Volatile so a setMaxResultRows() from another thread is seen by the command-build path: this class is
+  // documented as not thread safe, but the cap is a connection-wide knob an application may flip at any time.
+  private volatile Integer                    maxResultRows;
 
   public enum CONNECTION_STRATEGY {
     STICKY, ROUND_ROBIN, FIXED

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -85,6 +85,7 @@ public class RemoteHttpComponent extends RWLockContext {
   protected        String                      currentServer;
   protected        int                         currentPort;
   private         Pair<String, Integer>       stickyTransactionServer;
+  private         Integer                     maxResultRows;
 
   public enum CONNECTION_STRATEGY {
     STICKY, ROUND_ROBIN, FIXED
@@ -155,6 +156,30 @@ public class RemoteHttpComponent extends RWLockContext {
         throw ie;
       throw new IOException("HTTP request failed: " + request.uri(), cause);
     }
+  }
+
+  /**
+   * Maximum number of rows the server is asked to serialize per command, or {@code null} (the default) to
+   * leave the decision to the server.
+   *
+   * @see #setMaxResultRows(Integer)
+   */
+  public Integer getMaxResultRows() {
+    return maxResultRows;
+  }
+
+  /**
+   * Sets the maximum number of rows the server serializes per command, sent as the {@code limit} field of the
+   * request. Use {@code -1} for no cap, so a query with no LIMIT of its own returns every row exactly like the
+   * embedded API does, and {@code null} to leave the decision to the server: a query stating its own LIMIT is
+   * always honored as written, while a query stating none is capped by the server default
+   * ({@code arcadedb.server.httpQueryDefaultLimit}) and the driver logs a warning when that cap drops rows
+   * (issue #5711).
+   * <p>
+   * Beware that removing the cap makes the server materialize the whole result set in memory before answering.
+   */
+  public void setMaxResultRows(final Integer maxResultRows) {
+    this.maxResultRows = maxResultRows;
   }
 
   public int getTimeout() {
@@ -294,6 +319,8 @@ public class RemoteHttpComponent extends RWLockContext {
           jsonRequest.put("command", payloadCommand);
           jsonRequest.put("serializer", "record");
           jsonRequest.put("retries", txRetries);
+          if (maxResultRows != null)
+            jsonRequest.put("limit", maxResultRows);
 
           if (params != null)
             jsonRequest.put("params", new JSONObject(params));

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -168,13 +168,32 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
     LogManager.instance().log(this, Level.WARNING,
         "Query on database '%s' returned more rows than the default HTTP limit of %d: the response has been truncated to %d rows. "
             + "Set 'limit' in the request, add an explicit LIMIT to the query, or raise '%s'. Query: %s", databaseName, limit,
-        outcome.returned(), GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT.getKey(), abbreviate(command));
+        outcome.returned(), GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT.getKey(), abbreviateForLog(command));
   }
 
-  private static String abbreviate(final String command) {
+  /**
+   * Prepares a client-supplied command to be echoed in a log line: caps the length so a large payload cannot
+   * flood the log, and replaces control characters with a space so an embedded line break cannot forge log
+   * lines of its own. Same concern - and same shape - as
+   * {@link AbstractServerHttpHandler#sanitizeRequestId(String)} for the {@code X-Request-Id} header; allocates
+   * only when the command actually needs cleaning. Package-private for direct unit testing.
+   */
+  static String abbreviateForLog(final String command) {
     if (command == null)
       return null;
-    return command.length() <= MAX_LOGGED_COMMAND_CHARS ? command : command.substring(0, MAX_LOGGED_COMMAND_CHARS) + "...";
+    final int len = Math.min(command.length(), MAX_LOGGED_COMMAND_CHARS);
+    StringBuilder cleaned = null;
+    for (int i = 0; i < len; i++) {
+      final char c = command.charAt(i);
+      if (c < 0x20 || c == 0x7F) {
+        if (cleaned == null)
+          cleaned = new StringBuilder(len).append(command, 0, i);
+        cleaned.append(' ');
+      } else if (cleaned != null)
+        cleaned.append(c);
+    }
+    final String result = cleaned != null ? cleaned.toString() : command.substring(0, len);
+    return command.length() > MAX_LOGGED_COMMAND_CHARS ? result + "..." : result;
   }
 
   protected SerializationOutcome serializeResultSet(final Database database, final String serializer, final int limit,
@@ -347,6 +366,12 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
 
   /**
    * True when the cap stopped the serialization with at least one row still pending in the result set.
+   * <p>
+   * That pending row comes from a different place on the two surfaces, and both are exact. The GET endpoint runs
+   * the query as written, so a lazy result set still has rows of its own when the cap bites. The POST endpoints
+   * rewrite the command to push a LIMIT down, which would otherwise make the engine stop at exactly the cap and
+   * leave the truncation undetectable, so what they push down is one row above it (see
+   * {@link PostCommandHandler#truncationProbeLimit(int)}).
    */
   private static boolean isTruncated(final ResultSet qResult, final int limit, final int serialized) {
     return limit > 0 && serialized >= limit && qResult.hasNext();

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -120,6 +120,32 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
   }
 
   /**
+   * Rejection of a request row limit that is not an integer this server can apply, worded identically wherever
+   * the limit arrives from so the two surfaces report the same thing. Mapped to HTTP 400 by the
+   * {@link IllegalArgumentException} arm of {@link AbstractServerHttpHandler}.
+   */
+  protected static IllegalArgumentException unusableLimit(final String field, final Throwable cause) {
+    return new IllegalArgumentException(
+        "Field '" + field + "' must be an integer between " + Integer.MIN_VALUE + " and " + Integer.MAX_VALUE, cause);
+  }
+
+  /**
+   * Parses the textual row limit of the GET endpoint, or returns {@code null} when the parameter is absent or
+   * empty - an empty parameter states nothing, so it must not be read as a value. A value that is not an
+   * int-representable integer is a client error carrying the same message as the JSON field of the POST
+   * endpoints, instead of the raw {@link NumberFormatException} wording of the JDK.
+   */
+  protected static Integer parseLimitParameter(final String raw, final String field) {
+    if (raw == null || raw.isBlank())
+      return null;
+    try {
+      return Integer.valueOf(raw.trim());
+    } catch (final NumberFormatException e) {
+      throw unusableLimit(field, e);
+    }
+  }
+
+  /**
    * LIMIT carried by the execution plan of the given result set, or 0 when unavailable. SQL exposes it for
    * both single statements and single-statement scripts; languages that do not build an
    * {@link com.arcadedb.query.sql.executor.ExecutionPlan} (e.g. Cypher on the non-EXPLAIN path) return 0, and

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -181,9 +181,13 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
     if (!outcome.truncated() || requestLimit != null || planLimit >= limit)
       return;
 
+    // The advice deliberately leads with the request field: a LIMIT in the query text raises the cap only for a
+    // language that exposes it on the execution plan, so telling a Cypher caller to add one - it may well have
+    // one already - would send it after a fix that cannot work.
     LogManager.instance().log(this, Level.WARNING,
         "Query on database '%s' returned more rows than the default HTTP limit of %d: the response has been truncated to %d rows. "
-            + "Set 'limit' in the request, add an explicit LIMIT to the query, or raise '%s'. Query: %s", databaseName, limit,
+            + "Set 'limit' in the request or raise '%s'; a LIMIT written in the query raises the cap only for a language that "
+            + "exposes it on the execution plan, which SQL does and Cypher does not. Query: %s", databaseName, limit,
         outcome.returned(), GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT.getKey(), abbreviateForLog(command));
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
@@ -26,6 +27,7 @@ import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
@@ -39,22 +41,148 @@ import com.arcadedb.server.http.HttpServer;
 
 import java.util.*;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import static com.arcadedb.schema.Property.RID_PROPERTY;
 
 public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
 
-  public static final int DEFAULT_LIMIT = 20_000;
+  /**
+   * Default value of {@link GlobalConfiguration#SERVER_HTTP_QUERY_DEFAULT_LIMIT}, kept as a constant for the
+   * tests and the clients that referenced it before the cap became configurable. Handlers must read the
+   * effective value from the server configuration via {@link #getDefaultLimit()}, never from this constant.
+   */
+  public static final int DEFAULT_LIMIT = (Integer) GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT.getDefValue();
+
+  /**
+   * Name of the response field carrying the number of rows serialized into the response.
+   */
+  public static final String RETURNED_FIELD = "returned";
+
+  /**
+   * Name of the response field carrying the effective row cap applied while serializing.
+   */
+  public static final String LIMIT_FIELD = "limit";
+
+  /**
+   * Name of the response field telling whether the cap cut the result short.
+   */
+  public static final String TRUNCATED_FIELD = "truncated";
+
+  /**
+   * Upper bound on how much of a command is echoed in the truncation warning, so a large payload cannot flood
+   * the log: the leading characters are what identifies the query for an operator.
+   */
+  private static final int MAX_LOGGED_COMMAND_CHARS = 120;
+
+  /**
+   * Outcome of serializing a {@link ResultSet} into an HTTP response: how many rows reached the response and
+   * whether the effective limit cut the result short.
+   * <p>
+   * {@code truncated} is true only when the cap was reached <i>and</i> the result set still had at least one
+   * more row, so a result whose size happens to match the cap exactly is not reported as truncated. For the
+   * row-oriented serializers ({@code record}, {@code studio} and the default one) the flag is exact. For the
+   * {@code graph} serializer the cap counts graph elements rather than rows, and a last row whose expansion
+   * was cut mid-way is not reported when no further row is pending.
+   */
+  public record SerializationOutcome(int returned, boolean truncated) {
+    static final SerializationOutcome EMPTY = new SerializationOutcome(0, false);
+  }
 
   public AbstractQueryHandler(final HttpServer httpServer) {
     super(httpServer);
   }
 
-  protected void serializeResultSet(final Database database, final String serializer, final int limit, final JSONObject response,
-      final ResultSet qResult) {
+  /**
+   * Effective default row cap for this server, applied only when the caller expressed no limit of its own.
+   */
+  protected int getDefaultLimit() {
+    return httpServer.getServer().getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT);
+  }
+
+  /**
+   * Resolves the row cap to apply while serializing, in decreasing order of explicitness:
+   * <ol>
+   * <li>the {@code limit} field of the request, when present: the caller stated the size of the page it
+   * wants, and that statement wins over everything else (a value {@code <= 0} means unlimited);</li>
+   * <li>otherwise the configured default, raised to the LIMIT the query itself carries when the engine
+   * exposes it on the execution plan: honoring it is what keeps the HTTP surface from silently returning
+   * fewer rows than the query asked for (issue #5711).</li>
+   * </ol>
+   * The plan LIMIT can only raise the cap, never lower it. A LIMIT smaller than the default is already
+   * enforced by the engine, so capping at it would be redundant - and the plan of a query whose LIMIT is a
+   * parameter can be a cached copy still carrying the value of an earlier execution, so trusting it downwards
+   * would cut a result the engine had sized correctly.
+   *
+   * @param requestLimit {@code limit} field of the request, or {@code null} when absent
+   * @param planLimit    LIMIT exposed by the execution plan, or 0 when the query carries none / the language
+   *                     does not expose it
+   */
+  protected int resolveLimit(final Integer requestLimit, final int planLimit) {
+    if (requestLimit != null)
+      return requestLimit;
+    final int defaultLimit = getDefaultLimit();
+    // A non-positive default means the operator removed the cap: nothing to raise.
+    return defaultLimit > 0 ? Math.max(planLimit, defaultLimit) : defaultLimit;
+  }
+
+  /**
+   * LIMIT carried by the execution plan of the given result set, or 0 when unavailable. SQL exposes it for
+   * both single statements and single-statement scripts; languages that do not build an
+   * {@link com.arcadedb.query.sql.executor.ExecutionPlan} (e.g. Cypher on the non-EXPLAIN path) return 0, and
+   * their results are capped by the configured default with {@code truncated} reported when it bites.
+   */
+  protected int getPlanLimit(final ResultSet qResult) {
     if (qResult == null)
+      return 0;
+    try {
+      return qResult.getExecutionPlan().map(ExecutionPlan::getLimit).orElse(0);
+    } catch (final Exception e) {
+      // A language whose plan computes the limit lazily may fail here: fall back to "no limit exposed".
+      LogManager.instance().log(this, Level.FINE, "Cannot read the LIMIT from the execution plan", e);
+      return 0;
+    }
+  }
+
+  /**
+   * Reports the effective cap, the number of rows serialized and whether the result was cut short, so a
+   * truncated response is never indistinguishable from a complete one (issue #5711). Always present on the
+   * query/command endpoints, so a client can test {@code truncated} unconditionally.
+   */
+  protected static void reportLimits(final JSONObject response, final int limit, final SerializationOutcome outcome) {
+    response.put(LIMIT_FIELD, limit > 0 ? limit : -1);
+    response.put(RETURNED_FIELD, outcome.returned());
+    response.put(TRUNCATED_FIELD, outcome.truncated());
+  }
+
+  /**
+   * Logs a warning when the result was cut by the configured default rather than by a cap the caller asked
+   * for: that is the only truncation the client did not ask for, so an operator must be able to find it in
+   * the log. Truncation against an explicit request {@code limit} (or against the query's own LIMIT) is the
+   * expected outcome and stays silent.
+   */
+  protected void logIfTruncatedByDefault(final String databaseName, final String command, final int limit,
+      final Integer requestLimit, final int planLimit, final SerializationOutcome outcome) {
+    // planLimit > limit cannot happen (resolveLimit raises the cap to it), so this only skips the queries whose
+    // own LIMIT is what the cap came from.
+    if (!outcome.truncated() || requestLimit != null || planLimit >= limit)
       return;
+
+    LogManager.instance().log(this, Level.WARNING,
+        "Query on database '%s' returned more rows than the default HTTP limit of %d: the response has been truncated to %d rows. "
+            + "Set 'limit' in the request, add an explicit LIMIT to the query, or raise '%s'. Query: %s", databaseName, limit,
+        outcome.returned(), GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT.getKey(), abbreviate(command));
+  }
+
+  private static String abbreviate(final String command) {
+    if (command == null)
+      return null;
+    return command.length() <= MAX_LOGGED_COMMAND_CHARS ? command : command.substring(0, MAX_LOGGED_COMMAND_CHARS) + "...";
+  }
+
+  protected SerializationOutcome serializeResultSet(final Database database, final String serializer, final int limit,
+      final JSONObject response, final ResultSet qResult) {
+    if (qResult == null)
+      return SerializationOutcome.EMPTY;
 
     try {
     switch (serializer) {
@@ -92,7 +220,8 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
       }
 
       response.put("result", new JSONObject().put("vertices", vertices).put("edges", edges));
-      break;
+      final int serializedElements = vertices.length() + edges.length();
+      return new SerializationOutcome(serializedElements, isTruncated(qResult, limit, serializedElements));
     }
 
     case "studio": {
@@ -146,6 +275,10 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
           break;
       }
 
+      // Probed before the edge-completion pass below, which does not consume the result set but must not be
+      // allowed to hide whether rows were left behind.
+      final boolean truncated = isTruncated(qResult, limit, records.length());
+
       // FILTER OUT NOT CONNECTED EDGES
       for (final Identifiable entry : includedVertices) {
         if (limit > 0 && vertices.length() + edges.length() >= limit)
@@ -175,38 +308,50 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
       }
 
       response.put("result", new JSONObject().put("vertices", vertices).put("edges", edges).put("records", records));
-      break;
+      return new SerializationOutcome(records.length(), truncated);
     }
 
-    case "record": {
-      final JsonSerializer serializerImpl = JsonSerializer.createJsonSerializer()
+    case "record":
+      return serializeRows(database, qResult, limit, response, JsonSerializer.createJsonSerializer()
           .setIncludeVertexEdges(false)
           .setUseCollectionSize(false)
-          .setUseCollectionSizeForEdges(false);
-      final JSONArray result = new JSONArray();
-      while (qResult.hasNext()) {
-        final Result r = qResult.next();
-        result.put(serializerImpl.serializeResult(database, r));
-        if (limit > 0 && result.length() >= limit)
-          break;
-      }
-      response.put("result", result);
-      break;
-    }
+          .setUseCollectionSizeForEdges(false));
 
-    default: {
-      final JsonSerializer serializerImpl = JsonSerializer.createJsonSerializer().setIncludeVertexEdges(true)
+    default:
+      return serializeRows(database, qResult, limit, response, JsonSerializer.createJsonSerializer()
+          .setIncludeVertexEdges(true)
           .setUseCollectionSize(false)
-          .setUseCollectionSizeForEdges(false);
-      final JSONArray result = new JSONArray(limit > 0 ?
-          qResult.stream().limit(limit + 1).map(r -> serializerImpl.serializeResult(database, r)).collect(Collectors.toList()) :
-          qResult.stream().map(r -> serializerImpl.serializeResult(database, r)).collect(Collectors.toList()));
-      response.put("result", result);
-    }
+          .setUseCollectionSizeForEdges(false));
     }
     } finally {
       qResult.close();
     }
+  }
+
+  /**
+   * Serializes a result set as a flat array of rows, stopping at {@code limit} rows (0 or less = unlimited).
+   * Exactly {@code limit} rows are emitted when the cap bites: the row that does not fit is left in the
+   * result set on purpose, and is what {@link #isTruncated} probes to tell a truncated response from a
+   * complete one.
+   */
+  private static SerializationOutcome serializeRows(final Database database, final ResultSet qResult, final int limit,
+      final JSONObject response, final JsonSerializer serializerImpl) {
+    final JSONArray result = new JSONArray();
+    while (qResult.hasNext()) {
+      final Result r = qResult.next();
+      result.put(serializerImpl.serializeResult(database, r));
+      if (limit > 0 && result.length() >= limit)
+        break;
+    }
+    response.put("result", result);
+    return new SerializationOutcome(result.length(), isTruncated(qResult, limit, result.length()));
+  }
+
+  /**
+   * True when the cap stopped the serialization with at least one row still pending in the result set.
+   */
+  private static boolean isTruncated(final ResultSet qResult, final int limit, final int serialized) {
+    return limit > 0 && serialized >= limit && qResult.hasNext();
   }
 
   protected void analyzeResultContent(final Database database, final JsonGraphSerializer serializerImpl,

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -49,7 +49,7 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
   /**
    * Default value of {@link GlobalConfiguration#SERVER_HTTP_QUERY_DEFAULT_LIMIT}, kept as a constant for the
    * tests and the clients that referenced it before the cap became configurable. Handlers must read the
-   * effective value from the server configuration via {@link #getDefaultLimit()}, never from this constant.
+   * effective value from the server configuration via {@link #getDefaultRowLimit()}, never from this constant.
    */
   public static final int DEFAULT_LIMIT = (Integer) GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT.getDefValue();
 
@@ -93,13 +93,6 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
   }
 
   /**
-   * Effective default row cap for this server, applied only when the caller expressed no limit of its own.
-   */
-  protected int getDefaultLimit() {
-    return httpServer.getServer().getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT);
-  }
-
-  /**
    * Resolves the row cap to apply while serializing, in decreasing order of explicitness:
    * <ol>
    * <li>the {@code limit} field of the request, when present: the caller stated the size of the page it
@@ -120,7 +113,7 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
   protected int resolveLimit(final Integer requestLimit, final int planLimit) {
     if (requestLimit != null)
       return requestLimit;
-    final int defaultLimit = getDefaultLimit();
+    final int defaultLimit = getDefaultRowLimit();
     // A non-positive default means the operator removed the cap: nothing to raise.
     return defaultLimit > 0 ? Math.max(planLimit, defaultLimit) : defaultLimit;
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -120,16 +120,6 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
   }
 
   /**
-   * Rejection of a request row limit that is not an integer this server can apply, worded identically wherever
-   * the limit arrives from so the two surfaces report the same thing. Mapped to HTTP 400 by the
-   * {@link IllegalArgumentException} arm of {@link AbstractServerHttpHandler}.
-   */
-  protected static IllegalArgumentException unusableLimit(final String field, final Throwable cause) {
-    return new IllegalArgumentException(
-        "Field '" + field + "' must be an integer between " + Integer.MIN_VALUE + " and " + Integer.MAX_VALUE, cause);
-  }
-
-  /**
    * Parses the textual row limit of the GET endpoint, or returns {@code null} when the parameter is absent or
    * empty - an empty parameter states nothing, so it must not be read as a value. A value that is not an
    * int-representable integer is a client error carrying the same message as the JSON field of the POST

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -80,9 +80,10 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
    * <p>
    * {@code truncated} is true only when the cap was reached <i>and</i> the result set still had at least one
    * more row, so a result whose size happens to match the cap exactly is not reported as truncated. For the
-   * row-oriented serializers ({@code record}, {@code studio} and the default one) the flag is exact. For the
-   * {@code graph} serializer the cap counts graph elements rather than rows, and a last row whose expansion
-   * was cut mid-way is not reported when no further row is pending.
+   * row-oriented serializers ({@code record}, {@code studio} and the default one) the flag is exact and
+   * {@code returned} never exceeds the cap. For the {@code graph} serializer the cap counts graph elements
+   * rather than rows: {@code returned} can exceed the cap, because the row that reaches it is expanded whole,
+   * and a last row whose expansion was cut mid-way is not reported when no further row is pending.
    */
   public record SerializationOutcome(int returned, boolean truncated) {
     static final SerializationOutcome EMPTY = new SerializationOutcome(0, false);
@@ -123,6 +124,10 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
    * both single statements and single-statement scripts; languages that do not build an
    * {@link com.arcadedb.query.sql.executor.ExecutionPlan} (e.g. Cypher on the non-EXPLAIN path) return 0, and
    * their results are capped by the configured default with {@code truncated} reported when it bites.
+   * <p>
+   * A multi-statement script reports 0 today, but a value belonging to one of its statements would be
+   * harmless anyway: {@link #resolveLimit} only ever raises the cap with it, so a wrong value can widen the
+   * response but never cut it below what the configured default already allows.
    */
   protected int getPlanLimit(final ResultSet qResult) {
     if (qResult == null)

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -130,6 +130,31 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     return httpServer.getServer().getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT);
   }
 
+  /**
+   * Validates a row limit that arrived as a JSON value and narrows it to an {@code int}. Every endpoint reading
+   * a {@code limit} shares this so the same input gets the same answer: {@link Number#intValue()} truncates the
+   * high bits, so {@code 3000000000} would arrive as a negative value and be read as "unlimited", silently
+   * turning off the very cap the field governs (issue #5711). Out of range, NaN and a non-numeric value are all
+   * client errors, mapped to HTTP 400 by the {@link IllegalArgumentException} arm below.
+   */
+  protected static int requireIntLimit(final Object value, final String field) {
+    if (!(value instanceof Number n))
+      throw new IllegalArgumentException("Field '" + field + "' must be an integer");
+    final double magnitude = n.doubleValue();
+    if (Double.isNaN(magnitude) || magnitude > Integer.MAX_VALUE || magnitude < Integer.MIN_VALUE)
+      throw unusableLimit(field, null);
+    return n.intValue();
+  }
+
+  /**
+   * Rejection of a row limit that is not an integer this server can apply, worded identically wherever the limit
+   * arrives from so the surfaces report the same thing.
+   */
+  protected static IllegalArgumentException unusableLimit(final String field, final Throwable cause) {
+    return new IllegalArgumentException(
+        "Field '" + field + "' must be an integer between " + Integer.MIN_VALUE + " and " + Integer.MAX_VALUE, cause);
+  }
+
   protected String parseRequestPayload(final HttpServerExchange e) {
     if (!e.isInIoThread() && !e.isBlocking())
       e.startBlocking();

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -121,6 +121,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   protected abstract ExecutionResponse execute(HttpServerExchange exchange, ServerSecurityUser user, JSONObject payload)
           throws Exception;
 
+  /**
+   * Maximum number of rows an endpoint serializes into a single response when the caller states no limit of its
+   * own. A non-positive value means unlimited. Shared by every row-returning endpoint so one setting governs
+   * them all (issue #5711).
+   */
+  protected int getDefaultRowLimit() {
+    return httpServer.getServer().getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT);
+  }
+
   protected String parseRequestPayload(final HttpServerExchange e) {
     if (!e.isInIoThread() && !e.isBlocking())
       e.startBlocking();

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
@@ -20,7 +20,6 @@ package com.arcadedb.server.http.handler;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.log.LogManager;
-import com.arcadedb.query.sql.executor.ExecutionPlan;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
@@ -69,18 +68,19 @@ public class GetQueryHandler extends AbstractQueryHandler {
       try {
         final long engineStart = System.nanoTime();
         qResult = database.query(language, text);
-        final ExecutionPlan plan = qResult.getExecutionPlan().orElse(null);
-        int limit = plan != null ? plan.getLimit() : 0;
-        if (limit == 0) {
-          if (limitPar == null)
-            limit = DEFAULT_LIMIT;
-          else
-            limit = Integer.parseInt(limitPar);
-        }
+
+        // Same precedence as the POST endpoint: the caller's own 'limit' parameter, then the LIMIT the query
+        // carries, then the configured default - the only case that can drop rows the caller never asked to
+        // drop, and it is reported back with 'truncated' (issue #5711).
+        final Integer requestLimit = limitPar == null ? null : Integer.parseInt(limitPar);
+        final int planLimit = getPlanLimit(qResult);
+        final int limit = resolveLimit(requestLimit, planLimit);
         profile.addEngineNanos(System.nanoTime() - engineStart);
 
         final long serializationStart = System.nanoTime();
-        serializeResultSet(database, serializer, limit, response, qResult);
+        final SerializationOutcome outcome = serializeResultSet(database, serializer, limit, response, qResult);
+        reportLimits(response, limit, outcome);
+        logIfTruncatedByDefault(database.getName(), text, limit, requestLimit, planLimit, outcome);
         profile.addSerializationNanos(System.nanoTime() - serializationStart);
 
       } finally {

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
@@ -72,7 +72,7 @@ public class GetQueryHandler extends AbstractQueryHandler {
         // Same precedence as the POST endpoint: the caller's own 'limit' parameter, then the LIMIT the query
         // carries, then the configured default - the only case that can drop rows the caller never asked to
         // drop, and it is reported back with 'truncated' (issue #5711).
-        final Integer requestLimit = limitPar == null ? null : Integer.parseInt(limitPar);
+        final Integer requestLimit = parseLimitParameter(limitPar, "limit");
         final int planLimit = getPlanLimit(qResult);
         final int limit = resolveLimit(requestLimit, planLimit);
         profile.addEngineNanos(System.nanoTime() - engineStart);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -51,20 +51,14 @@ public class PostCommandHandler extends AbstractQueryHandler {
   }
 
   /**
-   * Appends an automatic trailing {@code LIMIT} to SELECT/MATCH SQL commands that do not already carry one,
-   * mirroring the historical heuristic while avoiding a full-command {@code toLowerCase} copy per request.
-   * The command is expected to be already trimmed. Only case-insensitive prefix/substring probes are used,
-   * and the last line is lowercased only when an explicit LIMIT may already be present.
-   */
-  static String appendAutomaticLimit(final String command, final String language, final int limit) {
-    return requiresAutomaticLimit(command, language, limit) ? command + " limit " + limit : command;
-  }
-
-  /**
-   * Tells whether {@link #appendAutomaticLimit} would append a trailing {@code LIMIT} to the given command,
-   * i.e. whether the command is a SELECT/MATCH that states no LIMIT of its own. The handler needs the answer
-   * separately from the rewritten text: a command that already carries a LIMIT has expressed the caller's own
-   * expectation, and that expectation - not the default cap - decides how many rows are serialized.
+   * Tells whether the given command needs an automatic trailing {@code LIMIT} pushed down, i.e. whether it is a
+   * SELECT/MATCH SQL command that states no LIMIT of its own. A command that already carries one has expressed
+   * the caller's own expectation, and that expectation - not the default cap - decides how many rows are
+   * serialized, so the text is left exactly as it arrived.
+   * <p>
+   * The historical heuristic is preserved while avoiding a full-command {@code toLowerCase} copy per request:
+   * the command is expected to be already trimmed, only case-insensitive prefix/substring probes are used, and
+   * the last line is lowercased only when an explicit LIMIT may already be present.
    */
   static boolean requiresAutomaticLimit(final String command, final String language, final int limit) {
     // A non-positive cap means unlimited, exactly as it does in the serializer: pushing 'limit 0' down would
@@ -144,8 +138,15 @@ public class PostCommandHandler extends AbstractQueryHandler {
     final Object value = map.get(field);
     if (value == null)
       return null;
-    if (value instanceof Number n)
+    if (value instanceof Number n) {
+      // Number.intValue() truncates the high bits, so 3000000000 would arrive as a negative value and be read
+      // as "unlimited" - silently turning off the very cap this field governs. Out-of-range is a client error.
+      final double magnitude = n.doubleValue();
+      if (Double.isNaN(magnitude) || magnitude > Integer.MAX_VALUE || magnitude < Integer.MIN_VALUE)
+        throw new IllegalArgumentException(
+            "Field '" + field + "' must be an integer between " + Integer.MIN_VALUE + " and " + Integer.MAX_VALUE);
       return n.intValue();
+    }
     throw new IllegalArgumentException("Field '" + field + "' must be an integer");
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -136,17 +136,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
    */
   private static Integer optionalIntField(final Map<String, Object> map, final String field) {
     final Object value = map.get(field);
-    if (value == null)
-      return null;
-    if (value instanceof Number n) {
-      // Number.intValue() truncates the high bits, so 3000000000 would arrive as a negative value and be read
-      // as "unlimited" - silently turning off the very cap this field governs. Out-of-range is a client error.
-      final double magnitude = n.doubleValue();
-      if (Double.isNaN(magnitude) || magnitude > Integer.MAX_VALUE || magnitude < Integer.MIN_VALUE)
-        throw unusableLimit(field, null);
-      return n.intValue();
-    }
-    throw new IllegalArgumentException("Field '" + field + "' must be an integer");
+    return value == null ? null : requireIntLimit(value, field);
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -57,28 +57,47 @@ public class PostCommandHandler extends AbstractQueryHandler {
    * and the last line is lowercased only when an explicit LIMIT may already be present.
    */
   static String appendAutomaticLimit(final String command, final String language, final int limit) {
-    if (limit == -1)
-      return command;
+    return requiresAutomaticLimit(command, language, limit) ? command + " limit " + limit : command;
+  }
+
+  /**
+   * Tells whether {@link #appendAutomaticLimit} would append a trailing {@code LIMIT} to the given command,
+   * i.e. whether the command is a SELECT/MATCH that states no LIMIT of its own. The handler needs the answer
+   * separately from the rewritten text: a command that already carries a LIMIT has expressed the caller's own
+   * expectation, and that expectation - not the default cap - decides how many rows are serialized.
+   */
+  static boolean requiresAutomaticLimit(final String command, final String language, final int limit) {
+    // A non-positive cap means unlimited, exactly as it does in the serializer: pushing 'limit 0' down would
+    // instead return no row at all, which is what the previous asymmetry did with a request carrying limit=0.
+    if (limit <= 0)
+      return false;
     if (!"sql".equalsIgnoreCase(language) && !"sqlScript".equalsIgnoreCase(language))
-      return command;
+      return false;
 
     final boolean isSelect = command.regionMatches(true, 0, "select", 0, 6);
     final boolean isMatch = command.regionMatches(true, 0, "match", 0, 5);
     if ((!isSelect && !isMatch) || command.endsWith(";"))
-      return command;
+      return false;
 
     if (!containsIgnoreCase(command, " limit ") && !containsIgnoreCase(command, "\nlimit "))
-      return command + " limit " + limit;
+      return true;
 
     // An explicit LIMIT may already be present somewhere: only the last line decides whether to append.
     final String[] lines = LINE_BREAK.split(command);
     final String[] words = lines[lines.length - 1].toLowerCase(Locale.ENGLISH).split(" ");
-    if (words.length > 1 //
+    return words.length > 1 //
         && !"limit".equals(words[words.length - 2]) //
-        && (words.length < 5 || !"limit".equals(words[words.length - 4])))
-      return command + " limit " + limit;
+        && (words.length < 5 || !"limit".equals(words[words.length - 4]));
+  }
 
-    return command;
+  /**
+   * LIMIT to push down into a command that carries none, one row above the cap the response will honor: the
+   * extra row never reaches the client and is what lets the serializer tell a result that ends exactly at the
+   * cap from one that was cut short (issue #5711). A non-positive cap means unlimited and is pushed down
+   * unchanged, and a cap of {@link Integer#MAX_VALUE} saturates instead of overflowing.
+   */
+  static int truncationProbeLimit(final int limit) {
+    return limit > 0 && limit < Integer.MAX_VALUE ? limit + 1 : limit;
   }
 
   /**
@@ -115,10 +134,16 @@ public class PostCommandHandler extends AbstractQueryHandler {
     throw new IllegalArgumentException("Field '" + field + "' must be a string");
   }
 
-  private static int requireIntField(final Map<String, Object> map, final String field, final int defaultValue) {
+  /**
+   * Returns the value of an optional request field that must be a JSON integer, or {@code null} when absent.
+   * The absence must stay distinguishable from any value the caller could send: {@code limit} is the caller's
+   * explicit statement of the page size it expects, and a default substituted for a missing field would be
+   * indistinguishable from that statement.
+   */
+  private static Integer optionalIntField(final Map<String, Object> map, final String field) {
     final Object value = map.get(field);
     if (value == null)
-      return defaultValue;
+      return null;
     if (value instanceof Number n)
       return n.intValue();
     throw new IllegalArgumentException("Field '" + field + "' must be an integer");
@@ -159,7 +184,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
     // and a command can legitimately carry HTML entities (e.g. &quot;, &amp;) inside its data. Decoding
     // them here corrupts the payload (e.g. breaks the embedded JSON of an INSERT ... CONTENT { ... }).
     String command = requireStringField(requestMap, "command");
-    final int limit = requireIntField(requestMap, "limit", DEFAULT_LIMIT);
+    final Integer requestLimit = optionalIntField(requestMap, "limit");
     final String serializer = requireStringField(requestMap, "serializer", "record");
     final String profileExecution = requireStringField(requestMap, "profileExecution", null);
 
@@ -198,7 +223,16 @@ public class PostCommandHandler extends AbstractQueryHandler {
     // and downgraded to HTTP 500.
     paramMap = AbstractQueryHandler.decodeTypedJsonMarkers(paramMap);
 
-    command = appendAutomaticLimit(command, language, limit);
+    // The cap used to push a LIMIT down into a command that states none: the caller's own 'limit' when
+    // present, the configured default otherwise. A command that already carries a LIMIT is left untouched and
+    // its own value decides the response size, resolved from the execution plan after execution.
+    final int autoLimit = requestLimit != null ? requestLimit : getDefaultLimit();
+    final boolean autoLimited = requiresAutomaticLimit(command, language, autoLimit);
+    // Kept for the log: a warning must show the operator the query the caller sent, not the rewritten one.
+    final String originalCommand = command;
+    if (autoLimited)
+      // One row above the cap: the extra row is never serialized, it only makes truncation detectable.
+      command = command + " limit " + truncationProbeLimit(autoLimit);
 
     if ("sqlScript".equalsIgnoreCase(language) && !command.endsWith(";"))
       command += ";";
@@ -226,6 +260,14 @@ public class PostCommandHandler extends AbstractQueryHandler {
         final JSONObject response = new JSONObject();
         response.put("user", user != null ? user.getName() : null);
 
+        // How many rows the response may carry, in decreasing order of explicitness: the request 'limit', the
+        // LIMIT the command carries (read back from the execution plan, and ignored when it is the one this
+        // handler pushed down itself), the configured default. Only the last one can drop rows the caller
+        // never asked to drop, and that is exactly what 'truncated' reports below (issue #5711).
+        final int planLimit = autoLimited ? 0 : getPlanLimit(qResult);
+        final int limit = resolveLimit(requestLimit, planLimit);
+        final SerializationOutcome outcome;
+
         if (qResult instanceof ExplainResultSet) {
           // EXPLAIN (or SQL PROFILE): extract plan, then drain the single record
           // so serializeResultSet produces an empty result structure
@@ -237,7 +279,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
           profile.addEngineNanos(System.nanoTime() - engineStart);
 
           final long serializationStart = System.nanoTime();
-          serializeResultSet(database, serializer, limit, response, qResult);
+          outcome = serializeResultSet(database, serializer, limit, response, qResult);
           response.put("explain", explainText);
           response.put("explainPlan", executionPlan.toResult().toJSON());
           profile.addSerializationNanos(System.nanoTime() - serializationStart);
@@ -251,7 +293,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
           profile.addEngineNanos(System.nanoTime() - engineStart);
 
           final long serializationStart = System.nanoTime();
-          serializeResultSet(database, serializer, limit, response, qResult);
+          outcome = serializeResultSet(database, serializer, limit, response, qResult);
 
           if (qResult != null) {
             final var qStats = qResult.getStatistics();
@@ -268,6 +310,9 @@ public class PostCommandHandler extends AbstractQueryHandler {
           }
           profile.addSerializationNanos(System.nanoTime() - serializationStart);
         }
+
+        reportLimits(response, limit, outcome);
+        logIfTruncatedByDefault(database.getName(), originalCommand, limit, requestLimit, planLimit, outcome);
 
         if (detailedProfile)
           response.put("profile", profile.toJSON());

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -226,7 +226,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
     // The cap used to push a LIMIT down into a command that states none: the caller's own 'limit' when
     // present, the configured default otherwise. A command that already carries a LIMIT is left untouched and
     // its own value decides the response size, resolved from the execution plan after execution.
-    final int autoLimit = requestLimit != null ? requestLimit : getDefaultLimit();
+    final int autoLimit = requestLimit != null ? requestLimit : getDefaultRowLimit();
     final boolean autoLimited = requiresAutomaticLimit(command, language, autoLimit);
     // Kept for the log: a warning must show the operator the query the caller sent, not the rewritten one.
     final String originalCommand = command;

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -143,8 +143,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
       // as "unlimited" - silently turning off the very cap this field governs. Out-of-range is a client error.
       final double magnitude = n.doubleValue();
       if (Double.isNaN(magnitude) || magnitude > Integer.MAX_VALUE || magnitude < Integer.MIN_VALUE)
-        throw new IllegalArgumentException(
-            "Field '" + field + "' must be an integer between " + Integer.MIN_VALUE + " and " + Integer.MAX_VALUE);
+        throw unusableLimit(field, null);
       return n.intValue();
     }
     throw new IllegalArgumentException("Field '" + field + "' must be an integer");

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -103,8 +103,11 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
     // Same cap and same semantics as the query/command endpoints: a non-positive value means unlimited. Note
     // that here the cap governs serialization only - the engine query below materializes the whole range
     // regardless, so removing the cap does not widen an already unbounded fetch.
-    final boolean callerSuppliedLimit = payload.has("limit");
-    final int limit = callerSuppliedLimit ? payload.getInt("limit") : getDefaultRowLimit();
+    // requireIntLimit rather than payload.getInt: the latter narrows with Number.intValue(), so a limit an int
+    // cannot hold would wrap to a negative value and be read as unlimited, exactly as on the other endpoints.
+    final Object rawLimit = payload.opt("limit");
+    final int limit = rawLimit != null ? requireIntLimit(rawLimit, "limit") : getDefaultRowLimit();
+    final boolean callerSuppliedLimit = rawLimit != null;
 
     // Resolve field projection
     final int[] columnIndices = resolveColumnIndices(payload, columns);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -132,6 +132,9 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
     result.put("columns", colNames);
     result.put("rows", rowsArray);
     result.put("count", count);
+    // A response cut by the limit must not look like a complete one (issue #5711).
+    result.put("limit", limit > 0 ? limit : -1);
+    result.put("truncated", rows.size() > count);
 
     return new ExecutionResponse(200, result.toString());
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -97,7 +97,9 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
       final List<ColumnDefinition> columns, final String typeName, final long fromTs, final long toTs,
       final TagFilter tagFilter) throws Exception {
 
-    // Same cap and same semantics as the query/command endpoints: a non-positive value means unlimited.
+    // Same cap and same semantics as the query/command endpoints: a non-positive value means unlimited. Note
+    // that here the cap governs serialization only - the engine query below materializes the whole range
+    // regardless, so removing the cap does not widen an already unbounded fetch.
     final int limit = payload.getInt("limit", getDefaultRowLimit());
 
     // Resolve field projection

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.timeseries.AggregationType;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
@@ -25,6 +26,7 @@ import com.arcadedb.engine.timeseries.MultiColumnAggregationRequest;
 import com.arcadedb.engine.timeseries.MultiColumnAggregationResult;
 import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.serializer.json.JSONArray;
@@ -36,6 +38,7 @@ import io.undertow.server.HttpServerExchange;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.logging.Level;
 
 /**
  * HTTP handler for TimeSeries query endpoint.
@@ -100,7 +103,8 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
     // Same cap and same semantics as the query/command endpoints: a non-positive value means unlimited. Note
     // that here the cap governs serialization only - the engine query below materializes the whole range
     // regardless, so removing the cap does not widen an already unbounded fetch.
-    final int limit = payload.getInt("limit", getDefaultRowLimit());
+    final boolean callerSuppliedLimit = payload.has("limit");
+    final int limit = callerSuppliedLimit ? payload.getInt("limit") : getDefaultRowLimit();
 
     // Resolve field projection
     final int[] columnIndices = resolveColumnIndices(payload, columns);
@@ -134,8 +138,17 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
     result.put("rows", rowsArray);
     result.put("count", count);
     // A response cut by the limit must not look like a complete one (issue #5711).
+    final boolean truncated = rows.size() > count;
     result.put("limit", limit > 0 ? limit : -1);
-    result.put("truncated", rows.size() > count);
+    result.put("truncated", truncated);
+
+    if (truncated && !callerSuppliedLimit)
+      // The caller stated no limit, so this truncation is the only one it did not ask for: an operator must be
+      // able to find it in the log, exactly as on the query and command endpoints.
+      LogManager.instance().log(this, Level.WARNING,
+          "Query on time series type '%s' returned %d rows, more than the default HTTP limit of %d: the response has been "
+              + "truncated. Set 'limit' in the request, or raise '%s'.", typeName, rows.size(), limit,
+          GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT.getKey());
 
     return new ExecutionResponse(200, result.toString());
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -43,8 +43,6 @@ import java.util.List;
  */
 public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
 
-  private static final int DEFAULT_LIMIT = 20_000;
-
   public PostTimeSeriesQueryHandler(final HttpServer httpServer) {
     super(httpServer);
   }
@@ -99,7 +97,8 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
       final List<ColumnDefinition> columns, final String typeName, final long fromTs, final long toTs,
       final TagFilter tagFilter) throws Exception {
 
-    final int limit = payload.getInt("limit", DEFAULT_LIMIT);
+    // Same cap and same semantics as the query/command endpoints: a non-positive value means unlimited.
+    final int limit = payload.getInt("limit", getDefaultRowLimit());
 
     // Resolve field projection
     final int[] columnIndices = resolveColumnIndices(payload, columns);
@@ -118,7 +117,7 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
 
     // Build rows array, applying limit
     final JSONArray rowsArray = new JSONArray();
-    final int count = Math.min(rows.size(), limit);
+    final int count = limit > 0 ? Math.min(rows.size(), limit) : rows.size();
     for (int i = 0; i < count; i++) {
       final Object[] row = rows.get(i);
       final JSONArray rowArray = new JSONArray();

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -527,7 +527,11 @@ public class CoreApiSpec implements OpenApiContributor {
   private Schema<?> createQueryResponseSchema() {
     final Schema<Object> schema = SpecBuilders.object("Query response object");
     schema.addProperty("result", SpecBuilders.arrayOf(SpecBuilders.object(null), "Query results"));
-    schema.addProperty("limit", SpecBuilders.integer("Effective row cap applied while serializing, -1 when uncapped"));
+    schema.addProperty("limit", SpecBuilders.integer(
+        """
+        Effective row cap applied while serializing, -1 when uncapped. This is the serializer's cap, not the \
+        query's own LIMIT: a query stating a LIMIT below the server default reports the default here, and \
+        'returned' with 'truncated' describe what the response actually carries."""));
     // 'executionTime' and 'recordCount' used to be documented here but no handler has ever emitted them:
     // 'returned' is the real row count, and timings are reported under 'profile' when profileExecution is set.
     schema.addProperty("returned", SpecBuilders.integer(

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -533,7 +533,9 @@ public class CoreApiSpec implements OpenApiContributor {
     schema.addProperty("returned", SpecBuilders.integer(
         """
         Number of rows carried by this response. With the 'graph' serializer, whose cap counts graph elements \
-        rather than rows, it is the number of serialized vertices plus edges."""));
+        rather than rows, it is the number of serialized vertices plus edges, and it can exceed 'limit': a \
+        single row can expand into several elements, and the expansion of the row that reaches the cap is not \
+        cut in half."""));
     schema.addProperty("truncated", SpecBuilders.bool(
         "True when the cap stopped the serialization with rows still pending, so the response is incomplete"));
     return schema;

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -500,7 +500,13 @@ public class CoreApiSpec implements OpenApiContributor {
         {"$int8": [v0, v1, ...]} for byte[] from integers in [-128, 127] (used to send \
         INT8-encoded vectors to LSM_VECTOR indexes without a float32 round-trip)."""));
     schema.addProperty("serializer", SpecBuilders.string("Response serializer").example("json"));
-    schema.addProperty("limit", SpecBuilders.integer("Maximum number of results").example(100));
+    schema.addProperty("limit", SpecBuilders.integer(
+        """
+        Maximum number of rows to serialize into the response. When omitted, a LIMIT stated by the query is \
+        honored as written and only a query stating none is capped by the server default \
+        ('arcadedb.server.httpQueryDefaultLimit'). Use -1 for no cap. The response always reports the cap \
+        that was applied ('limit'), how many rows it carries ('returned') and whether rows were left \
+        behind ('truncated').""").example(100));
     schema.setRequired(List.of("command"));
     return schema;
   }
@@ -523,6 +529,10 @@ public class CoreApiSpec implements OpenApiContributor {
     schema.addProperty("result", SpecBuilders.arrayOf(SpecBuilders.object(null), "Query results"));
     schema.addProperty("executionTime", SpecBuilders.integer("Execution time in milliseconds"));
     schema.addProperty("recordCount", SpecBuilders.integer("Number of records returned"));
+    schema.addProperty("limit", SpecBuilders.integer("Effective row cap applied while serializing, -1 when uncapped"));
+    schema.addProperty("returned", SpecBuilders.integer("Number of rows carried by this response"));
+    schema.addProperty("truncated", SpecBuilders.bool(
+        "True when the cap stopped the serialization with rows still pending, so the response is incomplete"));
     return schema;
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -527,10 +527,13 @@ public class CoreApiSpec implements OpenApiContributor {
   private Schema<?> createQueryResponseSchema() {
     final Schema<Object> schema = SpecBuilders.object("Query response object");
     schema.addProperty("result", SpecBuilders.arrayOf(SpecBuilders.object(null), "Query results"));
-    schema.addProperty("executionTime", SpecBuilders.integer("Execution time in milliseconds"));
-    schema.addProperty("recordCount", SpecBuilders.integer("Number of records returned"));
     schema.addProperty("limit", SpecBuilders.integer("Effective row cap applied while serializing, -1 when uncapped"));
-    schema.addProperty("returned", SpecBuilders.integer("Number of rows carried by this response"));
+    // 'executionTime' and 'recordCount' used to be documented here but no handler has ever emitted them:
+    // 'returned' is the real row count, and timings are reported under 'profile' when profileExecution is set.
+    schema.addProperty("returned", SpecBuilders.integer(
+        """
+        Number of rows carried by this response. With the 'graph' serializer, whose cap counts graph elements \
+        rather than rows, it is the number of serialized vertices plus edges."""));
     schema.addProperty("truncated", SpecBuilders.bool(
         "True when the cap stopped the serialization with rows still pending, so the response is incomplete"));
     return schema;

--- a/server/src/test/java/com/arcadedb/server/HTTPDocumentIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPDocumentIT.java
@@ -276,6 +276,70 @@ class HTTPDocumentIT extends BaseGraphServerTest {
     });
   }
 
+  /**
+   * Issue #5711: the LIMIT the caller wrote in the query must not be overridden by the serializer default, and
+   * the POST endpoint must agree with the GET one (see {@link #checkQueryInGetWithLimitAboveDefaultCut()}).
+   */
+  @Test
+  void checkQueryInPostWithLimitAboveDefaultCut() throws Exception {
+    testEachServer(serverIndex -> {
+      final HttpURLConnection connection = (HttpURLConnection) new URL(
+          "http://localhost:248" + serverIndex + "/api/v1/query/" + DATABASE_NAME).openConnection();
+
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Authorization",
+          "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+      formatPayload(connection, "sql", "select from Person limit " + (TOTAL - 1), "record", Collections.emptyMap());
+      connection.connect();
+
+      try {
+        final String response = readResponse(connection);
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+
+        final JSONObject responseAsJson = new JSONObject(response);
+        assertThat(responseAsJson.getJSONArray("result").length()).isEqualTo(TOTAL - 1);
+        assertThat(responseAsJson.getInt("returned")).isEqualTo(TOTAL - 1);
+        assertThat(responseAsJson.getInt("limit")).isEqualTo(TOTAL - 1);
+        assertThat(responseAsJson.getBoolean("truncated")).isFalse();
+
+      } finally {
+        connection.disconnect();
+      }
+    });
+  }
+
+  /**
+   * Issue #5711: when the default cap - and not the caller - is what cut the result short, the response must say
+   * so instead of looking complete.
+   */
+  @Test
+  void checkQueryInPostReportsDefaultLimitTruncation() throws Exception {
+    testEachServer(serverIndex -> {
+      final HttpURLConnection connection = (HttpURLConnection) new URL(
+          "http://localhost:248" + serverIndex + "/api/v1/query/" + DATABASE_NAME).openConnection();
+
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Authorization",
+          "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+      formatPayload(connection, "sql", "select from Person", "record", Collections.emptyMap());
+      connection.connect();
+
+      try {
+        final String response = readResponse(connection);
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+
+        final JSONObject responseAsJson = new JSONObject(response);
+        assertThat(responseAsJson.getJSONArray("result").length()).isEqualTo(AbstractQueryHandler.DEFAULT_LIMIT);
+        assertThat(responseAsJson.getInt("returned")).isEqualTo(AbstractQueryHandler.DEFAULT_LIMIT);
+        assertThat(responseAsJson.getInt("limit")).isEqualTo(AbstractQueryHandler.DEFAULT_LIMIT);
+        assertThat(responseAsJson.getBoolean("truncated")).isTrue();
+
+      } finally {
+        connection.disconnect();
+      }
+    });
+  }
+
   @Test
   void checkQueryInGetWithDefaultLimit() throws Exception {
     testEachServer(serverIndex -> {

--- a/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
@@ -85,11 +85,13 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
 
       // A non-positive limit means unlimited here too, as it does on the query/command endpoints: it used to
       // reach Math.min(rows, -1) and return no row at all while reporting the result as truncated.
-      request.put("limit", -1);
-      final JSONObject unlimited = postTsQuery(serverIndex, request);
-      assertThat(unlimited.getInt("count")).isEqualTo(3);
-      assertThat(unlimited.getInt("limit")).isEqualTo(-1);
-      assertThat(unlimited.getBoolean("truncated")).isFalse();
+      for (final int unlimitedLimit : new int[] { -1, 0 }) {
+        request.put("limit", unlimitedLimit);
+        final JSONObject unlimited = postTsQuery(serverIndex, request);
+        assertThat(unlimited.getInt("count")).isEqualTo(3);
+        assertThat(unlimited.getInt("limit")).isEqualTo(-1);
+        assertThat(unlimited.getBoolean("truncated")).isFalse();
+      }
     });
   }
 

--- a/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
@@ -59,6 +59,32 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
     });
   }
 
+  /**
+   * Issue #5711: a response the row limit cut short must say so instead of looking like a complete one.
+   */
+  @Test
+  void rawQueryReportsTruncation() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeAndIngestData(serverIndex);
+
+      final JSONObject request = new JSONObject();
+      request.put("type", "weather");
+      request.put("from", 1000L);
+      request.put("to", 3000L);
+      request.put("limit", 2);
+
+      final JSONObject truncated = postTsQuery(serverIndex, request);
+      assertThat(truncated.getInt("count")).isEqualTo(2);
+      assertThat(truncated.getInt("limit")).isEqualTo(2);
+      assertThat(truncated.getBoolean("truncated")).isTrue();
+
+      request.put("limit", 3);
+      final JSONObject complete = postTsQuery(serverIndex, request);
+      assertThat(complete.getInt("count")).isEqualTo(3);
+      assertThat(complete.getBoolean("truncated")).isFalse();
+    });
+  }
+
   @Test
   void aggregatedQuery() throws Exception {
     testEachServer(serverIndex -> {

--- a/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
@@ -82,6 +82,14 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
       final JSONObject complete = postTsQuery(serverIndex, request);
       assertThat(complete.getInt("count")).isEqualTo(3);
       assertThat(complete.getBoolean("truncated")).isFalse();
+
+      // A non-positive limit means unlimited here too, as it does on the query/command endpoints: it used to
+      // reach Math.min(rows, -1) and return no row at all while reporting the result as truncated.
+      request.put("limit", -1);
+      final JSONObject unlimited = postTsQuery(serverIndex, request);
+      assertThat(unlimited.getInt("count")).isEqualTo(3);
+      assertThat(unlimited.getInt("limit")).isEqualTo(-1);
+      assertThat(unlimited.getBoolean("truncated")).isFalse();
     });
   }
 

--- a/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
@@ -85,6 +85,11 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
 
       // A non-positive limit means unlimited here too, as it does on the query/command endpoints: it used to
       // reach Math.min(rows, -1) and return no row at all while reporting the result as truncated.
+      // A limit an int cannot hold must not wrap into a negative value and be read as unlimited: it is a client
+      // error here exactly as it is on the query and command endpoints.
+      request.put("limit", 3_000_000_000L);
+      assertThat(postTsQueryRaw(serverIndex, request)).isEqualTo(400);
+
       for (final int unlimitedLimit : new int[] { -1, 0 }) {
         request.put("limit", unlimitedLimit);
         final JSONObject unlimited = postTsQuery(serverIndex, request);

--- a/server/src/test/java/com/arcadedb/server/http/handler/AbstractQueryHandlerLogAbbreviationTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/AbstractQueryHandlerLogAbbreviationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AbstractQueryHandler#abbreviateForLog(String)}: the truncation warning echoes a
+ * client-supplied command, so the command must not be able to flood the log with its own size nor forge log
+ * lines of its own with an embedded line break (issue #5711).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class AbstractQueryHandlerLogAbbreviationTest {
+
+  @Test
+  void aShortSingleLineCommandIsUnchanged() {
+    final String command = "SELECT i FROM V";
+    assertThat(AbstractQueryHandler.abbreviateForLog(command)).isEqualTo(command);
+  }
+
+  @Test
+  void aNullCommandStaysNull() {
+    assertThat(AbstractQueryHandler.abbreviateForLog(null)).isNull();
+  }
+
+  @Test
+  void aLongCommandIsCappedAndMarked() {
+    final String command = "SELECT " + "x".repeat(500) + " FROM V";
+    final String abbreviated = AbstractQueryHandler.abbreviateForLog(command);
+
+    assertThat(abbreviated).hasSize(120 + "...".length());
+    assertThat(abbreviated).startsWith("SELECT xxx").endsWith("...");
+  }
+
+  @Test
+  void aCommandOfExactlyTheCapIsNotMarked() {
+    final String command = "x".repeat(120);
+    assertThat(AbstractQueryHandler.abbreviateForLog(command)).isEqualTo(command);
+  }
+
+  @Test
+  void controlCharactersCannotForgeALogLine() {
+    // A command carrying its own line break would otherwise appear in the log as a second, fabricated entry.
+    final String abbreviated = AbstractQueryHandler.abbreviateForLog(
+        "SELECT i FROM V\n2026-08-01 00:00:00.000 SEVER [Forged] nothing happened\r\tend");
+
+    assertThat(abbreviated).doesNotContain("\n").doesNotContain("\r").doesNotContain("\t");
+    assertThat(abbreviated).isEqualTo("SELECT i FROM V 2026-08-01 00:00:00.000 SEVER [Forged] nothing happened  end");
+  }
+
+  @Test
+  void aLineBreakBeyondTheCapIsDroppedWithTheRest() {
+    final String abbreviated = AbstractQueryHandler.abbreviateForLog("SELECT " + "x".repeat(200) + "\nforged");
+
+    assertThat(abbreviated).doesNotContain("forged");
+    assertThat(abbreviated).hasSize(120 + "...".length());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
@@ -217,6 +217,13 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
   }
 
   @Test
+  void theGetEndpointRejectsAnUnusableLimitTheSameWayThePostEndpointDoes() throws Exception {
+    // Both surfaces must answer the same way to the same unusable value: a client error, not a server error.
+    assertThat(getStatus("SELECT i FROM " + TYPE_NAME, "abc")).isEqualTo(400);
+    assertThat(getStatus("SELECT i FROM " + TYPE_NAME, "3000000000")).isEqualTo(400);
+  }
+
+  @Test
   void theHttpAndTheEmbeddedSurfaceAgreeOnTheSameQuery() throws Exception {
     final String command = "SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS;
 
@@ -392,6 +399,16 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
   }
 
   private JSONObject get(final String command, final String limit) throws Exception {
+    final HttpResponse<String> response = sendGet(command, limit);
+    assertThat(response.statusCode()).isEqualTo(200);
+    return new JSONObject(response.body());
+  }
+
+  private int getStatus(final String command, final String limit) throws Exception {
+    return sendGet(command, limit).statusCode();
+  }
+
+  private HttpResponse<String> sendGet(final String command, final String limit) throws Exception {
     // The command travels as a path segment: URLEncoder emits '+' for a space, which is only a space in a
     // query string.
     final String url = "http://127.0.0.1:2480/api/v1/query/" + getDatabaseName() + "/sql/"
@@ -405,9 +422,7 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
             "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
         .build();
 
-    final HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-    assertThat(response.statusCode()).isEqualTo(200);
-    return new JSONObject(response.body());
+    return client.send(request, BodyHandlers.ofString());
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
@@ -205,6 +205,18 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
   }
 
   @Test
+  void aRequestLimitTooLargeForAnIntIsRejected() throws Exception {
+    // Narrowing it with Number.intValue() would wrap 3000000000 to a negative value, which reads as
+    // "unlimited" and silently turns off the cap the field governs: it is a client error instead.
+    final int status = postStatus("query", new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME)
+        .put("limit", 3_000_000_000L));
+
+    assertThat(status).isEqualTo(400);
+  }
+
+  @Test
   void theHttpAndTheEmbeddedSurfaceAgreeOnTheSameQuery() throws Exception {
     final String command = "SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS;
 
@@ -358,6 +370,16 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
   }
 
   private JSONObject post(final String endpoint, final JSONObject payload) throws Exception {
+    final HttpResponse<String> response = send(endpoint, payload);
+    assertThat(response.statusCode()).isEqualTo(200);
+    return new JSONObject(response.body());
+  }
+
+  private int postStatus(final String endpoint, final JSONObject payload) throws Exception {
+    return send(endpoint, payload).statusCode();
+  }
+
+  private HttpResponse<String> send(final String endpoint, final JSONObject payload) throws Exception {
     final HttpRequest request = HttpRequest.newBuilder()
         .uri(new URI("http://127.0.0.1:2480/api/v1/" + endpoint + "/" + getDatabaseName()))
         .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
@@ -366,9 +388,7 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
             "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
         .build();
 
-    final HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-    assertThat(response.statusCode()).isEqualTo(200);
-    return new JSONObject(response.body());
+    return client.send(request, BodyHandlers.ofString());
   }
 
   private JSONObject get(final String command, final String limit) throws Exception {

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
@@ -115,6 +115,21 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
   }
 
   @Test
+  void aResultOfExactlyTheDefaultCapIsNotFlagged() throws Exception {
+    // The boundary the 'cap + 1' probe exists for: the command states no LIMIT, so the handler pushes down
+    // 'limit 51', and the engine returns exactly the 50 rows that match. Nothing was left behind, so the
+    // response must not claim otherwise - this is the false-positive guard for the probe itself.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME + " WHERE i < " + CAP));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CAP);
+    assertThat(response.getInt("returned")).isEqualTo(CAP);
+    assertThat(response.getInt("limit")).isEqualTo(CAP);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
   void theRequestLimitWinsOverTheQueryLimitAndIsReported() throws Exception {
     final JSONObject response = query(new JSONObject()
         .put("language", "sql")

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
@@ -36,6 +36,12 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -278,39 +284,50 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
   @Test
   void theRemoteDriverHonorsTheQueryLimit() {
     try (final RemoteDatabase remote = newRemoteDatabase()) {
-      int rows = 0;
-      try (final ResultSet resultSet = remote.query("sql", "SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS)) {
-        while (resultSet.hasNext()) {
-          resultSet.next();
-          rows++;
-        }
-      }
-      assertThat(rows).isEqualTo(TOTAL_ROWS);
+      assertThat(countRows(remote, "SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS)).isEqualTo(TOTAL_ROWS);
     }
   }
 
   @Test
   void theRemoteDriverCanRemoveTheCap() {
     try (final RemoteDatabase remote = newRemoteDatabase()) {
-      int rows = 0;
-      try (final ResultSet resultSet = remote.query("sql", "SELECT i FROM " + TYPE_NAME)) {
-        while (resultSet.hasNext()) {
-          resultSet.next();
-          rows++;
-        }
-      }
-      assertThat(rows).isEqualTo(CAP);
+      assertThat(countRows(remote, "SELECT i FROM " + TYPE_NAME)).isEqualTo(CAP);
 
       remote.setMaxResultRows(-1);
-      rows = 0;
-      try (final ResultSet resultSet = remote.query("sql", "SELECT i FROM " + TYPE_NAME)) {
-        while (resultSet.hasNext()) {
-          resultSet.next();
-          rows++;
-        }
-      }
-      assertThat(rows).isEqualTo(TOTAL_ROWS);
+      assertThat(countRows(remote, "SELECT i FROM " + TYPE_NAME)).isEqualTo(TOTAL_ROWS);
     }
+  }
+
+  @Test
+  void theRemoteDriverWarnsOnlyWhenItDidNotAskForTheCap() {
+    final CapturingHandler captured = new CapturingHandler();
+    final Logger logger = Logger.getLogger(RemoteDatabase.class.getName());
+    logger.addHandler(captured);
+    try (final RemoteDatabase remote = newRemoteDatabase()) {
+      // Nobody asked for a cap, so the truncation is a partial answer the application must hear about.
+      assertThat(countRows(remote, "SELECT i FROM " + TYPE_NAME)).isEqualTo(CAP);
+      assertThat(captured.messages()).anyMatch(m -> m.contains("truncated the result set"));
+
+      // The application set its own page size: the truncation is what it asked for, so warning on every page
+      // would only flood its log - the same rule the server applies to a request carrying its own 'limit'.
+      captured.clear();
+      remote.setMaxResultRows(10);
+      assertThat(countRows(remote, "SELECT i FROM " + TYPE_NAME)).isEqualTo(10);
+      assertThat(captured.messages()).noneMatch(m -> m.contains("truncated the result set"));
+    } finally {
+      logger.removeHandler(captured);
+    }
+  }
+
+  private static int countRows(final RemoteDatabase remote, final String query) {
+    int rows = 0;
+    try (final ResultSet resultSet = remote.query("sql", query)) {
+      while (resultSet.hasNext()) {
+        resultSet.next();
+        rows++;
+      }
+    }
+    return rows;
   }
 
   private RemoteDatabase newRemoteDatabase() {
@@ -356,5 +373,44 @@ class HttpQueryTruncationIT extends BaseGraphServerTest {
     final HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
     assertThat(response.statusCode()).isEqualTo(200);
     return new JSONObject(response.body());
+  }
+
+  /**
+   * Collects the formatted WARNING (and above) messages published to a logger.
+   */
+  private static final class CapturingHandler extends Handler {
+    private final List<String> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(final LogRecord record) {
+      if (record == null || record.getLevel().intValue() < Level.WARNING.intValue())
+        return;
+      String message = record.getMessage();
+      if (message != null && record.getParameters() != null && record.getParameters().length > 0) {
+        try {
+          message = message.formatted(record.getParameters());
+        } catch (final Exception ignored) {
+          // keep the raw message: the assertions only look for a substring of the template
+        }
+      }
+      if (message != null)
+        records.add(message);
+    }
+
+    List<String> messages() {
+      return List.copyOf(records);
+    }
+
+    void clear() {
+      records.clear();
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryTruncationIT.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5711: a response the row cap cut short must never be indistinguishable from a complete one, and the
+ * cap must never override a limit the caller stated itself - neither the {@code limit} field of the request nor
+ * the LIMIT clause of the query.
+ * <p>
+ * The server default cap is lowered to {@link #CAP} rows for these tests so the same semantics can be checked
+ * without materializing 20,000 records.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class HttpQueryTruncationIT extends BaseGraphServerTest {
+  private static final int    CAP        = 50;
+  private static final int    TOTAL_ROWS = 60;
+  private static final String TYPE_NAME  = "TruncatedRow";
+
+  private final HttpClient client = HttpClient.newHttpClient();
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    config.setValue(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT, CAP);
+  }
+
+  @BeforeEach
+  void createRows() {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    // A vertex type so the same rows are reachable from SQL and from Cypher.
+    database.getSchema().createVertexType(TYPE_NAME);
+    database.transaction(() -> {
+      for (int i = 0; i < TOTAL_ROWS; i++)
+        database.newVertex(TYPE_NAME).set("i", i).save();
+    });
+  }
+
+  @Test
+  void queryLimitAboveTheDefaultCapIsHonored() throws Exception {
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getInt("returned")).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getInt("limit")).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void truncationByTheDefaultCapIsReported() throws Exception {
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CAP);
+    assertThat(response.getInt("returned")).isEqualTo(CAP);
+    assertThat(response.getInt("limit")).isEqualTo(CAP);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void aCompleteResultIsNeverFlaggedAsTruncated() throws Exception {
+    // The result ends exactly at the cap: no row was left behind, so nothing must be reported.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME + " LIMIT " + CAP));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CAP);
+    assertThat(response.getInt("returned")).isEqualTo(CAP);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void theRequestLimitWinsOverTheQueryLimitAndIsReported() throws Exception {
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS)
+        .put("limit", 10));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(10);
+    assertThat(response.getInt("returned")).isEqualTo(10);
+    assertThat(response.getInt("limit")).isEqualTo(10);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void anUnlimitedRequestLimitReturnsEveryRow() throws Exception {
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME)
+        .put("limit", -1));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getInt("returned")).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getInt("limit")).isEqualTo(-1);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void aParameterizedLimitIsHonoredOnEveryExecution() throws Exception {
+    // The cap is read back from the execution plan, and a plan reports the LIMIT value of the execution it was
+    // built for. Today a plan carrying a LIMIT step is never cached, so the value is always fresh; the cap is
+    // nevertheless never lowered below the configured default, so a plan that did come back from the cache
+    // could not cut the second query down to the 5 rows the first one asked for.
+    final String command = "SELECT i FROM " + TYPE_NAME + " LIMIT :max";
+
+    final JSONObject first = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", command)
+        .put("params", new JSONObject().put("max", 5)));
+    assertThat(first.getJSONArray("result").length()).isEqualTo(5);
+    assertThat(first.getBoolean("truncated")).isFalse();
+
+    final JSONObject second = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", command)
+        .put("params", new JSONObject().put("max", 40)));
+    assertThat(second.getJSONArray("result").length()).isEqualTo(40);
+    assertThat(second.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void aZeroRequestLimitMeansUnlimited() throws Exception {
+    // 0 means unlimited in the serializer, so it must mean unlimited on the way in too: it used to be pushed
+    // down as a literal LIMIT 0 and return nothing.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME)
+        .put("limit", 0));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getInt("limit")).isEqualTo(-1);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void theGraphSerializerReportsTruncation() throws Exception {
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT FROM " + TYPE_NAME)
+        .put("serializer", "graph"));
+
+    assertThat(response.getJSONObject("result").getJSONArray("vertices").length()).isEqualTo(CAP);
+    assertThat(response.getInt("returned")).isEqualTo(CAP);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void theHttpAndTheEmbeddedSurfaceAgreeOnTheSameQuery() throws Exception {
+    final String command = "SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS;
+
+    int embeddedRows = 0;
+    try (final ResultSet resultSet = getServerDatabase(0, getDatabaseName()).query("sql", command)) {
+      while (resultSet.hasNext()) {
+        resultSet.next();
+        embeddedRows++;
+      }
+    }
+
+    final JSONObject response = query(new JSONObject().put("language", "sql").put("command", command));
+
+    assertThat(embeddedRows).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getInt("returned")).isEqualTo(embeddedRows);
+  }
+
+  @Test
+  void theStudioSerializerReportsTruncation() throws Exception {
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME)
+        .put("serializer", "studio"));
+
+    assertThat(response.getJSONObject("result").getJSONArray("records").length()).isEqualTo(CAP);
+    assertThat(response.getInt("returned")).isEqualTo(CAP);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void theDefaultSerializerEmitsExactlyTheCap() throws Exception {
+    // Any unknown serializer name falls back to the default one, which used to emit one row above the cap.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME)
+        .put("serializer", "json"));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CAP);
+    assertThat(response.getInt("returned")).isEqualTo(CAP);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void aCypherQueryTruncatedByTheDefaultCapIsReported() throws Exception {
+    // Cypher exposes no execution plan on the query path, so its own LIMIT cannot be read back: the cap still
+    // applies, but the response says so instead of looking complete.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "opencypher")
+        .put("command", "MATCH (n:" + TYPE_NAME + ") RETURN n.i AS i"));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CAP);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void aWriteCommandAlwaysReportsTheLimitFields() throws Exception {
+    final JSONObject response = command(new JSONObject()
+        .put("language", "sql")
+        .put("command", "CREATE VERTEX " + TYPE_NAME + " SET i = 1000"));
+
+    assertThat(response.getInt("returned")).isEqualTo(1);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void theGetEndpointHonorsTheQueryLimit() throws Exception {
+    final JSONObject response = get("SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS, null);
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getInt("limit")).isEqualTo(TOTAL_ROWS);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void theGetEndpointReportsTruncationByTheDefaultCap() throws Exception {
+    final JSONObject response = get("SELECT i FROM " + TYPE_NAME, null);
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CAP);
+    assertThat(response.getInt("limit")).isEqualTo(CAP);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void theGetEndpointLimitParameterWinsOverTheQueryLimit() throws Exception {
+    final JSONObject response = get("SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS, "10");
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(10);
+    assertThat(response.getInt("limit")).isEqualTo(10);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void theRemoteDriverHonorsTheQueryLimit() {
+    try (final RemoteDatabase remote = newRemoteDatabase()) {
+      int rows = 0;
+      try (final ResultSet resultSet = remote.query("sql", "SELECT i FROM " + TYPE_NAME + " LIMIT " + TOTAL_ROWS)) {
+        while (resultSet.hasNext()) {
+          resultSet.next();
+          rows++;
+        }
+      }
+      assertThat(rows).isEqualTo(TOTAL_ROWS);
+    }
+  }
+
+  @Test
+  void theRemoteDriverCanRemoveTheCap() {
+    try (final RemoteDatabase remote = newRemoteDatabase()) {
+      int rows = 0;
+      try (final ResultSet resultSet = remote.query("sql", "SELECT i FROM " + TYPE_NAME)) {
+        while (resultSet.hasNext()) {
+          resultSet.next();
+          rows++;
+        }
+      }
+      assertThat(rows).isEqualTo(CAP);
+
+      remote.setMaxResultRows(-1);
+      rows = 0;
+      try (final ResultSet resultSet = remote.query("sql", "SELECT i FROM " + TYPE_NAME)) {
+        while (resultSet.hasNext()) {
+          resultSet.next();
+          rows++;
+        }
+      }
+      assertThat(rows).isEqualTo(TOTAL_ROWS);
+    }
+  }
+
+  private RemoteDatabase newRemoteDatabase() {
+    return new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private JSONObject query(final JSONObject payload) throws Exception {
+    return post("query", payload);
+  }
+
+  private JSONObject command(final JSONObject payload) throws Exception {
+    return post("command", payload);
+  }
+
+  private JSONObject post(final String endpoint, final JSONObject payload) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI("http://127.0.0.1:2480/api/v1/" + endpoint + "/" + getDatabaseName()))
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .setHeader("Content-Type", "application/json")
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+    final HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    return new JSONObject(response.body());
+  }
+
+  private JSONObject get(final String command, final String limit) throws Exception {
+    // The command travels as a path segment: URLEncoder emits '+' for a space, which is only a space in a
+    // query string.
+    final String url = "http://127.0.0.1:2480/api/v1/query/" + getDatabaseName() + "/sql/"
+        + URLEncoder.encode(command, StandardCharsets.UTF_8).replace("+", "%20")
+        + (limit == null ? "" : "?limit=" + limit);
+
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI(url))
+        .GET()
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+    final HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    return new JSONObject(response.body());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostCommandHandlerAutoLimitTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostCommandHandlerAutoLimitTest.java
@@ -23,10 +23,11 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for {@link PostCommandHandler#appendAutomaticLimit(String, String, int)}: the automatic
- * trailing-LIMIT heuristic must behave exactly as the previous inline implementation while avoiding a
- * full-command {@code toLowerCase} copy per request. The command passed in is already trimmed, as in the
- * handler.
+ * Unit tests for {@link PostCommandHandler#requiresAutomaticLimit(String, String, int)}, the predicate that
+ * decides whether the handler pushes a trailing {@code LIMIT} into the command: it must behave exactly as the
+ * previous inline implementation while avoiding a full-command {@code toLowerCase} copy per request, because a
+ * command that already carries a LIMIT has stated the caller's own expectation and must not be rewritten
+ * (issue #5711). The command passed in is already trimmed, as in the handler.
  */
 class PostCommandHandlerAutoLimitTest {
 
@@ -34,93 +35,79 @@ class PostCommandHandlerAutoLimitTest {
 
   @Test
   void appendsLimitToPlainSelect() {
-    assertThat(PostCommandHandler.appendAutomaticLimit("select from V", "sql", LIMIT))
-        .isEqualTo("select from V limit " + LIMIT);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select from V", "sql", LIMIT)).isTrue();
   }
 
   @Test
   void appendsLimitToMatch() {
-    assertThat(PostCommandHandler.appendAutomaticLimit("match {type: V, as: v} return v", "sql", LIMIT))
-        .isEqualTo("match {type: V, as: v} return v limit " + LIMIT);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("match {type: V, as: v} return v", "sql", LIMIT)).isTrue();
   }
 
   @Test
   void prefixCheckIsCaseInsensitive() {
-    assertThat(PostCommandHandler.appendAutomaticLimit("SELECT from V", "sql", LIMIT))
-        .isEqualTo("SELECT from V limit " + LIMIT);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("SELECT from V", "sql", LIMIT)).isTrue();
   }
 
   @Test
   void doesNotAppendWhenExplicitLowercaseLimitAlreadyPresent() {
-    final String cmd = "select from V limit 5";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT)).isEqualTo(cmd);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select from V limit 5", "sql", LIMIT)).isFalse();
   }
 
   @Test
   void doesNotAppendWhenExplicitUppercaseLimitAlreadyPresent() {
-    final String cmd = "select from V LIMIT 5";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT)).isEqualTo(cmd);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select from V LIMIT 5", "sql", LIMIT)).isFalse();
   }
 
   @Test
   void doesNotAppendWhenCommandEndsWithSemicolon() {
-    final String cmd = "select from V;";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT)).isEqualTo(cmd);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select from V;", "sql", LIMIT)).isFalse();
   }
 
   @Test
   void doesNotAppendToNonSelectOrMatch() {
-    final String cmd = "insert into V set name = 'a'";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT)).isEqualTo(cmd);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("insert into V set name = 'a'", "sql", LIMIT)).isFalse();
   }
 
   @Test
   void doesNotAppendForNonSqlLanguage() {
-    final String cmd = "MATCH (n) RETURN n";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "cypher", LIMIT)).isEqualTo(cmd);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("MATCH (n) RETURN n", "cypher", LIMIT)).isFalse();
   }
 
   @Test
   void doesNotAppendWhenLimitDisabled() {
-    final String cmd = "select from V";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", -1)).isEqualTo(cmd);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select from V", "sql", -1)).isFalse();
   }
 
   @Test
   void doesNotAppendWhenLimitIsZero() {
     // A non-positive cap means unlimited, as it does in the serializer: appending 'limit 0' would return no row.
-    final String cmd = "select from V";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", 0)).isEqualTo(cmd);
-  }
-
-  @Test
-  void probeLimitIsOneRowAboveTheCapAndSaturates() {
-    // The extra row is never serialized: it only tells a result ending at the cap from a truncated one.
-    assertThat(PostCommandHandler.truncationProbeLimit(LIMIT)).isEqualTo(LIMIT + 1);
-    assertThat(PostCommandHandler.truncationProbeLimit(Integer.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
-    assertThat(PostCommandHandler.truncationProbeLimit(0)).isEqualTo(0);
-    assertThat(PostCommandHandler.truncationProbeLimit(-1)).isEqualTo(-1);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select from V", "sql", 0)).isFalse();
   }
 
   @Test
   void appendsWhenLimitSubstringIsNotAStandaloneClause() {
     // "limitless" must not be mistaken for an existing LIMIT clause.
-    final String cmd = "select limitless from V";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT))
-        .isEqualTo("select limitless from V limit " + LIMIT);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select limitless from V", "sql", LIMIT)).isTrue();
   }
 
   @Test
   void appendsWhenLimitOnlyOnEarlierLineButNotOnLastLine() {
     // A subquery LIMIT on an earlier line must still let the outer query receive a trailing LIMIT.
-    final String cmd = "select from (select from V limit 3)\nwhere x > 1";
-    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT))
-        .isEqualTo(cmd + " limit " + LIMIT);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select from (select from V limit 3)\nwhere x > 1", "sql", LIMIT)).isTrue();
   }
 
   @Test
   void handlesSqlScriptLanguage() {
-    assertThat(PostCommandHandler.appendAutomaticLimit("select from V", "sqlScript", LIMIT))
-        .isEqualTo("select from V limit " + LIMIT);
+    assertThat(PostCommandHandler.requiresAutomaticLimit("select from V", "sqlScript", LIMIT)).isTrue();
+  }
+
+  @Test
+  void probeLimitIsOneRowAboveTheCapAndSaturates() {
+    // What the handler actually pushes down: the extra row is never serialized, it only tells a result ending
+    // at the cap from a truncated one.
+    assertThat(PostCommandHandler.truncationProbeLimit(LIMIT)).isEqualTo(LIMIT + 1);
+    assertThat(PostCommandHandler.truncationProbeLimit(Integer.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(PostCommandHandler.truncationProbeLimit(0)).isEqualTo(0);
+    assertThat(PostCommandHandler.truncationProbeLimit(-1)).isEqualTo(-1);
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostCommandHandlerAutoLimitTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostCommandHandlerAutoLimitTest.java
@@ -87,6 +87,22 @@ class PostCommandHandlerAutoLimitTest {
   }
 
   @Test
+  void doesNotAppendWhenLimitIsZero() {
+    // A non-positive cap means unlimited, as it does in the serializer: appending 'limit 0' would return no row.
+    final String cmd = "select from V";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", 0)).isEqualTo(cmd);
+  }
+
+  @Test
+  void probeLimitIsOneRowAboveTheCapAndSaturates() {
+    // The extra row is never serialized: it only tells a result ending at the cap from a truncated one.
+    assertThat(PostCommandHandler.truncationProbeLimit(LIMIT)).isEqualTo(LIMIT + 1);
+    assertThat(PostCommandHandler.truncationProbeLimit(Integer.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(PostCommandHandler.truncationProbeLimit(0)).isEqualTo(0);
+    assertThat(PostCommandHandler.truncationProbeLimit(-1)).isEqualTo(-1);
+  }
+
+  @Test
   void appendsWhenLimitSubstringIsNotAStandaloneClause() {
     // "limitless" must not be mistaken for an existing LIMIT clause.
     final String cmd = "select limitless from V";

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3033,6 +3033,16 @@ function applyDefaultLabel(value) {
   if (globalCy != null) renderGraph();
 }
 
+/**
+ * Renders the number of returned rows, flagging a response the server cut short at its row limit so a partial
+ * result cannot be read as a complete one (issue #5711).
+ */
+function renderResultCount(data, count) {
+  if (data.truncated === true)
+    $("#result-num").html(count + ' <span class="text-warning" title="More rows matched: raise the limit to see them.">(truncated)</span>');
+  else $("#result-num").html(count);
+}
+
 function browseType(typeName) {
   let database = getCurrentDatabase();
   if (!database) return;
@@ -3071,7 +3081,7 @@ function browseType(typeName) {
     } else {
       globalResultset = data.result;
       globalCy = null;
-      $("#result-num").html(data.result.records.length);
+      renderResultCount(data, data.result.records.length);
       renderGraph();
     }
 
@@ -3232,7 +3242,7 @@ function executeCommandTable() {
       let elapsed = new Date() - beginTime;
       $("#result-elapsed").html(elapsed);
 
-      $("#result-num").html(data.result.records.length);
+      renderResultCount(data, data.result.records.length);
       $("#resultJson").val(JSON.stringify(data, null, 2));
       $("#resultExplain").val(data.explain != null ? data.explain : "No profiler data found");
 
@@ -3287,7 +3297,7 @@ function executeCommandGraph() {
       let elapsed = new Date() - beginTime;
       $("#result-elapsed").html(elapsed);
 
-      $("#result-num").html(data.result.records.length);
+      renderResultCount(data, data.result.records.length);
       $("#resultJson").val(JSON.stringify(data, null, 2));
       $("#resultExplain").val(data.explain != null ? data.explain : "No profiler data found");
 


### PR DESCRIPTION
Fixes #5711

## The defect

`POST /api/v1/query|command` capped the serialized rows at `AbstractQueryHandler.DEFAULT_LIMIT` (20,000) **after** the engine had produced them, and reported the cap nowhere: same `200`, same body shape, no flag, no count. A caller paging by writing `LIMIT` into its own SQL - the obvious thing to do - got 20,000 rows for any larger page and nothing in the answer said so. It also made the HTTP and embedded surfaces disagree on the same query against the same data, which is how @tae898 caught it (a "HTTP is 4.7x faster at 100k rows" measurement that was really HTTP returning a fifth of the rows).

Confirmed as reported, and the asymmetry is worse than the issue states: `GET /query` **already** read the LIMIT back from the execution plan and honored it, so the two HTTP surfaces disagreed with each other too. The Java remote driver sends no `limit` at all, so it inherited the same silent truncation.

## What this changes

**1. A limit the caller stated is honored as written.** The cap is the request's `limit` when present, otherwise the configured default *raised to* the LIMIT the query carries (read back from the execution plan). `SELECT i FROM R LIMIT 30000` now returns 30,000 rows over HTTP exactly as embedded.

The plan LIMIT can only **raise** the cap, never lower it - deliberately, and not just for simplicity:
- a LIMIT smaller than the default is already enforced by the engine, so capping at it would be redundant;
- a plan carrying a **parameterized** LIMIT (`LIMIT :max`) reports the value of the execution it was built for, and `ExecutionPlanCache.get()` hands back a `copy(context)` that keeps that int. Today a plan containing a `LimitExecutionStep` is never cached (`ExecutionStepInternal.canBeCached()` defaults to false and `LimitExecutionStep` does not override it), so the value is always fresh - but trusting it downwards would make the cap depend on that implementation detail. Raising only is immune to it.

**2. Truncation is always visible.** Both endpoints now always report `limit`, `returned` and `truncated`:

```json
{ "result": [ ... ], "limit": 20000, "returned": 20000, "truncated": true }
```

`truncated` is true only when the cap stopped serialization with at least one row still pending, so a result ending exactly at the cap is not a false positive. To make that detectable for a command with no LIMIT of its own, the pushed-down LIMIT is now `cap + 1`: the extra row is the probe and never reaches the client.

**3. A warning, but only for the truncation nobody asked for.** The server logs `WARNING` naming the database, the cap, the row count and the (abbreviated) query - only when the *default* did the cutting. Truncation against a `limit` the caller sent is the expected outcome and stays silent, so Studio's paging does not flood the log.

**4. The cap is now an operator setting**: `arcadedb.server.httpQueryDefaultLimit` (default 20000, `-1`/`0` unlimited). It applies only to callers that state no limit of their own.

**5. `POST /timeseries/{db}/query`** had the same shape (`count = min(rows, limit)`, no signal) and now reports `limit`/`truncated` too.

**6. Java remote driver.** `RemoteDatabase` warns when the server reports a truncated result instead of handing the application a partial `ResultSet` that looks complete, and `setMaxResultRows(Integer)` sets the cap per connection - `-1` removes it, giving embedded parity for a query with no LIMIT.

**7. Studio** marks the row count `(truncated)` when the result it displays was cut short.

### On the issue's suggestion 2 (fail with 400 when the SQL LIMIT exceeds the cap)

Not implemented, deliberately: with (1) that case no longer exists - the SQL LIMIT *is* the cap. The only truncation left against an explicit statement is when the caller *also* sent a smaller `limit`, where the request field is the more specific instruction and a 400 would be wrong. This also keeps the fix backward compatible for clients that write large LIMITs today.

### Not in scope, worth its own issue

- **A hard ceiling** (like `arcadedb.server.grpcQueryMaxResultRows`, which fails with `RESOURCE_EXHAUSTED` rather than truncating). Honoring a caller's LIMIT does not introduce a new capability - `"limit": -1` has always been an unbounded escape hatch for the same authenticated actor - but any *finite* default ceiling would break existing `limit: -1` users, so it needs its own decision.
- **Cypher cannot expose its LIMIT.** A non-EXPLAIN Cypher `ResultSet` carries no `ExecutionPlan`, so `MATCH ... RETURN n LIMIT 30000` is still capped by the default - now flagged and logged instead of silent. Wiring a plan (or the top-level RETURN's LIMIT) through the Cypher engine would close that gap.

## Behaviour changes

- A serializer name other than `graph`/`studio`/`record` used to emit `limit + 1` rows; it now emits exactly `limit`, like the others.
- On `GET /query` an explicit `limit` parameter now wins over the LIMIT in the query text (it used to be the reverse), matching POST.
- `"limit": 0` now means unlimited everywhere, as it already did inside the serializer. It used to be pushed down as a literal `LIMIT 0` (zero rows) for a query with no LIMIT, while returning every row for a query that had one.
- Responses carry three new top-level fields. Additive, and the driver/Studio consumers read `result` by name.

## Verification

- **`HttpQueryTruncationIT`** (new, 18 tests) - lowers the cap to 50 via `onServerConfiguration` so the semantics are checked without 20k rows: query LIMIT above the cap honored; default-cap truncation reported; a result ending exactly at the cap not flagged; request `limit` winning over the query LIMIT; `-1` and `0` unlimited; HTTP vs embedded row-count parity; `studio`, `graph` and default serializers; Cypher flagged; parameterized LIMIT honored per execution; a write command still reporting the fields; the three GET cases; and the remote driver (query LIMIT honored, `setMaxResultRows(-1)` removing the cap).
- **`HTTPDocumentIT`** - two tests at the *shipped* 20,000 default over 20,002 records: `checkQueryInPostWithLimitAboveDefaultCut` (returns 20,001, `truncated: false`) is the direct regression test - it returns 20,000 on `main` - and `checkQueryInPostReportsDefaultLimitTruncation` pins the flagged path. Complements the pre-existing GET-side `checkQueryInGetWithLimitAboveDefaultCut`.
- **`TimeSeriesQueryHandlerIT.rawQueryReportsTruncation`**, **`PostCommandHandlerAutoLimitTest`** (+3: `limit: 0`, probe saturation).
- Suites run green: `com.arcadedb.server.http.**` (496), `HTTPDocumentIT`, `HTTPGraphIT`, `HTTPTransactionIT`, `AbstractQueryHandler*`, `PostCommand*`, `Issue4689*`, all `Remote*`/`*Remote*IT` (80), `TimeSeriesQueryHandlerIT`, `console`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8C35vrQkW1y1gaEvWzRPc
