### PR TITLE
fix(engine) #5675: CREATE INDEX IF NOT EXISTS answers for the index asked for, not for any index on those properties

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1660,3 +1660,66 @@ An index that already exists on disk is unaffected either way - the page size is
 a builder.
 
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.2...26.8.1
+
+## `CREATE INDEX IF NOT EXISTS` no longer reports success for an index that is not the one asked for
+
+`IF NOT EXISTS` matched a pre-existing index on the indexed property set alone. The property set is what the index
+name is derived from, and it says nothing about what the index does, so a `NOTUNIQUE` index answered "already there"
+to a request for a `UNIQUE` one:
+
+```sql
+CREATE INDEX ON T (Scalar) NOTUNIQUE;
+CREATE INDEX IF NOT EXISTS ON T (Scalar) UNIQUE;   -- reported success, created no constraint
+INSERT INTO T SET Scalar = 'x';
+INSERT INTO T SET Scalar = 'x';                    -- accepted
+```
+
+Schema-migration DDL uses `IF NOT EXISTS` precisely so it can be re-applied, so tightening an index from `NOTUNIQUE`
+to `UNIQUE` did nothing while the application carried on believing a uniqueness constraint protected its data. Issue
+#5675. The same statement without the guard reported the clash, which is what made the guard the thing suppressing an
+error the server already knew how to raise.
+
+`IF NOT EXISTS` is now satisfied only when the existing index provides what was asked for: the same index kind, and a
+uniqueness constraint at least as strong.
+
+- A `UNIQUE` index still satisfies a `NOTUNIQUE` request. It indexes exactly the same keys, so the statement stays the
+  no-op it was, and it is never weakened into a plain index.
+- A `NOTUNIQUE` index no longer satisfies a `UNIQUE` request. The statement is refused, naming both definitions.
+- An index of a different KIND on the same properties - a `FULL_TEXT` index where a range index was asked for, or the
+  reverse - is refused for the same reason. That one was silent too.
+
+### An existing index is never dropped implicitly any more
+
+The refusal is the answer even in the case the request could technically be granted by rebuilding. Underneath,
+`TypeIndexBuilder.create()` with `withIgnoreIfExists(true)` used to drop the existing index and rebuild it with the
+requested definition. That is not a recoverable operation: if the rebuild then fails on the data already stored - two
+records sharing the key the new index has to keep unique - the type is left with **no index at all** and an error. On
+an index the type only inherited it took away the parent type's index instead, which is issue #4083.
+
+So `withIgnoreIfExists` now means only what it says. Callers that genuinely mean "make this the definition" opt in
+explicitly:
+
+```java
+database.getSchema().buildTypeIndex("T", new String[] { "Scalar" })
+    .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true)
+    .withReplaceIfIncompatible(true)     // new: may take away the plain index on those properties
+    .create();
+```
+
+and even then the replacement is undone if the new index cannot be built, so a failed upgrade costs an error rather
+than an index. An inherited index is still never replaced.
+
+### Cypher: a uniqueness constraint over a plain index still upgrades it
+
+`CREATE CONSTRAINT ... REQUIRE ... IS UNIQUE` and `... IS NODE KEY` are statements about the data rather than requests
+to create an index if one is missing, so they are the callers that opt into the replacement above. Neo4j keeps the
+range index and the constraint as two separate objects; ArcadeDB has one index per property set and a unique index
+covers both roles, so the upgrade is the equivalent end state and a Neo4j migration script that creates indexes and
+then constraints keeps working. Cypher's own `CREATE INDEX` does not opt in: it finds a unique index sufficient and
+leaves it alone rather than replacing it with a plain one.
+
+### A manual index name that already names a different index
+
+Reachable only through `CREATE INDEX <name> IF NOT EXISTS ...`, since the auto-derived name is built from the property
+list. A name that already belongs to an index on other properties used to satisfy the guard; it is now reported, since
+two different property sets under one name are two different indexes.

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1723,3 +1723,15 @@ leaves it alone rather than replacing it with a plain one.
 Reachable only through `CREATE INDEX <name> IF NOT EXISTS ...`, since the auto-derived name is built from the property
 list. A name that already belongs to an index on other properties used to satisfy the guard; it is now reported, since
 two different property sets under one name are two different indexes.
