### PR TITLE
fix(engine) #5723: a copied type keeps its index definitions, its records' content, and index entries

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1599,4 +1599,56 @@ build indexes through the embedded API with a computed page size, check that the
 An index that already exists on disk is unaffected either way - the page size is read from the component file, not from
 a builder.
 
+## Copying a type copies its records and its index definitions, not just their names
+
+`Schema.copyType()` - what `DocumentType` → `VertexType` conversion goes through - was reported as losing the page
+size of every index on the copy (#5723). It was, and that turned out to be the least of it. The same thirty lines held
+three defects, and the two that were not reported are the ones that made the copy wrong rather than differently tuned.
+
+**The copy had no data in its indexes.** The indexes were created inside the transaction that copies the records.
+`TypeIndexBuilder.create()` builds each bucket's index in its own transaction (`joinCurrent=false`), which from inside
+an enclosing transaction neither sees the records still pending in it nor commits the entries it produces. So every
+index on the copy came out empty, and any query the planner routed through one answered nothing - silently, since an
+empty index is indistinguishable from a type with no matching rows:
+
+```java
+schema.copyType("Doc", "Doc2", LocalVertexType.class, 1, 65_536, 1_000);
+database.query("sql", "SELECT FROM Doc2 WHERE k = 'v1'");   // 0 rows, and the record is right there
+```
+
+The index build now runs after the record-copy transaction has committed.
+
+**The copied records were empty.** `ImmutableDocument.propertiesAsMap()` was the one accessor of that class that did
+not lazy-load: it answered `Collections.emptyMap()` whenever the record had not been materialised yet, which is the
+state of every record handed out by `iterateType()` and `scanBucket()`. `copyType()` reads each source record that
+way, so it faithfully created the right *number* of records, each with no properties. The same silent emptiness
+affected a `DetachedDocument` built off a record straight from a scan. `propertiesAsMap()` now loads first, like
+`get()`, `has()`, `getPropertyNames()` and `toJSON()` already did; the empty map remains the answer only for a record
+that genuinely cannot be materialised.
+
+**And the index definitions were rebuilt from three attributes.** The copy went through the three-argument
+`createTypeIndex` overload, so the index type, the uniqueness flag and the property list survived and everything else
+was replaced by a default: the tuned page size from the report, the null strategy, the collations that make a lookup
+case-insensitive, and the entire type-specific configuration. That last one is not a tuning difference - a copied
+`FULL_TEXT` index tokenized and ranked with the default analyzer instead of the configured one, a copied `GEOSPATIAL`
+index dropped to the default geohash resolution, and a copied `LSM_VECTOR` index came up with `dimensions` 0.
+
+Carrying a definition into a new index file now has an accessor of its own, `IndexInternal.getMetadataForNewFile()`,
+alongside the `getPageSizeForNewFile()` that #5713 introduced for the page size. It exists because `getMetadata()`
+cannot answer this question for the wrapper index types: a full-text index keeps its analyzers and BM25 parameters in
+its own `FullTextIndexMetadata` and a geospatial one keeps its resolution and layout in plain fields, while
+`getMetadata()` delegates to the underlying LSM-Tree and hands back a definition with none of it. `IndexMetadata.copy()`
+is now polymorphic across all five metadata classes, so each carries its own settings and there is no second field list
+to forget. Per-index runtime state deliberately does not ride along: the copy starts empty, so inheriting the dense
+vector index's build state or the full-text corpus counters would describe a different set of records.
+
+A user-supplied index name is the one attribute not carried over. It is unique across the schema and still belongs to
+the source type, so the copy takes the auto-derived `NewType[properties]` form rather than colliding with it.
+
+The other sites that rebuild an index from its own definition - `TRUNCATE TYPE`, `CHECK DATABASE FIX`, and the
+propagation to a freshly added bucket or sub type - still read `getMetadata()` and so still lose a full-text or
+geospatial configuration. They are unchanged here and tracked separately: each is a distinct user-visible operation and
+deserves its own regression test rather than riding along with this one. `REBUILD INDEX` is already correct; it
+reconstructs the typed metadata from the persisted JSON.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1645,6 +1645,13 @@ vector index's build state or the full-text corpus counters would describe a dif
 A user-supplied index name is the one attribute not carried over. It is unique across the schema and still belongs to
 the source type, so the copy takes the auto-derived `NewType[properties]` form rather than colliding with it.
 
+**One behaviour change reaches outside `copyType()`.** `LSMVectorIndexMetadata.copy()` already existed and carried only
+the collations; routing it through the shared `copyCommonTo()` means it now also carries the user-supplied index name.
+Its other caller is `TRUNCATE TYPE`, which drops and recreates each index from its own definition - so a manually named
+`LSM_VECTOR` index now keeps its name across a truncate, where before it came back under the auto-derived
+`Type[properties]` form. Nothing else was affected: every other index type already kept its name there, because that
+path hands the original metadata object straight back rather than copying it.
+
 The other sites that rebuild an index from its own definition - `TRUNCATE TYPE`, `CHECK DATABASE FIX`, and the
 propagation to a freshly added bucket or sub type - still read `getMetadata()` and so still lose a full-text or
 geospatial configuration. They are unchanged here and tracked separately: each is a distinct user-visible operation and

--- a/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
@@ -115,9 +115,22 @@ public class ImmutableDocument extends BaseDocument {
     return result;
   }
 
+  /**
+   * Lazy-loads before reading, like every other accessor on this class ({@link #get}, {@link #has},
+   * {@link #getPropertyNames}, {@link #toJSON}). Without it a record that had not been materialised yet - which is
+   * every record handed out by {@code iterateType()} / {@code scanBucket()} - answered an EMPTY map instead of its
+   * properties, silently. That is what made {@code copyType()} copy the right NUMBER of records and none of their
+   * content (issue #5723), and what left {@link DetachedDocument} empty when detaching a record straight off a scan.
+   * <p>
+   * The empty map remains the answer for a record that genuinely cannot be materialised: no database, no RID to load
+   * from, or an after-read event that filtered the record away.
+   */
   @Override
   public Map<String, Object> propertiesAsMap() {
-    if (database == null || buffer == null)
+    if (database == null || (buffer == null && rid == null))
+      return Collections.emptyMap();
+    checkForLazyLoading();
+    if (buffer == null)
       return Collections.emptyMap();
     buffer.position(propertiesStartingPosition);
     return database.getSerializer().deserializeProperties(database, buffer, new EmbeddedModifierObject(this), rid);
@@ -132,10 +145,13 @@ public class ImmutableDocument extends BaseDocument {
    * @return map of property name to value for the requested fields only
    */
   public Map<String, Object> propertiesAsMap(final String... fieldNames) {
-    if (database == null || buffer == null)
+    if (database == null || (buffer == null && rid == null))
       return Collections.emptyMap();
     if (fieldNames == null || fieldNames.length == 0)
       return propertiesAsMap();
+    checkForLazyLoading();
+    if (buffer == null)
+      return Collections.emptyMap();
     buffer.position(propertiesStartingPosition);
     return database.getSerializer().deserializeProperties(database, buffer, new EmbeddedModifierObject(this), rid, fieldNames);
   }

--- a/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
@@ -132,6 +132,8 @@ public class ImmutableDocument extends BaseDocument {
     checkForLazyLoading();
     if (buffer == null)
       return Collections.emptyMap();
+    // NOT redundant with the positioning checkForLazyLoading() does: when an after-read event returns a DIFFERENT
+    // record (the encryption path), that method replaces the buffer with a freshly serialised one and leaves it at 0.
     buffer.position(propertiesStartingPosition);
     return database.getSerializer().deserializeProperties(database, buffer, new EmbeddedModifierObject(this), rid);
   }

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -125,6 +125,23 @@ public interface IndexInternal extends Index {
     return getPageSize();
   }
 
+  /**
+   * Configuration to replay when this index's definition is carried over into a NEW index file - a rebuild, a truncate,
+   * a propagation to a freshly added bucket or sub type, a {@code copyType()}. The companion of
+   * {@link #getPageSizeForNewFile()} for everything that is not the page size, and the value to feed
+   * {@link IndexMetadata#copy(String, String[], int)} before handing it to a builder.
+   * <p>
+   * Distinct from {@link #getMetadata()} because that one answers whatever the index stores internally, which for the
+   * wrapper index types is the UNDERLYING LSM-Tree's plain {@link IndexMetadata}: a full-text index keeps its analyzers
+   * and BM25 configuration in its own {@code FullTextIndexMetadata}, a geospatial one keeps its resolution and layout
+   * in its own fields, and neither is reachable through the underlying index. A carry-over site reading
+   * {@code getMetadata()} therefore silently recreates the index with the default configuration (issue #5723) - which
+   * for a full-text index means a different analyzer and a different ranking.
+   */
+  default IndexMetadata getMetadataForNewFile() {
+    return getMetadata();
+  }
+
   boolean isCompacting();
 
   boolean isValid();

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -687,4 +687,16 @@ public class TypeIndex implements RangeIndex, IndexInternal {
       return getFirstUnderlyingIndex().getMetadata();
     return null;
   }
+
+  @Override
+  public IndexMetadata getMetadataForNewFile() {
+    // Same precedence as getMetadata(), but the delegate answers with the type-specific configuration a wrapper index
+    // keeps outside the underlying LSM-Tree. Same definition across every bucket sub-index, so the first one answers
+    // for all of them.
+    if (metadata != null)
+      return metadata;
+    if (!indexesOnBuckets.isEmpty())
+      return getFirstUnderlyingIndex().getMetadataForNewFile();
+    return null;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -1110,6 +1110,15 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     return underlyingIndex.getMetadata();
   }
 
+  /**
+   * The analyzers, query-parser options and BM25 configuration live here, not on the underlying LSM-Tree, so a site
+   * carrying this definition into a new index file has to read them from this instance (issue #5723).
+   */
+  @Override
+  public IndexMetadata getMetadataForNewFile() {
+    return ftMetadata != null ? ftMetadata : underlyingIndex.getMetadata();
+  }
+
   @Override
   public boolean isCompacting() {
     return underlyingIndex.isCompacting();

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -345,17 +345,10 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
    */
   @Override
   public IndexMetadata getMetadataForNewFile() {
-    final IndexMetadata base = underlyingIndex.getMetadata();
-    final GeoIndexMetadata geoMetadata = new GeoIndexMetadata(base != null ? base.typeName : null,
-        base != null ? base.propertyNames.toArray(new String[0]) : new String[0],
-        base != null ? base.associatedBucketId : -1);
-    if (base != null) {
-      geoMetadata.collations = base.collations;
-      geoMetadata.typeIndexName = base.typeIndexName;
-    }
-    geoMetadata.setPrecision(precision);
-    geoMetadata.setTokenization(tokenization);
-    return geoMetadata;
+    // Unlike the full-text and sparse-vector wrappers, there is no stored GeoIndexMetadata to hand back: this class
+    // holds the two settings as plain fields. GeoIndexMetadata.from() reassembles the definition, keeping the
+    // base-field copy inside the metadata hierarchy where copyCommonTo() lives.
+    return GeoIndexMetadata.from(underlyingIndex.getMetadata(), precision, tokenization);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -338,6 +338,26 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
     return underlyingIndex.getMetadata();
   }
 
+  /**
+   * The geohash resolution and the storage layout are held here as plain fields, not on the underlying LSM-Tree, so a
+   * site carrying this definition into a new index file has to read them from this instance: through
+   * {@link #getMetadata()} a copy would silently drop to the default precision (issue #5723).
+   */
+  @Override
+  public IndexMetadata getMetadataForNewFile() {
+    final IndexMetadata base = underlyingIndex.getMetadata();
+    final GeoIndexMetadata geoMetadata = new GeoIndexMetadata(base != null ? base.typeName : null,
+        base != null ? base.propertyNames.toArray(new String[0]) : new String[0],
+        base != null ? base.associatedBucketId : -1);
+    if (base != null) {
+      geoMetadata.collations = base.collations;
+      geoMetadata.typeIndexName = base.typeIndexName;
+    }
+    geoMetadata.setPrecision(precision);
+    geoMetadata.setTokenization(tokenization);
+    return geoMetadata;
+  }
+
   @Override
   public boolean isCompacting() {
     return underlyingIndex.isCompacting();

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -545,6 +545,15 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     return underlyingIndex.getMetadata();
   }
 
+  /**
+   * The dimensionality, the scoring modifier and the weight quantization live here, not on the underlying LSM-Tree, so
+   * a site carrying this definition into a new index file has to read them from this instance (issue #5723).
+   */
+  @Override
+  public IndexMetadata getMetadataForNewFile() {
+    return sparseMetadata != null ? sparseMetadata : underlyingIndex.getMetadata();
+  }
+
   @Override
   public boolean isCompacting() {
     return underlyingIndex.isCompacting();

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -133,6 +133,31 @@ public class FullTextIndexMetadata extends IndexMetadata {
     return new FullTextIndexMetadata(typeName, propertyNames, bucketId);
   }
 
+  /**
+   * Carries the analyzers, the query-parser options and the BM25 configuration over, per-field entries included: those
+   * are keyed by property name, which a copy keeps.
+   * <p>
+   * The corpus counters are NOT copied. They describe the documents indexed so far, and the copy is about to index a
+   * different set - starting from none - so inheriting them would skew every BM25 score until something recomputed
+   * them. A fresh instance starts at {@code countersValid == false}, which is the state that makes the first query
+   * validate them against the live data.
+   */
+  @Override
+  public FullTextIndexMetadata copy(final String typeName, final String[] propertyNames, final int bucketId) {
+    final FullTextIndexMetadata copy = copyCommonTo(new FullTextIndexMetadata(typeName, propertyNames, bucketId));
+    copy.analyzerClass = analyzerClass;
+    copy.indexAnalyzerClass = indexAnalyzerClass;
+    copy.queryAnalyzerClass = queryAnalyzerClass;
+    copy.allowLeadingWildcard = allowLeadingWildcard;
+    copy.defaultOperator = defaultOperator;
+    copy.fieldAnalyzers.putAll(fieldAnalyzers);
+    copy.similarity = similarity;
+    copy.bm25K1 = bm25K1;
+    copy.bm25B = bm25B;
+    copy.fieldBoosts.putAll(fieldBoosts);
+    return copy;
+  }
+
   @Override
   public void fromJSON(final JSONObject metadata) {
     if (metadata.has("typeName"))

--- a/engine/src/main/java/com/arcadedb/schema/GeoIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/GeoIndexMetadata.java
@@ -103,6 +103,27 @@ public class GeoIndexMetadata extends IndexMetadata {
   }
 
   /**
+   * Reassembles a geospatial definition from the common index metadata plus the two settings a geospatial index keeps
+   * outside it. {@code LSMTreeGeoIndex} holds the resolution and the layout as plain fields and its underlying LSM-Tree
+   * carries a base {@link IndexMetadata}, so answering "the definition to create a new file with" means putting the two
+   * halves back together. It belongs here rather than on the index because copying the base fields is
+   * {@link #copyCommonTo}'s job, and that is only reachable from inside this hierarchy.
+   *
+   * @param base         common metadata of the underlying index, or {@code null} when there is none
+   * @param precision    geohash resolution of the index
+   * @param tokenization storage layout of the index
+   */
+  public static GeoIndexMetadata from(final IndexMetadata base, final int precision, final TOKENIZATION tokenization) {
+    final GeoIndexMetadata metadata = base != null ?
+        base.copyCommonTo(new GeoIndexMetadata(base.typeName, base.propertyNames.toArray(new String[0]),
+            base.associatedBucketId)) :
+        new GeoIndexMetadata(null, new String[0], -1);
+    metadata.setPrecision(precision);
+    metadata.setTokenization(tokenization);
+    return metadata;
+  }
+
+  /**
    * Carries the geohash resolution AND the storage layout over. The layout is a property of what is written in the
    * file, not a preference, so a copy that is going to be populated from the same definition keeps it; a caller that
    * knows it is re-tokenizing every record from scratch - a rebuild - overrides it with

--- a/engine/src/main/java/com/arcadedb/schema/GeoIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/GeoIndexMetadata.java
@@ -102,6 +102,20 @@ public class GeoIndexMetadata extends IndexMetadata {
     this.tokenization = readTokenization(metadata);
   }
 
+  /**
+   * Carries the geohash resolution AND the storage layout over. The layout is a property of what is written in the
+   * file, not a preference, so a copy that is going to be populated from the same definition keeps it; a caller that
+   * knows it is re-tokenizing every record from scratch - a rebuild - overrides it with
+   * {@link #DEFAULT_TOKENIZATION} afterwards.
+   */
+  @Override
+  public GeoIndexMetadata copy(final String typeName, final String[] propertyNames, final int bucketId) {
+    final GeoIndexMetadata copy = copyCommonTo(new GeoIndexMetadata(typeName, propertyNames, bucketId));
+    copy.precision = precision;
+    copy.tokenization = tokenization;
+    return copy;
+  }
+
   @Override
   public Set<String> getUserMetadataKeys() {
     return USER_METADATA_KEYS;

--- a/engine/src/main/java/com/arcadedb/schema/IndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexMetadata.java
@@ -49,6 +49,40 @@ public class IndexMetadata {
     this.associatedBucketId = bucketId;
   }
 
+  /**
+   * Returns a fresh instance carrying every SETTING of this definition, retargeted to the given type, properties and
+   * bucket. This is what "carry the index configuration over into a new index file" means: a rebuild, a truncate, the
+   * propagation to a freshly added bucket or sub type, a {@code copyType()}.
+   * <p>
+   * Two things the copy deliberately leaves behind. Anything that is per-index RUNTIME state rather than a setting -
+   * the dense vector index's {@code buildState}, the full-text corpus counters - because the new file starts empty and
+   * would otherwise inherit statistics describing a different set of records. And the association to a bucket, which
+   * the caller re-establishes by passing the target {@code bucketId} (or -1 when the per-bucket builder will bind it
+   * during {@code create()}).
+   * <p>
+   * Every subclass overrides this so its own settings ride along; there is no second field list to keep in sync, which
+   * is the point. Missing overrides are how a page size (issue #5713), a null strategy, a collation and a whole
+   * type-specific configuration all ended up being replaced by defaults on {@code copyType()} (issue #5723).
+   *
+   * @param typeName      type the copy belongs to
+   * @param propertyNames indexed properties of the copy
+   * @param bucketId      associated bucket, or -1 when not bound yet
+   */
+  public IndexMetadata copy(final String typeName, final String[] propertyNames, final int bucketId) {
+    return copyCommonTo(new IndexMetadata(typeName, propertyNames, bucketId));
+  }
+
+  /**
+   * Copies the settings held by this base class onto a copy an override has just instantiated, and hands it back so the
+   * override can keep chaining. {@code collations} is shared rather than cloned: it is assigned wholesale and never
+   * mutated in place.
+   */
+  protected final <T extends IndexMetadata> T copyCommonTo(final T copy) {
+    copy.collations = collations;
+    copy.typeIndexName = typeIndexName;
+    return copy;
+  }
+
   public void fromJSON(final JSONObject metadata) {
     typeName = metadata.getString("typeName");
     propertyNames = metadata.getJSONArray("properties").toListOfStrings();

--- a/engine/src/main/java/com/arcadedb/schema/LSMSparseVectorIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/LSMSparseVectorIndexMetadata.java
@@ -78,6 +78,16 @@ public class LSMSparseVectorIndexMetadata extends IndexMetadata {
   }
 
   @Override
+  public LSMSparseVectorIndexMetadata copy(final String typeName, final String[] propertyNames, final int bucketId) {
+    final LSMSparseVectorIndexMetadata copy = copyCommonTo(
+        new LSMSparseVectorIndexMetadata(typeName, propertyNames, bucketId));
+    copy.dimensions = dimensions;
+    copy.modifier = modifier;
+    copy.weightQuantization = weightQuantization;
+    return copy;
+  }
+
+  @Override
   public Set<String> getUserMetadataKeys() {
     return USER_METADATA_KEYS;
   }

--- a/engine/src/main/java/com/arcadedb/schema/LSMVectorIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/LSMVectorIndexMetadata.java
@@ -104,8 +104,9 @@ public class LSMVectorIndexMetadata extends IndexMetadata {
    * @param propertyNames indexed properties of the copy
    * @param bucketId      associated bucket, or -1 when not bound yet
    */
+  @Override
   public LSMVectorIndexMetadata copy(final String typeName, final String[] propertyNames, final int bucketId) {
-    final LSMVectorIndexMetadata copy = new LSMVectorIndexMetadata(typeName, propertyNames, bucketId);
+    final LSMVectorIndexMetadata copy = copyCommonTo(new LSMVectorIndexMetadata(typeName, propertyNames, bucketId));
     copy.dimensions = dimensions;
     copy.similarityFunction = similarityFunction;
     copy.quantizationType = quantizationType;
@@ -126,7 +127,6 @@ public class LSMVectorIndexMetadata extends IndexMetadata {
     copy.pqClusters = pqClusters;
     copy.pqCenterGlobally = pqCenterGlobally;
     copy.pqTrainingLimit = pqTrainingLimit;
-    copy.collations = collations;
     return copy;
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -610,17 +610,19 @@ public class LocalSchema implements Schema {
           }
         }
 
-        // COPY INDEXES
-        for (final Index index : oldType.getAllIndexes(false))
-          newType.createTypeIndex(index.getType(), index.isUnique(),
-              index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]));
-
         database.commit();
 
       } finally {
         if (database.isTransactionActive())
           database.rollback();
       }
+
+      // COPY INDEXES. Deliberately outside the record-copy transaction: each index build opens its own transaction
+      // (TypeIndexBuilder.create wraps every bucket's build in a database.transaction(..., joinCurrent=false, ...)) and
+      // has to both see the copied records and commit its own entries. Run from inside an enclosing transaction it did
+      // neither, so every index on the copy came out EMPTY - a copy whose indexed queries silently answer nothing.
+      for (final Index index : oldType.getAllIndexes(false))
+        copyIndexDefinition((IndexInternal) index, newTypeName);
 
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error on renaming type '%s' into '%s'", e, typeName, newTypeName);
@@ -638,6 +640,43 @@ public class LocalSchema implements Schema {
     }
 
     return newType;
+  }
+
+  /**
+   * Recreates one index of the source type on the copy, carrying the WHOLE definition over rather than only the index
+   * type, the uniqueness flag and the property list.
+   * <p>
+   * Everything else used to be silently replaced by a default (issue #5723): the page size deliberately tuned at
+   * creation, the null strategy, the collations that make an index case-insensitive, and the type-specific
+   * configuration - a full-text index's analyzers and BM25 parameters, a geospatial index's resolution, a vector
+   * index's dimensions and similarity, without which the copy is not merely differently tuned but unusable.
+   * <p>
+   * The one attribute deliberately NOT carried over is a user-supplied index name: it is unique across the schema, so
+   * reusing it would collide with the index still held by the source type. The copy takes the auto-derived
+   * {@code newTypeName[properties]} form instead.
+   */
+  private void copyIndexDefinition(final IndexInternal index, final String newTypeName) {
+    final List<String> propertyNames = index.getPropertyNames();
+    final String[] properties = propertyNames.toArray(new String[propertyNames.size()]);
+
+    // withType() may swap the builder for a type-specific subclass (TypeFullTextIndexBuilder, TypeLSMVectorIndexBuilder,
+    // ...), so call it first and keep the returned reference instead of chaining off the original.
+    final TypeIndexBuilder builder = buildTypeIndex(newTypeName, properties).withType(index.getType());
+    builder.withUnique(index.isUnique());
+    // getPageSizeForNewFile(), not getPageSize(): the definition goes back through the validating creation path, and a
+    // HASH index predating #5713 can hold a page size that path refuses - which must not make copyType() fail.
+    builder.withPageSize(index.getPageSizeForNewFile());
+    builder.withNullStrategy(index.getNullStrategy());
+
+    final IndexMetadata sourceMetadata = index.getMetadataForNewFile();
+    if (sourceMetadata != null) {
+      // bucketId -1: the per-bucket builder binds each sub-index during create().
+      final IndexMetadata metadata = sourceMetadata.copy(newTypeName, properties, -1);
+      metadata.typeIndexName = null;
+      builder.withMetadata(metadata);
+    }
+
+    builder.create();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -557,6 +557,26 @@ public class LocalSchema implements Schema {
     this.encoding = encoding;
   }
 
+  /**
+   * Creates {@code newTypeName} as a copy of {@code typeName}: its properties, its records, and the definitions of the
+   * indexes it declares itself.
+   * <p>
+   * <b>Not atomic, by construction.</b> The records commit first - in batches of {@code transactionBatchSize}, so a
+   * large type does not hold one transaction open - and only then are the indexes built, each in its own transaction.
+   * The index build has to run outside the record-copy transaction to see the records at all (see the comment at that
+   * call site), which is what puts a commit boundary in the middle of the operation. The safety net for a failure on
+   * either side of it is the {@code catch} below: it drops {@code newTypeName}, and with it the buckets and records
+   * already committed, so a failed copy leaves the schema as it found it rather than a half-built type. The SOURCE type
+   * is only ever read, so it is unaffected either way.
+   *
+   * @param typeName             type to copy from, left untouched
+   * @param newTypeName          type to create, which must not exist yet
+   * @param newTypeClass         {@link LocalDocumentType} or {@link LocalVertexType}; edge types are not supported
+   * @param buckets              number of buckets of the new type
+   * @param pageSize             page size of the new type's buckets, not of its indexes - those keep the page size of
+   *                             the index they are copied from
+   * @param transactionBatchSize records to copy per transaction, or 0 to copy them all in one
+   */
   @Override
   public DocumentType copyType(final String typeName, final String newTypeName, final Class<? extends DocumentType> newTypeClass,
       final int buckets, final int pageSize, final int transactionBatchSize) {

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -645,7 +645,10 @@ public class LocalSchema implements Schema {
         copyIndexDefinition((IndexInternal) index, newTypeName);
 
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on renaming type '%s' into '%s'", e, typeName, newTypeName);
+      // "copying", not "renaming": nothing here renames anything, and the source type is still there afterwards. The
+      // old wording is why issue #5723 was filed against a renameType() that does not exist - a rename goes through
+      // LocalDocumentType.rename(), which renames buckets in place and never recreates an index.
+      LogManager.instance().log(this, Level.SEVERE, "Error on copying type '%s' into '%s'", e, typeName, newTypeName);
 
       if (newType != null)
         try {

--- a/engine/src/test/java/com/arcadedb/database/ImmutableDocumentLazyLoadingInconsistencyTest.java
+++ b/engine/src/test/java/com/arcadedb/database/ImmutableDocumentLazyLoadingInconsistencyTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.database;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.event.AfterRecordReadListener;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
@@ -281,6 +282,32 @@ public class ImmutableDocumentLazyLoadingInconsistencyTest extends TestHelper {
     database.transaction(() -> {
       final ImmutableDocument scanned = (ImmutableDocument) database.iterateType("SecurityTest", false).next();
       assertThat(scanned.propertiesAsMap("publicProperty")).containsExactly(entry("publicProperty", "public_value"));
+    });
+  }
+
+  /**
+   * The other half of the #5723 change, stated deliberately: a record whose RID no longer resolves now REPORTS that,
+   * where before the missing lazy load was indistinguishable from a record with no properties. This is the same
+   * contract {@link #consistentExceptionTypesInLazyLoading()} pins down for the other accessors - an accessor of this
+   * class does not answer for a record it could not read.
+   */
+  @Test
+  void propertiesAsMapReportsARecordThatNoLongerResolves() {
+    final RID[] documentRid = new RID[1];
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("SecurityTest");
+      doc.set("publicProperty", "public_value");
+      doc.save();
+      documentRid[0] = doc.getIdentity();
+    });
+
+    database.transaction(() -> {
+      // Not loaded yet: the buffer is only materialised on the first access, which is the whole point here.
+      final ImmutableDocument stale = (ImmutableDocument) database.lookupByRID(documentRid[0], false);
+      database.deleteRecord(database.lookupByRID(documentRid[0], true));
+
+      assertThatThrownBy(stale::propertiesAsMap).isInstanceOf(RecordNotFoundException.class);
+      assertThatThrownBy(() -> stale.propertiesAsMap("publicProperty")).isInstanceOf(RecordNotFoundException.class);
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/ImmutableDocumentLazyLoadingInconsistencyTest.java
+++ b/engine/src/test/java/com/arcadedb/database/ImmutableDocumentLazyLoadingInconsistencyTest.java
@@ -24,11 +24,13 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.util.Iterator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 
 /**
  * Test to verify the fix for issue #2560 - ImmutableDocument.checkForLazyLoading() consistency.
@@ -111,6 +113,8 @@ public class ImmutableDocumentLazyLoadingInconsistencyTest extends TestHelper {
             ImmutableDocument::toJSON,
             ImmutableDocument::toMap,
             ImmutableDocument::getPropertyNames,
+            ImmutableDocument::propertiesAsMap,
+            d -> d.propertiesAsMap("secretProperty"),
             d -> d.get("secretProperty")
         ).forEach(action -> {
           // Get a new instance for each test to ensure lazy loading is triggered
@@ -164,6 +168,12 @@ public class ImmutableDocumentLazyLoadingInconsistencyTest extends TestHelper {
 
         final ImmutableDocument immutableDoc6 = (ImmutableDocument) database.lookupByRID(documentRid, false);
         assertThat(immutableDoc6.getPropertyNames()).contains("secretProperty");
+
+        final ImmutableDocument immutableDoc7 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThat(immutableDoc7.propertiesAsMap()).containsEntry("secretProperty", "secret_value");
+
+        final ImmutableDocument immutableDoc8 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThat(immutableDoc8.propertiesAsMap("secretProperty")).containsEntry("secretProperty", "secret_value");
 
       } finally {
         // Clean up the security listener
@@ -240,6 +250,37 @@ public class ImmutableDocumentLazyLoadingInconsistencyTest extends TestHelper {
       } finally {
         database.getEvents().unregisterListener(illegalStateListener);
       }
+    });
+  }
+
+  /**
+   * Regression for issue #5723: {@code propertiesAsMap()} was the one accessor that did not lazy-load, so a record
+   * handed out by a scan - never materialised - answered an EMPTY map instead of its properties. Silently: no
+   * exception, no log, just a record that looks like it has nothing on it. {@code copyType()} read every record that
+   * way and copied their emptiness.
+   */
+  @Test
+  void propertiesAsMapLoadsARecordComingStraightFromAScan() {
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("SecurityTest");
+      doc.set("publicProperty", "public_value");
+      doc.set("secretProperty", "secret_value");
+      doc.save();
+    });
+
+    database.transaction(() -> {
+      final Iterator<Record> iterator = database.iterateType("SecurityTest", false);
+      assertThat(iterator.hasNext()).isTrue();
+      final Document scanned = (Document) iterator.next();
+
+      assertThat(scanned.propertiesAsMap())//
+          .containsEntry("publicProperty", "public_value")//
+          .containsEntry("secretProperty", "secret_value");
+    });
+
+    database.transaction(() -> {
+      final ImmutableDocument scanned = (ImmutableDocument) database.iterateType("SecurityTest", false).next();
+      assertThat(scanned.propertiesAsMap("publicProperty")).containsExactly(entry("publicProperty", "public_value"));
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/schema/Issue5723CopyTypeIndexConfigurationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue5723CopyTypeIndexConfigurationTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.fulltext.LSMTreeFullTextIndex;
+import com.arcadedb.index.geospatial.LSMTreeGeoIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
+import com.arcadedb.query.sql.executor.ResultSet;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5723: {@code LocalSchema.copyType()} recreated the source type's indexes through the
+ * three-argument {@code createTypeIndex} overload, so every attribute of the definition other than the index type, the
+ * uniqueness flag and the property list was silently replaced by a default on the copy - the tuned page size, the null
+ * strategy, the collations, and the whole type-specific configuration of a full-text, geospatial or vector index.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5723CopyTypeIndexConfigurationTest extends TestHelper {
+
+  private static final String ENGLISH_ANALYZER = "org.apache.lucene.analysis.en.EnglishAnalyzer";
+
+  @Test
+  void copyTypeKeepsThePageSize() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("k", Type.STRING);
+      database.getSchema().buildTypeIndex("Doc", new String[] { "k" })//
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).withPageSize(16_384).create();
+    });
+    database.transaction(() -> database.newDocument("Doc").set("k", "v1").save());
+
+    assertThat(indexOf("Doc").getPageSize()).as("the fixture must not use the default page size").isEqualTo(16_384);
+
+    database.getSchema().copyType("Doc", "Doc2", LocalDocumentType.class, 1, 65_536, 1_000);
+
+    final IndexInternal copied = indexOf("Doc2");
+    assertThat(copied.getPageSize()).as("the copy must keep the page size of the original").isEqualTo(16_384);
+    assertThat(copied.isUnique()).isTrue();
+    assertThat(copied.getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
+    assertThat(copied.countEntries()).as("the copy must be populated with the copied records").isEqualTo(1);
+  }
+
+  /**
+   * A HASH index cannot be created above 65536 bytes (#5713), and the page size a copy asks for goes back through that
+   * same validating creation path. Carrying the current value blindly would make copying a type that predates the guard
+   * fail; {@code getPageSizeForNewFile()} answers with a legal one instead.
+   */
+  @Test
+  void copyTypeKeepsTheHashPageSize() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("k", Type.STRING);
+      database.getSchema().buildTypeIndex("Doc", new String[] { "k" })//
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).withPageSize(8_192).create();
+    });
+    database.transaction(() -> database.newDocument("Doc").set("k", "v1").save());
+
+    assertThat(indexOf("Doc").getPageSize()).isEqualTo(8_192);
+
+    database.getSchema().copyType("Doc", "Doc2", LocalDocumentType.class, 1, 65_536, 1_000);
+
+    assertThat(indexOf("Doc2").getPageSize()).as("the copy must keep the page size of the original").isEqualTo(8_192);
+    assertThat(indexOf("Doc2").getType()).isEqualTo(Schema.INDEX_TYPE.HASH);
+  }
+
+  @Test
+  void copyTypeKeepsTheNullStrategy() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("k", Type.STRING);
+      database.getSchema().buildTypeIndex("Doc", new String[] { "k" })//
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false)//
+          .withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR).create();
+    });
+
+    assertThat(indexOf("Doc").getNullStrategy()).isEqualTo(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR);
+
+    database.getSchema().copyType("Doc", "Doc2", LocalDocumentType.class, 1, 65_536, 1_000);
+
+    assertThat(indexOf("Doc2").getNullStrategy()).as("the copy must keep the null strategy of the original")//
+        .isEqualTo(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR);
+  }
+
+  /**
+   * The collation is what makes a lookup case-insensitive, so losing it turns a working query into one that returns
+   * nothing. Asserted on behaviour, not only on the persisted attribute.
+   */
+  @Test
+  void copyTypeKeepsTheCaseInsensitiveCollation() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("k", Type.STRING);
+      database.command("sql", "CREATE INDEX ON Doc (k COLLATE CI) UNIQUE");
+    });
+    database.transaction(() -> database.newDocument("Doc").set("k", "Hello").save());
+
+    database.getSchema().copyType("Doc", "Doc2", LocalDocumentType.class, 1, 65_536, 1_000);
+
+    assertThat(indexOf("Doc2").getMetadata().collations).as("the copy must keep the collations of the original")//
+        .isEqualTo(List.of(IndexMetadata.COLLATION_CI));
+
+    try (final ResultSet rs = database.query("sql", "SELECT FROM Doc2 WHERE k = 'HELLO'")) {
+      assertThat(rs.hasNext()).as("the case-insensitive lookup must still match on the copy").isTrue();
+    }
+  }
+
+  /**
+   * The analyzer and the BM25 parameters live on the full-text wrapper, not on the LSM-Tree underneath it, so the
+   * carry-over has to read them from there. A copy that lost them tokenizes differently and ranks differently.
+   */
+  @Test
+  void copyTypeKeepsTheFullTextConfiguration() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("text", Type.STRING);
+      final TypeFullTextIndexBuilder builder = (TypeFullTextIndexBuilder) database.getSchema()//
+          .buildTypeIndex("Doc", new String[] { "text" }).withType(Schema.INDEX_TYPE.FULL_TEXT);
+      builder.withAnalyzer(ENGLISH_ANALYZER).withAllowLeadingWildcard(true).withDefaultOperator("AND")//
+          .withBM25(1.5f, 0.5f);
+      builder.create();
+    });
+    database.transaction(() -> database.newDocument("Doc").set("text", "the quick brown foxes").save());
+
+    database.getSchema().copyType("Doc", "Doc2", LocalDocumentType.class, 1, 65_536, 1_000);
+
+    final FullTextIndexMetadata copied = fullTextMetadataOf("Doc2");
+    assertThat(copied.getAnalyzerClass()).as("the copy must keep the analyzer of the original").isEqualTo(ENGLISH_ANALYZER);
+    assertThat(copied.isAllowLeadingWildcard()).isTrue();
+    assertThat(copied.getDefaultOperator()).isEqualTo("AND");
+    assertThat(copied.getBm25K1()).isEqualTo(1.5f);
+    assertThat(copied.getBm25B()).isEqualTo(0.5f);
+    assertThat(copied.getSimilarity()).isEqualTo(FullTextIndexMetadata.SIMILARITY_BM25);
+    // The English analyzer stems "foxes" to "fox": the record is findable through the stem only if the analyzer survived.
+    assertThat(indexOf("Doc2").get(new Object[] { "fox" }).hasNext()).isTrue();
+  }
+
+  /**
+   * The geohash resolution and the storage layout are plain fields on the geospatial wrapper. Losing the resolution
+   * changes the cell size the index is built with, silently.
+   */
+  @Test
+  void copyTypeKeepsTheGeospatialPrecision() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("Doc");
+      type.createProperty("name", Type.STRING);
+      type.createProperty("coords", Type.STRING);
+      final TypeIndexBuilder builder = database.getSchema().buildTypeIndex("Doc", new String[] { "coords" })//
+          .withType(Schema.INDEX_TYPE.GEOSPATIAL);
+      final GeoIndexMetadata metadata = new GeoIndexMetadata("Doc", new String[] { "coords" }, -1);
+      metadata.setPrecision(7);
+      builder.withMetadata(metadata);
+      builder.create();
+    });
+    database.transaction(//
+        () -> database.command("sql", "INSERT INTO Doc SET name = 'Rome', coords = 'POINT (12.5 41.9)'"));
+
+    database.getSchema().copyType("Doc", "Doc2", LocalDocumentType.class, 1, 65_536, 1_000);
+
+    final LSMTreeGeoIndex copied = (LSMTreeGeoIndex) subIndexOf("Doc2");
+    assertThat(copied.getPrecision()).as("the copy must keep the geohash precision of the original").isEqualTo(7);
+    assertThat(copied.getTokenization()).isEqualTo(GeoIndexMetadata.TOKENIZATION.FRONTIER);
+
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM Doc2 WHERE geo.intersects(coords,"
+        + " geo.geomFromText('POLYGON ((10 38, 16 38, 16 44, 10 44, 10 38))')) = true")) {
+      assertThat(rs.hasNext()).isTrue();
+    }
+  }
+
+  /**
+   * Without its dimensions and similarity a vector index is not merely differently tuned, it is unusable: the copy
+   * would come up with dimensions 0 and reject every write.
+   */
+  @Test
+  void copyTypeKeepsTheVectorConfiguration() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("embedding", Type.ARRAY_OF_FLOATS);
+      database.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA {dimensions: 4, similarity: 'EUCLIDEAN'}");
+    });
+    database.transaction(() -> database.newDocument("Doc").set("embedding", new float[] { 1f, 2f, 3f, 4f }).save());
+
+    database.getSchema().copyType("Doc", "Doc2", LocalDocumentType.class, 1, 65_536, 1_000);
+
+    final LSMVectorIndexMetadata copied = (LSMVectorIndexMetadata) indexOf("Doc2").getMetadataForNewFile();
+    assertThat(copied.dimensions).as("the copy must keep the dimensions of the original").isEqualTo(4);
+    assertThat(copied.similarityFunction).isEqualTo(VectorSimilarityFunction.EUCLIDEAN);
+  }
+
+  /**
+   * A user-supplied index name is unique across the schema and still belongs to the source type, so the copy takes the
+   * auto-derived form rather than colliding with it.
+   */
+  @Test
+  void copyTypeDoesNotReuseTheManualIndexName() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("k", Type.STRING);
+      database.command("sql", "CREATE INDEX myIndex ON Doc (k) UNIQUE");
+    });
+
+    database.getSchema().copyType("Doc", "Doc2", LocalDocumentType.class, 1, 65_536, 1_000);
+
+    assertThat(database.getSchema().existsIndex("myIndex")).isTrue();
+    assertThat(database.getSchema().getIndexByName("myIndex").getTypeName()).isEqualTo("Doc");
+    assertThat(database.getSchema().getType("Doc2").getAllIndexes(false).iterator().next().getName()).isEqualTo("Doc2[k]");
+  }
+
+  private IndexInternal indexOf(final String typeName) {
+    return (IndexInternal) database.getSchema().getType(typeName).getAllIndexes(false).iterator().next();
+  }
+
+  private IndexInternal subIndexOf(final String typeName) {
+    return ((TypeIndex) indexOf(typeName)).getSubIndexes().getFirst();
+  }
+
+  private FullTextIndexMetadata fullTextMetadataOf(final String typeName) {
+    return (FullTextIndexMetadata) ((LSMTreeFullTextIndex) subIndexOf(typeName)).getMetadataForNewFile();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue5723CopyTypeIndexConfigurationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue5723CopyTypeIndexConfigurationTest.java
@@ -223,6 +223,62 @@ class Issue5723CopyTypeIndexConfigurationTest extends TestHelper {
     assertThat(database.getSchema().getType("Doc2").getAllIndexes(false).iterator().next().getName()).isEqualTo("Doc2[k]");
   }
 
+  /**
+   * The conversion that motivates {@code copyType()} in the first place is document to vertex, and that goes through
+   * the other branch of the record-copy loop ({@code database.newVertex(...)}). Every other case here copies to a
+   * document type, so this one covers the branch the reported scenario actually takes.
+   */
+  @Test
+  void copyTypeToAVertexTypeKeepsTheDefinitionAndTheRecords() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("k", Type.STRING);
+      database.getSchema().buildTypeIndex("Doc", new String[] { "k" })//
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).withPageSize(16_384).create();
+    });
+    database.transaction(() -> database.newDocument("Doc").set("k", "v1").save());
+
+    database.getSchema().copyType("Doc", "Doc2", LocalVertexType.class, 1, 65_536, 1_000);
+
+    assertThat(database.getSchema().getType("Doc2")).isInstanceOf(LocalVertexType.class);
+
+    final IndexInternal copied = indexOf("Doc2");
+    assertThat(copied.getPageSize()).isEqualTo(16_384);
+    assertThat(copied.countEntries()).as("the vertex copy must be populated with the copied records").isEqualTo(1);
+
+    try (final ResultSet rs = database.query("sql", "SELECT k FROM Doc2 WHERE k = 'v1'")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("k")).as("the vertex copy must carry the record content").isEqualTo("v1");
+    }
+  }
+
+  /**
+   * {@code LSMVectorIndexMetadata.copy()} carried only the collations before this change and now goes through
+   * {@code copyCommonTo()}, which also carries the user-supplied index name. That reaches one caller outside
+   * {@code copyType()} - {@code TRUNCATE TYPE}, which drops and recreates the index from its own definition - so a
+   * manually named vector index now keeps its name across a truncate instead of reverting to the auto-derived form.
+   * Asserted here rather than left to be inferred.
+   */
+  @Test
+  void truncatingAManuallyNamedVectorIndexKeepsItsName() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("embedding", Type.ARRAY_OF_FLOATS);
+      database.command("sql", "CREATE INDEX myVectorIndex ON Doc (embedding) LSM_VECTOR"//
+          + " METADATA {dimensions: 4, similarity: 'EUCLIDEAN'}");
+    });
+    database.transaction(() -> database.newDocument("Doc").set("embedding", new float[] { 1f, 2f, 3f, 4f }).save());
+
+    assertThat(database.getSchema().existsIndex("myVectorIndex")).isTrue();
+
+    database.transaction(() -> database.command("sql", "TRUNCATE TYPE Doc"));
+
+    assertThat(database.getSchema().existsIndex("myVectorIndex")).as("the truncated index must keep its manual name")//
+        .isTrue();
+    final LSMVectorIndexMetadata metadata = (LSMVectorIndexMetadata) //
+        ((IndexInternal) database.getSchema().getIndexByName("myVectorIndex")).getMetadataForNewFile();
+    assertThat(metadata.dimensions).isEqualTo(4);
+    assertThat(metadata.similarityFunction).isEqualTo(VectorSimilarityFunction.EUCLIDEAN);
+  }
+
   private IndexInternal indexOf(final String typeName) {
     return (IndexInternal) database.getSchema().getType(typeName).getAllIndexes(false).iterator().next();
   }


