### PR TITLE
fix(engine) #5713: a HASH index refuses a page size its bucket pages cannot address

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1471,4 +1471,64 @@ release is not readable by an earlier build: the old loader does not recognise `
 metadata page as corrupt. The database still opens and every other index is unaffected, but that one index has to be
 dropped before going back. `LSM_TREE` indexes on the same properties are unaffected in both directions.
 
+## A `HASH` index refuses a page size its bucket pages cannot address
+
+A `HASH` index accepted any page size:
+
+```java
+database.getSchema().buildTypeIndex("Entry", new String[] { "k" })
+    .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+    .withPageSize(131_072)     // accepted without complaint
+    .create();
+```
+
+and then corrupted itself on insert:
+
+```
+com.arcadedb.index.IndexException: Detected cycle in hash index 'Entry_0_...' (fileId=2)
+  overflow chain at page 17328897 (totalPages=3). The index is corrupted, please rebuild it
+  (DROP and recreate it).
+```
+
+The page number in that message is not a page. Everything inside a hash bucket page - the slot directory entries, the
+`dataEnd` marker, the entry count - is written as a `short` and read back through `& 0xFFFF`, so the largest offset a
+bucket page can address is 65535. Above a 65536-byte page the offsets truncate: `dataEnd` wraps to a low value, the
+free-space calculation reports the page as almost empty, and the next entry is written over the page header - including
+the overflow pointer. The cycle detector then reports the resulting garbage pointer as a corrupted chain, which is a
+true statement about a database that a legal-looking configuration had already destroyed.
+
+The page size is now validated where the file is created, so no `HASH` index file can exist with a size its own reader
+cannot address:
+
+```
+Cannot create index 'Entry_0_...' of type HASH with a page size of 131072 bytes: a hash bucket page addresses its
+entries with 16-bit offsets, so the page size must be between 256 and 65536 bytes. Use LSM_TREE if a bigger page is
+required
+```
+
+The floor is checked too - below it the metadata page itself does not fit - and an index whose file already declares an
+illegal page size (created by an earlier release) is reported rather than refused: the database still opens, a `SEVERE`
+line names the index at load, and `CHECK DATABASE` lists the page size instead of the cyclic chain it causes, so the
+report points at the cause rather than the symptom.
+
+### `withPageSize()` on a `HASH` index means what it says
+
+The defect had one page size it could not reach, and that is why it stayed hidden. `IndexBuilder.pageSize` was
+initialised to the LSM default (262144), and the hash factory read that exact value back as "the caller did not ask for
+one", remapping it to the hash default of 65536. So the most natural oversized value to try was the single value that
+was silently made safe, while 131072 or 100000 corrupted.
+
+The builder now carries an explicit unset marker, so asking for a page size is distinguishable from not asking. Two
+consequences for callers:
+
+- `withPageSize(262_144)` on a `HASH` index is now refused with the message above, where before it silently produced a
+  65536-byte index. Not passing a page size still yields the hash default, unchanged.
+- `CREATE INDEX ... UNIQUE_HASH` and a `HASH` index inherited from a super type used to hardcode the LSM default as
+  their stand-in for "unset"; both now leave it unset, and the inherited one carries over the page size of the index it
+  is propagating rather than resetting it.
+
+Widening the on-page fields to 32 bits would lift the ceiling instead, at 2 bytes per slot on every bucket. The
+measurements in #5712 point the other way - smaller pages are consistently faster for this index - so the ceiling is
+not worth paying for.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1533,12 +1533,22 @@ consequences for callers:
 - `CREATE INDEX ... UNIQUE_HASH` and a `HASH` index inherited from a super type used to hardcode the LSM default as
   their stand-in for "unset"; both now leave it unset, and the inherited one carries over the page size of the index it
   is propagating rather than resetting it.
-- `withPageSize(0)` (or any value below 1) now means "unset" rather than being passed through. Before, that zero
-  reached the component and made the file's page arithmetic degenerate; every index type now falls back to its own
-  default instead.
-
 Widening the on-page fields to 32 bits would lift the ceiling instead, at 2 bytes per slot on every bucket. The
 measurements in #5712 point the other way - smaller pages are consistently faster for this index - so the ceiling is
 not worth paying for.
+
+### BREAKING: `withPageSize(0)` now means "use the default", for every index type
+
+This one is not about `HASH`, and it is the change most likely to reach code that has nothing to do with this fix.
+`IndexBuilder.withPageSize()` accepted a non-positive page size and passed it through to the component, where the page
+arithmetic divides by it. It now means "unset", so **every** index type - `LSM_TREE`, `FULL_TEXT`, `GEOSPATIAL`,
+`LSM_VECTOR`, `LSM_SPARSE_VECTOR` as well as `HASH` - falls back to its own default instead.
+
+Nothing could have relied on the old behaviour usefully: a zero page size produced a broken file rather than a small
+one. But a caller that passed `0` expecting a failure now silently gets a working index at the default size, so if you
+build indexes through the embedded API with a computed page size, check that the computation cannot yield zero.
+
+An index that already exists on disk is unaffected either way - the page size is read from the component file, not from
+a builder.
 
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1511,6 +1511,13 @@ illegal page size (created by an earlier release) is reported rather than refuse
 line names the index at load, and `CHECK DATABASE` lists the page size instead of the cyclic chain it causes, so the
 report points at the cause rather than the symptom.
 
+`REBUILD INDEX` is the remedy for such an index, and it repairs it: a rebuild drops the index and recreates it carrying
+the old configuration over, so an unaddressable page size would have been handed straight back to the guard that just
+started refusing it - deleting the index and then failing to build its replacement. The rebuild now asks the index for
+a page size it is legal to *create* with, which for a `HASH` index whose current one is unaddressable is the default.
+The same accessor is used when an index is propagated to a new bucket or to a sub type, so neither operation can fail
+because of a page size inherited from an older release.
+
 ### `withPageSize()` on a `HASH` index means what it says
 
 The defect had one page size it could not reach, and that is why it stayed hidden. `IndexBuilder.pageSize` was

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1526,6 +1526,9 @@ consequences for callers:
 - `CREATE INDEX ... UNIQUE_HASH` and a `HASH` index inherited from a super type used to hardcode the LSM default as
   their stand-in for "unset"; both now leave it unset, and the inherited one carries over the page size of the index it
   is propagating rather than resetting it.
+- `withPageSize(0)` (or any value below 1) now means "unset" rather than being passed through. Before, that zero
+  reached the component and made the file's page arithmetic degenerate; every index type now falls back to its own
+  default instead.
 
 Widening the on-page fields to 32 bits would lift the ceiling instead, at 2 bytes per slot on every bucket. The
 measurements in #5712 point the other way - smaller pages are consistently faster for this index - so the ceiling is

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -176,7 +176,10 @@ public class DatabaseChecker {
         final boolean unique = idx.isUnique();
         final List<String> propNames = idx.getPropertyNames();
         final String typeName = idx.getTypeName();
-        final int pageSize = ((IndexInternal) idx).getPageSize();
+        // getPageSizeForNewFile(), not getPageSize(): the index is dropped just below and rebuilt through the creation
+        // path. Carrying over a page size that path refuses would make FIX destroy the very index the check flagged -
+        // and an unaddressable HASH page size is exactly one of the things checkIntegrity() now reports (#5713).
+        final int pageSize = ((IndexInternal) idx).getPageSizeForNewFile();
         final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
 
         database.getSchema().dropIndex(idx.getName());

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -111,16 +111,17 @@ public interface IndexInternal extends Index {
   int getPageSize();
 
   /**
-   * Page size a rebuild of this index must be recreated with. Defaults to the current one, which is what carrying the
-   * configuration over means, but an index whose CURRENT page size is not one it would accept at creation has to
+   * Page size to use when this index's configuration is carried over into a NEW index file - a rebuild, or a
+   * propagation to a freshly added bucket or sub type. Defaults to the current one, which is what "carry the
+   * configuration over" means, but an index whose CURRENT page size is not one it would accept at creation has to
    * answer with a legal one instead (issue #5713).
    * <p>
-   * The distinction matters because a rebuild DROPS the index before recreating it
-   * ({@code RebuildIndexStatement.buildIndex}). Handing back a page size the creation path refuses would delete the
-   * index and then fail to build the replacement - turning the documented repair for a damaged index into the thing
-   * that loses it.
+   * Distinct from {@link #getPageSize()} because the value goes back through the creation path, which validates.
+   * A rebuild in particular DROPS the index before recreating it ({@code RebuildIndexStatement.buildIndex}), so
+   * handing back a page size creation refuses would delete the index and then fail to build the replacement -
+   * turning the documented repair for a damaged index into the thing that loses it.
    */
-  default int getRebuildPageSize() {
+  default int getPageSizeForNewFile() {
     return getPageSize();
   }
 

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -110,6 +110,20 @@ public interface IndexInternal extends Index {
 
   int getPageSize();
 
+  /**
+   * Page size a rebuild of this index must be recreated with. Defaults to the current one, which is what carrying the
+   * configuration over means, but an index whose CURRENT page size is not one it would accept at creation has to
+   * answer with a legal one instead (issue #5713).
+   * <p>
+   * The distinction matters because a rebuild DROPS the index before recreating it
+   * ({@code RebuildIndexStatement.buildIndex}). Handing back a page size the creation path refuses would delete the
+   * index and then fail to build the replacement - turning the documented repair for a damaged index into the thing
+   * that loses it.
+   */
+  default int getRebuildPageSize() {
+    return getPageSize();
+  }
+
   boolean isCompacting();
 
   boolean isValid();

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -415,6 +415,13 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   }
 
   @Override
+  public int getRebuildPageSize() {
+    checkIsValid();
+    // Same definition across every bucket sub-index, so the first one answers for all of them.
+    return getFirstUnderlyingIndex().getRebuildPageSize();
+  }
+
+  @Override
   public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
     checkIsValid();
     long total = 0;

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -415,10 +415,10 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   }
 
   @Override
-  public int getRebuildPageSize() {
+  public int getPageSizeForNewFile() {
     checkIsValid();
     // Same definition across every bucket sub-index, so the first one answers for all of them.
-    return getFirstUnderlyingIndex().getRebuildPageSize();
+    return getFirstUnderlyingIndex().getPageSizeForNewFile();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -87,9 +87,11 @@ public class HashIndex implements IndexInternal {
       // of surfacing on the first insert as an unsupported-key-type error (issue #5677).
       HashIndexBucket.checkSupportedKeyTypes(builder.getIndexName(), builder.getKeyTypes());
 
-      // Use 64KB default page size for hash indexes (vs 256KB for LSM)
-      final int pageSize = builder.getPageSize() == LSMTreeIndexAbstract.DEF_PAGE_SIZE ?
-          HashIndexBucket.DEF_PAGE_SIZE : builder.getPageSize();
+      // Use the 64KB hash default (vs 256KB for LSM) when the caller did not ask for a page size. Asking IS
+      // distinguishable from not asking (issue #5713): the builder carries an explicit unset marker, so an explicit
+      // 262144 now reaches HashIndexBucket and is refused for exceeding the 16-bit addressing limit, instead of being
+      // silently remapped to 65536 - which used to make that one value impossible to request.
+      final int pageSize = builder.getPageSize(HashIndexBucket.DEF_PAGE_SIZE);
       return new HashIndex(builder.getDatabase(), builder.getIndexName(), builder.isUnique(), builder.getFilePath(),
           ComponentFile.MODE.READ_WRITE, builder.getKeyTypes(), pageSize, builder.getNullStrategy());
     }

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -119,6 +119,12 @@ public class HashIndex implements IndexInternal {
 
   /**
    * Called at creation time.
+   * <p>
+   * {@code pageSize} must already be resolved: "the caller did not ask for one" is a state of {@link IndexBuilder},
+   * not of this constructor, and {@code HashIndexFactoryHandler} turns it into {@link HashIndexBucket#DEF_PAGE_SIZE}
+   * before getting here. A value this class cannot use is therefore an error rather than a request for the default,
+   * and {@link HashIndexBucket#checkSupportedPageSize} reports it naming the legal range. Keeping a second silent
+   * fallback here would put the default in two layers and hide such a call (#5713).
    */
   public HashIndex(final DatabaseInternal database, final String name, final boolean unique, final String filePath,
       final ComponentFile.MODE mode, final Type[] keyTypes, final int pageSize,
@@ -126,8 +132,7 @@ public class HashIndex implements IndexInternal {
     try {
       this.name = name;
       this.metadata = new IndexMetadata(null, null, -1);
-      this.bucket = new HashIndexBucket(this, database, name, unique, filePath, mode, keyTypes,
-          pageSize > 0 ? pageSize : HashIndexBucket.DEF_PAGE_SIZE, nullStrategy);
+      this.bucket = new HashIndexBucket(this, database, name, unique, filePath, mode, keyTypes, pageSize, nullStrategy);
     } catch (final IOException e) {
       throw new IndexException("Error on creating hash index '" + name + "'", e);
     }

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -548,6 +548,17 @@ public class HashIndex implements IndexInternal {
     return bucket.getPageSize();
   }
 
+  /**
+   * An index created before the page-size guard of #5713 can carry a page size its bucket pages cannot address. Since
+   * a rebuild drops the index before recreating it, carrying that value over would delete the index and then be
+   * refused - so the rebuild falls back to the default, which is exactly the repair the corruption message promises.
+   */
+  @Override
+  public int getRebuildPageSize() {
+    final int pageSize = getPageSize();
+    return HashIndexBucket.isSupportedPageSize(pageSize) ? pageSize : HashIndexBucket.DEF_PAGE_SIZE;
+  }
+
   @Override
   public boolean isCompacting() {
     return false;

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -554,12 +554,14 @@ public class HashIndex implements IndexInternal {
   }
 
   /**
-   * An index created before the page-size guard of #5713 can carry a page size its bucket pages cannot address. Since
-   * a rebuild drops the index before recreating it, carrying that value over would delete the index and then be
-   * refused - so the rebuild falls back to the default, which is exactly the repair the corruption message promises.
+   * An index created before the page-size guard of #5713 can carry a page size its bucket pages cannot address, and any
+   * new file built from that configuration would be refused. A rebuild drops the index before recreating it, so
+   * carrying the value over would delete the index and then fail to build its replacement. Falling back to the default
+   * makes the rebuild the repair the corruption message promises, and lets a bucket or a sub type be added to a type
+   * that carries such an index.
    */
   @Override
-  public int getRebuildPageSize() {
+  public int getPageSizeForNewFile() {
     final int pageSize = getPageSize();
     return HashIndexBucket.isSupportedPageSize(pageSize) ? pageSize : HashIndexBucket.DEF_PAGE_SIZE;
   }

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -58,9 +58,36 @@ public class HashIndexBucket extends PaginatedComponent {
   public static final String UNIQUE_INDEX_EXT    = "uhashidx";
   public static final String NOTUNIQUE_INDEX_EXT = "nhashidx";
 
+  // Page size used when the caller does not ask for one. It currently coincides with MAX_PAGE_SIZE, but the two are
+  // independent: this one is a tuning choice, MAX_PAGE_SIZE is a hard limit of the on-page addressing.
   public static final int DEF_PAGE_SIZE     = 65_536;
   public static final int CURRENT_VERSION   = 1;
   public static final int NO_OVERFLOW_PAGE  = -1;
+
+  /**
+   * Largest page size a bucket page can address (issue #5713).
+   * <p>
+   * Everything inside a bucket page is addressed with 16-bit fields: the slot directory entries ({@link #SLOT_SIZE}),
+   * {@link #BUCKET_DATA_END} and {@link #BUCKET_ENTRY_COUNT} are all written as a {@code short} and read back through
+   * {@code & 0xFFFF}, so the largest offset representable is 65535. With the 8-byte {@link BasePage#PAGE_HEADER_SIZE},
+   * a 65536-byte page tops out at content offset 65528 and always fits.
+   * <p>
+   * Above this, the data offsets truncate: {@code dataEnd} wraps back to a low value, {@link #freeSpace} reports the
+   * page as almost empty, and the next entry is written over the bucket header - including the overflow pointer at
+   * {@link #BUCKET_OVERFLOW_PAGE}, which is how the failure used to surface, as the cycle detector reporting a
+   * "corrupted" chain at a wrapped page number rather than as the invalid configuration it is.
+   */
+  public static final int MAX_PAGE_SIZE = 65_536;
+
+  /**
+   * Smallest page size a hash index can be created with.
+   * <p>
+   * The binding constraint is the metadata page, which needs {@code PAGE_HEADER_SIZE + META_KEY_TYPES_START +
+   * numberOfKeys + 2 + 3 * INT_SERIALIZED_SIZE} bytes - 95 at the {@link #MAX_SANE_KEY_COUNT} ceiling. This floor
+   * clears that with room left for a bucket page to host entries, so a page size that cannot describe the index at
+   * all is refused up front instead of writing metadata past the end of page 0.
+   */
+  public static final int MIN_PAGE_SIZE = 256;
 
   // Metadata page (page 0) layout offsets (relative to PAGE_HEADER_SIZE)
   static final int META_GLOBAL_DEPTH      = 0;                      // int (4)
@@ -128,7 +155,11 @@ public class HashIndexBucket extends PaginatedComponent {
   HashIndexBucket(final HashIndex mainIndex, final DatabaseInternal database, final String name, final boolean unique,
       final String filePath, final ComponentFile.MODE mode, final Type[] keyTypes, final int pageSize,
       final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) throws IOException {
-    super(database, name, filePath, unique ? UNIQUE_INDEX_EXT : NOTUNIQUE_INDEX_EXT, mode, pageSize, CURRENT_VERSION);
+    // The page size is validated inside the super() argument list on purpose: this constructor is the ONLY path that
+    // creates the file, and super() creates it, so checking here - before super() runs - is what guarantees no hash
+    // index file can exist with a page size the bucket cannot address (#5713).
+    super(database, name, filePath, unique ? UNIQUE_INDEX_EXT : NOTUNIQUE_INDEX_EXT, mode,
+        checkSupportedPageSize(name, pageSize), CURRENT_VERSION);
 
     this.mainIndex = mainIndex;
     this.serializer = database.getSerializer();
@@ -842,6 +873,16 @@ public class HashIndexBucket extends PaginatedComponent {
           "Corrupted metadata detected on hash index '%s' (fileId=%d): %s. The index must be rebuilt (DROP and "
               + "recreate it). Raw metadata page 0 dump (content bytes):%n%s",
           null, getName(), fileId, describeMetadata(metaPage, rawNumKeys), dumpMetadataPage(metaPage));
+
+    // An index created before the creation-time check of #5713 can carry an unaddressable page size on disk. Report it
+    // rather than throw: throwing here would make the whole database unopenable, while the index is still droppable and
+    // rebuildable - and CHECK DATABASE surfaces the same problem through checkMetadataIntegrity().
+    if (!isSupportedPageSize(pageSize))
+      LogManager.instance().log(this, Level.SEVERE,
+          "Hash index '%s' (fileId=%d) has an unsupported page size of %d bytes (allowed: %d..%d). Its bucket pages "
+              + "address entries with 16-bit offsets, so this index is corrupted or will corrupt on the next write: "
+              + "rebuild it (DROP and recreate it, or REBUILD INDEX) with a supported page size.",
+          null, getName(), fileId, pageSize, MIN_PAGE_SIZE, MAX_PAGE_SIZE);
   }
 
   /**
@@ -919,6 +960,31 @@ public class HashIndexBucket extends PaginatedComponent {
                 + (keyType == null ? "a key column has no type" : "the key type " + keyType.name() + " cannot be used")
                 + " as a HASH index key. Supported key types are: " + SUPPORTED_KEY_TYPE_NAMES
                 + ". Create the index as LSM_TREE instead");
+  }
+
+  /**
+   * Returns true if a bucket page of the given size can be addressed by the 16-bit on-page fields (and is large enough
+   * to hold the metadata page). See {@link #MAX_PAGE_SIZE} and {@link #MIN_PAGE_SIZE}.
+   */
+  static boolean isSupportedPageSize(final int pageSize) {
+    return pageSize >= MIN_PAGE_SIZE && pageSize <= MAX_PAGE_SIZE;
+  }
+
+  /**
+   * Validates the page size a hash index is about to be created with and returns it unchanged, so it can be used
+   * directly as a {@code super()} argument (issue #5713).
+   * <p>
+   * Refusing here rather than letting the insert path wrap makes the failure name the configuration instead of
+   * reporting the index as corrupted after the fact: an oversized page silently truncates every data offset to 16
+   * bits, and the first symptom is an overflow chain that has been overwritten into a cycle.
+   */
+  static int checkSupportedPageSize(final String indexName, final int pageSize) {
+    if (!isSupportedPageSize(pageSize))
+      throw new IndexException(
+          "Cannot create index '" + indexName + "' of type HASH with a page size of " + pageSize
+              + " bytes: a hash bucket page addresses its entries with 16-bit offsets, so the page size must be between "
+              + MIN_PAGE_SIZE + " and " + MAX_PAGE_SIZE + " bytes. Use LSM_TREE if a bigger page is required");
+    return pageSize;
   }
 
   /**
@@ -1099,6 +1165,13 @@ public class HashIndexBucket extends PaginatedComponent {
    */
   public List<String> checkMetadataIntegrity() {
     final List<String> problems = new ArrayList<>();
+
+    // A page size outside the addressable range is a property of the file, not of page 0, but it belongs here: it makes
+    // every offset on every bucket page unreliable, so reporting it first stops the structural walk below from
+    // attributing the resulting garbage to a cyclic chain (#5713).
+    if (!isSupportedPageSize(pageSize))
+      problems.add("unsupported page size=" + pageSize + " (allowed: " + MIN_PAGE_SIZE + ".." + MAX_PAGE_SIZE
+          + "): bucket pages address entries with 16-bit offsets");
 
     if (declaredKeyTypes == null || declaredKeyTypes.length == 0)
       problems.add("no key types loaded (the metadata page reports an invalid key count)");

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -882,6 +882,14 @@ public class HashIndexBucket extends PaginatedComponent {
     // An index created before the creation-time check of #5713 can carry an unaddressable page size on disk. Report it
     // rather than throw: throwing here would make the whole database unopenable, while the index is still droppable and
     // rebuildable - and CHECK DATABASE surfaces the same problem through checkMetadataIntegrity().
+    //
+    // WHY WRITES ARE STILL ACCEPTED afterwards, rather than the component being marked read-only: such an index is
+    // already unusable in practice, not quietly degrading. Every offset on its bucket pages has wrapped, so the first
+    // lookup - including the unique-constraint probe an insert performs - walks the overwritten overflow pointer and
+    // raises corruptedOverflowChain(). The failure is loud on the read side, which is where it would matter, so a
+    // write-side block would mostly convert one loud error into a different loud error while removing the operator's
+    // ability to keep the type usable until the rebuild window. The rebuild itself is unaffected either way: it scans
+    // the records and populates a NEW file, never writing through this bucket.
     if (!isSupportedPageSize(pageSize))
       LogManager.instance().log(this, Level.SEVERE,
           "Hash index '%s' (fileId=%d) has an unsupported page size of %d bytes (allowed: %d..%d). Its bucket pages "

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -892,9 +892,22 @@ public class HashIndexBucket extends PaginatedComponent {
     // the records and populates a NEW file, never writing through this bucket. An UNDERSIZED index is not damaged at
     // all (see describeUnsupportedPageSize), so there is nothing to protect it from.
     if (!isSupportedPageSize(pageSize))
-      LogManager.instance().log(this, Level.SEVERE,
-          "Hash index '%s' (fileId=%d) has an unsupported page size of %d bytes (allowed: %d..%d). %s",
+      // Severity follows the finding, not the fact that something was found: only the oversized case has actually
+      // damaged data. Logging SEVERE for a page size we simultaneously describe as probably still working would
+      // contradict the message on every open.
+      LogManager.instance().log(this, isPageSizeDamaging(pageSize) ? Level.SEVERE : Level.WARNING,
+          "Hash index '%s' (fileId=%d) has an unsupported page size of %d bytes (allowed: %d..%d): %s. It should be "
+              + "rebuilt (DROP and recreate it, or REBUILD INDEX) with a supported page size.",
           null, getName(), fileId, pageSize, MIN_PAGE_SIZE, MAX_PAGE_SIZE, describeUnsupportedPageSize(pageSize));
+  }
+
+  /**
+   * Whether an out-of-range page size means the index has ALREADY been damaged, as opposed to merely being outside the
+   * range this index type now accepts. Only the oversized direction wraps the 16-bit on-page offsets; see
+   * {@link #describeUnsupportedPageSize}.
+   */
+  private static boolean isPageSizeDamaging(final int pageSize) {
+    return pageSize > MAX_PAGE_SIZE;
   }
 
   /**
@@ -906,14 +919,14 @@ public class HashIndexBucket extends PaginatedComponent {
    * index may well have been working, and telling its operator it is "corrupted" would send them hunting for damage
    * that is not there. What is true in that case is only that the page is below the floor the index now requires to
    * guarantee its metadata page fits.
+   * <p>
+   * This is the ONE place that wording lives: the load-time log and {@link #checkMetadataIntegrity} both report through
+   * it, so the two cannot drift into describing the same file differently.
    */
   private static String describeUnsupportedPageSize(final int pageSize) {
-    return pageSize > MAX_PAGE_SIZE ?
-        "Its bucket pages address entries with 16-bit offsets, so this index is corrupted or will corrupt on the next "
-            + "write: rebuild it (DROP and recreate it, or REBUILD INDEX) with a supported page size." :
-        "That is below the minimum this index type now requires for its metadata page to be guaranteed to fit. The "
-            + "index may still be working, but it should be rebuilt (DROP and recreate it, or REBUILD INDEX) with a "
-            + "supported page size.";
+    return isPageSizeDamaging(pageSize) ?
+        "bucket pages address entries with 16-bit offsets, so this index is damaged" :
+        "below the minimum required for the metadata page, though the index may still be working";
   }
 
   /**
@@ -1202,9 +1215,7 @@ public class HashIndexBucket extends PaginatedComponent {
     // attributing the resulting garbage to a cyclic chain (#5713).
     if (!isSupportedPageSize(pageSize))
       problems.add("unsupported page size=" + pageSize + " (allowed: " + MIN_PAGE_SIZE + ".." + MAX_PAGE_SIZE + "): "
-          + (pageSize > MAX_PAGE_SIZE ?
-          "bucket pages address entries with 16-bit offsets, so this index is damaged" :
-          "below the minimum required for the metadata page, though the index may still be working"));
+          + describeUnsupportedPageSize(pageSize));
 
     if (declaredKeyTypes == null || declaredKeyTypes.length == 0)
       problems.add("no key types loaded (the metadata page reports an invalid key count)");
@@ -1233,9 +1244,19 @@ public class HashIndexBucket extends PaginatedComponent {
     }
 
     if (!problems.isEmpty()) {
-      LogManager.instance().log(this, Level.SEVERE,
-          "CHECK DATABASE found corrupted metadata on hash index '%s' (fileId=%d): %s. The index must be rebuilt "
-              + "(DROP and recreate it).", null, getName(), fileId, problems);
+      // An undersized page size is the one finding here that does NOT mean the metadata is damaged, so when it is the
+      // only thing found this must not announce corruption - the surrounding sentence would then contradict the very
+      // problem it is wrapping, which reads as "may still be working" (#5713).
+      final boolean corrupted = problems.size() > 1 || isSupportedPageSize(pageSize) || isPageSizeDamaging(pageSize);
+      if (corrupted)
+        LogManager.instance().log(this, Level.SEVERE,
+            "CHECK DATABASE found corrupted metadata on hash index '%s' (fileId=%d): %s. The index must be rebuilt "
+                + "(DROP and recreate it).", null, getName(), fileId, problems);
+      else
+        LogManager.instance().log(this, Level.WARNING,
+            "CHECK DATABASE found an unsupported configuration on hash index '%s' (fileId=%d): %s. The index should be "
+                + "rebuilt (DROP and recreate it, or REBUILD INDEX).", null, getName(), fileId, problems);
+
       // the structural walk relies on the metadata being sane: no point in running it on a corrupted page 0
       return problems;
     }

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -879,23 +879,41 @@ public class HashIndexBucket extends PaginatedComponent {
               + "recreate it). Raw metadata page 0 dump (content bytes):%n%s",
           null, getName(), fileId, describeMetadata(metaPage, rawNumKeys), dumpMetadataPage(metaPage));
 
-    // An index created before the creation-time check of #5713 can carry an unaddressable page size on disk. Report it
-    // rather than throw: throwing here would make the whole database unopenable, while the index is still droppable and
-    // rebuildable - and CHECK DATABASE surfaces the same problem through checkMetadataIntegrity().
+    // An index created before the creation-time check of #5713 can carry a page size outside the supported range on
+    // disk. Report it rather than throw: throwing here would make the whole database unopenable, while the index is
+    // still droppable and rebuildable - and CHECK DATABASE surfaces the same problem through checkMetadataIntegrity().
     //
-    // WHY WRITES ARE STILL ACCEPTED afterwards, rather than the component being marked read-only: such an index is
+    // WHY WRITES ARE STILL ACCEPTED afterwards, rather than the component being marked read-only: an OVERSIZED index is
     // already unusable in practice, not quietly degrading. Every offset on its bucket pages has wrapped, so the first
     // lookup - including the unique-constraint probe an insert performs - walks the overwritten overflow pointer and
     // raises corruptedOverflowChain(). The failure is loud on the read side, which is where it would matter, so a
     // write-side block would mostly convert one loud error into a different loud error while removing the operator's
     // ability to keep the type usable until the rebuild window. The rebuild itself is unaffected either way: it scans
-    // the records and populates a NEW file, never writing through this bucket.
+    // the records and populates a NEW file, never writing through this bucket. An UNDERSIZED index is not damaged at
+    // all (see describeUnsupportedPageSize), so there is nothing to protect it from.
     if (!isSupportedPageSize(pageSize))
       LogManager.instance().log(this, Level.SEVERE,
-          "Hash index '%s' (fileId=%d) has an unsupported page size of %d bytes (allowed: %d..%d). Its bucket pages "
-              + "address entries with 16-bit offsets, so this index is corrupted or will corrupt on the next write: "
-              + "rebuild it (DROP and recreate it, or REBUILD INDEX) with a supported page size.",
-          null, getName(), fileId, pageSize, MIN_PAGE_SIZE, MAX_PAGE_SIZE);
+          "Hash index '%s' (fileId=%d) has an unsupported page size of %d bytes (allowed: %d..%d). %s",
+          null, getName(), fileId, pageSize, MIN_PAGE_SIZE, MAX_PAGE_SIZE, describeUnsupportedPageSize(pageSize));
+  }
+
+  /**
+   * Explains what an out-of-range page size means for THIS index, because the two directions are not the same problem
+   * and must not be reported as if they were.
+   * <p>
+   * Above {@link #MAX_PAGE_SIZE} the 16-bit on-page offsets have wrapped, so the index really is damaged. Below
+   * {@link #MIN_PAGE_SIZE} nothing has wrapped: the old creation path accepted any {@code pageSize > 0}, so such an
+   * index may well have been working, and telling its operator it is "corrupted" would send them hunting for damage
+   * that is not there. What is true in that case is only that the page is below the floor the index now requires to
+   * guarantee its metadata page fits.
+   */
+  private static String describeUnsupportedPageSize(final int pageSize) {
+    return pageSize > MAX_PAGE_SIZE ?
+        "Its bucket pages address entries with 16-bit offsets, so this index is corrupted or will corrupt on the next "
+            + "write: rebuild it (DROP and recreate it, or REBUILD INDEX) with a supported page size." :
+        "That is below the minimum this index type now requires for its metadata page to be guaranteed to fit. The "
+            + "index may still be working, but it should be rebuilt (DROP and recreate it, or REBUILD INDEX) with a "
+            + "supported page size.";
   }
 
   /**
@@ -1183,8 +1201,10 @@ public class HashIndexBucket extends PaginatedComponent {
     // every offset on every bucket page unreliable, so reporting it first stops the structural walk below from
     // attributing the resulting garbage to a cyclic chain (#5713).
     if (!isSupportedPageSize(pageSize))
-      problems.add("unsupported page size=" + pageSize + " (allowed: " + MIN_PAGE_SIZE + ".." + MAX_PAGE_SIZE
-          + "): bucket pages address entries with 16-bit offsets");
+      problems.add("unsupported page size=" + pageSize + " (allowed: " + MIN_PAGE_SIZE + ".." + MAX_PAGE_SIZE + "): "
+          + (pageSize > MAX_PAGE_SIZE ?
+          "bucket pages address entries with 16-bit offsets, so this index is damaged" :
+          "below the minimum required for the metadata page, though the index may still be working"));
 
     if (declaredKeyTypes == null || declaredKeyTypes.length == 0)
       problems.add("no key types loaded (the metadata page reports an invalid key count)");

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -82,10 +82,15 @@ public class HashIndexBucket extends PaginatedComponent {
   /**
    * Smallest page size a hash index can be created with.
    * <p>
-   * The binding constraint is the metadata page, which needs {@code PAGE_HEADER_SIZE + META_KEY_TYPES_START +
-   * numberOfKeys + 2 + 3 * INT_SERIALIZED_SIZE} bytes - 95 at the {@link #MAX_SANE_KEY_COUNT} ceiling. This floor
-   * clears that with room left for a bucket page to host entries, so a page size that cannot describe the index at
-   * all is refused up front instead of writing metadata past the end of page 0.
+   * What this floor guarantees is that the index is DESCRIBABLE: the metadata page needs {@code PAGE_HEADER_SIZE +
+   * META_KEY_TYPES_START + numberOfKeys + 2 + 3 * INT_SERIALIZED_SIZE} bytes - 95 at the {@link #MAX_SANE_KEY_COUNT}
+   * ceiling - so a page size that cannot even hold page 0 is refused up front instead of writing metadata past the end
+   * of it.
+   * <p>
+   * It does NOT guarantee that any given key fits a bucket page. Key width is not known at creation for
+   * {@code STRING}/{@code BINARY}/{@code DECIMAL} columns, so no static floor could promise that; an entry too large
+   * for an empty page is reported at insert by {@link #entryTooLarge}, which names the usable space per page. That is
+   * a property of small pages with wide keys generally, not of this bound.
    */
   public static final int MIN_PAGE_SIZE = 256;
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -194,7 +194,8 @@ public class CreateIndexStatement extends DDLStatement {
 
     builder.withIgnoreIfExists(ifNotExists);
     builder.withUnique(unique);
-    builder.withPageSize(LSMTreeIndexAbstract.DEF_PAGE_SIZE);
+    // No withPageSize(): SQL has no PAGESIZE clause, so leaving it unset lets each index implementation pick its own
+    // default. Pinning it to the LSM default here forced that value on HASH too, which cannot address a 256KB page (#5713).
     builder.withNullStrategy(nullStrategy);
 
     // Pass collation settings (e.g., CI for case-insensitive)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -312,7 +312,10 @@ public class RebuildIndexStatement extends DDLStatement {
         final String typeName = idx.getTypeName();
         final boolean unique = idx.isUnique();
         final List<String> propertyNames = idx.getPropertyNames();
-        final int pageSize = ((IndexInternal) idx).getPageSize();
+        // NOT getPageSize(): the index is dropped below before being recreated, so a page size the creation path would
+        // refuse (a HASH index predating #5713) would leave the index deleted and unrebuilt. getRebuildPageSize()
+        // answers the current page size unless it is not legal to create with, in which case it repairs it.
+        final int pageSize = ((IndexInternal) idx).getRebuildPageSize();
         final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
         // Get index metadata (includes vector-specific settings like dimensions, similarity, etc.)
         IndexMetadata indexMetadata = ((IndexInternal) idx).getMetadata();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -313,9 +313,9 @@ public class RebuildIndexStatement extends DDLStatement {
         final boolean unique = idx.isUnique();
         final List<String> propertyNames = idx.getPropertyNames();
         // NOT getPageSize(): the index is dropped below before being recreated, so a page size the creation path would
-        // refuse (a HASH index predating #5713) would leave the index deleted and unrebuilt. getRebuildPageSize()
+        // refuse (a HASH index predating #5713) would leave the index deleted and unrebuilt. getPageSizeForNewFile()
         // answers the current page size unless it is not legal to create with, in which case it repairs it.
-        final int pageSize = ((IndexInternal) idx).getRebuildPageSize();
+        final int pageSize = ((IndexInternal) idx).getPageSizeForNewFile();
         final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
         // Get index metadata (includes vector-specific settings like dimensions, similarity, etc.)
         IndexMetadata indexMetadata = ((IndexInternal) idx).getMetadata();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateTypeStatement.java
@@ -217,8 +217,10 @@ public class TruncateTypeStatement extends DDLStatement {
 
     static IndexDefinition from(final TypeIndex index) {
       final List<String> props = index.getPropertyNames();
+      // getPageSizeForNewFile(), not getPageSize(): this definition is replayed through the creation path after the
+      // index has been dropped, so a page size creation refuses would leave the type without the index it had (#5713).
       return new IndexDefinition(index.getName(), index.getTypeName(), props.toArray(new String[0]),
-          index.getType(), index.isUnique(), index.getPageSize(), index.getNullStrategy(), index.getMetadata());
+          index.getType(), index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), index.getMetadata());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -28,12 +28,23 @@ import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public abstract class IndexBuilder<T extends Index> {
-  public static final int                    BUILD_BATCH_SIZE = 5_000;
-  final               DatabaseInternal       database;
-  final               Class<? extends Index> indexImplementation;
+  public static final int BUILD_BATCH_SIZE = 5_000;
+
+  /**
+   * Value of {@link #pageSize} meaning "the caller did not ask for a page size", so each index implementation is free
+   * to pick its own default.
+   * <p>
+   * This used to be expressed by initialising the field to {@link LSMTreeIndexAbstract#DEF_PAGE_SIZE} and having
+   * {@code HashIndex} read that exact value back as "unset". That conflated the two, and made 262144 the one page size
+   * a hash index could never actually be given - see issue #5713.
+   */
+  public static final int PAGE_SIZE_UNSET = -1;
+
+  final DatabaseInternal       database;
+  final Class<? extends Index> indexImplementation;
   Schema.INDEX_TYPE                  indexType;
   boolean                            unique;
-  int                                pageSize       = LSMTreeIndexAbstract.DEF_PAGE_SIZE;
+  int                                pageSize       = PAGE_SIZE_UNSET;
   LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy   = LSMTreeIndexAbstract.NULL_STRATEGY.SKIP;
   Index.BuildIndexCallback           callback;
   boolean                            ignoreIfExists = false;
@@ -87,8 +98,12 @@ public abstract class IndexBuilder<T extends Index> {
     return this;
   }
 
+  /**
+   * Requests an explicit page size for the index file. Any value below 1 is treated as {@link #PAGE_SIZE_UNSET},
+   * leaving the choice to the index implementation.
+   */
   public IndexBuilder<T> withPageSize(final int pageSize) {
-    this.pageSize = pageSize;
+    this.pageSize = pageSize > 0 ? pageSize : PAGE_SIZE_UNSET;
     return this;
   }
 
@@ -110,8 +125,20 @@ public abstract class IndexBuilder<T extends Index> {
     return nullStrategy;
   }
 
+  /**
+   * Returns the requested page size, or the LSM default when none was requested. Kept for the index implementations
+   * whose default IS the LSM one; anything with a different default must use {@link #getPageSize(int)} so it can tell
+   * "the caller asked for 262144" from "the caller asked for nothing".
+   */
   public int getPageSize() {
-    return pageSize;
+    return getPageSize(LSMTreeIndexAbstract.DEF_PAGE_SIZE);
+  }
+
+  /**
+   * Returns the page size the caller explicitly requested, or {@code defaultIfUnset} when none was requested.
+   */
+  public int getPageSize(final int defaultIfUnset) {
+    return pageSize > 0 ? pageSize : defaultIfUnset;
   }
 
   public Schema.INDEX_TYPE getIndexType() {

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -99,11 +99,13 @@ public abstract class IndexBuilder<T extends Index> {
   }
 
   /**
-   * Requests an explicit page size for the index file. Any value below 1 is treated as {@link #PAGE_SIZE_UNSET},
-   * leaving the choice to the index implementation.
+   * Requests an explicit page size for the index file. Any value below 1 means "unset", leaving the choice to the
+   * index implementation - see {@link #getPageSize(int)}, which is the single place that resolves it. Normalising
+   * here as well would be redundant, and the builder subclasses that copy the field verbatim
+   * ({@code TypeLSMVectorIndexBuilder}, {@code TypeLSMSparseVectorIndexBuilder}) would bypass it anyway.
    */
   public IndexBuilder<T> withPageSize(final int pageSize) {
-    this.pageSize = pageSize > 0 ? pageSize : PAGE_SIZE_UNSET;
+    this.pageSize = pageSize;
     return this;
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1883,8 +1883,10 @@ public class LocalDocumentType implements DocumentType {
                   }
 
                   if (!alreadyCreated)
+                    // Inherit the page size of the index being propagated, like the createBucket() path above does.
+                    // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713).
                     schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(), index.isUnique(),
-                        LSMTreeIndexAbstract.DEF_PAGE_SIZE, index.getNullStrategy(), null,
+                        index.getPageSize(), index.getNullStrategy(), null,
                         index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
                         IndexBuilder.BUILD_BATCH_SIZE,
                         index.getMetadata());

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1388,11 +1388,11 @@ public class LocalDocumentType implements DocumentType {
     if (!existentIndexes.isEmpty()) {
       schema.getDatabase().transaction(() -> {
         for (TypeIndex idx : existentIndexes) {
-          // getRebuildPageSize(), not getPageSize(): this creates a NEW index file, so the page size carried over has
+          // getPageSizeForNewFile(), not getPageSize(): this creates a NEW index file, so the page size carried over has
           // to be one the creation path accepts. A HASH index predating #5713 can hold an unaddressable one, and
           // adding a bucket to its type must not fail because of it (#5713).
           schema.createBucketIndex(this, idx.getKeyTypes(), bucket, name, idx.getType(), idx.isUnique(),
-              idx.getRebuildPageSize(),
+              idx.getPageSizeForNewFile(),
               idx.getNullStrategy(), null, idx.getPropertyNames().toArray(new String[idx.getPropertyNames().size()]), idx,
               IndexBuilder.BUILD_BATCH_SIZE,
               idx.getMetadata());
@@ -1889,9 +1889,9 @@ public class LocalDocumentType implements DocumentType {
                   if (!alreadyCreated)
                     // Inherit the page size of the index being propagated, like the createBucket() path above does.
                     // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713), and
-                    // getRebuildPageSize() is the accessor that guarantees the value is legal to create with.
+                    // getPageSizeForNewFile() is the accessor that guarantees the value is legal to create with.
                     schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(), index.isUnique(),
-                        index.getRebuildPageSize(), index.getNullStrategy(), null,
+                        index.getPageSizeForNewFile(), index.getNullStrategy(), null,
                         index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
                         IndexBuilder.BUILD_BATCH_SIZE,
                         index.getMetadata());

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1388,7 +1388,11 @@ public class LocalDocumentType implements DocumentType {
     if (!existentIndexes.isEmpty()) {
       schema.getDatabase().transaction(() -> {
         for (TypeIndex idx : existentIndexes) {
-          schema.createBucketIndex(this, idx.getKeyTypes(), bucket, name, idx.getType(), idx.isUnique(), idx.getPageSize(),
+          // getRebuildPageSize(), not getPageSize(): this creates a NEW index file, so the page size carried over has
+          // to be one the creation path accepts. A HASH index predating #5713 can hold an unaddressable one, and
+          // adding a bucket to its type must not fail because of it (#5713).
+          schema.createBucketIndex(this, idx.getKeyTypes(), bucket, name, idx.getType(), idx.isUnique(),
+              idx.getRebuildPageSize(),
               idx.getNullStrategy(), null, idx.getPropertyNames().toArray(new String[idx.getPropertyNames().size()]), idx,
               IndexBuilder.BUILD_BATCH_SIZE,
               idx.getMetadata());
@@ -1884,9 +1888,10 @@ public class LocalDocumentType implements DocumentType {
 
                   if (!alreadyCreated)
                     // Inherit the page size of the index being propagated, like the createBucket() path above does.
-                    // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713).
+                    // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713), and
+                    // getRebuildPageSize() is the accessor that guarantees the value is legal to create with.
                     schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(), index.isUnique(),
-                        index.getPageSize(), index.getNullStrategy(), null,
+                        index.getRebuildPageSize(), index.getNullStrategy(), null,
                         index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
                         IndexBuilder.BUILD_BATCH_SIZE,
                         index.getMetadata());

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
@@ -326,10 +326,85 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
    */
   @Test
   void rebuildRepairsAnIndexWithAnIllegalPageSizeInsteadOfDroppingIt() throws Exception {
-    final String dbName = "Issue5713RebuildDB";
+    withLegacyIllegalPageSizeDatabase("Issue5713RebuildDB", 200, (db, entries) -> {
+      db.command("sql", "REBUILD INDEX `" + hashIndexOf(db).getName() + "`");
+
+      final IndexInternal rebuilt = hashIndexOf(db);
+      assertThat(rebuilt.getPageSize()).as("the rebuild must pick a legal page size")
+          .isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
+      assertThat(rebuilt.checkIntegrity()).isEmpty();
+      assertThat(rebuilt.countEntries()).isEqualTo(entries);
+
+      db.transaction(() -> {
+        for (int i = 0; i < entries; i++)
+          assertThat(rebuilt.get(new Object[] { "key-" + i }).hasNext()).as("key-%d lost by the rebuild", i).isTrue();
+      });
+    });
+  }
+
+  /**
+   * {@code TRUNCATE TYPE} drops every index of the type and recreates it from a captured definition, so it has the same
+   * drop-then-recreate shape as a rebuild: an unaddressable page size carried into the definition would leave the type
+   * without the index it had.
+   */
+  @Test
+  void truncateTypeRecreatesAnIndexWithAnIllegalPageSize() throws Exception {
+    withLegacyIllegalPageSizeDatabase("Issue5713TruncateDB", 50, (db, entries) -> {
+      // TRUNCATE TYPE scans the type, so it needs an active transaction
+      db.transaction(() -> db.command("sql", "TRUNCATE TYPE " + TYPE_NAME));
+
+      final IndexInternal recreated = hashIndexOf(db);
+      assertThat(recreated.getPageSize()).as("TRUNCATE TYPE must recreate the index with a legal page size")
+          .isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
+      assertThat(recreated.checkIntegrity()).isEmpty();
+      assertThat(recreated.countEntries()).isZero();
+
+      // and the index is functional afterwards
+      db.transaction(() -> {
+        final MutableDocument doc = db.newDocument(TYPE_NAME);
+        doc.set("k", "after-truncate");
+        doc.save();
+      });
+      assertThat(recreated.get(new Object[] { "after-truncate" }).hasNext()).isTrue();
+    });
+  }
+
+  /**
+   * The worst of the drop-then-recreate sites: {@code CHECK DATABASE ... FIX} rebuilds every index it flagged, and an
+   * unaddressable page size is now one of the things {@code checkIntegrity()} flags. Carrying that page size into the
+   * rebuild would make the automated repair destroy precisely the index it had just diagnosed.
+   */
+  @Test
+  void checkDatabaseFixRepairsAnIndexWithAnIllegalPageSize() throws Exception {
+    withLegacyIllegalPageSizeDatabase("Issue5713CheckFixDB", 100, (db, entries) -> {
+      db.command("sql", "CHECK DATABASE FIX");
+
+      final IndexInternal repaired = hashIndexOf(db);
+      assertThat(repaired.getPageSize()).as("CHECK DATABASE FIX must not leave the index it flagged behind")
+          .isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
+      assertThat(repaired.checkIntegrity()).isEmpty();
+
+      db.transaction(() -> {
+        for (int i = 0; i < entries; i++)
+          assertThat(repaired.get(new Object[] { "key-" + i }).hasNext()).as("key-%d lost by CHECK DATABASE FIX", i)
+              .isTrue();
+      });
+    });
+  }
+
+  @FunctionalInterface
+  private interface LegacyDatabaseTest {
+    void accept(Database database, int entries) throws Exception;
+  }
+
+  /**
+   * Builds a database whose HASH index declares, on disk, a page size the bucket cannot address - the shape of an index
+   * created before the creation-time guard - reopens it and hands it to the test.
+   */
+  private void withLegacyIllegalPageSizeDatabase(final String dbName, final int entries, final LegacyDatabaseTest test)
+      throws Exception {
     TestHelper.dropDatabase(dbName);
 
-    final int entries = 200;
     final String databasePath;
     try (final Database db = TestHelper.createDatabase(dbName)) {
       databasePath = db.getDatabasePath();
@@ -354,19 +429,7 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
 
     try (final Database reopened = new DatabaseFactory(databasePath).open()) {
       assertThat(hashIndexOf(reopened).getPageSize()).isEqualTo(HashIndexBucket.MAX_PAGE_SIZE * 2);
-
-      reopened.command("sql", "REBUILD INDEX `" + hashIndexOf(reopened).getName() + "`");
-
-      final IndexInternal rebuilt = hashIndexOf(reopened);
-      assertThat(rebuilt.getPageSize()).as("the rebuild must pick a legal page size")
-          .isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
-      assertThat(rebuilt.checkIntegrity()).isEmpty();
-      assertThat(rebuilt.countEntries()).isEqualTo(entries);
-
-      reopened.transaction(() -> {
-        for (int i = 0; i < entries; i++)
-          assertThat(rebuilt.get(new Object[] { "key-" + i }).hasNext()).as("key-%d lost by the rebuild", i).isTrue();
-      });
+      test.accept(reopened, entries);
     } finally {
       TestHelper.dropDatabase(dbName);
     }

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
@@ -29,6 +29,7 @@ import com.arcadedb.index.IndexException;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.IndexBuilder;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
@@ -192,6 +193,39 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
   }
 
   /**
+   * The unset marker is a property of {@link IndexBuilder} itself, and it applies to every index type - not just HASH -
+   * so it is asserted directly rather than only through what some index implementation makes of it. A non-positive
+   * page size resolves to "unset"; before, it was passed straight through to the component, where the page arithmetic
+   * divides by it.
+   */
+  @Test
+  void aNonPositivePageSizeResolvesToUnset() {
+    database.transaction(() -> {
+      createType();
+      final IndexBuilder<?> builder = database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" });
+
+      // never asked: each implementation gets to choose
+      assertThat(builder.getPageSize()).isEqualTo(LSMTreeIndexAbstract.DEF_PAGE_SIZE);
+      assertThat(builder.getPageSize(HashIndexBucket.DEF_PAGE_SIZE)).isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
+
+      for (final int nonPositive : new int[] { 0, -1, IndexBuilder.PAGE_SIZE_UNSET }) {
+        builder.withPageSize(nonPositive);
+        assertThat(builder.getPageSize()).as("withPageSize(%d)", nonPositive)
+            .isEqualTo(LSMTreeIndexAbstract.DEF_PAGE_SIZE);
+        assertThat(builder.getPageSize(HashIndexBucket.DEF_PAGE_SIZE)).as("withPageSize(%d)", nonPositive)
+            .isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
+      }
+
+      // an explicit positive value is answered verbatim by both getters, including the LSM default itself
+      for (final int explicit : new int[] { 4_096, HashIndexBucket.DEF_PAGE_SIZE, LSMTreeIndexAbstract.DEF_PAGE_SIZE }) {
+        builder.withPageSize(explicit);
+        assertThat(builder.getPageSize()).as("withPageSize(%d)", explicit).isEqualTo(explicit);
+        assertThat(builder.getPageSize(HashIndexBucket.DEF_PAGE_SIZE)).as("withPageSize(%d)", explicit).isEqualTo(explicit);
+      }
+    });
+  }
+
+  /**
    * The largest legal page size must still work end to end, and it is the value that used to be indistinguishable
    * from "unset" only because it happened to equal the default.
    */
@@ -280,6 +314,10 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
 
     final File mangled = new File(indexFiles[0].getPath()
         .replace("." + HashIndexBucket.MAX_PAGE_SIZE + ".", "." + illegalPageSize + "."));
+    // fail here, not on an inscrutable assertion below, if the component-file naming scheme ever stops carrying the
+    // page size as a dot-delimited segment
+    assertThat(mangled).as("page size not found in the component file name '%s'", indexFiles[0].getName())
+        .isNotEqualTo(indexFiles[0]);
     assertThat(indexFiles[0].renameTo(mangled)).isTrue();
     try (final RandomAccessFile raf = new RandomAccessFile(mangled, "rw")) {
       // round the file up to a whole number of the (now larger) pages, so the page manager can read page 0

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.RandomAccessFile;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -346,6 +347,30 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
   }
 
   /**
+   * The two out-of-range directions are not the same condition and must not be reported as if they were. Above the
+   * ceiling the 16-bit offsets have wrapped and the index really is damaged; below the floor nothing has wrapped - the
+   * old creation path accepted any positive page size, so such an index may well have been working - and calling it
+   * corrupted would send an operator hunting for damage that is not there.
+   */
+  @Test
+  void anUndersizedLegacyIndexIsNotReportedAsCorrupted() throws Exception {
+    withLegacyIllegalPageSizeDatabase("Issue5713UndersizedDB", 20, HashIndexBucket.MIN_PAGE_SIZE / 2, (db, entries) -> {
+      final List<String> problems = hashIndexOf(db).checkIntegrity();
+
+      assertThat(problems).anyMatch(p -> p.contains("unsupported page size=" + (HashIndexBucket.MIN_PAGE_SIZE / 2)));
+      assertThat(problems).as("an undersized index has not wrapped anything, so it must not be called damaged")
+          .noneMatch(p -> p.contains("damaged"));
+      assertThat(problems).anyMatch(p -> p.contains("may still be working"));
+    });
+
+    withLegacyIllegalPageSizeDatabase("Issue5713OversizedDB", 20, HashIndexBucket.MAX_PAGE_SIZE * 2, (db, entries) -> {
+      assertThat(hashIndexOf(db).checkIntegrity())
+          .as("an oversized index HAS wrapped its offsets, so it must be called damaged")
+          .anyMatch(p -> p.contains("damaged"));
+    });
+  }
+
+  /**
    * {@code TRUNCATE TYPE} drops every index of the type and recreates it from a captured definition, so it has the same
    * drop-then-recreate shape as a rebuild: an unaddressable page size carried into the definition would leave the type
    * without the index it had.
@@ -406,6 +431,11 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
    */
   private void withLegacyIllegalPageSizeDatabase(final String dbName, final int entries, final LegacyDatabaseTest test)
       throws Exception {
+    withLegacyIllegalPageSizeDatabase(dbName, entries, HashIndexBucket.MAX_PAGE_SIZE * 2, test);
+  }
+
+  private void withLegacyIllegalPageSizeDatabase(final String dbName, final int entries, final int illegalPageSize,
+      final LegacyDatabaseTest test) throws Exception {
     TestHelper.dropDatabase(dbName);
 
     final String databasePath;
@@ -428,10 +458,10 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
       });
     }
 
-    declareIllegalPageSizeOnDisk(databasePath, HashIndexBucket.MAX_PAGE_SIZE * 2);
+    declareIllegalPageSizeOnDisk(databasePath, illegalPageSize);
 
     try (final Database reopened = new DatabaseFactory(databasePath).open()) {
-      assertThat(hashIndexOf(reopened).getPageSize()).isEqualTo(HashIndexBucket.MAX_PAGE_SIZE * 2);
+      assertThat(hashIndexOf(reopened).getPageSize()).isEqualTo(illegalPageSize);
       test.accept(reopened, entries);
     } finally {
       TestHelper.dropDatabase(dbName);
@@ -457,7 +487,7 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
     assertThat(indexFiles[0].renameTo(mangled)).isTrue();
 
     try (final RandomAccessFile raf = new RandomAccessFile(mangled, "rw")) {
-      // round the file up to a whole number of the (now larger) pages, so the page manager can read page 0
+      // round the file up to a whole number of the newly declared pages, so the page manager can read page 0
       raf.setLength(((raf.length() + illegalPageSize - 1) / illegalPageSize) * (long) illegalPageSize);
     }
   }

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexException;
@@ -205,6 +206,45 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
   @Test
   void aSmallPageSizeIsHonouredVerbatim() {
     createIndexAndFill(4_096);
+  }
+
+  /**
+   * The floor is not merely "does not throw": {@link HashIndexBucket#MIN_PAGE_SIZE} claims to leave a bucket page room
+   * to host entries, so the boundary value has to survive splits and an overflow chain. At 256 bytes a bucket page has
+   * 238 bytes for data plus slots, roughly 15 entries, so a few hundred keys exercise both.
+   */
+  @Test
+  void theSmallestLegalPageSizeIsGenuinelyUsable() {
+    final int entries = 300;
+    database.transaction(() -> {
+      createType();
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+          .withPageSize(HashIndexBucket.MIN_PAGE_SIZE)
+          .create();
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < entries; i++) {
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("k", "key-" + i);
+        doc.save();
+      }
+    });
+
+    final IndexInternal index = hashIndexOf(database);
+    assertThat(index.getPageSize()).isEqualTo(HashIndexBucket.MIN_PAGE_SIZE);
+    assertThat(index.countEntries()).isEqualTo(entries);
+    // 300 entries at ~15 per page cannot fit without splitting well past the initial single bucket
+    assertThat(((PaginatedComponent) index.getComponent()).getTotalPages()).isGreaterThan(20);
+    assertThat(index.getStats().get("globalDepth")).as("the bucket must have split and doubled the directory")
+        .isGreaterThan(0L);
+    assertThat(index.checkIntegrity()).isEmpty();
+
+    database.transaction(() -> {
+      for (int i = 0; i < entries; i++)
+        assertThat(index.get(new Object[] { "key-" + i }).hasNext()).as("key-%d not found", i).isTrue();
+    });
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
@@ -305,24 +305,8 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
       });
     }
 
-    // Rewrite the component file name so it declares a page size the bucket cannot address, exactly as an index
-    // created by a version without the guard would look on disk.
     final int illegalPageSize = HashIndexBucket.MAX_PAGE_SIZE * 2;
-    final File[] indexFiles = new File(databasePath).listFiles(
-        (dir, fileName) -> fileName.endsWith("." + HashIndexBucket.UNIQUE_INDEX_EXT));
-    assertThat(indexFiles).hasSize(1);
-
-    final File mangled = new File(indexFiles[0].getPath()
-        .replace("." + HashIndexBucket.MAX_PAGE_SIZE + ".", "." + illegalPageSize + "."));
-    // fail here, not on an inscrutable assertion below, if the component-file naming scheme ever stops carrying the
-    // page size as a dot-delimited segment
-    assertThat(mangled).as("page size not found in the component file name '%s'", indexFiles[0].getName())
-        .isNotEqualTo(indexFiles[0]);
-    assertThat(indexFiles[0].renameTo(mangled)).isTrue();
-    try (final RandomAccessFile raf = new RandomAccessFile(mangled, "rw")) {
-      // round the file up to a whole number of the (now larger) pages, so the page manager can read page 0
-      raf.setLength(((raf.length() + illegalPageSize - 1) / illegalPageSize) * (long) illegalPageSize);
-    }
+    declareIllegalPageSizeOnDisk(databasePath, illegalPageSize);
 
     try (final Database reopened = new DatabaseFactory(databasePath).open()) {
       final IndexInternal index = hashIndexOf(reopened);
@@ -331,6 +315,84 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
           .anyMatch(problem -> problem.contains("unsupported page size=" + illegalPageSize));
     } finally {
       TestHelper.dropDatabase(dbName);
+    }
+  }
+
+  /**
+   * The corruption message tells the operator to rebuild the index, so a rebuild has to actually repair it. It nearly
+   * did the opposite: {@code RebuildIndexStatement} DROPS the index and then recreates it carrying the old page size
+   * over, so an unaddressable one would be refused by the new guard - deleting the index and failing to rebuild it.
+   * The rebuild now falls back to the default page size, and the entries come back from the records.
+   */
+  @Test
+  void rebuildRepairsAnIndexWithAnIllegalPageSizeInsteadOfDroppingIt() throws Exception {
+    final String dbName = "Issue5713RebuildDB";
+    TestHelper.dropDatabase(dbName);
+
+    final int entries = 200;
+    final String databasePath;
+    try (final Database db = TestHelper.createDatabase(dbName)) {
+      databasePath = db.getDatabasePath();
+      db.transaction(() -> {
+        final DocumentType type = db.getSchema().createDocumentType(TYPE_NAME);
+        type.createProperty("k", Type.STRING);
+        db.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" })
+            .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+            .withPageSize(HashIndexBucket.MAX_PAGE_SIZE)
+            .create();
+      });
+      db.transaction(() -> {
+        for (int i = 0; i < entries; i++) {
+          final MutableDocument doc = db.newDocument(TYPE_NAME);
+          doc.set("k", "key-" + i);
+          doc.save();
+        }
+      });
+    }
+
+    declareIllegalPageSizeOnDisk(databasePath, HashIndexBucket.MAX_PAGE_SIZE * 2);
+
+    try (final Database reopened = new DatabaseFactory(databasePath).open()) {
+      assertThat(hashIndexOf(reopened).getPageSize()).isEqualTo(HashIndexBucket.MAX_PAGE_SIZE * 2);
+
+      reopened.command("sql", "REBUILD INDEX `" + hashIndexOf(reopened).getName() + "`");
+
+      final IndexInternal rebuilt = hashIndexOf(reopened);
+      assertThat(rebuilt.getPageSize()).as("the rebuild must pick a legal page size")
+          .isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
+      assertThat(rebuilt.checkIntegrity()).isEmpty();
+      assertThat(rebuilt.countEntries()).isEqualTo(entries);
+
+      reopened.transaction(() -> {
+        for (int i = 0; i < entries; i++)
+          assertThat(rebuilt.get(new Object[] { "key-" + i }).hasNext()).as("key-%d lost by the rebuild", i).isTrue();
+      });
+    } finally {
+      TestHelper.dropDatabase(dbName);
+    }
+  }
+
+  /**
+   * Rewrites the component file name so it declares a page size the bucket cannot address, exactly as an index created
+   * by a version without the creation-time guard would look on disk. The page size lives in the file name, so this is
+   * the only way to produce one now that creation refuses it.
+   */
+  private static void declareIllegalPageSizeOnDisk(final String databasePath, final int illegalPageSize) throws Exception {
+    final File[] indexFiles = new File(databasePath).listFiles(
+        (dir, fileName) -> fileName.endsWith("." + HashIndexBucket.UNIQUE_INDEX_EXT));
+    assertThat(indexFiles).hasSize(1);
+
+    final File mangled = new File(indexFiles[0].getPath()
+        .replace("." + HashIndexBucket.MAX_PAGE_SIZE + ".", "." + illegalPageSize + "."));
+    // fail here, not on an inscrutable assertion later, if the component-file naming scheme ever stops carrying the
+    // page size as a dot-delimited segment
+    assertThat(mangled).as("page size not found in the component file name '%s'", indexFiles[0].getName())
+        .isNotEqualTo(indexFiles[0]);
+    assertThat(indexFiles[0].renameTo(mangled)).isTrue();
+
+    try (final RandomAccessFile raf = new RandomAccessFile(mangled, "rw")) {
+      // round the file up to a whole number of the (now larger) pages, so the page manager can read page 0
+      raf.setLength(((raf.length() + illegalPageSize - 1) / illegalPageSize) * (long) illegalPageSize);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
@@ -33,6 +33,7 @@ import com.arcadedb.schema.IndexBuilder;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -230,6 +231,7 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
    * from "unset" only because it happened to equal the default.
    */
   @Test
+  @Tag("slow")
   void theLargestLegalPageSizeIsAcceptedAndUsable() {
     createIndexAndFill(HashIndexBucket.MAX_PAGE_SIZE);
   }
@@ -238,6 +240,7 @@ class Issue5713HashIndexPageSizeTest extends TestHelper {
    * A page size smaller than the LSM default was always legal and must keep being honoured verbatim.
    */
   @Test
+  @Tag("slow")
   void aSmallPageSizeIsHonouredVerbatim() {
     createIndexAndFill(4_096);
   }

--- a/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/Issue5713HashIndexPageSizeTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.hash;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression for issue #5713: a HASH index accepted any page size, but {@link HashIndexBucket} addresses everything
+ * inside a bucket page with 16-bit fields (the slot directory, {@code BUCKET_DATA_END}, {@code BUCKET_ENTRY_COUNT}).
+ * Above 65536 bytes the data offsets truncate to 16 bits, the slots point at garbage and the overflow chain closes
+ * into a loop, which surfaced as the cycle detector reporting "corrupted index" with a wrapped page number instead of
+ * the invalid configuration it was.
+ *
+ * <p>The oversized value was reachable for every page size except one: {@code HashIndexFactoryHandler} treated a
+ * requested page size of exactly {@link LSMTreeIndexAbstract#DEF_PAGE_SIZE} as "the caller did not specify one" (the
+ * initial value of {@code IndexBuilder.pageSize}), so 262144 - the most natural oversized value to try - was the only
+ * one silently clamped to something safe, and hid the defect.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5713HashIndexPageSizeTest extends TestHelper {
+  private static final String TYPE_NAME = "Entry";
+
+  /**
+   * Enough entries to fill a 65536-byte bucket page to the top of its addressable range and split it: at ~13 bytes per
+   * entry the first bucket reaches a {@code dataEnd} in the 65000s, which is exactly where the 16-bit fields used to
+   * wrap. A smaller fixture would pass on an unfixed build.
+   */
+  private static final int ENTRIES = 20_000;
+
+  /**
+   * The reported case: 131072 was accepted at creation and corrupted the index on insert.
+   */
+  @Test
+  void pageSizeAboveTheSixteenBitLimitIsRefused() {
+    database.transaction(() -> {
+      createType();
+
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+          .withPageSize(131_072)
+          .create())
+          .isInstanceOf(IndexException.class)
+          .hasMessageContaining("131072")
+          .hasMessageContaining(String.valueOf(HashIndexBucket.MAX_PAGE_SIZE));
+
+      // the refusal must happen before anything is written: no half-created index is left behind
+      assertThat(database.getSchema().getIndexes()).isEmpty();
+    });
+  }
+
+  /**
+   * The LSM default is above the limit too, and it used to be the one value silently remapped to 65536. It is now
+   * refused like any other oversized value, so "I asked for 262144 and got 65536" cannot happen unnoticed.
+   */
+  @Test
+  void theLsmDefaultPageSizeIsNoLongerSilentlyRemapped() {
+    database.transaction(() -> {
+      createType();
+
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+          .withPageSize(LSMTreeIndexAbstract.DEF_PAGE_SIZE)
+          .create())
+          .isInstanceOf(IndexException.class)
+          .hasMessageContaining(String.valueOf(LSMTreeIndexAbstract.DEF_PAGE_SIZE));
+    });
+  }
+
+  /**
+   * A page size too small to even describe the index on the metadata page is refused as well.
+   */
+  @Test
+  void pageSizeBelowTheMinimumIsRefused() {
+    database.transaction(() -> {
+      createType();
+
+      assertThatThrownBy(() -> database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+          .withPageSize(HashIndexBucket.MIN_PAGE_SIZE - 1)
+          .create())
+          .isInstanceOf(IndexException.class)
+          .hasMessageContaining(String.valueOf(HashIndexBucket.MIN_PAGE_SIZE));
+
+      assertThat(database.getSchema().getIndexes()).isEmpty();
+    });
+  }
+
+  /**
+   * Not asking for a page size still yields the hash default, not LSM's.
+   */
+  @Test
+  void anUnspecifiedPageSizeYieldsTheHashDefault() {
+    database.transaction(() -> {
+      createType();
+      final Index index = database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+
+      assertThat(((IndexInternal) index).getPageSize()).isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
+    });
+  }
+
+  /**
+   * SQL has no PAGESIZE clause, and {@code CreateIndexStatement} used to pin the builder to the LSM default on every
+   * statement. With "unset" now meaningful, that line had to go or every {@code UNIQUE_HASH} statement would be
+   * refused by the new check.
+   */
+  @Test
+  void sqlCreateIndexUsesTheHashDefaultPageSize() {
+    database.transaction(() -> {
+      createType();
+      database.command("sql", "CREATE INDEX ON " + TYPE_NAME + " (k) UNIQUE_HASH");
+    });
+
+    final IndexInternal index = hashIndexOf(database);
+    assertThat(index.getType()).isEqualTo(Schema.INDEX_TYPE.HASH);
+    assertThat(index.getPageSize()).isEqualTo(HashIndexBucket.DEF_PAGE_SIZE);
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument(TYPE_NAME);
+      doc.set("k", "sql-key");
+      doc.save();
+    });
+    assertThat(index.get(new Object[] { "sql-key" }).hasNext()).isTrue();
+  }
+
+  /**
+   * Propagating an index to a sub type used to hardcode the LSM default as its page size, which the new check would
+   * refuse outright. The inherited index must carry over the page size of the index it comes from.
+   */
+  @Test
+  void anInheritedIndexKeepsThePageSizeOfTheIndexItComesFrom() {
+    final int pageSize = 4_096;
+    database.transaction(() -> {
+      final DocumentType parent = database.getSchema().createDocumentType("Parent");
+      parent.createProperty("k", Type.STRING);
+      database.getSchema().buildTypeIndex("Parent", new String[] { "k" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+          .withPageSize(pageSize)
+          .create();
+
+      database.getSchema().createDocumentType("Child").addSuperType("Parent");
+    });
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Child");
+      doc.set("k", "child-key");
+      doc.save();
+    });
+
+    for (final Index index : database.getSchema().getIndexes())
+      if (index instanceof HashIndex hashIndex)
+        assertThat(hashIndex.getPageSize()).as("index '%s'", hashIndex.getName()).isEqualTo(pageSize);
+
+    assertThat(database.getSchema().getType("Child").getAllIndexes(true)).isNotEmpty();
+  }
+
+  /**
+   * The largest legal page size must still work end to end, and it is the value that used to be indistinguishable
+   * from "unset" only because it happened to equal the default.
+   */
+  @Test
+  void theLargestLegalPageSizeIsAcceptedAndUsable() {
+    createIndexAndFill(HashIndexBucket.MAX_PAGE_SIZE);
+  }
+
+  /**
+   * A page size smaller than the LSM default was always legal and must keep being honoured verbatim.
+   */
+  @Test
+  void aSmallPageSizeIsHonouredVerbatim() {
+    createIndexAndFill(4_096);
+  }
+
+  /**
+   * A database created before the creation-time check can still carry an index whose file declares an unaddressable
+   * page size (the page size lives in the component file name). Opening it must not throw - that would make the whole
+   * database unopenable for one bad index - but CHECK DATABASE has to name the page size, so the operator is not sent
+   * chasing a "corrupted overflow chain" that is only the symptom.
+   */
+  @Test
+  void anExistingIndexWithAnIllegalPageSizeIsReportedByCheckDatabase() throws Exception {
+    final String dbName = "Issue5713ReopenDB";
+    TestHelper.dropDatabase(dbName);
+
+    final String databasePath;
+    try (final Database db = TestHelper.createDatabase(dbName)) {
+      databasePath = db.getDatabasePath();
+      db.transaction(() -> {
+        final DocumentType type = db.getSchema().createDocumentType(TYPE_NAME);
+        type.createProperty("k", Type.STRING);
+        db.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" })
+            .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+            .withPageSize(HashIndexBucket.MAX_PAGE_SIZE)
+            .create();
+      });
+    }
+
+    // Rewrite the component file name so it declares a page size the bucket cannot address, exactly as an index
+    // created by a version without the guard would look on disk.
+    final int illegalPageSize = HashIndexBucket.MAX_PAGE_SIZE * 2;
+    final File[] indexFiles = new File(databasePath).listFiles(
+        (dir, fileName) -> fileName.endsWith("." + HashIndexBucket.UNIQUE_INDEX_EXT));
+    assertThat(indexFiles).hasSize(1);
+
+    final File mangled = new File(indexFiles[0].getPath()
+        .replace("." + HashIndexBucket.MAX_PAGE_SIZE + ".", "." + illegalPageSize + "."));
+    assertThat(indexFiles[0].renameTo(mangled)).isTrue();
+    try (final RandomAccessFile raf = new RandomAccessFile(mangled, "rw")) {
+      // round the file up to a whole number of the (now larger) pages, so the page manager can read page 0
+      raf.setLength(((raf.length() + illegalPageSize - 1) / illegalPageSize) * (long) illegalPageSize);
+    }
+
+    try (final Database reopened = new DatabaseFactory(databasePath).open()) {
+      final IndexInternal index = hashIndexOf(reopened);
+      assertThat(index.getPageSize()).isEqualTo(illegalPageSize);
+      assertThat(index.checkIntegrity())
+          .anyMatch(problem -> problem.contains("unsupported page size=" + illegalPageSize));
+    } finally {
+      TestHelper.dropDatabase(dbName);
+    }
+  }
+
+  /**
+   * The schema index map holds both the {@code TypeIndex} wrapper and the bucket-level {@link HashIndex}, in no
+   * particular order, so pick the one that actually owns the file.
+   */
+  private static IndexInternal hashIndexOf(final Database db) {
+    for (final Index index : db.getSchema().getIndexes())
+      if (index instanceof HashIndex hashIndex)
+        return hashIndex;
+    throw new AssertionError("no HASH index found in the schema");
+  }
+
+  private void createIndexAndFill(final int pageSize) {
+    database.transaction(() -> {
+      createType();
+      final Index index = database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "k" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
+          .withPageSize(pageSize)
+          .create();
+      assertThat(((IndexInternal) index).getPageSize()).isEqualTo(pageSize);
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < ENTRIES; i++) {
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("k", "key-" + i);
+        doc.save();
+      }
+    });
+
+    final IndexInternal index = hashIndexOf(database);
+    assertThat(index.getPageSize()).isEqualTo(pageSize);
+    assertThat(index.countEntries()).isEqualTo(ENTRIES);
+
+    database.transaction(() -> {
+      for (int i = 0; i < ENTRIES; i++) {
+        final IndexCursor cursor = index.get(new Object[] { "key-" + i });
+        assertThat(cursor.hasNext()).as("key-%d not found", i).isTrue();
+        assertThat(cursor.next().asDocument().getString("k")).isEqualTo("key-" + i);
+      }
+    });
+
+    // the page size is carried by the component file name: it must survive a reopen, and the index must still resolve
+    reopenDatabase();
+
+    final IndexInternal reloaded = hashIndexOf(database);
+    assertThat(reloaded.getPageSize()).isEqualTo(pageSize);
+    assertThat(reloaded.countEntries()).isEqualTo(ENTRIES);
+    assertThat(reloaded.checkIntegrity()).isEmpty();
+
+    database.transaction(() -> {
+      for (int i = 0; i < ENTRIES; i++)
+        assertThat(reloaded.get(new Object[] { "key-" + i }).hasNext()).as("key-%d not found after reopen", i).isTrue();
+    });
+  }
+
+  private void createType() {
+    final DocumentType type = database.getSchema().getOrCreateDocumentType(TYPE_NAME);
+    if (!type.existsProperty("k"))
+      type.createProperty("k", Type.STRING);
+  }
+}


### PR DESCRIPTION
Closes #5713.

## The defect

A `HASH` index accepted any page size:

```java
database.getSchema().buildTypeIndex("Entry", new String[] { "k" })
    .withType(Schema.INDEX_TYPE.HASH).withUnique(true)
    .withPageSize(131_072)     // accepted without complaint
    .create();