+
+### The index kind is now read before the existing-index lookup
+
+`TypeIndexBuilder.create()` validates `indexType` at the top, because deciding whether the index already on those
+properties covers the request needs to know what the request is. One embedded-API shape changes as a result: a builder
+with **no** `withType(...)` and `withIgnoreIfExists(true)` used to hand back the existing index on those properties,
+and now raises `DatabaseMetadataException` the way it always did when no index was there. Every in-tree caller sets the
+type; a get-or-create helper that relied on omitting it has to pass the type it expects.
+
+A failed replacement restores the page size along with the rest of the definition, via `getPageSizeForNewFile()` - the
+same accessor a rebuild uses, so a page size the current file carries but creation would refuse cannot turn the restore
+into a second failure (#5713).

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1735,3 +1735,17 @@ type; a get-or-create helper that relied on omitting it has to pass the type it 
 A failed replacement restores the page size along with the rest of the definition, via `getPageSizeForNewFile()` - the
 same accessor a rebuild uses, so a page size the current file carries but creation would refuse cannot turn the restore
 into a second failure (#5713).
+
+### Embedded API: `getOrCreateTypeIndex` no longer upgrades an incompatible index
+
+`LocalSchema.getOrCreateTypeIndex(...)` sets `withIgnoreIfExists(true)`, so it inherits the change above: asked for a
+`UNIQUE` index where a `NOTUNIQUE` one already covers those properties, it used to drop and rebuild, and now raises
+`IllegalArgumentException` naming both definitions. That is the point of the fix - the rebuild is what could leave the
+type with no index - but embedded callers using it as an "ensure this index" helper across a schema change are the ones
+who will meet the new exception. Either drop the old index explicitly, or build through
+`buildTypeIndex(...).withReplaceIfIncompatible(true)` if replacing it really is what you mean.
+
+The replacement restores the previous definition on failure, including a manual index name (carried on the index
+metadata, the same route `CREATE INDEX <name>` uses) and the page size. It is not atomic, though: the drop and the
+build are separate schema changes, so a process that dies between them leaves the type without an index on those
+properties until one is created again. Only an explicit `withReplaceIfIncompatible` is exposed to that window.

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -1736,7 +1736,10 @@ A failed replacement restores the page size along with the rest of the definitio
 same accessor a rebuild uses, so a page size the current file carries but creation would refuse cannot turn the restore
 into a second failure (#5713).
 
-### Embedded API: `getOrCreateTypeIndex` no longer upgrades an incompatible index
+### BREAKING: `getOrCreateTypeIndex` no longer upgrades an incompatible index
+
+This one surfaces at runtime rather than at compile time, so it is the change embedded callers are most likely to meet
+without warning.
 
 `LocalSchema.getOrCreateTypeIndex(...)` sets `withIgnoreIfExists(true)`, so it inherits the change above: asked for a
 `UNIQUE` index where a `NOTUNIQUE` one already covers those properties, it used to drop and rebuild, and now raises

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -506,6 +506,10 @@ public class OpenCypherQueryEngine implements QueryEngine {
       b.withType(Schema.INDEX_TYPE.LSM_TREE);
       b.withUnique(true);
       b.withIgnoreIfExists(ddl.isIfNotExists());
+      // A constraint says what the data must satisfy, so a plain index already on the property is upgraded rather than
+      // reported as being in the way. Neo4j keeps the range index and the constraint as two objects; ArcadeDB has one
+      // index per property set, and a unique one indexes the same keys, so this is the equivalent end state (#5675).
+      b.withReplaceIfIncompatible(true);
       if (anyUndeclared)
         b.withDefaultKeyTypesForUndeclaredProperties(defaultKeyTypes);
       b.create();
@@ -541,6 +545,9 @@ public class OpenCypherQueryEngine implements QueryEngine {
       b.withType(Schema.INDEX_TYPE.LSM_TREE);
       b.withUnique(true);
       b.withIgnoreIfExists(ddl.isIfNotExists());
+      // Same reasoning as the UNIQUE arm above: NODE KEY is a constraint, so it upgrades a plain index on the same
+      // properties instead of colliding with it.
+      b.withReplaceIfIncompatible(true);
       if (anyUndeclared)
         b.withDefaultKeyTypesForUndeclaredProperties(defaultKeyTypes);
       b.create();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -33,6 +33,7 @@ import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.IndexBuilder;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.TypeFullTextIndexBuilder;
 import com.arcadedb.schema.TypeGeoIndexBuilder;
@@ -166,6 +167,24 @@ public class CreateIndexStatement extends DDLStatement {
 
     if (database.getSchema().existsIndex(name.getValue())) {
       if (ifNotExists) {
+        // The name this matched on is derived from the indexed property set alone, so it says nothing about what the
+        // index actually does. Answering "already exists" on the name only meant a NOTUNIQUE index reported success to
+        // a request for a UNIQUE one, and the migration that asked for the constraint carried on without it (#5675).
+        final Index existing = database.getSchema().getIndexByName(name.getValue());
+        final List<String> requestedProperties = List.of(fields);
+
+        // Reachable only through a manual index name: the auto-derived form above is built from the property list, so
+        // a name match implies a property match. Two different property sets under one name are two different indexes.
+        if (!existing.getPropertyNames().equals(requestedProperties))
+          throw new IllegalArgumentException(
+              "Cannot create the index '" + name.getValue() + "' on type '" + typeName.getStringValue() + "' properties "
+                  + requestedProperties + " because an index with that name already exists on type '" + existing.getTypeName()
+                  + "' properties " + existing.getPropertyNames() + ". Drop it first or choose a different index name");
+
+        if (!IndexBuilder.satisfiesRequest(existing, indexType, unique))
+          throw IndexBuilder.conflictWithExistingIndex(existing, indexType, unique, typeName.getStringValue(),
+              requestedProperties);
+
         final InternalResultSet rs = new InternalResultSet();
         final ResultInternal result = new ResultInternal(context.getDatabase());
         result.setProperty("operation", "create index");

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -173,9 +173,12 @@ public class CreateIndexStatement extends DDLStatement {
         final Index existing = database.getSchema().getIndexByName(name.getValue());
         final List<String> requestedProperties = List.of(fields);
 
-        // Reachable only through a manual index name: the auto-derived form above is built from the property list, so
-        // a name match implies a property match. Two different property sets under one name are two different indexes.
-        if (!existing.getPropertyNames().equals(requestedProperties))
+        // Reachable only through a manual index name: the auto-derived form above is built from the type name and the
+        // property list, so a name match implies both already match. Index names are global, so a manual one can name
+        // an index on ANOTHER type, or on other properties of this one - either way it is a different index, and
+        // answering "already exists" would leave the requested one uncreated with nothing said about why.
+        if (!existing.getTypeName().equals(typeName.getStringValue())
+            || !existing.getPropertyNames().equals(requestedProperties))
           throw new IllegalArgumentException(
               "Cannot create the index '" + name.getValue() + "' on type '" + typeName.getStringValue() + "' properties "
                   + requestedProperties + " because an index with that name already exists on type '" + existing.getTypeName()

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -87,8 +87,10 @@ public abstract class IndexBuilder<T extends Index> {
    * is about - and reporting success there is what let a schema migration proceed believing a uniqueness constraint
    * protected its data (issue #5675).
    * <p>
-   * The null strategy is deliberately not part of this: unlike the kind and the uniqueness it can be changed on the
-   * index in place, so a mismatch is not a reason to refuse the statement.
+   * The null strategy is deliberately not part of this: unlike the kind and the uniqueness it is not structural - it
+   * is settable on an existing index through {@code ALTER} - so a mismatch is not a reason to refuse the statement.
+   * Note that a satisfied request stays a plain no-op: the requested strategy is NOT applied to the existing index,
+   * which is what {@code IF NOT EXISTS} asks for.
    */
   public static boolean satisfiesRequest(final Index existing, final Schema.INDEX_TYPE requestedType,
       final boolean requestedUnique) {

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -22,6 +22,8 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 
+import java.util.List;
+
 /**
  * Builder class for index types.
  *
@@ -44,15 +46,22 @@ public abstract class IndexBuilder<T extends Index> {
   final Class<? extends Index> indexImplementation;
   Schema.INDEX_TYPE                  indexType;
   boolean                            unique;
-  int                                pageSize       = PAGE_SIZE_UNSET;
-  LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy   = LSMTreeIndexAbstract.NULL_STRATEGY.SKIP;
+  int                                pageSize              = PAGE_SIZE_UNSET;
+  LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy          = LSMTreeIndexAbstract.NULL_STRATEGY.SKIP;
   Index.BuildIndexCallback           callback;
-  boolean                            ignoreIfExists = false;
-  String                             indexName      = null;
-  String                             filePath       = null;
+  boolean                            ignoreIfExists        = false;
+  /**
+   * Explicit permission to take away an index that does not provide what was asked for - see
+   * {@link #withReplaceIfIncompatible(boolean)}. Kept separate from {@link #ignoreIfExists} on purpose: "I can live
+   * with what is there" and "replace what is there" are different intents, and conflating them is what made a guarded
+   * {@code CREATE INDEX} silently rebuild an index the caller only meant to skip (issue #5675).
+   */
+  boolean                            replaceIfIncompatible = false;
+  String                             indexName             = null;
+  String                             filePath              = null;
   Type[]                             keyTypes;
-  int                                batchSize      = BUILD_BATCH_SIZE;
-  int                                maxAttempts    = 1;
+  int                                batchSize             = BUILD_BATCH_SIZE;
+  int                                maxAttempts           = 1;
   /**
    * The one and only metadata slot of the builder hierarchy. {@link TypeIndexBuilder} used to declare a field of the
    * same name, which SHADOWED this one: {@code withMetadata()} wrote here while {@code create()} read there, so every
@@ -65,6 +74,59 @@ public abstract class IndexBuilder<T extends Index> {
   protected IndexBuilder(final DatabaseInternal database, final Class<? extends Index> indexImplementation) {
     this.database = database;
     this.indexImplementation = indexImplementation;
+  }
+
+  /**
+   * Answers whether {@code existing} already provides everything the caller asked for, which is the only thing that
+   * makes an {@code IF NOT EXISTS} / {@link #withIgnoreIfExists(boolean)} request a legitimate no-op.
+   * <p>
+   * The kind of index has to match: a {@code FULL_TEXT} index on a property is not a range index on it, so answering
+   * success to a request for the other one leaves the caller with something it cannot use. Uniqueness is directional
+   * instead: a {@code UNIQUE} index indexes exactly the keys a {@code NOTUNIQUE} one would, so it covers a
+   * {@code NOTUNIQUE} request, while a {@code NOTUNIQUE} index does not carry the constraint a {@code UNIQUE} request
+   * is about - and reporting success there is what let a schema migration proceed believing a uniqueness constraint
+   * protected its data (issue #5675).
+   * <p>
+   * The null strategy is deliberately not part of this: unlike the kind and the uniqueness it can be changed on the
+   * index in place, so a mismatch is not a reason to refuse the statement.
+   */
+  public static boolean satisfiesRequest(final Index existing, final Schema.INDEX_TYPE requestedType,
+      final boolean requestedUnique) {
+    if (existing.getType() != requestedType)
+      return false;
+    return existing.isUnique() || !requestedUnique;
+  }
+
+  /**
+   * Builds the error reported when an index on the same properties exists but {@link #satisfiesRequest} rejected it.
+   * <p>
+   * Refusing is the answer in every case, including the one the request could technically be granted by rebuilding:
+   * dropping the existing index to recreate it with the requested definition is not recoverable if the rebuild then
+   * fails on the data already stored - the type is left with no index at all - and on an inherited index it silently
+   * takes away the parent type's index (issue #4083). An explicit {@code DROP INDEX} is one statement away and leaves
+   * the operator in control of when the index disappears.
+   * <p>
+   * {@link IllegalArgumentException} on purpose: the HTTP layer maps it to a 400, which is what a schema request the
+   * server can read but cannot honour is.
+   */
+  public static IllegalArgumentException conflictWithExistingIndex(final Index existing,
+      final Schema.INDEX_TYPE requestedType, final boolean requestedUnique, final String requestedTypeName,
+      final List<String> requestedProperties) {
+    final boolean inherited = !existing.getTypeName().equals(requestedTypeName);
+    return new IllegalArgumentException(
+        "Cannot create the index on type '" + requestedTypeName + "' properties " + requestedProperties + " as "
+            + describeDefinition(requestedType, requestedUnique) + " because the index '" + existing.getName()
+            + "' already exists on " + (inherited ? "the parent type '" + existing.getTypeName() + "' and " : "")
+            + "the same properties as " + describeDefinition(existing.getType(), existing.isUnique())
+            + (inherited ?
+            ". Drop the parent index or align the definition: it is not replaced implicitly because that would take "
+                + "the index away from the parent type" :
+            ". Drop the existing index first: it is not replaced implicitly because a rebuild that the stored data "
+                + "cannot satisfy would leave the type with no index at all"));
+  }
+
+  private static String describeDefinition(final Schema.INDEX_TYPE indexType, final boolean unique) {
+    return indexType + " (unique=" + unique + ")";
   }
 
   public abstract T create();
@@ -95,6 +157,26 @@ public abstract class IndexBuilder<T extends Index> {
 
   public IndexBuilder<T> withIgnoreIfExists(final boolean ignoreIfExists) {
     this.ignoreIfExists = ignoreIfExists;
+    return this;
+  }
+
+  /**
+   * Allows the index already defined on the same properties to be replaced when it does not provide what this builder
+   * asks for - see {@link #satisfiesRequest}. Without it such a request is refused, because a rebuild the stored data
+   * cannot satisfy would leave the type with no index at all.
+   * <p>
+   * Only for callers whose statement genuinely means "make this the definition", not merely "create it if missing":
+   * the Cypher {@code CREATE CONSTRAINT ... IS UNIQUE} over a property that already carries a plain index is the one
+   * in the engine today. Neo4j keeps the range index and the constraint as two separate objects there; ArcadeDB has a
+   * single index per property set, and a unique one indexes exactly the same keys, so upgrading it is the equivalent
+   * end state.
+   * <p>
+   * An index the type only INHERITS is never replaced even with this set - taking it away would silently remove the
+   * parent type's index (issue #4083). The replacement is also undone if the new index cannot be built, so a failed
+   * upgrade leaves the previous definition in place.
+   */
+  public IndexBuilder<T> withReplaceIfIncompatible(final boolean replaceIfIncompatible) {
+    this.replaceIfIncompatible = replaceIfIncompatible;
     return this;
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -91,6 +91,14 @@ public abstract class IndexBuilder<T extends Index> {
    * is settable on an existing index through {@code ALTER} - so a mismatch is not a reason to refuse the statement.
    * Note that a satisfied request stays a plain no-op: the requested strategy is NOT applied to the existing index,
    * which is what {@code IF NOT EXISTS} asks for.
+   * <p>
+   * <b>Not compared either: the settings an index type keeps of its own</b> - vector {@code dimensions}, full-text
+   * analyzers, geospatial precision, collations. Two same-kind indexes configured differently still satisfy each other
+   * here, so a guarded {@code CREATE INDEX ... LSM_VECTOR} over an existing vector index with other dimensions stays a
+   * no-op. That is the same shape of surprise as issue #5675 one level down, and it is left open on purpose: those
+   * settings live in per-index-type {@link IndexMetadata} subclasses with no common notion of "provides at least what
+   * was asked for" (is a 768-dimension index acceptable to a request for 384? is a stricter analyzer?), and answering
+   * it needs a per-type rule rather than the structural comparison above.
    */
   public static boolean satisfiesRequest(final Index existing, final Schema.INDEX_TYPE requestedType,
       final boolean requestedUnique) {

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -29,6 +29,7 @@ import com.arcadedb.index.IndexException;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.index.lsm.LSMTreeIndexBulkLoader;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.security.SecurityDatabaseUser;
@@ -186,6 +187,12 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   public TypeIndex create() {
     database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
 
+    // Checked before the existing-index lookup below, which needs the requested index type to decide whether an index
+    // already on those properties covers the request.
+    if (indexType == null)
+      throw new DatabaseMetadataException(
+          "Cannot create index on type '" + metadata.typeName + "' because indexType was not specified");
+
     // Wait for any running async tasks (e.g., compaction) to complete before creating new index
     // This prevents NeedRetryException when creating multiple indexes sequentially on large datasets
     while (database.isAsyncProcessing())
@@ -202,49 +209,40 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     final LocalSchema schema = database.getSchema().getEmbedded();
 
     final LocalDocumentType type = schema.getType(metadata.typeName);
-    // First try the type's own index (no hierarchy walk). If found, we may legitimately drop and
-    // recreate it when the user requested a different uniqueness / null strategy via IF NOT EXISTS.
-    // If not found locally, fall back to the polymorphic walk to detect inherited indexes - those
-    // we never drop (that would silently delete the parent type's index and leave an orphan entry
-    // in the schema JSON, which is the user-reported follow-up to issue #4083 where Studio's
-    // refresh later complains "index Investigacion[cuij] could not be created").
+    // First try the type's own index (no hierarchy walk), then fall back to the polymorphic walk so an index the type
+    // only inherits is found too. Either way the outcome below is the same: it is used to answer the request, never
+    // to make room for it.
     TypeIndex existingTypeIndex = type.getIndexByProperties(metadata.propertyNames);
-    final boolean existingIsInherited;
-    if (existingTypeIndex != null) {
-      existingIsInherited = false;
-    } else {
+    if (existingTypeIndex == null)
       existingTypeIndex = type.getPolymorphicIndexByProperties(metadata.propertyNames);
-      existingIsInherited = existingTypeIndex != null;
-    }
+
+    // Non-null only on the replacement path below: the definition to put back if the new index cannot be built.
+    ReplacedIndexDefinition replaced = null;
 
     if (existingTypeIndex != null) {
-      if (ignoreIfExists) {
-        if (existingTypeIndex.getNullStrategy() != null && existingTypeIndex.getNullStrategy() == null ||//
-            existingTypeIndex.isUnique() != unique) {
-          if (existingIsInherited) {
-            // Different index type/uniqueness on an INHERITED index. Dropping it would wipe the
-            // parent type's index. Treat as a hard schema conflict instead of silently destroying
-            // the parent's index (issue #4083 follow-up).
-            throw new IllegalArgumentException(
-                "Cannot create index on type '" + metadata.typeName + "' for properties '"
-                    + Arrays.asList(metadata.propertyNames) + "' (unique=" + unique + ") because parent type '"
-                    + existingTypeIndex.getTypeName() + "' already declares an index '" + existingTypeIndex.getName()
-                    + "' with unique=" + existingTypeIndex.isUnique()
-                    + ". Drop the parent index first or align the unique flag");
-          }
-          // DIFFERENT BUT OWN: DROP AND RECREATE IT
-          existingTypeIndex.drop();
-        } else
-          return existingTypeIndex;
-      } else
+      // "Ignore if exists" means the caller can live with what is already there - but only when what is already there
+      // provides what was asked for. A mismatch used to DROP the existing index and rebuild it with the requested
+      // definition: on an inherited index that wiped the parent type's index and left an orphan entry in the schema
+      // JSON (issue #4083), and on the type's own index it threw away a working index for a rebuild the stored data
+      // may not even allow, leaving the type with none at all (issue #5675). Only an explicit
+      // {@link #withReplaceIfIncompatible} takes an index away now, and it puts it back on failure.
+      final boolean satisfied = satisfiesRequest(existingTypeIndex, indexType, unique);
+
+      if (satisfied && ignoreIfExists)
+        return existingTypeIndex;
+
+      if (!satisfied && replaceIfIncompatible && existingTypeIndex.getTypeName().equals(metadata.typeName))
+        // Own index, and the caller explicitly asked to replace what does not fit. Recorded here and dropped further
+        // down, once everything that could still refuse the request has had its say.
+        replaced = ReplacedIndexDefinition.of(existingTypeIndex);
+      else if (!satisfied && (ignoreIfExists || replaceIfIncompatible))
+        throw conflictWithExistingIndex(existingTypeIndex, indexType, unique, metadata.typeName, metadata.propertyNames);
+      else
         throw new IllegalArgumentException(
             "Found the existent index '" + existingTypeIndex.getName() + "' defined on the properties '" + Arrays.asList(
                 metadata.propertyNames) + "' for type '" + metadata.typeName + "'");
     }
 
-    if (indexType == null)
-      throw new DatabaseMetadataException(
-          "Cannot create index on type '" + metadata.typeName + "' because indexType was not specified");
     if (metadata.propertyNames.isEmpty())
       throw new DatabaseMetadataException(
           "Cannot create index on type '" + metadata.typeName + "' because there are no property defined");
@@ -359,6 +357,12 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     if (sortedBuild)
       validateSortedBuildPreconditions();
 
+    // Last thing before the build: everything above can still refuse the request (an undeclared property, a BY ITEM on
+    // a non-LIST, a sorted build on a replicated database), and none of those refusals may cost the caller the index it
+    // already had.
+    if (replaced != null)
+      existingTypeIndex.drop();
+
     final TypeIndex created;
     try {
       final long recordFileChangesStarted = System.nanoTime();
@@ -402,11 +406,13 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
       if (cleanupIndexes(schema, indexes, e)
           && (recoveryMarker[0] == null || recoveryMarker[0].baselineRestored(database)))
         clearRecoveryMarker(recoveryMarker[0], e);
+      restoreReplacedIndex(replaced, e);
       throw e;
     } catch (final Throwable e) {
       if (cleanupIndexes(schema, indexes, e)
           && (recoveryMarker[0] == null || recoveryMarker[0].baselineRestored(database)))
         clearRecoveryMarker(recoveryMarker[0], e);
+      restoreReplacedIndex(replaced, e);
       // Carry the root cause into the message: this exception is what the SQL/HTTP layers report back, and
       // without the reason a configuration mistake (a missing vector 'dimensions', an incompatible property
       // type, ...) reaches the user as a bare "Error on creating index" with nowhere to go (issue #5607).
@@ -437,6 +443,52 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     }
 
     return created;
+  }
+
+  /**
+   * The definition of an index dropped to make room for a replacement, kept so it can be rebuilt if the replacement
+   * fails. Enough to reproduce it: the kind, the uniqueness, the null strategy, the properties, and the metadata that
+   * carries the collations plus whatever settings the index type keeps of its own (analyzers, geospatial precision,
+   * vector dimensions, ...).
+   */
+  private record ReplacedIndexDefinition(Schema.INDEX_TYPE indexType, boolean unique,
+                                         LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, String typeName,
+                                         String[] propertyNames, IndexMetadata metadata) {
+
+    static ReplacedIndexDefinition of(final TypeIndex index) {
+      final IndexInternal[] onBuckets = index.getIndexesOnBuckets();
+      return new ReplacedIndexDefinition(index.getType(), index.isUnique(), index.getNullStrategy(), index.getTypeName(),
+          index.getPropertyNames().toArray(new String[0]), onBuckets.length > 0 ? onBuckets[0].getMetadata() : null);
+    }
+  }
+
+  /**
+   * Puts back the index that {@link #withReplaceIfIncompatible(boolean)} took away, so a replacement the stored data
+   * could not satisfy - the reason the implicit rebuild was removed in the first place (issue #5675) - costs the caller
+   * an error instead of an index.
+   * <p>
+   * A failure to restore is attached to the original error rather than raised: what the caller has to act on is why the
+   * new index could not be built, and hiding that behind the second failure would leave them with neither answer.
+   */
+  private void restoreReplacedIndex(final ReplacedIndexDefinition replaced, final Throwable failure) {
+    if (replaced == null)
+      return;
+
+    try {
+      final TypeIndexBuilder restore = database.getSchema().getEmbedded()
+          .buildTypeIndex(replaced.typeName(), replaced.propertyNames()).withType(replaced.indexType());
+      restore.withUnique(replaced.unique());
+      restore.withNullStrategy(replaced.nullStrategy());
+      if (replaced.metadata() != null)
+        restore.withMetadata(replaced.metadata());
+      restore.create();
+    } catch (final Throwable restoreError) {
+      failure.addSuppressed(restoreError);
+      LogManager.instance().log(this, Level.SEVERE,
+          "Cannot restore the index on type '%s' properties %s that was replaced by a failed CREATE INDEX. The type is "
+              + "left without an index on those properties", restoreError, replaced.typeName(),
+          Arrays.asList(replaced.propertyNames()));
+    }
   }
 
   protected Index createBucketIndex(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -447,18 +447,30 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
   /**
    * The definition of an index dropped to make room for a replacement, kept so it can be rebuilt if the replacement
-   * fails. Enough to reproduce it: the kind, the uniqueness, the null strategy, the properties, and the metadata that
-   * carries the collations plus whatever settings the index type keeps of its own (analyzers, geospatial precision,
-   * vector dimensions, ...).
+   * fails. Enough to reproduce it: the kind, the uniqueness, the null strategy, the page size, the properties, and the
+   * metadata that carries the collations plus whatever settings the index type keeps of its own (analyzers,
+   * geospatial precision, vector dimensions, ...).
    */
   private record ReplacedIndexDefinition(Schema.INDEX_TYPE indexType, boolean unique,
-                                         LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, String typeName,
+                                         LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, int pageSize, String typeName,
                                          String[] propertyNames, IndexMetadata metadata) {
 
     static ReplacedIndexDefinition of(final TypeIndex index) {
       final IndexInternal[] onBuckets = index.getIndexesOnBuckets();
-      return new ReplacedIndexDefinition(index.getType(), index.isUnique(), index.getNullStrategy(), index.getTypeName(),
-          index.getPropertyNames().toArray(new String[0]), onBuckets.length > 0 ? onBuckets[0].getMetadata() : null);
+
+      // Templated off a BUCKET-level metadata rather than built fresh, deliberately: only its concrete subclass knows
+      // the settings of that index type (analyzers, geospatial precision, vector dimensions), and there is no generic
+      // way to copy them onto a new instance. It is read as a TEMPLATE, exactly like the one the normal path builds:
+      // LocalSchema.createBucketIndex takes the collations and the TypeIndex name off it and leaves the rest to the
+      // per-bucket index it creates, so the bucket id it happens to carry never reaches the restored index. Nothing
+      // else reads it either - the index it belongs to is dropped before the restore can run.
+      final IndexMetadata metadata = onBuckets.length > 0 ? onBuckets[0].getMetadata() : null;
+
+      // getPageSizeForNewFile(), not getPageSize(): the value goes back through the creation path, which validates it,
+      // and an index whose current page size is not one creation would accept answers with a legal one instead. Asking
+      // for the raw current size could make the restore fail on exactly the index the restore exists to save (#5713).
+      return new ReplacedIndexDefinition(index.getType(), index.isUnique(), index.getNullStrategy(),
+          index.getPageSizeForNewFile(), index.getTypeName(), index.getPropertyNames().toArray(new String[0]), metadata);
     }
   }
 
@@ -479,6 +491,7 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
           .buildTypeIndex(replaced.typeName(), replaced.propertyNames()).withType(replaced.indexType());
       restore.withUnique(replaced.unique());
       restore.withNullStrategy(replaced.nullStrategy());
+      restore.withPageSize(replaced.pageSize());
       if (replaced.metadata() != null)
         restore.withMetadata(replaced.metadata());
       restore.create();

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -360,6 +360,16 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     // Last thing before the build: everything above can still refuse the request (an undeclared property, a BY ITEM on
     // a non-LIST, a sorted build on a replicated database), and none of those refusals may cost the caller the index it
     // already had.
+    //
+    // NOT ATOMIC, and deliberately so. The drop is its own committed schema change - LocalSchema.dropIndex wraps itself
+    // in recordFileChanges, and so does the build below - so the two cannot be rolled back as one. The window is
+    // covered for a FAILING build (restoreReplacedIndex in the catch arms below) but not for a process that dies inside
+    // it: the type then reopens with no index on those properties and has to be given one again. Making it atomic means
+    // holding a schema transaction across a full index build, which is the wrong trade for a DDL statement that already
+    // rebuilds every entry. Narrowing it further would mean building the new index alongside the old one, which
+    // LocalDocumentType.indexesByProperties cannot represent - one index per property set is the invariant.
+    //
+    // Only an explicit withReplaceIfIncompatible reaches here, so nothing is exposed to this window without asking.
     if (replaced != null)
       existingTypeIndex.drop();
 

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -238,9 +238,16 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
       else if (!satisfied && (ignoreIfExists || replaceIfIncompatible))
         throw conflictWithExistingIndex(existingTypeIndex, indexType, unique, metadata.typeName, metadata.propertyNames);
       else
+        // Reached when the request was NOT guarded, whether or not the existing index satisfies it. The suffix names
+        // the guard that makes the statement idempotent: the satisfied case here is a caller asking twice for
+        // something already there - a Cypher CREATE CONSTRAINT without IF NOT EXISTS over its own unique index, say -
+        // and the bare sentence left them to work out that the guard was the missing piece. The sentence itself is
+        // unchanged: it is long-standing wording that callers may already match on.
         throw new IllegalArgumentException(
             "Found the existent index '" + existingTypeIndex.getName() + "' defined on the properties '" + Arrays.asList(
-                metadata.propertyNames) + "' for type '" + metadata.typeName + "'");
+                metadata.propertyNames) + "' for type '" + metadata.typeName + "'" + (satisfied ?
+                ". It already provides what was requested: use IF NOT EXISTS to make this statement idempotent" :
+                ". Drop it first if the definition has to change"));
     }
 
     if (metadata.propertyNames.isEmpty())

--- a/engine/src/test/java/com/arcadedb/index/Issue5675IndexIfNotExistsConflictTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5675IndexIfNotExistsConflictTest.java
@@ -269,6 +269,59 @@ public class Issue5675IndexIfNotExistsConflictTest extends TestHelper {
   }
 
   /**
+   * The restore is faithful to the whole definition, and a manual index name is part of it: an index the caller named
+   * itself must come back under that name rather than the auto-derived one. It travels on the captured
+   * {@link com.arcadedb.schema.IndexMetadata#typeIndexName}, which {@code LocalSchema.createBucketIndex} copies onto
+   * each bucket index and {@code LocalDocumentType.addIndexInternal} then honours when minting the TypeIndex (#4139) -
+   * the same route a manual name takes on the normal creation path.
+   */
+  @Test
+  void aFailedUpgradeRestoresAManualIndexNameAndItsPageSize() {
+    database.getSchema().buildTypeIndex("T", new String[] { "Scalar" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(false).withPageSize(16_384).withIndexName("HandPicked").create();
+
+    assertThat(database.getSchema().existsIndex("HandPicked")).isTrue();
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO T SET Scalar = 'x'");
+      database.command("sql", "INSERT INTO T SET Scalar = 'x'");
+    });
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("T", new String[] { "Scalar" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).withReplaceIfIncompatible(true).create())
+        .isNotNull();
+
+    assertThat(database.getSchema().existsIndex("HandPicked"))
+        .as("the restored index keeps the name its owner gave it, not the auto-derived one")
+        .isTrue();
+    assertThat(database.getSchema().getIndexByName("HandPicked").isUnique()).isFalse();
+    assertThat(((IndexInternal) database.getSchema().getIndexByName("HandPicked")).getPageSize()).isEqualTo(16_384);
+    assertThat(database.getSchema().existsIndex("T[Scalar]")).isFalse();
+  }
+
+  /**
+   * Replacement is for the type's OWN index. An index it merely inherits belongs to the parent, and taking it away
+   * there is the silent parent-index loss of issue #4083, so the explicit opt-in does not reach it.
+   */
+  @Test
+  void replaceIfIncompatibleStillRefusesAnInheritedIndex() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Parent");
+      database.command("sql", "CREATE PROPERTY Parent.Code STRING");
+      database.command("sql", "CREATE INDEX ON Parent (Code) NOTUNIQUE");
+      database.command("sql", "CREATE VERTEX TYPE Child EXTENDS Parent");
+    });
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("Child", new String[] { "Code" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).withReplaceIfIncompatible(true).create())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Parent");
+
+    assertThat(database.getSchema().existsIndex("Parent[Code]")).isTrue();
+    assertThat(database.getSchema().getIndexByName("Parent[Code]").isUnique()).isFalse();
+  }
+
+  /**
    * A manual index name is global, so it can already name an index on ANOTHER type. That is a different index, and the
    * guard must say so rather than answer "already exists" and leave the requested one uncreated.
    */

--- a/engine/src/test/java/com/arcadedb/index/Issue5675IndexIfNotExistsConflictTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5675IndexIfNotExistsConflictTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.index;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DatabaseMetadataException;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
@@ -239,6 +240,70 @@ public class Issue5675IndexIfNotExistsConflictTest extends TestHelper {
     assertThat(database.getSchema().existsIndex("T[Scalar]")).isTrue();
     assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isFalse();
     assertThat(database.query("sql", "SELECT FROM T WHERE Scalar = 'x'").stream().count()).isEqualTo(2L);
+  }
+
+  /**
+   * The restore puts back the whole definition, page size included: it is the one attribute that is not derivable from
+   * the properties, so losing it would silently re-file the index at the implementation default.
+   */
+  @Test
+  void aFailedUpgradeRestoresThePageSizeToo() {
+    database.getSchema().buildTypeIndex("T", new String[] { "Scalar" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(false).withPageSize(16_384).create();
+
+    final int pageSizeBefore = ((IndexInternal) database.getSchema().getIndexByName("T[Scalar]")).getPageSize();
+    assertThat(pageSizeBefore).isEqualTo(16_384);
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO T SET Scalar = 'x'");
+      database.command("sql", "INSERT INTO T SET Scalar = 'x'");
+    });
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("T", new String[] { "Scalar" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).withReplaceIfIncompatible(true).create())
+        .isNotNull();
+
+    assertThat(database.getSchema().existsIndex("T[Scalar]")).isTrue();
+    assertThat(((IndexInternal) database.getSchema().getIndexByName("T[Scalar]")).getPageSize()).isEqualTo(pageSizeBefore);
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isFalse();
+  }
+
+  /**
+   * A manual index name is global, so it can already name an index on ANOTHER type. That is a different index, and the
+   * guard must say so rather than answer "already exists" and leave the requested one uncreated.
+   */
+  @Test
+  void guardedCreateWithANameTakenByAnotherTypeIsReported() {
+    database.command("sql", "CREATE INDEX SharedName ON T (Scalar) NOTUNIQUE");
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE U");
+      database.command("sql", "CREATE PROPERTY U.Scalar STRING");
+    });
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX SharedName IF NOT EXISTS ON U (Scalar) NOTUNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("SharedName");
+
+    assertThat(database.getSchema().getIndexByName("SharedName").getTypeName()).isEqualTo("T");
+    assertThat(database.getSchema().getType("U").getAllIndexes(false)).isEmpty();
+  }
+
+  /**
+   * The requested index kind is read before the existing-index lookup, because deciding whether what is already there
+   * covers the request needs to know what the request is. A builder with no kind is therefore refused even when an
+   * index on those properties exists - where it used to hand that index back.
+   */
+  @Test
+  void aBuilderWithoutAnIndexTypeIsRefused() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) NOTUNIQUE");
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("T", new String[] { "Scalar" })
+        .withIgnoreIfExists(true).create())
+        .isInstanceOf(DatabaseMetadataException.class)
+        .hasMessageContaining("indexType");
+
+    assertThat(database.getSchema().existsIndex("T[Scalar]")).isTrue();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/Issue5675IndexIfNotExistsConflictTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5675IndexIfNotExistsConflictTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5675: {@code CREATE INDEX IF NOT EXISTS} matched a pre-existing index on the
+ * indexed property set alone and reported success even when the existing index did not provide what the
+ * statement asked for. Tightening a {@code NOTUNIQUE} index to {@code UNIQUE} therefore did nothing while
+ * telling the caller the unique constraint was in place.
+ * <p>
+ * The rule these tests pin down: {@code IF NOT EXISTS} is satisfied only when the existing index already
+ * provides everything requested - the same index type and a uniqueness constraint at least as strong. A
+ * {@code UNIQUE} index satisfies a {@code NOTUNIQUE} request (it indexes the same keys); a {@code NOTUNIQUE}
+ * index does not satisfy a {@code UNIQUE} request. Anything else is a conflict reported to the caller, and
+ * the existing index is never dropped implicitly.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue5675IndexIfNotExistsConflictTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE T");
+      database.command("sql", "CREATE PROPERTY T.Scalar STRING");
+
+      database.command("sql", "CREATE VERTEX TYPE L");
+      database.command("sql", "CREATE PROPERTY L.Items LIST OF STRING");
+    });
+  }
+
+  /**
+   * The reported case: a NOTUNIQUE index exists, the guarded statement asks for UNIQUE. The request cannot be
+   * honoured by the existing index, so it must be reported instead of answering success.
+   */
+  @Test
+  void guardedUniqueOverNotUniqueIsReported() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) NOTUNIQUE");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX IF NOT EXISTS ON T (Scalar) UNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("T[Scalar]")
+        .hasMessageContaining("Scalar");
+
+    // The existing index must survive the rejected request.
+    assertThat(database.getSchema().existsIndex("T[Scalar]")).isTrue();
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isFalse();
+
+    // And it must still be usable: the rejection must not have left a half-dropped index behind.
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO T SET Tag = 'a', Scalar = 'x'");
+      database.command("sql", "INSERT INTO T SET Tag = 'b', Scalar = 'x'");
+    });
+    assertThat(database.countType("T", false)).isEqualTo(2L);
+  }
+
+  /**
+   * Same conflict reached through the {@code BY ITEM} modifier, whose auto-derived index name only started
+   * matching the canonical form after the #4879/#4881 fix - which is what turned the loud failure of 26.4.1
+   * into the silent success reported here.
+   */
+  @Test
+  void guardedUniqueOverNotUniqueByItemIsReported() {
+    database.command("sql", "CREATE INDEX ON L (Items BY ITEM) NOTUNIQUE");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX IF NOT EXISTS ON L (Items BY ITEM) UNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("L[Itemsbyitem]");
+
+    assertThat(database.getSchema().getIndexByName("L[Itemsbyitem]").isUnique()).isFalse();
+  }
+
+  /**
+   * A UNIQUE index already provides what a NOTUNIQUE request asks for (the same keys are indexed), so the
+   * guarded statement is a no-op. It must never weaken the existing constraint by dropping and recreating it.
+   */
+  @Test
+  void guardedNotUniqueOverUniqueKeepsTheConstraint() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) UNIQUE");
+
+    final ResultSet rs = database.command("sql", "CREATE INDEX IF NOT EXISTS ON T (Scalar) NOTUNIQUE");
+    assertThat(rs.next().<Boolean>getProperty("created")).isFalse();
+
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isTrue();
+
+    database.transaction(() -> database.command("sql", "INSERT INTO T SET Scalar = 'x'"));
+    assertThatThrownBy(
+        () -> database.transaction(() -> database.command("sql", "INSERT INTO T SET Scalar = 'x'")))
+        .isInstanceOf(DuplicatedKeyException.class);
+  }
+
+  /**
+   * The plain idempotent case must stay a no-op: same index type, same uniqueness.
+   */
+  @Test
+  void guardedRepeatOfTheSameDefinitionIsANoOp() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) NOTUNIQUE");
+
+    final ResultSet rs = database.command("sql", "CREATE INDEX IF NOT EXISTS ON T (Scalar) NOTUNIQUE");
+    assertThat(rs.next().<Boolean>getProperty("created")).isFalse();
+
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isFalse();
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
+  }
+
+  /**
+   * Uniqueness is not the only part of the definition {@code IF NOT EXISTS} used to ignore: an index of a
+   * different KIND on the same properties answered success too, leaving the caller with a full-text index
+   * where it asked for a range one.
+   */
+  @Test
+  void guardedIndexTypeMismatchIsReported() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) FULL_TEXT");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX IF NOT EXISTS ON T (Scalar) NOTUNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("FULL_TEXT");
+
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").getType()).isEqualTo(Schema.INDEX_TYPE.FULL_TEXT);
+  }
+
+  /**
+   * The same conflict must be reported when the statement carries a manual index name, where the name-based
+   * shortcut does not fire and the request reaches the builder's property-based lookup instead.
+   */
+  @Test
+  void guardedUniqueWithManualNameOverNotUniqueIsReported() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) NOTUNIQUE");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX MyIdx IF NOT EXISTS ON T (Scalar) UNIQUE"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("T[Scalar]");
+
+    assertThat(database.getSchema().existsIndex("T[Scalar]")).isTrue();
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isFalse();
+    assertThat(database.getSchema().existsIndex("MyIdx")).isFalse();
+  }
+
+  /**
+   * The engine API takes the same route: {@code withIgnoreIfExists(true)} used to drop the existing index and
+   * rebuild it with the requested uniqueness, so a rebuild that failed on the duplicates already stored left
+   * the type with no index at all.
+   */
+  @Test
+  void builderIgnoreIfExistsNeverDropsAConflictingIndex() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) NOTUNIQUE");
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO T SET Scalar = 'x'");
+      database.command("sql", "INSERT INTO T SET Scalar = 'x'");
+    });
+
+    assertThatThrownBy(() -> database.getSchema().buildTypeIndex("T", new String[] { "Scalar" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).withIgnoreIfExists(true).create())
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThat(database.getSchema().existsIndex("T[Scalar]")).isTrue();
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isFalse();
+
+    // The surviving index must still resolve both duplicates.
+    assertThat(database.query("sql", "SELECT FROM T WHERE Scalar = 'x'").stream().count()).isEqualTo(2L);
+  }
+
+  /**
+   * The unguarded form keeps reporting the clash it always reported.
+   */
+  @Test
+  void unguardedCreateOverAnExistingIndexStillFails() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) NOTUNIQUE");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX ON T (Scalar) UNIQUE"))
+        .hasMessageContaining("T[Scalar]");
+  }
+
+  /**
+   * A Cypher uniqueness constraint is a statement about the data, not a request to create an index if one is missing,
+   * so it still upgrades a plain index on the same properties - the one caller allowed to replace an index. Neo4j
+   * keeps the range index and the constraint side by side; ArcadeDB has a single index per property set and a unique
+   * one indexes the same keys, so this is the equivalent end state.
+   */
+  @Test
+  void cypherUniqueConstraintUpgradesAPlainIndex() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) NOTUNIQUE");
+
+    database.command("opencypher", "CREATE CONSTRAINT IF NOT EXISTS FOR (n:T) REQUIRE n.Scalar IS UNIQUE");
+
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isTrue();
+
+    database.transaction(() -> database.command("sql", "INSERT INTO T SET Scalar = 'x'"));
+    assertThatThrownBy(
+        () -> database.transaction(() -> database.command("sql", "INSERT INTO T SET Scalar = 'x'")))
+        .isInstanceOf(DuplicatedKeyException.class);
+  }
+
+  /**
+   * The upgrade above is why an index may be dropped at all, so the case it cannot complete has to leave the previous
+   * definition standing: duplicates already stored make the unique index impossible, and the type must not be left
+   * without the index it had.
+   */
+  @Test
+  void aFailedConstraintUpgradeLeavesThePlainIndexInPlace() {
+    database.command("sql", "CREATE INDEX ON T (Scalar) NOTUNIQUE");
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO T SET Scalar = 'x'");
+      database.command("sql", "INSERT INTO T SET Scalar = 'x'");
+    });
+
+    assertThatThrownBy(
+        () -> database.command("opencypher", "CREATE CONSTRAINT IF NOT EXISTS FOR (n:T) REQUIRE n.Scalar IS UNIQUE"))
+        .isNotNull();
+
+    assertThat(database.getSchema().existsIndex("T[Scalar]")).isTrue();
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isFalse();
+    assertThat(database.query("sql", "SELECT FROM T WHERE Scalar = 'x'").stream().count()).isEqualTo(2L);
+  }
+
+  /**
+   * A guarded statement on a property with no index at all must still create one.
+   */
+  @Test
+  void guardedCreateOnAFreshPropertyCreatesTheIndex() {
+    assertThatNoException().isThrownBy(() -> database.command("sql", "CREATE INDEX IF NOT EXISTS ON T (Scalar) UNIQUE"));
+
+    assertThat(database.getSchema().getIndexByName("T[Scalar]").isUnique()).isTrue();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/Issue5675CreateIndexIfNotExistsHttpTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5675CreateIndexIfNotExistsHttpTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5675 over HTTP, which is how it was reported. A {@code CREATE INDEX IF NOT EXISTS ... UNIQUE} that a
+ * pre-existing {@code NOTUNIQUE} index cannot satisfy answered 200 with {@code "created": false}; the caller had no
+ * way to tell that from the constraint actually being there.
+ * <p>
+ * The status matters as much as the refusal: an unsatisfiable schema request is a client mistake, so it has to come
+ * back as 400. It reaches the handler as an {@code IllegalArgumentException}, which is one of the few exception types
+ * with a 400 arm of its own - reporting it as anything else would degrade the answer to a 500 and tell clients and
+ * load balancers to retry a request that can only ever fail the same way.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5675CreateIndexIfNotExistsHttpTest extends BaseGraphServerTest {
+
+  private static final String DATABASE_NAME = "graph";
+
+  @Test
+  void aGuardedUniqueOverANotUniqueIndexIsAClientError() throws Exception {
+    testEachServer(serverIndex -> {
+      executeCommand(serverIndex, "sql", "CREATE VERTEX TYPE TightenHttp");
+      executeCommand(serverIndex, "sql", "CREATE PROPERTY TightenHttp.Scalar STRING");
+      executeCommand(serverIndex, "sql", "CREATE INDEX ON TightenHttp (Scalar) NOTUNIQUE");
+
+      final JSONObject error = commandExpecting(serverIndex, 400,
+          "CREATE INDEX IF NOT EXISTS ON TightenHttp (Scalar) UNIQUE");
+
+      // Asserting the status alone would not do: an unrelated 400 would pass for the refusal under test.
+      assertThat(error.getString("detail"))
+          .as("the reason travels to the client, not just the status")
+          .contains("TightenHttp[Scalar]");
+
+      // And the duplicate the caller was told was impossible must still be impossible to hide: the index is
+      // unchanged, so the insert that used to be silently accepted still is - loudly this time, because the caller
+      // now knows the constraint was never created.
+      commandExpecting(serverIndex, 200, "INSERT INTO TightenHttp SET Scalar = 'x'");
+      commandExpecting(serverIndex, 200, "INSERT INTO TightenHttp SET Scalar = 'x'");
+    });
+  }
+
+  /**
+   * The idempotent case the guard exists for must stay a 200 answering {@code created: false}, so the test above
+   * cannot pass by refusing every guarded statement.
+   */
+  @Test
+  void aGuardedRepeatOfTheSameDefinitionIsStillANoOp() throws Exception {
+    testEachServer(serverIndex -> {
+      executeCommand(serverIndex, "sql", "CREATE VERTEX TYPE RepeatHttp");
+      executeCommand(serverIndex, "sql", "CREATE PROPERTY RepeatHttp.Scalar STRING");
+      executeCommand(serverIndex, "sql", "CREATE INDEX ON RepeatHttp (Scalar) UNIQUE");
+
+      final JSONObject response = commandExpecting(serverIndex, 200,
+          "CREATE INDEX IF NOT EXISTS ON RepeatHttp (Scalar) UNIQUE");
+
+      assertThat(response.getJSONArray("result").getJSONObject(0).getBoolean("created")).isFalse();
+    });
+  }
+
+  /** Posts a SQL command, asserts the HTTP status, and returns the parsed body (the error body on a failure). */
+  private JSONObject commandExpecting(final int serverIndex, final int expectedStatus, final String sql)
+      throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/" + DATABASE_NAME).openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+
+    final JSONObject payload = new JSONObject();
+    payload.put("language", "sql");
+    payload.put("command", sql);
+    formatPayload(connection, payload);
+    connection.connect();
+
+    try {
+      // The status is read BEFORE the body: which stream carries it depends on the status, and asking for the error
+      // stream of a successful response hands back null.
+      final int status = connection.getResponseCode();
+      final String body = status < 400 ? readResponse(connection) : readError(connection);
+      assertThat(status).as("HTTP status for `%s`; body: %s", sql, body).isEqualTo(expectedStatus);
+      return new JSONObject(body);
+    } finally {
+      connection.disconnect();
+    }
+  }
+}


