### PR TITLE
fix(engine): warn when DOT_PRODUCT index has non-unit vectors (#5750)

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -149,6 +149,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // enough to never matter and large enough that a small index is fully resident from the first query.
   private static final int MIN_SEARCH_CACHE_SIZE = 8_192;
 
+  // DOT_PRODUCT is the fast path for cosine on already-normalized data, and JVector documents unit length as its
+  // precondition. How many ordinals a rebuild samples to notice that the precondition is not met, and how far a
+  // magnitude may drift from 1 before it counts as violated (float accumulation over a few thousand dimensions
+  // moves the last digits, so an exact comparison would flag correctly normalized data).
+  private static final int    UNIT_VECTOR_SAMPLE_SIZE  = 1_000;
+  private static final double UNIT_MAGNITUDE_TOLERANCE = 0.01;
+  // Squared bounds, so the sample costs one multiply-add per component and no square root at all.
+  private static final double MIN_UNIT_MAGNITUDE_SQUARED = (1.0 - UNIT_MAGNITUDE_TOLERANCE) * (1.0 - UNIT_MAGNITUDE_TOLERANCE);
+  private static final double MAX_UNIT_MAGNITUDE_SQUARED = (1.0 + UNIT_MAGNITUDE_TOLERANCE) * (1.0 + UNIT_MAGNITUDE_TOLERANCE);
+
   // Not final: a compaction swaps in a new data file, and this index is named after its component - see
   // getMostRecentFileName(). Every node names the index after the file it holds, so the leader has to
   // follow its own rename or its schema stops matching the followers that rebuilt it from that file.
@@ -184,6 +194,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // Set once the ignored location-cache limit has been reported, so a rebuild does not repeat the warning.
   // compareAndSet, not a plain flag: two threads racing the first call would otherwise both log it.
   private final    AtomicBoolean                 locationCacheCapReported = new AtomicBoolean();
+  // Same idea for the DOT_PRODUCT unit-length warning: an ingest crosses the rebuild threshold every time the
+  // pending set grows by a fraction of the graph, so a million-row load rebuilds a hundred-odd times and would
+  // otherwise repeat the same warning on each of them. Set only when the warning is actually emitted, so an index
+  // that starts out normalized and later is not still gets told once.
+  private final    AtomicBoolean                 nonUnitVectorsReported   = new AtomicBoolean();
 
   // Graph file for persistent storage of graph topology
   // Allows lazy-loading graph from disk and avoiding expensive rebuilds
@@ -1929,6 +1944,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
       vectors = pageVectors;
 
+      reportNonUnitVectorsOnDotProduct(pageVectors, finalActiveVectorIds.length);
+
       // Publish the ordinal mapping and the build state under the write lock so searches never observe an
       // ordinal map that disagrees with the vectors snapshot they captured (issue #4581).
       lock.writeLock().lock();
@@ -2269,6 +2286,60 @@ public class LSMVectorIndex implements Index, IndexInternal {
       LogManager.instance().log(this, Level.SEVERE, "Error building graph from scratch", e);
       throw new IndexException("Error building graph from scratch", e);
     }
+  }
+
+  /**
+   * Warns once when a {@code DOT_PRODUCT} index is being built over vectors that are not unit length.
+   * <p>
+   * {@code VectorSimilarityFunction.DOT_PRODUCT} scores {@code (1 + dot(a, b)) / 2} and documents unit length as its
+   * precondition: it exists as the cheap path for cosine on data that is already normalized. Honour it and the raw dot
+   * product stays in {@code [-1, 1]}, so the score stays in {@code [0, 1]} and zero is a genuine floor, which is what
+   * {@link #UNREADABLE_NODE_SCORE} relies on to keep an unreadable node from outranking a real one. Break it and the
+   * dot product is unbounded below, real vectors can score under zero, and a tombstone at exactly zero wastes beam
+   * budget. It cannot enter a result - {@code LiveVectorBitsFilter} decides membership, not the score - so the cost is
+   * recall and work, not a wrong answer. Silently worse rankings than COSINE would have given is the opposite of the
+   * reason to pick this metric, hence the warning.
+   * <p>
+   * The rebuild has already read and validated every vector, so sampling costs no I/O beyond what the cache already
+   * holds, and it is bounded at {@link #UNIT_VECTOR_SAMPLE_SIZE} ordinals regardless of index size. Unreadable
+   * ordinals are skipped: the placeholder {@code ArcadePageVectorValues} hands back is all ones, whose magnitude is
+   * {@code sqrt(dimensions)}, and counting it would report a normalization problem the data does not have.
+   *
+   * @param vectors     the vector view the graph is about to be built on
+   * @param totalActive number of active ordinals in that view
+   */
+  private void reportNonUnitVectorsOnDotProduct(final ArcadePageVectorValues vectors, final int totalActive) {
+    if (metadata.similarityFunction != VectorSimilarityFunction.DOT_PRODUCT || nonUnitVectorsReported.get())
+      return;
+
+    final int sampleSize = Math.min(totalActive, UNIT_VECTOR_SAMPLE_SIZE);
+    int sampled = 0;
+    int nonUnit = 0;
+
+    for (int ordinal = 0; ordinal < sampleSize; ordinal++) {
+      final VectorFloat<?> vector = vectors.getVector(ordinal);
+      if (vector == null || vectors.isDeletedSentinel(vector))
+        continue;
+
+      double magnitudeSquared = 0.0;
+      for (int i = 0; i < vector.length(); i++) {
+        final float component = vector.get(i);
+        magnitudeSquared += (double) component * component;
+      }
+
+      ++sampled;
+      if (magnitudeSquared < MIN_UNIT_MAGNITUDE_SQUARED || magnitudeSquared > MAX_UNIT_MAGNITUDE_SQUARED)
+        ++nonUnit;
+    }
+
+    if (nonUnit == 0 || !nonUnitVectorsReported.compareAndSet(false, true))
+      return;
+
+    LogManager.instance().log(this, Level.WARNING,
+        "Vector index '%s' uses DOT_PRODUCT but %d of the %d sampled vectors (%d%%) are not unit length. DOT_PRODUCT is "
+            + "defined only for normalized vectors, so search quality is degraded: normalize the vectors on ingest or "
+            + "recreate the index with COSINE. This is reported once per index",
+        indexName, nonUnit, sampled, nonUnit * 100 / sampled);
   }
 
   private long getTxChunkSize() {

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexDotProductUnitVectorTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexDotProductUnitVectorTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5750: an {@code LSM_VECTOR} index declared with {@code DOT_PRODUCT} used to accept
+ * vectors of any magnitude in silence.
+ * <p>
+ * {@code DOT_PRODUCT} is the cheap path for cosine on data that is already normalized, and JVector documents unit
+ * length as its precondition. Broken, the raw dot product is unbounded below, so a real vector can score under the
+ * zero an unreadable node is scored at and waste beam budget, and rankings come out quietly worse than the
+ * {@code COSINE} the user did not pick. The build now says so.
+ * <p>
+ * The three cases pinned here are what makes the warning useful rather than noise: it fires when the precondition is
+ * broken, it stays silent when it is honoured, and it does not repeat. The last one is not cosmetic - a bulk ingest
+ * crosses the rebuild threshold every time the pending set grows by a fraction of the graph, so an unguarded warning
+ * would be emitted a hundred-odd times over a million-row load.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LSMVectorIndexDotProductUnitVectorTest extends TestHelper {
+
+  private static final int DIMENSIONS  = 16;
+  private static final int NUM_VECTORS = 40;
+
+  @Test
+  void aDotProductIndexWarnsOnceAboutNonUnitVectors() {
+    // Capture from before the first vector exists: any build at all has to be inside the window, or a rebuild that
+    // beat the assertions to it would consume the one warning and the test would read the silence as a regression.
+    final List<String> warnings = new CopyOnWriteArrayList<>();
+    final Logger originalLogger = swapInCapturingLogger(warnings);
+    try {
+      createIndexAndPopulate("DOT_PRODUCT", false);
+      final LSMVectorIndex index = bucketIndex();
+
+      index.buildVectorGraphNow();
+      assertThat(unitLengthWarnings(warnings))
+          .as("a DOT_PRODUCT build over vectors that are not unit length must warn (captured=%s)", warnings)
+          .hasSize(1);
+      assertThat(unitLengthWarnings(warnings).getFirst())
+          .as("the warning must name the index and say what to do about it")
+          .contains("DOT_PRODUCT").contains("COSINE").contains(index.getName());
+
+      // Every later rebuild re-reads the same non-unit vectors. Without the once-per-index guard each one repeats
+      // the warning, which under sustained ingestion is the actual operational cost of this fix.
+      index.buildVectorGraphNow();
+      index.buildVectorGraphNow();
+      assertThat(unitLengthWarnings(warnings))
+          .as("the warning is reported once per index, not once per rebuild (captured=%s)", warnings)
+          .hasSize(1);
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
+  }
+
+  @Test
+  void aDotProductIndexOverUnitVectorsStaysSilent() {
+    final List<String> warnings = new CopyOnWriteArrayList<>();
+    final Logger originalLogger = swapInCapturingLogger(warnings);
+    try {
+      createIndexAndPopulate("DOT_PRODUCT", true);
+      bucketIndex().buildVectorGraphNow();
+      assertThat(unitLengthWarnings(warnings))
+          .as("normalized vectors honour the precondition, so there is nothing to report (captured=%s)", warnings)
+          .isEmpty();
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
+  }
+
+  /**
+   * {@code COSINE} divides the magnitude out, so a non-unit vector is not a misconfiguration there. Warning on it
+   * would train operators to ignore the message on the metric where it does mean something.
+   */
+  @Test
+  void aCosineIndexOverNonUnitVectorsStaysSilent() {
+    final List<String> warnings = new CopyOnWriteArrayList<>();
+    final Logger originalLogger = swapInCapturingLogger(warnings);
+    try {
+      createIndexAndPopulate("COSINE", false);
+      bucketIndex().buildVectorGraphNow();
+      assertThat(unitLengthWarnings(warnings))
+          .as("the unit-length precondition belongs to DOT_PRODUCT alone (captured=%s)", warnings)
+          .isEmpty();
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
+  }
+
+  private void createIndexAndPopulate(final String similarity, final boolean normalized) {
+    // Per-database, so it cannot leak into the rest of the suite. Without it the inactivity timer can start a
+    // rebuild on its own schedule, which is a second writer racing the explicit builds below.
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 0);
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA {"dimensions": %d, "similarity": "%s"}\
+          """.formatted(DIMENSIONS, similarity));
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < NUM_VECTORS; i++)
+        database.newVertex("Doc").set("name", "doc" + i).set("embedding", embeddingOf(i, normalized)).save();
+    });
+  }
+
+  private LSMVectorIndex bucketIndex() {
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[embedding]");
+    return (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+  }
+
+  private static List<String> unitLengthWarnings(final List<String> warnings) {
+    return warnings.stream().filter(w -> w.contains("not unit length")).toList();
+  }
+
+  private static Logger swapInCapturingLogger(final List<String> warnings) {
+    final Logger original = readLogger();
+    LogManager.instance().setLogger(new CapturingLogger(warnings, original));
+    return original;
+  }
+
+  private static Logger readLogger() {
+    try {
+      final Field field = LogManager.instance().getClass().getDeclaredField("logger");
+      field.setAccessible(true);
+      return (Logger) field.get(LogManager.instance());
+    } catch (final ReflectiveOperationException e) {
+      throw new IllegalStateException("Cannot read the active logger", e);
+    }
+  }
+
+  /**
+   * A pseudo-random direction per vertex from a fixed seed, scaled to a magnitude that is unmistakably not 1 unless
+   * the caller asks for the normalized variant. The directions are random rather than structured so the fixture is
+   * in general position: no two vertices are collinear and none sits on an axis, which is what keeps the graph build
+   * from having to break ties.
+   */
+  private static float[] embeddingOf(final int i, final boolean normalized) {
+    final Random random = new Random(i * 31L + 7);
+    final float[] embedding = new float[DIMENSIONS];
+    double magnitudeSquared = 0;
+    for (int d = 0; d < DIMENSIONS; d++) {
+      embedding[d] = random.nextFloat() * 2 - 1;
+      magnitudeSquared += (double) embedding[d] * embedding[d];
+    }
+
+    // A random 16-dimensional direction already has a magnitude around 2.3, far outside the 1% tolerance, but scale
+    // it anyway so the fixture states its own intent instead of relying on the dimension count.
+    final double magnitude = Math.sqrt(magnitudeSquared);
+    final double scale = normalized ? 1 / magnitude : (3.0 + i * 0.1) / magnitude;
+    for (int d = 0; d < DIMENSIONS; d++)
+      embedding[d] = (float) (embedding[d] * scale);
+
+    return embedding;
+  }
+
+  @Override
+  protected String getDatabasePath() {
+    return "target/databases/LSMVectorIndexDotProductUnitVectorTest";
+  }
+
+  /**
+   * Captures WARNING-and-above messages while forwarding every record to the production logger, so swapping it in
+   * does not hide anything else the run logs. Swapping the LogManager logger bypasses JUL, so the assertions do not
+   * depend on handler or level state another test in the same JVM may have left behind.
+   */
+  private static final class CapturingLogger implements Logger {
+    private final List<String> warnings;
+    private final Logger       delegate;
+
+    CapturingLogger(final List<String> warnings, final Logger delegate) {
+      this.warnings = warnings;
+      this.delegate = delegate;
+    }
+
+    private void capture(final Level level, final String message, final Object... args) {
+      if (message == null || level.intValue() < Level.WARNING.intValue())
+        return;
+      String formatted = message;
+      if (args != null && args.length > 0) {
+        try {
+          formatted = message.formatted(args);
+        } catch (final Exception ignored) {
+          // Fall back to the raw template, which still carries the text the assertions match on.
+        }
+      }
+      warnings.add(formatted);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
+        final Object arg6, final Object arg7, final Object arg8, final Object arg9, final Object arg10, final Object arg11,
+        final Object arg12, final Object arg13, final Object arg14, final Object arg15, final Object arg16,
+        final Object arg17) {
+      capture(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15,
+          arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10,
+          arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      capture(level, message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fixes #5750

JVector's `VectorSimilarityFunction.DOT_PRODUCT` javadoc states:

> NOTE: this similarity is intended as an optimized way to perform cosine similarity. In order to use it, all vectors must be normalized, including both document and query vectors. Using dot product with vectors that are not normalized can result in errors or poor search results.

ArcadeDB did not enforce this precondition. With unit vectors `dot` is in `[-1, 1]` and the score is in `[0, 1]`, so a tombstone scored at `0.0` is at or below every real score. For non-unit vectors the dot product is unbounded below, so a real vector can score below 0 and a tombstone would outrank it in the beam — a recall/efficiency issue.

### Fix

Sample the first 1000 vectors during graph build and log a `WARNING` when any are not unit length. The check is nearly free because the build already reads every vector.

This implements **Option 1** from the issue (sampled check during build), as recommended by the issue author.

### Details

- Only runs when `similarityFunction == DOT_PRODUCT`
- Samples up to 1000 vectors from the preloaded/pre-validated vector set
- Logs a single WARNING with the count and percentage of non-unit vectors found
- Magnitude threshold: `|mag - 1.0| > 0.01` (tolerance for float precision)
- No new I/O, no data changes, no breaking change
