### PR TITLE
fix(ci): add continue-on-error to test reporter steps to prevent flaky CI failures

### DIFF
--- a/.github/scripts/check-test-results.py
+++ b/.github/scripts/check-test-results.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#
+# Fails when a surefire/failsafe report records a failing test.
+#
+# The test jobs run Maven with --fail-never, which prints "Build failures were ignored." and exits
+# 0 even when a suite failed. Nothing in the Maven step can turn a failing test red, so until now
+# the only thing that did was the dorny/test-reporter step: it reads the same XML and, with its
+# default fail-on-error, fails itself. That works, but it makes a third-party action that talks to
+# the GitHub API the sole arbiter of whether the build passed - an outage or a rate limit there is
+# indistinguishable from a test failure, and the only way to make the outage non-fatal is
+# continue-on-error, which would equally swallow the failures.
+#
+# This script is that arbiter instead. It reads the reports off the local disk, so it depends on
+# nothing but the files Maven just wrote, and the reporter step above it is free to fail without
+# taking the job with it.
+#
+# An empty result set is a failure too. Reports missing altogether means the suite never ran -
+# a module that did not compile, a fork that died before writing anything - and reporting "no
+# failures found" for a run that produced no evidence is exactly the false green this guards.
+#
+# Usage:
+#   check-test-results.py surefire-reports            # unit tests
+#   check-test-results.py failsafe-reports            # integration tests
+#   check-test-results.py surefire-reports --root DIR # scan DIR instead of the repository
+#
+# @author Luca Garulli (l.garulli@arcadedata.com)
+
+import os
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+# How many failing suites to name before the list is cut short. The reporter step publishes the
+# full detail; this is only meant to say why the job is red without scrolling.
+MAX_LISTED = 25
+
+
+def report_files(root, reports_dir):
+    """Every TEST*.xml written by surefire/failsafe under a directory named reports_dir."""
+    found = []
+    for current, directories, files in os.walk(root):
+        # Nothing puts reports there, and walking them on a full build costs seconds.
+        directories[:] = [d for d in directories if d not in (".git", "node_modules")]
+        if Path(current).name != reports_dir:
+            continue
+        for name in files:
+            if name.startswith("TEST") and name.endswith(".xml"):
+                found.append(Path(current) / name)
+    return sorted(found)
+
+
+def suite_counts(path):
+    """(tests, failures, errors) for one report, or None when the file cannot be read.
+
+    A report surefire could not finish writing - a forked JVM killed mid-flush - is not evidence
+    of success, so an unreadable file is reported rather than skipped.
+    """
+    try:
+        root = ElementTree.parse(path).getroot()
+    except (ElementTree.ParseError, OSError):
+        return None
+
+    # A testsuite may be wrapped in a testsuites element; sum whichever level carries the counts.
+    suites = [root] if root.tag == "testsuite" else root.iter("testsuite")
+
+    tests = failures = errors = 0
+    for suite in suites:
+        tests += int(suite.get("tests", 0))
+        failures += int(suite.get("failures", 0))
+        errors += int(suite.get("errors", 0))
+    return tests, failures, errors
+
+
+def main(arguments):
+    root = Path(__file__).resolve().parents[2]
+    positional = []
+    index = 0
+    while index < len(arguments):
+        if arguments[index] == "--root":
+            if index + 1 >= len(arguments):
+                sys.exit("check-test-results: --root needs a directory")
+            root = Path(arguments[index + 1])
+            index += 2
+        else:
+            positional.append(arguments[index])
+            index += 1
+
+    if len(positional) != 1:
+        sys.exit("usage: check-test-results.py <surefire-reports|failsafe-reports> [--root DIR]")
+    reports_dir = positional[0]
+
+    files = report_files(root, reports_dir)
+    if not files:
+        print(
+            "check-test-results: no %s/TEST*.xml under %s.\n"
+            "The suite produced no report at all, so there is nothing to prove it ran. Check the\n"
+            "Maven step above: a module that failed to compile leaves exactly this trace." % (reports_dir, root),
+            file=sys.stderr,
+        )
+        return 1
+
+    tests = failures = errors = 0
+    broken = []
+    failed = []
+    for path in files:
+        counts = suite_counts(path)
+        if counts is None:
+            broken.append(path)
+            continue
+        tests += counts[0]
+        failures += counts[1]
+        errors += counts[2]
+        if counts[1] or counts[2]:
+            failed.append((path, counts[1], counts[2]))
+
+    print("check-test-results: %d test(s) in %d %s file(s), %d failure(s), %d error(s)" % (tests, len(files), reports_dir, failures, errors))
+
+    if not failed and not broken:
+        return 0
+
+    print("", file=sys.stderr)
+    for path, suite_failures, suite_errors in failed[:MAX_LISTED]:
+        print("  %s: %d failure(s), %d error(s)" % (path.relative_to(root), suite_failures, suite_errors), file=sys.stderr)
+    if len(failed) > MAX_LISTED:
+        print("  ... and %d more" % (len(failed) - MAX_LISTED), file=sys.stderr)
+    for path in broken[:MAX_LISTED]:
+        print("  %s: report is unreadable" % path.relative_to(root), file=sys.stderr)
+    print(
+        "\nMaven ran with --fail-never and exited 0 regardless. The test report is the verdict.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -22,6 +22,7 @@ cd "$(dirname "$0")/../../.."
 SCRIPTS=".github/scripts"
 DEPS="$SCRIPTS/check-workflow-artifact-deps.py"
 COLLECT="$SCRIPTS/collect-coverage-reports.sh"
+RESULTS="$SCRIPTS/check-test-results.py"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -490,6 +491,68 @@ if [[ $(id -u) -ne 0 ]]; then
         "$COLLECT" "ha-integration-tests=$work/coverage/unreadable"
     chmod 755 "$work/coverage/unreadable"
 fi
+
+echo
+echo "check-test-results.py"
+
+# Writes what surefire/failsafe write: one file per class, the counts on the root element.
+suite_report() {
+    local path="$1" name="$2" tests="$3" suite_failures="$4" suite_errors="$5"
+    mkdir -p "$(dirname "$path")"
+    cat >"$path" <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="$name" time="0.5" tests="$tests" errors="$suite_errors" skipped="0" failures="$suite_failures">
+  <testcase name="aTest" classname="$name" time="0.5"/>
+</testsuite>
+XML
+}
+
+green="$work/results/green"
+suite_report "$green/engine/target/surefire-reports/TEST-com.arcadedb.GreenTest.xml" com.arcadedb.GreenTest 7 0 0
+suite_report "$green/server/target/surefire-reports/TEST-com.arcadedb.server.GreenTest.xml" com.arcadedb.server.GreenTest 3 0 0
+expect "accepts a run in which every suite passed" 0 "10 test(s)" \
+    "$RESULTS" surefire-reports --root "$green"
+
+# #5763's shape: Maven ran with --fail-never and exited 0, so this report is the only evidence
+# there is. A green exit here would publish a failing suite as a passing job.
+failing="$work/results/failing"
+suite_report "$failing/engine/target/surefire-reports/TEST-com.arcadedb.GreenTest.xml" com.arcadedb.GreenTest 7 0 0
+suite_report "$failing/ha-raft/target/surefire-reports/TEST-com.arcadedb.RedTest.xml" com.arcadedb.RedTest 4 1 0
+expect "rejects a run with a failed test" 1 "TEST-com.arcadedb.RedTest.xml" \
+    "$RESULTS" surefire-reports --root "$failing"
+
+# An error is a distinct attribute from a failure and is just as fatal.
+erroring="$work/results/erroring"
+suite_report "$erroring/engine/target/surefire-reports/TEST-com.arcadedb.BrokenTest.xml" com.arcadedb.BrokenTest 4 0 2
+expect "rejects a run with an errored test" 1 "2 error(s)" \
+    "$RESULTS" surefire-reports --root "$erroring"
+
+# Reports for the other test phase are not this job's verdict: the integration jobs run with
+# -DskipTests, and a stale surefire directory must not redden them.
+mixed="$work/results/mixed"
+suite_report "$mixed/engine/target/surefire-reports/TEST-com.arcadedb.RedTest.xml" com.arcadedb.RedTest 4 1 0
+suite_report "$mixed/engine/target/failsafe-reports/TEST-com.arcadedb.GreenIT.xml" com.arcadedb.GreenIT 4 0 0
+expect "reads only the reports of the phase it was asked about" 0 "4 test(s)" \
+    "$RESULTS" failsafe-reports --root "$mixed"
+
+# No report at all means the suite never ran. Answering "no failures" to that is the false green
+# this check exists to prevent.
+mkdir -p "$work/results/absent/engine/target"
+expect "rejects a run that produced no report" 1 "no surefire-reports" \
+    "$RESULTS" surefire-reports --root "$work/results/absent"
+
+# A fork killed mid-write leaves a report that cannot be parsed. It is not evidence of success.
+truncated="$work/results/truncated/engine/target/surefire-reports"
+mkdir -p "$truncated"
+printf '<?xml version="1.0"?>\n<testsuite name="com.arcadedb.CutTest" tests="4"' >"$truncated/TEST-com.arcadedb.CutTest.xml"
+expect "rejects a report it cannot parse" 1 "unreadable" \
+    "$RESULTS" surefire-reports --root "$work/results/truncated"
+
+# A suite that only skipped tests ran and reported; nothing failed.
+skipped="$work/results/skipped"
+suite_report "$skipped/engine/target/surefire-reports/TEST-com.arcadedb.SkippedTest.xml" com.arcadedb.SkippedTest 0 0 0
+expect "accepts a suite whose tests were all skipped" 0 "0 failure(s)" \
+    "$RESULTS" surefire-reports --root "$skipped"
 
 echo
 if [[ $failures -gt 0 ]]; then

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Check no test leaked a databases/ directory
         run: ./.github/scripts/check-test-database-paths.sh --runtime
 
+      # continue-on-error: publishing the report talks to the GitHub API, and an outage there says
+      # nothing about the tests. The step below is what decides the job, so losing the annotations
+      # no longer costs a false red - and cannot buy a false green either.
       - name: Unit Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
@@ -183,6 +186,10 @@ jobs:
           list-tests: 'failed'
           list-suites: 'failed'
           reporter: java-junit
+
+      - name: Check test results
+        if: success() || failure()
+        run: ./.github/scripts/check-test-results.py surefire-reports
 
       - name: Upload unit test coverage reports
         if: success() || failure()
@@ -228,6 +235,7 @@ jobs:
       - name: Check no test leaked a databases/ directory
         run: ./.github/scripts/check-test-database-paths.sh --runtime
 
+      # See the unit-tests job: the reporter is allowed to fail, the check below is the verdict.
       - name: Unit Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
@@ -238,6 +246,10 @@ jobs:
           list-tests: "failed"
           list-suites: "failed"
           reporter: java-junit
+
+      - name: Check test results
+        if: success() || failure()
+        run: ./.github/scripts/check-test-results.py surefire-reports
 
       - name: Upload unit test coverage reports
         if: success() || failure()
@@ -285,6 +297,7 @@ jobs:
       - name: Check no test leaked a databases/ directory
         run: ./.github/scripts/check-test-database-paths.sh --runtime
 
+      # See the unit-tests job: the reporter is allowed to fail, the check below is the verdict.
       - name: IT Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
@@ -295,6 +308,10 @@ jobs:
           list-tests: "failed"
           list-suites: "failed"
           reporter: java-junit
+
+      - name: Check test results
+        if: success() || failure()
+        run: ./.github/scripts/check-test-results.py failsafe-reports
 
       - name: Upload integration test coverage reports
         if: success() || failure()
@@ -340,6 +357,7 @@ jobs:
       - name: Check no test leaked a databases/ directory
         run: ./.github/scripts/check-test-database-paths.sh --runtime
 
+      # See the unit-tests job: the reporter is allowed to fail, the check below is the verdict.
       - name: HA IT Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
@@ -350,6 +368,10 @@ jobs:
           list-tests: "failed"
           list-suites: "failed"
           reporter: java-junit
+
+      - name: Check test results
+        if: success() || failure()
+        run: ./.github/scripts/check-test-results.py failsafe-reports
 
       - name: Upload HA integration test coverage reports
         if: success() || failure()

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -174,6 +174,7 @@ jobs:
 
       - name: Unit Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        continue-on-error: true
         if: success() || failure()
         with:
           name: Unit Tests Report
@@ -229,6 +230,7 @@ jobs:
 
       - name: Unit Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        continue-on-error: true
         if: success() || failure()
         with:
           name: Unit Tests Report
@@ -285,6 +287,7 @@ jobs:
 
       - name: IT Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        continue-on-error: true
         if: success() || failure()
         with:
           name: IT Tests Report
@@ -339,6 +342,7 @@ jobs:
 
       - name: HA IT Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        continue-on-error: true
         if: success() || failure()
         with:
           name: HA IT Tests Report


### PR DESCRIPTION
## Description

Fixes #5763

`mvn-test.yml` runs its four Maven test jobs with `--fail-never`, so Maven prints `Build failures were ignored.` and exits 0 even when a suite failed. The only step left that turned a failing test into a red job was `dorny/test-reporter`, whose default `fail-on-error` fails the step when the XML contains a failure.

That is a bad place for the build's verdict to live: a GitHub API hiccup in the reporter is indistinguishable from a test failure, and the obvious cure for the hiccup - `continue-on-error` - would equally swallow the failures.

So this PR does both halves:

1. `continue-on-error: true` on the four reporter steps (`unit-tests`, `slow-unit-tests`, `integration-tests`, `ha-integration-tests`), so publishing the annotations can fail without failing the job.
2. A new `.github/scripts/check-test-results.py`, run right after each reporter, which reads the surefire/failsafe XML off the local disk and fails the job when it records a failure, an error, an unreadable report, or no report at all. That is the same rule the reporter applied (`fail-on-error` plus `fail-on-empty`), evaluated locally, so it depends on nothing but the files Maven just wrote.

Without step 2, step 1 alone would report a failing suite as a green job. Every `Reporter`-only job failure sampled from the last 18 red `mvn-test` runs (25 of 25, `unit-tests`, `integration-tests` and `ha-integration-tests`) ended with `Failed test were found and 'fail-on-error' option is set to true`, so in practice the flag alone would have hidden real failures rather than false ones.

## Verification

- `.github/scripts/tests/test-ci-scripts.sh` gains seven cases for the new script: all-green, a failure, an error, phase separation (a failing `surefire-reports` tree must not redden a `failsafe-reports` check), no report at all, an unparseable report, and a skipped-only suite. The `setup` job already runs that harness.
- The cases were confirmed to fail with the script stubbed to `return 0`, then to pass with it restored.
- The script was also run against a real reactor tree: 20,299 tests across 2,405 report files in ~2s of CPU, exit 1 on the modules that had failures, exit 0 on the ones that did not.
