### PR TITLE
fix: fix flaky test by calling findStagingDirectory before gate.countDown (#5718) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineDeferredDropTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineDeferredDropTest.java
@@ -154,8 +154,9 @@ class ArcadeStateMachineDeferredDropTest {
 
     assertThat(new DatabaseFactory(databaseDirectory.toString()).exists()).isFalse();
 
+    final Path staged = findStagingDirectory();
     gate.countDown();
-    awaitGone(findStagingDirectory());
+    awaitGone(staged);
   }
 
   /**


### PR DESCRIPTION
## Fix

In `theDatabaseNameIsReusableAsSoonAsApplyReturns`, `findStagingDirectory()` was called AFTER `gate.countDown()` unblocked the deferred deleter, creating a race where the deleter could delete the staging directory before the test method listed it.

## Root cause

The test releases the deleter before it looks for the directory the deleter is about to remove:

```java
gate.countDown();                     // unblocks the deferred deleter
awaitGone(findStagingDirectory());    // ...then lists the staging dirs
```

`gate.countDown()` lets the blocked executor task proceed, so `DeferredDatabaseDeleter` can complete its recursive delete before `findStagingDirectory()` runs `Files.list`. When the deleter wins, zero staging directories remain and the `hasSize(1)` assertion fails.

## Fix

Capture the staging directory reference before unblocking the deleter, matching the pattern used by the sibling test `applyDeregistersTheDatabaseWithoutDeletingItsFilesInline`.

```java
final Path staged = findStagingDirectory();
gate.countDown();
awaitGone(staged);
```

Fixes #5718