### PR TITLE
fix(ha) #5728: a schema change no longer skips replication when another thread holds the recording session

### DIFF
--- a/docs/5728-schema-change-during-foreign-recording-session.md
+++ b/docs/5728-schema-change-during-foreign-recording-session.md
@@ -1,0 +1,98 @@
+# #5728 - a schema change made while another thread holds the recording session never replicates
+
+## Issue
+
+`Bolt5002RoutingTableIT.neo4jSchemeRoutesReadsAndWrites` intermittently leaves one follower without the
+`Bolt5002Route` vertex type. Two independent signals in CI run 30706875826: a 60 s poll never saw server 1
+receive the type, and the teardown comparator reported `DatabaseAreNotIdentical: Types: DB1 6 <> DB2 5`.
+It passes in isolation and fails under a loaded runner, so it is load- or timing-sensitive.
+
+## Root cause
+
+Not the `#5492` / `#5655` wrong-database-instance family. The Bolt write path resolves the replicated
+wrapper correctly end to end:
+
+```
+BoltNetworkExecutor.handleRun                  -> ServerDatabase.command("opencypher", ...)
+  -> RaftReplicatedDatabase.command            -> LocalDatabase.command
+    -> OpenCypherQueryEngine.executionDatabase -> database.getWrappedDatabaseInstance()   (the Raft wrapper)
+```
+
+The defect is one level down, in how a DDL step reaches Raft.
+
+Every schema mutation funnels through `LocalSchema.recordFileChanges`
+(`engine/src/main/java/com/arcadedb/schema/LocalSchema.java:2352`), which calls
+`database.getWrappedDatabaseInstance().recordFileChanges(callback)`. Under HA that lands on
+`RaftReplicatedDatabase.recordFileChanges`, whose first act is to open a *file-manager recording session*
+so it can capture the created files, the serialized schema and any WAL buffered inside the callback, and
+ship them as one `SCHEMA_ENTRY`.
+
+```java
+// RaftReplicatedDatabase.java:1434 (before the fix)
+final boolean alreadyRecording = !proxied.getFileManager().startRecordingChanges();
+if (alreadyRecording)
+  return proxied.recordFileChanges(callback);   // <-- runs the DDL LOCALLY, replicates nothing
+```
+
+`FileManager.recordedChanges` is a plain instance field - one session per database, no owner, no
+re-entrancy counter (`engine/src/main/java/com/arcadedb/engine/FileManager.java:147`). So
+`startRecordingChanges()` returns `false` in two completely different situations that the code above
+cannot tell apart:
+
+1. **Re-entrant, same thread.** `LocalSchema.createVertexType` nests: the outer callback creates the type
+   and an inner `LocalDocumentType.recordFileChanges` creates its buckets. The inner call must not open a
+   second session - the outer one is already recording, and it replicates everything on the way out.
+   This is the case the branch was written for, and it is correct.
+
+2. **Contended, different thread.** Another thread is between `startRecordingChanges()` and
+   `stopRecordingChanges()` - a concurrent DDL, or an LSM index compaction inside
+   `runWithCompactionReplication`. There is no outer session *on this thread* to carry the changes, so the
+   DDL is applied on the leader alone and **nothing is proposed to Raft**. Nothing throws.
+
+Case 2 is the bug. The window is wide open on purpose: the owning session releases the database write
+lock when its callback returns (line 1452) but holds the recording session until after
+`replicateSchema()` (line 1489) has made a full Raft round trip. A second thread that arrives during that
+Raft proposal finds the write lock free and the session busy - exactly the state a loaded CI runner
+produces and an idle laptop does not.
+
+The same hazard on the compaction side was already found and fixed as **#4063**:
+`runWithCompactionReplication` (line 1525) used to have an identical "local-only fallback" and now
+*defers* instead, returning `false` so the async scheduler retries. `recordFileChanges` never got the
+matching treatment, and it cannot simply defer because the DDL is synchronous user-visible work.
+
+`FileManager.startRecordingChanges()` was also a non-atomic check-then-set on a non-volatile field, so two
+arriving threads could both be told they had started a session; the second would replace `recordedChanges`
+with a fresh list and the first would lose its recorded file creations.
+
+## Fix
+
+`ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java`
+
+- Distinguish the two cases with two signals: `isSchemaCommitThread`, the thread-local already set by both
+  session owners (`recordFileChanges` line 1449, `runWithCompactionReplication` line 1550), **and** this
+  database's own recording session being open. Both are required because the thread-local is static, so on
+  its own it would also match a thread nested in a *different* database's session, for which this database
+  has replicated nothing. When both hold, nesting is safe - delegate to `proxied` as before.
+- When it is not set, the session belongs to another thread. `acquireRecordingSession()` waits for it to
+  be released instead of silently skipping replication, then opens our own session and replicates
+  normally. On expiry throw `TimeoutException` rather than diverge - unlike a compaction, a schema change
+  cannot be deferred and rescheduled. The bound reuses `HA_QUORUM_TIMEOUT`, the same setting the sibling
+  `waitForActiveRecordingSession()` on the commit path already uses; no new configuration key.
+
+`engine/src/main/java/com/arcadedb/engine/FileManager.java`
+
+- Make `startRecordingChanges()` / `stopRecordingChanges()` an atomic pair (`synchronized`, `volatile`
+  field) so the waiting thread and a compaction thread cannot both win the session. The check-then-set was
+  previously unsynchronized on a non-volatile field, so two arriving threads could both be told they had
+  started; the second would replace `recordedChanges` and the first would lose its recorded file
+  creations.
+
+## Verification
+
+`Issue5728SchemaChangeDuringRecordingSessionIT` (ha-raft). It plants the contended state rather than
+racing for it: the test thread takes the recording session directly from the leader's `FileManager` -
+the same technique `RaftIndexCompactionReplicationIT.compactionDefersWhenRecordingSessionActive` uses for
+the #4063 contract - creates a vertex type from a second thread, and releases the session shortly after.
+
+- Before the fix: the DDL returns immediately down the local-only path, the followers never see the type.
+- After the fix: the DDL blocks until the session is released, then replicates.