### PR DESCRIPTION
Fixes #5675.

## The bug

`IF NOT EXISTS` matched a pre-existing index on the auto-derived index name. That name is built from the indexed property set alone, so it says nothing about what the index *does*:

```sql
CREATE INDEX ON T (Scalar) NOTUNIQUE;
CREATE INDEX IF NOT EXISTS ON T (Scalar) UNIQUE;   -- reported success, created no constraint
INSERT INTO T SET Scalar = 'x';
INSERT INTO T SET Scalar = 'x';                    -- accepted
```

Migration DDL uses `IF NOT EXISTS` precisely so it can be re-applied, so tightening an index from `NOTUNIQUE` to `UNIQUE` did nothing while the application carried on believing a uniqueness constraint protected its data.

## Two more problems found underneath

1. **`withIgnoreIfExists(true)` dropped the caller's index.** `TypeIndexBuilder.create()` reacted to a uniqueness mismatch by dropping the existing index and rebuilding it. That is not recoverable: when the stored data has duplicates the rebuild fails and the type is left with **no index at all**. `builderIgnoreIfExistsNeverDropsAConflictingIndex` in the new test reproduced exactly that before the fix. On an *inherited* index the same code took away the parent type's index, which is issue #4083.
2. **The kind of index was ignored too.** A `FULL_TEXT` index satisfied a request for a range index on the same properties, silently. And the null-strategy half of the condition was dead code: `existingTypeIndex.getNullStrategy() != null && existingTypeIndex.getNullStrategy() == null` is never true.