### PR DESCRIPTION
Closes #5723.

The issue reports that `LocalSchema.copyType()` loses the page size of every index on the copy. It does. Writing the regression test for it surfaced two more defects in the same thirty lines, and they are the ones that make the copy **wrong** rather than differently tuned.

(The issue names `renameType()`. There is no such method: `ALTER TYPE ... NAME ...` goes through `LocalDocumentType.rename()`, which renames buckets in place and never recreates an index. The affected method is `copyType()`, which is what a document-to-vertex conversion goes through.)

## 1. Every index on the copy came out EMPTY

The indexes were created inside the transaction that copies the records. `TypeIndexBuilder.create()` builds each bucket's index in its own transaction (`joinCurrent=false`), which from inside an enclosing transaction neither sees the records still pending in it nor commits the entries it produces. So the copy carried indexes with zero entries, and any query the planner routed through one answered nothing - silently, since an empty index is indistinguishable from a type with no matching rows.

```java
schema.copyType("Doc", "Doc2", LocalVertexType.class, 1, 65_536, 1_000);
database.query("sql", "SELECT FROM Doc2 WHERE k = 'v1'");   // 0 rows, and the record is right there
```

Verified by experiment, not by reading: moving the loop back inside the transaction reproduces `entries=0` exactly.

## 2. The copied records were EMPTY