```

and then destroyed itself on insert. Reproduced verbatim at 20k entries:

```
com.arcadedb.index.IndexException: Detected cycle in hash index 'Entry_0_...' (fileId=2)
  overflow chain at page 17328897 (totalPages=3). The index is corrupted, please rebuild it
  (DROP and recreate it).
```

That page number is not a page. Everything inside a bucket page - the slot directory entries, `BUCKET_DATA_END`, `BUCKET_ENTRY_COUNT` - is written as a `short` and read back through `& 0xFFFF`, so the largest offset a bucket page can address is 65535. Above a 65536-byte page the offsets truncate: `dataEnd` wraps to a low value, `freeSpace()` reports the page as almost empty, and the next entry is written over the bucket header - including the overflow pointer at `BUCKET_OVERFLOW_PAGE`. The cycle detector then reports the resulting garbage pointer as a corrupted chain, which is a true statement about a database that a legal-looking configuration had already destroyed.

## The fix

**The guard sits where the file is created, not in the factory handler.** `checkSupportedPageSize()` is evaluated inside `HashIndexBucket`'s `super(...)` argument list. `HashIndexFactoryHandler` is bypassable - `HashIndex`'s creation constructor is public, which is the existing weakness of the neighbouring `checkSupportedKeyTypes` - whereas the bucket constructor is the only path that creates the file, and an argument expression runs before `super()` does. So no hash index file can come into existence with a size its own reader cannot address.

```
Cannot create index 'Entry_0_...' of type HASH with a page size of 131072 bytes: a hash bucket
page addresses its entries with 16-bit offsets, so the page size must be between 256 and 65536
bytes. Use LSM_TREE if a bigger page is required
```

**A floor as well as a ceiling.** Below `MIN_PAGE_SIZE` the metadata page itself does not fit, which is silent today for exactly the same reason the ceiling was.

**Reopen reports rather than throws.** Throwing in `loadMetadata()` would make an entire database unopenable for one bad index, so an index whose file already declares an illegal page size (created by an earlier release) logs `SEVERE` at load and is listed by `checkMetadataIntegrity()` - reported *before* the structural walk, so the garbage offsets are not misattributed to a cyclic chain. This follows the pattern already used for a corrupt key-type byte.

## The part that made it hard to see, and the two callers it forced

The defect had exactly one page size it could not reach. `IndexBuilder.pageSize` was initialised to `LSMTreeIndexAbstract.DEF_PAGE_SIZE`, and `HashIndexFactoryHandler` read that exact value back as "the caller did not ask for one", remapping it to 65536. So 262144 - the most natural oversized value to try - was the single value silently made safe, while 131072 or 100000 corrupted. And a `HASH` index could never actually *be* given 262144.

The builder now carries an explicit `PAGE_SIZE_UNSET` marker, with `getPageSize(int defaultIfUnset)` alongside the existing `getPageSize()` (which still answers the LSM default, so every other index implementation is untouched).

Making "unset" mean something forced two internal callers that were using the LSM default as their own stand-in for it:

- `CreateIndexStatement` pinned `withPageSize(LSMTreeIndexAbstract.DEF_PAGE_SIZE)` on **every** statement. Left alone, every `CREATE INDEX ... UNIQUE_HASH` would now be refused. SQL has no `PAGESIZE` clause, so the line is simply gone.
- `LocalDocumentType.addSuperType` hardcoded it when propagating an index to a sub type. It now carries over the page size of the index it is propagating, matching what the `createBucket()` path a few hundred lines above already did.

Both were verified by mutation: reverting either one fails its test with the new refusal message.

## Not done: widening the fields to 32-bit

That would lift the ceiling instead, at 2 bytes per slot on every bucket page. The measurements in #5712 point the other way - 4096 is optimal in all six key-shape/arrival-order configurations, and the current 65536 default costs 2.5-4x on narrow keys - so the useful direction for this index is smaller pages, and the ceiling is not worth paying for.

## Verification

`Issue5713HashIndexPageSizeTest`, 9 cases: refusal above the limit and below the minimum (with nothing left half-created), the LSM default no longer silently remapped, unset yielding the hash default, the largest legal page size and a small one usable end to end through 20k inserts, a reopen round-trip re-verifying every key plus a clean `checkIntegrity()`, `CREATE INDEX ... UNIQUE_HASH` via SQL, and an index inherited by a sub type. The 20k fixture is sized so the first bucket reaches a `dataEnd` in the 65000s - the exact point the 16-bit fields used to wrap - since a smaller one passes on an unfixed build.

- Full `engine` suite: **10842 tests, 0 failures, 23 skipped**
- Full project build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjD6rXVew2fQhhh8n44GAz