### PR TITLE
fix(engine) #5747: do not rebuild a persisted HNSW graph on close

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4907,7 +4907,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // Build and persist graph if it hasn't been built yet
       // This ensures the graph is available on next database open (fast restart)
       // Build graph if it's in LOADING (never built) or MUTABLE (has pending changes) state
-      if (vectorIndex.size() > 0 && (graphState == GraphState.LOADING || graphState == GraphState.MUTABLE)) {
+      //
+      // LOADING means "not loaded into memory", which is not the same as "not
+      // persisted on disk": the graph loads lazily on the first search, so a
+      // session that never searched leaves it LOADING even when a complete
+      // graph is already on disk, and rebuilding then only reproduces a file
+      // that already exists. initializeGraphIndex() already draws exactly this
+      // distinction with the same predicate.
+      final boolean graphAlreadyOnDisk = graphFile != null && graphFile.hasPersistedGraph();
+      if (vectorIndex.size() > 0 && (graphState == GraphState.MUTABLE
+          || (graphState == GraphState.LOADING && !graphAlreadyOnDisk))) {
         try {
           LogManager.instance()
               .log(this, Level.FINE, "Building graph before close for index: %s (this may take 1-2 minutes for large datasets)",

--- a/engine/src/test/java/com/arcadedb/index/vector/VectorIndexNoRebuildOnUnusedCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/VectorIndexNoRebuildOnUnusedCloseTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A session that never searches the vector index must not rewrite its HNSW graph on close.
+ * <p>
+ * {@code GraphState.LOADING} means "not loaded into memory", which is not the same as "not
+ * persisted on disk": the graph is lazily loaded on the first search, so a session that only
+ * reads documents leaves the state at LOADING even when a complete graph is already on disk.
+ * Treating that as "never built" makes close rebuild the graph from scratch to produce a file
+ * that already exists, which is O(n log n) in the index size and lands on sessions that never
+ * used the index at all.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/5747">issue #5747</a>
+ */
+class VectorIndexNoRebuildOnUnusedCloseTest extends TestHelper {
+
+  private static final int VECTORS = 300;
+
+  @Test
+  void closingWithoutSearchingDoesNotRewriteTheGraph() throws Exception {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      for (int i = 0; i < VECTORS; i++)
+        database.command("sql", "INSERT INTO Doc SET name = ?, embedding = ?", "d" + i, embedding(i));
+    });
+
+    database.command("sql", """
+        CREATE INDEX ON Doc (embedding) LSM_VECTOR
+        METADATA {
+          "dimensions": 4,
+          "similarity": "COSINE"
+        }""");
+
+    // Search once so the graph is loaded and persisted in a settled state, then close.
+    assertThat(search()).isNotZero();
+    reopenDatabase();
+
+    final File graph = graphFile();
+    final byte[] contentBefore = Files.readAllBytes(graph.toPath());
+    final long modifiedBefore = graph.lastModified();
+
+    // A session that reads documents and never touches the vector index. Nothing here
+    // changes the index, so closing must leave the persisted graph exactly as it was.
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM Doc LIMIT 10")) {
+      while (rs.hasNext())
+        rs.next();
+    }
+    reopenDatabase();
+
+    assertThat(graphFile()).exists();
+    assertThat(Files.readAllBytes(graphFile().toPath()))
+        .as("closing a database whose vector index was never used must not rewrite the graph")
+        .isEqualTo(contentBefore);
+    assertThat(graphFile().lastModified())
+        .as("the persisted graph was rewritten on close by a session that never searched")
+        .isEqualTo(modifiedBefore);
+
+    // And the index is still usable afterwards.
+    assertThat(search()).isNotZero();
+  }
+
+  private int search() {
+    int rows = 0;
+    try (final ResultSet rs = database.query("sql",
+        "SELECT name FROM (SELECT expand(vectorNeighbors('Doc[embedding]', [1.0, 0.0, 0.0, 0.0], 5)))")) {
+      while (rs.hasNext()) {
+        rs.next();
+        rows++;
+      }
+    }
+    return rows;
+  }
+
+  private File graphFile() {
+    final File[] found = new File(getDatabasePath())
+        .listFiles((dir, name) -> name.contains(LSMVectorIndexGraphFile.FILE_EXT));
+    assertThat(found).as("persisted graph file").isNotNull().isNotEmpty();
+    return found[0];
+  }
+
+  private static float[] embedding(final int i) {
+    // Spread over the unit sphere so the graph has real structure to preserve.
+    final double a = i * 0.05;
+    return new float[] {(float) Math.cos(a), (float) Math.sin(a), (float) (i % 7) / 7f, (float) (i % 3) / 3f};
+  }
+}


### PR DESCRIPTION
Fixes #5747.

`LSMVectorIndex.flush()` rebuilds the HNSW graph when `graphState` is `LOADING`
or `MUTABLE`. `MUTABLE` is right: there are pending changes. `LOADING` is not,
because it means "not loaded into memory", which is not the same as "not
persisted on disk".

The graph loads lazily on the first search, so a session that only reads
documents leaves the state at `LOADING` even when a complete graph is already on
disk, and close then rebuilds it from scratch to produce a file that already
exists. `initializeGraphIndex()` already draws exactly this distinction with
`graphFile.hasPersistedGraph()`; this applies the same test in `flush()`.

## Measured

One host, 64-dim COSINE, 9 reps with 3 warmup, median. Both arms are the same
harness on the same data; a classpath check confirms which jar each arm loaded.

| vectors | what the session did | close before | close after |
|---|---|---|---|
| 100k | read a document | 6,197.79 ms | **4.34 ms** |
| 1M | read a document | 216,068.3 ms | **13.2 ms** |
| 1M | two indexes, queried neither | 379,014.3 ms | **15.2 ms** |
| 1M | two indexes, queried one | 190,448.5 ms | **14.9 ms** |
| 1M | **ran a vector search** | 14.1 ms | 16.3 ms |
| 3M | read a document | 1,006,000 ms | not re-run |

The fifth row is the safety check. Sessions that do search already skipped the
rebuild, and this leaves them where they were.

At 3M the close was 1,006 s against an original build of 1,011 s, so the close
rebuild is a complete re-run of the build. The cost is also per index rather
than per database: with two indexes and only one queried, the untouched one
still cost 190 s on its own.

## Correctness

- New test `VectorIndexNoRebuildOnUnusedCloseTest` asserts the persisted graph
  is byte-identical and unmodified after a session that reads documents and
  never searches. It **fails on unpatched code** and passes with the change.
- Separately: after adding 200 vectors to an existing index, closing and
  reopening, all 200 new and all 200 pre-existing vectors are still found by
  search, identically on patched and unpatched builds. The `MUTABLE` branch
  still rebuilds as it should.
- The full `com.arcadedb.index.vector` suite (22 classes) passes.

## One behaviour change worth stating

If a session adds vectors and then crashes before close, the on-disk graph is
stale and the state is `LOADING`. The current unconditional rebuild repairs that
incidentally. With this change the repair happens at the next search instead,
through the staleness check already in `ensureGraphAvailable()`
(`graphSize < rebuiltOrdinalToVectorId.length`, added for #3722). So the repair
moves from incidental to deliberate rather than disappearing, but it is a real
change and you may prefer a different call on it.

Happy to adjust the approach or add cases to the test.