`ImmutableDocument.propertiesAsMap()` was the one accessor of that class that did not call `checkForLazyLoading()` - it returned `Collections.emptyMap()` whenever `buffer == null`, which is the state of every record handed out by `iterateType()` and `scanBucket()`. `copyType()` reads each source record that way, so it faithfully created the right *number* of records, each with no properties. The same silent emptiness hit a `DetachedDocument` built off a record straight from a scan.

It now loads first, like `get()`, `has()`, `getPropertyNames()`, `toMap()` and `toJSON()` already did. The empty map remains the answer only for a record that genuinely cannot be materialised (no database, no RID, or an after-read event that filtered it away), so the class's exception-propagation contract from #2560 is preserved - the two new entries in `ImmutableDocumentLazyLoadingInconsistencyTest`'s accessor list assert exactly that.

## 3. The reported one, wider than reported

The copy went through the three-argument `createTypeIndex` overload, so the index type, the uniqueness flag and the property list survived and **everything else** was replaced by a default: the tuned page size from the report, the null strategy, the collations that make a lookup case-insensitive, and the entire type-specific configuration. That last one is not a tuning difference - a copied `FULL_TEXT` index tokenized and ranked with the default analyzer, a copied `GEOSPATIAL` index dropped to the default geohash resolution, and a copied `LSM_VECTOR` index came up with `dimensions` 0.

