### PR TITLE
perf(engine) #5773: CHECK DATABASE looks at each vertex and edge once, and stops announcing a removal it never performs

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -2156,3 +2156,24 @@ Two smaller alignments in the same files:
 - `totalWarnings` counted occurrences while the retained `warnings` is a `Set`, so two findings that render to the
   same message collapsed to one line and counted two - the total could exceed the retained size on a run nowhere
   near its cap. Both sides now count distinct messages, in `GraphDatabaseChecker` and in `DatabaseChecker`.
+
+Both are a **reported-statistic change**, so they are worth knowing about if you consume `CHECK DATABASE` output
+programmatically rather than reading it: `totalWarnings` now answers "how many distinct messages", where it used to
+answer "how many times something was reported". On a run whose findings all render differently - the normal case -
+the number is unchanged. On one with repeats it drops, and it can no longer exceed the size of the `warnings` set
+on an uncapped run. `totalCorruptedRecords` gains the same guarantee past the cap.
+
+The four hand-written copies of that rule are gone with them, into `CollectionUtils.addBounded`, which is now the
+one place the retain-and-de-duplicate policy is written down. Two of the four had drifted apart, which is what made
+the counters disagree in the first place.
+
+### `CHECK DATABASE` at `verboseLevel 0` no longer logs the warnings it had to drop
+
+Also an alignment, and the one behaviour change here an operator could notice directly. When a run exceeds its
+warning cap, the message that cannot be retained is logged instead, so it is not lost silently. The two arms
+disagreed about whether `verboseLevel 0` switched that off: the graph arm logged regardless, the document arm
+honoured the flag. They now both honour it, on the grounds that a caller passing `0` asked for no logging - and the
+retained set plus `totalWarnings` still report that something was dropped either way.
+
+If you run a **capped** check **quietly** and relied on the dropped messages appearing in the log, pass a
+`verboseLevel` above zero. A default `CHECK DATABASE` is unaffected: it runs at verbosity 1.

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -2105,3 +2105,54 @@ the second. But `lookupByRID` *is* the first - it performs the same
 `asVertex(true)`, whose `loadContent` flag is what forces the decode. `LocalBucket.getRecord` and `LocalBucket.scan`
 resolve placeholders and multi-page chains identically and skip the same slot markers, so no corruption shape reaches
 one enumeration and not the other. Pinned by a test that corrupts a record and asserts both scopes report it.
