### PR TITLE
fix(engine) #5720: a script that hits RETURN or BREAK releases every line before it

### DIFF
--- a/docs/5720-script-return-break-close-plans.md
+++ b/docs/5720-script-return-break-close-plans.md
@@ -64,5 +64,25 @@ stub plans:
 
 All three fail against the old `close()` (nothing is released, so the recording list is empty).
 
-Regression check: `SQLScriptLargeBatchTest`, `ScriptLineStepCloseTest`, and the SQL script/batch test classes
-in `engine`.
+Regression check: `mvn -pl engine test -Dtest='com.arcadedb.query.sql.**'` - 2345 tests, 0 failures, covering
+`SQLScriptTest`, `BatchTest`, `SQLScriptLargeBatchTest`, `ScriptLineStepCloseTest` and
+`IfStatementExecutionTest`.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5738
+
+### Review cycles
+
+- cycle 1 - `5c49345` - initial fix, test, and this document. The `claude-review` workflow run
+  (30721189108) stayed queued for over 45 minutes without a runner being assigned, so no bot review landed on
+  this head. No review feedback was received, and nothing was changed in response.
+
+### Deferred items
+
+None - no review comments were received to defer.
+
+### Final state
+
+`timeout` - the automated review loop exited without a bot review on the head commit. The change itself is
+verified by the tests above; the review is still owned by the developer.

