### PR TITLE
ci: add continue-on-error to dorny/test-reporter steps (#5763)

### DIFF
--- a/.github/scripts/check-test-reporter-guards.py
+++ b/.github/scripts/check-test-reporter-guards.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+#
+# Fails when a test-reporter step is allowed to fail in a job that has nothing else to fail on.
+#
+# `dorny/test-reporter` publishes a check run from the surefire/failsafe XML. It runs no tests, so
+# when the GitHub check-run API is contended its failure says nothing about the code - it just
+# turns a job red whose tests all passed. That is #5763, and the fix is `continue-on-error: true`
+# on the reporter step.
+#
+# The fix is only safe while something else in the job still fails on a failing test, and that is
+# not a given here. Four jobs in mvn-test.yml run Maven with `--fail-never`, which makes the test
+# command exit 0 no matter how many tests failed; they carry a `check-test-results.py` step that
+# reads the XML and supplies the verdict. Put `continue-on-error` on a reporter in a job shaped
+# like that *without* the verdict step and the job can no longer fail at all: every red turns
+# green, including the real ones. The nightly load / benchmark / ha-resilience workflows are
+# exactly that shape today - `--fail-never` and no verdict step - which is why their reporters
+# deliberately do not carry `continue-on-error`.
+#
+# So the invariant is not "every reporter should be continue-on-error". It is:
+#
+#     a reporter may only be allowed to fail in a job that can still fail on its own.
+#
+# This script enforces it. A job is reported when all three hold:
+#
+#   1. it has a `dorny/test-reporter` step with `continue-on-error: true`,
+#   2. some `run:` step in it swallows test failures (`--fail-never`, `-Dmaven.test.failure.ignore`,
+#      `-DtestFailureIgnore`, a trailing `|| true`),
+#   3. and no step supplies an independent verdict (`check-test-results.py`).
+#
+# Nothing here guesses at which step "is the tests". A job whose test command exits non-zero on a
+# failing test - the six e2e jobs, which run plain `mvnw verify` / `npm test` / `pytest` /
+# `dotnet test` / `gotestsum` - already fails on its own, so its reporter is free to be decorative.
+#
+# Usage:
+#   check-test-reporter-guards.py                 # check .github/workflows
+#   check-test-reporter-guards.py FILE|DIR ...    # check the given workflows
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - the workflow installs it explicitly
+    sys.exit("check-test-reporter-guards: PyYAML is required (pip install pyyaml)")
+
+REPORTER_ACTION = "dorny/test-reporter"
+
+# The step that turns a failing test back into a failing job when the test command will not.
+VERDICT_STEP = "check-test-results.py"
+
+# Flags that make a test command exit 0 with failing tests. `|| true` is anchored at the end of a
+# line so a `--fail-never` buried mid-pipeline is still seen, but an unrelated `|| true` guard on a
+# `mkdir` is not mistaken for one.
+SWALLOWERS = (
+    re.compile(r"--fail-never\b"),
+    re.compile(r"-Dmaven\.test\.failure\.ignore(=true)?\b"),
+    re.compile(r"-DtestFailureIgnore(=true)?\b"),
+    re.compile(r"\|\|\s*true\s*$", re.MULTILINE),
+)
+
+
+def action_of(step):
+    uses = step.get("uses")
+    return uses.split("@", 1)[0].strip() if isinstance(uses, str) else ""
+
+
+def steps_of(job):
+    steps = job.get("steps")
+    return [step for step in steps if isinstance(step, dict)] if isinstance(steps, list) else []
+
+
+def name_of(step, index):
+    name = step.get("name")
+    return name if isinstance(name, str) and name else step.get("uses") or "step #%d" % (index + 1)
+
+
+# `continue-on-error` accepts an expression, and an expression cannot be resolved statically. It is
+# read as "may be allowed to fail", because a reporter that is conditionally exempt in a job that
+# cannot fail on its own is the same hazard on the runs where the condition holds.
+def may_continue_on_error(step):
+    value = step.get("continue-on-error", False)
+    return value is True or (isinstance(value, str) and value.strip().lower() not in ("false", ""))
+
+
+def swallowed_by(step):
+    """The failure-swallowing flag in this step's `run:`, or None."""
+    run = step.get("run")
+    if not isinstance(run, str):
+        return None
+    for swallower in SWALLOWERS:
+        found = swallower.search(run)
+        if found:
+            return found.group(0).strip()
+    return None
+
+
+def has_verdict(steps):
+    return any(VERDICT_STEP in step.get("run", "") for step in steps if isinstance(step.get("run"), str))
+
+
+def check_workflow(path):
+    try:
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as error:
+        return ["%s: is not valid YAML: %s" % (path, error)]
+
+    jobs = (document or {}).get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+
+    violations = []
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        steps = steps_of(job)
+        if has_verdict(steps):
+            continue
+
+        exempt = [
+            (index, step)
+            for index, step in enumerate(steps)
+            if action_of(step) == REPORTER_ACTION and may_continue_on_error(step)
+        ]
+        if not exempt:
+            continue
+
+        swallowing = [(index, step, swallowed_by(step)) for index, step in enumerate(steps)]
+        swallowing = [(index, step, flag) for index, step, flag in swallowing if flag]
+        if not swallowing:
+            continue
+
+        for index, step in exempt:
+            culprit, culprit_step, flag = swallowing[0]
+            violations.append(
+                "%s: job '%s', step '%s' is continue-on-error, but step '%s' runs the tests with "
+                "'%s' and no '%s' step supplies a verdict\n"
+                "    -> nothing in this job can fail on a failing test: add a %s step, or drop "
+                "continue-on-error from the reporter"
+                % (
+                    path,
+                    job_name,
+                    name_of(step, index),
+                    name_of(culprit_step, culprit),
+                    flag,
+                    VERDICT_STEP,
+                    VERDICT_STEP,
+                )
+            )
+    return violations
+
+
+def workflow_files(arguments):
+    default = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+    targets = [Path(a) for a in arguments] or [default]
+    files = []
+    for target in targets:
+        if target.is_dir():
+            files += sorted(p for p in target.iterdir() if p.suffix in (".yml", ".yaml"))
+        elif target.exists():
+            files.append(target)
+        else:
+            sys.exit("check-test-reporter-guards: no such file or directory: %s" % target)
+    return files
+
+
+def main(arguments):
+    files = workflow_files(arguments)
+    violations = [violation for path in files for violation in check_workflow(path)]
+
+    if violations:
+        print("Test-reporter steps exempted from failing a job that cannot fail on its own:\n", file=sys.stderr)
+        for violation in violations:
+            print("  %s\n" % violation, file=sys.stderr)
+        print(
+            "A reporter publishes results, it does not produce them, so it should never decide a\n"
+            "job (#5763). But a job running with --fail-never has no other verdict unless\n"
+            "check-test-results.py gives it one - exempting the reporter there makes the job green\n"
+            "on every failure, which is worse than the false red it was meant to remove.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("check-test-reporter-guards: %d workflow(s) checked, no unguarded reporter exemptions" % len(files))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -23,6 +23,7 @@ SCRIPTS=".github/scripts"
 DEPS="$SCRIPTS/check-workflow-artifact-deps.py"
 COLLECT="$SCRIPTS/collect-coverage-reports.sh"
 RESULTS="$SCRIPTS/check-test-results.py"
+GUARDS="$SCRIPTS/check-test-reporter-guards.py"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -553,6 +554,102 @@ skipped="$work/results/skipped"
 suite_report "$skipped/engine/target/surefire-reports/TEST-com.arcadedb.SkippedTest.xml" com.arcadedb.SkippedTest 0 0 0
 expect "accepts a suite whose tests were all skipped" 0 "0 failure(s)" \
     "$RESULTS" surefire-reports --root "$skipped"
+
+echo
+echo "check-test-reporter-guards.py"
+
+# The #5763 fix: the reporter is decorative, so it must not redden a job whose tests passed. It is
+# only decorative while the job can still fail on its own, and these fixtures pin both directions.
+
+# The e2e shape. `mvnw verify` exits non-zero on a failing test, so the job's verdict is the test
+# step itself and exempting the reporter costs nothing.
+mkdir -p "$work/reporter-e2e"
+cat >"$work/reporter-e2e/ci.yml" <<'YAML'
+name: e2e
+on: [ push ]
+jobs:
+  java-e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: E2E Tests
+        run: ./mvnw verify -Pintegration -pl e2e
+      - name: E2E Tests Reporter
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        continue-on-error: true
+YAML
+expect "accepts an exempt reporter in a job whose test step is the verdict" 0 "" \
+    "$GUARDS" "$work/reporter-e2e"
+
+# The unit-tests shape: --fail-never makes the test step exit 0 regardless, and check-test-results.py
+# is what turns a failing test back into a failing job. Exempting the reporter is safe here too.
+mkdir -p "$work/reporter-verdict"
+cat >"$work/reporter-verdict/ci.yml" <<'YAML'
+name: verdict
+on: [ push ]
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Tests with Coverage
+        run: ./mvnw verify --fail-never -Pcoverage
+      - name: Unit Tests Reporter
+        uses: dorny/test-reporter@v3
+        continue-on-error: true
+      - name: Check test results
+        run: ./.github/scripts/check-test-results.py surefire-reports
+YAML
+expect "accepts an exempt reporter in a --fail-never job that checks its results" 0 "" \
+    "$GUARDS" "$work/reporter-verdict"
+
+# The false green. Same --fail-never job with the verdict step removed: the test command cannot
+# fail, and now neither can the reporter, so every failing test publishes as a green job.
+mkdir -p "$work/reporter-false-green"
+grep -v "check-test-results.py" "$work/reporter-verdict/ci.yml" |
+    grep -v "name: Check test results" >"$work/reporter-false-green/ci.yml"
+expect "rejects an exempt reporter in a --fail-never job with no verdict step" 1 "--fail-never" \
+    "$GUARDS" "$work/reporter-false-green"
+
+# The nightly workflows are that same shape, and are correct precisely because their reporters are
+# not exempt: there, the reporter failing is the only thing that reports a failing test.
+mkdir -p "$work/reporter-nightly"
+grep -v "continue-on-error: true" "$work/reporter-false-green/ci.yml" >"$work/reporter-nightly/ci.yml"
+expect "accepts a --fail-never job whose reporter is not exempt" 0 "" \
+    "$GUARDS" "$work/reporter-nightly"
+
+# `continue-on-error` takes an expression, and an expression that evaluates true on some runs is
+# the same hazard on those runs. It cannot be resolved statically, so it is read as exempt.
+mkdir -p "$work/reporter-expression"
+sed 's/continue-on-error: true/continue-on-error: ${{ github.event_name == '"'"'push'"'"' }}/' \
+    "$work/reporter-false-green/ci.yml" >"$work/reporter-expression/ci.yml"
+expect "rejects a reporter exempted by an unresolvable expression" 1 "supplies a verdict" \
+    "$GUARDS" "$work/reporter-expression"
+
+# A `|| true` on a step that is not the tests must not be read as a swallowed test failure: it
+# would report every job that guards an optional cleanup, in a check that gates the whole build.
+mkdir -p "$work/reporter-unrelated-guard"
+cat >"$work/reporter-unrelated-guard/ci.yml" <<'YAML'
+name: guarded
+on: [ push ]
+jobs:
+  js-e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: E2E Node.js Tests
+        run: |
+          npm ci
+          npm test
+      - name: JS E2E Tests Reporter
+        uses: dorny/test-reporter@v3
+        continue-on-error: true
+YAML
+expect "accepts a job whose test step exits on failure" 0 "" \
+    "$GUARDS" "$work/reporter-unrelated-guard"
+
+# The live workflows are the point of the check, so they are asserted directly as well: mvn-test.yml
+# must stay clean with the e2e reporters exempt, and the nightly workflows with theirs not.
+expect "accepts the workflows as they stand" 0 "no unguarded reporter exemptions" \
+    "$GUARDS"
 
 echo
 if [[ $failures -gt 0 ]]; then

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -179,6 +179,7 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
+        continue-on-error: true
         with:
           name: Unit Tests Report
           path: "**/surefire-reports/TEST*.xml"
@@ -240,6 +241,7 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
+        continue-on-error: true
         with:
           name: Unit Tests Report
           path: "**/surefire-reports/TEST*.xml"
@@ -302,6 +304,7 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
+        continue-on-error: true
         with:
           name: IT Tests Report
           path: "**/failsafe-reports/TEST*.xml"
@@ -362,6 +365,7 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
+        continue-on-error: true
         with:
           name: HA IT Tests Report
           path: "**/failsafe-reports/TEST*.xml"
@@ -460,6 +464,7 @@ jobs:
       - name: E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
+        continue-on-error: true
         with:
           name: Java E2E Tests Report
           path: "e2e/target/failsafe-reports/TEST*.xml"
@@ -506,6 +511,7 @@ jobs:
       - name: JS E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
+        continue-on-error: true
         with:
           name: JS E2E Tests Report
           path: "e2e-js/reports/jest-junit.xml"
@@ -563,6 +569,7 @@ jobs:
       - name: Studio E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
+        continue-on-error: true
         with:
           name: Studio E2E Tests Report
           path: "e2e-studio/reports/playwright-junit.xml"
@@ -624,6 +631,7 @@ jobs:
       - name: Python E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
+        continue-on-error: true
         with:
           name: Python E2E Tests Report
           path: "e2e-python/reports/python-junit.xml"
@@ -679,6 +687,7 @@ jobs:
       - name: C# E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
+        continue-on-error: true
         with:
           name: C# E2E Tests Report
           path: "e2e-csharp/ArcadeDB.E2ETests/reports/csharp-junit.xml"
@@ -745,6 +754,7 @@ jobs:
       - name: Go E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
+        continue-on-error: true
         with:
           name: Go E2E Tests Report
           path: "e2e-go/reports/go-junit.xml"

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -32,14 +32,16 @@ jobs:
         with:
           python-version: "3.13.0"
           cache: "pip"
-      # Both steps below need PyYAML, so it gets its own step rather than hiding inside the first
-      # one that happens to run - reordering those would otherwise break the second confusingly.
+      # Every step below needs PyYAML, so it gets its own step rather than hiding inside the first
+      # one that happens to run - reordering those would otherwise break the rest confusingly.
       # Pinned for the same reason the actions here are pinned to a SHA: this job gates every other
       # one, so what it installs should not change under it between runs.
       - name: Install workflow linting dependencies
         run: python3 -m pip install --quiet pyyaml==6.0.3
       - name: Check workflow artifact dependencies
         run: ./.github/scripts/check-workflow-artifact-deps.py
+      - name: Check test reporter guards
+        run: ./.github/scripts/check-test-reporter-guards.py
       - name: Check CI scripts
         run: ./.github/scripts/tests/test-ci-scripts.sh
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
@@ -179,7 +181,6 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
-        continue-on-error: true
         with:
           name: Unit Tests Report
           path: "**/surefire-reports/TEST*.xml"
@@ -241,7 +242,6 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
-        continue-on-error: true
         with:
           name: Unit Tests Report
           path: "**/surefire-reports/TEST*.xml"
@@ -304,7 +304,6 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
-        continue-on-error: true
         with:
           name: IT Tests Report
           path: "**/failsafe-reports/TEST*.xml"
@@ -365,7 +364,6 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
-        continue-on-error: true
         with:
           name: HA IT Tests Report
           path: "**/failsafe-reports/TEST*.xml"
@@ -461,6 +459,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
 
+      # continue-on-error: same reasoning as the unit-tests job, with a different verdict step. The
+      # e2e suites do not run with --fail-never, so the test step above already fails the job on a
+      # failing test and no check-test-results.py is needed. The reporter only publishes annotations,
+      # so letting it fail removes the false red without ever hiding a real failure.
       - name: E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
@@ -508,6 +510,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
 
+      # See the java-e2e-tests job: the test step is the verdict, the reporter is decorative.
       - name: JS E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
@@ -566,6 +569,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
 
+      # See the java-e2e-tests job: the test step is the verdict, the reporter is decorative.
       - name: Studio E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
@@ -628,6 +632,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
 
+      # See the java-e2e-tests job: the test step is the verdict, the reporter is decorative.
       - name: Python E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
@@ -684,6 +689,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
 
+      # See the java-e2e-tests job: the test step is the verdict, the reporter is decorative.
       - name: C# E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
@@ -751,6 +757,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
 
+      # See the java-e2e-tests job: the test step is the verdict, the reporter is decorative.
       - name: Go E2E Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()


### PR DESCRIPTION
## Description

The `dorny/test-reporter` steps in `mvn-test.yml` fail intermittently when the test artifact is missing or empty, causing the entire job to show as red even though **all tests passed**.

### Fix

Add `continue-on-error: true` to each of the 10 `dorny/test-reporter` steps. This ensures the test reporter's failure doesn't mask the actual test results — the step still runs and reports, but a transient artifact resolution failure won't turn the whole job red.

### Evidence

Observed across three separate jobs on PR #5736, on different commits, always with the same shape — the test-reporter step fails while every test step before it passed.

Fixes #5763
