### PR TITLE
fix(serializer) #5770: serializeForRead renders EXTERNAL values inline on read paths

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/BaseRecord.java
+++ b/engine/src/main/java/com/arcadedb/database/BaseRecord.java
@@ -89,8 +89,10 @@ public abstract class BaseRecord implements Record {
           // CREATE A BUFFER FROM THE MODIFIED RECORD, THE SAME WAY ImmutableDocument.checkForLazyLoading() DOES.
           // TAKING getBuffer() INSTEAD WOULD DISCARD WHAT THE LISTENER DID: ON A DIRTY MutableDocument THAT BUFFER
           // STILL HOLDS THE PRE-MODIFICATION CONTENT, AND IT IS null OUTRIGHT FOR A RECORD BUILT FROM SCRATCH.
+          // serializeForRead() INSTEAD OF serialize(): THIS IS A READ, SO AN EXTERNAL PROPERTY MUST BE RENDERED INLINE
+          // INSTEAD OF BEING WRITTEN TO (OR DELETED FROM) THE PAIRED EXTERNAL BUCKET (ISSUE #5770).
           // getNotReusable() IS MANDATORY: FOR A DIRTY RECORD THE SERIALIZER RETURNS THE PER-THREAD SCRATCH BUFFER
-          buffer = database.getSerializer().serialize(database, loaded).getNotReusable();
+          buffer = database.getSerializer().serializeForRead(database, loaded).getNotReusable();
         }
 
       } catch (final RecordNotFoundException e) {

--- a/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
@@ -266,9 +266,11 @@ public class ImmutableDocument extends BaseDocument {
         return false;
       } else if (loaded != this) {
         // CREATE A BUFFER FROM THE MODIFIED RECORD. THIS IS NEEDED FOR ENCRYPTION THAT UPDATE THE RECORD WITH A MUTABLE.
+        // serializeForRead() INSTEAD OF serialize(): THIS IS A READ, SO AN EXTERNAL PROPERTY MUST BE RENDERED INLINE
+        // INSTEAD OF BEING WRITTEN TO (OR DELETED FROM) THE PAIRED EXTERNAL BUCKET (ISSUE #5770).
         // getNotReusable() IS MANDATORY: FOR A DIRTY RECORD THE SERIALIZER RETURNS THE PER-THREAD SCRATCH BUFFER, WHICH
         // IT COPIES OUT, WHILE THE ALREADY-PRIVATE BUFFER OF THE OTHER BRANCH IS KEPT AS IS
-        buffer = database.getSerializer().serialize(database, loaded).getNotReusable();
+        buffer = database.getSerializer().serializeForRead(database, loaded).getNotReusable();
         // THE SERIALIZER HANDS THE BUFFER BACK AT 0 OR AT 1 DEPENDING ON THE BRANCH IT TOOK: NORMALISE IT SO THE
         // POSTCONDITION OF THIS METHOD HOLDS ON EVERY PATH
         buffer.position(propertiesStartingPosition);

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -123,25 +123,35 @@ public class BinarySerializer {
   }
 
   /**
-   * Read-only serialization: creates a buffer-backed representation of the record without writing to the external
-   * bucket. EXTERNAL property values are serialized inline instead of being written to the paired bucket, and the
-   * orphan-cleanup pass is skipped entirely. Use this when re-serializing a record on a read path (e.g., after an
-   * {@code AfterRecordReadListener} returns a modified record) to avoid the surprising side effect of writes and
-   * deletes on the external bucket during a read operation.
+   * Read-only serialization: renders the record into a buffer without touching the paired external bucket. The value
+   * of a property flagged EXTERNAL is serialized INLINE (it is already in memory, deserialized by the read that got
+   * us here) instead of being written to the external bucket, and the orphan-cleanup pass is skipped entirely.
    * <p>
-   * The resulting buffer is complete and self-contained but does NOT carry TYPE_EXTERNAL markers — subsequent
-   * writes through the normal {@link #serialize} path will re-create the external pointers correctly.
+   * Use it on a read path, where the caller has to materialize a record an {@code AfterRecordReadListener} handed
+   * back modified: {@link com.arcadedb.database.ImmutableDocument#checkForLazyLoading()} and
+   * {@link com.arcadedb.database.BaseRecord#reload()} are the two such callers. Going through {@link #serialize}
+   * there makes a plain read create or update records in the external bucket, and lets orphan cleanup DELETE them,
+   * wherever the read happens to be running (issue #5770).
+   * <p>
+   * The buffer that comes back is complete and self-contained for READING: every value resolves without a second
+   * lookup. It carries no TYPE_EXTERNAL pointer though, so it is not a substitute for the stored record: a later
+   * update of that same in-memory record cannot recover the RIDs of its external blobs from it and will allocate
+   * new ones, leaving the previous blobs to the orphan scan. That is the accepted cost of not writing on a read.
+   * <p>
+   * Record types that have no properties at all (edge segments, stripe directories, external value records) never
+   * reach the external bucket, so they fall through to the normal {@link #serialize} path unchanged.
    *
    * @param database the database
-   * @param record   the record to serialize (must be a MutableDocument, MutableVertex, or MutableEdge)
-   * @return a read-only buffer with inline property values
+   * @param record   the record to serialize
+   *
+   * @return a buffer with EXTERNAL property values rendered inline
    */
   public Binary serializeForRead(final DatabaseInternal database, final Record record) {
     return switch (record.getRecordType()) {
-      case Document.RECORD_TYPE, EmbeddedDocument.RECORD_TYPE -> serializeDocument(database, (MutableDocument) record, true);
-      case Vertex.RECORD_TYPE -> serializeVertex(database, (MutableVertex) record, true);
-      case Edge.RECORD_TYPE -> serializeEdge(database, (MutableEdge) record, true);
-      default -> throw new IllegalArgumentException("Cannot serialize a record of type=" + record.getRecordType());
+      case Document.RECORD_TYPE, EmbeddedDocument.RECORD_TYPE -> serializeDocument(database, (Document) record, true);
+      case Vertex.RECORD_TYPE -> serializeVertex(database, (VertexInternal) record, true);
+      case Edge.RECORD_TYPE -> serializeEdge(database, (Edge) record, true);
+      default -> serialize(database, record);
     };
   }
 
@@ -914,7 +924,12 @@ public class BinarySerializer {
     return serializeProperties(database, record, header, content, false);
   }
 
-  private Binary serializeProperties(final Database database, final Document record, final Binary header, final Binary content, final boolean readOnly) {
+  /**
+   * @param readOnly when true the record is being rendered for a READ ({@link #serializeForRead}): EXTERNAL properties
+   *                 are serialized inline and no record in the paired external bucket is created, updated or deleted.
+   */
+  private Binary serializeProperties(final Database database, final Document record, final Binary header,
+      final Binary content, final boolean readOnly) {
     final int headerSizePosition = header.position();
     header.putInt(0); // TEMPORARY PLACEHOLDER FOR HEADER SIZE
 
@@ -968,6 +983,7 @@ public class BinarySerializer {
       final int startContentPosition = content.position();
 
       final Property propertyDef = documentType.getPropertyIfExists(propertyName);
+      // ON A READ (readOnly) THE VALUE IS WRITTEN INLINE BY THE else BRANCH BELOW: THE EXTERNAL BUCKET IS NEVER TOUCHED
       if (propertyDef != null && propertyDef.isExternal() && !readOnly) {
         // NULL is not externalised. set("field", null) is treated semantically the same as remove("field")
         // for storage purposes: we write a TYPE_NULL byte INLINE in the main record and let the orphan-

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -122,7 +122,34 @@ public class BinarySerializer {
     };
   }
 
+  /**
+   * Read-only serialization: creates a buffer-backed representation of the record without writing to the external
+   * bucket. EXTERNAL property values are serialized inline instead of being written to the paired bucket, and the
+   * orphan-cleanup pass is skipped entirely. Use this when re-serializing a record on a read path (e.g., after an
+   * {@code AfterRecordReadListener} returns a modified record) to avoid the surprising side effect of writes and
+   * deletes on the external bucket during a read operation.
+   * <p>
+   * The resulting buffer is complete and self-contained but does NOT carry TYPE_EXTERNAL markers — subsequent
+   * writes through the normal {@link #serialize} path will re-create the external pointers correctly.
+   *
+   * @param database the database
+   * @param record   the record to serialize (must be a MutableDocument, MutableVertex, or MutableEdge)
+   * @return a read-only buffer with inline property values
+   */
+  public Binary serializeForRead(final DatabaseInternal database, final Record record) {
+    return switch (record.getRecordType()) {
+      case Document.RECORD_TYPE, EmbeddedDocument.RECORD_TYPE -> serializeDocument(database, (MutableDocument) record, true);
+      case Vertex.RECORD_TYPE -> serializeVertex(database, (MutableVertex) record, true);
+      case Edge.RECORD_TYPE -> serializeEdge(database, (MutableEdge) record, true);
+      default -> throw new IllegalArgumentException("Cannot serialize a record of type=" + record.getRecordType());
+    };
+  }
+
   public Binary serializeDocument(final DatabaseInternal database, final Document document) {
+    return serializeDocument(database, document, false);
+  }
+
+  public Binary serializeDocument(final DatabaseInternal database, final Document document, final boolean readOnly) {
     Binary header = ((BaseRecord) document).getBuffer();
 
     final DatabaseContext.DatabaseContextTL context = database.getContext();
@@ -140,12 +167,16 @@ public class BinarySerializer {
     }
 
     if (serializeProperties)
-      return serializeProperties(database, document, header, context.getTemporaryBuffer2());
+      return serializeProperties(database, document, header, context.getTemporaryBuffer2(), readOnly);
 
     return header;
   }
 
   public Binary serializeVertex(final DatabaseInternal database, final VertexInternal vertex) {
+    return serializeVertex(database, vertex, false);
+  }
+
+  public Binary serializeVertex(final DatabaseInternal database, final VertexInternal vertex, final boolean readOnly) {
     Binary header = ((BaseRecord) vertex).getBuffer();
 
     final DatabaseContext.DatabaseContextTL context = database.getContext();
@@ -182,12 +213,16 @@ public class BinarySerializer {
     }
 
     if (serializeProperties)
-      return serializeProperties(database, vertex, header, context.getTemporaryBuffer2());
+      return serializeProperties(database, vertex, header, context.getTemporaryBuffer2(), readOnly);
 
     return header;
   }
 
   public Binary serializeEdge(final DatabaseInternal database, final Edge edge) {
+    return serializeEdge(database, edge, false);
+  }
+
+  public Binary serializeEdge(final DatabaseInternal database, final Edge edge, final boolean readOnly) {
     Binary header = ((BaseRecord) edge).getBuffer();
 
     final DatabaseContext.DatabaseContextTL context = database.getContext();
@@ -209,7 +244,7 @@ public class BinarySerializer {
     serializeValue(database, header, BinaryTypes.TYPE_COMPRESSED_RID, edge.getIn());
 
     if (serializeProperties)
-      return serializeProperties(database, edge, header, context.getTemporaryBuffer2());
+      return serializeProperties(database, edge, header, context.getTemporaryBuffer2(), readOnly);
 
     return header;
   }
@@ -876,15 +911,19 @@ public class BinarySerializer {
   }
 
   public Binary serializeProperties(final Database database, final Document record, final Binary header, final Binary content) {
+    return serializeProperties(database, record, header, content, false);
+  }
+
+  private Binary serializeProperties(final Database database, final Document record, final Binary header, final Binary content, final boolean readOnly) {
     final int headerSizePosition = header.position();
     header.putInt(0); // TEMPORARY PLACEHOLDER FOR HEADER SIZE
 
     final Map<String, Object> properties = record.propertiesAsMap();
     final Dictionary dictionary = database.getSchema().getDictionary();
     final DocumentType documentType = record.getType();
-    // For records being UPDATED, look up existing external RIDs from the old buffer so we can update the external bucket
-    // record in place rather than allocating a new one. New records (no identity yet) get an empty map.
-    final Map<String, RID> existingExternalRids = findExistingExternalRids(database, record);
+
+    // In read-only mode no external bucket interactions occur, so we skip the old-buffer scan entirely.
+    final Map<String, RID> existingExternalRids = readOnly ? Collections.emptyMap() : findExistingExternalRids(database, record);
     // Track which existing external RIDs we re-used (kept) so we can delete the rest as orphans below. An entry is
     // orphaned when the property is no longer EXTERNAL (toggled off via ALTER), was renamed, or was dropped entirely.
     final Set<String> consumedExternalProperties = existingExternalRids.isEmpty() ? null : new HashSet<>();
@@ -929,7 +968,7 @@ public class BinarySerializer {
       final int startContentPosition = content.position();
 
       final Property propertyDef = documentType.getPropertyIfExists(propertyName);
-      if (propertyDef != null && propertyDef.isExternal()) {
+      if (propertyDef != null && propertyDef.isExternal() && !readOnly) {
         // NULL is not externalised. set("field", null) is treated semantically the same as remove("field")
         // for storage purposes: we write a TYPE_NULL byte INLINE in the main record and let the orphan-
         // cleanup pass at the end of this method delete any pre-existing external blob (the property is

--- a/engine/src/test/java/com/arcadedb/schema/ExternalPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/ExternalPropertyTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.EmbeddedDocument;
@@ -1071,5 +1072,45 @@ class ExternalPropertyTest extends TestHelper {
     final ResultSet rs = database.query("sql", "SELECT blob FROM Doc");
     assertThat(rs.hasNext()).isTrue();
     assertThat((String) rs.next().getProperty("blob")).isEqualTo("v");
+  }
+
+  /**
+   * Verifies that {@link BinarySerializer#serializeForRead} renders EXTERNAL property values inline without writing
+   * to the external bucket. When an {@code AfterRecordReadListener} returns a modified record on a read path, the
+   * serializer must use {@code serializeForRead()} to avoid silently creating or updating records in the paired
+   * external bucket.
+   * <p>
+   * This test creates a record with an EXTERNAL property, then directly calls {@code serializeForRead()} on a
+   * modified copy and asserts that the external bucket's record count is unchanged.
+   */
+  @Test
+  void serializeForReadDoesNotWriteToExternalBucket() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("Doc");
+    type.createProperty("name", Type.STRING);
+    type.createProperty("blob", Type.STRING).setExternal(true);
+
+    // Create a record with an external property.
+    database.transaction(() -> database.newDocument("Doc").set("name", "test").set("blob", "hello").save());
+
+    // Count records in the external bucket before the serialization.
+    final var primaryBucket = type.getBuckets(false).getFirst();
+    final Integer extBucketId = ((LocalDocumentType) type).getExternalBucketIdFor(primaryBucket.getFileId());
+    final LocalBucket extBucket = ((LocalSchema) database.getSchema().getEmbedded())
+        .getBucketById(extBucketId);
+    final long extCountBefore = extBucket.count();
+
+    // Load the record, modify it, and serialize via serializeForRead.
+    final Document loaded = (Document) database.iterateType("Doc", true).next();
+    final MutableDocument modified = loaded.modify().set("name", "modified");
+    final Binary buffer = ((DatabaseInternal) database).getSerializer()
+        .serializeForRead((DatabaseInternal) database, modified);
+
+    // The buffer must be non-null and contain the modified property.
+    assertThat(buffer).isNotNull();
+    assertThat(buffer.size()).isGreaterThan(0);
+
+    // The external bucket count must NOT have changed: serializeForRead must not write.
+    final long extCountAfter = extBucket.count();
+    assertThat(extCountAfter).as("serializeForRead must not write to the external bucket").isEqualTo(extCountBefore);
   }
 }

--- a/engine/src/test/java/com/arcadedb/schema/ExternalPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/ExternalPropertyTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.database.MutableEmbeddedDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.event.AfterRecordReadListener;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.DatabaseIsReadOnlyException;
 import com.arcadedb.graph.MutableVertex;
@@ -1075,42 +1076,217 @@ class ExternalPropertyTest extends TestHelper {
   }
 
   /**
-   * Verifies that {@link BinarySerializer#serializeForRead} renders EXTERNAL property values inline without writing
-   * to the external bucket. When an {@code AfterRecordReadListener} returns a modified record on a read path, the
-   * serializer must use {@code serializeForRead()} to avoid silently creating or updating records in the paired
-   * external bucket.
+   * Issue #5770: a read must not write. When an {@code AfterRecordReadListener} hands back a DIFFERENT record - the
+   * shape of the documented encryption recipe - {@code ImmutableDocument.checkForLazyLoading()} has to render that
+   * record into a buffer. Going through {@code serialize()} there ran the EXTERNAL branch of
+   * {@code BinarySerializer.serializeProperties()}, which creates or UPDATES the blob in the paired external bucket
+   * (and lets orphan cleanup delete blobs), so merely reading the record overwrote the stored value with whatever the
+   * listener returned. {@code serializeForRead()} renders the value inline instead.
    * <p>
-   * This test creates a record with an EXTERNAL property, then directly calls {@code serializeForRead()} on a
-   * modified copy and asserts that the external bucket's record count is unchanged.
+   * The discriminating assertion is the stored value: with the listener detached, the record must still read back the
+   * value it was saved with. Before the fix it reads back the listener's value, which the read had persisted.
    */
   @Test
-  void serializeForReadDoesNotWriteToExternalBucket() throws Exception {
+  void afterReadListenerReturningAModifiedRecordDoesNotWriteToTheExternalBucket() {
     final DocumentType type = database.getSchema().createDocumentType("Doc");
     type.createProperty("name", Type.STRING);
     type.createProperty("blob", Type.STRING).setExternal(true);
 
-    // Create a record with an external property.
-    database.transaction(() -> database.newDocument("Doc").set("name", "test").set("blob", "hello").save());
+    final RID[] saved = new RID[1];
+    database.transaction(() -> {
+      final MutableDocument d = database.newDocument("Doc").set("name", "original").set("blob", "encrypted_value");
+      d.save();
+      saved[0] = d.getIdentity();
+    });
 
-    // Count records in the external bucket before the serialization.
-    final var primaryBucket = type.getBuckets(false).getFirst();
-    final Integer extBucketId = ((LocalDocumentType) type).getExternalBucketIdFor(primaryBucket.getFileId());
-    final LocalBucket extBucket = ((LocalSchema) database.getSchema().getEmbedded())
-        .getBucketById(extBucketId);
-    final long extCountBefore = extBucket.count();
+    final Integer extBucketId = ((LocalDocumentType) type).getExternalBucketIdFor(saved[0].getBucketId());
+    final LocalBucket externalBucket = ((LocalSchema) database.getSchema().getEmbedded()).getBucketById(extBucketId);
+    final long extCountBefore = externalBucket.count();
 
-    // Load the record, modify it, and serialize via serializeForRead.
-    final Document loaded = (Document) database.iterateType("Doc", true).next();
-    final MutableDocument modified = loaded.modify().set("name", "modified");
-    final Binary buffer = ((DatabaseInternal) database).getSerializer()
-        .serializeForRead((DatabaseInternal) database, modified);
+    // MIMICS THE ENCRYPTION HOOK: HAND BACK A DIFFERENT, DIRTY RECORD ON EVERY READ
+    final AfterRecordReadListener rewriter = record -> ((Document) record).modify().set("blob", "decrypted_value");
+    type.getEvents().registerListener(rewriter);
 
-    // The buffer must be non-null and contain the modified property.
-    assertThat(buffer).isNotNull();
-    assertThat(buffer.size()).isGreaterThan(0);
+    final int[] modifiedPages = new int[1];
+    try {
+      database.transaction(() -> {
+        // loadContent=false LEAVES THE RECORD UNMATERIALISED, SO THE READ BELOW GOES THROUGH checkForLazyLoading()
+        final Document read = database.lookupByRID(saved[0], false).asDocument();
+        assertThat(read.get("blob")).isEqualTo("decrypted_value");
+        assertThat(read.get("name")).isEqualTo("original");
+        modifiedPages[0] = ((DatabaseInternal) database).getTransaction().getModifiedPages();
+      });
+    } finally {
+      type.getEvents().unregisterListener(rewriter);
+    }
 
-    // The external bucket count must NOT have changed: serializeForRead must not write.
-    final long extCountAfter = extBucket.count();
-    assertThat(extCountAfter).as("serializeForRead must not write to the external bucket").isEqualTo(extCountBefore);
+    database.transaction(() -> assertThat(database.lookupByRID(saved[0], true).asDocument().get("blob"))
+        .as("the stored external value must survive the read untouched")
+        .isEqualTo("encrypted_value"));
+
+    assertThat(externalBucket.count()).as("reading a record must not add or delete external records")
+        .isEqualTo(extCountBefore);
+    assertThat(modifiedPages[0]).as("reading a record must not modify any page").isZero();
+  }
+
+  /**
+   * The second read path of issue #5770. {@code BaseRecord.reload()} materialises a listener-modified record exactly
+   * like {@code ImmutableDocument.checkForLazyLoading()} does, so it needs the same read-only serialization: patching
+   * only one of the two leaves the external bucket writable from a {@code reload()}.
+   */
+  @Test
+  void reloadWithAnAfterReadListenerDoesNotWriteToTheExternalBucket() {
+    final DocumentType type = database.getSchema().createDocumentType("Doc");
+    type.createProperty("name", Type.STRING);
+    type.createProperty("blob", Type.STRING).setExternal(true);
+
+    final RID[] saved = new RID[1];
+    database.transaction(() -> {
+      final MutableDocument d = database.newDocument("Doc").set("name", "original").set("blob", "encrypted_value");
+      d.save();
+      saved[0] = d.getIdentity();
+    });
+
+    final Integer extBucketId = ((LocalDocumentType) type).getExternalBucketIdFor(saved[0].getBucketId());
+    final LocalBucket externalBucket = ((LocalSchema) database.getSchema().getEmbedded()).getBucketById(extBucketId);
+    final long extCountBefore = externalBucket.count();
+
+    final AfterRecordReadListener rewriter = record -> ((Document) record).modify().set("blob", "decrypted_value");
+    type.getEvents().registerListener(rewriter);
+
+    try {
+      database.transaction(() -> {
+        final Document read = database.lookupByRID(saved[0], false).asDocument();
+        read.reload();
+        assertThat(read.get("blob")).isEqualTo("decrypted_value");
+      });
+    } finally {
+      type.getEvents().unregisterListener(rewriter);
+    }
+
+    assertThat(externalBucket.count()).isEqualTo(extCountBefore);
+
+    database.transaction(() -> assertThat(database.lookupByRID(saved[0], true).asDocument().get("blob"))
+        .as("the stored external value must survive the reload untouched")
+        .isEqualTo("encrypted_value"));
+  }
+
+  /**
+   * The listener of the encryption recipe rewrites a plain property, not the EXTERNAL one. The record still has to
+   * read back its EXTERNAL value: rendering it inline is what keeps the buffer complete. Skipping external properties
+   * on a read instead - the shortcut issue #5770 explicitly rejects - would answer null here.
+   */
+  @Test
+  void afterReadListenerRewritingAPlainPropertyStillResolvesTheExternalValue() {
+    final DocumentType type = database.getSchema().createDocumentType("Doc");
+    type.createProperty("name", Type.STRING);
+    type.createProperty("blob", Type.STRING).setExternal(true);
+
+    final RID[] saved = new RID[1];
+    database.transaction(() -> {
+      final MutableDocument d = database.newDocument("Doc").set("name", "original").set("blob", "external_payload");
+      d.save();
+      saved[0] = d.getIdentity();
+    });
+
+    final Integer extBucketId = ((LocalDocumentType) type).getExternalBucketIdFor(saved[0].getBucketId());
+    final LocalBucket externalBucket = ((LocalSchema) database.getSchema().getEmbedded()).getBucketById(extBucketId);
+    final long extCountBefore = externalBucket.count();
+
+    final AfterRecordReadListener rewriter = record -> ((Document) record).modify().set("name", "rewritten");
+    type.getEvents().registerListener(rewriter);
+
+    try {
+      database.transaction(() -> {
+        final Document read = database.lookupByRID(saved[0], false).asDocument();
+        assertThat(read.get("name")).isEqualTo("rewritten");
+        assertThat(read.get("blob")).as("the EXTERNAL value must still resolve on the read path")
+            .isEqualTo("external_payload");
+        assertThat(read.getPropertyNames()).containsExactlyInAnyOrder("name", "blob");
+        assertThat(read.toMap(false)).containsEntry("name", "rewritten").containsEntry("blob", "external_payload");
+      });
+    } finally {
+      type.getEvents().unregisterListener(rewriter);
+    }
+
+    assertThat(externalBucket.count()).isEqualTo(extCountBefore);
+  }
+
+  /**
+   * The vertex shape of the same path: {@code serializeVertex()} has its own read-only overload, and the encryption
+   * recipe this listener mimics ({@code RecordEncryptionTest}) is written on vertices.
+   */
+  @Test
+  void afterReadListenerOnAVertexDoesNotWriteToTheExternalBucket() {
+    final VertexType type = database.getSchema().createVertexType("V");
+    type.createProperty("name", Type.STRING);
+    type.createProperty("embedding", Type.ARRAY_OF_FLOATS).setExternal(true);
+
+    final float[] embedding = new float[] { 1.5f, -2.25f, 3.125f };
+
+    final RID[] saved = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex v = database.newVertex("V").set("name", "original").set("embedding", embedding);
+      v.save();
+      saved[0] = v.getIdentity();
+    });
+
+    final Integer extBucketId = ((LocalDocumentType) type).getExternalBucketIdFor(saved[0].getBucketId());
+    final LocalBucket externalBucket = ((LocalSchema) database.getSchema().getEmbedded()).getBucketById(extBucketId);
+    final long extCountBefore = externalBucket.count();
+
+    final float[] rewritten = new float[] { 9.5f, 8.25f, 7.125f };
+    final AfterRecordReadListener rewriter = record -> record.asVertex().modify().set("embedding", rewritten);
+    type.getEvents().registerListener(rewriter);
+
+    try {
+      database.transaction(() -> {
+        final var read = database.lookupByRID(saved[0], false).asVertex();
+        assertThat(read.get("name")).isEqualTo("original");
+        assertThat((float[]) read.get("embedding")).containsExactly(rewritten);
+      });
+    } finally {
+      type.getEvents().unregisterListener(rewriter);
+    }
+
+    assertThat(externalBucket.count()).isEqualTo(extCountBefore);
+
+    database.transaction(() -> assertThat((float[]) database.lookupByRID(saved[0], true).asVertex().get("embedding"))
+        .as("the stored external value must survive the read untouched")
+        .containsExactly(embedding));
+  }
+
+  /**
+   * The buffer {@code serializeForRead()} produces has to be usable on its own: the EXTERNAL value is written inline,
+   * so a reader resolves it without a second lookup in the paired bucket.
+   */
+  @Test
+  void serializeForReadRendersExternalValuesInline() {
+    final DocumentType type = database.getSchema().createDocumentType("Doc");
+    type.createProperty("name", Type.STRING);
+    type.createProperty("blob", Type.STRING).setExternal(true);
+
+    database.transaction(() -> database.newDocument("Doc").set("name", "original").set("blob", "payload").save());
+
+    final Integer extBucketId = ((LocalDocumentType) type).getExternalBucketIdFor(
+        type.getBuckets(false).getFirst().getFileId());
+    final LocalBucket externalBucket = ((LocalSchema) database.getSchema().getEmbedded()).getBucketById(extBucketId);
+    final long extCountBefore = externalBucket.count();
+
+    database.transaction(() -> {
+      final DatabaseInternal db = (DatabaseInternal) database;
+      final Document loaded = database.iterateType("Doc", true).next().asDocument();
+      final MutableDocument modified = loaded.modify().set("name", "modified");
+
+      final Binary buffer = db.getSerializer().serializeForRead(db, modified).getNotReusable();
+      buffer.position(1); // SKIP THE RECORD-TYPE BYTE
+
+      final Map<String, Object> properties = db.getSerializer()
+          .deserializeProperties(database, buffer, null, modified.getIdentity());
+      assertThat(properties).containsEntry("name", "modified").containsEntry("blob", "payload");
+    });
+
+    assertThat(externalBucket.count()).as("serializeForRead must not write to the external bucket")
+        .isEqualTo(extCountBefore);
   }
 }


### PR DESCRIPTION
## Description

Fixes #5770

When an `AfterRecordReadListener` returns a modified record, the reader re-serialises it into a buffer via `serialize()`. For EXTERNAL properties, this calls `writeExternalPropertyValue()` which creates or updates records in the paired external bucket — a write on a read path, with the additional risk of orphan cleanup deleting external records as a side effect.

### Fix

Add a read-only serialization mode (`serializeForRead`) that:

- **Renders EXTERNAL property values inline** instead of writing to the paired bucket
- **Skips the orphan-cleanup pass** entirely — no external bucket writes or deletes
- **Produces a complete, self-contained buffer** by using the existing `serializeValue()` path for EXTERNAL properties

The normal `serialize()` path is unchanged — EXTERNAL properties continue to be written to the paired bucket during regular writes.

Also updated `ImmutableDocument.checkForLazyLoading()` to use `serializeForRead()` when re-serialising a listener-modified record on the read path.

### Test

`serializeForReadDoesNotWriteToExternalBucket` — creates a document with an EXTERNAL property, serializes a modified copy via `serializeForRead()`, and asserts that the external bucket record count is unchanged.