### PR TITLE
fix(engine) #5771: reload() on ImmutableVertex/ImmutableEdge now re-parses edge pointers [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/BaseDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/BaseDocument.java
@@ -171,11 +171,29 @@ public abstract class BaseDocument extends BaseRecord implements Document, Docum
     return RECORD_TYPE;
   }
 
+  /**
+   * Re-derives the fixed prefix of a <b>freshly installed</b> buffer and leaves the buffer on the first byte of the
+   * properties section, updating {@link #propertiesStartingPosition} to match. {@link #reload()} is its only caller,
+   * deliberately: the already-materialised read path only has to move a cursor, and re-deriving the prefix there would
+   * charge every property read of every vertex and edge for a prefix parse and two RID allocations.
+   * <p>
+   * A plain document has no prefix beyond the record-type byte, so the inherited {@code propertiesStartingPosition} of
+   * 1 already describes any buffer of this shape and seeking to it is enough. The shapes that do carry a prefix - a
+   * vertex with its two edge-list head pointers, an edge with its out/in RIDs - override this to read the prefix out of
+   * the <i>current</i> buffer instead of trusting a field that described the previous one. Without that, a
+   * {@link #reload()} left the parsed prefix pointing at the pre-reload content: the vertex kept answering with the
+   * edges it had before the reload (issue #5771), and an edge whose replacement buffer had shorter compressed RIDs kept
+   * a {@code propertiesStartingPosition} pointing past its own properties.
+   */
+  protected void parseRecordPrefix() {
+    buffer.position(propertiesStartingPosition);
+  }
+
   @Override
   public void reload() {
     super.reload();
     if (buffer != null)
-      buffer.position(propertiesStartingPosition);
+      parseRecordPrefix();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
@@ -227,24 +227,6 @@ public class ImmutableDocument extends BaseDocument {
   }
 
   /**
-   * Positions the buffer at the start of the properties section. Called by both {@link #reload()} and
-   * {@link #checkForLazyLoading()} after a fresh buffer has been loaded or reloaded. Subclasses with a fixed prefix
-   * (e.g. vertices with edge pointers, edges with out/in RIDs) override this to parse their prefix and set
-   * {@code propertiesStartingPosition} to the right value. The default implementation seeks to the already-known
-   * position, which is correct for plain documents.
-   */
-  protected void positionAtProperties() {
-    buffer.position(propertiesStartingPosition);
-  }
-
-  @Override
-  public void reload() {
-    super.reload();
-    if (buffer != null)
-      positionAtProperties();
-  }
-
-  /**
    * Materialises the record if it has not been loaded yet.
    * <p>
    * <b>Postcondition:</b> on return, either {@code buffer} is {@code null} - the record was filtered away by an
@@ -276,7 +258,7 @@ public class ImmutableDocument extends BaseDocument {
         throw new DatabaseOperationException("Document cannot be loaded because RID is null");
 
       buffer = database.getSchema().getBucketById(rid.getBucketId()).getRecord(rid);
-      positionAtProperties();
+      buffer.position(propertiesStartingPosition);
 
       final Record loaded = database.invokeAfterReadEvents(this);
       if (loaded == null) {
@@ -289,13 +271,13 @@ public class ImmutableDocument extends BaseDocument {
         buffer = database.getSerializer().serialize(database, loaded).getNotReusable();
         // THE SERIALIZER HANDS THE BUFFER BACK AT 0 OR AT 1 DEPENDING ON THE BRANCH IT TOOK: NORMALISE IT SO THE
         // POSTCONDITION OF THIS METHOD HOLDS ON EVERY PATH
-        positionAtProperties();
+        buffer.position(propertiesStartingPosition);
       }
 
       return true;
     }
 
-    positionAtProperties();
+    buffer.position(propertiesStartingPosition);
     return false;
   }
 }

--- a/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
@@ -227,6 +227,24 @@ public class ImmutableDocument extends BaseDocument {
   }
 
   /**
+   * Positions the buffer at the start of the properties section. Called by both {@link #reload()} and
+   * {@link #checkForLazyLoading()} after a fresh buffer has been loaded or reloaded. Subclasses with a fixed prefix
+   * (e.g. vertices with edge pointers, edges with out/in RIDs) override this to parse their prefix and set
+   * {@code propertiesStartingPosition} to the right value. The default implementation seeks to the already-known
+   * position, which is correct for plain documents.
+   */
+  protected void positionAtProperties() {
+    buffer.position(propertiesStartingPosition);
+  }
+
+  @Override
+  public void reload() {
+    super.reload();
+    if (buffer != null)
+      positionAtProperties();
+  }
+
+  /**
    * Materialises the record if it has not been loaded yet.
    * <p>
    * <b>Postcondition:</b> on return, either {@code buffer} is {@code null} - the record was filtered away by an
@@ -258,7 +276,7 @@ public class ImmutableDocument extends BaseDocument {
         throw new DatabaseOperationException("Document cannot be loaded because RID is null");
 
       buffer = database.getSchema().getBucketById(rid.getBucketId()).getRecord(rid);
-      buffer.position(propertiesStartingPosition);
+      positionAtProperties();
 
       final Record loaded = database.invokeAfterReadEvents(this);
       if (loaded == null) {
@@ -271,13 +289,13 @@ public class ImmutableDocument extends BaseDocument {
         buffer = database.getSerializer().serialize(database, loaded).getNotReusable();
         // THE SERIALIZER HANDS THE BUFFER BACK AT 0 OR AT 1 DEPENDING ON THE BRANCH IT TOOK: NORMALISE IT SO THE
         // POSTCONDITION OF THIS METHOD HOLDS ON EVERY PATH
-        buffer.position(propertiesStartingPosition);
+        positionAtProperties();
       }
 
       return true;
     }
 
-    buffer.position(propertiesStartingPosition);
+    positionAtProperties();
     return false;
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableEdge.java
@@ -190,4 +190,12 @@ public class ImmutableEdge extends ImmutableDocument implements Edge {
     }
     return false;
   }
+
+  @Override
+  protected void positionAtProperties() {
+    buffer.position(1); // SKIP RECORD TYPE
+    out = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
+    in = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
+    propertiesStartingPosition = buffer.position();
+  }
 }

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableEdge.java
@@ -53,12 +53,19 @@ public class ImmutableEdge extends ImmutableDocument implements Edge {
 
   public ImmutableEdge(final Database graph, final DocumentType type, final RID rid, final Binary buffer) {
     super(graph, type, rid, buffer);
-    if (buffer != null) {
-      buffer.position(1); // SKIP RECORD TYPE
-      out = (RID) database.getSerializer().deserializeValue(graph, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
-      in = (RID) database.getSerializer().deserializeValue(graph, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
-      propertiesStartingPosition = buffer.position();
-    }
+    if (buffer != null)
+      parseVertexPointers();
+  }
+
+  /**
+   * Reads the fixed edge prefix - the record-type byte followed by the out and in vertex RIDs, both compressed, so the
+   * prefix has no fixed length - and leaves the buffer on the first byte of the properties.
+   */
+  private void parseVertexPointers() {
+    buffer.position(1); // SKIP RECORD TYPE
+    out = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
+    in = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
+    propertiesStartingPosition = buffer.position();
   }
 
   public synchronized MutableEdge modify() {
@@ -182,20 +189,20 @@ public class ImmutableEdge extends ImmutableDocument implements Edge {
   @Override
   protected boolean checkForLazyLoading() {
     if (rid != null && (super.checkForLazyLoading() || (buffer != null && buffer.position() == 1))) {
-      buffer.position(1); // SKIP RECORD TYPE
-      out = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
-      in = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
-      propertiesStartingPosition = buffer.position();
+      parseVertexPointers();
       return true;
     }
     return false;
   }
 
+  /**
+   * Same reason as {@code ImmutableVertex.parseRecordPrefix()}: the out/in RIDs and the offset they push the
+   * properties to belong to the buffer they were read from, and a reload installs another one. The prefix is not even
+   * a fixed length here, the two RIDs being compressed, so a stale {@code propertiesStartingPosition} can point past
+   * the properties rather than merely at the wrong one.
+   */
   @Override
-  protected void positionAtProperties() {
-    buffer.position(1); // SKIP RECORD TYPE
-    out = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
-    in = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_COMPRESSED_RID, null);
-    propertiesStartingPosition = buffer.position();
+  protected void parseRecordPrefix() {
+    parseVertexPointers();
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
@@ -113,8 +113,13 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
     super.reload();
   }
 
+  /**
+   * A reloaded vertex carries a buffer the parsed prefix never described, so the edge pointers have to be read again:
+   * without this the vertex went on answering with the edges it held before the reload (issue #5771), which is the
+   * opposite of what the caller asked for by reloading.
+   */
   @Override
-  protected void positionAtProperties() {
+  protected void parseRecordPrefix() {
     parseEdgePointers();
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
@@ -114,6 +114,11 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
   }
 
   @Override
+  protected void positionAtProperties() {
+    parseEdgePointers();
+  }
+
+  @Override
   public RID getOutEdgesHeadChunk() {
     checkForLazyLoading();
     return outEdges;

--- a/engine/src/test/java/com/arcadedb/graph/Issue5771VertexReloadEdgePointerTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5771VertexReloadEdgePointerTest.java
@@ -24,95 +24,183 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Regression test for issue #5771: {@code reload()} on an {@link ImmutableVertex} does not refresh the edge pointers,
- * so the vertex keeps reporting its pre-reload edges after a reload that should pick up another transaction's changes.
+ * Regression test for issue #5771: {@code reload()} on an {@link ImmutableVertex} kept the edge pointers it had parsed
+ * out of the previous buffer, so a vertex reloaded to pick up another transaction's changes went on reporting its
+ * pre-reload edges.
  * <p>
- * The fix introduced a {@code positionAtProperties()} hook in {@link com.arcadedb.database.ImmutableDocument}
- * that both {@code reload()} and {@code checkForLazyLoading()} call after a fresh buffer is available.
- * {@link ImmutableVertex} overrides it to call {@code parseEdgePointers()}, {@link ImmutableEdge} overrides it to
- * re-parse the out/in RIDs.
+ * The pointers are re-derived from the buffer by {@code parseRecordPrefix()}, which
+ * {@link com.arcadedb.database.BaseDocument#reload()} calls on the buffer it has just installed. The test holds the
+ * immutable instance across the transaction that adds the edge, which is the only shape that meets the defect: an edge
+ * added through a freshly looked-up vertex never sees a stale parse.
  */
 public class Issue5771VertexReloadEdgePointerTest extends BaseGraphTest {
 
   @Test
-  void vertexReloadRefreshesEdgePointers() {
-    // 1. Materialise the vertex BEFORE any edge exists (so edge pointers are null)
+  void reloadRefreshesOutEdgesHeadChunk() {
+    final RID[] rids = createTwoUnconnectedVertices();
+    final RID sourceRID = rids[0];
+    final RID targetRID = rids[1];
+
+    // MATERIALISE THE IMMUTABLE VERTEX WHILE IT STILL HAS NO EDGES: THIS IS WHAT PARSES THE PREFIX THE FIX HAS TO REDO
     database.begin();
-    final ImmutableVertex v1 = (ImmutableVertex) database.lookupByRID(root, false);
-    // Force materialisation by calling any accessor that triggers checkForLazyLoading + parseEdgePointers
-    assertThat(v1.getOutEdgesHeadChunk()).isNull();
-    assertThat(v1.getInEdgesHeadChunk()).isNull();
+    final ImmutableVertex source = (ImmutableVertex) database.lookupByRID(sourceRID, true);
+    assertThat(source.getOutEdgesHeadChunk()).isNull();
     database.commit();
 
-    // 2. In a new transaction, add an edge to the vertex
+    database.transaction(() -> database.lookupByRID(sourceRID, true).asVertex()
+        .newEdge(EDGE1_TYPE_NAME, database.lookupByRID(targetRID, true), "name", "reloaded"));
+
     database.begin();
-    final Vertex v2 = (Vertex) database.lookupByRID(root, true);
-    final Vertex other = database.newVertex(VERTEX2_TYPE_NAME);
-    other.set("name", "other");
-    other.save();
-    v2.newEdge(EDGE1_TYPE_NAME, other, "name", "E1");
-    database.commit();
+    try {
+      source.reload();
 
-    // 3. Now reload the ORIGINAL vertex reference (v1, not v2) in a fresh transaction
-    database.begin();
-    v1.reload();
-
-    // 4. After reload, the edge pointers should reflect the new edge
-    final RID outEdges = v1.getOutEdgesHeadChunk();
-    assertThat(outEdges).as("reload() should refresh outEdges to pick up the new edge").isNotNull();
-
-    // 5. Verify countEdges also reflects the new state
-    assertThat(v1.countEdges(Vertex.DIRECTION.OUT, EDGE1_TYPE_NAME)).isEqualTo(1);
-    database.commit();
+      assertThat(source.getOutEdgesHeadChunk()).as("reload() must re-read the out-edge head chunk from the fresh buffer")
+          .isEqualTo(((VertexInternal) database.lookupByRID(sourceRID, true)).getOutEdgesHeadChunk());
+      assertThat(source.countEdges(Vertex.DIRECTION.OUT, EDGE1_TYPE_NAME)).isEqualTo(1L);
+    } finally {
+      database.commit();
+    }
   }
 
   @Test
-  void vertexReloadRefreshesInEdgesOnTarget() {
-    // 1. Create two vertices, materialise them both before any edges
+  void reloadRefreshesInEdgesHeadChunk() {
+    final RID[] rids = createTwoUnconnectedVertices();
+    final RID sourceRID = rids[0];
+    final RID targetRID = rids[1];
+
     database.begin();
-    final ImmutableVertex v1 = (ImmutableVertex) database.lookupByRID(root, false);
-    final Vertex target = database.newVertex(VERTEX2_TYPE_NAME);
-    target.set("name", "target");
-    target.save();
-    final ImmutableVertex immutableTarget = (ImmutableVertex) database.lookupByRID(target.getIdentity(), false);
-    assertThat(immutableTarget.getInEdgesHeadChunk()).isNull();
+    final ImmutableVertex target = (ImmutableVertex) database.lookupByRID(targetRID, true);
+    assertThat(target.getInEdgesHeadChunk()).isNull();
     database.commit();
 
-    // 2. Add an edge from v1 to target
-    database.begin();
-    final Vertex v1Mut = (Vertex) database.lookupByRID(root, true);
-    v1Mut.newEdge(EDGE1_TYPE_NAME, target, "name", "E1");
-    database.commit();
+    database.transaction(() -> database.lookupByRID(sourceRID, true).asVertex()
+        .newEdge(EDGE1_TYPE_NAME, database.lookupByRID(targetRID, true), "name", "reloaded"));
 
-    // 3. Reload the target vertex
     database.begin();
-    immutableTarget.reload();
+    try {
+      target.reload();
 
-    // 4. Verify inEdges is now populated
-    assertThat(immutableTarget.getInEdgesHeadChunk())
-        .as("reload() on the target vertex should refresh inEdges").isNotNull();
-    assertThat(immutableTarget.countEdges(Vertex.DIRECTION.IN, EDGE1_TYPE_NAME)).isEqualTo(1);
-    database.commit();
+      assertThat(target.getInEdgesHeadChunk()).as("reload() must re-read the in-edge head chunk from the fresh buffer")
+          .isEqualTo(((VertexInternal) database.lookupByRID(targetRID, true)).getInEdgesHeadChunk());
+      assertThat(target.countEdges(Vertex.DIRECTION.IN, EDGE1_TYPE_NAME)).isEqualTo(1L);
+    } finally {
+      database.commit();
+    }
   }
 
+  /**
+   * The properties have to survive the re-parse: the prefix is read again to find where they start, and getting that
+   * wrong reads the properties from the middle of the edge pointers instead.
+   */
   @Test
-  void vertexReloadWithNoEdgesStillWorks() {
-    // 1. Materialise a vertex that will never get edges
+  void reloadKeepsReadingTheVertexProperties() {
+    final RID[] rids = createTwoUnconnectedVertices();
+    final RID sourceRID = rids[0];
+    final RID targetRID = rids[1];
+
     database.begin();
-    final Vertex isolated = database.newVertex(VERTEX2_TYPE_NAME);
-    isolated.set("name", "isolated");
-    isolated.save();
-    final ImmutableVertex iso = (ImmutableVertex) database.lookupByRID(isolated.getIdentity(), false);
-    assertThat(iso.getOutEdgesHeadChunk()).isNull();
-    assertThat(iso.getInEdgesHeadChunk()).isNull();
+    final ImmutableVertex source = (ImmutableVertex) database.lookupByRID(sourceRID, true);
+    assertThat(source.getString("name")).isEqualTo("source");
     database.commit();
 
-    // 2. Reload in a fresh transaction — should not throw
+    database.transaction(() -> {
+      database.lookupByRID(sourceRID, true).asVertex().newEdge(EDGE1_TYPE_NAME, database.lookupByRID(targetRID, true));
+      database.lookupByRID(sourceRID, true).asVertex().modify().set("name", "renamed").save();
+    });
+
     database.begin();
-    iso.reload();
-    // Edge pointers should still be null (no edges were added)
-    assertThat(iso.getOutEdgesHeadChunk()).isNull();
-    assertThat(iso.getInEdgesHeadChunk()).isNull();
+    try {
+      source.reload();
+
+      assertThat(source.getString("name")).isEqualTo("renamed");
+      assertThat(source.getPropertyNames()).contains("name");
+      assertThat(source.getOutEdgesHeadChunk()).isNotNull();
+    } finally {
+      database.commit();
+    }
+  }
+
+  /**
+   * A vertex that never gains an edge must come back from a reload with both pointers still null, and must not blow up
+   * on the re-parse of a prefix whose RIDs are the {@code -1} markers.
+   */
+  @Test
+  void reloadOfAVertexWithoutEdgesKeepsBothPointersNull() {
+    final RID[] rids = createTwoUnconnectedVertices();
+    final RID isolatedRID = rids[0];
+
+    database.begin();
+    final ImmutableVertex isolated = (ImmutableVertex) database.lookupByRID(isolatedRID, true);
+    assertThat(isolated.getOutEdgesHeadChunk()).isNull();
+    assertThat(isolated.getInEdgesHeadChunk()).isNull();
     database.commit();
+
+    database.begin();
+    try {
+      isolated.reload();
+
+      assertThat(isolated.getOutEdgesHeadChunk()).isNull();
+      assertThat(isolated.getInEdgesHeadChunk()).isNull();
+      assertThat(isolated.getString("name")).isEqualTo("source");
+    } finally {
+      database.commit();
+    }
+  }
+
+  /**
+   * The edge shape of the same hook: {@link ImmutableEdge} re-derives its out/in RIDs and its properties offset from
+   * the reloaded buffer rather than from the fields the previous buffer left behind.
+   */
+  @Test
+  void reloadOfAnEdgeKeepsItsEndpointsAndSeesTheNewProperty() {
+    final RID[] rids = createTwoUnconnectedVertices();
+    final RID sourceRID = rids[0];
+    final RID targetRID = rids[1];
+
+    final RID[] edgeRID = new RID[1];
+    database.transaction(() -> edgeRID[0] = database.lookupByRID(sourceRID, true).asVertex()
+        .newEdge(EDGE1_TYPE_NAME, database.lookupByRID(targetRID, true), "name", "before").getIdentity());
+
+    database.begin();
+    final ImmutableEdge edge = (ImmutableEdge) database.lookupByRID(edgeRID[0], true);
+    assertThat(edge.getString("name")).isEqualTo("before");
+    database.commit();
+
+    database.transaction(() -> database.lookupByRID(edgeRID[0], true).asEdge().modify().set("name", "after").save());
+
+    database.begin();
+    try {
+      edge.reload();
+
+      assertThat(edge.getOut()).isEqualTo(sourceRID);
+      assertThat(edge.getIn()).isEqualTo(targetRID);
+      assertThat(edge.getString("name")).isEqualTo("after");
+    } finally {
+      database.commit();
+    }
+  }
+
+  /**
+   * Creates a source and a target vertex with no edge between them. {@code BaseGraphTest} wires its own {@code root}
+   * vertex up with edges in the fixture, so a test about "the pointers were null when the vertex was parsed" needs
+   * vertices of its own.
+   *
+   * @return the source RID at index 0 and the target RID at index 1
+   */
+  private RID[] createTwoUnconnectedVertices() {
+    final RID[] rids = new RID[2];
+    database.transaction(() -> {
+      final MutableVertex source = database.newVertex(VERTEX1_TYPE_NAME);
+      source.set("name", "source");
+      source.save();
+
+      final MutableVertex target = database.newVertex(VERTEX2_TYPE_NAME);
+      target.set("name", "target");
+      target.save();
+
+      rids[0] = source.getIdentity();
+      rids[1] = target.getIdentity();
+    });
+    return rids;
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/Issue5771VertexReloadEdgePointerTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5771VertexReloadEdgePointerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.database.RID;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5771: {@code reload()} on an {@link ImmutableVertex} does not refresh the edge pointers,
+ * so the vertex keeps reporting its pre-reload edges after a reload that should pick up another transaction's changes.
+ * <p>
+ * The fix introduced a {@code positionAtProperties()} hook in {@link com.arcadedb.database.ImmutableDocument}
+ * that both {@code reload()} and {@code checkForLazyLoading()} call after a fresh buffer is available.
+ * {@link ImmutableVertex} overrides it to call {@code parseEdgePointers()}, {@link ImmutableEdge} overrides it to
+ * re-parse the out/in RIDs.
+ */
+public class Issue5771VertexReloadEdgePointerTest extends BaseGraphTest {
+
+  @Test
+  void vertexReloadRefreshesEdgePointers() {
+    // 1. Materialise the vertex BEFORE any edge exists (so edge pointers are null)
+    database.begin();
+    final ImmutableVertex v1 = (ImmutableVertex) database.lookupByRID(root, false);
+    // Force materialisation by calling any accessor that triggers checkForLazyLoading + parseEdgePointers
+    assertThat(v1.getOutEdgesHeadChunk()).isNull();
+    assertThat(v1.getInEdgesHeadChunk()).isNull();
+    database.commit();
+
+    // 2. In a new transaction, add an edge to the vertex
+    database.begin();
+    final Vertex v2 = (Vertex) database.lookupByRID(root, true);
+    final Vertex other = database.newVertex(VERTEX2_TYPE_NAME);
+    other.set("name", "other");
+    other.save();
+    v2.newEdge(EDGE1_TYPE_NAME, other, "name", "E1");
+    database.commit();
+
+    // 3. Now reload the ORIGINAL vertex reference (v1, not v2) in a fresh transaction
+    database.begin();
+    v1.reload();
+
+    // 4. After reload, the edge pointers should reflect the new edge
+    final RID outEdges = v1.getOutEdgesHeadChunk();
+    assertThat(outEdges).as("reload() should refresh outEdges to pick up the new edge").isNotNull();
+
+    // 5. Verify countEdges also reflects the new state
+    assertThat(v1.countEdges(Vertex.DIRECTION.OUT, EDGE1_TYPE_NAME)).isEqualTo(1);
+    database.commit();
+  }
+
+  @Test
+  void vertexReloadRefreshesInEdgesOnTarget() {
+    // 1. Create two vertices, materialise them both before any edges
+    database.begin();
+    final ImmutableVertex v1 = (ImmutableVertex) database.lookupByRID(root, false);
+    final Vertex target = database.newVertex(VERTEX2_TYPE_NAME);
+    target.set("name", "target");
+    target.save();
+    final ImmutableVertex immutableTarget = (ImmutableVertex) database.lookupByRID(target.getIdentity(), false);
+    assertThat(immutableTarget.getInEdgesHeadChunk()).isNull();
+    database.commit();
+
+    // 2. Add an edge from v1 to target
+    database.begin();
+    final Vertex v1Mut = (Vertex) database.lookupByRID(root, true);
+    v1Mut.newEdge(EDGE1_TYPE_NAME, target, "name", "E1");
+    database.commit();
+
+    // 3. Reload the target vertex
+    database.begin();
+    immutableTarget.reload();
+
+    // 4. Verify inEdges is now populated
+    assertThat(immutableTarget.getInEdgesHeadChunk())
+        .as("reload() on the target vertex should refresh inEdges").isNotNull();
+    assertThat(immutableTarget.countEdges(Vertex.DIRECTION.IN, EDGE1_TYPE_NAME)).isEqualTo(1);
+    database.commit();
+  }
+
+  @Test
+  void vertexReloadWithNoEdgesStillWorks() {
+    // 1. Materialise a vertex that will never get edges
+    database.begin();
+    final Vertex isolated = database.newVertex(VERTEX2_TYPE_NAME);
+    isolated.set("name", "isolated");
+    isolated.save();
+    final ImmutableVertex iso = (ImmutableVertex) database.lookupByRID(isolated.getIdentity(), false);
+    assertThat(iso.getOutEdgesHeadChunk()).isNull();
+    assertThat(iso.getInEdgesHeadChunk()).isNull();
+    database.commit();
+
+    // 2. Reload in a fresh transaction — should not throw
+    database.begin();
+    iso.reload();
+    // Edge pointers should still be null (no edges were added)
+    assertThat(iso.getOutEdgesHeadChunk()).isNull();
+    assertThat(iso.getInEdgesHeadChunk()).isNull();
+    database.commit();
+  }
+}


### PR DESCRIPTION
## Problem

`ImmutableVertex.reload()` nulls the buffer and delegates to `BaseRecord.reload()`, which loads a fresh buffer but does not re-parse the edge pointers. After reload, `checkForLazyLoading()` skips `parseEdgePointers()` because `buffer.position()` is at `propertiesStartingPosition` (25), not at position 1. The `outEdges`/`inEdges` fields retain their pre-reload values, so a vertex reports stale edges even after a reload that should pick up another transaction's changes.

`ImmutableEdge` has the same problem: its `checkForLazyLoading()` also relies on a `buffer.position() == 1` probe that is false after reload.

## Fix

Introduce a `positionAtProperties()` hook in `ImmutableDocument` that both `reload()` and `checkForLazyLoading()` call after a fresh buffer is available. The default implementation seeks to `propertiesStartingPosition` (correct for plain documents).

- `ImmutableVertex` overrides `positionAtProperties()` to call `parseEdgePointers()`, which re-reads the vertex prefix (out-edge RID + in-edge RID) from the fresh buffer.
- `ImmutableEdge` overrides `positionAtProperties()` to re-parse the out/in RIDs from the fresh buffer.

This makes the edge-pointer re-parse explicit rather than inferred from a positional probe, and removes the stale-`propertiesStartingPosition` hazard on both reload paths.

Fixes #5771