### PR TITLE
fix: close ScriptLineStep chain iteratively to prevent StackOverflow on large batch scripts

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptLineStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptLineStep.java
@@ -101,11 +101,19 @@ public class ScriptLineStep extends AbstractExecutionStep {
 
   @Override
   public void close() {
-    try {
-      if (plan != null)
-        plan.close();
-    } finally {
-      super.close();
+    if (plan != null)
+      plan.close();
+
+    // Walk the prev chain iteratively to avoid StackOverflow on long
+    // script chains (see GH#5708). Each ScriptLineStep has its own plan
+    // that must be closed. The prev chain is a singly-linked list.
+    ExecutionStepInternal current = prev;
+    prev = null;
+    while (current instanceof ScriptLineStep step) {
+      if (step.plan != null)
+        step.plan.close();
+      current = step.prev;
+      step.prev = null;
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SQLScriptAdditionalCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SQLScriptAdditionalCoverageTest.java
@@ -523,4 +523,20 @@ class SQLScriptAdditionalCoverageTest extends TestHelper {
       }
     };
   }
+
+  // --- Large script close chain: GH#5708 ---
+  @Test
+  void largeScriptCloseDoesNotStackOverflow() {
+    database.getSchema().createDocumentType("LargeScript");
+    final StringBuilder script = new StringBuilder();
+    for (int i = 0; i < 2000; i++) {
+      script.append("INSERT INTO LargeScript SET val = ").append(i).append(";\n");
+    }
+    database.transaction(() -> {
+      database.command("sqlscript", script.toString());
+    });
+    final ResultSet rs = database.query("sql", "SELECT count(*) as cnt FROM LargeScript");
+    assertThat(rs.next().<Long>getProperty("cnt")).isEqualTo(2000L);
+    rs.close();
+  }
 }


### PR DESCRIPTION
## Problem

Importing data with a large SQL batch script fails with a `StackOverflowError` once the command finishes:



The statements themselves execute fine — the failure happens while releasing the execution plan.

## Root cause

`SQLScriptQueryEngine.executeInternal()` builds one `ScriptLineStep` per statement and links them into a `prev` chain. Closing the plan calls `ScriptLineStep.close()` → `super.close()` → `AbstractExecutionStep.close()` → `prev.close()`, creating a recursive unwinding that is about two stack frames per statement. A script of a few thousand statements exhausts the stack.

Execution itself is iterative (`ScriptExecutionPlan.executeUntilReturn()` loops over the step list), which is why the import runs to completion and only the cleanup blows up.

## Fix

Replace the recursive `super.close()` call in `ScriptLineStep.close()` with an iterative walk of the `prev` chain. Each `ScriptLineStep` closes its own plan directly, then walks the chain to close the remaining steps. The `prev` link is nulled after closing to prevent double-close.

## Test

Added `largeScriptCloseDoesNotStackOverflow()` that runs a 2000-statement INSERT batch script and verifies it completes without error.

Fixes #5708