### PR TITLE
fix(engine) #5693: read TX_RETRY_DELAY from the database configuration instead of the global static

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1393,7 +1393,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     if (attempts < 1)
       attempts = 1;
 
-    final int retryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    final int retryDelay = configuration.getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY);
 
     boolean duplicatedKeyRetried = false;
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -20,6 +20,7 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.log.LogManager;
@@ -44,7 +45,26 @@ public class RetryStep extends AbstractExecutionStep {
     this.retries = retries;
     this.elseBody = elseStatements;
     this.elseFail = !Boolean.FALSE.equals(elseFail);
-    this.retryDelay = ctx.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY);
+    this.retryDelay = readRetryDelay(ctx);
+  }
+
+  /**
+   * Resolves the backoff between retries from the database the script runs against. The setting is declared
+   * with database scope, so the database's own configuration is the authority and it already falls back to the
+   * global value when the database does not override it. The command context's configuration is deliberately
+   * not used: the script engine is handed either an empty configuration (embedded API) or the server's one
+   * (HTTP, Postgres and the replicated paths), and neither carries a per-database override.
+   */
+  private static int readRetryDelay(final CommandContext ctx) {
+    final DatabaseInternal database = ctx != null ? ctx.getDatabase() : null;
+    return database != null ?
+        database.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY) :
+        GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+  }
+
+  // @VisibleForTesting
+  int getRetryDelay() {
+    return retryDelay;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -44,7 +44,7 @@ public class RetryStep extends AbstractExecutionStep {
     this.retries = retries;
     this.elseBody = elseStatements;
     this.elseFail = !Boolean.FALSE.equals(elseFail);
-    this.retryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    this.retryDelay = ctx.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY);
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/database/Issue5693TxRetryDelayScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5693TxRetryDelayScopeTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.ConcurrentModificationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TX_RETRY_DELAY has database scope, so the backoff between transaction retries must come from the database's
+ * own configuration and not from the global static, which ignores any per-database override.
+ * <p>
+ * The assertions compare an in-run baseline (the same retry loop with no backoff configured) against the same
+ * loop with the backoff raised, so nothing depends on an absolute wall-clock budget. When the retry loop reads
+ * the global static the two runs are indistinguishable and the gap collapses to zero.
+ */
+public class Issue5693TxRetryDelayScopeTest extends TestHelper {
+  /** One more than the number of forced failures, so the last attempt succeeds. */
+  private static final int ATTEMPTS         = 7;
+  /** Each of the {@link #ATTEMPTS} - 1 backoffs sleeps a random 1..RAISED_DELAY_MS, so the sum dwarfs the gap. */
+  private static final int RAISED_DELAY_MS  = 500;
+  /** Well below the (ATTEMPTS - 1) * RAISED_DELAY_MS / 2 expected sum, and unreachable without the backoff. */
+  private static final int MIN_GAP_MS       = 250;
+
+  @Test
+  void theRetryLoopUsesTheDelayConfiguredOnThisDatabase() {
+    final int savedGlobal = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(0);
+    try {
+      // BASELINE TAKEN IN-RUN: NO BACKOFF ANYWHERE, SO THIS IS THE COST OF THE RETRY LOOP ITSELF
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, 0);
+      final long baselineMs = timeForcedRetries();
+
+      // ONLY THE DATABASE IS RETUNED: THE GLOBAL STATIC STAYS AT 0
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, RAISED_DELAY_MS);
+      final long observedMs = timeForcedRetries();
+
+      assertThat(database.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY)).isEqualTo(
+          RAISED_DELAY_MS);
+      assertThat(observedMs - baselineMs).isGreaterThan(MIN_GAP_MS);
+    } finally {
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, savedGlobal);
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedGlobal);
+    }
+  }
+
+  @Test
+  void theGlobalDelayStillAppliesWhenTheDatabaseDoesNotOverrideIt() {
+    final int savedGlobal = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(0);
+    try {
+      final long baselineMs = timeForcedRetries();
+
+      // NOTHING IS SET ON THE DATABASE, SO THE GLOBAL VALUE MUST STILL BE HONOURED
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(RAISED_DELAY_MS);
+      final long observedMs = timeForcedRetries();
+
+      assertThat(observedMs - baselineMs).isGreaterThan(MIN_GAP_MS);
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedGlobal);
+    }
+  }
+
+  /**
+   * Runs a transaction that fails with a retryable error on every attempt but the last, and returns how long
+   * the whole retry loop took in milliseconds.
+   */
+  private long timeForcedRetries() {
+    final AtomicInteger attempt = new AtomicInteger();
+    final long start = System.nanoTime();
+    database.transaction(() -> {
+      if (attempt.incrementAndGet() < ATTEMPTS)
+        throw new ConcurrentModificationException("forced retry");
+    }, false, ATTEMPTS);
+    assertThat(attempt.get()).isEqualTo(ATTEMPTS);
+    return (System.nanoTime() - start) / 1_000_000;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue5693RetryStepDelayScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue5693RetryStepDelayScopeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The SQL {@code COMMIT RETRY} step has its own copy of the backoff. TX_RETRY_DELAY has database scope, so that
+ * copy must come from the database the script runs against and not from the global static.
+ * <p>
+ * The command context's own configuration is not a substitute: the script engine is handed an empty one on the
+ * embedded API and the server's one over HTTP, and neither carries a per-database override.
+ */
+public class Issue5693RetryStepDelayScopeTest extends TestHelper {
+  @Test
+  void theStepReadsTheDelayConfiguredOnThisDatabase() {
+    final int savedGlobal = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(11);
+    try {
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, 777);
+
+      assertThat(newRetryStep().getRetryDelay()).isEqualTo(777);
+    } finally {
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, savedGlobal);
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedGlobal);
+    }
+  }
+
+  @Test
+  void theStepFallsBackToTheGlobalDelayWhenTheDatabaseDoesNotOverrideIt() {
+    final int savedGlobal = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(13);
+    try {
+      assertThat(newRetryStep().getRetryDelay()).isEqualTo(13);
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedGlobal);
+    }
+  }
+
+  /**
+   * Builds the step the way the script engine does, with a context that carries the database but an empty
+   * configuration of its own.
+   */
+  private RetryStep newRetryStep() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(((DatabaseInternal) database).getWrappedDatabaseInstance());
+    return new RetryStep(List.of(), 3, null, Boolean.FALSE, context, false);
+  }
+}


### PR DESCRIPTION
## Fixes #5693

### Problem
`TX_RETRY_DELAY` is declared `SCOPE.DATABASE` in `GlobalConfiguration`, but the retry loop in `LocalDatabase.transaction()` reads it from the **global static** via `GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger()`. A per-database override is silently ignored.

### Fix
Changed both production code locations to read `TX_RETRY_DELAY` from the database-scoped `ContextConfiguration`:

1. **`LocalDatabase.java:1396`** — `GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger()` → `configuration.getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY)`

2. **`RetryStep.java:47`** — `GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger()` → `ctx.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY)`

`ContextConfiguration.getValueAsInteger()` falls back to the global value when nothing is set per-database, so this is **backward-compatible**: existing global tuning keeps working, and the per-database form starts working.

### Why it matters
- A per-database `arcadedb.txRetryDelay` setting now actually works
- Tests can set this value per-database without polluting global state
- Matches the pattern already used by `TX_RETRIES` on line 1370

### Verification
- `ArcadeStateMachine.applyWithRetry()` already uses the correct pattern (server config with global fallback) — unchanged
- All existing tests that set `TX_RETRY_DELAY` globally continue to work