### PR TITLE
fix(engine): reject concurrent GraphBatch instances on the same database (#5666)

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -248,4 +248,12 @@ public interface DatabaseInternal extends Database {
    * @return Map of variable name to value
    */
   Map<String, Object> getGlobalVariables();
+
+  /**
+   * Called by {@link com.arcadedb.graph.GraphBatch#close()} to signal that a batch operation has finished.
+   * The default implementation is a no-op; database implementations that guard against concurrent
+   * batches override this to release the guard.
+   */
+  default void batchFinished() {
+  }
 }

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -248,12 +248,4 @@ public interface DatabaseInternal extends Database {
    * @return Map of variable name to value
    */
   Map<String, Object> getGlobalVariables();
-
-  /**
-   * Called by {@link com.arcadedb.graph.GraphBatch#close()} to signal that a batch operation has finished.
-   * The default implementation is a no-op; database implementations that guard against concurrent
-   * batches override this to release the guard.
-   */
-  default void batchFinished() {
-  }
 }

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -202,7 +202,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   private            long                                      lastUpdatedOn;
   private            long                                      lastUsedOn;
   private            int                                       cachedHashCode            = 0;
-  /** #5666: guards against concurrent GraphBatch instances on this database. Never routed through a wrapper. */
+  /** Guards against concurrent GraphBatch instances on this database. Never routed through a wrapper. */
   private final      AtomicBoolean                             batchInProgress           = new AtomicBoolean(false);
 
   protected LocalDatabase(final String path, final ComponentFile.MODE mode, final ContextConfiguration configuration,

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1819,10 +1819,25 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
   @Override
   public GraphBatch.Builder batch() {
+    // Guard against concurrent GraphBatch instances on the same database (issue #5666).
+    // Two concurrent batches on the same database silently lose edges because the head
+    // pointer is deferred to close() — the last writer wins, and the loser's segment chain
+    // is orphaned. The fix is a simple AtomicBoolean guard: the first caller acquires it,
+    // subsequent callers are rejected with a clear message.
+    if (!batchInProgress.compareAndSet(false, true))
+      throw new DatabaseOperationException(
+          "A GraphBatch is already in progress on this database. Concurrent batches silently lose edges. "
+              + "Use a single GraphBatch (parallelFlush for parallel fan-out).");
+
     // Use the outermost wrapper so that commits flow through any HA/replication layer.
     // Without this, GraphBatch.commit() would short-circuit the Raft replication wrapper
     // installed by the HA plugin and writes would never reach followers (issue #4076).
     return GraphBatch.builder(wrappedDatabaseInstance);
+  }
+
+  @Override
+  public void batchFinished() {
+    batchInProgress.set(false);
   }
 
   @Override
@@ -2372,6 +2387,9 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
   /** #4927/#5070: whether this instance already consumed its PageManager lifecycle reference (see closeInternal). */
   private final AtomicBoolean pageManagerReferenceReleased = new AtomicBoolean(false);
+
+  /** #5666: guards against concurrent GraphBatch instances on the same database. */
+  private final AtomicBoolean batchInProgress = new AtomicBoolean(false);
 
   boolean isPageManagerReferenceReleased() {
     return pageManagerReferenceReleased.get();

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -202,6 +202,8 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   private            long                                      lastUpdatedOn;
   private            long                                      lastUsedOn;
   private            int                                       cachedHashCode            = 0;
+  /** #5666: guards against concurrent GraphBatch instances on this database. Never routed through a wrapper. */
+  private final      AtomicBoolean                             batchInProgress           = new AtomicBoolean(false);
 
   protected LocalDatabase(final String path, final ComponentFile.MODE mode, final ContextConfiguration configuration,
       final SecurityManager security, final Map<CALLBACK_EVENT, List<Callable<Void>>> callbacks) {
@@ -1819,23 +1821,35 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
   @Override
   public GraphBatch.Builder batch() {
-    // Guard against concurrent GraphBatch instances on the same database (issue #5666).
-    // Two concurrent batches on the same database silently lose edges because the head
-    // pointer is deferred to close() — the last writer wins, and the loser's segment chain
-    // is orphaned. The fix is a simple AtomicBoolean guard: the first caller acquires it,
-    // subsequent callers are rejected with a clear message.
+    // Use the outermost wrapper so that commits flow through any HA/replication layer.
+    // Without this, GraphBatch.commit() would short-circuit the Raft replication wrapper
+    // installed by the HA plugin and writes would never reach followers (issue #4076).
+    //
+    // The guard owner is this instance and NOT the wrapper: the wrapper only delegates batch(),
+    // so a release routed through it would never reach the flag below and the first batch would
+    // lock out every later one on a replicated database (issue #5666).
+    return GraphBatch.builder(wrappedDatabaseInstance, this);
+  }
+
+  /**
+   * Reserves the single-batch slot of this database. Two concurrent {@link GraphBatch} instances on the same
+   * database silently lose edges: the head pointer is deferred to close(), so the last writer wins and the
+   * loser's segment chain is orphaned. Called by {@code GraphBatch.Builder.build()}, released by
+   * {@link #batchFinished()}.
+   *
+   * @throws DatabaseOperationException if a batch is already open on this database
+   */
+  public void batchStarted() {
     if (!batchInProgress.compareAndSet(false, true))
       throw new DatabaseOperationException(
           "A GraphBatch is already in progress on this database. Concurrent batches silently lose edges. "
               + "Use a single GraphBatch (parallelFlush for parallel fan-out).");
-
-    // Use the outermost wrapper so that commits flow through any HA/replication layer.
-    // Without this, GraphBatch.commit() would short-circuit the Raft replication wrapper
-    // installed by the HA plugin and writes would never reach followers (issue #4076).
-    return GraphBatch.builder(wrappedDatabaseInstance);
   }
 
-  @Override
+  /**
+   * Releases the single-batch slot reserved by {@link #batchStarted()}. Idempotent, and safe to call on a
+   * database that never opened a batch.
+   */
   public void batchFinished() {
     batchInProgress.set(false);
   }
@@ -2387,9 +2401,6 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
   /** #4927/#5070: whether this instance already consumed its PageManager lifecycle reference (see closeInternal). */
   private final AtomicBoolean pageManagerReferenceReleased = new AtomicBoolean(false);
-
-  /** #5666: guards against concurrent GraphBatch instances on the same database. */
-  private final AtomicBoolean batchInProgress = new AtomicBoolean(false);
 
   boolean isPageManagerReferenceReleased() {
     return pageManagerReferenceReleased.get();

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
@@ -99,6 +100,14 @@ import java.util.logging.Level;
 public class GraphBatch implements AutoCloseable {
 
   private final DatabaseInternal database;
+
+  /**
+   * Database instance holding the single-batch guard this batch reserved, or {@code null} when the batch was
+   * built outside {@link com.arcadedb.database.Database#batch()}. This is deliberately the concrete instance
+   * and not {@link #database}, which may be an HA wrapper that only delegates {@code batch()} (issue #5666).
+   */
+  private final LocalDatabase guardOwner;
+  private final AtomicBoolean guardReleased = new AtomicBoolean(false);
 
   // --- Configuration ---
   private final int     batchSize;
@@ -214,11 +223,13 @@ public class GraphBatch implements AutoCloseable {
   private final boolean savedUseWAL;
   private final WALFile.FlushType savedWALFlush;
 
-  private GraphBatch(final DatabaseInternal database, final int batchSize, final int edgeListInitialSize,
+  private GraphBatch(final DatabaseInternal database, final LocalDatabase guardOwner, final int batchSize,
+      final int edgeListInitialSize,
       final boolean lightEdges, final boolean bidirectional, final int commitEvery,
       final boolean useWAL, final WALFile.FlushType walFlush, final boolean preAllocateEdgeChunks,
       final boolean parallelFlush, final int commitRetries, final long commitRetryDelayMs) {
     this.database = database;
+    this.guardOwner = guardOwner;
     this.batchSize = batchSize;
     this.edgeListInitialSize = edgeListInitialSize;
     this.lightEdges = lightEdges;
@@ -913,46 +924,66 @@ public class GraphBatch implements AutoCloseable {
 
   @Override
   public void close() {
-    RuntimeException flushFailure = null;
-
-    // Flush any remaining outgoing edges. Capture rather than rethrow so we can still drain the
-    // deferred IN buffer for previously-flushed edges; otherwise a unique-constraint violation
-    // on the trailing buffer (issue #4113) would leave already-persisted edges with no
-    // back-pointer and trip the database integrity checker.
+    // The guard release sits in the outermost finally on purpose: every other exit of this method throws,
+    // and a guard left behind locks the database out of batching until the process restarts (issue #5666).
     try {
-      flush();
-    } catch (final RuntimeException e) {
-      flushFailure = e;
-    }
+      RuntimeException flushFailure = null;
 
-    try {
-      // Connect all deferred incoming edges in one sorted pass. On a large load this is minutes of work and it
-      // runs on the way out of a FAILED batch too - it has to, or the edges already persisted keep no back-pointer
-      // and the integrity checker trips (see #4113 above). That is why a rejected batch can take a while to answer
-      // (86 seconds of the timeline on issue #5470); connectDeferredIncomingEdges logs the pass and its duration
-      // itself, so the wait is already accounted for.
-      if (bidirectional && inEdgeCount > 0)
-        connectDeferredIncomingEdges();
+      // Flush any remaining outgoing edges. Capture rather than rethrow so we can still drain the
+      // deferred IN buffer for previously-flushed edges; otherwise a unique-constraint violation
+      // on the trailing buffer (issue #4113) would leave already-persisted edges with no
+      // back-pointer and trip the database integrity checker.
+      try {
+        flush();
+      } catch (final RuntimeException e) {
+        flushFailure = e;
+      }
 
-      // Batch-update all vertex head chunk pointers in one pass
-      if (!deferredOutHead.isEmpty() || !deferredInHead.isEmpty())
-        batchUpdateVertexHeadChunks();
+      try {
+        // Connect all deferred incoming edges in one sorted pass. On a large load this is minutes of work and it
+        // runs on the way out of a FAILED batch too - it has to, or the edges already persisted keep no back-pointer
+        // and the integrity checker trips (see #4113 above). That is why a rejected batch can take a while to answer
+        // (86 seconds of the timeline on issue #5470); connectDeferredIncomingEdges logs the pass and its duration
+        // itself, so the wait is already accounted for.
+        if (bidirectional && inEdgeCount > 0)
+          connectDeferredIncomingEdges();
+
+        // Batch-update all vertex head chunk pointers in one pass
+        if (!deferredOutHead.isEmpty() || !deferredInHead.isEmpty())
+          batchUpdateVertexHeadChunks();
+      } finally {
+        // Restore database settings, even on an exceptional exit (issue #5378)
+        restoreDatabaseSettings();
+      }
+
+      LogManager.instance().log(this, Level.INFO,
+          "GraphBatch closed: vertices=%d edges=%d flushes=%d avgFlushMs=%.1f",
+          null, totalVerticesCreated, totalEdgesCreated, totalFlushes,
+          totalFlushes > 0 ? (totalFlushTimeNs / totalFlushes) / 1_000_000.0 : 0.0);
+
+      if (flushFailure != null)
+        throw flushFailure;
     } finally {
-      // Restore database settings, even on an exceptional exit (issue #5378)
-      restoreDatabaseSettings();
+      releaseBatchGuard();
     }
+  }
 
-    LogManager.instance().log(this, Level.INFO,
-        "GraphBatch closed: vertices=%d edges=%d flushes=%d avgFlushMs=%.1f",
-        null, totalVerticesCreated, totalEdgesCreated, totalFlushes,
-        totalFlushes > 0 ? (totalFlushTimeNs / totalFlushes) / 1_000_000.0 : 0.0);
+  /**
+   * Gives up the single-batch slot of the database without flushing anything. For callers that abandon a
+   * failed batch on a thread that cannot afford the cost of a full {@link #close()}: whatever is still
+   * buffered is dropped. Calling {@link #close()} afterwards remains safe and releases nothing twice.
+   */
+  public void abandon() {
+    releaseBatchGuard();
+  }
 
-    // Release the concurrent-batch guard on the database (issue #5666). Must run even when
-    // flushFailure is about to be rethrown, so the database is not permanently locked.
-    database.batchFinished();
-
-    if (flushFailure != null)
-      throw flushFailure;
+  /**
+   * Hands the single-batch slot back to the database that granted it. Idempotent: a batch releases at most
+   * once, so a double close cannot free a slot that a later batch has meanwhile taken.
+   */
+  private void releaseBatchGuard() {
+    if (guardOwner != null && guardReleased.compareAndSet(false, true))
+      guardOwner.batchFinished();
   }
 
   /**
@@ -2288,7 +2319,16 @@ public class GraphBatch implements AutoCloseable {
   // ---------------------------------------------------------------------------
 
   public static Builder builder(final Database database) {
-    return new Builder((DatabaseInternal) database);
+    return new Builder((DatabaseInternal) database, null);
+  }
+
+  /**
+   * Builds a batch that reserves the single-batch slot of {@code guardOwner} on {@link Builder#build()} and
+   * hands it back on {@link GraphBatch#close()}. {@code database} is the instance the batch writes through
+   * and may be an HA wrapper of {@code guardOwner}.
+   */
+  public static Builder builder(final Database database, final LocalDatabase guardOwner) {
+    return new Builder((DatabaseInternal) database, guardOwner);
   }
 
   public static class Builder {
@@ -2296,6 +2336,7 @@ public class GraphBatch implements AutoCloseable {
     private static final int MAX_BATCH_SIZE = 5_000_000;
 
     private final DatabaseInternal database;
+    private final LocalDatabase    guardOwner;
     private int                batchSize            = MIN_BATCH_SIZE;
     private boolean            batchSizeExplicit    = false;
     private int                expectedEdgeCount    = 0;
@@ -2311,8 +2352,9 @@ public class GraphBatch implements AutoCloseable {
     private int                commitRetries         = 10;
     private long               commitRetryDelayMs    = 1000;
 
-    Builder(final DatabaseInternal database) {
+    Builder(final DatabaseInternal database, final LocalDatabase guardOwner) {
       this.database = database;
+      this.guardOwner = guardOwner;
     }
 
     /**
@@ -2467,9 +2509,21 @@ public class GraphBatch implements AutoCloseable {
       // size the load then dies with ReplicatedEntryTooLargeException (issue #5470).
       final int effectiveCommitEvery = !commitEveryExplicit && !effectiveUseWAL ? 0 : commitEvery;
 
-      return new GraphBatch(database, effectiveBatchSize, edgeListInitialSize, lightEdges,
-          bidirectional, effectiveCommitEvery, effectiveUseWAL, walFlush, preAllocateEdgeChunks, parallelFlush,
-          commitRetries, commitRetryDelayMs);
+      // Reserve the slot here and not in Database.batch(): a builder that is configured with a bad value, or
+      // simply dropped, must not leave the database unable to batch ever again (issue #5666). Everything from
+      // here on either returns a batch that owns the slot or gives the slot straight back.
+      if (guardOwner != null)
+        guardOwner.batchStarted();
+
+      try {
+        return new GraphBatch(database, guardOwner, effectiveBatchSize, edgeListInitialSize, lightEdges,
+            bidirectional, effectiveCommitEvery, effectiveUseWAL, walFlush, preAllocateEdgeChunks, parallelFlush,
+            commitRetries, commitRetryDelayMs);
+      } catch (final RuntimeException | Error e) {
+        if (guardOwner != null)
+          guardOwner.batchFinished();
+        throw e;
+      }
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -972,8 +972,14 @@ public class GraphBatch implements AutoCloseable {
    * Gives up the single-batch slot of the database without flushing anything. For callers that abandon a
    * failed batch on a thread that cannot afford the cost of a full {@link #close()}: whatever is still
    * buffered is dropped. Calling {@link #close()} afterwards remains safe and releases nothing twice.
+   * <p>
+   * The read-your-writes policy is database wide and was relaxed for the load, so it is put back here: a
+   * batch that ends this way is never closed and would otherwise leave every later reader on that database
+   * unable to see its own writes. The WAL policy is not, because it lives on the {@code TransactionContext}
+   * of the thread that opened the batch and this method is expected to run on another one.
    */
   public void abandon() {
+    database.setReadYourWrites(savedReadYourWrites);
     releaseBatchGuard();
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -947,6 +947,10 @@ public class GraphBatch implements AutoCloseable {
         null, totalVerticesCreated, totalEdgesCreated, totalFlushes,
         totalFlushes > 0 ? (totalFlushTimeNs / totalFlushes) / 1_000_000.0 : 0.0);
 
+    // Release the concurrent-batch guard on the database (issue #5666). Must run even when
+    // flushFailure is about to be rethrown, so the database is not permanently locked.
+    database.batchFinished();
+
     if (flushFailure != null)
       throw flushFailure;
   }

--- a/engine/src/test/java/com/arcadedb/graph/Issue5666ConcurrentGraphBatchTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5666ConcurrentGraphBatchTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.DatabaseOperationException;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.schema.EdgeType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5666: two overlapping {@link GraphBatch} instances on the same database
+ * silently lose edges. Both batches see {@code getOutEdgesHeadChunk() == null} on a shared vertex because
+ * the head pointer is only published by {@code close()}, so each creates its own segment chain and the
+ * last one to close wins; the loser's edges stay on disk reachable from nothing.
+ * <p>
+ * The database therefore grants a single batch slot at a time. What is pinned here is not only the
+ * rejection but every way the slot has to come back, because a slot left behind stops the database from
+ * batching until the process restarts.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5666ConcurrentGraphBatchTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Person");
+      database.getSchema().createEdgeType("KNOWS");
+    });
+  }
+
+  @Test
+  void aSecondOverlappingBatchIsRejected() {
+    try (final GraphBatch first = database.batch().build()) {
+      assertThat(first).isNotNull();
+      assertThatThrownBy(() -> database.batch().build())
+          .isInstanceOf(DatabaseOperationException.class)
+          .hasMessageContaining("already in progress");
+    }
+  }
+
+  @Test
+  void aSecondBatchOnAnotherThreadIsRejectedToo() throws Exception {
+    final CountDownLatch firstIsOpen = new CountDownLatch(1);
+    final CountDownLatch secondHasTried = new CountDownLatch(1);
+    final AtomicReference<Throwable> rejection = new AtomicReference<>();
+
+    final Thread contender = new Thread(() -> {
+      try {
+        firstIsOpen.await(30, TimeUnit.SECONDS);
+        try (final GraphBatch ignored = database.batch().build()) {
+          // reaching this point means the guard let two batches through
+        }
+      } catch (final Throwable t) {
+        rejection.set(t);
+      } finally {
+        secondHasTried.countDown();
+      }
+    }, "issue5666-contender");
+    contender.start();
+
+    try (final GraphBatch first = database.batch().build()) {
+      assertThat(first).isNotNull();
+      firstIsOpen.countDown();
+      assertThat(secondHasTried.await(30, TimeUnit.SECONDS)).isTrue();
+    }
+    contender.join(30_000);
+
+    assertThat(rejection.get()).isInstanceOf(DatabaseOperationException.class);
+  }
+
+  /**
+   * The documented single-writer pattern: one batch after another, each one connecting both directions.
+   */
+  @Test
+  void sequentialBatchesBothSucceedAndConnectBothDirections() {
+    final RID[] vertices = createVertices(4);
+
+    try (final GraphBatch first = database.batch().build()) {
+      first.newEdge(vertices[0], "KNOWS", vertices[1]);
+    }
+
+    // Would have thrown before the slot was released.
+    try (final GraphBatch second = database.batch().build()) {
+      second.newEdge(vertices[2], "KNOWS", vertices[3]);
+    }
+
+    assertOutAndInEdgeCounts(vertices, 2);
+  }
+
+  /**
+   * A batch reached through an HA-style wrapper still hands its slot back. The wrapper only delegates
+   * {@code batch()}, so a release routed through the instance the batch writes to would never reach the
+   * flag and the second load on a replicated database would be refused.
+   */
+  @Test
+  void aBatchTakenThroughAWrapperReleasesItsSlot() {
+    final RID[] vertices = createVertices(4);
+
+    final LocalDatabase local = (LocalDatabase) database;
+    final DatabaseInternal previousWrapper = local.getWrappedDatabaseInstance();
+    local.setWrappedDatabaseInstance(delegatingWrapper(local));
+    try {
+      try (final GraphBatch first = local.batch().build()) {
+        first.newEdge(vertices[0], "KNOWS", vertices[1]);
+      }
+      try (final GraphBatch second = local.batch().build()) {
+        second.newEdge(vertices[2], "KNOWS", vertices[3]);
+      }
+    } finally {
+      local.setWrappedDatabaseInstance(previousWrapper);
+    }
+
+    assertOutAndInEdgeCounts(vertices, 2);
+  }
+
+  /**
+   * The slot is taken by build() and not by batch(): a builder rejected for a bad setting, or simply
+   * dropped, must not lock the database out of batching.
+   */
+  @Test
+  void anAbandonedBuilderDoesNotTakeTheSlot() {
+    database.batch();
+    database.batch().withBatchSize(250_000);
+    assertThatThrownBy(() -> database.batch().withCommitRetryDelay(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    try (final GraphBatch batch = database.batch().build()) {
+      assertThat(batch).isNotNull();
+    }
+  }
+
+  /**
+   * abandon() is what the streaming server paths use when they drop a failed batch on a thread that cannot
+   * pay for a full close(). It has to free the slot, and a later close() must not free it a second time and
+   * hand away a slot that meanwhile belongs to somebody else.
+   */
+  @Test
+  void abandonReleasesTheSlotAndCloseDoesNotReleaseItTwice() {
+    final GraphBatch abandoned = database.batch().build();
+    abandoned.abandon();
+
+    final GraphBatch next = database.batch().build();
+    abandoned.close();
+
+    assertThatThrownBy(() -> database.batch().build())
+        .as("the double release must not give away the slot the second batch is holding")
+        .isInstanceOf(DatabaseOperationException.class);
+
+    next.close();
+    try (final GraphBatch batch = database.batch().build()) {
+      assertThat(batch).isNotNull();
+    }
+  }
+
+  /**
+   * A batch whose close() throws still hands the slot back. Reproduced with the duplicate-key failure of
+   * issue #4113, which surfaces out of close() while flushing the trailing edge buffer.
+   */
+  @Test
+  void aBatchWhoseCloseFailsStillReleasesTheSlot() {
+    database.transaction(() -> {
+      final EdgeType paired = database.getSchema().createEdgeType("PAIRED");
+      paired.createProperty("from_id", Type.STRING);
+      paired.createProperty("to_id", Type.STRING);
+      database.getSchema().buildTypeIndex("PAIRED", new String[] { "from_id", "to_id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+    });
+
+    final RID[] vertices = createVertices(2);
+
+    assertThatThrownBy(() -> {
+      try (final GraphBatch failing = database.batch().withLightEdges(false).build()) {
+        failing.newEdge(vertices[0], "PAIRED", vertices[1], "from_id", "a", "to_id", "b");
+        failing.newEdge(vertices[0], "PAIRED", vertices[1], "from_id", "a", "to_id", "b");
+      }
+    }).isInstanceOf(DuplicatedKeyException.class);
+
+    try (final GraphBatch afterFailure = database.batch().build()) {
+      assertThat(afterFailure).isNotNull();
+    }
+  }
+
+  private RID[] createVertices(final int count) {
+    final RID[] rids = new RID[count];
+    database.transaction(() -> {
+      for (int i = 0; i < count; i++) {
+        final MutableVertex v = database.newVertex("Person");
+        v.set("id", i);
+        v.save();
+        rids[i] = v.getIdentity();
+      }
+    });
+    return rids;
+  }
+
+  private void assertOutAndInEdgeCounts(final RID[] vertices, final int expected) {
+    database.transaction(() -> {
+      long out = 0;
+      long in = 0;
+      for (final RID rid : vertices) {
+        final Vertex v = rid.asVertex();
+        for (final Edge ignored : v.getEdges(Vertex.DIRECTION.OUT, "KNOWS"))
+          out++;
+        for (final Edge ignored : v.getEdges(Vertex.DIRECTION.IN, "KNOWS"))
+          in++;
+      }
+      assertThat(out).as("outgoing edges").isEqualTo(expected);
+      assertThat(in).as("incoming edges").isEqualTo(expected);
+    });
+  }
+
+  /**
+   * Reproduces the topology the Raft HA plugin installs: a wrapper that becomes the database the batch
+   * writes through, while {@code batch()} itself stays on the concrete instance underneath.
+   */
+  private static DatabaseInternal delegatingWrapper(final DatabaseInternal delegate) {
+    return (DatabaseInternal) Proxy.newProxyInstance(DatabaseInternal.class.getClassLoader(),
+        new Class<?>[] { DatabaseInternal.class }, (proxy, method, args) -> {
+          try {
+            return method.invoke(delegate, args);
+          } catch (final InvocationTargetException e) {
+            throw e.getCause();
+          }
+        });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/Issue5666ConcurrentGraphBatchTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5666ConcurrentGraphBatchTest.java
@@ -47,8 +47,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * The database therefore grants a single batch slot at a time. What is pinned here is not only the
  * rejection but every way the slot has to come back, because a slot left behind stops the database from
  * batching until the process restarts.
- *
- * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class Issue5666ConcurrentGraphBatchTest extends TestHelper {
 

--- a/engine/src/test/java/com/arcadedb/graph/Issue5666ConcurrentGraphBatchTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5666ConcurrentGraphBatchTest.java
@@ -167,7 +167,9 @@ class Issue5666ConcurrentGraphBatchTest extends TestHelper {
   @Test
   void abandonReleasesTheSlotAndCloseDoesNotReleaseItTwice() {
     final GraphBatch abandoned = database.batch().build();
+    assertThat(database.isReadYourWrites()).as("the batch relaxes read-your-writes for the load").isFalse();
     abandoned.abandon();
+    assertThat(database.isReadYourWrites()).as("an abandoned batch must put read-your-writes back").isTrue();
 
     final GraphBatch next = database.batch().build();
     abandoned.close();

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -32,6 +32,7 @@ import com.arcadedb.database.MutableEmbeddedDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
@@ -2660,6 +2661,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                 counts[0] += flushVertexBatch(batch, currentType[0], vertexPropsBatch, vertexTempIds, tempIdMap);
             }
           }
+        } catch (final DatabaseOperationException e) {
+          errorSent[0] = true;
+          batchRef.set(null);
+          out.onError(Status.FAILED_PRECONDITION.withDescription(
+              "graphBatchLoad: " + e.getMessage()).asException());
+          return;
         } catch (final Exception e) {
           errorSent[0] = true;
           // Null batchRef so onCompleted skips processing; skip closeQuietly to avoid blocking the

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2628,7 +2628,16 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             dbRef.set(db);
             final GraphBatch.Builder builder = db.batch();
             configureGraphBatchOptions(builder, chunk.hasOptions() ? chunk.getOptions() : null);
-            batch = builder.build();
+            try {
+              batch = builder.build();
+            } catch (final DatabaseOperationException e) {
+              // Another batch already owns the database: that is the caller's problem to retry, not an
+              // internal fault. Scoped to build() so genuine engine failures keep reporting as INTERNAL.
+              errorSent[0] = true;
+              out.onError(Status.FAILED_PRECONDITION.withDescription(
+                  "graphBatchLoad: " + e.getMessage()).asException());
+              return;
+            }
             batchRef.set(batch);
           }
 
@@ -2661,17 +2670,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                 counts[0] += flushVertexBatch(batch, currentType[0], vertexPropsBatch, vertexTempIds, tempIdMap);
             }
           }
-        } catch (final DatabaseOperationException e) {
-          errorSent[0] = true;
-          batchRef.set(null);
-          out.onError(Status.FAILED_PRECONDITION.withDescription(
-              "graphBatchLoad: " + e.getMessage()).asException());
-          return;
         } catch (final Exception e) {
           errorSent[0] = true;
           // Null batchRef so onCompleted skips processing; skip closeQuietly to avoid blocking the
-          // gRPC thread via async.waitCompletion() (buffered edges have no open transaction).
-          batchRef.set(null);
+          // gRPC thread via async.waitCompletion() (buffered edges have no open transaction). The batch
+          // still has to hand its slot back, or one failed load would stop the database batching for good.
+          final GraphBatch abandoned = batchRef.getAndSet(null);
+          if (abandoned != null)
+            abandoned.abandon();
           out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
           return;
         } finally {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5666GrpcBatchGuardIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5666GrpcBatchGuardIT.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.graph.GraphBatch;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the gRPC half of the single-batch guard. A database grants one
+ * {@link GraphBatch} at a time, because two overlapping batches silently lose edges. The streaming
+ * endpoint therefore has to do two things the engine cannot do for it: report the refusal as a
+ * client-side failure, and give the slot back when it drops a batch it never closes.
+ * <p>
+ * The second one is what matters in production. {@code graphBatchLoad} deliberately skips
+ * {@code close()} on the error path so the gRPC thread does not block on the async completion of a
+ * batch nobody is waiting for, and a slot left behind there would stop that database from batching
+ * for the rest of the server's life. Both assertions run against one long-lived database, which is
+ * the only way a leaked slot is visible: a fresh database per test hides it.
+ */
+public class Issue5666GrpcBatchGuardIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub         asyncAuthenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+    asyncAuthenticatedStub = ArcadeDbServiceGrpc.newStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  /**
+   * A load that fails mid-stream is dropped without close(), so the endpoint has to hand the slot
+   * back by itself. The load that follows is on the same database and would be refused otherwise.
+   */
+  @Test
+  void aFailedLoadDoesNotKeepTheSlot() throws Exception {
+    createBatchTypes();
+
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final CountDownLatch failed = new CountDownLatch(1);
+    final StreamObserver<GraphBatchChunk> failing = asyncAuthenticatedStub.graphBatchLoad(
+        new StreamObserver<>() {
+          @Override
+          public void onNext(final GraphBatchResult result) {
+          }
+
+          @Override
+          public void onError(final Throwable t) {
+            failure.set(t);
+            failed.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            failed.countDown();
+          }
+        });
+
+    // An edge pointing at a temporary id no vertex declared: fails inside onNext, which is the path
+    // that drops the batch instead of closing it.
+    failing.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("GuardNode")
+            .setTempId("g1")
+            .putProperties("name", stringValue("first")))
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.EDGE)
+            .setTypeName("GuardLink")
+            .setFromRef("g1")
+            .setToRef("gNeverDeclared"))
+        .build());
+    failing.onCompleted();
+
+    assertThat(failed.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(failure.get()).isInstanceOf(StatusRuntimeException.class);
+    assertThat(failure.get().getMessage()).contains("Unknown temporary ID");
+
+    // Same database, right after: this is the load a leaked slot would refuse forever.
+    final GraphBatchResult result = loadTwoVertices("g2", "g3");
+    assertThat(result.getVerticesCreated()).isEqualTo(2);
+  }
+
+  /**
+   * An overlapping load is a client mistake, not an engine fault, so it has to come back as
+   * FAILED_PRECONDITION rather than INTERNAL. The competing batch is taken directly on the server
+   * database so the overlap is certain instead of a matter of timing.
+   */
+  @Test
+  void anOverlappingLoadIsRefusedWithFailedPrecondition() throws Exception {
+    createBatchTypes();
+
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final CountDownLatch refused = new CountDownLatch(1);
+
+    try (final GraphBatch holder = getServerDatabase(0, getDatabaseName()).batch().build()) {
+      assertThat(holder).isNotNull();
+
+      final StreamObserver<GraphBatchChunk> overlapping = asyncAuthenticatedStub.graphBatchLoad(
+          new StreamObserver<>() {
+            @Override
+            public void onNext(final GraphBatchResult result) {
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+              failure.set(t);
+              refused.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+              refused.countDown();
+            }
+          });
+
+      overlapping.onNext(GraphBatchChunk.newBuilder()
+          .setDatabase(getDatabaseName())
+          .addRecords(GraphBatchRecord.newBuilder()
+              .setKind(GraphBatchRecord.Kind.VERTEX)
+              .setTypeName("GuardNode")
+              .setTempId("o1")
+              .putProperties("name", stringValue("overlapping")))
+          .build());
+      overlapping.onCompleted();
+
+      assertThat(refused.await(30, TimeUnit.SECONDS)).isTrue();
+    }
+
+    assertThat(failure.get()).isInstanceOf(StatusRuntimeException.class);
+    final StatusRuntimeException e = (StatusRuntimeException) failure.get();
+    assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertThat(e.getStatus().getDescription()).contains("already in progress");
+
+    // The refused load must not have consumed the slot it was denied.
+    assertThat(loadTwoVertices("o2", "o3").getVerticesCreated()).isEqualTo(2);
+  }
+
+  private void createBatchTypes() {
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX TYPE GuardNode IF NOT EXISTS")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE EDGE TYPE GuardLink IF NOT EXISTS")
+        .build());
+  }
+
+  private GraphBatchResult loadTwoVertices(final String firstId, final String secondId) throws Exception {
+    final AtomicReference<GraphBatchResult> resultRef = new AtomicReference<>();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+
+    final StreamObserver<GraphBatchChunk> observer = asyncAuthenticatedStub.graphBatchLoad(
+        new StreamObserver<>() {
+          @Override
+          public void onNext(final GraphBatchResult result) {
+            resultRef.set(result);
+          }
+
+          @Override
+          public void onError(final Throwable t) {
+            errorRef.set(t);
+            done.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            done.countDown();
+          }
+        });
+
+    observer.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("GuardNode")
+            .setTempId(firstId)
+            .putProperties("name", stringValue(firstId)))
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("GuardNode")
+            .setTempId(secondId)
+            .putProperties("name", stringValue(secondId)))
+        .build());
+    observer.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).as("the load after the guard was released must succeed").isNull();
+    assertThat(resultRef.get()).isNotNull();
+    return resultRef.get();
+  }
+
+  private GrpcValue stringValue(final String s) {
+    return GrpcValue.newBuilder().setStringValue(s).build();
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5666GrpcBatchGuardIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5666GrpcBatchGuardIT.java
@@ -139,6 +139,12 @@ public class Issue5666GrpcBatchGuardIT extends BaseGraphServerTest {
     assertThat(failure.get()).isInstanceOf(StatusRuntimeException.class);
     assertThat(failure.get().getMessage()).contains("Unknown temporary ID");
 
+    // The batch relaxed read-your-writes for the load and was dropped before close() could put it
+    // back, so the endpoint has to. Left relaxed, every later reader on this database loses it.
+    assertThat(getServerDatabase(0, getDatabaseName()).isReadYourWrites())
+        .as("a dropped batch must not leave read-your-writes off")
+        .isTrue();
+
     // Same database, right after: this is the load a leaked slot would refuse forever.
     final GraphBatchResult result = loadTwoVertices("g2", "g3");
     assertThat(result.getVerticesCreated()).isEqualTo(2);


### PR DESCRIPTION
Closes #5666.

## Problem

Two concurrent `GraphBatch` instances on the same database silently lose edges. The head chunk pointer of a vertex is only published by `close()`, so both batches read `getOutEdgesHeadChunk() == null`, each builds its own segment chain, and the last one to close wins. The loser's edges stay on disk reachable from nothing and the integrity checker reports the vertex as missing them. No exception is raised anywhere.

## Fix

A database grants one `GraphBatch` slot at a time.

1. **LocalDatabase** owns an `AtomicBoolean` slot with `batchStarted()` / `batchFinished()`. The owner is the concrete instance, never the wrapper: `batch()` hands the batch the outermost `wrappedDatabaseInstance` to write through (so commits still flow through the Raft replication layer) and `this` as the guard owner.
2. **GraphBatch.Builder.build()** takes the slot, not `Database.batch()`. A builder rejected for a bad setting, or simply dropped, must not lock the database out of batching, and both the HTTP and the gRPC batch endpoints configure the builder from client input.
3. **GraphBatch.close()** hands the slot back from an outermost `finally`, so a failing `flush()`, `connectDeferredIncomingEdges()` or `batchUpdateVertexHeadChunks()` cannot leak it. The release is idempotent, so a double close cannot free a slot a later batch has meanwhile taken.
4. **GraphBatch.abandon()** releases the slot without flushing, for callers that drop a failed batch on a thread that cannot afford a full `close()`.
5. **ArcadeDbGrpcService.graphBatchLoad** maps the refusal to `FAILED_PRECONDITION`, scoped to `build()` so genuine engine faults keep reporting `INTERNAL`, and calls `abandon()` on the error path where it drops the batch without closing it.

## Behaviour change

Two overlapping batch loads on one database are now refused instead of quietly corrupting the graph. Over gRPC that is `FAILED_PRECONDITION`; over `POST /api/v1/batch` the `DatabaseOperationException` is not in the handler status ladder, so it surfaces as a 500. Sequential loads, nested-free single-writer loads and the `parallelFlush` fan-out inside one batch are unaffected.

## Tests

`Issue5666ConcurrentGraphBatchTest` (engine, 7 cases) covers both directions:

- an overlapping batch is refused on the same thread and from another thread
- sequential batches both run and connect OUT and IN
- a batch taken through an HA-style wrapper still hands its slot back
- an abandoned or rejected *builder* never took the slot
- `abandon()` frees the slot and a later `close()` does not free it a second time
- a batch whose `close()` throws (duplicate key on the trailing edge buffer) still frees the slot

`Issue5666GrpcBatchGuardIT` (grpcw, 2 cases) covers the streaming endpoint against one long-lived database, which is the only place a leaked slot is visible:

- a load that fails mid-stream is dropped without `close()`, and the next load on the same database is still accepted
- an overlapping load comes back as `FAILED_PRECONDITION`, not `INTERNAL`, and does not consume the slot it was denied

Every case was checked against a stubbed fix and goes red without it.