--- a/docs/5720-script-return-break-close-plans.md
+++ b/docs/5720-script-return-break-close-plans.md
@@ -1,0 +1,68 @@
+# #5720 - a script that hits RETURN or BREAK never closes the plans of the statements before it
+
+## Problem
+
+`ScriptExecutionPlan.close()` was a single call:
+
+```java
+public void close() {
+  lastStep.close();
+}
+```
+
+That relies on `lastStep` being the tail of the `prev` chain built by `chain()`, so that closing it cascades
+over every `ScriptLineStep` and releases the per-statement `InternalExecutionPlan` each one holds.
+
+`executeUntilReturn()` and `doExecute()` break that assumption. On the RETURN path `lastStep` becomes the
+`ReturnStep` that `ScriptLineStep.executeUntilReturn()` builds; on the BREAK path it becomes a fresh
+`BreakStep`. Neither constructor calls `setPrevious(...)` and neither class overrides `close()`, so
+`AbstractExecutionStep.close()` finds `prev == null` and returns immediately. Every script line executed
+before the RETURN/BREAK, and every plan it holds, was dropped without `close()`.
+
+## Impact
+
+A resource-release gap, not a crash: result sets, index cursors and iterators held by the per-statement plans
+were left to the garbage collector instead of being released deterministically. It scales with the number of
+statements that ran before the RETURN/BREAK.
+
+## Root cause
+
+`lastStep` is an execution cursor, not an ownership handle. Ownership of the per-statement plans lives in the
+`steps` list, which `chain()` also links through `prev`. Closing the tail of `steps` is therefore the only
+entry point that releases everything, and it is the one the old code did not use once `lastStep` had been
+swapped.
+
+## Fix
+
+`ScriptExecutionPlan.close()` now closes the tail of `steps` instead of `lastStep`. The walk stays iterative:
+`ScriptLineStep.close()` (from #5709) consumes the run of script lines in a loop, so a large batch that
+returns early does not push one frame per statement.
+
+`lastStep` is deliberately not closed separately:
+
+- on the normal path it *is* `steps.getLast()`, already released by the chain walk;
+- on the RETURN/BREAK paths it is a `ReturnStep` or a `BreakStep`, which hold no resources of their own
+  (`ReturnStep` holds a statement, `BreakStep` holds nothing) - closing them is a no-op;
+- when it is a step borrowed from a nested plan (an inner `ScriptExecutionPlan`/`IfExecutionPlan` returns its
+  own last step), that nested plan is itself held by one of this plan's script lines, so the chain walk
+  already releases it. Closing it again here would double-close the inner chain.
+
+`setSteps()` has no caller, so `chain()` is the only writer of `steps` and the list tail is always the chain
+tail.
+
+## Verification
+
+New `ScriptExecutionPlanCloseTest` (engine, unit lane), driving `ScriptExecutionPlan` directly over recording
+stub plans:
+
+- `aScriptThatReturnsEarlyStillReleasesEveryLineBeforeIt` - RETURN in the middle of the script; every
+  recording line is released, tail to head.
+- `aScriptThatBreaksStillReleasesEveryLineBeforeIt` - same for the BREAK path.
+- `closingALargeScriptThatReturnedEarlyDoesNotOverflowTheStack` - 20,000 lines closed on a thread built with
+  an explicit 1 MB stack, so the verdict does not depend on the CI JVM's `-Xss`. Pins the iterative walk that
+  #5709 introduced.
+
+All three fail against the old `close()` (nothing is released, so the recording list is empty).
+
+Regression check: `SQLScriptLargeBatchTest`, `ScriptLineStepCloseTest`, and the SQL script/batch test classes
+in `engine`.

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScriptExecutionPlan.java
@@ -56,9 +56,24 @@ public class ScriptExecutionPlan implements InternalExecutionPlan {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * The script lines are chained through {@code prev} by {@link #chain}, so releasing the tail of
+   * {@link #steps} cascades over every line and the per-statement plan each one holds. {@code lastStep} is an
+   * execution cursor, not an ownership handle: {@link #executeUntilReturn()} and {@link #doExecute} swap it
+   * for a {@link ReturnStep} or a {@link BreakStep} that is not part of the chain, so closing it would
+   * release nothing.
+   * <p>
+   * Nothing is closed through {@code lastStep} on purpose. On the normal path it is already the tail of
+   * {@link #steps}; on the RETURN/BREAK paths it holds no resources of its own; and when it is the last step
+   * of a nested plan, that plan is held by one of these script lines and is released by the walk below, so
+   * closing it here would close the nested chain twice.
+   * <p>
+   * The walk in {@link ScriptLineStep#close()} is iterative, which keeps a large batch off the stack.
+   */
   @Override
   public void close() {
-    lastStep.close();
+    if (!steps.isEmpty())
+      steps.getLast().close();
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionPlanCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionPlanCloseTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.query.sql.parser.BreakStatement;
+import com.arcadedb.query.sql.parser.ReturnStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A script that hits a RETURN or a BREAK swaps the plan's {@code lastStep} for a step outside the chain of
+ * script lines. Releasing the plan must still release every line that ran before it, and must do so
+ * iteratively so a large batch does not blow the stack.
+ */
+public class ScriptExecutionPlanCloseTest {
+  private static final int LINES = 20_000;
+
+  /** Minimal per-statement plan that records its own release and can stand in for a BREAK. */
+  private static class RecordingPlan implements InternalExecutionPlan {
+    private final String       name;
+    private final List<String> closed;
+    private final boolean      breaks;
+
+    RecordingPlan(final String name, final List<String> closed, final boolean breaks) {
+      this.name = name;
+      this.closed = closed;
+      this.breaks = breaks;
+    }
+
+    @Override
+    public void close() {
+      closed.add(name);
+    }
+
+    @Override
+    public ResultSet fetchNext(final int n) {
+      return breaks ? BreakStatement.BREAK_RESULTSET : new InternalResultSet();
+    }
+
+    @Override
+    public void reset(final CommandContext context) {
+    }
+
+    @Override
+    public boolean canBeCached() {
+      return false;
+    }
+
+    @Override
+    public List<ExecutionStep> getSteps() {
+      return List.of();
+    }
+
+    @Override
+    public String prettyPrint(final int depth, final int indent) {
+      return name;
+    }
+
+    @Override
+    public Result toResult() {
+      return null;
+    }
+  }
+
+  @Test
+  void aScriptThatReturnsEarlyStillReleasesEveryLineBeforeIt() {
+    final CommandContext context = new BasicCommandContext();
+    final List<String> closed = new ArrayList<>();
+
+    final ScriptExecutionPlan plan = new ScriptExecutionPlan(context);
+    plan.chain(new RecordingPlan("line0", closed, false));
+    plan.chain(new SingleOpExecutionPlan(context, new ReturnStatement(-1)));
+    plan.chain(new RecordingPlan("line2", closed, false));
+
+    assertThat(plan.executeUntilReturn()).isInstanceOf(ReturnStep.class);
+
+    plan.close();
+
+    assertThat(closed).containsExactly("line2", "line0");
+  }
+
+  @Test
+  void aScriptThatBreaksStillReleasesEveryLineBeforeIt() {
+    final CommandContext context = new BasicCommandContext();
+    final List<String> closed = new ArrayList<>();
+
+    final ScriptExecutionPlan plan = new ScriptExecutionPlan(context);
+    plan.chain(new RecordingPlan("line0", closed, false));
+    plan.chain(new RecordingPlan("line1", closed, true));
+    plan.chain(new RecordingPlan("line2", closed, false));
+
+    assertThat(plan.executeUntilReturn()).isInstanceOf(BreakStep.class);
+
+    plan.close();
+
+    assertThat(closed).containsExactly("line2", "line1", "line0");
+  }
+
+  /**
+   * The chain of script lines is as long as the user's batch, so the release walk has to stay iterative: an
+   * explicit 1 MB stack keeps the verdict independent of the JVM's default {@code -Xss}.
+   */
+  @Test
+  void closingALargeScriptThatReturnedEarlyDoesNotOverflowTheStack() throws InterruptedException {
+    final CommandContext context = new BasicCommandContext();
+    final List<String> closed = new ArrayList<>();
+
+    final ScriptExecutionPlan plan = new ScriptExecutionPlan(context);
+    plan.chain(new SingleOpExecutionPlan(context, new ReturnStatement(-1)));
+    for (int i = 0; i < LINES; i++)
+      plan.chain(new RecordingPlan("line" + i, closed, false));
+
+    assertThat(plan.executeUntilReturn()).isInstanceOf(ReturnStep.class);
+
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread runner = new Thread(null, () -> {
+      try {
+        plan.close();
+      } catch (final Throwable t) {
+        failure.set(t);
+      }
+    }, "script-return-close", 1024 * 1024);
+
+    runner.start();
+    runner.join();
+
+    assertThat(failure.get()).isNull();
+    assertThat(closed).hasSize(LINES);
+  }
+}


### PR DESCRIPTION
Closes #5720

`ScriptExecutionPlan.close()` was `lastStep.close()`, which releases the whole script only while `lastStep` is the tail of the `prev` chain that `chain()` builds. `executeUntilReturn()` and `doExecute()` swap it for the `ReturnStep` that `ScriptLineStep.executeUntilReturn()` creates, or for a fresh `BreakStep`. Neither constructor calls `setPrevious(...)` and neither class overrides `close()`, so `AbstractExecutionStep.close()` found `prev == null` and returned immediately: every script line executed before the RETURN/BREAK, and the per-statement `InternalExecutionPlan` each one holds, was dropped without `close()`. That is a resource-release gap (result sets, index cursors, iterators left to the GC) which scales with the number of statements that ran before the RETURN. `close()` now releases the tail of the `steps` list, which is what actually owns those plans; `lastStep` is deliberately not closed separately, because on the normal path it already is that tail, on the RETURN/BREAK paths it holds no resources of its own, and when it is a step borrowed from a nested plan that plan is released by the same walk. The walk in `ScriptLineStep.close()` (from #5709) is iterative, so a large batch that returns early does not push one frame per statement.

## Test plan

- [ ] `ScriptExecutionPlanCloseTest.aScriptThatReturnsEarlyStillReleasesEveryLineBeforeIt` - a RETURN in the middle of the script; every recording line is released, tail to head
- [ ] `ScriptExecutionPlanCloseTest.aScriptThatBreaksStillReleasesEveryLineBeforeIt` - same for the BREAK path
- [ ] `ScriptExecutionPlanCloseTest.closingALargeScriptThatReturnedEarlyDoesNotOverflowTheStack` - 20,000 lines closed on a thread built with an explicit 1 MB stack, so the verdict does not depend on the CI JVM's `-Xss`; pins the iterative walk introduced by #5709
- [ ] All three fail against the old `close()` (nothing is released, so the recording list comes back empty) - verified before applying the fix
- [ ] Regression: `mvn -pl engine test -Dtest='com.arcadedb.query.sql.**'` - 2345 tests, 0 failures, including `SQLScriptTest`, `BatchTest`, `SQLScriptLargeBatchTest`, `ScriptLineStepCloseTest`, `IfStatementExecutionTest`