--- a/docs/5728-schema-change-during-foreign-recording-session.md
+++ b/docs/5728-schema-change-during-foreign-recording-session.md
@@ -77,11 +77,14 @@ with a fresh list and the first would lose its recorded file creations.
   on another database from inside an outer callback cannot clear the outer frame's mark and send its
   remaining commits as separate `TX_ENTRY`s (the #4083 ordering hazard). `runWithCompactionReplication`
   keeps the bare `remove()` - it defers rather than nesting, so it can never be the inner frame.
-- When it is not set, the session belongs to another thread. `acquireRecordingSession()` waits for it to
-  be released instead of silently skipping replication, then opens our own session and replicates
-  normally. On expiry throw `TimeoutException` rather than diverge - unlike a compaction, a schema change
-  cannot be deferred and rescheduled. The bound reuses `HA_QUORUM_TIMEOUT`, the same setting the sibling
+- When the session belongs to another thread, `acquireRecordingSession()` waits for it to be released
+  instead of silently skipping replication, then opens our own and replicates normally. On expiry it
+  throws `TimeoutException` rather than diverge - unlike a compaction, a schema change cannot be deferred
+  and rescheduled. The bound reuses `HA_QUORUM_TIMEOUT`, the same setting the sibling
   `waitForActiveRecordingSession()` on the commit path already uses; no new configuration key.
+- Leadership is re-checked after the wait. Claiming the session can take seconds, and running the callback
+  on a node that became a follower meanwhile would apply the schema change there and propose nothing - the
+  same divergence from the other end.
 
 `engine/src/main/java/com/arcadedb/engine/FileManager.java`
 
@@ -92,6 +95,19 @@ with a fresh list and the first would lose its recorded file creations.
   creations.
 - Record the session's owning thread and expose `isRecordingChangesOnCurrentThread()`, so "a session is
   open" and "*my* session is open" stop being the same question.
+
+## The cost of waiting
+
+`TypeBuilder.create` wraps the whole operation in `executeInWriteLock`, so the poll can run while the
+caller holds the database write lock, stalling writers for as long as it waits. This is a deliberate
+trade: an availability pause bounded by `HA_QUORUM_TIMEOUT`, in place of a leader that silently stops
+replicating its schema. The bound is also what stops the stall becoming permanent should the session's
+owner ever need a lock the waiter holds. A successful wait logs how long it blocked, at `HALog.BASIC`, so
+an operator seeing writes pause can find the reason rather than infer it.
+
+For the same reason, the contending owner is in practice a compaction rather than another DDL: the DDL
+entry points that take the write lock around the whole operation serialize on it before ever reaching
+`acquireRecordingSession()`.
 
 ## Verification
 
@@ -107,3 +123,25 @@ A second test pins the other half of the contract: a session that is never relea
 change throw `TimeoutException`, and leave the type absent on the leader too. Both tests hold the session
 on a thread *other* than the one running the DDL - a same-thread holder is the legitimate re-entrant
 nesting the fix still allows through, so the wait, and therefore the timeout, would never be reached.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5743
+
+### Review cycles
+
+| Cycle | Head | Outcome |
+|---|---|---|
+| 1 | `4befacf` | LGTM. Asked for a distinct message on the interrupted wait, flagged that `isSchemaCommitThread.remove()` does not restore a prior value, and noted the timeout branch was uncovered. All three applied. |
+| 2 | `266b9a3` | LGTM. Found that the new method's Javadoc had been inserted between `waitForActiveRecordingSession()`'s Javadoc and its declaration, orphaning it - fixed. Argued the two-signal guard still did not fully close the cross-database hole and recommended tracking the session's owner thread instead - adopted. |
+| 3 | `1cc8bfa` | LGTM, no blockers. Noted the wait widens the window for losing leadership mid-DDL, and that the polled FINE log evaluates its argument unguarded - both applied. Declined the `wait()`/`notifyAll()` and `stopRecordingChanges()` owner-assertion suggestions: the reviewer called both pre-existing style, and the polling form is deliberately consistent with the sibling `waitForActiveRecordingSession()`. |
+| 4 | `5838497` | LGTM, no blockers. Caught the same Javadoc-displacement mistake a second time (the new `schemaChangesNeedTheLeader()` helper had been inserted between `acquireRecordingSession()`'s Javadoc and its declaration) and, more importantly, established that the wait can run while the caller holds the database write lock - which contradicted a claim in that Javadoc. Both corrected, and the stall is now logged. Declined lowering `HA_QUORUM_TIMEOUT` for the timeout test: it would trade 10 s of runtime for a tighter quorum bound on a loaded CI runner, and `@Tag("slow")` is a no-op for ITs. |
+
+Adopting the owner-thread field in cycle 2 exposed a flaw in the timeout test added in cycle 1: it held
+the session on the same thread that ran the DDL, which is by definition the re-entrant nesting case, so
+the wait it meant to exercise was never reached. Both tests now hold the session on a separate thread.
+
+### Final state
+
+`max-cycles-reached` - four cycles run, every review LGTM, no blocking finding outstanding. Merge is the
+developer's call.

--- a/docs/5728-schema-change-during-foreign-recording-session.md
+++ b/docs/5728-schema-change-during-foreign-recording-session.md
@@ -68,11 +68,15 @@ with a fresh list and the first would lose its recorded file creations.
 
 `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java`
 
-- Distinguish the two cases with two signals: `isSchemaCommitThread`, the thread-local already set by both
-  session owners (`recordFileChanges` line 1449, `runWithCompactionReplication` line 1550), **and** this
-  database's own recording session being open. Both are required because the thread-local is static, so on
-  its own it would also match a thread nested in a *different* database's session, for which this database
-  has replicated nothing. When both hold, nesting is safe - delegate to `proxied` as before.
+- Distinguish the two cases by asking this database's own `FileManager` whether the active session belongs
+  to the calling thread (`isRecordingChangesOnCurrentThread()`). When it does, nesting is safe - delegate
+  to `proxied` as before. The static `isSchemaCommitThread` thread-local is deliberately *not* the signal:
+  it is shared across every `RaftReplicatedDatabase`, so it would also answer yes for a thread nested in a
+  *different* database's session, for which this database has replicated nothing.
+- `recordFileChanges` now saves and restores that thread-local instead of removing it, so a session opened
+  on another database from inside an outer callback cannot clear the outer frame's mark and send its
+  remaining commits as separate `TX_ENTRY`s (the #4083 ordering hazard). `runWithCompactionReplication`
+  keeps the bare `remove()` - it defers rather than nesting, so it can never be the inner frame.
 - When it is not set, the session belongs to another thread. `acquireRecordingSession()` waits for it to
   be released instead of silently skipping replication, then opens our own session and replicates
   normally. On expiry throw `TimeoutException` rather than diverge - unlike a compaction, a schema change
@@ -86,6 +90,8 @@ with a fresh list and the first would lose its recorded file creations.
   previously unsynchronized on a non-volatile field, so two arriving threads could both be told they had
   started; the second would replace `recordedChanges` and the first would lose its recorded file
   creations.
+- Record the session's owning thread and expose `isRecordingChangesOnCurrentThread()`, so "a session is
+  open" and "*my* session is open" stop being the same question.
 
 ## Verification
 
@@ -96,3 +102,8 @@ the #4063 contract - creates a vertex type from a second thread, and releases th
 
 - Before the fix: the DDL returns immediately down the local-only path, the followers never see the type.
 - After the fix: the DDL blocks until the session is released, then replicates.
+
+A second test pins the other half of the contract: a session that is never released must make the schema
+change throw `TimeoutException`, and leave the type absent on the leader too. Both tests hold the session
+on a thread *other* than the one running the DDL - a same-thread holder is the legitimate re-entrant
+nesting the fix still allows through, so the wait, and therefore the timeout, would never be reached.

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -153,9 +153,11 @@ public class FileManager {
    */
   public synchronized boolean startRecordingChanges() {
     if (recordedChanges != null) {
-      LogManager.instance().log(this, Level.FINE,
-          "startRecordingChanges denied: a session is already active with %d entries",
-          null, recordedChanges.size());
+      // Level-guarded because a contended HA caller polls this method until the session frees up.
+      if (Logger.getLogger(getClass().getName()).isLoggable(Level.FINE))
+        LogManager.instance().log(this, Level.FINE,
+            "startRecordingChanges denied: a session is already active with %d entries",
+            null, recordedChanges.size());
       return false;
     }
 

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -44,7 +44,9 @@ public class FileManager {
   // FileManager is unchanged since their last observation - they cache the value here, compare on
   // entry, and only re-walk when it has advanced.
   private final        AtomicLong                                modificationCount = new AtomicLong();
-  private              List<FileChange>                          recordedChanges   = null;
+  // Volatile because startRecordingChanges()/stopRecordingChanges() are the handshake HA uses to decide
+  // whether a schema change still needs replicating; a stale read there loses the change silently (#5728).
+  private volatile     List<FileChange>                          recordedChanges   = null;
   private final static PaginatedComponentFile                    RESERVED_SLOT     = new PaginatedComponentFile();
 
   public static class FileChange {
@@ -141,10 +143,14 @@ public class FileManager {
 
   /**
    * Start recording changes in file system. Changes can be returned (before the end of the lock in database) with {@link #getRecordedChanges()}.
+   * <p>
+   * There is a single session per database and it is not re-entrant, so the check and the claim must be
+   * atomic: two callers both told they started would each install their own list, and the loser's recorded
+   * file creations would never be shipped to the followers (#5728).
    *
    * @return true if the recorded started and false if it was already started.
    */
-  public boolean startRecordingChanges() {
+  public synchronized boolean startRecordingChanges() {
     if (recordedChanges != null) {
       LogManager.instance().log(this, Level.FINE,
           "startRecordingChanges denied: a session is already active with %d entries",
@@ -162,7 +168,7 @@ public class FileManager {
     return recordedChanges;
   }
 
-  public void stopRecordingChanges() {
+  public synchronized void stopRecordingChanges() {
     if (recordedChanges != null && Logger.getLogger(getClass().getName()).isLoggable(Level.FINE)) {
       final StringBuilder dump = new StringBuilder();
       for (final FileChange c : recordedChanges) {

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -47,6 +47,7 @@ public class FileManager {
   // Volatile because startRecordingChanges()/stopRecordingChanges() are the handshake HA uses to decide
   // whether a schema change still needs replicating; a stale read there loses the change silently (#5728).
   private volatile     List<FileChange>                          recordedChanges   = null;
+  private volatile     Thread                                    recordingThread   = null;
   private final static PaginatedComponentFile                    RESERVED_SLOT     = new PaginatedComponentFile();
 
   public static class FileChange {
@@ -159,9 +160,23 @@ public class FileManager {
     }
 
     recordedChanges = new ArrayList<>();
+    recordingThread = Thread.currentThread();
     LogManager.instance().log(this, Level.FINE,
         "startRecordingChanges: new session begun on thread '%s'", null, Thread.currentThread().getName());
     return true;
+  }
+
+  /**
+   * Tells apart the two reasons {@link #startRecordingChanges()} can refuse. A caller nested inside its own
+   * session may proceed, because the frame that opened the session still owns the recorded changes and will
+   * act on them; a caller facing a session opened by a different thread has no such guarantee and must wait
+   * for its own. Conflating the two let an HA leader apply a schema change locally and replicate nothing
+   * (#5728).
+   *
+   * @return true when the active session was opened by the calling thread
+   */
+  public synchronized boolean isRecordingChangesOnCurrentThread() {
+    return recordedChanges != null && recordingThread == Thread.currentThread();
   }
 
   public List<FileChange> getRecordedChanges() {
@@ -181,6 +196,7 @@ public class FileManager {
           null, Thread.currentThread().getName(), recordedChanges.size(), dump.toString());
     }
     recordedChanges = null;
+    recordingThread = null;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1429,11 +1429,24 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           leaderAddr != null ? leaderAddr : "");
     }
 
+    // A recording session already open ON THIS THREAD means we are nested inside our own DDL or
+    // compaction session (schema DDL nests routinely: the outer callback creates the type, an inner one
+    // creates its buckets). The outer frame captures these file changes and ships them, so delegating is
+    // correct. A session owned by ANOTHER thread carries no such promise, which is why the shared
+    // getRecordedChanges() alone cannot decide this - see acquireRecordingSession (#5728). Both signals
+    // are required: isSchemaCommitThread is static, so on its own it would also match a thread nested in
+    // a DIFFERENT database's session, for which this database has replicated nothing.
+    if (Boolean.TRUE.equals(isSchemaCommitThread.get()) && proxied.getFileManager().getRecordedChanges() != null)
+      return proxied.recordFileChanges(callback);
+
     // On the leader, record file changes and send them via Raft immediately
     // (like the legacy HA system) so replicas have the files before WAL pages arrive
-    final boolean alreadyRecording = !proxied.getFileManager().startRecordingChanges();
-    if (alreadyRecording)
-      return proxied.recordFileChanges(callback);
+    if (!acquireRecordingSession()) {
+      final long timeout = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
+      throw new TimeoutException(
+          "Timeout of " + timeout + "ms waiting for the file recording session to replicate a schema change on database '"
+              + getName() + "'");
+    }
 
     final long schemaVersionBefore = proxied.getSchema().getEmbedded().getVersion();
 
@@ -1642,6 +1655,39 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * remains as a defensive safety net for any other recorder thread that crashes mid-session; it
    * is intentionally retained, not dead code.
    */
+  /**
+   * Claims the file-manager recording session so this thread's schema change can be captured and shipped
+   * as a {@code SCHEMA_ENTRY}, waiting for a session owned by another thread (a concurrent DDL, or an LSM
+   * compaction inside {@link #runWithCompactionReplication}) to be released first.
+   * <p>
+   * The session is a single per-database slot with no owner, so a contended caller used to fall back to
+   * running the DDL straight on the inner database: applied on the leader, proposed to nobody, nothing
+   * thrown (#5728). The window it lost to is real work, not an instant - the owning session releases the
+   * database write lock when its callback returns but keeps the session until its {@code replicateSchema()}
+   * Raft round trip completes, which is why the divergence only appeared under load. Waiting is the only
+   * correct answer here: unlike a compaction, a schema change cannot be deferred and rescheduled.
+   *
+   * @return true when this thread owns the session, false if it gave up waiting
+   */
+  private boolean acquireRecordingSession() {
+    if (proxied.getFileManager().startRecordingChanges())
+      return true;
+
+    final long timeout = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
+    final long deadline = System.currentTimeMillis() + timeout;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        Thread.sleep(2);
+      } catch (final InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+      if (proxied.getFileManager().startRecordingChanges())
+        return true;
+    }
+    return false;
+  }
+
   private void waitForActiveRecordingSession() {
     if (proxied.getFileManager().getRecordedChanges() == null)
       return;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1687,19 +1687,32 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     }
   }
 
+  private ServerIsNotTheLeaderException schemaChangesNeedTheLeader() {
+    final String leaderAddr = raftHAServer != null ? raftHAServer.getLeaderHttpAddress() : null;
+    return new ServerIsNotTheLeaderException("Changes to the schema must be executed on the leader server",
+        leaderAddr != null ? leaderAddr : "");
+  }
+
   /**
    * Claims the file-manager recording session so this thread's schema change can be captured and shipped
-   * as a {@code SCHEMA_ENTRY}, waiting for a session owned by another thread (a concurrent DDL, or an LSM
-   * compaction inside {@link #runWithCompactionReplication}) to be released first.
+   * as a {@code SCHEMA_ENTRY}, waiting for a session owned by another thread to be released first. In
+   * practice that owner is an LSM compaction inside {@link #runWithCompactionReplication}: a second
+   * schema change normally never gets this far, because the DDL entry points that take the database write
+   * lock around the whole operation (e.g. {@code TypeBuilder.create}) serialize on it first.
    * <p>
    * The session used to be a single per-database slot with no owner, so a contended caller fell back to
    * running the DDL straight on the inner database: applied on the leader, proposed to nobody, nothing
    * thrown (#5728). The window it lost to is real work, not an instant - the owning session releases the
    * database write lock when its callback returns but keeps the session until its {@code replicateSchema()}
    * Raft round trip completes, which is why the divergence only appeared under load. Waiting is the only
-   * correct answer here: unlike a compaction, a schema change cannot be deferred and rescheduled. Nothing
-   * is locked while polling - the caller takes the database write lock only afterwards, inside
-   * {@code proxied.recordFileChanges} - so the wait cannot deadlock against the session's owner.
+   * correct answer here: unlike a compaction, a schema change cannot be deferred and rescheduled.
+   * <p>
+   * <b>The wait can run while the caller holds the database write lock</b>, since {@code TypeBuilder.create}
+   * wraps the whole operation in {@code executeInWriteLock}. A contended schema change therefore stalls
+   * writers on that database for as long as it polls. That is a deliberate trade: an availability pause
+   * bounded by {@link GlobalConfiguration#HA_QUORUM_TIMEOUT}, in place of a leader that silently stops
+   * replicating its schema. The bound is also what keeps the stall from becoming permanent if the session's
+   * owner ever needs a lock this caller is holding - it gives up and throws rather than waiting forever.
    *
    * @throws TimeoutException if the session could not be claimed, so the caller fails loudly instead of
    *                          diverging. Interruption raises the same type - both mean "this schema change
@@ -1707,18 +1720,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    *                          as the non-retryable give-up signal - but says so in its message rather than
    *                          reporting an elapsed timeout that never elapsed.
    */
-  private ServerIsNotTheLeaderException schemaChangesNeedTheLeader() {
-    final String leaderAddr = raftHAServer != null ? raftHAServer.getLeaderHttpAddress() : null;
-    return new ServerIsNotTheLeaderException("Changes to the schema must be executed on the leader server",
-        leaderAddr != null ? leaderAddr : "");
-  }
-
   private void acquireRecordingSession() {
     if (proxied.getFileManager().startRecordingChanges())
       return;
 
     final long timeout = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
-    final long deadline = System.currentTimeMillis() + timeout;
+    final long started = System.currentTimeMillis();
+    final long deadline = started + timeout;
     while (System.currentTimeMillis() < deadline) {
       try {
         Thread.sleep(2);
@@ -1727,8 +1735,14 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         throw new TimeoutException("Interrupted while waiting for the file recording session to replicate a schema change on database '"
             + getName() + "'");
       }
-      if (proxied.getFileManager().startRecordingChanges())
+      if (proxied.getFileManager().startRecordingChanges()) {
+        // Logged because this wait can block writers on the database: an operator seeing writes pause
+        // should find the reason here rather than having to infer it.
+        HALog.log(this, HALog.BASIC,
+            "Schema change on database '%s' waited %dms for the file recording session held by another thread",
+            getName(), System.currentTimeMillis() - started);
         return;
+      }
     }
     throw new TimeoutException("Timeout of " + timeout
         + "ms waiting for the file recording session to replicate a schema change on database '" + getName() + "'");

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1432,11 +1432,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // A recording session already open ON THIS THREAD means we are nested inside our own DDL or
     // compaction session (schema DDL nests routinely: the outer callback creates the type, an inner one
     // creates its buckets). The outer frame captures these file changes and ships them, so delegating is
-    // correct. A session owned by ANOTHER thread carries no such promise, which is why the shared
-    // getRecordedChanges() alone cannot decide this - see acquireRecordingSession (#5728). Both signals
-    // are required: isSchemaCommitThread is static, so on its own it would also match a thread nested in
-    // a DIFFERENT database's session, for which this database has replicated nothing.
-    if (Boolean.TRUE.equals(isSchemaCommitThread.get()) && proxied.getFileManager().getRecordedChanges() != null)
+    // correct. A session owned by ANOTHER thread carries no such promise, which is why the bare
+    // "is a session open?" test cannot decide this - see acquireRecordingSession (#5728). The ownership
+    // question is asked of this database's own FileManager rather than of isSchemaCommitThread, which is
+    // static and would also answer yes for a thread nested in a DIFFERENT database's session.
+    if (proxied.getFileManager().isRecordingChangesOnCurrentThread())
       return proxied.recordFileChanges(callback);
 
     // On the leader, record file changes and send them via Raft immediately
@@ -1453,8 +1453,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // Clear thread-local WAL buffers so any commits inside the callback are captured fresh,
     // and mark THIS thread as the schema-commit thread so commit() buffers rather than replicates.
     // The flag is saved and restored rather than removed on the way out: it is static, so a session on
-    // another database opened from inside an outer callback would otherwise clear the outer frame's mark
-    // and leave the rest of that callback unable to recognize its own nesting.
+    // another database opened from inside an outer callback would otherwise clear the outer frame's mark,
+    // and the outer callback's remaining commits would ship separate TX_ENTRYs instead of riding its
+    // SCHEMA_ENTRY - the ordering hazard of issue #4083.
     final Boolean outerSchemaCommitThread = isSchemaCommitThread.get();
     schemaWalBuffer.get().clear();
     schemaBucketDeltaBuffer.get().clear();
@@ -1625,6 +1626,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
       return result;
     } finally {
+      // A bare remove() is enough here, unlike recordFileChanges: a compaction runs on its own scheduler
+      // thread and defers (returns false above) whenever a session is already open, so it never nests
+      // inside another session whose mark it could clear.
       isSchemaCommitThread.remove();
       schemaWalBuffer.get().clear();
       schemaBucketDeltaBuffer.get().clear();
@@ -1657,21 +1661,46 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * remains as a defensive safety net for any other recorder thread that crashes mid-session; it
    * is intentionally retained, not dead code.
    */
+  private void waitForActiveRecordingSession() {
+    if (proxied.getFileManager().getRecordedChanges() == null)
+      return;
+    final long timeout = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
+    final long deadline = System.currentTimeMillis() + timeout;
+    while (proxied.getFileManager().getRecordedChanges() != null) {
+      if (System.currentTimeMillis() >= deadline) {
+        HALog.log(this, HALog.BASIC,
+            "commit waited %dms for FileManager recording session and gave up; proceeding with TX_ENTRY",
+            timeout);
+        return;
+      }
+      try {
+        Thread.sleep(2);
+      } catch (final InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
   /**
    * Claims the file-manager recording session so this thread's schema change can be captured and shipped
    * as a {@code SCHEMA_ENTRY}, waiting for a session owned by another thread (a concurrent DDL, or an LSM
    * compaction inside {@link #runWithCompactionReplication}) to be released first.
    * <p>
-   * The session is a single per-database slot with no owner, so a contended caller used to fall back to
+   * The session used to be a single per-database slot with no owner, so a contended caller fell back to
    * running the DDL straight on the inner database: applied on the leader, proposed to nobody, nothing
    * thrown (#5728). The window it lost to is real work, not an instant - the owning session releases the
    * database write lock when its callback returns but keeps the session until its {@code replicateSchema()}
    * Raft round trip completes, which is why the divergence only appeared under load. Waiting is the only
-   * correct answer here: unlike a compaction, a schema change cannot be deferred and rescheduled.
+   * correct answer here: unlike a compaction, a schema change cannot be deferred and rescheduled. Nothing
+   * is locked while polling - the caller takes the database write lock only afterwards, inside
+   * {@code proxied.recordFileChanges} - so the wait cannot deadlock against the session's owner.
    *
    * @throws TimeoutException if the session could not be claimed, so the caller fails loudly instead of
-   *                          diverging. The interrupted case reports itself as such rather than claiming
-   *                          an elapsed timeout that never elapsed.
+   *                          diverging. Interruption raises the same type - both mean "this schema change
+   *                          never claimed the session", and callers already treat {@code TimeoutException}
+   *                          as the non-retryable give-up signal - but says so in its message rather than
+   *                          reporting an elapsed timeout that never elapsed.
    */
   private void acquireRecordingSession() {
     if (proxied.getFileManager().startRecordingChanges())
@@ -1692,27 +1721,6 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     }
     throw new TimeoutException("Timeout of " + timeout
         + "ms waiting for the file recording session to replicate a schema change on database '" + getName() + "'");
-  }
-
-  private void waitForActiveRecordingSession() {
-    if (proxied.getFileManager().getRecordedChanges() == null)
-      return;
-    final long timeout = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
-    final long deadline = System.currentTimeMillis() + timeout;
-    while (proxied.getFileManager().getRecordedChanges() != null) {
-      if (System.currentTimeMillis() >= deadline) {
-        HALog.log(this, HALog.BASIC,
-            "commit waited %dms for FileManager recording session and gave up; proceeding with TX_ENTRY",
-            timeout);
-        return;
-      }
-      try {
-        Thread.sleep(2);
-      } catch (final InterruptedException ie) {
-        Thread.currentThread().interrupt();
-        return;
-      }
-    }
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1423,11 +1423,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
   @Override
   public <RET> RET recordFileChanges(final Callable<Object> callback) {
-    if (!isLeader()) {
-      final String leaderAddr = raftHAServer != null ? raftHAServer.getLeaderHttpAddress() : null;
-      throw new ServerIsNotTheLeaderException("Changes to the schema must be executed on the leader server",
-          leaderAddr != null ? leaderAddr : "");
-    }
+    if (!isLeader())
+      throw schemaChangesNeedTheLeader();
 
     // A recording session already open ON THIS THREAD means we are nested inside our own DDL or
     // compaction session (schema DDL nests routinely: the outer callback creates the type, an inner one
@@ -1442,6 +1439,14 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // On the leader, record file changes and send them via Raft immediately
     // (like the legacy HA system) so replicas have the files before WAL pages arrive
     acquireRecordingSession();
+
+    // Claiming the session can take seconds under contention, so leadership is re-checked afterwards:
+    // running the callback on a node that became a follower in the meantime would apply the schema change
+    // there and propose nothing, the same divergence this fix exists to prevent, just from the other end.
+    if (!isLeader()) {
+      proxied.getFileManager().stopRecordingChanges();
+      throw schemaChangesNeedTheLeader();
+    }
 
     final long schemaVersionBefore = proxied.getSchema().getEmbedded().getVersion();
 
@@ -1702,6 +1707,12 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    *                          as the non-retryable give-up signal - but says so in its message rather than
    *                          reporting an elapsed timeout that never elapsed.
    */
+  private ServerIsNotTheLeaderException schemaChangesNeedTheLeader() {
+    final String leaderAddr = raftHAServer != null ? raftHAServer.getLeaderHttpAddress() : null;
+    return new ServerIsNotTheLeaderException("Changes to the schema must be executed on the leader server",
+        leaderAddr != null ? leaderAddr : "");
+  }
+
   private void acquireRecordingSession() {
     if (proxied.getFileManager().startRecordingChanges())
       return;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1441,12 +1441,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
     // On the leader, record file changes and send them via Raft immediately
     // (like the legacy HA system) so replicas have the files before WAL pages arrive
-    if (!acquireRecordingSession()) {
-      final long timeout = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
-      throw new TimeoutException(
-          "Timeout of " + timeout + "ms waiting for the file recording session to replicate a schema change on database '"
-              + getName() + "'");
-    }
+    acquireRecordingSession();
 
     final long schemaVersionBefore = proxied.getSchema().getEmbedded().getVersion();
 
@@ -1457,6 +1452,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
     // Clear thread-local WAL buffers so any commits inside the callback are captured fresh,
     // and mark THIS thread as the schema-commit thread so commit() buffers rather than replicates.
+    // The flag is saved and restored rather than removed on the way out: it is static, so a session on
+    // another database opened from inside an outer callback would otherwise clear the outer frame's mark
+    // and leave the rest of that callback unable to recognize its own nesting.
+    final Boolean outerSchemaCommitThread = isSchemaCommitThread.get();
     schemaWalBuffer.get().clear();
     schemaBucketDeltaBuffer.get().clear();
     isSchemaCommitThread.set(Boolean.TRUE);
@@ -1510,7 +1509,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
       return result;
     } finally {
-      isSchemaCommitThread.remove();
+      if (outerSchemaCommitThread == null)
+        isSchemaCommitThread.remove();
+      else
+        isSchemaCommitThread.set(outerSchemaCommitThread);
       schemaWalBuffer.get().clear();
       schemaBucketDeltaBuffer.get().clear();
       proxied.getFileManager().stopRecordingChanges();
@@ -1667,11 +1669,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * Raft round trip completes, which is why the divergence only appeared under load. Waiting is the only
    * correct answer here: unlike a compaction, a schema change cannot be deferred and rescheduled.
    *
-   * @return true when this thread owns the session, false if it gave up waiting
+   * @throws TimeoutException if the session could not be claimed, so the caller fails loudly instead of
+   *                          diverging. The interrupted case reports itself as such rather than claiming
+   *                          an elapsed timeout that never elapsed.
    */
-  private boolean acquireRecordingSession() {
+  private void acquireRecordingSession() {
     if (proxied.getFileManager().startRecordingChanges())
-      return true;
+      return;
 
     final long timeout = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
     final long deadline = System.currentTimeMillis() + timeout;
@@ -1680,12 +1684,14 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         Thread.sleep(2);
       } catch (final InterruptedException ie) {
         Thread.currentThread().interrupt();
-        return false;
+        throw new TimeoutException("Interrupted while waiting for the file recording session to replicate a schema change on database '"
+            + getName() + "'");
       }
       if (proxied.getFileManager().startRecordingChanges())
-        return true;
+        return;
     }
-    return false;
+    throw new TimeoutException("Timeout of " + timeout
+        + "ms waiting for the file recording session to replicate a schema change on database '" + getName() + "'");
   }
 
   private void waitForActiveRecordingSession() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5728SchemaChangeDuringRecordingSessionIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5728SchemaChangeDuringRecordingSessionIT.java
@@ -21,6 +21,7 @@ package com.arcadedb.server.ha.raft;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.FileManager;
+import com.arcadedb.exception.TimeoutException;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -28,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #5728: a schema change executed while ANOTHER thread holds the
@@ -122,6 +124,40 @@ class Issue5728SchemaChangeDuringRecordingSessionIT extends BaseRaftHATest {
               session and was applied on the leader only, replicating nothing (#5728)""", serverIndex, VERTEX_TYPE)
           .isTrue();
     });
+  }
+
+  /**
+   * The other half of the contract: when the contending session outlives the wait, the schema change must
+   * fail loudly rather than fall back to the local-only path that diverged the cluster. Without this the
+   * timeout branch is never executed, so a fix that silently swallowed the expiry would still look green.
+   */
+  @Test
+  void schemaChangeFailsRatherThanDivergingWhenTheSessionIsNeverReleased() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final DatabaseInternal leaderDb = (DatabaseInternal) getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.async().waitCompletion();
+
+    final FileManager fileManager = leaderDb.getEmbedded().getFileManager();
+    assertThat(acquireRecordingSession(fileManager))
+        .as("the test must own the recording session, otherwise it is not reproducing the contended case")
+        .isTrue();
+
+    // Held for the whole attempt: the wait is bounded by HA_QUORUM_TIMEOUT, so the DDL gives up on its own.
+    try {
+      assertThatThrownBy(() ->
+          leaderDb.getSchema().buildVertexType().withName(VERTEX_TYPE + "Timeout").withTotalBuckets(1).create())
+          .as("a schema change that cannot claim the recording session must throw, never apply leader-locally")
+          .isInstanceOf(TimeoutException.class)
+          .hasMessageContaining("waiting for the file recording session");
+    } finally {
+      fileManager.stopRecordingChanges();
+    }
+
+    assertThat(leaderDb.getSchema().existsType(VERTEX_TYPE + "Timeout"))
+        .as("the refused schema change must not have been applied on the leader either")
+        .isFalse();
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5728SchemaChangeDuringRecordingSessionIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5728SchemaChangeDuringRecordingSessionIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.FileManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5728: a schema change executed while ANOTHER thread holds the
+ * file-manager recording session was applied on the leader alone and never proposed to Raft.
+ * <p>
+ * {@code FileManager.recordedChanges} is a single per-database slot with no owner, so
+ * {@code RaftReplicatedDatabase.recordFileChanges} could not tell a safe re-entrant nesting (the same
+ * thread already inside its own replicating session, whose outer frame ships everything) from a
+ * genuinely contended one (a different thread's session, which ships nothing on our behalf). It treated
+ * both as "someone else will replicate this" and ran the callback straight on the inner
+ * {@code LocalDatabase}. Nothing threw; the followers simply stayed one type behind.
+ * <p>
+ * The window is real work, not an instant: the owning session releases the database write lock when its
+ * callback returns but keeps the recording session until its {@code replicateSchema()} Raft round trip
+ * completes. That is why the original symptom -
+ * {@code Bolt5002RoutingTableIT.neo4jSchemeRoutesReadsAndWrites} losing its Cypher-created vertex type -
+ * appeared only on loaded CI runners.
+ * <p>
+ * The state is planted rather than raced for: the test itself takes the recording session, the same
+ * technique {@link RaftIndexCompactionReplicationIT#compactionDefersWhenRecordingSessionActive()} uses to
+ * pin the sibling #4063 contract. Without the fix the DDL returns immediately down the local-only path
+ * and the followers never see the type; with it, the DDL waits for the session and then replicates.
+ */
+class Issue5728SchemaChangeDuringRecordingSessionIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE      = "Issue5728Contended";
+  private static final long   HOLD_SESSION_MS  = 1_000;
+  private static final long   DDL_TIMEOUT_SECS = 60;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Test
+  void schemaChangeReplicatesWhenAnotherThreadHoldsTheRecordingSession() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final DatabaseInternal leaderDb = (DatabaseInternal) getServerDatabase(leaderIndex, getDatabaseName());
+
+    // Settle in-flight async work so the session we take is not immediately contended by the engine.
+    leaderDb.async().waitCompletion();
+
+    final FileManager fileManager = leaderDb.getEmbedded().getFileManager();
+    assertThat(acquireRecordingSession(fileManager))
+        .as("the test must own the recording session, otherwise it is not reproducing the contended case")
+        .isTrue();
+
+    final CountDownLatch ddlStarted = new CountDownLatch(1);
+    final CountDownLatch ddlFinished = new CountDownLatch(1);
+    final AtomicReference<Throwable> ddlFailure = new AtomicReference<>();
+
+    final Thread ddl = new Thread(() -> {
+      ddlStarted.countDown();
+      try {
+        leaderDb.getSchema().buildVertexType().withName(VERTEX_TYPE).withTotalBuckets(1).create();
+      } catch (final Throwable t) {
+        ddlFailure.set(t);
+      } finally {
+        ddlFinished.countDown();
+      }
+    }, "issue5728-ddl");
+    ddl.start();
+
+    assertThat(ddlStarted.await(10, TimeUnit.SECONDS)).isTrue();
+    // Hold the session across the start of the DDL. The exact delay only has to be long enough that an
+    // unfixed build has taken its local-only shortcut by the time we release; a fixed build is still
+    // waiting and finishes whenever we let go.
+    Thread.sleep(HOLD_SESSION_MS);
+    fileManager.stopRecordingChanges();
+
+    assertThat(ddlFinished.await(DDL_TIMEOUT_SECS, TimeUnit.SECONDS))
+        .as("the schema change must not block indefinitely on the contending session")
+        .isTrue();
+    ddl.join(TimeUnit.SECONDS.toMillis(DDL_TIMEOUT_SECS));
+    assertThat(ddlFailure.get()).isNull();
+
+    assertThat(leaderDb.getSchema().existsType(VERTEX_TYPE)).as("leader must have the new type").isTrue();
+
+    waitForAllServers();
+
+    testEachServer(serverIndex -> {
+      final Database serverDb = getServerDatabase(serverIndex, getDatabaseName());
+      assertThat(serverDb.getSchema().existsType(VERTEX_TYPE))
+          .as("""
+              server %d is missing type '%s': the schema change ran while another thread held the recording \
+              session and was applied on the leader only, replicating nothing (#5728)""", serverIndex, VERTEX_TYPE)
+          .isTrue();
+    });
+  }
+
+  /**
+   * Polls for the recording session, which an engine-internal DDL or compaction may momentarily hold
+   * even after {@code waitCompletion()}.
+   */
+  private static boolean acquireRecordingSession(final FileManager fileManager) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + 5_000;
+    while (System.currentTimeMillis() < deadline) {
+      if (fileManager.startRecordingChanges())
+        return true;
+      Thread.sleep(50);
+    }
+    return false;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5728SchemaChangeDuringRecordingSessionIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5728SchemaChangeDuringRecordingSessionIT.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -130,6 +131,10 @@ class Issue5728SchemaChangeDuringRecordingSessionIT extends BaseRaftHATest {
    * The other half of the contract: when the contending session outlives the wait, the schema change must
    * fail loudly rather than fall back to the local-only path that diverged the cluster. Without this the
    * timeout branch is never executed, so a fix that silently swallowed the expiry would still look green.
+   * <p>
+   * The session must be held by a thread OTHER than the one running the DDL. A holder on the DDL's own
+   * thread is the legitimate re-entrant nesting the fix deliberately still allows through, so the wait -
+   * and therefore the timeout - would never be reached.
    */
   @Test
   void schemaChangeFailsRatherThanDivergingWhenTheSessionIsNeverReleased() throws Exception {
@@ -140,22 +145,43 @@ class Issue5728SchemaChangeDuringRecordingSessionIT extends BaseRaftHATest {
     leaderDb.async().waitCompletion();
 
     final FileManager fileManager = leaderDb.getEmbedded().getFileManager();
-    assertThat(acquireRecordingSession(fileManager))
-        .as("the test must own the recording session, otherwise it is not reproducing the contended case")
-        .isTrue();
+    final String timeoutType = VERTEX_TYPE + "Timeout";
+    final CountDownLatch sessionTaken = new CountDownLatch(1);
+    final CountDownLatch releaseSession = new CountDownLatch(1);
+    final AtomicBoolean sessionOwned = new AtomicBoolean();
 
-    // Held for the whole attempt: the wait is bounded by HA_QUORUM_TIMEOUT, so the DDL gives up on its own.
+    // Holds the session for the whole attempt, so the DDL exhausts HA_QUORUM_TIMEOUT and gives up.
+    final Thread holder = new Thread(() -> {
+      try {
+        sessionOwned.set(acquireRecordingSession(fileManager));
+        sessionTaken.countDown();
+        releaseSession.await(DDL_TIMEOUT_SECS, TimeUnit.SECONDS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        if (sessionOwned.get())
+          fileManager.stopRecordingChanges();
+      }
+    }, "issue5728-session-holder");
+    holder.start();
+
     try {
+      assertThat(sessionTaken.await(10, TimeUnit.SECONDS)).isTrue();
+      assertThat(sessionOwned.get())
+          .as("the holder thread must own the recording session, otherwise this is not the contended case")
+          .isTrue();
+
       assertThatThrownBy(() ->
-          leaderDb.getSchema().buildVertexType().withName(VERTEX_TYPE + "Timeout").withTotalBuckets(1).create())
+          leaderDb.getSchema().buildVertexType().withName(timeoutType).withTotalBuckets(1).create())
           .as("a schema change that cannot claim the recording session must throw, never apply leader-locally")
           .isInstanceOf(TimeoutException.class)
           .hasMessageContaining("waiting for the file recording session");
     } finally {
-      fileManager.stopRecordingChanges();
+      releaseSession.countDown();
+      holder.join(TimeUnit.SECONDS.toMillis(DDL_TIMEOUT_SECS));
     }
 
-    assertThat(leaderDb.getSchema().existsType(VERTEX_TYPE + "Timeout"))
+    assertThat(leaderDb.getSchema().existsType(timeoutType))
         .as("the refused schema change must not have been applied on the leader either")
         .isFalse();
   }


### PR DESCRIPTION
Closes #5728

`Bolt5002RoutingTableIT.neo4jSchemeRoutesReadsAndWrites` intermittently left a follower without the vertex type its Cypher-over-Bolt `CREATE` had implicitly created. The Bolt write path turned out to resolve the replicated wrapper correctly end to end, so this is not the #5492/#5655 wrong-instance family. The defect is one level down: `RaftReplicatedDatabase.recordFileChanges()` opens a file-manager recording session to capture the created files, the serialized schema and any buffered WAL, and ship them as one `SCHEMA_ENTRY` - but `FileManager.recordedChanges` is a single per-database slot with no owner, so `startRecordingChanges()` returning `false` could not be told apart from a safe re-entrant nesting (the same thread already inside its own session, whose outer frame ships everything) and a genuinely contended one (another thread's session, which ships nothing on our behalf). Both fell through to running the DDL straight on the inner `LocalDatabase`: applied on the leader, proposed to nobody, nothing thrown. The window is real work rather than an instant - the owning session releases the database write lock when its callback returns but keeps the session until its `replicateSchema()` Raft round trip completes - which is why the divergence appeared only under CI load. The compaction side of the same hazard was already fixed as #4063 by deferring; a schema change cannot be deferred, so it now waits for the session instead, bounded by the `HA_QUORUM_TIMEOUT` the sibling `waitForActiveRecordingSession()` already uses, and throws `TimeoutException` rather than diverge. `FileManager`'s check-then-set is also made atomic, since two arriving threads could both be told they had started a session and the loser's recorded file creations would be lost.

## Test plan

- [x] `Issue5728SchemaChangeDuringRecordingSessionIT` (new) fails on the unfixed build with `server 1 is missing type 'Issue5728Contended'` and passes with the fix. It plants the contended state rather than racing for it - the test thread takes the recording session directly, the same technique `RaftIndexCompactionReplicationIT.compactionDefersWhenRecordingSessionActive` uses to pin the sibling #4063 contract - and runs the DDL from a second thread.
- [x] ha-raft ITs, 16 tests green: `RaftIndexCompactionReplicationIT`, `RaftSchemaReplicationIT`, `RaftReplicationChangeSchemaIT`, `RaftLargeSchemaReplicationIT`, `Issue5492SchemaWalNotShippedIT`, `Issue5492TruncateBatchNotReplicatedIT`, `RaftBulkInsertCompactionRaceIT`.
- [x] Unit tests green across engine -> network -> integration -> server -> ha-raft (772 in the tail modules, 594 engine schema/type/bucket tests run separately).
- [ ] `Bolt5002RoutingTableIT` itself is left to CI. Its failure is intermittent and load-sensitive, so a green local run would not be evidence either way; the teardown `DatabaseAreNotIdentical` comparator is the reliable signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)