## The better alternative to the suggested fix

The issue suggests passing `getPageSizeForNewFile()` through. That fixes one attribute of five and leaves a copied full-text or vector index broken, so the fix generalises the accessor instead of the call:

- **`IndexInternal.getMetadataForNewFile()`**, the companion of the `getPageSizeForNewFile()` that #5713 introduced. It exists because `getMetadata()` cannot answer this question for the wrapper index types: `LSMTreeFullTextIndex` keeps its analyzers and BM25 parameters in its own `FullTextIndexMetadata` and `LSMTreeGeoIndex` keeps its resolution and layout in plain fields, while both `getMetadata()`s delegate to the underlying LSM-Tree and hand back a definition with none of it.
- **`IndexMetadata.copy(typeName, propertyNames, bucketId)`** promoted from `LSMVectorIndexMetadata` to a polymorphic method with overrides on all four subclasses, plus a `final copyCommonTo()` for the shared fields. There is no second field list to keep in sync, which is the point. Per-index RUNTIME state deliberately does not ride along - the dense vector index's build state, the full-text corpus counters - because the new file starts empty and inherited statistics would describe a different set of records.

A user-supplied index name is the one attribute deliberately not carried over: it is unique across the schema and still belongs to the source type, so the copy takes the auto-derived `NewType[properties]` form rather than colliding with it.