## The rule now

`IF NOT EXISTS` is satisfied only when the existing index provides what was asked for:

- same index kind, and
- a uniqueness constraint at least as strong.

So a `UNIQUE` index still satisfies a `NOTUNIQUE` request (it indexes the same keys, and is never weakened into a plain index), while a `NOTUNIQUE` index does not satisfy a `UNIQUE` request. Anything the existing index does not provide is reported, naming both definitions, as an `IllegalArgumentException` -> **HTTP 400**.

### Nothing is dropped implicitly

Refusal is the answer even where the request could technically be granted by rebuilding, because the rebuild is the unsafe part. A caller that genuinely means "make this the definition" opts in:

```java
database.getSchema().buildTypeIndex("T", new String[] { "Scalar" })
    .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true)
    .withReplaceIfIncompatible(true)     // new
    .create();
```

and even then the drop happens as late as possible (after every remaining validation) and the previous definition — kind, uniqueness, null strategy, properties, metadata — is **restored** if the new index cannot be built. An inherited index is never replaced.

### Cypher stays Neo4j-compatible

`CREATE CONSTRAINT ... IS UNIQUE` and `... IS NODE KEY` are statements about the data rather than "create it if missing", so they are the callers that opt into the replacement. Neo4j keeps the range index and the constraint as two objects; ArcadeDB has one index per property set and a unique index covers both roles, so the upgrade is the equivalent end state and a Neo4j migration script that creates indexes and then constraints keeps working. Cypher's own `CREATE INDEX` does **not** opt in — it finds a unique index sufficient and leaves it alone rather than replacing it with a plain one, which closes a silent *weakening* of a constraint that existed before.

## Alternative considered

The issue offers "create the unique index" or "fail". Doing the first implicitly is what the code already did, and it is the thing that can lose an index — so this PR does the second by default and makes the first an explicit, restorable opt-in rather than a side effect of a guard clause.

## Tests

- `engine/.../Issue5675IndexIfNotExistsConflictTest` — 11 cases: the reported scalar and `BY ITEM` forms, the reverse direction staying a no-op, index-kind mismatch, manual index names, the builder never dropping a conflicting index, the Cypher constraint upgrade, and a **failed** constraint upgrade leaving the plain index in place (mutation-checked: reverting the restore fails this test).
- `server/.../Issue5675CreateIndexIfNotExistsHttpTest` — the 400 and its detail message over HTTP, plus the idempotent 200 with `created: false` so the refusal test cannot pass by refusing everything.

Full engine suite: 1237 test classes green. (`ACIDTransactionTest#indexCreationWhileAsyncMustFail` failed once while three engine suites ran concurrently on this machine and passes in isolation — a contention flake, unrelated: it kills the database mid-build and asserts on recovery.) Server index + HTTP suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8C35vrQkW1y1gaEvWzRPc