### PR TITLE
fix(engine) #5762: an empty vector index no longer reports a database close at SEVERE

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1711,25 +1711,28 @@ public class LSMVectorIndex implements Index, IndexInternal {
     lock.writeLock().lock();
     final int[] vectorIds;
     try {
-      // CRITICAL: If we couldn't read any entries from pages (e.g., during database close),
-      // DON'T replace vectorIndex - use what's already in memory!
+      // CRITICAL: If we couldn't read any live entry from pages, DON'T replace vectorIndex - use what's already
+      // in memory! Publishing an empty location index here would drop entries that only exist in RAM.
       if (!ridToLatestVector.isEmpty()) {
         // Update vectorIndex to match what we found on pages (sync it with disk state).
         if (!locationIndexAlreadyPublished)
           publishLocationIndex(ridToLatestVector.values());
         vectorIds = finalActiveVectorIdsFromPages; // Use vector IDs from pages (may include doc-scan fallback)
       } else {
-        LogManager.instance().log(this, Level.SEVERE,
-            "FALLBACK: Could not read vectors from pages (database closing), using existing vectorIndex with %d entries",
-            vectorIndex.size());
         // Build vector IDs from existing vectorIndex
         vectorIds = vectorIndex.getAllVectorIds().filter(id -> {
           final VectorLocationIndex.VectorLocation loc = vectorIndex.getLocation(id);
           return loc != null && !loc.deleted;
         }).sorted().toArray();
-        LogManager.instance()
-            .log(this, Level.SEVERE, "FALLBACK: Built %d active vector IDs from in-memory vectorIndex",
-                vectorIds.length);
+
+        // Pages holding no live vector is the ordinary state of a brand new index, and of one whose records have
+        // all been deleted: there the tombstones cancel every entry out. Neither says the database is going away,
+        // and neither is worth a level operators alert on. Only a disagreement between the two sources is: memory
+        // still knows about live vectors the pages did not yield, which is what an interrupted rebuild or an
+        // unreadable data file looks like. Report what was observed, never a cause that was not checked.
+        LogManager.instance().log(this, vectorIds.length > 0 ? Level.WARNING : Level.FINE,
+            "No live vector read from the pages of index %s (%d entries parsed): building the graph from the in-memory index instead (%d live of %d entries)",
+            indexName, totalEntriesRead[0], vectorIds.length, vectorIndex.size());
       }
     } finally {
       lock.writeLock().unlock();

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexEmptyRebuildLogTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexEmptyRebuildLogTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.log.WarningCapture;
+import com.arcadedb.log.WarningCapture.LogLine;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A vector index whose pages hold no live vector is the most ordinary state there is: it has just been created, or
+ * every record it covered has been deleted. The graph rebuild used to report both at SEVERE, and to blame a database
+ * close it had never checked for. SEVERE is the level operators page on, so two of them per index creation is how a
+ * class gets filtered out of alerting right before it has something real to say.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LSMVectorIndexEmptyRebuildLogTest extends TestHelper {
+
+  private static final int DIMENSIONS = 8;
+
+  @Test
+  void creatingAnEmptyVectorIndexReportsNothingAtWarningOrAbove() {
+    final List<LogLine> lines = WarningCapture.capture(Level.WARNING, () -> database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql",
+          "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA {\"dimensions\": " + DIMENSIONS + "}");
+    }));
+
+    // The claim the old message made, checked against the state it claimed it from.
+    assertThat(database.isOpen()).isTrue();
+    assertRebuildIsNotAlarming(lines);
+  }
+
+  /**
+   * The same for an index that had vectors and lost them all: the pages are full of tombstones, so the live set the
+   * rebuild computes is empty exactly as it is for a fresh index.
+   */
+  @Test
+  void emptyingAVectorIndexReportsNothingAtWarningOrAbove() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql",
+          "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA {\"dimensions\": " + DIMENSIONS + "}");
+      for (int i = 0; i < 5; i++)
+        database.command("sql", "INSERT INTO Doc SET name = ?, embedding = ?", "v" + i, vector(i));
+    });
+
+    final LSMVectorIndex index = vectorIndex();
+    index.buildVectorGraphNow();
+
+    database.transaction(() -> database.command("sql", "DELETE FROM Doc"));
+
+    final List<LogLine> lines = WarningCapture.capture(Level.WARNING, index::buildVectorGraphNow);
+
+    assertThat(database.isOpen()).isTrue();
+    assertRebuildIsNotAlarming(lines);
+  }
+
+  /**
+   * Nothing at all, not merely nothing at SEVERE. Asserting only the absence of SEVERE would leave the other half of
+   * the fix unguarded: a routine empty index reported at WARNING is still a line an operator has to triage, and the
+   * WARNING arm of the rebuild is reserved for the one case that is a real disagreement between pages and memory.
+   */
+  private static void assertRebuildIsNotAlarming(final List<LogLine> lines) {
+    assertThat(lines)
+        .as("An empty vector index is a routine state and must not be reported at WARNING or above")
+        .isEmpty();
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[embedding]");
+    return (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+  }
+
+  private static float[] vector(final int seed) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (seed + 1) * (i + 1) / 10f;
+    return v;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/log/WarningCapture.java
+++ b/engine/src/test/java/com/arcadedb/log/WarningCapture.java
@@ -16,18 +16,16 @@
  * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.arcadedb.partitioning;
+package com.arcadedb.log;
 
-import com.arcadedb.log.LogManager;
-import com.arcadedb.log.Logger;
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 
 /**
- * Collects the WARNING (or worse) lines the engine logs while a block of code runs. Shared by the partitioned
- * strategy tests, whose whole subject is what gets reported and what deliberately does not.
+ * Collects the WARNING (or worse) lines the engine logs while a block of code runs. Shared by every test whose
+ * subject is what the engine reports, what it deliberately does not, and at which level.
  * <p>
  * Deliberately not a {@code java.util.logging} handler. The test resources set {@code com.arcadedb.level=SEVERE}, so
  * whether a WARNING ever reaches a JUL handler depends on which loggers the rest of the suite happened to
@@ -42,25 +40,34 @@ import java.util.logging.Level;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-final class WarningCapture {
+public final class WarningCapture {
+
+  /** One captured line, kept with its level so a test can assert the level and not only the text. */
+  public record LogLine(Level level, String message) {
+  }
 
   private WarningCapture() {
   }
 
   /** Runs {@code action} and returns the WARNING-or-worse messages the engine logged while it ran. */
-  static List<String> captureWarnings(final Runnable action) {
-    return capture(action, Level.WARNING);
+  public static List<String> captureWarnings(final Runnable action) {
+    return messagesOf(capture(Level.WARNING, action));
   }
 
   /**
    * The same, restricted to SEVERE. Lets a test assert that a condition it expects to be reported is reported at the
    * level that says "this database is configured that way" rather than the one that says "the engine is broken".
    */
-  static List<String> captureSevere(final Runnable action) {
-    return capture(action, Level.SEVERE);
+  public static List<String> captureSevere(final Runnable action) {
+    return messagesOf(capture(Level.SEVERE, action));
   }
 
-  private static List<String> capture(final Runnable action, final Level minimum) {
+  /**
+   * Runs {@code action} and returns every line logged at {@code minimum} or above, level included. Use this when the
+   * assertion is about the level itself: that a routine condition is not shouted at SEVERE, or that a real anomaly is
+   * still reported at WARNING rather than silently swallowed.
+   */
+  public static List<LogLine> capture(final Level minimum, final Runnable action) {
     final CapturingLogger capturing = new CapturingLogger(LogManager.instance().getLogger(), minimum);
     LogManager.instance().setLogger(capturing);
     try {
@@ -71,10 +78,17 @@ final class WarningCapture {
     return capturing.messages;
   }
 
+  private static List<String> messagesOf(final List<LogLine> lines) {
+    final List<String> messages = new ArrayList<>(lines.size());
+    for (final LogLine line : lines)
+      messages.add(line.message());
+    return messages;
+  }
+
   private static final class CapturingLogger implements Logger {
-    private final Logger       delegate;
-    private final Level        minimum;
-    private final List<String> messages = new CopyOnWriteArrayList<>();
+    private final Logger        delegate;
+    private final Level         minimum;
+    private final List<LogLine> messages = new CopyOnWriteArrayList<>();
 
     private CapturingLogger(final Logger delegate, final Level minimum) {
       this.delegate = delegate;
@@ -85,11 +99,11 @@ final class WarningCapture {
       if (message == null || level.intValue() < minimum.intValue())
         return;
       try {
-        messages.add(args.length > 0 ? message.formatted(args) : message);
+        messages.add(new LogLine(level, args.length > 0 ? message.formatted(args) : message));
       } catch (final Exception ignored) {
         // A message whose placeholders do not match the arguments is still worth having in the list verbatim:
         // dropping it would turn a formatting bug into a test that silently stops seeing the line it asserts on.
-        messages.add(message);
+        messages.add(new LogLine(level, message));
       }
     }
 

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -33,8 +33,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 
-import static com.arcadedb.partitioning.WarningCapture.captureSevere;
-import static com.arcadedb.partitioning.WarningCapture.captureWarnings;
+import static com.arcadedb.log.WarningCapture.captureSevere;
+import static com.arcadedb.log.WarningCapture.captureWarnings;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategySuitabilityTest.java
@@ -44,7 +44,7 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 
-import static com.arcadedb.partitioning.WarningCapture.captureWarnings;
+import static com.arcadedb.log.WarningCapture.captureWarnings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 


### PR DESCRIPTION
Fixes #5762

## What was wrong with this PR

The branch as submitted contained none of the change its title described. Its two commits were `fix(build): uncomment benchmark exclusion in surefire config (#5697)` and a bot refresh of `bolt/conformance/COMPATIBILITY.md`, so the diff was `pom.xml` plus a docs file and the log statements were untouched. The branch has been rebased onto `main` and rewritten to contain the described fix and nothing else. That benchmark-exclusion change is already open on its own as #5730, so nothing is lost by dropping it here.

## The fix

`buildGraphFromScratchExclusively()` reads "the pages hold no live vector" as evidence that the database is closing, and says so twice at SEVERE. That state is the ordinary one for a brand new index, and for one whose records have all been deleted, where the tombstones cancel every page entry out. The database is open in both cases, so the message asserts a cause that was never checked, and SEVERE is the level operators alert on.

Downgrading a misleading message would still leave it misleading, so both the level and the text change:

- the two lines become one, since the second carried nothing the first did not;
- it reports what was observed (index name, entries parsed from pages, live and total in-memory entries) rather than a diagnosis;
- FINE when nothing is live anywhere, which is the routine case from the issue;
- WARNING only when the in-memory index still holds live vectors the pages did not yield, which is what an interrupted rebuild or an unreadable data file actually looks like.

The fallback behaviour itself is unchanged: the graph is still built from the in-memory location index, which is correct for every one of these cases.

## Testing

`LSMVectorIndexEmptyRebuildLogTest` covers the two routine cases, index creation with no records and deletion of every record, and asserts that the rebuild reports nothing at WARNING or above. Asserting only the absence of SEVERE would have left the other half of the change unguarded: an empty index reported at WARNING is still a line an operator has to triage, and the WARNING arm is reserved for the pages and the memory actually disagreeing.

Both halves were checked by reverting the production change and watching the test go red:

- restoring the original two SEVERE lines fails both methods with `Expecting empty but was: [LogLine[level=SEVERE, message=FALLBACK: Could not read vectors from pages (database closing), ...], LogLine[level=SEVERE, message=FALLBACK: Built 0 active vector IDs from in-memory vectorIndex]]`, which also proves both routine cases really reach the branch;
- making the level an unconditional `WARNING` fails both methods too, on the new message text.

`WarningCapture`, the log-capturing helper the partitioned strategy tests already used, moves from `com.arcadedb.partitioning` to `com.arcadedb.log` so both suites share it rather than adding a sixth ad hoc capturing logger to the engine tests. It now records the level next to the message so a test can assert the level itself.

`mvn -pl engine -am test -Dtest='com.arcadedb.index.vector.*Test'`: 267 tests, 0 failures. `mvn -pl engine -am test -Dtest=LSMVectorIndexEmptyRebuildLogTest,PartitionedStrategyLifecycleTest,PartitionedStrategySuitabilityTest`: 35 tests, 0 failures, so the two suites that consume the moved helper are unaffected by the move.