## Deliberately out of scope

The other sites that rebuild an index from its own definition - `TruncateTypeStatement`, `DatabaseChecker` (CHECK DATABASE FIX), and both `LocalDocumentType` propagation paths - still read `getMetadata()` and so still lose a full-text or geospatial configuration. Each is a distinct user-visible operation that deserves its own regression test and its own blast radius, which is the same reasoning #5723 used to split itself off from #5717; a follow-up issue tracks them. `RebuildIndexStatement` is already correct - it reconstructs the typed metadata from the persisted JSON - and could now use the new accessor instead, but that is a refactor with no behaviour change.

## Tests

`Issue5723CopyTypeIndexConfigurationTest` (new, 8 cases): page size on `LSM_TREE` and on `HASH` (where the value goes back through the validating creation path #5713 added), null strategy, CI collation asserted through a case-insensitive lookup on the copy, full-text analyzer/BM25/operator asserted through an English-stem lookup, geospatial precision asserted through a spatial query, vector dimensions and similarity, and the manual-index-name non-collision. Plus `entries == 1` on the copy, which is what catches defect 1.

`ImmutableDocumentLazyLoadingInconsistencyTest`: `propertiesAsMap()` and `propertiesAsMap(fields)` added to the exception-propagation and happy-path accessor lists, and a new case asserting a record straight off `iterateType()` answers its properties.

Verified locally: `com.arcadedb.query.**` 10330 tests 0 failures, `com.arcadedb.database.**` 176 tests 0 failures, `com.arcadedb.schema.** + com.arcadedb.index.**` 942 tests with one unrelated timing flake (`LSMVectorIndexRecoveryTest#vectorNeighborsShouldReturnCorrectCountAfterIncrementalInsertAndRebuild`, an inactivity-rebuild deadline assertion, passes in isolation), `com.arcadedb.graph.** + com.arcadedb.serializer.**` 336 tests 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjD6rXVew2fQhhh8n44GAz