+
+*(Superseded below: the corollary is that the type-wide arm's first pass was the redundant one, and #5773 removed
+it. Both arms now run exactly one pass.)*
+
+## `CHECK DATABASE` stops looking at every vertex and edge twice
+
+Follow-ups from #5764 (#5773). The observation above cuts the other way too: if one pass answers everything for the
+scoped arm, the type-wide arm's **first** pass is doing work its second pass already does.
+
+### The redundant pass is gone
+
+`checkVertices` and `checkEdges` opened with a raw bucket scan that built every record and decoded it, then ran the
+real connectivity/endpoint walk through `scanType` - which performs the identical `newImmutableRecord(...)` from the
+identical raw page view and opens with the identical `asVertex(true)`/`asEdge(true)`. Nothing the first pass could
+see escaped the second: a construction failure lands inside `LocalBucket.scan`'s per-slot `try` and is routed to the
+error callback that warns and flags the record, and a decode failure lands in the walk's own `catch`. The dropped
+pass in fact saw *less*, since it passed a `null` error callback and so only logged a failure inside the bucket
+machinery itself (placeholder resolution, a multi-page chain read) instead of reporting it.
+
+Measured rather than assumed, because "materialises every record twice" makes the saving sound larger than it is:
+on a warm 200k-vertex / 200k-edge graph the per-type steps went 173 ms -> 162 ms (vertices) and 155 ms -> 142 ms
+(edges), and a full `CHECK DATABASE` 509 ms -> 472 ms - about 7%. The pass is cheap because `asVertex(true)` parses
+the edge pointers, not the properties. What it mostly buys is correctness of the report, below.
+
+**Visible change:** the progress `total` for a vertex/edge step is now the record count, where it was twice the
+record count (it was written as literally `2 * countType`). A progress bar reading it will simply be accurate.
+
+### `CHECK DATABASE` no longer says it is "removing" records it does not remove
+
+The dropped pass emitted `vertex <rid> cannot be loaded, removing it` (and the edge equivalent). Removal happens only
+under `FIX`, so a plain `CHECK DATABASE` announced a removal and removed nothing. #5764 fixed exactly this wording on
+the document arm; the vertex and edge arms had the conditional version of the same defect, and both messages leave
+with the pass that emitted them. The surviving wording is `vertex <rid> cannot be loaded (error: ...)`, which names
+the failure as well.
+
+**If you parse `CHECK DATABASE` output:** a corrupt vertex or edge now produces **one** warning per record instead
+of two, and the `, removing it` message is gone. `corruptedRecords` is a set, so the corrupted total is unchanged;
+`totalWarnings` drops by one per corrupt record. `FIX` still deletes exactly what it deleted before.
+
+### The two warning/corrupted counters answer the same question
+
+Two smaller alignments in the same files:
+
+- `GraphDatabaseChecker.addCorrupted` incremented unconditionally once past its retention cap, while the
+  `DatabaseChecker` twin added by #5764 checked `contains` first - so a RID still present in the retained set was
+  counted again by one and not by the other. `checkEdges` really does flag one RID twice (an edge whose IN and OUT
+  vertices are both gone), so the two helpers disagreed on the same input. They now share the `contains`-checking
+  behaviour: exact de-duplication while under the cap, degrading past it only for RIDs the cap refused to retain.
+- `totalWarnings` counted occurrences while the retained `warnings` is a `Set`, so two findings that render to the
+  same message collapsed to one line and counted two - the total could exceed the retained size on a run nowhere
+  near its cap. Both sides now count distinct messages, in `GraphDatabaseChecker` and in `DatabaseChecker`.

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -488,7 +488,9 @@ public class DatabaseChecker {
    */
   private void addWarning(final String warning) {
     final LinkedHashSet<String> warnings = (LinkedHashSet<String>) result.get("warnings");
-    // Read BEFORE the record: addBounded grows the set, so "was it retained" cannot be asked afterwards.
+    // Read BEFORE the record: addBounded grows the set, so "was it retained" cannot be asked afterwards. Mirrors
+    // addBounded's own boundary test - same size(), same add(), so they cannot disagree. See the twin in
+    // GraphDatabaseChecker.CheckReport.warn().
     final boolean retaining = warnings.size() < maxWarnings;
     if (!CollectionUtils.addBounded(warnings, maxWarnings, warning))
       return;

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -466,19 +466,33 @@ public class DatabaseChecker {
   }
 
   /**
-   * Records a warning raised by this class itself (as opposed to one merged in from a nested checker): always
-   * counted, retained only while under {@code maxWarnings}, and - like {@code GraphDatabaseChecker.addWarning} -
-   * LOGGED when it has to be dropped, so a capped run does not lose the message silently.
+   * Records a warning raised by this class itself (as opposed to one merged in from a nested checker): counted,
+   * retained only while under {@code maxWarnings}, and - like {@code GraphDatabaseChecker.addWarning} - LOGGED when
+   * it has to be dropped, so a capped run does not lose the message silently.
    * <p>
    * #5764: shared with the type-wide {@link #checkDocuments}, which used to bypass the totals and the cap.
+   * <p>
+   * #5773: de-duplicated on the same terms as {@link #addCorrupted}, and for the same reason. The retained
+   * {@code warnings} is a {@code Set}, so two findings that render to the same message have always collapsed to one
+   * line; the total used to count both, which made it exceed the retained size on a run nowhere near its cap. Both
+   * sides now answer "distinct messages".
+   * <p>
+   * The one residual: a message produced identically by two DIFFERENT sub-checks (each {@code GraphDatabaseChecker}
+   * keeps its own set, and {@link #updateStats} sums their totals while the sets are union-ed here) is still
+   * retained once and counted twice. Reachable only for the few messages that carry no RID - "reconnected N
+   * outgoing edges" for two types that reconnected the same N - and closing it would mean threading a dropped-count
+   * out of every sub-check instead of a total, which buys nothing an operator reads.
    */
   private void addWarning(final String warning) {
-    result.put("totalWarnings", (Long) result.get("totalWarnings") + 1);
     final LinkedHashSet<String> warnings = (LinkedHashSet<String>) result.get("warnings");
-    if (warnings.size() < maxWarnings)
-      warnings.add(warning);
+    if (warnings.size() < maxWarnings) {
+      if (!warnings.add(warning))
+        return;
+    } else if (warnings.contains(warning))
+      return;
     else if (verboseLevel > 0)
       LogManager.instance().log(this, Level.WARNING, "- " + warning);
+    result.put("totalWarnings", (Long) result.get("totalWarnings") + 1);
   }
 
   /**
@@ -493,6 +507,10 @@ public class DatabaseChecker {
    * every RID ever counted, which is precisely the memory the cap exists to refuse. Neither caller reaches it today
    * - the type-wide bucket scan visits each RID once, and the RECORD scope is a {@link Set}, so a duplicate cannot
    * survive as far as {@link #groupRecordsByType()}.
+   * <p>
+   * #5773: {@code GraphDatabaseChecker.addCorrupted} used to increment unconditionally past the cap, so the two
+   * near-identical helpers disagreed on the same input (its {@code checkEdges} DOES flag one RID twice, for an edge
+   * whose endpoints are both gone). They now share this behaviour; keep them aligned rather than "fixing" one back.
    * <p>
    * The cap is {@code maxWarnings} because that is the only bound this class has; the {@code maxCorrupted} the
    * graph arms take is a separate knob {@link GraphDatabaseChecker} owns, and it is passed the remaining budget

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -468,9 +468,11 @@ public class DatabaseChecker {
 
   /**
    * Records a warning raised by this class itself (as opposed to one merged in from a nested checker), under the same
-   * {@link CollectionUtils#addBounded} rule as {@link #addCorrupted}, and - like
-   * {@code GraphDatabaseChecker.addWarning} - LOGGED when the cap meant it could not be retained, so a capped run
-   * does not lose the message silently.
+   * {@link CollectionUtils#addBounded} rule as {@link #addCorrupted}, and - like {@code GraphDatabaseChecker}'s twin -
+   * LOGGED when the cap meant it could not be retained, so a capped run does not lose the message silently. Both
+   * honour {@code verboseLevel == 0} as "the caller asked for no logging"; before #5773 only this one did, so the
+   * same dropped message was audible from one arm and silent from the other. The retained set and
+   * {@code totalWarnings} still report how many were dropped either way.
    * <p>
    * #5764: shared with the type-wide {@link #checkDocuments}, which used to bypass the totals and the cap.
    * <p>

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -488,13 +488,11 @@ public class DatabaseChecker {
    */
   private void addWarning(final String warning) {
     final LinkedHashSet<String> warnings = (LinkedHashSet<String>) result.get("warnings");
-    // Read BEFORE the record: addBounded grows the set, so "was it retained" cannot be asked afterwards. Mirrors
-    // addBounded's own boundary test - same size(), same add(), so they cannot disagree. See the twin in
-    // GraphDatabaseChecker.CheckReport.warn().
-    final boolean retaining = warnings.size() < maxWarnings;
     if (!CollectionUtils.addBounded(warnings, maxWarnings, warning))
       return;
-    if (!retaining && verboseLevel > 0)
+    // The set answers whether it was retained - see the twin in GraphDatabaseChecker.CheckReport.warn() for why
+    // that is asked of the set rather than by re-deriving addBounded's cap rule here.
+    if (verboseLevel > 0 && !warnings.contains(warning))
       LogManager.instance().log(this, Level.WARNING, "- " + warning);
     result.put("totalWarnings", (Long) result.get("totalWarnings") + 1);
   }

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -37,6 +37,7 @@ import com.arcadedb.schema.LocalVertexType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.serializer.BinarySerializer;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.CollectionUtils;
 import com.arcadedb.utility.LongHashSet;
 import com.arcadedb.utility.ProgressCallback;
 
@@ -466,16 +467,16 @@ public class DatabaseChecker {
   }
 
   /**
-   * Records a warning raised by this class itself (as opposed to one merged in from a nested checker): counted,
-   * retained only while under {@code maxWarnings}, and - like {@code GraphDatabaseChecker.addWarning} - LOGGED when
-   * it has to be dropped, so a capped run does not lose the message silently.
+   * Records a warning raised by this class itself (as opposed to one merged in from a nested checker), under the same
+   * {@link CollectionUtils#addBounded} rule as {@link #addCorrupted}, and - like
+   * {@code GraphDatabaseChecker.addWarning} - LOGGED when the cap meant it could not be retained, so a capped run
+   * does not lose the message silently.
    * <p>
    * #5764: shared with the type-wide {@link #checkDocuments}, which used to bypass the totals and the cap.
    * <p>
-   * #5773: de-duplicated on the same terms as {@link #addCorrupted}, and for the same reason. The retained
-   * {@code warnings} is a {@code Set}, so two findings that render to the same message have always collapsed to one
-   * line; the total used to count both, which made it exceed the retained size on a run nowhere near its cap. Both
-   * sides now answer "distinct messages".
+   * #5773: de-duplicated, where it used to count occurrences. The retained {@code warnings} is a {@code Set}, so two
+   * findings that render to the same message have always collapsed to one line; the total counted both, which made it
+   * exceed the retained size on a run nowhere near its cap. Both sides now answer "distinct messages".
    * <p>
    * The one residual: a message produced identically by two DIFFERENT sub-checks (each {@code GraphDatabaseChecker}
    * keeps its own set, and {@link #updateStats} sums their totals while the sets are union-ed here) is still
@@ -485,45 +486,34 @@ public class DatabaseChecker {
    */
   private void addWarning(final String warning) {
     final LinkedHashSet<String> warnings = (LinkedHashSet<String>) result.get("warnings");
-    if (warnings.size() < maxWarnings) {
-      if (!warnings.add(warning))
-        return;
-    } else if (warnings.contains(warning))
+    // Read BEFORE the record: addBounded grows the set, so "was it retained" cannot be asked afterwards.
+    final boolean retaining = warnings.size() < maxWarnings;
+    if (!CollectionUtils.addBounded(warnings, maxWarnings, warning))
       return;
-    else if (verboseLevel > 0)
+    if (!retaining && verboseLevel > 0)
       LogManager.instance().log(this, Level.WARNING, "- " + warning);
     result.put("totalWarnings", (Long) result.get("totalWarnings") + 1);
   }
 
   /**
-   * Flags a record as corrupted, bounded the way {@code GraphDatabaseChecker.addCorrupted} bounds the graph arms:
-   * the total keeps counting, the retained set does not grow without limit.
+   * Flags a record as corrupted under {@link CollectionUtils#addBounded}, which documents the retain-and-de-duplicate
+   * rule itself: exact while under the cap, degrading past it only for RIDs the cap refused to retain. Neither caller
+   * of THIS one reaches the degraded case today - the type-wide bucket scan visits each RID once, and the RECORD scope
+   * is a {@link Set}, so a duplicate cannot survive as far as {@link #groupRecordsByType()}.
    * <p>
-   * De-duplication is EXACT while the set is under the cap - a record flagged twice is one corrupted record, since
-   * the set itself answers "have I seen this". Past the cap it degrades to what the retained set can still answer:
-   * a RID already in the set is still recognised (which is why the {@code contains} check is there rather than an
-   * unconditional increment), but one that was never retained cannot be, so a second flag on it counts twice. That
-   * is deliberate and not worth closing: the only way to keep it exact past the cap is a second unbounded set of
-   * every RID ever counted, which is precisely the memory the cap exists to refuse. Neither caller reaches it today
-   * - the type-wide bucket scan visits each RID once, and the RECORD scope is a {@link Set}, so a duplicate cannot
-   * survive as far as {@link #groupRecordsByType()}.
-   * <p>
-   * #5773: {@code GraphDatabaseChecker.addCorrupted} used to increment unconditionally past the cap, so the two
-   * near-identical helpers disagreed on the same input (its {@code checkEdges} DOES flag one RID twice, for an edge
-   * whose endpoints are both gone). They now share this behaviour; keep them aligned rather than "fixing" one back.
+   * #5773: there used to be four hand-written copies of that rule across this class and
+   * {@link GraphDatabaseChecker}, and two of them disagreed past the cap - the graph one incremented unconditionally
+   * there, so a RID still present in its retained set was counted again. That case IS reachable (its
+   * {@code checkEdges} flags one RID twice for an edge whose endpoints are both gone). Extracting the rule is what
+   * keeps them from drifting apart again; do not re-inline it.
    * <p>
    * The cap is {@code maxWarnings} because that is the only bound this class has; the {@code maxCorrupted} the
    * graph arms take is a separate knob {@link GraphDatabaseChecker} owns, and it is passed the remaining budget
    * from this same field by {@link #checkScopedRecords}. Two names, one setting.
    */
   private void addCorrupted(final RID rid) {
-    final LinkedHashSet<RID> corrupted = (LinkedHashSet<RID>) result.get("corruptedRecords");
-    if (corrupted.size() < maxWarnings) {
-      if (!corrupted.add(rid))
-        return;
-    } else if (corrupted.contains(rid))
-      return;
-    result.put("totalCorruptedRecords", (Long) result.get("totalCorruptedRecords") + 1);
+    if (CollectionUtils.addBounded((LinkedHashSet<RID>) result.get("corruptedRecords"), maxWarnings, rid))
+      result.put("totalCorruptedRecords", (Long) result.get("totalCorruptedRecords") + 1);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -488,11 +488,10 @@ public class DatabaseChecker {
    */
   private void addWarning(final String warning) {
     final LinkedHashSet<String> warnings = (LinkedHashSet<String>) result.get("warnings");
-    if (!CollectionUtils.addBounded(warnings, maxWarnings, warning))
+    final CollectionUtils.BoundedAdd outcome = CollectionUtils.addBounded(warnings, maxWarnings, warning);
+    if (!outcome.isFirstSighting())
       return;
-    // The set answers whether it was retained - see the twin in GraphDatabaseChecker.CheckReport.warn() for why
-    // that is asked of the set rather than by re-deriving addBounded's cap rule here.
-    if (verboseLevel > 0 && !warnings.contains(warning))
+    if (outcome == CollectionUtils.BoundedAdd.DROPPED && verboseLevel > 0)
       LogManager.instance().log(this, Level.WARNING, "- " + warning);
     result.put("totalWarnings", (Long) result.get("totalWarnings") + 1);
   }
@@ -514,7 +513,8 @@ public class DatabaseChecker {
    * from this same field by {@link #checkScopedRecords}. Two names, one setting.
    */
   private void addCorrupted(final RID rid) {
-    if (CollectionUtils.addBounded((LinkedHashSet<RID>) result.get("corruptedRecords"), maxWarnings, rid))
+    if (CollectionUtils.addBounded((LinkedHashSet<RID>) result.get("corruptedRecords"), maxWarnings, rid)
+        .isFirstSighting())
       result.put("totalCorruptedRecords", (Long) result.get("totalCorruptedRecords") + 1);
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -151,8 +151,8 @@ public class GraphDatabaseChecker {
    * the alternative if the always-on cost proves unwelcome; left always-on for now.
    */
   public Map<String, Object> reclaimOrphanedEdgeSegments(final int verboseLevel, final int maxWarnings) {
-    final LinkedHashSet<String> warnings = new LinkedHashSet<>();
-    final AtomicLong totalWarnings = new AtomicLong();
+    // Warnings only: this pass reports, it never flags a record corrupted, so the corrupted cap is irrelevant.
+    final CheckReport report = new CheckReport(maxWarnings, maxWarnings, verboseLevel);
     final Map<String, Object> stats = new HashMap<>();
 
     final Map<Integer, LongHashSet> reachable = new HashMap<>();
@@ -187,7 +187,7 @@ public class GraphDatabaseChecker {
             final boolean inComplete = markReachableSegments(vertex.getInEdgesHeadChunk(), reachable);
             if (!outComplete || !inComplete) {
               reachabilityComplete.set(false);
-              addWarning(warnings, totalWarnings, maxWarnings, "vertex " + record.getIdentity()
+              report.warn("vertex " + record.getIdentity()
                   + " edge chain could not be fully walked during the orphan reclaim (a segment read failed); "
                   + "the reclaim will be skipped to avoid deleting live data");
             }
@@ -196,8 +196,7 @@ public class GraphDatabaseChecker {
             // record construction, so a truncated/corrupt vertex normally fails to load inside the scan and
             // surfaces through that callback; this catches any residual failure of asVertex here. Same effect.
             reachabilityComplete.set(false);
-            addWarning(warnings, totalWarnings, maxWarnings,
-                "vertex " + record.getIdentity() + " could not be walked during the orphan reclaim (error: " + describe(e)
+            report.warn("vertex " + record.getIdentity() + " could not be walked during the orphan reclaim (error: " + describe(e)
                     + ")");
           }
           return true;
@@ -205,8 +204,7 @@ public class GraphDatabaseChecker {
           // A vertex record that cannot even be loaded during the scan is the same fail-closed case: its
           // segments were never marked, so the deletion phase must not run.
           reachabilityComplete.set(false);
-          addWarning(warnings, totalWarnings, maxWarnings,
-              "vertex " + rid + " could not be loaded during the orphan reclaim (error: " + describe(exception) + ")");
+          report.warn("vertex " + rid + " could not be loaded during the orphan reclaim (error: " + describe(exception) + ")");
           return true;
         });
 
@@ -234,18 +232,16 @@ public class GraphDatabaseChecker {
           } catch (final RecordNotFoundException e) {
             // ALREADY GONE
           } catch (final Exception e) {
-            addWarning(warnings, totalWarnings, maxWarnings,
-                "orphaned edge segment " + orphan + " could not be reclaimed (error: " + describe(e) + ")");
+            report.warn("orphaned edge segment " + orphan + " could not be reclaimed (error: " + describe(e) + ")");
           }
         }
       } else {
-        addWarning(warnings, totalWarnings, maxWarnings,
-            "orphaned edge segment reclaim skipped: the reachability walk did not complete (one or more vertices "
+        report.warn("orphaned edge segment reclaim skipped: the reachability walk did not complete (one or more vertices "
                 + "could not be walked); no segments were deleted to avoid destroying live data");
       }
 
       if (verboseLevel > 0)
-        for (final String warning : warnings)
+        for (final String warning : report.warnings)
           LogManager.instance().log(this, Level.WARNING, "- " + warning);
 
       database.commit();
@@ -254,8 +250,8 @@ public class GraphDatabaseChecker {
     } finally {
       stats.put("orphanedEdgeSegments", orphans);
       stats.put("orphanedEdgeSegmentsReclaimed", reclaimed);
-      stats.put("warnings", warnings);
-      stats.put("totalWarnings", totalWarnings.get());
+      stats.put("warnings", report.warnings);
+      stats.put("totalWarnings", report.totalWarnings.get());
     }
     return stats;
   }
@@ -422,12 +418,7 @@ public class GraphDatabaseChecker {
   public Map<String, Object> checkVertices(final String typeName, final Collection<RID> scopedRecords,
       final boolean fix, final int verboseLevel, final int maxWarnings, final int maxCorrupted) {
     final AtomicLong autoFix = new AtomicLong();
-    final AtomicLong invalidLinks = new AtomicLong();
-    final AtomicLong duplicateLightEdges = new AtomicLong();
-    final AtomicLong totalWarnings = new AtomicLong();
-    final AtomicLong totalCorrupted = new AtomicLong();
-    final LinkedHashSet<RID> corruptedRecords = new LinkedHashSet<>();
-    final LinkedHashSet<String> warnings = new LinkedHashSet<>();
+    final CheckReport report = new CheckReport(maxWarnings, maxCorrupted, verboseLevel);
     final Set<RID> reconnectOutEdges = new HashSet<>();
     final Set<RID> reconnectInEdges = new HashSet<>();
     final Map<RID, Long> missingReferences = new HashMap<>();
@@ -445,18 +436,15 @@ public class GraphDatabaseChecker {
 
           final RID vertexIdentity = vertex.getIdentity();
 
-          vertex = checkOutgoingEdges(fix, vertex, warnings, totalWarnings, maxWarnings, vertexIdentity, invalidLinks,
-              corruptedRecords, totalCorrupted, maxCorrupted, reconnectOutEdges, reconnectInEdges, missingReferences,
-              missingReferenceErrors, duplicateLightEdges);
+          vertex = checkOutgoingEdges(fix, vertex, vertexIdentity, reconnectOutEdges, reconnectInEdges,
+              missingReferences, missingReferenceErrors, report);
 
-          checkIncomingEdges(fix, vertex, warnings, totalWarnings, maxWarnings, vertexIdentity, invalidLinks,
-              corruptedRecords, totalCorrupted, maxCorrupted, reconnectInEdges, reconnectOutEdges, missingReferences,
-              missingReferenceErrors);
+          checkIncomingEdges(fix, vertex, vertexIdentity, reconnectInEdges, reconnectOutEdges, missingReferences,
+              missingReferenceErrors, report);
 
         } catch (final Throwable e) {
-          addWarning(warnings, totalWarnings, maxWarnings,
-              "vertex " + record.getIdentity() + " cannot be loaded (error: " + describe(e) + ")");
-          addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, record.getIdentity());
+          report.warn("vertex " + record.getIdentity() + " cannot be loaded (error: " + describe(e) + ")");
+          report.corrupt(record.getIdentity());
         }
       };
 
@@ -473,7 +461,7 @@ public class GraphDatabaseChecker {
             // after a failed delete, a typo'd or already-deleted RID would otherwise buy exactly the cost the
             // scope was reached for. Reported, not repaired.
             progressTick();
-            addWarning(warnings, totalWarnings, maxWarnings, "vertex " + rid + " does not exist");
+            report.warn("vertex " + rid + " does not exist");
           } catch (final Exception e) {
             // Exception, not Throwable, so an Error raised by the LOOKUP (OOM, StackOverflow) is not recorded as
             // "this record is corrupt" and does not have fix mode delete a healthy record. Scope of that, stated
@@ -481,9 +469,8 @@ public class GraphDatabaseChecker {
             // matching the type-wide path, so an Error raised in THERE is still flagged. Narrowing that one would
             // change the type-wide behaviour too, which is not this change's business.
             progressTick();
-            addWarning(warnings, totalWarnings, maxWarnings,
-                "vertex " + rid + " cannot be loaded (error: " + describe(e) + ")");
-            addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
+            report.warn("vertex " + rid + " cannot be loaded (error: " + describe(e) + ")");
+            report.corrupt(rid);
           }
         }
       } else {
@@ -496,9 +483,8 @@ public class GraphDatabaseChecker {
           return true;
         }, (rid, exception) -> {
           progressTick();
-          addWarning(warnings, totalWarnings, maxWarnings,
-              "vertex " + rid + " cannot be loaded (error: " + describe(exception) + ")");
-          addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
+          report.warn("vertex " + rid + " cannot be loaded (error: " + describe(exception) + ")");
+          report.corrupt(rid);
           return true;
         });
       }
@@ -507,9 +493,9 @@ public class GraphDatabaseChecker {
 
       if (fix) {
         if (!reconnectOutEdges.isEmpty() || !reconnectInEdges.isEmpty())
-          reconnectEdges(reconnectOutEdges, reconnectInEdges, corruptedRecords, warnings, totalWarnings, maxWarnings, stats);
+          reconnectEdges(reconnectOutEdges, reconnectInEdges, report, stats);
 
-        for (final RID rid : corruptedRecords) {
+        for (final RID rid : report.corruptedRecords) {
           if (rid == null)
             continue;
 
@@ -519,26 +505,25 @@ public class GraphDatabaseChecker {
           } catch (final RecordNotFoundException e) {
             // IGNORE IT
           } catch (final Throwable e) {
-            addWarning(warnings, totalWarnings, maxWarnings,
-                "Cannot fix the record " + rid + ": error on delete (error: " + e.getMessage() + ")");
+            report.warn("Cannot fix the record " + rid + ": error on delete (error: " + e.getMessage() + ")");
           }
         }
       }
 
       if (verboseLevel > 0)
-        for (final String warning : warnings)
+        for (final String warning : report.warnings)
           LogManager.instance().log(this, Level.WARNING, "- " + warning);
 
       database.commit();
 
     } finally {
       stats.put("autoFix", autoFix.get());
-      stats.put("corruptedRecords", corruptedRecords);
-      stats.put("duplicateLightEdges", duplicateLightEdges.get());
-      stats.put("invalidLinks", invalidLinks.get());
-      stats.put("warnings", warnings);
-      stats.put("totalWarnings", totalWarnings.get());
-      stats.put("totalCorruptedRecords", totalCorrupted.get());
+      stats.put("corruptedRecords", report.corruptedRecords);
+      stats.put("duplicateLightEdges", report.duplicateLightEdges.get());
+      stats.put("invalidLinks", report.invalidLinks.get());
+      stats.put("warnings", report.warnings);
+      stats.put("totalWarnings", report.totalWarnings.get());
+      stats.put("totalCorruptedRecords", report.totalCorrupted.get());
       stats.put("missingReferences", missingReferences);
       stats.put("missingReferenceErrors", missingReferenceErrors);
     }
@@ -553,8 +538,8 @@ public class GraphDatabaseChecker {
    * entry may still point to a far endpoint vertex that no longer exists (the edge record survives, its target
    * does not): that is the same behaviour as before and the {@code checkEdges} pass reports it.
    */
-  private void reconnectEdges(Set<RID> reconnectOutEdges, Set<RID> reconnectInEdges, Set<RID> corruptedRecords,
-      Collection<String> warnings, AtomicLong totalWarnings, int maxWarnings, Map<String, Object> stats) {
+  private void reconnectEdges(Set<RID> reconnectOutEdges, Set<RID> reconnectInEdges, CheckReport report,
+      Map<String, Object> stats) {
     // BROWSE ALL THE EDGES AND COLLECT THE ONES PART OF THE RECONNECTION
     final List<EdgeType> edgeTypes = new ArrayList<>();
     for (DocumentType schemaType : database.getSchema().getTypes()) {
@@ -575,7 +560,7 @@ public class GraphDatabaseChecker {
         progressTick();
         try {
           final Edge e = record.asEdge(true);
-          if (corruptedRecords.contains(e.getIdentity()))
+          if (report.corruptedRecords.contains(e.getIdentity()))
             // ABOUT TO BE DELETED BY THE FIX: re-adding it would rebuild a dangling entry
             return true;
           if (reconnectOutEdges.contains(e.getOut()))
@@ -585,11 +570,11 @@ public class GraphDatabaseChecker {
           if (bidirectional && reconnectInEdges.contains(e.getIn()))
             inEdgesToReconnect.add(e);
         } catch (final Exception e) {
-          warnUnreadableEdgeDuringRebuild(warnings, totalWarnings, maxWarnings, record.getIdentity(), e);
+          warnUnreadableEdgeDuringRebuild(report, record.getIdentity(), e);
         }
         return true;
       }, (rid, exception) -> {
-        warnUnreadableEdgeDuringRebuild(warnings, totalWarnings, maxWarnings, rid, exception);
+        warnUnreadableEdgeDuringRebuild(report, rid, exception);
         return true;
       });
     }
@@ -600,7 +585,7 @@ public class GraphDatabaseChecker {
         // getOrCreateEdgeList dispatches on the head record type, so promoted (striped) vertices work too
         graphEngine.getOrCreateEdgeList(vertex, Vertex.DIRECTION.OUT).add(e.getIdentity(), e.getIn());
       }
-      addWarning(warnings, totalWarnings, maxWarnings, "reconnected " + outEdgesToReconnect.size() + " outgoing edges");
+      report.warn("reconnected " + outEdgesToReconnect.size() + " outgoing edges");
       stats.put("outEdgesToReconnect", outEdgesToReconnect);
     }
 
@@ -609,21 +594,19 @@ public class GraphDatabaseChecker {
         final MutableVertex vertex = e.getInVertex().modify();
         graphEngine.getOrCreateEdgeList(vertex, Vertex.DIRECTION.IN).add(e.getIdentity(), e.getOut());
       }
-      addWarning(warnings, totalWarnings, maxWarnings, "reconnected " + inEdgesToReconnect.size() + " incoming edges");
+      report.warn("reconnected " + inEdgesToReconnect.size() + " incoming edges");
       stats.put("inEdgesToReconnect", inEdgesToReconnect);
     }
   }
 
-  private static void warnUnreadableEdgeDuringRebuild(final Collection<String> warnings, final AtomicLong totalWarnings,
-      final int maxWarnings, final Object rid, final Throwable error) {
-    addWarning(warnings, totalWarnings, maxWarnings,
-        "edge " + rid + " could not be read during the edge-list rebuild, skipping it (error: " + describe(error) + ")");
+  private static void warnUnreadableEdgeDuringRebuild(final CheckReport report, final Object rid,
+      final Throwable error) {
+    report.warn("edge " + rid + " could not be read during the edge-list rebuild, skipping it (error: " + describe(error) + ")");
   }
 
-  private void checkIncomingEdges(boolean fix, Vertex vertex, Collection<String> warnings, AtomicLong totalWarnings, int maxWarnings,
-      RID vertexIdentity, AtomicLong invalidLinks, LinkedHashSet<RID> corruptedRecords, AtomicLong totalCorrupted,
-      int maxCorrupted, Set<RID> reconnectInEdges, Set<RID> reconnectOutEdges, Map<RID, Long> missingReferences,
-      Map<RID, String> missingReferenceErrors) {
+  private void checkIncomingEdges(boolean fix, Vertex vertex, RID vertexIdentity, Set<RID> reconnectInEdges,
+      Set<RID> reconnectOutEdges, Map<RID, Long> missingReferences, Map<RID, String> missingReferenceErrors,
+      CheckReport report) {
     if (((VertexInternal) vertex).getInEdgesHeadChunk() != null) {
       EdgeLinkedList inEdges = null;
       try {
@@ -634,7 +617,7 @@ public class GraphDatabaseChecker {
 
       if (inEdges == null) {
         final RID headChunkRID = ((VertexInternal) vertex).getInEdgesHeadChunk();
-        addWarning(warnings, totalWarnings, maxWarnings, "vertex " + vertexIdentity + " in edges record " + headChunkRID
+        report.warn("vertex " + vertexIdentity + " in edges record " + headChunkRID
             + " is not valid" + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
         if (fix) {
           vertex = resetChain(vertex, Vertex.DIRECTION.IN);
@@ -671,14 +654,14 @@ public class GraphDatabaseChecker {
             boolean removeEntry = false;
 
             if (edgeRID == null) {
-              addWarning(warnings, totalWarnings, maxWarnings, "outgoing edge null from vertex " + vertexIdentity);
+              report.warn("outgoing edge null from vertex " + vertexIdentity);
               removeEntry = true;
-              invalidLinks.incrementAndGet();
+              report.invalidLinks.incrementAndGet();
             } else if (vertexRID == null) {
-              addWarning(warnings, totalWarnings, maxWarnings, "outgoing vertex null from vertex " + vertexIdentity);
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+              report.warn("outgoing vertex null from vertex " + vertexIdentity);
+              report.corrupt(edgeRID);
               removeEntry = true;
-              invalidLinks.incrementAndGet();
+              report.invalidLinks.incrementAndGet();
             } else {
               if (edgeRID.getPosition() < 0)
                 // LIGHTWEIGHT EDGE
@@ -690,37 +673,33 @@ public class GraphDatabaseChecker {
                 VertexInternal inVertex = null;
 
                 if (edge.getOut() == null || !edge.getOut().isValid()) {
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "edge " + edgeRID + " has an invalid outgoing link " + edge.getIn());
-                  addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                  report.warn("edge " + edgeRID + " has an invalid outgoing link " + edge.getIn());
+                  report.corrupt(edgeRID);
                   removeEntry = true;
-                  invalidLinks.incrementAndGet();
+                  report.invalidLinks.incrementAndGet();
                 } else {
                   try {
                     inVertex = (VertexInternal) edge.getOutVertex().asVertex(true);
                   } catch (final RecordNotFoundException e) {
-                    addWarning(warnings, totalWarnings, maxWarnings,
-                        "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
-                    trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getOut(), describe(e));
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                    report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
+                    trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
+                    report.corrupt(edgeRID);
                     removeEntry = true;
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getOut());
-                    invalidLinks.incrementAndGet();
+                    report.corrupt(edge.getOut());
+                    report.invalidLinks.incrementAndGet();
                   } catch (final Exception e) {
                     // UNKNOWN ERROR ON LOADING
-                    addWarning(warnings, totalWarnings, maxWarnings,
-                        "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
+                    report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
                             + describe(e) + ")");
-                    trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getOut(), describe(e));
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                    trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
+                    report.corrupt(edgeRID);
                     removeEntry = true;
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getOut());
+                    report.corrupt(edge.getOut());
                   }
                 }
 
                 if (!edge.getIn().equals(vertexIdentity)) {
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "edge " + edgeRID + " has an incoming link " + edge.getIn() + " different from expected " + vertexIdentity);
+                  report.warn("edge " + edgeRID + " has an incoming link " + edge.getIn() + " different from expected " + vertexIdentity);
 
                   // CHECK ALL INCOMING EDGES
                   int totalEdges = 0;
@@ -741,8 +720,7 @@ public class GraphDatabaseChecker {
                     else
                       ++totalEdgesError;
                   }
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "edge " + edgeRID + " has an incoming link " + edge.getOut() + " different from expected " + vertexIdentity
+                  report.warn("edge " + edgeRID + " has an incoming link " + edge.getOut() + " different from expected " + vertexIdentity
                           + ". Found " + totalEdges + " edges, of which " + totalEdgesOk + " are correct, "
                           + totalEdgesErrorFromSameVertex + " are from the same vertex and " + totalEdgesError + " are different");
 
@@ -760,22 +738,21 @@ public class GraphDatabaseChecker {
                       // SKIP THE REST OF THE EDGES
                       break;
                     } else {
-                      addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                      report.corrupt(edgeRID);
                       removeEntry = true;
-                      invalidLinks.incrementAndGet();
+                      report.invalidLinks.incrementAndGet();
                     }
                   } else {
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                    report.corrupt(edgeRID);
                     removeEntry = true;
-                    invalidLinks.incrementAndGet();
+                    report.invalidLinks.incrementAndGet();
                   }
 
                 } else if (!edge.getOut().equals(vertexRID)) {
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "edge " + edgeRID + " has an outgoing link " + edge.getOut() + " different from expected " + vertexRID);
-                  addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                  report.warn("edge " + edgeRID + " has an outgoing link " + edge.getOut() + " different from expected " + vertexRID);
+                  report.corrupt(edgeRID);
                   removeEntry = true;
-                  invalidLinks.incrementAndGet();
+                  report.invalidLinks.incrementAndGet();
                 }
 
                 if (((EdgeType) edge.getType()).isBidirectional() && inVertex != null) {
@@ -787,16 +764,14 @@ public class GraphDatabaseChecker {
                     // guard the probe failure flagged the edge as corrupted and fix mode deleted a VALID edge).
                     // Register the far vertex so its list is rebuilt from the surviving edge records instead.
                     if (reconnectOutEdges.add(inVertex.getIdentity())) {
-                      addWarning(warnings, totalWarnings, maxWarnings,
-                          "vertex " + inVertex.getIdentity() + " outgoing edge list is unreadable (error: "
+                      report.warn("vertex " + inVertex.getIdentity() + " outgoing edge list is unreadable (error: "
                               + describe(probeError) + ")" + (fix ? ", rebuilding it from the surviving edge records" : ""));
                       if (fix)
                         resetChain(inVertex, Vertex.DIRECTION.OUT);
                     }
                   }
                   if (connected != null && !connected && !reconnectOutEdges.contains(inVertex.getIdentity())) {
-                    addWarning(warnings, totalWarnings, maxWarnings,
-                        "edge " + edgeRID + " was not connected from the incoming vertex " + edge.getOut() + " to the vertex "
+                    report.warn("edge " + edgeRID + " was not connected from the incoming vertex " + edge.getOut() + " to the vertex "
                             + vertexIdentity);
                     if (fix) {
                       inVertex = inVertex.modify();
@@ -807,15 +782,14 @@ public class GraphDatabaseChecker {
                 }
 
               } catch (final RecordNotFoundException e) {
-                addWarning(warnings, totalWarnings, maxWarnings, "edge " + edgeRID + " not found");
-                addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                report.warn("edge " + edgeRID + " not found");
+                report.corrupt(edgeRID);
                 removeEntry = true;
-                invalidLinks.incrementAndGet();
+                report.invalidLinks.incrementAndGet();
               } catch (final Exception e) {
                 // UNKNOWN ERROR ON LOADING
-                addWarning(warnings, totalWarnings, maxWarnings,
-                    "edge " + edgeRID + " error on loading (error: " + describe(e) + ")");
-                addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                report.warn("edge " + edgeRID + " error on loading (error: " + describe(e) + ")");
+                report.corrupt(edgeRID);
                 removeEntry = true;
               }
             }
@@ -831,8 +805,7 @@ public class GraphDatabaseChecker {
         }
 
         if (chainBroken) {
-          addWarning(warnings, totalWarnings, maxWarnings,
-              "error on loading incoming edges from vertex " + vertexIdentity + " (error: " + chainError + ")"
+          report.warn("error on loading incoming edges from vertex " + vertexIdentity + " (error: " + chainError + ")"
                   + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
           if (fix) {
             vertex = resetChain(vertex, Vertex.DIRECTION.IN);
@@ -843,11 +816,9 @@ public class GraphDatabaseChecker {
     }
   }
 
-  private Vertex checkOutgoingEdges(final boolean fix, Vertex vertex, final Collection<String> warnings,
-      final AtomicLong totalWarnings, final int maxWarnings, final RID vertexIdentity, final AtomicLong invalidLinks,
-      final LinkedHashSet<RID> corruptedRecords, final AtomicLong totalCorrupted, final int maxCorrupted,
+  private Vertex checkOutgoingEdges(final boolean fix, Vertex vertex, final RID vertexIdentity,
       final Set<RID> reconnectOutEdges, final Set<RID> reconnectInEdges, final Map<RID, Long> missingReferences,
-      final Map<RID, String> missingReferenceErrors, final AtomicLong duplicateLightEdges) {
+      final Map<RID, String> missingReferenceErrors, final CheckReport report) {
     // CHECK THE EDGE IS CONNECTED FROM THE OTHER SIDE
     if (((VertexInternal) vertex).getOutEdgesHeadChunk() != null) {
       EdgeLinkedList outEdges = null;
@@ -859,7 +830,7 @@ public class GraphDatabaseChecker {
 
       if (outEdges == null) {
         final RID headChunkRID = ((VertexInternal) vertex).getOutEdgesHeadChunk();
-        addWarning(warnings, totalWarnings, maxWarnings, "vertex " + vertexIdentity + " out edges record " + headChunkRID
+        report.warn("vertex " + vertexIdentity + " out edges record " + headChunkRID
             + " is not valid" + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
         if (fix) {
           vertex = resetChain(vertex, Vertex.DIRECTION.OUT);
@@ -900,14 +871,14 @@ public class GraphDatabaseChecker {
             VertexInternal outVertex = null;
 
             if (edgeRID == null) {
-              addWarning(warnings, totalWarnings, maxWarnings, "outgoing edge null from vertex " + vertexIdentity);
+              report.warn("outgoing edge null from vertex " + vertexIdentity);
               removeEntry = true;
-              invalidLinks.incrementAndGet();
+              report.invalidLinks.incrementAndGet();
             } else if (vertexRID == null) {
-              addWarning(warnings, totalWarnings, maxWarnings, "outgoing vertex null from vertex " + vertexIdentity);
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+              report.warn("outgoing vertex null from vertex " + vertexIdentity);
+              report.corrupt(edgeRID);
               removeEntry = true;
-              invalidLinks.incrementAndGet();
+              report.invalidLinks.incrementAndGet();
             } else {
               try {
                 if (edgeRID.getPosition() < 0) {
@@ -930,38 +901,35 @@ public class GraphDatabaseChecker {
                     // lightweight edge is a modelling advisory, not damage. It reads fine, it just yields the edge
                     // twice. Counted once per duplicated EDGE - only the OUT lists are scanned, and every edge
                     // appears in exactly one of them, so the IN side would only double the same finding.
-                    duplicateLightEdges.incrementAndGet();
+                    report.duplicateLightEdges.incrementAndGet();
                   continue;
                 }
 
                 final Edge edge = edgeRID.asEdge(true);
 
                 if (edge.getIn() == null || !edge.getIn().isValid()) {
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "edge " + edgeRID + " has an invalid incoming link " + edge.getIn());
-                  addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                  report.warn("edge " + edgeRID + " has an invalid incoming link " + edge.getIn());
+                  report.corrupt(edgeRID);
                   removeEntry = true;
-                  invalidLinks.incrementAndGet();
+                  report.invalidLinks.incrementAndGet();
                 } else {
                   try {
                     outVertex = (VertexInternal) edge.getInVertex().asVertex(true);
                   } catch (final RecordNotFoundException e) {
-                    addWarning(warnings, totalWarnings, maxWarnings,
-                        "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
-                    trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getIn(), describe(e));
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                    report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
+                    trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
+                    report.corrupt(edgeRID);
                     removeEntry = true;
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
-                    invalidLinks.incrementAndGet();
+                    report.corrupt(edge.getIn());
+                    report.invalidLinks.incrementAndGet();
                   } catch (final Exception e) {
                     // UNKNOWN ERROR ON LOADING
-                    addWarning(warnings, totalWarnings, maxWarnings,
-                        "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
+                    report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
                             + describe(e) + ")");
-                    trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getIn(), describe(e));
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                    trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
+                    report.corrupt(edgeRID);
                     removeEntry = true;
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
+                    report.corrupt(edge.getIn());
                   }
                 }
 
@@ -986,8 +954,7 @@ public class GraphDatabaseChecker {
                     else
                       ++totalEdgesError;
                   }
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "edge " + edgeRID + " has an outgoing link " + edge.getOut() + " different from expected " + vertexIdentity
+                  report.warn("edge " + edgeRID + " has an outgoing link " + edge.getOut() + " different from expected " + vertexIdentity
                           + ". Found " + totalEdges + " edges, of which " + totalEdgesOk + " are correct, "
                           + totalEdgesErrorFromSameVertex + " are from the same vertex and " + totalEdgesError + " are different");
 
@@ -1006,22 +973,21 @@ public class GraphDatabaseChecker {
                       break;
 
                     } else {
-                      addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                      report.corrupt(edgeRID);
                       removeEntry = true;
-                      invalidLinks.incrementAndGet();
+                      report.invalidLinks.incrementAndGet();
                     }
                   } else {
-                    addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                    report.corrupt(edgeRID);
                     removeEntry = true;
-                    invalidLinks.incrementAndGet();
+                    report.invalidLinks.incrementAndGet();
                   }
 
                 } else if (!edge.getIn().equals(vertexRID)) {
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "edge " + edgeRID + " has an incoming link " + edge.getIn() + " different from expected " + vertexRID);
-                  addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                  report.warn("edge " + edgeRID + " has an incoming link " + edge.getIn() + " different from expected " + vertexRID);
+                  report.corrupt(edgeRID);
                   removeEntry = true;
-                  invalidLinks.incrementAndGet();
+                  report.invalidLinks.incrementAndGet();
                 }
 
                 if (((EdgeType) edge.getType()).isBidirectional() && outVertex != null) {
@@ -1034,16 +1000,14 @@ public class GraphDatabaseChecker {
                     // guard the probe failure flagged the edge as corrupted and fix mode deleted a VALID edge).
                     // Register the far vertex so its list is rebuilt from the surviving edge records instead.
                     if (reconnectInEdges.add(outVertex.getIdentity())) {
-                      addWarning(warnings, totalWarnings, maxWarnings,
-                          "vertex " + outVertex.getIdentity() + " incoming edge list is unreadable (error: "
+                      report.warn("vertex " + outVertex.getIdentity() + " incoming edge list is unreadable (error: "
                               + describe(probeError) + ")" + (fix ? ", rebuilding it from the surviving edge records" : ""));
                       if (fix)
                         resetChain(outVertex, Vertex.DIRECTION.IN);
                     }
                   }
                   if (connected != null && !connected && !reconnectInEdges.contains(outVertex.getIdentity())) {
-                    addWarning(warnings, totalWarnings, maxWarnings,
-                        "edge " + edgeRID + " was not connected from the outgoing vertex " + edge.getIn() + " back to the vertex "
+                    report.warn("edge " + edgeRID + " was not connected from the outgoing vertex " + edge.getIn() + " back to the vertex "
                             + vertexIdentity);
                     if (fix) {
                       outVertex = outVertex.modify();
@@ -1054,15 +1018,14 @@ public class GraphDatabaseChecker {
                 }
 
               } catch (final RecordNotFoundException e) {
-                addWarning(warnings, totalWarnings, maxWarnings, "edge " + edgeRID + " not found");
-                addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                report.warn("edge " + edgeRID + " not found");
+                report.corrupt(edgeRID);
                 removeEntry = true;
-                invalidLinks.incrementAndGet();
+                report.invalidLinks.incrementAndGet();
               } catch (final Exception e) {
                 // UNKNOWN ERROR ON LOADING
-                addWarning(warnings, totalWarnings, maxWarnings,
-                    "edge " + edgeRID + " error on loading (error: " + describe(e) + ")");
-                addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+                report.warn("edge " + edgeRID + " error on loading (error: " + describe(e) + ")");
+                report.corrupt(edgeRID);
                 removeEntry = true;
               }
             }
@@ -1079,8 +1042,7 @@ public class GraphDatabaseChecker {
         }
 
         if (chainBroken) {
-          addWarning(warnings, totalWarnings, maxWarnings,
-              "error on loading outgoing edges from vertex " + vertexIdentity + " (error: " + chainError + ")"
+          report.warn("error on loading outgoing edges from vertex " + vertexIdentity + " (error: " + chainError + ")"
                   + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
           if (fix) {
             vertex = resetChain(vertex, Vertex.DIRECTION.OUT);
@@ -1125,14 +1087,11 @@ public class GraphDatabaseChecker {
   public Map<String, Object> checkEdges(final String typeName, final Collection<RID> scopedRecords,
       final boolean fix, final int verboseLevel, final int maxWarnings, final int maxCorrupted) {
     final AtomicLong autoFix = new AtomicLong();
-    final AtomicLong invalidLinks = new AtomicLong();
     final AtomicLong missingReferenceBack = new AtomicLong();
-    final AtomicLong totalWarnings = new AtomicLong();
-    final AtomicLong totalCorrupted = new AtomicLong();
-    // Use a Set (matching checkVertices) so the same RID flagged on both sides of an edge is recorded once and
-    // totalCorrupted (which counts only genuinely new entries, see addCorrupted) stays aligned with its size.
-    final LinkedHashSet<RID> corruptedRecords = new LinkedHashSet<>();
-    final LinkedHashSet<String> warnings = new LinkedHashSet<>();
+    // CheckReport keeps corruptedRecords as a Set (matching checkVertices) so the same RID flagged on both sides of
+    // an edge is recorded once, and totalCorrupted - which counts only genuinely new entries, see
+    // CollectionUtils.addBounded - stays aligned with its size.
+    final CheckReport report = new CheckReport(maxWarnings, maxCorrupted, verboseLevel);
     final Map<RID, Long> missingReferences = new HashMap<>();
     final Map<RID, String> missingReferenceErrors = new HashMap<>();
     // Vertices whose edge LIST failed to walk during the back-reference probe: warned once each (a broken
@@ -1153,38 +1112,36 @@ public class GraphDatabaseChecker {
           final Edge edge = record.asEdge(true);
 
           if (edge == null) {
-            addWarning(warnings, totalWarnings, maxWarnings, "edge " + edgeRID + " cannot be loaded");
-            addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+            report.warn("edge " + edgeRID + " cannot be loaded");
+            report.corrupt(edgeRID);
 
           } else if (edge.getIn() == null || !edge.getIn().isValid()) {
-            addWarning(warnings, totalWarnings, maxWarnings, "edge " + edgeRID + " has an invalid incoming link " + edge.getIn());
-            addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
-            invalidLinks.incrementAndGet();
+            report.warn("edge " + edgeRID + " has an invalid incoming link " + edge.getIn());
+            report.corrupt(edgeRID);
+            report.invalidLinks.incrementAndGet();
 
           } else if (edge.getOut() == null || !edge.getOut().isValid()) {
-            addWarning(warnings, totalWarnings, maxWarnings, "edge " + edgeRID + " has an invalid outgoing link " + edge.getOut());
-            addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
-            invalidLinks.incrementAndGet();
+            report.warn("edge " + edgeRID + " has an invalid outgoing link " + edge.getOut());
+            report.corrupt(edgeRID);
+            report.invalidLinks.incrementAndGet();
 
           } else {
             Vertex inVertex = null;
             try {
               inVertex = edge.getInVertex().asVertex(true);
             } catch (final RecordNotFoundException e) {
-              addWarning(warnings, totalWarnings, maxWarnings,
-                  "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
-              trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getIn(), describe(e));
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
-              invalidLinks.incrementAndGet();
+              report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
+              trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
+              report.corrupt(edgeRID);
+              report.corrupt(edge.getIn());
+              report.invalidLinks.incrementAndGet();
             } catch (final Exception e) {
               // UNKNOWN ERROR ON LOADING
-              addWarning(warnings, totalWarnings, maxWarnings,
-                  "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
+              report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
                       + describe(e) + ")");
-              trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getIn(), describe(e));
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
+              trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
+              report.corrupt(edgeRID);
+              report.corrupt(edge.getIn());
             }
 
             if (inVertex != null)
@@ -1199,8 +1156,7 @@ public class GraphDatabaseChecker {
                 // fix mode over its broken chain). checkVertices runs after this phase and rebuilds the list
                 // from the surviving edge records.
                 if (unreadableListVertices.add(inVertex.getIdentity()))
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "vertex " + inVertex.getIdentity() + " incoming edge list is unreadable (error: " + describe(e)
+                  report.warn("vertex " + inVertex.getIdentity() + " incoming edge list is unreadable (error: " + describe(e)
                           + "), left to the vertex check to rebuild");
               }
 
@@ -1208,19 +1164,17 @@ public class GraphDatabaseChecker {
             try {
               outVertex = edge.getOutVertex().asVertex(true);
             } catch (final RecordNotFoundException e) {
-              addWarning(warnings, totalWarnings, maxWarnings,
-                  "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
-              trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getOut(), describe(e));
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
-              invalidLinks.incrementAndGet();
+              report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
+              trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
+              report.corrupt(edgeRID);
+              report.invalidLinks.incrementAndGet();
             } catch (final Exception e) {
               // UNKNOWN ERROR ON LOADING
-              addWarning(warnings, totalWarnings, maxWarnings,
-                  "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
+              report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
                       + describe(e) + ")");
-              trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getOut(), describe(e));
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getOut());
+              trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
+              report.corrupt(edgeRID);
+              report.corrupt(edge.getOut());
             }
 
             if (outVertex != null)
@@ -1232,16 +1186,14 @@ public class GraphDatabaseChecker {
               } catch (final Exception e) {
                 // Same as the incoming side: an unreadable LIST is not a corrupted edge or vertex.
                 if (unreadableListVertices.add(outVertex.getIdentity()))
-                  addWarning(warnings, totalWarnings, maxWarnings,
-                      "vertex " + outVertex.getIdentity() + " outgoing edge list is unreadable (error: " + describe(e)
+                  report.warn("vertex " + outVertex.getIdentity() + " outgoing edge list is unreadable (error: " + describe(e)
                           + "), left to the vertex check to rebuild");
               }
           }
 
         } catch (final Throwable e) {
-          addWarning(warnings, totalWarnings, maxWarnings,
-              "edge " + record.getIdentity() + " cannot be loaded (error: " + describe(e) + ")");
-          addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
+          report.warn("edge " + record.getIdentity() + " cannot be loaded (error: " + describe(e) + ")");
+          report.corrupt(edgeRID);
         }
       };
 
@@ -1255,13 +1207,12 @@ public class GraphDatabaseChecker {
             // See the vertex arm: a missing RID is reported, never flagged corrupted, so FIX does not rebuild
             // this bucket's indexes over what is usually just a stale or mistyped RID.
             progressTick();
-            addWarning(warnings, totalWarnings, maxWarnings, "edge " + rid + " does not exist");
+            report.warn("edge " + rid + " does not exist");
           } catch (final Exception e) {
             // See the vertex arm, including what that guard does and does not cover.
             progressTick();
-            addWarning(warnings, totalWarnings, maxWarnings,
-                "edge " + rid + " cannot be loaded (error: " + describe(e) + ")");
-            addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
+            report.warn("edge " + rid + " cannot be loaded (error: " + describe(e) + ")");
+            report.corrupt(rid);
           }
         }
       } else {
@@ -1274,9 +1225,8 @@ public class GraphDatabaseChecker {
           return true;
         }, (rid, exception) -> {
           progressTick();
-          addWarning(warnings, totalWarnings, maxWarnings,
-              "edge " + rid + " cannot be loaded (error: " + describe(exception) + ")");
-          addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
+          report.warn("edge " + rid + " cannot be loaded (error: " + describe(exception) + ")");
+          report.corrupt(rid);
           return true;
         });
       }
@@ -1284,7 +1234,7 @@ public class GraphDatabaseChecker {
       progressComplete();
 
       if (fix) {
-        for (final RID rid : corruptedRecords) {
+        for (final RID rid : report.corruptedRecords) {
           if (rid == null)
             continue;
 
@@ -1294,26 +1244,25 @@ public class GraphDatabaseChecker {
           } catch (final RecordNotFoundException e) {
             // IGNORE IT
           } catch (final Throwable e) {
-            addWarning(warnings, totalWarnings, maxWarnings,
-                "Cannot fix the record " + rid + ": error on delete (error: " + e.getMessage() + ")");
+            report.warn("Cannot fix the record " + rid + ": error on delete (error: " + e.getMessage() + ")");
           }
         }
       }
 
       if (verboseLevel > 0)
-        for (final String warning : warnings)
+        for (final String warning : report.warnings)
           LogManager.instance().log(this, Level.WARNING, "- " + warning);
 
       database.commit();
 
     } finally {
       stats.put("autoFix", autoFix.get());
-      stats.put("corruptedRecords", corruptedRecords);
-      stats.put("invalidLinks", invalidLinks.get());
+      stats.put("corruptedRecords", report.corruptedRecords);
+      stats.put("invalidLinks", report.invalidLinks.get());
       stats.put("missingReferenceBack", missingReferenceBack.get());
-      stats.put("warnings", warnings);
-      stats.put("totalWarnings", totalWarnings.get());
-      stats.put("totalCorruptedRecords", totalCorrupted.get());
+      stats.put("warnings", report.warnings);
+      stats.put("totalWarnings", report.totalWarnings.get());
+      stats.put("totalCorruptedRecords", report.totalCorrupted.get());
       stats.put("missingReferences", missingReferences);
       stats.put("missingReferenceErrors", missingReferenceErrors);
     }
@@ -1350,31 +1299,71 @@ public class GraphDatabaseChecker {
   }
 
   /**
-   * Records a warning under {@link CollectionUtils#addBounded} - the one retain-and-de-duplicate rule shared with
-   * {@link #addCorrupted} and with both {@code DatabaseChecker} counters - and LOGS the message when the cap meant
-   * it could not be retained, so a capped run does not lose it silently.
+   * What a check run reports: the retained warning messages and the retained corrupted RIDs, each with its own cap
+   * and its own running total.
    * <p>
-   * #5773: {@code totalWarnings} used to count OCCURRENCES while {@code DatabaseChecker} publishes the retained
-   * warnings as a {@code Set}, so two findings rendering to the same message (a vertex with two null entries in its
-   * edge list, say) collapsed to one line and counted two - the total exceeded the retained size on a run nowhere
-   * near its cap, which is exactly what makes a total useless. Both sides now answer "distinct messages", so an
-   * uncapped run has {@code totalWarnings == warnings.size()} and a capped one reports how many it could not keep.
+   * #5773 bundled the two collections with their caps and totals because they are ONE policy - both go through
+   * {@link CollectionUtils#addBounded}, which is where the retain-and-de-duplicate rule is documented - and because
+   * threading them as loose parameters is what made {@link #checkIncomingEdges} and {@link #checkOutgoingEdges}
+   * take fourteen and fifteen arguments (now eight each). There is no behaviour here that was not previously in the
+   * two static helpers this replaces; the value is that a caller can no longer pair one run's warnings with
+   * another's cap.
+   * <p>
+   * The caps are separate parameters rather than one because the callers pass different REMAINING budgets for the
+   * two collections (see {@code DatabaseChecker.checkScopedRecords}), even though both derive from that class's
+   * single {@code maxWarnings} setting.
    */
-  private static void addWarning(final Collection<String> warnings, final AtomicLong totalWarnings, final int maxWarnings,
-      final String message) {
-    // Read BEFORE the record: addBounded grows the collection, so "was it retained" cannot be asked afterwards.
-    final boolean retaining = warnings.size() < maxWarnings;
-    if (!CollectionUtils.addBounded(warnings, maxWarnings, message))
-      return;
-    if (!retaining)
-      LogManager.instance().log(GraphDatabaseChecker.class, Level.WARNING, message);
-    totalWarnings.incrementAndGet();
-  }
+  private static final class CheckReport {
+    final LinkedHashSet<String> warnings         = new LinkedHashSet<>();
+    final LinkedHashSet<RID>    corruptedRecords = new LinkedHashSet<>();
+    final AtomicLong            totalWarnings    = new AtomicLong();
+    final AtomicLong            totalCorrupted   = new AtomicLong();
+    // Uncapped run counters, here for the same reason: they are per-run accumulators every helper needs and
+    // nothing else does. checkEdges leaves duplicateLightEdges at zero and does not publish it, as before.
+    final AtomicLong            invalidLinks        = new AtomicLong();
+    final AtomicLong            duplicateLightEdges = new AtomicLong();
+    final int                   maxWarnings;
+    final int                   maxCorrupted;
+    /**
+     * Only used to decide whether a message the cap forced us to DROP is still logged. #5773: the two
+     * {@code addWarning} twins disagreed here - this one logged unconditionally while
+     * {@code DatabaseChecker.addWarning} gated on the same flag - so a caller asking for silence got it from one and
+     * not the other. Aligned on honouring it: a caller passing 0 asked for no logging, and the retained set plus
+     * {@code totalWarnings} still tell it how many were dropped.
+     */
+    final int                   verboseLevel;
 
-  /** Flags an item as corrupted under the same bounded, de-duplicating rule {@link #addWarning} uses. */
-  private static <T> void addCorrupted(final Collection<T> corrupted, final AtomicLong totalCorrupted, final int maxCorrupted,
-      final T item) {
-    if (CollectionUtils.addBounded(corrupted, maxCorrupted, item))
-      totalCorrupted.incrementAndGet();
+    CheckReport(final int maxWarnings, final int maxCorrupted, final int verboseLevel) {
+      this.maxWarnings = maxWarnings;
+      this.maxCorrupted = maxCorrupted;
+      this.verboseLevel = verboseLevel;
+    }
+
+    /**
+     * Records a warning, and LOGS it when the cap meant it could not be retained - so a capped run does not lose
+     * the message silently, unless the caller asked for silence with {@code verboseLevel == 0}.
+     * <p>
+     * #5773: {@code totalWarnings} used to count OCCURRENCES while {@code DatabaseChecker} publishes the retained
+     * warnings as a {@code Set}, so two findings rendering to the same message (a vertex with two null entries in
+     * its edge list, say) collapsed to one line and counted two - the total exceeded the retained size on a run
+     * nowhere near its cap, which is exactly what makes a total useless. Both sides now answer "distinct messages",
+     * so an uncapped run has {@code totalWarnings == warnings.size()} and a capped one reports how many it could
+     * not keep.
+     */
+    void warn(final String message) {
+      // Read BEFORE the record: addBounded grows the collection, so "was it retained" cannot be asked afterwards.
+      final boolean retaining = warnings.size() < maxWarnings;
+      if (!CollectionUtils.addBounded(warnings, maxWarnings, message))
+        return;
+      if (!retaining && verboseLevel > 0)
+        LogManager.instance().log(GraphDatabaseChecker.class, Level.WARNING, message);
+      totalWarnings.incrementAndGet();
+    }
+
+    /** Flags a record as corrupted under the same bounded, de-duplicating rule {@link #warn} uses. */
+    void corrupt(final RID rid) {
+      if (CollectionUtils.addBounded(corruptedRecords, maxCorrupted, rid))
+        totalCorrupted.incrementAndGet();
+    }
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -251,7 +251,7 @@ public class GraphDatabaseChecker {
       stats.put("orphanedEdgeSegments", orphans);
       stats.put("orphanedEdgeSegmentsReclaimed", reclaimed);
       stats.put("warnings", report.warnings);
-      stats.put("totalWarnings", report.totalWarnings.get());
+      stats.put("totalWarnings", report.totalWarnings);
     }
     return stats;
   }
@@ -519,11 +519,11 @@ public class GraphDatabaseChecker {
     } finally {
       stats.put("autoFix", autoFix.get());
       stats.put("corruptedRecords", report.corruptedRecords);
-      stats.put("duplicateLightEdges", report.duplicateLightEdges.get());
-      stats.put("invalidLinks", report.invalidLinks.get());
+      stats.put("duplicateLightEdges", report.duplicateLightEdges);
+      stats.put("invalidLinks", report.invalidLinks);
       stats.put("warnings", report.warnings);
-      stats.put("totalWarnings", report.totalWarnings.get());
-      stats.put("totalCorruptedRecords", report.totalCorrupted.get());
+      stats.put("totalWarnings", report.totalWarnings);
+      stats.put("totalCorruptedRecords", report.totalCorrupted);
       stats.put("missingReferences", missingReferences);
       stats.put("missingReferenceErrors", missingReferenceErrors);
     }
@@ -656,12 +656,12 @@ public class GraphDatabaseChecker {
             if (edgeRID == null) {
               report.warn("outgoing edge null from vertex " + vertexIdentity);
               removeEntry = true;
-              report.invalidLinks.incrementAndGet();
+              ++report.invalidLinks;
             } else if (vertexRID == null) {
               report.warn("outgoing vertex null from vertex " + vertexIdentity);
               report.corrupt(edgeRID);
               removeEntry = true;
-              report.invalidLinks.incrementAndGet();
+              ++report.invalidLinks;
             } else {
               if (edgeRID.getPosition() < 0)
                 // LIGHTWEIGHT EDGE
@@ -676,7 +676,7 @@ public class GraphDatabaseChecker {
                   report.warn("edge " + edgeRID + " has an invalid outgoing link " + edge.getIn());
                   report.corrupt(edgeRID);
                   removeEntry = true;
-                  report.invalidLinks.incrementAndGet();
+                  ++report.invalidLinks;
                 } else {
                   try {
                     inVertex = (VertexInternal) edge.getOutVertex().asVertex(true);
@@ -686,7 +686,7 @@ public class GraphDatabaseChecker {
                     report.corrupt(edgeRID);
                     removeEntry = true;
                     report.corrupt(edge.getOut());
-                    report.invalidLinks.incrementAndGet();
+                    ++report.invalidLinks;
                   } catch (final Exception e) {
                     // UNKNOWN ERROR ON LOADING
                     report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
@@ -740,19 +740,19 @@ public class GraphDatabaseChecker {
                     } else {
                       report.corrupt(edgeRID);
                       removeEntry = true;
-                      report.invalidLinks.incrementAndGet();
+                      ++report.invalidLinks;
                     }
                   } else {
                     report.corrupt(edgeRID);
                     removeEntry = true;
-                    report.invalidLinks.incrementAndGet();
+                    ++report.invalidLinks;
                   }
 
                 } else if (!edge.getOut().equals(vertexRID)) {
                   report.warn("edge " + edgeRID + " has an outgoing link " + edge.getOut() + " different from expected " + vertexRID);
                   report.corrupt(edgeRID);
                   removeEntry = true;
-                  report.invalidLinks.incrementAndGet();
+                  ++report.invalidLinks;
                 }
 
                 if (((EdgeType) edge.getType()).isBidirectional() && inVertex != null) {
@@ -785,7 +785,7 @@ public class GraphDatabaseChecker {
                 report.warn("edge " + edgeRID + " not found");
                 report.corrupt(edgeRID);
                 removeEntry = true;
-                report.invalidLinks.incrementAndGet();
+                ++report.invalidLinks;
               } catch (final Exception e) {
                 // UNKNOWN ERROR ON LOADING
                 report.warn("edge " + edgeRID + " error on loading (error: " + describe(e) + ")");
@@ -873,12 +873,12 @@ public class GraphDatabaseChecker {
             if (edgeRID == null) {
               report.warn("outgoing edge null from vertex " + vertexIdentity);
               removeEntry = true;
-              report.invalidLinks.incrementAndGet();
+              ++report.invalidLinks;
             } else if (vertexRID == null) {
               report.warn("outgoing vertex null from vertex " + vertexIdentity);
               report.corrupt(edgeRID);
               removeEntry = true;
-              report.invalidLinks.incrementAndGet();
+              ++report.invalidLinks;
             } else {
               try {
                 if (edgeRID.getPosition() < 0) {
@@ -901,7 +901,7 @@ public class GraphDatabaseChecker {
                     // lightweight edge is a modelling advisory, not damage. It reads fine, it just yields the edge
                     // twice. Counted once per duplicated EDGE - only the OUT lists are scanned, and every edge
                     // appears in exactly one of them, so the IN side would only double the same finding.
-                    report.duplicateLightEdges.incrementAndGet();
+                    ++report.duplicateLightEdges;
                   continue;
                 }
 
@@ -911,7 +911,7 @@ public class GraphDatabaseChecker {
                   report.warn("edge " + edgeRID + " has an invalid incoming link " + edge.getIn());
                   report.corrupt(edgeRID);
                   removeEntry = true;
-                  report.invalidLinks.incrementAndGet();
+                  ++report.invalidLinks;
                 } else {
                   try {
                     outVertex = (VertexInternal) edge.getInVertex().asVertex(true);
@@ -921,7 +921,7 @@ public class GraphDatabaseChecker {
                     report.corrupt(edgeRID);
                     removeEntry = true;
                     report.corrupt(edge.getIn());
-                    report.invalidLinks.incrementAndGet();
+                    ++report.invalidLinks;
                   } catch (final Exception e) {
                     // UNKNOWN ERROR ON LOADING
                     report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
@@ -975,19 +975,19 @@ public class GraphDatabaseChecker {
                     } else {
                       report.corrupt(edgeRID);
                       removeEntry = true;
-                      report.invalidLinks.incrementAndGet();
+                      ++report.invalidLinks;
                     }
                   } else {
                     report.corrupt(edgeRID);
                     removeEntry = true;
-                    report.invalidLinks.incrementAndGet();
+                    ++report.invalidLinks;
                   }
 
                 } else if (!edge.getIn().equals(vertexRID)) {
                   report.warn("edge " + edgeRID + " has an incoming link " + edge.getIn() + " different from expected " + vertexRID);
                   report.corrupt(edgeRID);
                   removeEntry = true;
-                  report.invalidLinks.incrementAndGet();
+                  ++report.invalidLinks;
                 }
 
                 if (((EdgeType) edge.getType()).isBidirectional() && outVertex != null) {
@@ -1021,7 +1021,7 @@ public class GraphDatabaseChecker {
                 report.warn("edge " + edgeRID + " not found");
                 report.corrupt(edgeRID);
                 removeEntry = true;
-                report.invalidLinks.incrementAndGet();
+                ++report.invalidLinks;
               } catch (final Exception e) {
                 // UNKNOWN ERROR ON LOADING
                 report.warn("edge " + edgeRID + " error on loading (error: " + describe(e) + ")");
@@ -1118,12 +1118,12 @@ public class GraphDatabaseChecker {
           } else if (edge.getIn() == null || !edge.getIn().isValid()) {
             report.warn("edge " + edgeRID + " has an invalid incoming link " + edge.getIn());
             report.corrupt(edgeRID);
-            report.invalidLinks.incrementAndGet();
+            ++report.invalidLinks;
 
           } else if (edge.getOut() == null || !edge.getOut().isValid()) {
             report.warn("edge " + edgeRID + " has an invalid outgoing link " + edge.getOut());
             report.corrupt(edgeRID);
-            report.invalidLinks.incrementAndGet();
+            ++report.invalidLinks;
 
           } else {
             Vertex inVertex = null;
@@ -1134,7 +1134,7 @@ public class GraphDatabaseChecker {
               trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getIn(), describe(e));
               report.corrupt(edgeRID);
               report.corrupt(edge.getIn());
-              report.invalidLinks.incrementAndGet();
+              ++report.invalidLinks;
             } catch (final Exception e) {
               // UNKNOWN ERROR ON LOADING
               report.warn("edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
@@ -1167,7 +1167,7 @@ public class GraphDatabaseChecker {
               report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
               trackMissingReference(missingReferences, missingReferenceErrors, report.maxWarnings, edge.getOut(), describe(e));
               report.corrupt(edgeRID);
-              report.invalidLinks.incrementAndGet();
+              ++report.invalidLinks;
             } catch (final Exception e) {
               // UNKNOWN ERROR ON LOADING
               report.warn("edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
@@ -1258,11 +1258,11 @@ public class GraphDatabaseChecker {
     } finally {
       stats.put("autoFix", autoFix.get());
       stats.put("corruptedRecords", report.corruptedRecords);
-      stats.put("invalidLinks", report.invalidLinks.get());
+      stats.put("invalidLinks", report.invalidLinks);
       stats.put("missingReferenceBack", missingReferenceBack.get());
       stats.put("warnings", report.warnings);
-      stats.put("totalWarnings", report.totalWarnings.get());
-      stats.put("totalCorruptedRecords", report.totalCorrupted.get());
+      stats.put("totalWarnings", report.totalWarnings);
+      stats.put("totalCorruptedRecords", report.totalCorrupted);
       stats.put("missingReferences", missingReferences);
       stats.put("missingReferenceErrors", missingReferenceErrors);
     }
@@ -1316,12 +1316,16 @@ public class GraphDatabaseChecker {
   private static final class CheckReport {
     final LinkedHashSet<String> warnings         = new LinkedHashSet<>();
     final LinkedHashSet<RID>    corruptedRecords = new LinkedHashSet<>();
-    final AtomicLong            totalWarnings    = new AtomicLong();
-    final AtomicLong            totalCorrupted   = new AtomicLong();
+    // PLAIN longs, not AtomicLong: a check run is single-threaded (scanType walks sequentially) and the sets beside
+    // them are not thread-safe either, so an atomic counter here would advertise a concurrency this class does not
+    // have and cannot support. They were atomics only because the previous shape passed them as parameters, which
+    // a mutable holder is the Java way to do; as fields of one object they no longer need to be.
+    long                        totalWarnings;
+    long                        totalCorrupted;
     // Uncapped run counters, here for the same reason: they are per-run accumulators every helper needs and
     // nothing else does. checkEdges leaves duplicateLightEdges at zero and does not publish it, as before.
-    final AtomicLong            invalidLinks        = new AtomicLong();
-    final AtomicLong            duplicateLightEdges = new AtomicLong();
+    long                        invalidLinks;
+    long                        duplicateLightEdges;
     final int                   maxWarnings;
     final int                   maxCorrupted;
     /**
@@ -1351,21 +1355,18 @@ public class GraphDatabaseChecker {
      * not keep.
      */
     void warn(final String message) {
-      if (!CollectionUtils.addBounded(warnings, maxWarnings, message))
+      final CollectionUtils.BoundedAdd outcome = CollectionUtils.addBounded(warnings, maxWarnings, message);
+      if (!outcome.isFirstSighting())
         return;
-      // The SET answers whether it was retained, so the cap rule stays in addBounded alone rather than being
-      // re-derived here: a new message that is absent AFTER the call is one the cap refused to keep. Asking before
-      // the call instead would mean mirroring addBounded's own boundary test, which is a second copy of the rule
-      // this class exists to have only one of.
-      if (verboseLevel > 0 && !warnings.contains(message))
+      if (outcome == CollectionUtils.BoundedAdd.DROPPED && verboseLevel > 0)
         LogManager.instance().log(GraphDatabaseChecker.class, Level.WARNING, message);
-      totalWarnings.incrementAndGet();
+      ++totalWarnings;
     }
 
     /** Flags a record as corrupted under the same bounded, de-duplicating rule {@link #warn} uses. */
     void corrupt(final RID rid) {
-      if (CollectionUtils.addBounded(corruptedRecords, maxCorrupted, rid))
-        totalCorrupted.incrementAndGet();
+      if (CollectionUtils.addBounded(corruptedRecords, maxCorrupted, rid).isFirstSighting())
+        ++totalCorrupted;
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -29,6 +29,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.LocalVertexType;
 import com.arcadedb.schema.Schema;
+import com.arcadedb.utility.CollectionUtils;
 import com.arcadedb.utility.LongHashSet;
 import com.arcadedb.utility.Pair;
 import com.arcadedb.utility.ProgressCallback;
@@ -1349,8 +1350,9 @@ public class GraphDatabaseChecker {
   }
 
   /**
-   * Records a warning, bounded by {@code maxWarnings} and de-duplicated exactly the way {@link #addCorrupted} bounds
-   * and de-duplicates the corrupted-record set - the two are one policy, stated once here and once there.
+   * Records a warning under {@link CollectionUtils#addBounded} - the one retain-and-de-duplicate rule shared with
+   * {@link #addCorrupted} and with both {@code DatabaseChecker} counters - and LOGS the message when the cap meant
+   * it could not be retained, so a capped run does not lose it silently.
    * <p>
    * #5773: {@code totalWarnings} used to count OCCURRENCES while {@code DatabaseChecker} publishes the retained
    * warnings as a {@code Set}, so two findings rendering to the same message (a vertex with two null entries in its
@@ -1360,38 +1362,19 @@ public class GraphDatabaseChecker {
    */
   private static void addWarning(final Collection<String> warnings, final AtomicLong totalWarnings, final int maxWarnings,
       final String message) {
-    if (warnings.size() < maxWarnings) {
-      // Under the cap the retained set itself answers "have I already said this". Collection.add() returns false
-      // for an item already present in a Set.
-      if (!warnings.add(message))
-        return;
-    } else if (warnings.contains(message))
-      // Past the cap: still recognised while it is retained (see addCorrupted for the limit of that).
+    // Read BEFORE the record: addBounded grows the collection, so "was it retained" cannot be asked afterwards.
+    final boolean retaining = warnings.size() < maxWarnings;
+    if (!CollectionUtils.addBounded(warnings, maxWarnings, message))
       return;
-    else
-      // Dropped rather than retained, so it is not lost silently.
+    if (!retaining)
       LogManager.instance().log(GraphDatabaseChecker.class, Level.WARNING, message);
     totalWarnings.incrementAndGet();
   }
 
-  /**
-   * Flags an item as corrupted, bounded by {@code maxCorrupted}: the total keeps counting, the retained collection
-   * does not grow without limit.
-   * <p>
-   * De-duplication is EXACT while the collection is under the cap - the collection itself answers "have I seen
-   * this". Past the cap it degrades to what the retained collection can still answer: an item already in it is
-   * recognised (hence the {@code contains} check rather than an unconditional increment, aligned with
-   * {@code DatabaseChecker.addCorrupted} by #5773), but one that was never retained cannot be, so a second flag on
-   * it counts twice. Deliberate: the only way to keep it exact past the cap is a second unbounded collection of
-   * every item ever counted, which is precisely the memory the cap exists to refuse.
-   */
+  /** Flags an item as corrupted under the same bounded, de-duplicating rule {@link #addWarning} uses. */
   private static <T> void addCorrupted(final Collection<T> corrupted, final AtomicLong totalCorrupted, final int maxCorrupted,
       final T item) {
-    if (corrupted.size() < maxCorrupted) {
-      if (!corrupted.add(item))
-        return;
-    } else if (corrupted.contains(item))
-      return;
-    totalCorrupted.incrementAndGet();
+    if (CollectionUtils.addBounded(corrupted, maxCorrupted, item))
+      totalCorrupted.incrementAndGet();
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1351,7 +1351,10 @@ public class GraphDatabaseChecker {
      * not keep.
      */
     void warn(final String message) {
-      // Read BEFORE the record: addBounded grows the collection, so "was it retained" cannot be asked afterwards.
+      // Read BEFORE the record: addBounded grows the set, so "was it retained" cannot be asked afterwards. This
+      // deliberately mirrors addBounded's own boundary test rather than being told the answer - the two read the
+      // same size() before the same add(), so they cannot disagree. If addBounded's retention policy ever stops
+      // being "under the cap", this needs to learn the new answer rather than keep guessing it.
       final boolean retaining = warnings.size() < maxWarnings;
       if (!CollectionUtils.addBounded(warnings, maxWarnings, message))
         return;

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1351,14 +1351,13 @@ public class GraphDatabaseChecker {
      * not keep.
      */
     void warn(final String message) {
-      // Read BEFORE the record: addBounded grows the set, so "was it retained" cannot be asked afterwards. This
-      // deliberately mirrors addBounded's own boundary test rather than being told the answer - the two read the
-      // same size() before the same add(), so they cannot disagree. If addBounded's retention policy ever stops
-      // being "under the cap", this needs to learn the new answer rather than keep guessing it.
-      final boolean retaining = warnings.size() < maxWarnings;
       if (!CollectionUtils.addBounded(warnings, maxWarnings, message))
         return;
-      if (!retaining && verboseLevel > 0)
+      // The SET answers whether it was retained, so the cap rule stays in addBounded alone rather than being
+      // re-derived here: a new message that is absent AFTER the call is one the cap refused to keep. Asking before
+      // the call instead would mean mirroring addBounded's own boundary test, which is a second copy of the rule
+      // this class exists to have only one of.
+      if (verboseLevel > 0 && !warnings.contains(message))
         LogManager.instance().log(GraphDatabaseChecker.class, Level.WARNING, message);
       totalWarnings.incrementAndGet();
     }

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -150,7 +150,7 @@ public class GraphDatabaseChecker {
    * the alternative if the always-on cost proves unwelcome; left always-on for now.
    */
   public Map<String, Object> reclaimOrphanedEdgeSegments(final int verboseLevel, final int maxWarnings) {
-    final List<String> warnings = new ArrayList<>();
+    final LinkedHashSet<String> warnings = new LinkedHashSet<>();
     final AtomicLong totalWarnings = new AtomicLong();
     final Map<String, Object> stats = new HashMap<>();
 
@@ -391,18 +391,32 @@ public class GraphDatabaseChecker {
    * every surviving edge that points at the vertex, and no index maps endpoints back to edges. So the scoped run
    * saves the vertex passes, not the edge pass.
    * <p>
-   * #5764 - why ONE pass here answers what TWO answer below, which is not obvious from the shapes. The type-wide
-   * arm materialises each record twice: once from the raw page view in the bucket scan
-   * ({@code newImmutableRecord(type, rid, view)} then {@code asVertex(true)}), and once again through the
-   * connectivity walk. The scoped arm looks like it runs only the second - but {@code LocalDatabase.lookupByRID}
-   * IS the first: it calls the same {@code newImmutableRecord(type, rid, bucket.getRecord(rid).copyOfContent())},
-   * and {@link #checkVertices}' shared {@code checkConnectivity} opens with the same {@code asVertex(true)}, whose
-   * {@code loadContent} flag is what forces the buffer decode. Both halves of the type-wide first pass therefore
-   * run per listed RID, and no corruption shape reaches one enumeration but not the other:
-   * {@code LocalBucket.getRecord} and {@code LocalBucket.scan} resolve placeholders and multi-page chains
-   * identically and skip the same slot markers. The type-wide pass is a second look at the same bytes, kept there
-   * because a scan is how a whole type is enumerated at all - not a check the scoped run is missing. Pinned by
-   * {@code CheckDatabaseRecordScopeTest.theScopedAndTypeWideRunsAgreeOnAGenuinelyCorruptedRecord}.
+   * #5764/#5773 - both arms materialise each record EXACTLY ONCE, which is not obvious from the shapes and is the
+   * reason the type-wide arm no longer opens with a raw bucket scan of its own. The scoped arm materialises through
+   * {@code LocalDatabase.lookupByRID}; the type-wide arm through {@code LocalDatabase.scanType}, whose callback does
+   * the same {@code newImmutableRecord(type, rid, view)} from the same raw page view that {@code lookupByRID} builds
+   * from {@code bucket.getRecord(rid).copyOfContent()}. Both then hand the record to the shared
+   * {@code checkConnectivity}, which opens with the same {@code asVertex(true)} whose {@code loadContent} flag forces
+   * the buffer decode. No corruption shape reaches one enumeration but not the other: {@code LocalBucket.getRecord}
+   * and {@code LocalBucket.scan} resolve placeholders and multi-page chains identically and skip the same slot
+   * markers. Pinned by {@code CheckDatabaseRecordScopeTest.theScopedAndTypeWideRunsAgreeOnAGenuinelyCorruptedRecord}.
+   * <p>
+   * #5773 - what the dropped type-wide first pass did, and why removing it detects strictly no less. It scanned the
+   * buckets, built each record with {@code newImmutableRecord} and called {@code asVertex(true)}, flagging a failure
+   * of either. The surviving {@code scanType} pass does the FIRST of those inside {@code LocalBucket.scan}'s per-slot
+   * {@code try}, so a construction failure is routed to the {@code errorRecordCallback} below (which warns and flags
+   * the record), and the SECOND inside {@code checkConnectivity}'s {@code catch (Throwable)}, which warns and flags
+   * it likewise. The dropped pass in fact saw LESS: it passed a {@code null} error callback, so a failure inside the
+   * bucket machinery itself (placeholder resolution, a multi-page chain read) was only logged, never reported.
+   * <p>
+   * What removing it is and is not worth, MEASURED rather than assumed - the record-materialisation count halves,
+   * but materialisation is not what the step spends its time on. On a warm 200k-vertex / 200k-edge graph with no
+   * super-node, the per-type steps went 173 ms -> 162 ms (vertices) and 155 ms -> 142 ms (edges), about 7% each; a
+   * full {@code CHECK DATABASE} went 509 ms -> 472 ms. The pass is cheap because {@code asVertex(true)} only parses
+   * the edge pointers, not the properties. The real reasons to drop it are that it was provably redundant and that
+   * it emitted a "vertex/edge <rid> cannot be loaded, REMOVING IT" warning on runs without {@code FIX}, which
+   * remove nothing - and a duplicate warning per corrupt record besides. Pinned by
+   * {@code CheckDatabaseSinglePassTest}.
    */
   public Map<String, Object> checkVertices(final String typeName, final Collection<RID> scopedRecords,
       final boolean fix, final int verboseLevel, final int maxWarnings, final int maxCorrupted) {
@@ -412,7 +426,7 @@ public class GraphDatabaseChecker {
     final AtomicLong totalWarnings = new AtomicLong();
     final AtomicLong totalCorrupted = new AtomicLong();
     final LinkedHashSet<RID> corruptedRecords = new LinkedHashSet<>();
-    final List<String> warnings = new ArrayList<>();
+    final LinkedHashSet<String> warnings = new LinkedHashSet<>();
     final Set<RID> reconnectOutEdges = new HashSet<>();
     final Set<RID> reconnectInEdges = new HashSet<>();
     final Map<RID, Long> missingReferences = new HashMap<>();
@@ -472,25 +486,9 @@ public class GraphDatabaseChecker {
           }
         }
       } else {
-        // TWO FULL PASSES OVER THE TYPE (record-type scan + connectivity walk): progress total is 2x the count.
-        // countType reads the maintained bucket counters (no scan), so sizing the total is negligible.
-        progressBegin(progressStepName, 2 * database.countType(typeName, false));
-
-        // CHECK RECORD IS OF THE RIGHT TYPE
-        final DocumentType type = database.getSchema().getType(typeName);
-        for (final Bucket b : type.getBuckets(false)) {
-          b.scan((rid, view) -> {
-            try {
-              final Record record = database.getRecordFactory().newImmutableRecord(database, type, rid, view, null);
-              record.asVertex(true);
-            } catch (Exception e) {
-              addWarning(warnings, totalWarnings, maxWarnings, "vertex " + rid + " cannot be loaded, removing it");
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
-            }
-            progressTick();
-            return true;
-          }, null);
-        }
+        // ONE FULL PASS OVER THE TYPE (#5773): progress total is the record count. countType reads the maintained
+        // bucket counters (no scan), so sizing the total is negligible.
+        progressBegin(progressStepName, database.countType(typeName, false));
 
         database.scanType(typeName, false, record -> {
           checkConnectivity.accept(record);
@@ -535,8 +533,8 @@ public class GraphDatabaseChecker {
     } finally {
       stats.put("autoFix", autoFix.get());
       stats.put("corruptedRecords", corruptedRecords);
-stats.put("duplicateLightEdges", duplicateLightEdges.get());
-            stats.put("invalidLinks", invalidLinks.get());
+      stats.put("duplicateLightEdges", duplicateLightEdges.get());
+      stats.put("invalidLinks", invalidLinks.get());
       stats.put("warnings", warnings);
       stats.put("totalWarnings", totalWarnings.get());
       stats.put("totalCorruptedRecords", totalCorrupted.get());
@@ -555,7 +553,7 @@ stats.put("duplicateLightEdges", duplicateLightEdges.get());
    * does not): that is the same behaviour as before and the {@code checkEdges} pass reports it.
    */
   private void reconnectEdges(Set<RID> reconnectOutEdges, Set<RID> reconnectInEdges, Set<RID> corruptedRecords,
-      List<String> warnings, AtomicLong totalWarnings, int maxWarnings, Map<String, Object> stats) {
+      Collection<String> warnings, AtomicLong totalWarnings, int maxWarnings, Map<String, Object> stats) {
     // BROWSE ALL THE EDGES AND COLLECT THE ONES PART OF THE RECONNECTION
     final List<EdgeType> edgeTypes = new ArrayList<>();
     for (DocumentType schemaType : database.getSchema().getTypes()) {
@@ -615,13 +613,13 @@ stats.put("duplicateLightEdges", duplicateLightEdges.get());
     }
   }
 
-  private static void warnUnreadableEdgeDuringRebuild(final List<String> warnings, final AtomicLong totalWarnings,
+  private static void warnUnreadableEdgeDuringRebuild(final Collection<String> warnings, final AtomicLong totalWarnings,
       final int maxWarnings, final Object rid, final Throwable error) {
     addWarning(warnings, totalWarnings, maxWarnings,
         "edge " + rid + " could not be read during the edge-list rebuild, skipping it (error: " + describe(error) + ")");
   }
 
-  private void checkIncomingEdges(boolean fix, Vertex vertex, List<String> warnings, AtomicLong totalWarnings, int maxWarnings,
+  private void checkIncomingEdges(boolean fix, Vertex vertex, Collection<String> warnings, AtomicLong totalWarnings, int maxWarnings,
       RID vertexIdentity, AtomicLong invalidLinks, LinkedHashSet<RID> corruptedRecords, AtomicLong totalCorrupted,
       int maxCorrupted, Set<RID> reconnectInEdges, Set<RID> reconnectOutEdges, Map<RID, Long> missingReferences,
       Map<RID, String> missingReferenceErrors) {
@@ -844,7 +842,7 @@ stats.put("duplicateLightEdges", duplicateLightEdges.get());
     }
   }
 
-  private Vertex checkOutgoingEdges(final boolean fix, Vertex vertex, final List<String> warnings,
+  private Vertex checkOutgoingEdges(final boolean fix, Vertex vertex, final Collection<String> warnings,
       final AtomicLong totalWarnings, final int maxWarnings, final RID vertexIdentity, final AtomicLong invalidLinks,
       final LinkedHashSet<RID> corruptedRecords, final AtomicLong totalCorrupted, final int maxCorrupted,
       final Set<RID> reconnectOutEdges, final Set<RID> reconnectInEdges, final Map<RID, Long> missingReferences,
@@ -1133,7 +1131,7 @@ stats.put("duplicateLightEdges", duplicateLightEdges.get());
     // Use a Set (matching checkVertices) so the same RID flagged on both sides of an edge is recorded once and
     // totalCorrupted (which counts only genuinely new entries, see addCorrupted) stays aligned with its size.
     final LinkedHashSet<RID> corruptedRecords = new LinkedHashSet<>();
-    final List<String> warnings = new ArrayList<>();
+    final LinkedHashSet<String> warnings = new LinkedHashSet<>();
     final Map<RID, Long> missingReferences = new HashMap<>();
     final Map<RID, String> missingReferenceErrors = new HashMap<>();
     // Vertices whose edge LIST failed to walk during the back-reference probe: warned once each (a broken
@@ -1266,24 +1264,9 @@ stats.put("duplicateLightEdges", duplicateLightEdges.get());
           }
         }
       } else {
-        // TWO FULL PASSES OVER THE TYPE (record-type scan + endpoint checks): progress total is 2x the count.
-        progressBegin(progressStepName, 2 * database.countType(typeName, false));
-
-        // CHECK RECORD IS OF THE RIGHT TYPE
-        final DocumentType type = database.getSchema().getType(typeName);
-        for (final Bucket b : type.getBuckets(false)) {
-          b.scan((rid, view) -> {
-            try {
-              final Record record = database.getRecordFactory().newImmutableRecord(database, type, rid, view, null);
-              record.asEdge(true);
-            } catch (Exception e) {
-              addWarning(warnings, totalWarnings, maxWarnings, "edge " + rid + " cannot be loaded, removing it");
-              addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
-            }
-            progressTick();
-            return true;
-          }, null);
-        }
+        // ONE FULL PASS OVER THE TYPE (#5773): progress total is the record count. See checkVertices for why the
+        // record-type scan that used to precede this detected nothing the endpoint pass misses.
+        progressBegin(progressStepName, database.countType(typeName, false));
 
         database.scanType(typeName, false, record -> {
           checkEndpoints.accept(record);
@@ -1365,24 +1348,50 @@ stats.put("duplicateLightEdges", duplicateLightEdges.get());
     }
   }
 
-  private static void addWarning(final List<String> warnings, final AtomicLong totalWarnings, final int maxWarnings,
+  /**
+   * Records a warning, bounded by {@code maxWarnings} and de-duplicated exactly the way {@link #addCorrupted} bounds
+   * and de-duplicates the corrupted-record set - the two are one policy, stated once here and once there.
+   * <p>
+   * #5773: {@code totalWarnings} used to count OCCURRENCES while {@code DatabaseChecker} publishes the retained
+   * warnings as a {@code Set}, so two findings rendering to the same message (a vertex with two null entries in its
+   * edge list, say) collapsed to one line and counted two - the total exceeded the retained size on a run nowhere
+   * near its cap, which is exactly what makes a total useless. Both sides now answer "distinct messages", so an
+   * uncapped run has {@code totalWarnings == warnings.size()} and a capped one reports how many it could not keep.
+   */
+  private static void addWarning(final Collection<String> warnings, final AtomicLong totalWarnings, final int maxWarnings,
       final String message) {
-    totalWarnings.incrementAndGet();
-    if (warnings.size() < maxWarnings)
-      warnings.add(message);
+    if (warnings.size() < maxWarnings) {
+      // Under the cap the retained set itself answers "have I already said this". Collection.add() returns false
+      // for an item already present in a Set.
+      if (!warnings.add(message))
+        return;
+    } else if (warnings.contains(message))
+      // Past the cap: still recognised while it is retained (see addCorrupted for the limit of that).
+      return;
     else
+      // Dropped rather than retained, so it is not lost silently.
       LogManager.instance().log(GraphDatabaseChecker.class, Level.WARNING, message);
+    totalWarnings.incrementAndGet();
   }
 
+  /**
+   * Flags an item as corrupted, bounded by {@code maxCorrupted}: the total keeps counting, the retained collection
+   * does not grow without limit.
+   * <p>
+   * De-duplication is EXACT while the collection is under the cap - the collection itself answers "have I seen
+   * this". Past the cap it degrades to what the retained collection can still answer: an item already in it is
+   * recognised (hence the {@code contains} check rather than an unconditional increment, aligned with
+   * {@code DatabaseChecker.addCorrupted} by #5773), but one that was never retained cannot be, so a second flag on
+   * it counts twice. Deliberate: the only way to keep it exact past the cap is a second unbounded collection of
+   * every item ever counted, which is precisely the memory the cap exists to refuse.
+   */
   private static <T> void addCorrupted(final Collection<T> corrupted, final AtomicLong totalCorrupted, final int maxCorrupted,
       final T item) {
     if (corrupted.size() < maxCorrupted) {
-      // Under the cap: count the record only the first time it is recorded so totalCorrupted stays aligned with the
-      // de-duplicated collection size. Collection.add() returns false for an item already present in a Set.
-      if (corrupted.add(item))
-        totalCorrupted.incrementAndGet();
-    } else
-      // At/over the cap the item is not stored, so de-duplication is no longer possible: count the occurrence.
-      totalCorrupted.incrementAndGet();
+      if (!corrupted.add(item))
+        return;
+    } else if (corrupted.contains(item))
+      return;
+    totalCorrupted.incrementAndGet();
   }
 }

--- a/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
@@ -286,26 +286,34 @@ public class CollectionUtils {
   }
 
   /**
-   * Records {@code item} in a de-duplicating collection that must not grow past {@code max}, and answers whether this
-   * is the FIRST time it has been recorded - i.e. whether a counter kept alongside {@code retained} should tick.
+   * Records {@code item} in a de-duplicating set that must not grow past {@code max}, and answers whether this is the
+   * FIRST time it has been recorded - i.e. whether a counter kept alongside {@code retained} should tick.
    * <p>
    * Extracted by #5773 so the two {@code CHECK DATABASE} counters (warnings and corrupted records, in
    * {@code DatabaseChecker} and {@code GraphDatabaseChecker}) cannot drift apart again: they had four near-identical
    * copies of this rule and two of them disagreed past the cap. There is one rule now, and it is this method.
    * <p>
-   * De-duplication is EXACT while the collection is under the cap - the collection itself answers "have I seen this",
-   * which is why {@code retained} must be a {@link Set} for the answer to mean anything. Past the cap it degrades to
-   * what the retained collection can still answer: an item already in it is recognised, but one the cap refused to
-   * retain cannot be, so a later sighting of that item counts again. Deliberate: keeping it exact past the cap needs
-   * a second, unbounded collection of every item ever seen, which is precisely the memory the cap exists to refuse.
+   * De-duplication is EXACT while the set is under the cap - the set itself answers "have I seen this". Past the cap
+   * it degrades to what the retained set can still answer: an item already in it is recognised, but one the cap
+   * refused to retain cannot be, so a later sighting of that item counts again. Deliberate: keeping it exact past the
+   * cap needs a second, unbounded collection of every item ever seen, which is precisely the memory the cap exists to
+   * refuse.
+   * <p>
+   * {@link Set}, not {@link Collection}, is the parameter type on purpose: the whole rule rests on {@code add()}
+   * answering "was it already there", which a {@code List} never does - it would return true every time and the
+   * counter would count occurrences instead of distinct items, which is the exact bug #5773 fixed.
+   * <p>
+   * NOT thread-safe, and neither is the read-then-add it performs: {@code size()} is read before {@code add()}, so
+   * concurrent callers can both see room under the cap. Every caller today drives it from a single-threaded scan.
+   * Anything that parallelises such a scan has to supply its own synchronisation or a concurrent set.
    *
-   * @param retained the bounded, de-duplicating collection; not added to once it holds {@code max} items
+   * @param retained the bounded, de-duplicating set; not added to once it holds {@code max} items
    * @param max      the retention cap
    * @param item     the item to record
    *
    * @return true when {@code item} had not been recorded before
    */
-  public static <T> boolean addBounded(final Collection<T> retained, final int max, final T item) {
+  public static <T> boolean addBounded(final Set<T> retained, final int max, final T item) {
     return retained.size() < max ? retained.add(item) : !retained.contains(item);
   }
 }

--- a/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
@@ -284,4 +284,28 @@ public class CollectionUtils {
     // For object arrays, use Arrays.asList
     return Arrays.asList((Object[]) array);
   }
+
+  /**
+   * Records {@code item} in a de-duplicating collection that must not grow past {@code max}, and answers whether this
+   * is the FIRST time it has been recorded - i.e. whether a counter kept alongside {@code retained} should tick.
+   * <p>
+   * Extracted by #5773 so the two {@code CHECK DATABASE} counters (warnings and corrupted records, in
+   * {@code DatabaseChecker} and {@code GraphDatabaseChecker}) cannot drift apart again: they had four near-identical
+   * copies of this rule and two of them disagreed past the cap. There is one rule now, and it is this method.
+   * <p>
+   * De-duplication is EXACT while the collection is under the cap - the collection itself answers "have I seen this",
+   * which is why {@code retained} must be a {@link Set} for the answer to mean anything. Past the cap it degrades to
+   * what the retained collection can still answer: an item already in it is recognised, but one the cap refused to
+   * retain cannot be, so a later sighting of that item counts again. Deliberate: keeping it exact past the cap needs
+   * a second, unbounded collection of every item ever seen, which is precisely the memory the cap exists to refuse.
+   *
+   * @param retained the bounded, de-duplicating collection; not added to once it holds {@code max} items
+   * @param max      the retention cap
+   * @param item     the item to record
+   *
+   * @return true when {@code item} had not been recorded before
+   */
+  public static <T> boolean addBounded(final Collection<T> retained, final int max, final T item) {
+    return retained.size() < max ? retained.add(item) : !retained.contains(item);
+  }
 }

--- a/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/CollectionUtils.java
@@ -285,9 +285,23 @@ public class CollectionUtils {
     return Arrays.asList((Object[]) array);
   }
 
+  /** What {@link #addBounded} did with the item - the whole answer, so no caller has to re-derive part of it. */
+  public enum BoundedAdd {
+    /** First sighting, and the set had room: it is now in {@code retained}. */
+    RETAINED,
+    /** First sighting, but the cap refused it: counted, never retained. The case a caller may want to log. */
+    DROPPED,
+    /** Already recorded. Nothing to count. */
+    DUPLICATE;
+
+    /** True when this sighting was the first, i.e. when a counter kept alongside the set should tick. */
+    public boolean isFirstSighting() {
+      return this != DUPLICATE;
+    }
+  }
+
   /**
-   * Records {@code item} in a de-duplicating set that must not grow past {@code max}, and answers whether this is the
-   * FIRST time it has been recorded - i.e. whether a counter kept alongside {@code retained} should tick.
+   * Records {@code item} in a de-duplicating set that must not grow past {@code max}, and answers what became of it.
    * <p>
    * Extracted by #5773 so the two {@code CHECK DATABASE} counters (warnings and corrupted records, in
    * {@code DatabaseChecker} and {@code GraphDatabaseChecker}) cannot drift apart again: they had four near-identical
@@ -306,14 +320,21 @@ public class CollectionUtils {
    * NOT thread-safe, and neither is the read-then-add it performs: {@code size()} is read before {@code add()}, so
    * concurrent callers can both see room under the cap. Every caller today drives it from a single-threaded scan.
    * Anything that parallelises such a scan has to supply its own synchronisation or a concurrent set.
+   * <p>
+   * The three-valued return is what keeps the cap rule in this method ALONE. A plain boolean answers "count it?" but
+   * not "was it kept?", so a caller needing the second - to log what the cap forced it to drop - would have to either
+   * mirror the {@code size() < max} test before the call or re-interrogate the set after it. Both are the rule
+   * written down twice, which is the drift this method was extracted to end.
    *
    * @param retained the bounded, de-duplicating set; not added to once it holds {@code max} items
    * @param max      the retention cap
    * @param item     the item to record
    *
-   * @return true when {@code item} had not been recorded before
+   * @return whether {@code item} was retained, dropped by the cap, or already known
    */
-  public static <T> boolean addBounded(final Set<T> retained, final int max, final T item) {
-    return retained.size() < max ? retained.add(item) : !retained.contains(item);
+  public static <T> BoundedAdd addBounded(final Set<T> retained, final int max, final T item) {
+    if (retained.size() < max)
+      return retained.add(item) ? BoundedAdd.RETAINED : BoundedAdd.DUPLICATE;
+    return retained.contains(item) ? BoundedAdd.DUPLICATE : BoundedAdd.DROPPED;
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseSinglePassTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseSinglePassTest.java
@@ -28,6 +28,8 @@ import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
 import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -37,7 +39,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -268,6 +272,51 @@ class CheckDatabaseSinglePassTest extends TestHelper {
     assertThat((Long) stats.get("totalCorruptedRecords")).as("%s", stats).isEqualTo(1L);
   }
 
+  /**
+   * #5773: a warning the cap forced the checker to DROP is logged rather than lost - and both {@code addWarning}
+   * arms honour {@code verboseLevel == 0} as "the caller asked for no logging", where the graph one used to log
+   * regardless. The retained set and {@code totalWarnings} still report the drop either way, which is what makes
+   * honouring the flag safe.
+   */
+  @Test
+  void aDroppedWarningIsLoggedUnlessTheCallerAskedForSilence() {
+    createGraph(3);
+
+    final RID victim = firstOf("Person");
+    corruptRecordTypeByte(victim);
+
+    // maxWarnings 0: the finding is counted but never retained, which is the only path that reaches the log.
+    assertThat(capturedWhileChecking(0)).as("verboseLevel 0 asked for no logging").isEmpty();
+    assertThat(capturedWhileChecking(1)).as("otherwise the dropped message must still be audible")
+        .anyMatch(m -> m.contains(victim.toString()));
+
+    // Either way the caller can still see that something was dropped.
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkVertices("Person", null, false, 0, 0, 0);
+    assertThat((Collection<String>) stats.get("warnings")).as("nothing retained at cap 0: %s", stats).isEmpty();
+    assertThat((Long) stats.get("totalWarnings")).as("but counted: %s", stats).isEqualTo(1L);
+  }
+
+  /**
+   * Runs a capped type-wide vertex check at {@code verboseLevel} and returns the WARNING messages it logged.
+   * <p>
+   * NOTE: {@code LogManager} is a SINGLETON, so this swap is process-wide for its duration. It is restored in the
+   * finally and is safe only because surefire runs test classes sequentially within a fork - the same constraint
+   * the four capture sites this PR touched carry.
+   */
+  private List<String> capturedWhileChecking(final int verboseLevel) {
+    final List<String> captured = new CopyOnWriteArrayList<>();
+    final Logger original = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(new CapturingLogger(captured, original));
+    try {
+      new GraphDatabaseChecker((DatabaseInternal) database)
+          .checkVertices("Person", null, false, verboseLevel, 0, 0);
+    } finally {
+      LogManager.instance().setLogger(original);
+    }
+    return captured;
+  }
+
   private void assertBudgetIsOnePassPerRecord(final List<Emission> emissions, final String stepName,
       final long records) {
     assertThat(records).as("precondition: '%s' must have records to budget for", stepName).isGreaterThan(0L);
@@ -358,6 +407,45 @@ class CheckDatabaseSinglePassTest extends TestHelper {
         throw new RuntimeException(e);
       }
     });
+  }
+
+  /** Captures WARNING-and-above messages while forwarding every record on, so test output still shows what fired. */
+  private static final class CapturingLogger implements Logger {
+    private final List<String> captured;
+    private final Logger       delegate;
+
+    CapturingLogger(final List<String> captured, final Logger delegate) {
+      this.captured = captured;
+      this.delegate = delegate;
+    }
+
+    private void capture(final Level level, final String message) {
+      if (message != null && level.intValue() >= Level.WARNING.intValue())
+        captured.add(message);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
+        final Object arg6, final Object arg7, final Object arg8, final Object arg9, final Object arg10, final Object arg11,
+        final Object arg12, final Object arg13, final Object arg14, final Object arg15, final Object arg16,
+        final Object arg17) {
+      capture(level, message);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+          arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      capture(level, message);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
   }
 
   /** Reads a numeric check-database property, failing loudly when the field does not exist. */

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseSinglePassTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseSinglePassTest.java
@@ -236,8 +236,12 @@ class CheckDatabaseSinglePassTest extends TestHelper {
     final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
         .checkEdges("WorksAt", false, 0, 100, 1);
 
+    // The retained slot holds the EDGE because checkEndpoints flags it before the missing endpoint it found: the
+    // IN branch calls corrupt(edgeRID) first, then corrupt(edge.getIn()). Asserted rather than assumed, so a
+    // future reorder of that branch fails here instead of quietly changing what this test is measuring.
     final Collection<RID> corrupted = (Collection<RID>) stats.get("corruptedRecords");
-    assertThat(corrupted).as("precondition: the cap must actually bite").hasSize(1).containsExactly(edge);
+    assertThat(corrupted).as("precondition: the cap must bite, and the edge must be what it retained")
+        .hasSize(1).containsExactly(edge);
     // Flagged: the edge (twice - once per missing endpoint) and the missing IN vertex. The edge's second flag is
     // the one that must not count, because the set still answers "already seen" for it.
     assertThat((Long) stats.get("totalCorruptedRecords"))

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseSinglePassTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseSinglePassTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.DatabaseChecker;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5773: the type-wide arms of {@code CHECK DATABASE} materialise each vertex/edge record ONCE, not twice.
+ * <p>
+ * {@code GraphDatabaseChecker.checkVertices}/{@code checkEdges} used to open with a raw bucket scan that built
+ * every record and decoded it ({@code newImmutableRecord(...)} then {@code asVertex(true)}), and then run the
+ * connectivity/endpoint walk through {@code scanType} - which performs the identical construction from the
+ * identical raw page view and opens with the identical decode. The first pass therefore detected nothing the
+ * second misses, and the progress budget said so out loud ({@code 2 * countType}).
+ * <p>
+ * These tests pin both halves of dropping it: the budget is now one pass per record, and every corruption shape
+ * the removed pass could see is still reported by the surviving one - once, with the wording that does not
+ * promise a removal a non-fixing run never performs.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseSinglePassTest extends TestHelper {
+
+  private record Emission(String stepName, long done, long total) {
+  }
+
+  /** These tests deliberately corrupt records, so the blanket end-of-test check would always fire. */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  /**
+   * The measurable half: the per-type step budgets ONE unit of work per record. The budget is what the two passes
+   * were literally written as ({@code 2 * countType}), so a regression that reinstates a second pass either has to
+   * under-report progress or fails here.
+   */
+  @Test
+  void theTypeWideGraphStepsBudgetOnePassPerRecord() {
+    createGraph(50);
+
+    final List<Emission> emissions = new ArrayList<>();
+    new DatabaseChecker(database).setVerboseLevel(0)
+        .setProgressCallback((stepName, stepIndex, totalSteps, done, total) ->
+            emissions.add(new Emission(stepName, done, total)))
+        .check();
+
+    assertBudgetIsOnePassPerRecord(emissions, "Checking vertices 'Person'", database.countType("Person", false));
+    assertBudgetIsOnePassPerRecord(emissions, "Checking edges 'WorksAt'", database.countType("WorksAt", false));
+  }
+
+  /**
+   * The correctness half for a record that cannot be MATERIALISED at all (an unknown record-type byte): the
+   * removed pass caught it in the bucket scan, and {@code scanType}'s error callback catches it at the same point,
+   * because the construction it fails in sits inside the same {@code LocalBucket.scan} try block.
+   * <p>
+   * Also pins the wording (#5773 item 2): the surviving message does not say "removing it", which a check without
+   * {@code FIX} never does.
+   */
+  @Test
+  void anUnmaterialisableVertexIsReportedOnceByTheSurvivingPass() {
+    createGraph(3);
+
+    final RID victim = firstOf("Person");
+    corruptRecordTypeByte(victim);
+
+    final Result row = check("CHECK DATABASE TYPE Person");
+
+    final Collection<String> warnings = row.getProperty("warnings");
+    assertThat(warnings).as("the surviving pass must still report it: %s", row.toJSON())
+        .anyMatch(w -> w.startsWith("vertex " + victim + " cannot be loaded (error:"));
+    assertThat(warnings).as("a non-fixing check removes nothing: %s", row.toJSON())
+        .noneMatch(w -> w.contains("removing it"));
+    assertThat(longProperty(row, "totalWarnings")).as("reported ONCE, not once per pass: %s", row.toJSON())
+        .isEqualTo(1L);
+    assertThat(longProperty(row, "totalCorruptedRecords")).as("%s", row.toJSON()).isEqualTo(1L);
+  }
+
+  /**
+   * The correctness half for a record that materialises but cannot be DECODED as a vertex (a truncated buffer):
+   * the removed pass caught it in its own {@code asVertex(true)}, and the connectivity walk opens with the same
+   * call, so the finding survives - with the same "(error: ...)" wording, which is the one the removed pass did
+   * not use.
+   */
+  @Test
+  void anUndecodableVertexIsReportedOnceByTheSurvivingPass() {
+    createGraph(3);
+
+    final RID victim = firstOf("Person");
+    shrinkRecordBuffer(victim);
+
+    final Result row = check("CHECK DATABASE TYPE Person");
+
+    final Collection<String> warnings = row.getProperty("warnings");
+    assertThat(warnings).as("%s", row.toJSON())
+        .anyMatch(w -> w.startsWith("vertex " + victim + " cannot be loaded (error:"));
+    assertThat(warnings).as("%s", row.toJSON()).noneMatch(w -> w.contains("removing it"));
+    assertThat(longProperty(row, "totalWarnings")).as("%s", row.toJSON()).isEqualTo(1L);
+    assertThat(longProperty(row, "totalCorruptedRecords")).as("%s", row.toJSON()).isEqualTo(1L);
+  }
+
+  /**
+   * The dropped pass was labelled "CHECK RECORD IS OF THE RIGHT TYPE", so the shape it named explicitly gets its own
+   * proof: a record sitting in a VERTEX bucket that materialises as something else entirely. Two variants, because
+   * they fail in different places - a {@code Document} record-type byte builds an {@code ImmutableDocument} that the
+   * connectivity walk's {@code asVertex(true)} rejects, and an {@code EdgeSegment} one builds a record that is not a
+   * {@code Document} at all, so it fails in {@code scanType}'s own cast and lands in the error callback instead.
+   */
+  @Test
+  void aRecordOfTheWrongTypeInAVertexBucketIsStillFlagged() {
+    for (final byte recordType : new byte[] { Document.RECORD_TYPE, EdgeSegment.RECORD_TYPE }) {
+      createGraph(3);
+      try {
+        final RID victim = firstOf("Person");
+        setRecordTypeByte(victim, recordType);
+
+        final Result row = check("CHECK DATABASE TYPE Person");
+        assertThat((Collection<String>) row.getProperty("warnings"))
+            .as("record type %d: %s", recordType, row.toJSON())
+            .anyMatch(w -> w.startsWith("vertex " + victim + " cannot be loaded (error:"));
+        assertThat(longProperty(row, "totalCorruptedRecords")).as("record type %d: %s", recordType, row.toJSON())
+            .isEqualTo(1L);
+      } finally {
+        // Each iteration needs a pristine graph, and the corrupted record makes a drop the only clean way back.
+        database.getSchema().dropType("WorksAt");
+        database.getSchema().dropType("Person");
+        database.getSchema().dropType("Company");
+      }
+    }
+  }
+
+  /** The edge arm of the same equivalence: identical code, so identical proof. */
+  @Test
+  void anUnmaterialisableEdgeIsReportedOnceByTheSurvivingPass() {
+    createGraph(3);
+
+    final RID victim = firstOf("WorksAt");
+    corruptRecordTypeByte(victim);
+
+    // TYPE-scoped to the edge type: a corrupt edge record is ALSO reachable from its endpoints' edge lists, so a
+    // full-database run would report it a second time from the vertex arm and make this assertion say nothing.
+    final Result row = check("CHECK DATABASE TYPE WorksAt");
+
+    final Collection<String> warnings = row.getProperty("warnings");
+    assertThat(warnings).as("%s", row.toJSON())
+        .anyMatch(w -> w.startsWith("edge " + victim + " cannot be loaded (error:"));
+    assertThat(warnings).as("%s", row.toJSON()).noneMatch(w -> w.contains("removing it"));
+    assertThat(longProperty(row, "totalWarnings")).as("%s", row.toJSON()).isEqualTo(1L);
+    assertThat(longProperty(row, "totalCorruptedRecords")).as("%s", row.toJSON()).isEqualTo(1L);
+  }
+
+  /**
+   * A corrupted record is still DELETED by {@code FIX} once the pass that announced the removal is gone: the
+   * removal was never that pass's doing (it only added the RID to {@code corruptedRecords}), and the surviving
+   * pass adds the same RID.
+   */
+  @Test
+  void fixStillDeletesTheCorruptedRecord() {
+    createGraph(3);
+
+    final RID victim = firstOf("Person");
+    corruptRecordTypeByte(victim);
+
+    final Result row = check("CHECK DATABASE TYPE Person FIX");
+    assertThat(longProperty(row, "autoFix")).as("%s", row.toJSON()).isEqualTo(1L);
+
+    database.transaction(() -> assertThat(database.existsRecord(victim)).as("FIX must still remove it").isFalse());
+  }
+
+  /**
+   * #5773 item 4: past the retention cap, a RID that is STILL in the retained set must not be counted again.
+   * {@code GraphDatabaseChecker.addCorrupted} incremented unconditionally there while its {@code DatabaseChecker}
+   * twin already checked {@code contains} first, so the two disagreed on the same input.
+   * <p>
+   * Reached through the one caller that flags the same RID twice in one visit: an edge whose IN and OUT vertices
+   * are both gone flags the edge on each side. With a cap of 1 the edge is the only retained RID, so the second
+   * flag on it is exactly the case the {@code contains} check answers.
+   */
+  @Test
+  void theCorruptedTotalDoesNotDoubleCountARetainedRecordPastTheCap() {
+    createGraph(1);
+
+    final RID edge = firstOf("WorksAt");
+    final RID[] endpoints = new RID[2];
+    database.transaction(() -> {
+      final Edge e = edge.asEdge(true);
+      endpoints[0] = e.getIn();
+      endpoints[1] = e.getOut();
+    });
+
+    // Delete both endpoint VERTEX records underneath the edge, leaving the edge record itself intact.
+    for (final RID endpoint : endpoints)
+      database.transaction(() -> database.getSchema().getBucketById(endpoint.getBucketId()).deleteRecord(endpoint));
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkEdges("WorksAt", false, 0, 100, 1);
+
+    final Collection<RID> corrupted = (Collection<RID>) stats.get("corruptedRecords");
+    assertThat(corrupted).as("precondition: the cap must actually bite").hasSize(1).containsExactly(edge);
+    // Flagged: the edge (twice - once per missing endpoint) and the missing IN vertex. The edge's second flag is
+    // the one that must not count, because the set still answers "already seen" for it.
+    assertThat((Long) stats.get("totalCorruptedRecords"))
+        .as("a retained RID flagged twice is one corrupted record: %s", stats).isEqualTo(2L);
+  }
+
+  /**
+   * #5773 item 5: {@code totalWarnings} counts what the retained {@code warnings} collection keeps.
+   * {@code GraphDatabaseChecker} retained its warnings in a list while {@code DatabaseChecker} published them as a
+   * {@code Set}, so two findings rendering to the same message collapsed to one line but counted twice - the
+   * totals exceeded the retained size on a run that was nowhere near its cap.
+   * <p>
+   * Reached through the scoped arm, whose {@code Collection<RID>} a caller can hand the same RID twice (the SQL
+   * layer cannot - {@code DatabaseChecker.setRecords} takes a {@code Set}), so the identical message is produced
+   * twice with no page surgery. The corrupted-record side of the same visit is de-duplicated too.
+   */
+  @Test
+  void aFindingRenderedTwiceIsOneWarningOnBothSides() {
+    createGraph(3);
+
+    final RID victim = firstOf("Person");
+    corruptRecordTypeByte(victim);
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkVertices("Person", List.of(victim, victim), false, 0, 100, 100);
+
+    final Collection<String> warnings = (Collection<String>) stats.get("warnings");
+    assertThat(warnings).as("precondition: the corruption must be reported: %s", stats)
+        .anyMatch(w -> w.startsWith("vertex " + victim + " cannot be loaded (error:"));
+    assertThat(warnings).as("the same message is retained once: %s", stats).hasSize(1);
+    assertThat((Long) stats.get("totalWarnings")).as("and counted once: %s", stats).isEqualTo(1L);
+    assertThat((Long) stats.get("totalCorruptedRecords")).as("%s", stats).isEqualTo(1L);
+  }
+
+  private void assertBudgetIsOnePassPerRecord(final List<Emission> emissions, final String stepName,
+      final long records) {
+    assertThat(records).as("precondition: '%s' must have records to budget for", stepName).isGreaterThan(0L);
+
+    final List<Emission> step = emissions.stream().filter(e -> e.stepName.equals(stepName)).toList();
+    assertThat(step).as("emissions for step '%s'", stepName).isNotEmpty();
+    assertThat(step.getFirst().total).as("step '%s' must budget ONE pass per record", stepName).isEqualTo(records);
+    assertThat(step.getLast().done).as("step '%s' must reach its budget", stepName).isEqualTo(records);
+  }
+
+  private void createGraph(final int people) {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Person", 1);
+      database.getSchema().createVertexType("Company", 1);
+      database.getSchema().createEdgeType("WorksAt", 1);
+    });
+
+    database.transaction(() -> {
+      final MutableVertex company = database.newVertex("Company").set("name", "Arcade").save();
+      for (int i = 0; i < people; i++)
+        database.newVertex("Person").set("i", i).save().newEdge("WorksAt", company);
+    });
+  }
+
+  /** The RID of the first record of {@code typeName}, so the corruption helpers have a concrete victim. */
+  private RID firstOf(final String typeName) {
+    final RID[] holder = new RID[1];
+    database.transaction(() -> database.scanType(typeName, false, record -> {
+      holder[0] = record.getIdentity();
+      return false;
+    }));
+    assertThat(holder[0]).as("no record of type '%s' to corrupt", typeName).isNotNull();
+    return holder[0];
+  }
+
+  private Result check(final String command) {
+    try (final ResultSet rs = database.command("sql", command)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next();
+    }
+  }
+
+  /**
+   * Overwrites the record-type byte with a value no {@code RecordFactory} branch knows, so the record still
+   * occupies its slot but cannot be materialised at all - the shape the removed bucket scan met in
+   * {@code newImmutableRecord}.
+   */
+  private void corruptRecordTypeByte(final RID rid) {
+    setRecordTypeByte(rid, (byte) 99);
+  }
+
+  /** Rewrites the record-type byte of {@code rid} to {@code recordType}, leaving the rest of the record alone. */
+  private void setRecordTypeByte(final RID rid, final byte recordType) {
+    onRecordPage(rid, (page, recordOffset) -> {
+      final long[] recordSize = page.readNumberAndSize(recordOffset);
+      page.writeByte((int) (recordOffset + recordSize[1]), recordType);
+    });
+  }
+
+  /**
+   * Replaces the record-size varint with a single-byte varint encoding a size far below the fixed 25-byte vertex
+   * prefix: the record materialises lazily but cannot be decoded - the shape the removed pass met in its own
+   * {@code asVertex(true)}. zigzag(8) == 16.
+   */
+  private void shrinkRecordBuffer(final RID rid) {
+    onRecordPage(rid, (page, recordOffset) -> page.writeByte(recordOffset, (byte) 16));
+  }
+
+  /** Runs {@code mutation} against the page holding {@code rid}, at the offset where its size varint starts. */
+  private void onRecordPage(final RID rid, final BiConsumer<MutablePage, Integer> mutation) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = rid.getBucketId();
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
+
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
+        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
+        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
+        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
+        mutation.accept(page, recordOffset);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  /** Reads a numeric check-database property, failing loudly when the field does not exist. */
+  private static long longProperty(final Result row, final String name) {
+    final Object value = row.getProperty(name);
+    assertThat(value).as("check database must report '%s': %s", name, row.toJSON()).isNotNull();
+    return ((Number) value).longValue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerReclaimFailClosedTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerReclaimFailClosedTest.java
@@ -162,6 +162,34 @@ class GraphDatabaseCheckerReclaimFailClosedTest extends TestHelper {
     return chunks;
   }
 
+  /**
+   * #5773: the reclaim pass reports through the same bounded, de-duplicating counter as the vertex and edge arms,
+   * so its {@code totalWarnings} answers "how many distinct messages" and honours the retention cap. It used to
+   * keep an {@code ArrayList} and count occurrences; the change is quiet (its per-vertex messages carry distinct
+   * RIDs, so collisions are unlikely in practice) and this is the only test that pins it for THIS method.
+   */
+  @Test
+  void theReclaimPassCountsDistinctWarningsAndHonoursTheCap() {
+    // Same fixture as reclaimSkippedWhenAVertexCannotBeWalked: an unloadable hub makes the reclaim report.
+    final RID hub = buildHubWithMultiChunkInChain(500);
+    shrinkRecordContent(hub);
+    reopenDatabase();
+
+    final Map<String, Object> uncapped = new GraphDatabaseChecker((DatabaseInternal) database)
+        .reclaimOrphanedEdgeSegments(0, Integer.MAX_VALUE);
+    final Collection<String> warnings = (Collection<String>) uncapped.get("warnings");
+    assertThat(warnings).as("precondition: the reclaim must have reported something: %s", uncapped).isNotEmpty();
+    assertThat(((Number) uncapped.get("totalWarnings")).longValue())
+        .as("uncapped, the total is the retained count: %s", uncapped).isEqualTo(warnings.size());
+
+    // Capped at zero: nothing is retained, but the drop is still counted rather than vanishing.
+    final Map<String, Object> capped = new GraphDatabaseChecker((DatabaseInternal) database)
+        .reclaimOrphanedEdgeSegments(0, 0);
+    assertThat((Collection<String>) capped.get("warnings")).as("%s", capped).isEmpty();
+    assertThat(((Number) capped.get("totalWarnings")).longValue()).as("the drop is still counted: %s", capped)
+        .isGreaterThan(0L);
+  }
+
   private void assertReclaimSkipped(final Map<String, Object> stats) {
     // NOTHING was reclaimed: the incomplete walk disabled the deletion phase.
     assertThat(((Number) stats.get("orphanedEdgeSegmentsReclaimed")).longValue())

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBruteForceScanTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBruteForceScanTest.java
@@ -129,7 +129,12 @@ class LSMVectorIndexBruteForceScanTest extends TestHelper {
 
     // Capture WARNING logs to confirm the brute-force fallback actually fires.
     final List<String> captured = new CopyOnWriteArrayList<>();
-    final Logger originalLogger = readField(LogManager.instance(), "logger");
+    // #5773: getLogger(), not reflection on the private field - the accessor exists for exactly this
+    // save-and-restore, and a field rename would break the reflective form with no compile error. NOTE that
+    // LogManager is a SINGLETON, so this swap is PROCESS-WIDE until the finally below restores it: safe only
+    // because surefire runs test classes sequentially within a fork. Under class-level parallelism a concurrent
+    // test's WARNING output would land in the list below. There is no per-invocation seam to capture through.
+    final Logger originalLogger = LogManager.instance().getLogger();
     LogManager.instance().setLogger(new CapturingLogger(captured, originalLogger));
     try {
       // Query each surviving vertex with its own exact vector: the correct nearest neighbor is that

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
@@ -39,7 +39,6 @@ import com.arcadedb.utility.Pair;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -1653,7 +1652,12 @@ class LSMVectorIndexRecoveryTest extends TestHelper {
 
     // 5) Capture warnings/severe logs during the reopen.
     final List<String> captured = new CopyOnWriteArrayList<>();
-    final Logger originalLogger = readField(LogManager.instance(), "logger");
+    // #5773: getLogger(), not reflection on the private field - the accessor exists for exactly this
+    // save-and-restore, and a field rename would break the reflective form with no compile error. NOTE that
+    // LogManager is a SINGLETON, so this swap is PROCESS-WIDE until the finally below restores it: safe only
+    // because surefire runs test classes sequentially within a fork. Under class-level parallelism a concurrent
+    // test's WARNING output would land in the list below. There is no per-invocation seam to capture through.
+    final Logger originalLogger = LogManager.instance().getLogger();
     LogManager.instance().setLogger(new CapturingLogger(captured, originalLogger));
 
     try {
@@ -1877,13 +1881,6 @@ class LSMVectorIndexRecoveryTest extends TestHelper {
         return true;
     }
     return false;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> T readField(final Object target, final String name) throws Exception {
-    final Field f = target.getClass().getDeclaredField(name);
-    f.setAccessible(true);
-    return (T) f.get(target);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/QueryEngineManagerPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/query/QueryEngineManagerPoolTest.java
@@ -247,7 +247,12 @@ class QueryEngineManagerPoolTest {
     // server console (and routes through the slf4j chain in production); the test substitutes a
     // simple list-collector for the duration of the test, then restores.
     final List<String> warnings = Collections.synchronizedList(new ArrayList<>());
-    final Logger originalLogger = readField(LogManager.instance(), "logger");
+    // #5773: getLogger(), not reflection on the private field - the accessor exists for exactly this
+    // save-and-restore, and a field rename would break the reflective form with no compile error. NOTE that
+    // LogManager is a SINGLETON, so this swap is PROCESS-WIDE until the finally below restores it: safe only
+    // because surefire runs test classes sequentially within a fork. Under class-level parallelism a concurrent
+    // test's WARNING output would land in the list below. There is no per-invocation seam to capture through.
+    final Logger originalLogger = LogManager.instance().getLogger();
     LogManager.instance().setLogger(new Logger() {
       @Override public void log(final Object req, final Level level, final String msg,
           final Throwable th, final String ctx, final Object a1, final Object a2, final Object a3, final Object a4,
@@ -310,11 +315,4 @@ class QueryEngineManagerPoolTest {
     }
   }
 
-  private static <T> T readField(final Object target, final String name) throws Exception {
-    final java.lang.reflect.Field f = target.getClass().getDeclaredField(name);
-    f.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    final T v = (T) f.get(target);
-    return v;
-  }
 }

--- a/engine/src/test/java/com/arcadedb/schema/LocalSchemaOrphanIndexSelfHealTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/LocalSchemaOrphanIndexSelfHealTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
@@ -95,8 +94,17 @@ class LocalSchemaOrphanIndexSelfHealTest extends TestHelper {
     // This bypasses JUL entirely, so the assertion does not depend on JUL configuration state
     // left over by earlier tests in the same JVM (logger levels, filters, handler chains).
     // The pattern mirrors QueryEngineManagerPoolTest.saturationLogsThrottledWarning.
+    //
+    // NOTE (#5773): LogManager is a SINGLETON, so this swap is PROCESS-WIDE for its duration. It is restored in
+    // the finally below and is safe today only because surefire runs test classes sequentially within a fork; if
+    // class-level parallelism is ever enabled in this module, a concurrent test's WARNING output would land in
+    // the list below and its own delegate would be whatever this test installed. There is no per-invocation seam
+    // to capture through - the log call sites go straight to the singleton - so this is a constraint to know,
+    // not a defect to fix here.
     final List<String> warnings = new CopyOnWriteArrayList<>();
-    final Logger originalLogger = readField(LogManager.instance(), "logger");
+    // getLogger(), not reflection on the private field: the accessor exists for exactly this save-and-restore and
+    // a field rename would break the reflective form with no compile error.
+    final Logger originalLogger = LogManager.instance().getLogger();
     LogManager.instance().setLogger(new CapturingLogger(warnings, originalLogger));
 
     try {
@@ -142,13 +150,6 @@ class LocalSchemaOrphanIndexSelfHealTest extends TestHelper {
   @Override
   protected String getDatabasePath() {
     return "target/databases/LocalSchemaOrphanIndexSelfHealTest";
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> T readField(final Object target, final String name) throws Exception {
-    final Field f = target.getClass().getDeclaredField(name);
-    f.setAccessible(true);
-    return (T) f.get(target);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
@@ -294,26 +294,30 @@ class CollectionUtilsTest {
     assertThat(result).containsExactly("a", "b");
   }
 
-  /** #5773: under the cap, the retained set itself is the de-duplication - a repeat is not "new". */
+  /** #5773: under the cap, the retained set itself is the de-duplication - a repeat is not a first sighting. */
   @Test
   void addBoundedRetainsAndDeduplicatesUnderTheCap() {
     final Set<String> retained = new LinkedHashSet<>();
 
-    assertThat(CollectionUtils.addBounded(retained, 3, "a")).isTrue();
-    assertThat(CollectionUtils.addBounded(retained, 3, "b")).isTrue();
-    assertThat(CollectionUtils.addBounded(retained, 3, "a")).as("a repeat is not new").isFalse();
+    assertThat(CollectionUtils.addBounded(retained, 3, "a")).isEqualTo(CollectionUtils.BoundedAdd.RETAINED);
+    assertThat(CollectionUtils.addBounded(retained, 3, "b")).isEqualTo(CollectionUtils.BoundedAdd.RETAINED);
+    assertThat(CollectionUtils.addBounded(retained, 3, "a")).as("a repeat is not a first sighting")
+        .isEqualTo(CollectionUtils.BoundedAdd.DUPLICATE);
 
     assertThat(retained).containsExactly("a", "b");
   }
 
-  /** Past the cap nothing more is retained, so the collection stops growing. */
+  /** Past the cap nothing more is retained, so the collection stops growing - and says so. */
   @Test
   void addBoundedStopsRetainingAtTheCap() {
     final Set<String> retained = new LinkedHashSet<>();
     CollectionUtils.addBounded(retained, 2, "a");
     CollectionUtils.addBounded(retained, 2, "b");
 
-    assertThat(CollectionUtils.addBounded(retained, 2, "c")).as("unseen past the cap is still new").isTrue();
+    final CollectionUtils.BoundedAdd outcome = CollectionUtils.addBounded(retained, 2, "c");
+    assertThat(outcome).as("unseen past the cap is a first sighting, but a dropped one")
+        .isEqualTo(CollectionUtils.BoundedAdd.DROPPED);
+    assertThat(outcome.isFirstSighting()).as("so a counter beside the set still ticks").isTrue();
     assertThat(retained).as("but it is not retained").containsExactly("a", "b");
   }
 
@@ -327,20 +331,30 @@ class CollectionUtilsTest {
     final Set<String> retained = new LinkedHashSet<>();
     CollectionUtils.addBounded(retained, 1, "kept");
 
-    assertThat(CollectionUtils.addBounded(retained, 1, "kept")).as("still in the set, so still recognised").isFalse();
+    assertThat(CollectionUtils.addBounded(retained, 1, "kept")).as("still in the set, so still recognised")
+        .isEqualTo(CollectionUtils.BoundedAdd.DUPLICATE);
 
-    assertThat(CollectionUtils.addBounded(retained, 1, "dropped")).isTrue();
+    assertThat(CollectionUtils.addBounded(retained, 1, "dropped")).isEqualTo(CollectionUtils.BoundedAdd.DROPPED);
     assertThat(CollectionUtils.addBounded(retained, 1, "dropped"))
-        .as("never retained, so it cannot be recognised - counted again, by design").isTrue();
+        .as("never retained, so it cannot be recognised - counted again, by design")
+        .isEqualTo(CollectionUtils.BoundedAdd.DROPPED);
   }
 
-  /** A cap of zero retains nothing and therefore recognises nothing: every call is "new". */
+  /** A cap of zero retains nothing and therefore recognises nothing: every call is a dropped first sighting. */
   @Test
   void addBoundedWithAZeroCapRetainsNothing() {
     final Set<String> retained = new LinkedHashSet<>();
 
-    assertThat(CollectionUtils.addBounded(retained, 0, "a")).isTrue();
-    assertThat(CollectionUtils.addBounded(retained, 0, "a")).isTrue();
+    assertThat(CollectionUtils.addBounded(retained, 0, "a")).isEqualTo(CollectionUtils.BoundedAdd.DROPPED);
+    assertThat(CollectionUtils.addBounded(retained, 0, "a")).isEqualTo(CollectionUtils.BoundedAdd.DROPPED);
     assertThat(retained).isEmpty();
+  }
+
+  /** Only a duplicate is not a first sighting - the property both CHECK DATABASE counters tick on. */
+  @Test
+  void onlyADuplicateIsNotAFirstSighting() {
+    assertThat(CollectionUtils.BoundedAdd.RETAINED.isFirstSighting()).isTrue();
+    assertThat(CollectionUtils.BoundedAdd.DROPPED.isFirstSighting()).isTrue();
+    assertThat(CollectionUtils.BoundedAdd.DUPLICATE.isFirstSighting()).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/CollectionUtilsTest.java
@@ -293,4 +293,54 @@ class CollectionUtilsTest {
     final List<String> result = CollectionUtils.removeFromUnmodifiableList(original, "z");
     assertThat(result).containsExactly("a", "b");
   }
+
+  /** #5773: under the cap, the retained set itself is the de-duplication - a repeat is not "new". */
+  @Test
+  void addBoundedRetainsAndDeduplicatesUnderTheCap() {
+    final Set<String> retained = new LinkedHashSet<>();
+
+    assertThat(CollectionUtils.addBounded(retained, 3, "a")).isTrue();
+    assertThat(CollectionUtils.addBounded(retained, 3, "b")).isTrue();
+    assertThat(CollectionUtils.addBounded(retained, 3, "a")).as("a repeat is not new").isFalse();
+
+    assertThat(retained).containsExactly("a", "b");
+  }
+
+  /** Past the cap nothing more is retained, so the collection stops growing. */
+  @Test
+  void addBoundedStopsRetainingAtTheCap() {
+    final Set<String> retained = new LinkedHashSet<>();
+    CollectionUtils.addBounded(retained, 2, "a");
+    CollectionUtils.addBounded(retained, 2, "b");
+
+    assertThat(CollectionUtils.addBounded(retained, 2, "c")).as("unseen past the cap is still new").isTrue();
+    assertThat(retained).as("but it is not retained").containsExactly("a", "b");
+  }
+
+  /**
+   * The documented degradation, pinned so it cannot silently change in either direction: past the cap an item that
+   * is STILL retained is recognised (this is the case the two CHECK DATABASE counters used to disagree on), while an
+   * item the cap refused to retain cannot be, so a second sighting of it counts again.
+   */
+  @Test
+  void addBoundedRecognisesARetainedItemPastTheCapButNotADroppedOne() {
+    final Set<String> retained = new LinkedHashSet<>();
+    CollectionUtils.addBounded(retained, 1, "kept");
+
+    assertThat(CollectionUtils.addBounded(retained, 1, "kept")).as("still in the set, so still recognised").isFalse();
+
+    assertThat(CollectionUtils.addBounded(retained, 1, "dropped")).isTrue();
+    assertThat(CollectionUtils.addBounded(retained, 1, "dropped"))
+        .as("never retained, so it cannot be recognised - counted again, by design").isTrue();
+  }
+
+  /** A cap of zero retains nothing and therefore recognises nothing: every call is "new". */
+  @Test
+  void addBoundedWithAZeroCapRetainsNothing() {
+    final Set<String> retained = new LinkedHashSet<>();
+
+    assertThat(CollectionUtils.addBounded(retained, 0, "a")).isTrue();
+    assertThat(CollectionUtils.addBounded(retained, 0, "a")).isTrue();
+    assertThat(retained).isEmpty();
+  }
 }


### PR DESCRIPTION
Closes #5773.

Follow-ups from #5764, all five items. Item 1 turned out to be worth doing for a different reason than the issue gave, so the measurement is in the description rather than the claim.

## 1. `CHECK DATABASE` stops materialising every vertex and edge twice

`GraphDatabaseChecker.checkVertices`/`checkEdges` opened with a raw bucket scan that built each record with `newImmutableRecord(...)` and decoded it with `asVertex(true)`/`asEdge(true)`, then ran the real connectivity/endpoint walk through `scanType` - which performs the identical construction from the identical raw page view and opens with the identical decode. The progress budget said so out loud: `2 * countType`.

Nothing the first pass could see escaped the second:

- a **construction** failure in `scanType`'s callback sits inside `LocalBucket.scan`'s per-slot `try`, so it is routed to the `errorRecordCallback`, which warns and flags the record;
- a **decode** failure lands in `checkConnectivity`/`checkEndpoints`' own `catch (Throwable)`, which warns and flags it likewise.

The dropped pass in fact saw *less*: it passed a `null` error callback, so a failure inside the bucket machinery itself (placeholder resolution, a multi-page chain read) was only logged, never reported.

**Measured, because "materialises every record twice" oversells it.** On a warm 200k-vertex / 200k-edge graph with no super-node: vertices 173 ms -> 162 ms, edges 155 ms -> 142 ms, full `CHECK DATABASE` 509 ms -> 472 ms. About 7%, not 50%. The materialisation count does halve, but `asVertex(true)` only parses the edge pointers - not the properties - so materialisation was never what the step spent its time on. (The benchmark was a throwaway; a super-node fixture is useless here because `containsEdge()`'s O(degree) walk dominates everything else by two orders of magnitude - 108 s vs 0.5 s on the same record count.)

So the real payoff is the next item, plus deleting a provably redundant full scan of every bucket of every graph type.

## 2. The vertex and edge arms no longer say "removing it" when nothing is removed

That message was emitted only by the pass being dropped, so it leaves with it - no wording decision needed. #5764 fixed the same defect on the document arm, where it was wrong unconditionally; here it was wrong on every run without `FIX`, since removal happens only in the `corruptedRecords` delete loop.

**If you parse `CHECK DATABASE` output:** a corrupt vertex or edge now produces **one** warning instead of two, and `, removing it` is gone. The surviving wording is `vertex <rid> cannot be loaded (error: ...)`, which also names the failure. `corruptedRecords` is a set, so the corrupted total is unchanged; `totalWarnings` drops by one per corrupt record. The progress `total` for a vertex/edge step is now the record count instead of twice it. `FIX` deletes exactly what it deleted before.

## 3. Four tests use `LogManager.getLogger()` instead of reflecting on the private field

`LocalSchemaOrphanIndexSelfHealTest`, `LSMVectorIndexBruteForceScanTest`, `LSMVectorIndexRecoveryTest`, `QueryEngineManagerPoolTest` all did `readField(LogManager.instance(), "logger")` to keep the original logger before installing a capturing one. `getLogger()` is public and documented for exactly that; the reflective form would break on a field rename with no compile error. Two of the four `readField` helpers become unused and are removed.

Each site also gains the comment the issue asked for: the swap is **process-wide** (`LogManager` is a singleton) and is safe only because surefire runs test classes sequentially within a fork. There is no per-invocation seam to capture through, so it is a constraint to know, not a defect to fix.

## 4. The two `addCorrupted` implementations agree past the cap

`GraphDatabaseChecker.addCorrupted` incremented unconditionally once past `maxCorrupted`, while the `DatabaseChecker` twin added by #5764 checked `contains` first - so a RID still present in the retained set was counted again by one and not by the other. It is reachable: `checkEdges` flags one RID twice for an edge whose IN and OUT vertices are both gone. Aligned on the `contains`-checking version (exact de-duplication under the cap, degrading past it only for RIDs the cap refused to retain), and both Javadocs now say to keep them aligned.

## 5. `totalWarnings` counts what the retained `warnings` keeps

The retained `warnings` is published as a `LinkedHashSet`, so two findings that render to the same message have always collapsed to one line - while the total counted both, and so could exceed the retained size on a run nowhere near its cap. Both `GraphDatabaseChecker.addWarning` and `DatabaseChecker.addWarning` now de-duplicate on the same terms as `addCorrupted`. `GraphDatabaseChecker`'s per-run `warnings` becomes a `LinkedHashSet` (it was an `ArrayList` whose duplicates the outer set absorbed anyway).

One residual is documented rather than closed: a message produced identically by two *different* sub-checks is retained once and counted twice, since each `GraphDatabaseChecker` keeps its own set while `updateStats` sums their totals. Reachable only for the handful of messages carrying no RID.

## Tests

New `CheckDatabaseSinglePassTest` (8 tests), each failing before the change for the stated reason:

- the vertex and edge steps budget one pass per record, and reach it;
- a vertex that cannot be **materialised** (unknown record-type byte), one that cannot be **decoded** (truncated buffer), and one **of the wrong type** in a vertex bucket (a `Document` byte, which fails in `asVertex(true)`, and an `EdgeSegment` byte, which fails in `scanType`'s own cast and lands in the error callback) are each still reported by the surviving pass - the last one covering exactly what the dropped pass was labelled "CHECK RECORD IS OF THE RIGHT TYPE" for;
- the same for an unmaterialisable edge, scoped to the edge type so the vertex arm's second report cannot make the assertion vacuous;
- no warning says "removing it", and `FIX` still deletes the record;
- past the cap, a retained RID flagged twice counts once;
- a finding rendered twice is one warning and one corrupted record.

Green: the new class plus `CheckDatabaseTest`, `CheckDatabaseRecordScopeTest`, `CheckDatabaseProgressTest`, `CheckDatabaseExtendedTest`, `CheckDatabaseStatement*Test`, all four `GraphDatabaseChecker*Test`, and the four tests changed in item 3.

## Noted, not changed

`checkEdges` handles a missing endpoint asymmetrically: the IN arm flags both the edge **and the missing vertex RID** as corrupted, the OUT arm flags only the edge. Flagging a RID that raised `RecordNotFoundException` also contradicts the principle #5680/#5764 established in the scoped arms ("a RID that simply is not there is NOT corruption, and the difference is expensive" - it puts that bucket into `affectedBuckets`, so `FIX` drops and rebuilds every index on it). Left alone here because it changes what `FIX` rebuilds; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puky78GhudfgTHPtYSuFPm
