### PR TITLE
fix(engine) #5764: a refused vertex delete names the command that repairs it, and the conflict keeps its cause

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -2012,3 +2012,62 @@ The replacement restores the previous definition on failure, including a manual 
 metadata, the same route `CREATE INDEX <name>` uses) and the page size. It is not atomic, though: the drop and the
 build are separate schema changes, so a process that dies between them leaves the type without an index on those
 properties until one is created again. Only an explicit `withReplaceIfIncompatible` is exposed to that window.
+
+## A refused vertex delete names the command that repairs it, and the conflict keeps its cause
+
+Follow-ups from #5680, whose two halves landed separately (#5707 made `deleteVertex` strict, #5710 added the
+`CHECK DATABASE RECORD` scope), so the seams between them were never closed (#5764).
+
+### The repair advice names the scoped command, with the RID substituted
+
+Every recovery hint `GraphEngine.deleteVertex` emitted predated the scope it was written for, so they all pointed at
+a whole-database or whole-type run - two full passes over the vertex type plus an edge sweep - while the operator was
+holding the one piece of information that makes the repair cheap. And the retryable arm rethrew the conflict bare, so
+what actually reached a human was `getEdgeHeadChunkForWrite`'s "concurrent commit in flight", which says nothing about
+recovery at all.
+
+A delete refused because the vertex's own list cannot be walked now answers with the command to run:
+
+```
+Edge list IN of vertex #12:3 is not fully visible yet (concurrent commit in flight): ...
+  If it persists once the retries are spent the list is genuinely broken: run `CHECK DATABASE RECORD #12:3 FIX` to
+  rebuild its edge list from the surviving edge records, then retry the delete (the scope saves the vertex passes,
+  not the edge sweep the rebuild needs)
+```
+
+When the conflict comes from disconnecting a collected edge at its **other** end, the list that needs rebuilding
+belongs to the neighbour, so that is the RID named - repairing the healthy vertex under delete would do nothing.
+
+The `force` arms keep the whole-database form, deliberately: by the time they log, the delete has gone through, so
+the record a scoped check would be aimed at no longer exists. They say what the scoped form would have bought had it
+been run first.
+
+### `ConcurrentModificationException` carries the failure that produced it
+
+`NeedRetryException` already declared a `(message, cause)` constructor; `ConcurrentModificationException` exposed only
+`(String)`, so every site that raised one from a caught exception - eight across `GraphEngine`, `EdgeLinkedList` and
+`StripedEdgeList` - discarded the original stack. A conflict is normally absorbed by the retry and never seen, so the
+single run that does surface one is the retry-exhausted run: exactly the run whose stack trace has to be diagnosable.
+The cause is now kept. The exception class on the wire is unchanged, so nothing about HTTP status mapping or the
+remote driver's typed reconstruction moves; only the `detail` chain in a development-mode error body gets longer.
+
+### `CHECK DATABASE` reports a corrupt document the same way whichever scope found it
+
+The type-wide document check added to the `warnings` and `corruptedRecords` sets without touching `totalWarnings` and
+`totalCorruptedRecords`, so a run listed the finding while reporting zero of both - and, since the retained sets are
+capped and the totals are not, that divergence grew with the number of findings. It also called a document a
+"vertex", and said it was "removing it" when nothing on that path removes anything (`corruptedRecords` only drives the
+end-of-run index rebuild). Both paths now emit `document <rid> cannot be loaded`, count it, and honour `maxWarnings`.
+
+If you parse `CHECK DATABASE` output, note the two changes: the message text for an unloadable document, and
+`totalWarnings`/`totalCorruptedRecords` now being non-zero on a type-wide run that finds one.
+
+### The scoped vertex check runs one pass where the type-wide runs two - and that is correct
+
+Recorded rather than changed, since the asymmetry looks like a gap. The type-wide arm materialises each record from
+the raw page view in a bucket scan and then again through the connectivity walk; the scoped arm appears to run only
+the second. But `lookupByRID` *is* the first - it performs the same
+`newImmutableRecord(type, rid, bucket.getRecord(rid).copyOfContent())` - and the connectivity walk opens with the same
+`asVertex(true)`, whose `loadContent` flag is what forces the decode. `LocalBucket.getRecord` and `LocalBucket.scan`
+resolve placeholders and multi-page chains identically and skip the same slot markers, so no corruption shape reaches
+one enumeration and not the other. Pinned by a test that corrupts a record and asserts both scopes report it.

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -468,10 +468,20 @@ public class DatabaseChecker {
 
   /**
    * Flags a record as corrupted, bounded the way {@code GraphDatabaseChecker.addCorrupted} bounds the graph arms:
-   * the total keeps counting every occurrence, the retained set does not grow without limit.
+   * the total keeps counting, the retained set does not grow without limit.
    * <p>
-   * The total is incremented only for a RID the set has not already accounted for, so it stays comparable with the
-   * set's size for as long as the cap allows - a record flagged twice is one corrupted record.
+   * De-duplication is EXACT while the set is under the cap - a record flagged twice is one corrupted record, since
+   * the set itself answers "have I seen this". Past the cap it degrades to what the retained set can still answer:
+   * a RID already in the set is still recognised (which is why the {@code contains} check is there rather than an
+   * unconditional increment), but one that was never retained cannot be, so a second flag on it counts twice. That
+   * is deliberate and not worth closing: the only way to keep it exact past the cap is a second unbounded set of
+   * every RID ever counted, which is precisely the memory the cap exists to refuse. Neither caller reaches it today
+   * - the type-wide bucket scan visits each RID once, and the RECORD scope is a {@link Set}, so a duplicate cannot
+   * survive as far as {@link #groupRecordsByType()}.
+   * <p>
+   * The cap is {@code maxWarnings} because that is the only bound this class has; the {@code maxCorrupted} the
+   * graph arms take is a separate knob {@link GraphDatabaseChecker} owns, and it is passed the remaining budget
+   * from this same field by {@link #checkScopedRecords}. Two names, one setting.
    */
   private void addCorrupted(final RID rid) {
     final LinkedHashSet<RID> corrupted = (LinkedHashSet<RID>) result.get("corruptedRecords");

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -157,13 +157,13 @@ public class DatabaseChecker {
 
       if (droppedRecords > 0)
         // No count, for the same reason the refusal above quotes none.
-        addScopedWarning("one or more of the records given did not resolve to a RID and were not checked");
+        addWarning("one or more of the records given did not resolve to a RID and were not checked");
 
       if (compress)
         // COMPRESS is not scoped and cannot be: it works on buckets, not records. Legal and meaningful ("check
         // this record, then compress the database"), so it is not refused - but naming a record sets an
         // expectation of a bounded run, and this is the one clause that breaks it. Say so rather than surprise.
-        addScopedWarning(
+        addWarning(
             "COMPRESS is not limited by the RECORD scope: the whole database will be compressed after the check");
 
       checkScopedRecords(scoped);
@@ -283,12 +283,25 @@ public class DatabaseChecker {
         .collect(Collectors.toList());
   }
 
+  /**
+   * The type-wide document check. #5764 settled the three ways it used to disagree with its RECORD-scoped twin
+   * {@link #checkScopedDocuments} over the SAME finding, all of them in the reporting rather than in the check:
+   * <ul>
+   *   <li>it added to the {@code warnings}/{@code corruptedRecords} sets without touching
+   *   {@code totalWarnings}/{@code totalCorruptedRecords}, so a corrupt document reported different numbers
+   *   depending on which path found it - and, since the totals are what a capped run reports, reported zero once
+   *   the sets filled up;</li>
+   *   <li>it called a document a "vertex", and said it was "removing it" when nothing here removes anything -
+   *   {@code corruptedRecords} only drives the index rebuild at the end of {@link #check()};</li>
+   *   <li>it kept no cap at all, so a type whose whole bucket is unreadable retained one message per record.</li>
+   * </ul>
+   * Both paths now go through {@link #addWarning}/{@link #addCorrupted}. The accumulators are also per-type now:
+   * they used to be declared outside the loop and re-added to the result after every type, which the sets absorbed
+   * but paid for in re-insertions proportional to the square of the type count.
+   */
   private void checkDocuments(final List<DocumentType> documentTypes) {
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Checking documents...");
-
-    final List<String> warnings = new ArrayList<>();
-    final Set<RID> corruptedRecords = new LinkedHashSet<>();
 
     for (final DocumentType type : documentTypes) {
       stepBegin("Checking documents '" + type.getName() + "'", database.countType(type.getName(), false));
@@ -303,8 +316,8 @@ public class DatabaseChecker {
               final Record record = database.getRecordFactory().newImmutableRecord(database, type, rid, view, null);
               record.asDocument(true);
             } catch (Exception e) {
-              warnings.add("vertex " + rid + " cannot be loaded, removing it");
-              corruptedRecords.add(rid);
+              addWarning("document " + rid + " cannot be loaded");
+              addCorrupted(rid);
             }
             stepTick();
             return true;
@@ -316,9 +329,6 @@ public class DatabaseChecker {
       }
 
       stepComplete();
-
-      ((LinkedHashSet<String>) result.get("warnings")).addAll(warnings);
-      ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll(corruptedRecords);
     }
   }
 
@@ -405,7 +415,7 @@ public class DatabaseChecker {
         // The bucket belongs to no type (an internal file, or a RID the caller invented). Capped like every other
         // warning source: a caller passing thousands of bogus RIDs must not blow past maxWarnings.
         for (final RID rid : rids) {
-          addScopedWarning("record " + rid + " does not belong to any type");
+          addWarning("record " + rid + " does not belong to any type");
           stepTick();
         }
         stepComplete();
@@ -441,11 +451,13 @@ public class DatabaseChecker {
   }
 
   /**
-   * Records a RECORD-scope warning: always counted, retained only while under {@code maxWarnings}, and - like
-   * {@code GraphDatabaseChecker.addWarning} - LOGGED when it has to be dropped, so a capped run does not lose the
-   * message silently.
+   * Records a warning raised by this class itself (as opposed to one merged in from a nested checker): always
+   * counted, retained only while under {@code maxWarnings}, and - like {@code GraphDatabaseChecker.addWarning} -
+   * LOGGED when it has to be dropped, so a capped run does not lose the message silently.
+   * <p>
+   * #5764: shared with the type-wide {@link #checkDocuments}, which used to bypass the totals and the cap.
    */
-  private void addScopedWarning(final String warning) {
+  private void addWarning(final String warning) {
     result.put("totalWarnings", (Long) result.get("totalWarnings") + 1);
     final LinkedHashSet<String> warnings = (LinkedHashSet<String>) result.get("warnings");
     if (warnings.size() < maxWarnings)
@@ -455,14 +467,26 @@ public class DatabaseChecker {
   }
 
   /**
-   * The document arm of the RECORD scope: the same "does it load as a document" check {@link #checkDocuments} does,
-   * with the {@code maxWarnings} cap the record-belongs-to-no-type branch honours (the totals still count every
-   * occurrence, only the retained messages are bounded).
+   * Flags a record as corrupted, bounded the way {@code GraphDatabaseChecker.addCorrupted} bounds the graph arms:
+   * the total keeps counting every occurrence, the retained set does not grow without limit.
    * <p>
-   * NOTE, deliberately not aligned here: the type-wide {@link #checkDocuments} adds to the warnings and
-   * corrupted-records SETS without incrementing {@code totalWarnings}/{@code totalCorruptedRecords}, so the two
-   * paths report those totals differently for a corrupt document. This arm is the correct one; changing the
-   * type-wide path is a behaviour change to a command this issue does not otherwise touch.
+   * The total is incremented only for a RID the set has not already accounted for, so it stays comparable with the
+   * set's size for as long as the cap allows - a record flagged twice is one corrupted record.
+   */
+  private void addCorrupted(final RID rid) {
+    final LinkedHashSet<RID> corrupted = (LinkedHashSet<RID>) result.get("corruptedRecords");
+    if (corrupted.size() < maxWarnings) {
+      if (!corrupted.add(rid))
+        return;
+    } else if (corrupted.contains(rid))
+      return;
+    result.put("totalCorruptedRecords", (Long) result.get("totalCorruptedRecords") + 1);
+  }
+
+  /**
+   * The document arm of the RECORD scope: the same "does it load as a document" check {@link #checkDocuments} does,
+   * over the RIDs named instead of over every bucket of the type. Since #5764 the two report a finding identically
+   * - same message, same totals, same cap - so a corrupt document reads the same whichever path found it.
    */
   private void checkScopedDocuments(final DocumentType type, final List<RID> rids) {
     stepBegin("Checking records of '" + type.getName() + "'", rids.size());
@@ -475,17 +499,11 @@ public class DatabaseChecker {
         } catch (final RecordNotFoundException e) {
           // Not corruption: flagging it would put this bucket into affectedBuckets and have FIX drop and rebuild
           // every index on it - see the same guard in GraphDatabaseChecker's scoped arms.
-          addScopedWarning("document " + rid + " does not exist");
+          addWarning("document " + rid + " does not exist");
         } catch (final Exception e) {
           // NOT "removing it": corruptedRecords only drives the index rebuild, nothing deletes the record here.
-          // The type-wide checkDocuments says otherwise, and says "vertex" for a document while it is at it.
-          addScopedWarning("document " + rid + " cannot be loaded");
-          // Bounded like addCorrupted bounds the graph arms - the total keeps counting, the retained set does
-          // not grow without limit on a scope naming a large batch of unloadable documents.
-          final LinkedHashSet<RID> corrupted = (LinkedHashSet<RID>) result.get("corruptedRecords");
-          if (corrupted.size() < maxWarnings)
-            corrupted.add(rid);
-          result.put("totalCorruptedRecords", (Long) result.get("totalCorruptedRecords") + 1);
+          addWarning("document " + rid + " cannot be loaded");
+          addCorrupted(rid);
         }
         stepTick();
       }

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -66,6 +66,21 @@ public class DatabaseChecker {
           + "check. Drop the TYPE/BUCKET clause, or run the two checks separately";
   /** #5680: entries {@link #setRecords} discarded because they did not resolve; reported, never silent. */
   private       int                 droppedRecords = 0;
+  /**
+   * The ONLY retention bound this class has: it caps both the {@code warnings} messages ({@link #addWarning}) and
+   * the {@code corruptedRecords} set ({@link #addCorrupted}).
+   * <p>
+   * #5764, so a future reader does not "fix" the apparent inconsistency: {@code GraphDatabaseChecker} takes a
+   * SEPARATE {@code maxCorrupted} parameter for the same set, which looks like two policies on one run. It is one -
+   * {@link #checkEdges}, {@link #checkVertices} and {@link #checkScopedRecords} all pass this field's REMAINING
+   * budget into that parameter, so both names resolve to this setting. Aligning the two would mean adding a knob,
+   * not removing a divergence.
+   * <p>
+   * The cap is not purely cosmetic, which is why it is worth stating: the RETAINED {@code corruptedRecords} are
+   * what {@link #check()} turns into {@code affectedBuckets}, so a record dropped past the cap does not get the
+   * indexes on its bucket rebuilt under {@code FIX}. Only reachable on a run finding more than 100k corrupt
+   * records, where a bounded repair is the point.
+   */
   private       int                 maxWarnings  = 100_000;
   private final Map<String, Object> result       = new HashMap<>();
 

--- a/engine/src/main/java/com/arcadedb/exception/ConcurrentModificationException.java
+++ b/engine/src/main/java/com/arcadedb/exception/ConcurrentModificationException.java
@@ -22,4 +22,14 @@ public class ConcurrentModificationException extends NeedRetryException {
   public ConcurrentModificationException(final String s) {
     super(s);
   }
+
+  /**
+   * #5764: a conflict raised FROM a caught exception keeps it as the cause. Most of these are absorbed by the
+   * transaction retry and never seen, so the single run that does surface one is the retry-exhausted run - i.e.
+   * exactly the run whose stack trace has to be diagnosable, and the one that used to arrive with the original
+   * failure discarded. {@link NeedRetryException} already declared the pair; only this subclass was missing it.
+   */
+  public ConcurrentModificationException(final String s, final Throwable cause) {
+    super(s, cause);
+  }
 }

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -536,7 +536,7 @@ public class EdgeLinkedList {
     } catch (final RecordNotFoundException e) {
       throw new ConcurrentModificationException(
           "Edge list " + direction + " chunk " + chunkRID + " of vertex " + vertex.getIdentity()
-              + " not visible yet (concurrent commit in flight)");
+              + " not visible yet (concurrent commit in flight)", e);
     }
   }
 
@@ -647,7 +647,7 @@ public class EdgeLinkedList {
     } catch (final RecordNotFoundException e) {
       throw new ConcurrentModificationException(
           "Edge list " + direction + " chunk " + chunkRID + " of vertex " + vertex.getIdentity()
-              + " is no longer readable (concurrent commit in flight)");
+              + " is no longer readable (concurrent commit in flight)", e);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -390,6 +390,19 @@ public class GraphDatabaseChecker {
    * The edge-record scan inside {@link #reconnectEdges} is NOT scoped: rebuilding an adjacency means finding
    * every surviving edge that points at the vertex, and no index maps endpoints back to edges. So the scoped run
    * saves the vertex passes, not the edge pass.
+   * <p>
+   * #5764 - why ONE pass here answers what TWO answer below, which is not obvious from the shapes. The type-wide
+   * arm materialises each record twice: once from the raw page view in the bucket scan
+   * ({@code newImmutableRecord(type, rid, view)} then {@code asVertex(true)}), and once again through the
+   * connectivity walk. The scoped arm looks like it runs only the second - but {@code LocalDatabase.lookupByRID}
+   * IS the first: it calls the same {@code newImmutableRecord(type, rid, bucket.getRecord(rid).copyOfContent())},
+   * and {@link #checkVertices}' shared {@code checkConnectivity} opens with the same {@code asVertex(true)}, whose
+   * {@code loadContent} flag is what forces the buffer decode. Both halves of the type-wide first pass therefore
+   * run per listed RID, and no corruption shape reaches one enumeration but not the other:
+   * {@code LocalBucket.getRecord} and {@code LocalBucket.scan} resolve placeholders and multi-page chains
+   * identically and skip the same slot markers. The type-wide pass is a second look at the same bytes, kept there
+   * because a scan is how a whole type is enumerated at all - not a check the scoped run is missing. Pinned by
+   * {@code CheckDatabaseRecordScopeTest.theScopedAndTypeWideRunsAgreeOnAGenuinelyCorruptedRecord}.
    */
   public Map<String, Object> checkVertices(final String typeName, final Collection<RID> scopedRecords,
       final boolean fix, final int verboseLevel, final int maxWarnings, final int maxCorrupted) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -410,7 +410,7 @@ public class GraphEngine {
         // existing list here (silent edge loss) whenever this window was hit.
         throw new ConcurrentModificationException(
             "Edge list " + direction + " head chunk " + headRID + " of vertex " + vertex.getIdentity()
-                + " not visible yet (concurrent commit in flight)");
+                + " not visible yet (concurrent commit in flight)", e);
       }
 
     // FIRST EDGE IN THIS DIRECTION: the vertex record itself is rewritten (head pointer), so materialise the
@@ -708,6 +708,10 @@ public class GraphEngine {
    * {@code force}: {@link EdgeLinkedList#anchorForFullRemoval()} pins every page of the list at the version the
    * walk reads it at, and {@link #checkEdgeListHeadsUnchanged} re-reads the vertex's head pointers, for the append
    * that lands in a BRAND NEW chunk and so touches none of those pages.
+   * <p>
+   * #5764: every recovery hint this method emits names {@code CHECK DATABASE RECORD}, the scope #5710 added for
+   * exactly this case - see {@link #scopedRepairAdvice} and {@link #danglingRepairAdvice} for which of the two
+   * each outcome deserves.
    */
   public void deleteVertex(final VertexInternal vertex, final boolean force) {
     // #5660: the edge-list heads are pointers INSIDE the vertex record, so they must be read from the instance this
@@ -730,14 +734,20 @@ public class GraphEngine {
       } catch (final RecordNotFoundException e) {
         // ALREADY DELETED, IGNORE IT
       } catch (final NeedRetryException e) {
-        // THE EDGE LIST OF THE VERTEX AT THE OTHER END IS NOT READABLE (SEE getEdgeHeadChunkForWrite)
+        // THE EDGE LIST OF THE VERTEX AT THE OTHER END IS NOT READABLE (SEE getEdgeHeadChunkForWrite). #5764: the
+        // list that needs rebuilding belongs to the NEIGHBOUR, not to the vertex being deleted, so that is the RID
+        // the advice names - resolved best-effort, since reading the edge is what just failed.
+        final RID otherEnd = otherEndOf(edge, mostUpdatedVertex.getIdentity());
         if (!force)
-          throw e;
+          throw otherEnd != null ? withRepairAdvice(e, otherEnd) : e;
         LogManager.instance()
             .log(this, Level.WARNING, """
                     Cannot disconnect edge %s from the vertex at its other end while force-deleting vertex %s: \
-                    the reference survives, run a database check to repair it""", e, edge.getIdentity(),
-                mostUpdatedVertex.getIdentity());
+                    the reference survives, %s""", e, edge.getIdentity(), mostUpdatedVertex.getIdentity(),
+                otherEnd != null ?
+                    "rebuild that vertex's list with `CHECK DATABASE RECORD " + otherEnd + " FIX`, then "
+                        + danglingRepairAdvice() :
+                    danglingRepairAdvice());
       }
 
     if (hadOutList)
@@ -777,6 +787,73 @@ public class GraphEngine {
   private static RID[] readEdgeListHeads(final VertexInternal vertex) {
     try {
       return new RID[] { vertex.getOutEdgesHeadChunk(), vertex.getInEdgesHeadChunk() };
+    } catch (final RuntimeException e) {
+      return null;
+    }
+  }
+
+  /**
+   * #5764: the repair for a vertex whose edge list cannot be walked, named as a command that can be pasted into a
+   * console rather than as a category of command.
+   * <p>
+   * This is the outcome {@code CHECK DATABASE RECORD} (#5710) was added for: the delete was REFUSED, so the vertex
+   * is still there, and the operator holds the one piece of information that makes the repair cheap - the RID -
+   * while every message here used to point at a whole-database or whole-type run costing two full passes over the
+   * vertex type. Stated in the same breath because the scope does not bound everything: rebuilding an adjacency
+   * means finding every surviving edge that points at the vertex, and no index maps an endpoint back to its edges,
+   * so the edge sweep still runs once per distinct vertex type named.
+   *
+   * @see #danglingRepairAdvice() for the other outcome - the delete went THROUGH and left references behind.
+   */
+  private static String scopedRepairAdvice(final RID vertexRID) {
+    return "run `CHECK DATABASE RECORD " + vertexRID + " FIX` to rebuild its edge list from the surviving edge "
+        + "records, then retry the delete (the scope saves the vertex passes, not the edge sweep the rebuild needs)";
+  }
+
+  /**
+   * #5764: the repair for the OTHER outcome - the vertex record is gone and the references the delete could not
+   * remove now dangle. {@code CHECK DATABASE RECORD} cannot help there: the record it would be aimed at no longer
+   * exists, and the survivors are edges nobody can enumerate without a scan. So this one stays whole-database, and
+   * says what the scoped form would have bought had it been run BEFORE the delete.
+   */
+  private static String danglingRepairAdvice() {
+    return "run `CHECK DATABASE FIX` to drop the references that now dangle - rebuilding the list first with "
+        + "`CHECK DATABASE RECORD <vertex> FIX` and deleting without force is what keeps the edges";
+  }
+
+  /**
+   * #5764: the same retryable conflict, carrying the repair command for the vertex whose list could not be read.
+   * <p>
+   * A conflict is normally absorbed by the transaction retry and never seen, so the one run that DOES surface this
+   * message is the retry-exhausted one - which, by the design spelled out on {@link #collectEdgesToDelete}, is the
+   * run where the list is genuinely broken rather than transiently invisible. That is precisely the run whose
+   * message has to say how to recover, and it used to arrive carrying only {@code getEdgeHeadChunkForWrite}'s
+   * "concurrent commit in flight".
+   * <p>
+   * The class is preserved rather than re-typed: a retryable that is NOT a conflict (a lock timeout, replication
+   * back-pressure) means something else entirely, and rewriting it into a {@link ConcurrentModificationException}
+   * to improve a message would throw that distinction away.
+   */
+  private static NeedRetryException withRepairAdvice(final NeedRetryException e, final RID vertexRID) {
+    if (!(e instanceof ConcurrentModificationException))
+      return e;
+    return new ConcurrentModificationException(
+        e.getMessage() + ". If it persists once the retries are spent the list is genuinely broken: "
+            + scopedRepairAdvice(vertexRID), e);
+  }
+
+  /**
+   * The endpoint of {@code edge} that is not {@code vertexRID}, or {@code null} when it cannot be resolved.
+   * <p>
+   * Best-effort on purpose, and only ever used to enrich a message: this is called from the handler for an edge
+   * whose disconnection just failed, so the edge record itself may well be unreadable. A failure to name the
+   * neighbour must degrade the advice, never replace the original failure.
+   */
+  private static RID otherEndOf(final Identifiable edge, final RID vertexRID) {
+    try {
+      final Edge resolved = edge.asEdge();
+      final RID out = resolved.getOut();
+      return vertexRID.equals(out) ? resolved.getIn() : out;
     } catch (final RuntimeException e) {
       return null;
     }
@@ -823,11 +900,11 @@ public class GraphEngine {
       // The vertex is already gone: a concurrent transaction deleted it while this one was disconnecting its
       // edges. Retry, and let the re-read decide there is nothing left to delete.
       throw new ConcurrentModificationException(
-          "Vertex " + vertexRID + " was deleted by a concurrent transaction while its edges were being removed");
+          "Vertex " + vertexRID + " was deleted by a concurrent transaction while its edges were being removed", e);
     } catch (final ClassCastException e) {
       // The RID no longer names a vertex: the slot was reused after a concurrent delete. Same answer as above.
       throw new ConcurrentModificationException(
-          "Vertex " + vertexRID + " no longer names a vertex record (concurrent commit in flight)");
+          "Vertex " + vertexRID + " no longer names a vertex record (concurrent commit in flight)", e);
     }
 
     final RID[] committedHeads = readEdgeListHeads(committed);
@@ -901,11 +978,14 @@ public class GraphEngine {
       }
     } catch (final NeedRetryException e) {
       if (!force)
-        throw e;
+        // #5764: NOT a bare rethrow. What the operator saw was getEdgeHeadChunkForWrite's "concurrent commit in
+        // flight", which is the right diagnosis for the transient case that never reaches a human and says nothing
+        // about the permanent one that does. See withRepairAdvice.
+        throw withRepairAdvice(e, vertex.getIdentity());
       LogManager.instance()
           .log(this, Level.WARNING, """
-                  Cannot read the %s edge list of vertex %s while force-deleting it: its edges survive, run a \
-                  database check to repair them""", e, direction, vertex.getIdentity());
+                  Cannot read the %s edge list of vertex %s while force-deleting it: its edges survive, %s""", e,
+              direction, vertex.getIdentity(), danglingRepairAdvice());
     } catch (final SerializationException | NegativeArraySizeException | BufferUnderflowException
                    | IndexOutOfBoundsException | IllegalArgumentException | ClassCastException | SchemaException e) {
       // LINKED LIST COULD BE BROKEN. Not an oversight and not the case above: this arm is what is left once the
@@ -918,8 +998,9 @@ public class GraphEngine {
       // vertex whose buffer is corrupt reaches this method with force == false. Failing here would therefore make it
       // undeletable - precisely the "records that can't be deleted" complaint issues #4420 and #4432 fixed. The cost
       // is real and larger than the tolerated single dangling entry (everything behind the corrupt chunk is dropped,
-      // and the vertex is still deleted), which is why it is logged at WARNING: CHECK DATABASE ... FIX rebuilds the
-      // chain from the surviving edge records and is the way to delete such a vertex without losing its edges.
+      // and the vertex is still deleted), which is why it is logged at WARNING: `CHECK DATABASE RECORD <rid> FIX`
+      // rebuilds the chain from the surviving edge records and is the way to delete such a vertex without losing
+      // its edges - run BEFORE the delete, since by the time this fires the vertex is on its way out (#5764).
       //
       // The list is CLOSED, and deliberately not a blanket catch (Exception): "tolerate and delete anyway" is the
       // behaviour this whole method exists to take away from conditions that do not deserve it, so it must not be
@@ -936,7 +1017,7 @@ public class GraphEngine {
       LogManager.instance()
           .log(this, Level.WARNING, """
                   Cannot decode the %s edge list of vertex %s (corrupted chunk): deleting it anyway, edges behind the \
-                  damage survive - run a database check to repair them""", e, direction, vertex.getIdentity());
+                  damage survive - %s""", e, direction, vertex.getIdentity(), danglingRepairAdvice());
     }
     return edges != null;
   }
@@ -964,7 +1045,7 @@ public class GraphEngine {
     } catch (final RecordNotFoundException e) {
       throw new ConcurrentModificationException(
           "Edge list " + direction + " of vertex " + vertex.getIdentity()
-              + " is not fully readable (concurrent commit in flight): " + e.getMessage());
+              + " is not fully readable (concurrent commit in flight): " + e.getMessage(), e);
     }
   }
 
@@ -1529,7 +1610,7 @@ public class GraphEngine {
     } catch (final RecordNotFoundException e) {
       throw new ConcurrentModificationException(
           "Edge list " + direction + " of vertex " + vertex.getIdentity()
-              + " is not fully visible yet (concurrent commit in flight): " + e.getMessage());
+              + " is not fully visible yet (concurrent commit in flight): " + e.getMessage(), e);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -837,8 +837,12 @@ public class GraphEngine {
   private static NeedRetryException withRepairAdvice(final NeedRetryException e, final RID vertexRID) {
     if (!(e instanceof ConcurrentModificationException))
       return e;
+    // toString() rather than getMessage(): every conflict raised on this path carries a message today, but a
+    // message-less one would render the advice as "null. If it persists...", which reads as a bug in the advice
+    // rather than as a missing diagnosis. toString() degrades to the class name instead.
+    final String diagnosis = e.getMessage() != null ? e.getMessage() : e.toString();
     return new ConcurrentModificationException(
-        e.getMessage() + ". If it persists once the retries are spent the list is genuinely broken: "
+        diagnosis + ". If it persists once the retries are spent the list is genuinely broken: "
             + scopedRepairAdvice(vertexRID), e);
   }
 
@@ -848,6 +852,13 @@ public class GraphEngine {
    * Best-effort on purpose, and only ever used to enrich a message: this is called from the handler for an edge
    * whose disconnection just failed, so the edge record itself may well be unreadable. A failure to name the
    * neighbour must degrade the advice, never replace the original failure.
+   * <p>
+   * ONE case would answer {@code vertexRID} itself despite the name, and it is the right answer rather than a leak
+   * to be closed: a self-loop ({@code out == in == vertexRID}) has no other end, and the list that failed to
+   * disconnect it IS the vertex's own - so that is the RID whose repair the caller must name. Not reachable today,
+   * which is why there is no test for it: the only caller runs after BOTH of the vertex's lists have been collected
+   * successfully, and a self-loop is read out of those same two lists, so a list broken enough to fail the
+   * disconnection fails the collection first and never gets here. Stated so the equality is not "simplified" away.
    */
   private static RID otherEndOf(final Identifiable edge, final RID vertexRID) {
     try {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1043,6 +1043,9 @@ public class GraphEngine {
     try {
       return iterator.hasNext();
     } catch (final RecordNotFoundException e) {
+      // Interpolated AND kept as the cause, for the reason spelled out on getEdgeHeadChunkForWrite: the chunk that
+      // could not be loaded is named only inside the record-not-found message, and the top-level message is what
+      // reaches a log line (#5764).
       throw new ConcurrentModificationException(
           "Edge list " + direction + " of vertex " + vertex.getIdentity()
               + " is not fully readable (concurrent commit in flight): " + e.getMessage(), e);
@@ -1608,6 +1611,11 @@ public class GraphEngine {
         return null;
       return buildEdgeList(vertex, direction, rid);
     } catch (final RecordNotFoundException e) {
+      // The cause and the interpolated e.getMessage() are NOT redundant, though they read that way (#5764). This
+      // message is the only place the missing CHUNK's RID appears - the text above names the vertex, not the chunk,
+      // which is inside the record-not-found message - and the top-level message is what a log line and an HTTP
+      // error body carry, while the cause chain surfaces only in a full trace or a development-mode detail field.
+      // Pinned by Issue5670EdgeDeleteDanglingBackRefTest, which asserts the head chunk's RID is in this message.
       throw new ConcurrentModificationException(
           "Edge list " + direction + " of vertex " + vertex.getIdentity()
               + " is not fully visible yet (concurrent commit in flight): " + e.getMessage(), e);

--- a/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
+++ b/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
@@ -499,7 +499,8 @@ public class StripedEdgeList extends EdgeLinkedList {
         // (e.g. a removal leaving a stale back-reference). The miss is transient by construction (cross-file
         // commit publication) - surface it as a retryable conflict, symmetric with loadChunkForWrite.
         throw new ConcurrentModificationException(
-            "Stripe chain " + headRID + " of vertex " + vertex.getIdentity() + " not visible yet (concurrent commit in flight)");
+            "Stripe chain " + headRID + " of vertex " + vertex.getIdentity() + " not visible yet (concurrent commit in flight)",
+            e);
       final long now = System.currentTimeMillis();
       final long last = LAST_SKIPPED_CHAIN_WARN.get();
       if (now - last > 60_000 && LAST_SKIPPED_CHAIN_WARN.compareAndSet(last, now))

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRecordScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRecordScopeTest.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -432,11 +433,107 @@ class CheckDatabaseRecordScopeTest extends TestHelper {
   }
 
   /**
+   * #5764, item 4: the scoped arm materialises the record through {@code lookupByRID} and the type-wide arm through
+   * a raw bucket scan, so a corruption shape that surfaced only through the raw view would be caught by one and
+   * missed by the other. It cannot: {@code lookupByRID} IS that materialisation
+   * ({@code newImmutableRecord(type, rid, bucket.getRecord(rid).copyOfContent())}), and both then decode through the
+   * same {@code asVertex(true)}. Pinned rather than argued, so a future change to either enumeration that breaks the
+   * equivalence fails here.
+   */
+  @Test
+  void theScopedAndTypeWideRunsAgreeOnAGenuinelyCorruptedRecord() {
+    createSchema();
+
+    final RID[] victim = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex v = database.newVertex("Src").set("name", "corrupt-me");
+      v.save();
+      victim[0] = v.getIdentity();
+    });
+
+    shrinkRecordBuffer(victim[0]);
+
+    // Neither run is allowed to FIX: the point is that the two CHECKS see the same thing, and a fix would delete
+    // the record out from under the second one.
+    final long scopedCorrupted = corruptedReportedBy("CHECK DATABASE RECORD " + victim[0], victim[0]);
+    final long typeWideCorrupted = corruptedReportedBy("CHECK DATABASE TYPE Src", victim[0]);
+
+    assertThat(scopedCorrupted).as("the scoped run must flag the corrupted record").isEqualTo(1L);
+    assertThat(typeWideCorrupted).as("and the type-wide run must agree, not merely also complain")
+        .isEqualTo(scopedCorrupted);
+  }
+
+  /**
+   * #5764, item 3: the same corrupt DOCUMENT must read the same whichever path found it. The type-wide arm used to
+   * add to the warning and corrupted-record sets without touching {@code totalWarnings}/{@code totalCorruptedRecords}
+   * - so a run reported zero of both while listing the finding - and called the document a "vertex" it was
+   * "removing", when nothing on that path removes anything.
+   */
+  @Test
+  void aCorruptDocumentIsReportedIdenticallyByTheScopedAndTypeWideRuns() {
+    createSchema();
+    database.transaction(() -> database.getSchema().createDocumentType("Doc"));
+
+    final RID[] victim = new RID[1];
+    database.transaction(() -> victim[0] = database.newDocument("Doc").set("k", 1).save().getIdentity());
+
+    corruptRecordTypeByte(victim[0]);
+
+    final String expected = "document " + victim[0] + " cannot be loaded";
+
+    for (final String command : List.of("CHECK DATABASE RECORD " + victim[0], "CHECK DATABASE TYPE Doc")) {
+      try (final ResultSet rs = database.command("sql", command)) {
+        assertThat(rs.hasNext()).isTrue();
+        final Result row = rs.next();
+        assertThat((Collection<String>) row.getProperty("warnings")).as("%s: %s", command, row.toJSON())
+            .contains(expected);
+        assertThat(longProperty(row, "totalWarnings")).as("%s must COUNT what it reports: %s", command, row.toJSON())
+            .isGreaterThan(0L);
+        assertThat(longProperty(row, "totalCorruptedRecords")).as("%s: %s", command, row.toJSON()).isEqualTo(1L);
+      }
+    }
+  }
+
+  /** Runs a non-fixing check and returns its corrupted-record total, asserting the record was named in a warning. */
+  private long corruptedReportedBy(final String command, final RID rid) {
+    try (final ResultSet rs = database.command("sql", command)) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat((Collection<String>) row.getProperty("warnings")).as("%s: %s", command, row.toJSON())
+          .anyMatch(w -> w.contains(rid.toString()));
+      assertThat((Collection<?>) row.getProperty("rebuiltIndexes")).as("no FIX, so nothing may be rebuilt: %s",
+          row.toJSON()).isEmpty();
+      return longProperty(row, "totalCorruptedRecords");
+    }
+  }
+
+  /**
+   * Overwrites the record-type byte of {@code rid} with a value no {@code RecordFactory} branch knows, so the record
+   * still occupies its slot and still has a valid size, but cannot be materialised at all - the one corruption shape
+   * that reaches BOTH the raw-view construction of the type-wide scan and the {@code lookupByRID} of the scoped arm
+   * at the same point, which is what makes the two paths comparable.
+   */
+  private void corruptRecordTypeByte(final RID rid) {
+    onRecordPage(rid, (page, recordOffset) -> {
+      final long[] recordSize = page.readNumberAndSize(recordOffset);
+      page.writeByte((int) (recordOffset + recordSize[1]), (byte) 99);
+    });
+  }
+
+  /**
    * Replaces the record-size varint of {@code rid} with a single-byte varint encoding a size far below the fixed
    * 25-byte vertex prefix, so the record still occupies its slot but can no longer be read back as a vertex - the
    * on-disk shape of a corrupted (as opposed to a missing) record. zigzag(8) == 16.
    */
   private void shrinkRecordBuffer(final RID rid) {
+    onRecordPage(rid, (page, recordOffset) -> page.writeByte(recordOffset, (byte) 16));
+  }
+
+  /**
+   * Runs {@code mutation} against the page holding {@code rid}, handing it the content-relative offset where the
+   * record's size varint starts. Shared by the corruption helpers so they agree on the page layout.
+   */
+  private void onRecordPage(final RID rid, final BiConsumer<MutablePage, Integer> mutation) {
     final DatabaseInternal db = (DatabaseInternal) database;
     final int fileId = rid.getBucketId();
     final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
@@ -454,7 +551,7 @@ class CheckDatabaseRecordScopeTest extends TestHelper {
         final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
         final int recordOffset = (int) page.readUnsignedInt(slotOffset);
         assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
-        page.writeByte(recordOffset, (byte) 16);
+        mutation.accept(page, recordOffset);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }

--- a/engine/src/test/java/com/arcadedb/graph/Issue5764DeleteVertexRepairAdviceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5764DeleteVertexRepairAdviceTest.java
@@ -29,7 +29,6 @@ import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -158,7 +157,7 @@ class Issue5764DeleteVertexRepairAdviceTest extends TestHelper {
    * when run BEFORE the delete.
    */
   @Test
-  void aForcedDeleteAdvisesTheWholeDatabaseFixBecauseTheScopedFormCannotHelpAfterwards() throws Exception {
+  void aForcedDeleteAdvisesTheWholeDatabaseFixBecauseTheScopedFormCannotHelpAfterwards() {
     createSchema();
     final RID hubRID = createHub();
     final List<RID> edges = createEdges(hubRID, 1);
@@ -167,7 +166,9 @@ class Issue5764DeleteVertexRepairAdviceTest extends TestHelper {
     deleteRecord(outHeadChunk(srcRID));
 
     final List<String> warnings = new CopyOnWriteArrayList<>();
-    final Logger originalLogger = readField(LogManager.instance(), "logger");
+    // getLogger(), not reflection on the private field: LogManager exposes the accessor for exactly this - a
+    // caller that temporarily swaps the logger and has to put the original back.
+    final Logger originalLogger = LogManager.instance().getLogger();
     LogManager.instance().setLogger(new CapturingLogger(warnings, originalLogger));
     try {
       database.transaction(() -> graphEngine().deleteVertex((VertexInternal) srcRID.asVertex(), true));
@@ -201,13 +202,6 @@ class Issue5764DeleteVertexRepairAdviceTest extends TestHelper {
     for (Throwable current = e; current != null && !chain.contains(current); current = current.getCause())
       chain.add(current);
     return chain;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> T readField(final Object target, final String name) throws Exception {
-    final Field f = target.getClass().getDeclaredField(name);
-    f.setAccessible(true);
-    return (T) f.get(target);
   }
 
   private GraphEngine graphEngine() {

--- a/engine/src/test/java/com/arcadedb/graph/Issue5764DeleteVertexRepairAdviceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5764DeleteVertexRepairAdviceTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * #5764: what {@code GraphEngine.deleteVertex} tells an operator when it cannot walk an edge list, and what it
+ * keeps of the failure that made it say so.
+ * <p>
+ * #5680 made the delete strict and #5710 added {@code CHECK DATABASE RECORD}, but they landed separately, so every
+ * recovery hint the delete emitted still predated the scope it was written for: they all advised a whole-database
+ * or whole-type run, costing two full passes over the vertex type plus an edge sweep, while the operator was
+ * holding the one piece of information - the RID - that makes the repair cheap. And the retryable arm rethrew the
+ * conflict bare, so what surfaced was {@code getEdgeHeadChunkForWrite}'s "concurrent commit in flight", which is
+ * the right diagnosis for the transient case nobody ever sees and says nothing about the permanent one that
+ * reaches a human.
+ * <p>
+ * These tests pin the advice by EXECUTING it: the command is parsed out of the message the delete raised and run
+ * verbatim, and the delete must then go through. A message that named the wrong RID, or a command shape the SQL
+ * parser does not accept, fails here rather than in production.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5764DeleteVertexRepairAdviceTest extends TestHelper {
+
+  /** These tests deliberately break an edge-list chain, so the blanket end-of-test check would always fire. */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  private static final Pattern SCOPED_COMMAND = Pattern.compile("`(CHECK DATABASE RECORD [^`]+)`");
+
+  /**
+   * The case the {@code RECORD} scope exists for: the vertex's OWN list is unreadable, so the delete is REFUSED and
+   * the vertex is still there to be repaired. The message must name the command aimed at that vertex, and running
+   * exactly what it says must make the delete succeed and take every edge with it.
+   */
+  @Test
+  void theRefusedDeleteNamesAScopedRepairCommandThatReallyRepairsIt() {
+    createSchema();
+    final RID hubRID = createHub();
+    final List<RID> edges = createEdges(hubRID, 200);
+
+    deleteRecord(inChunkChain(hubRID).get(0));
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(() -> hubRID.asVertex().delete(), false, 1));
+    assertThat(thrown).isInstanceOf(ConcurrentModificationException.class);
+
+    final String command = scopedRepairCommandIn(thrown.getMessage());
+    assertThat(command).as("the delete must name the scoped repair: %s", thrown.getMessage())
+        .isEqualTo("CHECK DATABASE RECORD " + hubRID + " FIX");
+    // The original diagnosis is not replaced by the advice, only extended by it.
+    assertThat(thrown.getMessage()).contains("concurrent commit in flight");
+
+    // Not decoration: the exact string the operator was handed is what repairs the graph.
+    try (final ResultSet rs = database.command("sql", command)) {
+      assertThat(rs.hasNext()).isTrue();
+    }
+
+    database.transaction(() -> hubRID.asVertex().delete(), false, 1);
+
+    database.transaction(() -> {
+      assertThat(database.existsRecord(hubRID)).isFalse();
+      for (final RID edge : edges)
+        assertThat(database.existsRecord(edge)).as("edge " + edge + " outlived its vertex").isFalse();
+    });
+  }
+
+  /**
+   * The list that needs rebuilding is not always the one being deleted. When the conflict comes from disconnecting
+   * a collected edge at its OTHER end, the broken list belongs to the NEIGHBOUR - so that is the RID the advice has
+   * to name. Naming the vertex under delete would send the operator to repair a record that is perfectly healthy.
+   */
+  @Test
+  void aConflictRaisedByTheNeighbourNamesTheNeighbourAndNotTheVertexBeingDeleted() {
+    createSchema();
+    final RID hubRID = createHub();
+    final List<RID> edges = createEdges(hubRID, 20);
+    final RID srcRID = outVertexOf(edges.get(edges.size() - 1));
+
+    deleteRecord(inHeadChunk(hubRID));
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(() -> srcRID.asVertex().delete(), false, 1));
+    assertThat(thrown).isInstanceOf(ConcurrentModificationException.class);
+
+    final String command = scopedRepairCommandIn(thrown.getMessage());
+    assertThat(command).as("%s", thrown.getMessage()).isEqualTo("CHECK DATABASE RECORD " + hubRID + " FIX");
+    assertThat(command).as("the healthy vertex under delete must not be the repair target")
+        .doesNotContain(srcRID.toString());
+  }
+
+  /**
+   * The conflict keeps the failure that produced it. A retryable is normally absorbed and never seen, so the run
+   * that does surface one is the retry-exhausted run - exactly the run whose stack trace has to be diagnosable, and
+   * the one that used to arrive with the cause discarded because
+   * {@code ConcurrentModificationException} had no {@code (message, cause)} constructor at all.
+   */
+  @Test
+  void theConflictCarriesTheOriginalFailureAsItsCause() {
+    createSchema();
+    final RID hubRID = createHub();
+    createEdges(hubRID, 200);
+
+    deleteRecord(inChunkChain(hubRID).get(0));
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(() -> hubRID.asVertex().delete(), false, 1));
+    assertThat(thrown).isInstanceOf(ConcurrentModificationException.class);
+    assertThat(thrown.getCause()).as("the advice must WRAP the conflict, not replace it").isNotNull();
+
+    final List<Throwable> chain = causeChainOf(thrown);
+    assertThat(chain).as("cause chain: %s", chain)
+        .anyMatch(RecordNotFoundException.class::isInstance);
+  }
+
+  /**
+   * The other outcome, and the reason it gets DIFFERENT advice: under {@code force} the delete goes THROUGH, so by
+   * the time the warning is logged the record a scoped check would be aimed at no longer exists. Pointing there
+   * would be worse than the whole-database form it replaced - it names a repair that cannot run. The message must
+   * therefore keep the whole-database command for the references left dangling, and say what the scoped form buys
+   * when run BEFORE the delete.
+   */
+  @Test
+  void aForcedDeleteAdvisesTheWholeDatabaseFixBecauseTheScopedFormCannotHelpAfterwards() throws Exception {
+    createSchema();
+    final RID hubRID = createHub();
+    final List<RID> edges = createEdges(hubRID, 1);
+    final RID srcRID = outVertexOf(edges.get(0));
+
+    deleteRecord(outHeadChunk(srcRID));
+
+    final List<String> warnings = new CopyOnWriteArrayList<>();
+    final Logger originalLogger = readField(LogManager.instance(), "logger");
+    LogManager.instance().setLogger(new CapturingLogger(warnings, originalLogger));
+    try {
+      database.transaction(() -> graphEngine().deleteVertex((VertexInternal) srcRID.asVertex(), true));
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
+
+    database.transaction(() -> assertThat(database.existsRecord(srcRID)).isFalse());
+
+    final List<String> advice = warnings.stream().filter(w -> w.contains(srcRID.toString())).toList();
+    assertThat(advice).as("the forced delete must say what it left behind (captured=%s)", warnings).isNotEmpty();
+    assertThat(advice).allSatisfy(w -> {
+      assertThat(w).as("%s", w).contains("CHECK DATABASE FIX");
+      // The scoped form appears only as the placeholder shape describing what to do BEFORE a delete. It must never
+      // be handed out with the RID substituted here: the record it would name is the one just deleted.
+      assertThat(scopedRepairCommandIn(w)).as("%s", w).isEqualTo("CHECK DATABASE RECORD <vertex> FIX");
+      assertThat(w).as("%s", w).doesNotContain("CHECK DATABASE RECORD " + srcRID);
+    });
+  }
+
+  /** The scoped repair command inside a message, or {@code null} when it names none. */
+  private static String scopedRepairCommandIn(final String message) {
+    if (message == null)
+      return null;
+    final Matcher m = SCOPED_COMMAND.matcher(message);
+    return m.find() ? m.group(1) : null;
+  }
+
+  private static List<Throwable> causeChainOf(final Throwable e) {
+    final List<Throwable> chain = new ArrayList<>();
+    for (Throwable current = e; current != null && !chain.contains(current); current = current.getCause())
+      chain.add(current);
+    return chain;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T readField(final Object target, final String name) throws Exception {
+    final Field f = target.getClass().getDeclaredField(name);
+    f.setAccessible(true);
+    return (T) f.get(target);
+  }
+
+  private GraphEngine graphEngine() {
+    return ((DatabaseInternal) database).getGraphEngine();
+  }
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Hub", 1);
+      database.getSchema().createVertexType("Src", 16);
+      database.getSchema().createEdgeType("LINK", 16);
+    });
+  }
+
+  private RID createHub() {
+    final MutableVertex[] holder = new MutableVertex[1];
+    database.transaction(() -> {
+      holder[0] = database.newVertex("Hub");
+      holder[0].save();
+    });
+    return holder[0].getIdentity();
+  }
+
+  /** One edge per transaction, so the hub's IN chain grows chunk by chunk exactly as it does in production. */
+  private List<RID> createEdges(final RID hubRID, final int count) {
+    final List<RID> edges = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      final RID[] holder = new RID[1];
+      database.transaction(() -> {
+        final MutableVertex src = database.newVertex("Src");
+        src.save();
+        holder[0] = src.newEdge("LINK", hubRID).getIdentity();
+      });
+      edges.add(holder[0]);
+    }
+    return edges;
+  }
+
+  private RID outVertexOf(final RID edgeRID) {
+    final RID[] holder = new RID[1];
+    database.transaction(() -> holder[0] = edgeRID.asEdge().getOut());
+    return holder[0];
+  }
+
+  private RID outHeadChunk(final RID vertexRID) {
+    final RID[] holder = new RID[1];
+    database.transaction(() -> holder[0] = ((VertexInternal) vertexRID.asVertex()).getOutEdgesHeadChunk());
+    assertThat(holder[0]).as("the vertex must have an outgoing edge list").isNotNull();
+    return holder[0];
+  }
+
+  private RID inHeadChunk(final RID vertexRID) {
+    final RID[] holder = new RID[1];
+    database.transaction(() -> holder[0] = ((VertexInternal) vertexRID.asVertex()).getInEdgesHeadChunk());
+    assertThat(holder[0]).as("the vertex must have an incoming edge list").isNotNull();
+    return holder[0];
+  }
+
+  /** The hub's IN chunk chain, head first (newest chunk) to tail (the chunk created with the first edge). */
+  private List<RID> inChunkChain(final RID hubRID) {
+    final List<RID> chain = new ArrayList<>();
+    database.transaction(() -> {
+      RID rid = ((VertexInternal) hubRID.asVertex()).getInEdgesHeadChunk();
+      while (rid != null) {
+        chain.add(rid);
+        rid = ((EdgeSegment) database.lookupByRID(rid, true)).getPreviousRID();
+      }
+    });
+    return chain;
+  }
+
+  private void deleteRecord(final RID rid) {
+    database.transaction(() -> database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid));
+    database.transaction(() -> assertThat(database.existsRecord(rid)).isFalse());
+  }
+
+  /**
+   * Captures WARNING-and-above messages into a list while forwarding every record to the production logger, so the
+   * test output still shows what fired.
+   */
+  private static final class CapturingLogger implements Logger {
+    private final List<String> warnings;
+    private final Logger       delegate;
+
+    CapturingLogger(final List<String> warnings, final Logger delegate) {
+      this.warnings = warnings;
+      this.delegate = delegate;
+    }
+
+    private void capture(final Level level, final String message, final Object... args) {
+      if (message == null || level.intValue() < Level.WARNING.intValue())
+        return;
+      String formatted = message;
+      if (args != null && args.length > 0) {
+        try {
+          formatted = message.formatted(args);
+        } catch (final Exception ignored) {
+          // Fall back to the raw template - good enough for the substring matching above.
+        }
+      }
+      warnings.add(formatted);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+        final Object arg15, final Object arg16, final Object arg17) {
+      capture(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14,
+          arg15, arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      capture(level, message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/Issue5764DeleteVertexRepairAdviceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5764DeleteVertexRepairAdviceTest.java
@@ -155,6 +155,14 @@ class Issue5764DeleteVertexRepairAdviceTest extends TestHelper {
    * would be worse than the whole-database form it replaced - it names a repair that cannot run. The message must
    * therefore keep the whole-database command for the references left dangling, and say what the scoped form buys
    * when run BEFORE the delete.
+   * <p>
+   * NOTE on the capture: {@link LogManager} is a singleton, so swapping its logger is PROCESS-WIDE for the duration
+   * of the forced delete below. Restored in a {@code finally}, and safe under the suite as it runs today (surefire
+   * executes classes sequentially within a fork), but it is shared state: if class-level parallelism is ever
+   * enabled in this module, a concurrent test's WARNING output would land in {@code warnings} here and this test's
+   * delegate would be whatever that test installed. There is no per-invocation seam to capture through - the log
+   * call sites go straight to the singleton - so the alternative is asserting on nothing, which is worse than a
+   * documented window.
    */
   @Test
   void aForcedDeleteAdvisesTheWholeDatabaseFixBecauseTheScopedFormCannotHelpAfterwards() {


### PR DESCRIPTION
Closes #5764.

Follow-ups from #5680, whose two halves landed separately (#5707 made `deleteVertex` strict, #5710 added the `CHECK DATABASE RECORD` scope). Neither is defective; the seams between them were never closed.

Three of the four items needed code. The fourth turned out to be a non-issue that needed proving rather than fixing.

## 1. The repair advice names the scoped command, with the RID substituted

Every recovery hint `GraphEngine.deleteVertex` emitted predated the scope it was written for, so they all pointed at a whole-database or whole-type run - two full passes over the vertex type plus an edge sweep - while the operator was holding the one piece of information that makes the repair cheap. The retryable arm rethrew the conflict bare, so what actually reached a human was `getEdgeHeadChunkForWrite`'s "concurrent commit in flight", which says nothing about recovery.

**Departure from the report's suggestion.** Naming `CHECK DATABASE RECORD <rid> FIX` at all four sites would be wrong at three of them. The scoped form is the right answer only where the delete was **refused** and the vertex is still there to repair. The `force` arms log *after* the record is gone, so a scoped check would name a record that no longer exists - they keep the whole-database form and say what the scoped form buys when run *first*. And at the other-end conflict the broken list belongs to the **neighbour**, so that is the RID named; repairing the healthy vertex under delete would do nothing.

A refused delete now answers with:

```
Edge list IN of vertex #12:3 is not fully visible yet (concurrent commit in flight): ...
  If it persists once the retries are spent the list is genuinely broken: run `CHECK DATABASE RECORD #12:3 FIX`
  to rebuild its edge list from the surviving edge records, then retry the delete (the scope saves the vertex
  passes, not the edge sweep the rebuild needs)
```

The limit is stated in the same breath because the scope does not bound everything: the edge sweep the rebuild needs still runs once per distinct vertex type named.

## 2. `ConcurrentModificationException` carries the failure that produced it

`NeedRetryException` already declared `(message, cause)`; the subclass exposed only `(String)`, so eight sites across `GraphEngine`, `EdgeLinkedList` and `StripedEdgeList` kept the message and dropped the stack. A conflict is normally absorbed by the retry and never seen, so the single run that does surface one is the retry-exhausted run - exactly the one whose trace has to be diagnosable.

The wrapper preserves the exception class when the retryable is *not* a conflict (a lock timeout, replication back-pressure), so re-typing to improve a message cannot throw that distinction away. The class on the wire is unchanged, so nothing about HTTP status mapping or the remote driver's typed reconstruction moves; only the `detail` chain in a development-mode error body gets longer.

## 3. `checkDocuments` and `checkScopedDocuments` report a finding identically

The type-wide arm added to the `warnings`/`corruptedRecords` **sets** without touching `totalWarnings`/`totalCorruptedRecords`, so a run listed the finding while reporting zero of both. It also called a document a "vertex" it was "removing", when nothing on that path removes anything (`corruptedRecords` only drives the end-of-run index rebuild).

Two things the report did not mention, fixed while there: the type-wide arm honoured **no `maxWarnings` cap at all**, and its accumulators were declared outside the type loop and re-added to the result after every type (the sets absorbed it; the re-insertions were quadratic in the type count). Both paths now go through a shared `addWarning`/`addCorrupted`.

**Behaviour change worth noting for anyone parsing `CHECK DATABASE` output:** the message text for an unloadable document, and `totalWarnings`/`totalCorruptedRecords` now being non-zero on a type-wide run that finds one.

## 4. The scoped vertex check runs one pass where the type-wide runs two - and that is correct

Documented, not changed. `lookupByRID` **is** the raw-view materialisation the type-wide bucket scan does - the same `newImmutableRecord(type, rid, bucket.getRecord(rid).copyOfContent())` - and `checkConnectivity` opens with the same `asVertex(true)`, whose `loadContent` flag is what forces the buffer decode. Both halves of the type-wide first pass therefore run per listed RID. `LocalBucket.getRecord` and `LocalBucket.scan` resolve placeholders and multi-page chains identically and skip the same slot markers, so no corruption shape reaches one enumeration and not the other.

Adding the pass would have doubled the cost of the scope that exists to be cheap. Pinned by a test that corrupts a record and asserts both scopes report it, so a future change that breaks the equivalence fails there.

## Tests

New `Issue5764DeleteVertexRepairAdviceTest` (4 tests) pins the advice by **executing** it: the command is parsed out of the exception the delete raised and run verbatim, and the delete must then go through. A message naming the wrong RID, or a command shape the SQL parser does not accept, fails here rather than in production. It also pins the neighbour-vs-self RID choice, the cause chain, and that the `force` arm never hands out a RID-substituted scoped command.

Two tests added to `CheckDatabaseRecordScopeTest` for items 3 and 4.

Green: 371 `com.arcadedb.graph` tests, 802 `com.arcadedb.database` + `com.arcadedb.engine` tests, the SQL and index packages. One unrelated flake (`LSMVectorIndexRecoveryTest.vectorNeighborsShouldReturnCorrectCountAfterIncrementalInsertAndRebuild`, a timing-based inactivity-rebuild assertion) passes on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puky78GhudfgTHPtYSuFPm