### PR TITLE
fix: close all script steps in ScriptExecutionPlan.close() instead of relying on lastStep chain (#5720)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptExecutionPlan.java
@@ -58,7 +58,14 @@ public class ScriptExecutionPlan implements InternalExecutionPlan {
 
   @Override
   public void close() {
-    lastStep.close();
+    // Close all steps via the list instead of relying on lastStep's prev chain,
+    // because executeUntilReturn() can replace lastStep with a ReturnStep or
+    // BreakStep that is outside the chain (no prev link). Closing the last
+    // ScriptLineStep in the list walks the entire prev chain and closes all plans.
+    if (!steps.isEmpty()) {
+      steps.getLast().close();
+    }
+    steps.clear();
   }
 
   @Override


### PR DESCRIPTION
## Description

Fixes #5720

### Problem

`ScriptExecutionPlan.close()` relied on `lastStep` being the tail of the `prev` chain:

```java
@Override
public void close() {
    lastStep.close();
}
```

When `ScriptExecutionPlan.executeUntilReturn()` hits a `RETURN` or `BREAK`, it replaces `lastStep` with a new `ReturnStep` or `BreakStep` that has no `prev` link:

```java
// RETURN path
lastStep = returnStep;  // a fresh ReturnStep with no prev

// BREAK path  
lastStep = new BreakStep(context);  // a fresh BreakStep with no prev
```

`ReturnStep` and `BreakStep` don't override `close()`, so `AbstractExecutionStep.close()` finds `prev == null` and returns immediately. The actual `ScriptLineStep` plans in the `steps` list are never closed, leaking result sets, index cursors, and iterators.

### Fix

Close `steps.getLast()` (which walks the entire `prev` chain over all `ScriptLineStep`s), then clear the `steps` list. This ensures all script line plans are closed regardless of whether `lastStep` was replaced by a step outside the chain.

```java
@Override
public void close() {
    if (!steps.isEmpty()) {
        steps.getLast().close();
    }
    steps.clear();
}
```

### Verification

- `ScriptLineStep.close()` calls `plan.close()` then `super.close()` (which walks `prev`)
- Closing `steps.getLast()` walks the entire `prev` chain, closing every `ScriptLineStep` plan exactly once
- `ReturnStep` and `BreakStep` have no `prev` and no resources — their `close()` is a no-op
- The fix stays iterative (no recursion), consistent with the #5709 pattern