### PR TITLE
fix(engine) #5802: a mis-ordered index after an upgrade is reported as a queryable upgrade warning

### DIFF
--- a/docs/5802-lsm-key-order-upgrade-warning.md
+++ b/docs/5802-lsm-key-order-upgrade-warning.md
@@ -1,0 +1,156 @@
+# #5802 - a mis-ordered index after an in-place upgrade is only discoverable by grepping the startup log
+
+## Issue
+
+A production install running `26.7.2` had its `lib/*.jar` swapped for a build of current `main` and was
+restarted. Before any query ran, the log emitted one `WARNING` per affected index:
+
+```
+WARNI [LSMTreeIndexCompacted] Index 'Paper_0_84306331895885' is physically ordered differently
+than the current key comparator, so lookups can return fewer (or foreign) records than a scan:
+run 'REBUILD INDEX Paper_0_84306331895885'. Details: [page 20 entry 8: ...]
+```
+
+Both a `FULL_TEXT` index (`Paper[title,abstract]`) and a plain non-unique string index (`Author.name`)
+were reported. The reporter rolled back to `26.7.2` and asked two things:
+
+1. Is this an expected manual migration step, and should it be surfaced more prominently than a
+   `WARNING` log line?
+2. Is there any way to learn *which* indexes are affected without grepping the startup log?
+
+## Root cause of the underlying condition
+
+The report is accurate: the disorder is real, not a false positive from the new detector.
+
+`BinaryComparator.compareBytes(byte[], Binary)` - the routine the LSM binary search uses to place and to
+find a `STRING` key - compared bytes as **signed** until `#5321` (`02d5800ea`), while every other string
+comparison in the engine is unsigned. A UTF-8 lead byte is `>= 0x80`, so it is negative as a Java byte:
+under the old comparison `Á` sorted *before* every ASCII letter, under the new one it sorts after.
+
+That is why the reporter's `Author.name` evidence starts with an accented name and why several of the
+reported pairs are pure ASCII. The mutable index pages were physically laid out in signed order. A
+compaction then reads those pages with cursors that assume ascending order and merges them with
+`LSMTreeIndexAbstract.compareKeys` (object comparison, always unsigned), so once the two orders diverge
+at one accented key the merge emits a stretch of keys out of order - ASCII neighbours included - and
+writes them to the compacted pages as-is. `#5321` did not create the disorder; it made the reader
+disagree with what an older build had already written.
+
+The remedy is therefore correctly `REBUILD INDEX`, and it cannot be applied automatically: rebuilding
+every index of a multi-million-record database on the open path would turn a restart into an outage.
+
+## What was actually wrong
+
+The reporting, not the detection. `LSMTreeIndexCompacted.checkKeyOrderOnLoad()` (added in `8489de7fc`)
+was a dead end for an operator:
+
+- It named the **physical bucket sub-index** (`Paper_0_84306331895885`), the name a user never sees
+  anywhere else. The logical index they would act on is `Paper[title,abstract]`.
+- It existed only as a log line. There was no way to ask the database which indexes were affected, so a
+  restart whose logs had rotated away left no trace at all.
+- `CHECK DATABASE` does report it, but it walks **every page of every index** - not something to run on
+  the box the reporter was trying to bring back up.
+
+Meanwhile the engine already had exactly the right channel for "this index should be rebuilt, here is
+why": `IndexInternal.getUpgradeWarning()`. `LocalSchema.reportUpgradeWarning` logs it once per database
+open per **logical** index with the `REBUILD INDEX` command to run, and it is exposed as `upgradeWarning`
+on `schema:indexes` and `schema:index:<name>`, which is what Studio renders. The key-order check simply
+was not wired into it.
+
+## Fix
+
+`engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java`
+
+- `checkKeyOrderOnLoad()` records its verdict in a `volatile String keyOrderMismatch` instead of only
+  logging it, and exposes it through `getKeyOrderMismatch()`. Caching is what lets the reader honour the
+  `getUpgradeWarning()` contract of being cheap and side-effect free - it is called per index on every
+  schema listing and must not touch a page to answer.
+- The remaining log line keeps the physical evidence (page and entry numbers of *this* sub-index) but
+  drops to `FINE`. That detail is support material; the operator-facing warning is now the one below,
+  which names something they can act on. Emitting both at `WARNING` would restate the same finding under
+  two different names, which is the confusion the issue is about.
+
+`engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java`
+
+- `getUpgradeWarning()` returns the sub-index verdict. Only the compacted sub-index is covered: checking
+  the mutable pages means walking all of them, which is `checkIntegrity()`'s job for `CHECK DATABASE` and
+  not something the open path can afford.
+
+`engine/src/main/java/com/arcadedb/index/TypeIndex.java`
+
+- `getUpgradeWarning()` scans every bucket sub-index instead of answering from the first one. The
+  existing comment - "every bucket sub-index shares one definition, so the first one answers for all of
+  them" - holds for a warning derived from the *definition* (the geospatial cell layout of `#5478`), but
+  a key-order mismatch is physical state that one bucket can be in and another not. Asking only bucket 0
+  would report a type index healthy while one of its buckets needed a rebuild.
+
+`engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java`
+
+- Delegates `getUpgradeWarning()` to the LSM index it stores its terms in. It implements `IndexInternal`
+  by composition rather than inheritance, so without this it silently answered the interface default of
+  `null` - and a full-text index is the one whose keys are user text, where non-ASCII characters actually
+  live. This is the `Paper[title,abstract]` half of the report.
+
+### The channel's premise had to widen
+
+`getUpgradeWarning()` was built for one shape of advice: an index on an older layout that still answers
+correctly and is only missing what the new layout buys (the geospatial cell layout of `#5478`). Its
+contract said so, `LocalSchema.reportUpgradeWarning` repeated it, and Studio's banner told the reader in
+so many words that the flagged indexes "keep working as they are - rebuilding is optional".
+
+A key-order mismatch is the other shape: the index does **not** answer correctly. Reusing the channel
+without saying so would have put a reassurance directly above a message explaining that lookups return
+fewer records than a scan.
+
+- `engine/src/main/java/com/arcadedb/index/IndexInternal.java` and
+  `engine/src/main/java/com/arcadedb/schema/LocalSchema.java`: the contract now names both shapes and
+  asks an implementation to make clear which one it is reporting.
+- `studio/src/main/resources/static/js/studio-database.js`: the banner drops the blanket "they keep
+  working as they are - rebuilding is optional" and just says a rebuild can be run at any time. Each
+  message underneath already states what its own condition costs. No other Studio change was needed - it
+  already groups the flagged rows by `typeIndexName` and renders one
+  ``REBUILD INDEX `Paper[title,abstract]` `` per logical index.
+
+### Not changed
+
+`LSMTreeGeoIndex` and `LSMSparseVectorIndex` also wrap an LSM index by composition. Neither is exposed to
+this: geospatial keys are ASCII geohash cells and sparse-vector keys are dimension identifiers, so no key
+either one stores can be ordered differently by the signed/unsigned change. `LSMTreeGeoIndex` additionally
+already overrides `getUpgradeWarning()` for its own layout advisory.
+
+## What an operator now gets
+
+One `WARNING` per affected logical index at open, naming the command that repairs it:
+
+```
+Index 'Paper[title,abstract]' of database 'papers' should be rebuilt: its pages are physically sorted
+in a different key order than the one lookups apply, ... Run: REBUILD INDEX `Paper[title,abstract]`
+```
+
+and, independent of the log, the affected set as a query:
+
+```sql
+SELECT name, typeIndexName, upgradeWarning FROM schema:indexes WHERE upgradeWarning IS NOT NULL
+```
+
+`typeIndexName` is the name `REBUILD INDEX` takes. Studio flags the same rows.
+
+## Verification
+
+`engine/src/test/java/com/arcadedb/index/lsm/Issue5802KeyOrderUpgradeWarningTest.java`.
+
+The disorder is planted by swapping two pointers of a page's entry array - the same physical state an
+index written under the old comparator ends up in, reproduced without needing the old comparator, and the
+technique the existing `LSMTreeIndexKeyOrderCheckTest` established. Each test compacts, disorders, and
+reopens, because the check runs when the sub-index is wired up.
+
+| Test | Pins |
+|---|---|
+| `aHealthyIndexCarriesNoUpgradeWarning` | No warning on a correctly ordered index, so the others can fail |
+| `aDisorderedCompactedIndexIsReportedAsAnUpgradeWarning` | The load-time verdict reaches `getUpgradeWarning()` |
+| `theAffectedIndexesAreDiscoverableFromSchemaIndexes` | `schema:indexes` and `schema:index:<name>` expose it, with `typeIndexName` carrying the rebuildable name |
+| `aTypeIndexReportsAWarningRaisedByANonFirstBucket` | The `TypeIndex` fix: a warning from a bucket other than the first is not swallowed |
+| `rebuildingTheIndexClearsTheWarning` | `REBUILD INDEX` is a real remedy and the advisory does not persist past it |
+
+Before the fix four of the five fail; `aHealthyIndexCarriesNoUpgradeWarning` passes throughout.
+`LSMTreeIndexKeyOrderCheckTest` is unchanged and still passes: it asserts on `checkRootPagesKeyOrder`,
+`checkIntegrity()` and `CHECK DATABASE`, none of which this touches.

--- a/docs/5802-lsm-key-order-upgrade-warning.md
+++ b/docs/5802-lsm-key-order-upgrade-warning.md
@@ -146,10 +146,12 @@ open path can establish cheaply: the compacted sub-index of each index. Two thin
   it can be mis-ordered and still not appear. This is the pre-existing scope of the detection (the old log
   line was compacted-only too), not something this change narrowed, and widening it would mean walking
   every mutable page of every index on the open path.
-- An index whose check could not run - a page read that failed - now says so at `WARNING` rather than
-  `FINE`. Previously that was invisible, which mattered less when the check only fed a log line; now that
-  its verdict backs a query, a check that did not run would otherwise be indistinguishable from a clean
-  one.
+- An index whose check could not run - a page read that failed - reports a distinct "could not be
+  verified" advisory rather than nothing, and logs at `WARNING` rather than `FINE`. Publishing the
+  *unknown* verdict through the same field is the point: leaving it null would answer "healthy" for an
+  index nobody checked, sending the operator back to the startup log this change exists to replace.
+  Rebuilding is a valid response to unverifiable too - it makes the order correct by construction - so
+  the remedy the advisory names still applies.
 
 `CHECK DATABASE` remains the exhaustive answer, at the cost of walking every page. The query is the cheap
 first pass an operator runs on a restart, not a clearance.
@@ -169,7 +171,17 @@ reopens, because the check runs when the sub-index is wired up.
 | `aDisorderedCompactedIndexIsReportedAsAnUpgradeWarning` | The load-time verdict reaches `getUpgradeWarning()` |
 | `theAffectedIndexesAreDiscoverableFromSchemaIndexes` | `schema:indexes` and `schema:index:<name>` expose it, with `typeIndexName` carrying the rebuildable name |
 | `aTypeIndexReportsAWarningRaisedByANonFirstBucket` | The `TypeIndex` fix: a warning from a bucket other than the first is not swallowed |
+| `aDisorderedFullTextIndexReportsThroughTheCompositionWrapper` | The `LSMTreeFullTextIndex` delegate - the half of the report whose keys are user text |
 | `rebuildingTheIndexClearsTheWarning` | `REBUILD INDEX` is a real remedy and the advisory does not persist past it |
+
+The full-text test reaches the compacted component through `getFileIds()` and `Schema.getFileById()`
+rather than a typed accessor, so it works against a wrapper that holds its LSM index by composition
+without adding production API for the test's benefit.
+
+**Untested:** the "could not be verified" branch. Firing it needs a page read to fail, and the layer
+below already converts a key that cannot be read into a reported problem rather than an exception
+(`checkKeyOrderInPage` catches its own), so the remaining path is genuine I/O failure. Staging that needs
+either mocks or page-internal corruption brittle enough to test the fixture rather than the code.
 
 Before the fix four of the five fail; `aHealthyIndexCarriesNoUpgradeWarning` passes throughout.
 `LSMTreeIndexKeyOrderCheckTest` is unchanged and still passes: it asserts on `checkRootPagesKeyOrder`,

--- a/docs/5802-lsm-key-order-upgrade-warning.md
+++ b/docs/5802-lsm-key-order-upgrade-warning.md
@@ -203,3 +203,34 @@ either mocks or page-internal corruption brittle enough to test the fixture rath
 Before the fix four of the five fail; `aHealthyIndexCarriesNoUpgradeWarning` passes throughout.
 `LSMTreeIndexKeyOrderCheckTest` is unchanged and still passes: it asserts on `checkRootPagesKeyOrder`,
 `checkIntegrity()` and `CHECK DATABASE`, none of which this touches.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5804
+
+### Review cycles
+
+| Cycle | Head | Outcome |
+|---|---|---|
+| 1 | `5114ab3` | LGTM, no blockers. Asked that the compacted-only scope be stated (the `schema:indexes` query is not an exhaustive affected-set), that a check which throws not be silently lost, and noted geo/sparse exemption rests entirely on the ASCII-key invariant. All three applied - the third by making both wrappers delegate rather than documenting the invariant harder. |
+| 2 | `d039878` | LGTM, no blockers. Caught that cycle 1 fixed only half of its own point: the failed check was raised to `WARNING` but still left the verdict null, so the query kept answering "healthy". Now published as a distinct unverifiable advisory. Also caught that the `LSMTreeFullTextIndex` delegate - described as half the report - had no test; added, and proven to fail with the delegate stubbed back to `null`. PR body corrected where it contradicted the diff. |
+| 3 | `2bf7243` | LGTM, no blockers. Found a real defect in cycle 2's change: `keyOrderCheckedOnLoad` was set *before* the check ran, and `onAfterLoad` resolves the sub-index through `Schema.getFileById()`, which returns the same instance on every load - so one transient page-read failure on a replica's Raft apply or snapshot resync would have pinned false "needs rebuild" advice on a healthy index for the lifetime of the database. Now only a *completed* check latches, and a later success clears a stale verdict. Also corrected the lock-free javadoc, which called a plain reference read volatile. Declined ranking UNVERIFIABLE below MISMATCH in `TypeIndex`: both name the same remedy, and `schema:indexes` already shows every distinct message on its own bucket row. |
+| 4 | `0d2c395` | LGTM, no blockers. Caught that `LSMTreeGeoIndex` returned its layout advisory *before* falling through, contradicting the comment directly above it - the delegation exists so a mismatch cannot be hidden, and that ordering hid it. Underlying is asked first now. Also flagged the Studio banner collapsing three severities under one "should be rebuilt" header; the header now asserts neither severity nor remedy. Declined adding a severity field to the wire format to reorder information that already renders in full as separate message groups. |
+
+Three of the four cycles found something a previous cycle had introduced or left
+half-finished, all in the reporting path rather than the detection: the queryability of the unknown
+verdict (cycle 2), the latching of a transient failure (cycle 3), and the geo return ordering (cycle 4).
+The detection logic itself was untouched throughout.
+
+### Known gap
+
+The `KEY_ORDER_UNVERIFIABLE_WARNING` branch has no test. `checkKeyOrderInPage` already converts an
+unreadable key into a reported problem rather than an exception, so what remains is genuine I/O failure,
+and staging it needs either mocks or page corruption brittle enough to test the fixture rather than the
+code. Cycle 3 reduced the exposure instead of covering it: the verdict is now self-healing, so the worst
+case is a `WARNING` and an advisory that clears on the next successful load.
+
+### Final state
+
+`max-cycles-reached` - four cycles run, every review LGTM with no blocking finding. Merge is the
+developer's call.

--- a/docs/5802-lsm-key-order-upgrade-warning.md
+++ b/docs/5802-lsm-key-order-upgrade-warning.md
@@ -153,6 +153,15 @@ open path can establish cheaply: the compacted sub-index of each index. Two thin
   Rebuilding is a valid response to unverifiable too - it makes the order correct by construction - so
   the remedy the advisory names still applies.
 
+  That verdict is **not latched**. `checkKeyOrderOnLoad()` marks itself done only when the check
+  *completed*, so a run that threw is retried on the next load of the component, and a later success
+  publishes the clean verdict over the stale one. This matters because the callback runs on every
+  component load - including the Raft apply path on a replica and a snapshot resync, where a page read
+  can fail transiently - and `onAfterLoad` resolves the sub-index through
+  `Schema.getFileById()`, which hands back the *same* instance every time. Latching the first failure
+  would therefore pin false "needs rebuild" advice on a healthy replica index for the lifetime of the
+  database. The retry costs the bounded root-page read again, only in the already-failing case.
+
 `CHECK DATABASE` remains the exhaustive answer, at the cost of walking every page. The query is the cheap
 first pass an operator runs on a restart, not a clearance.
 

--- a/docs/5802-lsm-key-order-upgrade-warning.md
+++ b/docs/5802-lsm-key-order-upgrade-warning.md
@@ -110,12 +110,17 @@ fewer records than a scan.
   already groups the flagged rows by `typeIndexName` and renders one
   ``REBUILD INDEX `Paper[title,abstract]` `` per logical index.
 
-### Not changed
+### Every LSM-backed wrapper reports, invariant or not
 
-`LSMTreeGeoIndex` and `LSMSparseVectorIndex` also wrap an LSM index by composition. Neither is exposed to
-this: geospatial keys are ASCII geohash cells and sparse-vector keys are dimension identifiers, so no key
-either one stores can be ordered differently by the signed/unsigned change. `LSMTreeGeoIndex` additionally
-already overrides `getUpgradeWarning()` for its own layout advisory.
+`LSMTreeGeoIndex` and `LSMSparseVectorIndex` also wrap an LSM index by composition, and neither should
+ever be exposed to this: geohash cells and dimension identifiers are ASCII, so no key either stores can be
+ordered differently by the signed/unsigned change.
+
+They delegate anyway. `LSMTreeGeoIndex` returns its own layout advisory first and falls through to the
+underlying index when it has none; `LSMSparseVectorIndex` delegates outright. The argument for exempting
+them is a claim about the *keys*, not a property of those classes, and an override that returns early
+would hide a mismatch if the claim ever stopped holding - a silent wrong answer being the exact failure
+mode this whole issue is about.
 
 ## What an operator now gets
 
@@ -133,6 +138,21 @@ SELECT name, typeIndexName, upgradeWarning FROM schema:indexes WHERE upgradeWarn
 ```
 
 `typeIndexName` is the name `REBUILD INDEX` takes. Studio flags the same rows.
+
+**That query is not an exhaustive affected-set, and should not be described as one.** It reports what the
+open path can establish cheaply: the compacted sub-index of each index. Two things fall outside it.
+
+- An index small enough never to have been compacted has no compacted sub-index, so it is never checked -
+  it can be mis-ordered and still not appear. This is the pre-existing scope of the detection (the old log
+  line was compacted-only too), not something this change narrowed, and widening it would mean walking
+  every mutable page of every index on the open path.
+- An index whose check could not run - a page read that failed - now says so at `WARNING` rather than
+  `FINE`. Previously that was invisible, which mattered less when the check only fed a log line; now that
+  its verdict backs a query, a check that did not run would otherwise be indistinguishable from a clean
+  one.
+
+`CHECK DATABASE` remains the exhaustive answer, at the cost of walking every page. The query is the cheap
+first pass an operator runs on a restart, not a clearance.
 
 ## Verification
 

--- a/docs/5802-lsm-key-order-upgrade-warning.md
+++ b/docs/5802-lsm-key-order-upgrade-warning.md
@@ -104,10 +104,13 @@ fewer records than a scan.
 - `engine/src/main/java/com/arcadedb/index/IndexInternal.java` and
   `engine/src/main/java/com/arcadedb/schema/LocalSchema.java`: the contract now names both shapes and
   asks an implementation to make clear which one it is reporting.
-- `studio/src/main/resources/static/js/studio-database.js`: the banner drops the blanket "they keep
-  working as they are - rebuilding is optional" and just says a rebuild can be run at any time. Each
-  message underneath already states what its own condition costs. No other Studio change was needed - it
-  already groups the flagged rows by `typeIndexName` and renders one
+- `studio/src/main/resources/static/js/studio-database.js`: the banner header now states neither a
+  severity nor a remedy - "Some indexes need attention. Each note below says what is wrong and what to do
+  about it." Three conditions can reach it now (missing a newer layout's benefit, confirmed under-return,
+  and not verifiable at startup), and a shared header naming a remedy would overstate the mildest and
+  understate the worst. The per-message text carries both, and Studio already groups rows by message, so
+  each condition renders as its own block with its own affected index names. No other Studio change was
+  needed - it already keys those blocks on `typeIndexName` and renders one
   ``REBUILD INDEX `Paper[title,abstract]` `` per logical index.
 
 ### Every LSM-backed wrapper reports, invariant or not
@@ -116,11 +119,16 @@ fewer records than a scan.
 ever be exposed to this: geohash cells and dimension identifiers are ASCII, so no key either stores can be
 ordered differently by the signed/unsigned change.
 
-They delegate anyway. `LSMTreeGeoIndex` returns its own layout advisory first and falls through to the
-underlying index when it has none; `LSMSparseVectorIndex` delegates outright. The argument for exempting
-them is a claim about the *keys*, not a property of those classes, and an override that returns early
-would hide a mismatch if the claim ever stopped holding - a silent wrong answer being the exact failure
-mode this whole issue is about.
+They delegate anyway. `LSMSparseVectorIndex` delegates outright; `LSMTreeGeoIndex` asks the underlying
+index **first** and falls back to its own layout advisory. The argument for exempting them is a claim
+about the *keys*, not a property of those classes, and an override that returned early would hide a
+mismatch if the claim ever stopped holding - a silent wrong answer being the exact failure mode this
+whole issue is about.
+
+The geo ordering is deliberate and was corrected during review: asking the layout advisory first would
+have masked a key-order mismatch behind it, which is precisely what the delegation exists to prevent. A
+mismatch is a correctness fault (lookups under-return); the legacy cell layout is a cost advisory. The
+worse of the two wins.
 
 ## What an operator now gets
 

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -218,11 +218,14 @@ public interface IndexInternal extends Index {
   /**
    * Returns a human-readable reason why this index should be rebuilt, or {@code null} when there is none.
    * <p>
-   * An index whose on-disk layout predates a change the engine cannot apply in place keeps working with the old
-   * layout - correctness first - but does not get whatever the new one buys. This is how it says so: the schema
-   * load logs it once per database open, and it is exposed as {@code upgradeWarning} on {@code schema:indexes} and
-   * {@code schema:index:<name>}, which is what Studio renders. The remedy is always
-   * {@code REBUILD INDEX &lt;name&gt;}, so say what is lost and why, not what to type.
+   * Two shapes reach this. Most often an index whose on-disk layout predates a change the engine cannot apply in
+   * place keeps working with the old layout - correctness first - but does not get whatever the new one buys. The
+   * other is an index the current build can no longer read correctly at all, such as one whose physical key order
+   * predates the string comparison fix of #5321 and whose lookups therefore return fewer records than a scan
+   * (#5802). Either way this is how it says so: the schema load logs it once per database open, and it is exposed as
+   * {@code upgradeWarning} on {@code schema:indexes} and {@code schema:index:<name>}, which is what Studio renders.
+   * The remedy is always {@code REBUILD INDEX &lt;name&gt;}, so say what is lost and why, not what to type - and,
+   * since the two shapes cost the reader very different things, say which one this is.
    * <p>
    * Implementations must keep this cheap and side-effect free: it is called per index on every listing.
    */

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -325,8 +325,16 @@ public class TypeIndex implements RangeIndex, IndexInternal {
 
   @Override
   public String getUpgradeWarning() {
-    // Every bucket sub-index of a type index shares one definition, so the first one answers for all of them.
-    return getFirstUnderlyingIndex().getUpgradeWarning();
+    // A definition-derived warning is the same on every bucket sub-index, but a PHYSICAL one - a key order that no
+    // longer matches the comparator (#5802) - is raised per bucket, and asking only the first one would report a type
+    // index healthy while another of its buckets needs a rebuild. The first answer found wins: they read alike, and
+    // the remedy is one REBUILD INDEX over the whole logical index either way.
+    for (final IndexInternal index : indexesOnBuckets) {
+      final String warning = index.getUpgradeWarning();
+      if (warning != null)
+        return warning;
+    }
+    return null;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -1124,6 +1124,16 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     return underlyingIndex.isCompacting();
   }
 
+  /**
+   * A full-text index stores its terms in an ordinary LSM string index, so it is exposed to the same physical
+   * key-order mismatch after an upgrade (#5802) - and its terms are user text, which is where non-ASCII characters
+   * actually live.
+   */
+  @Override
+  public String getUpgradeWarning() {
+    return underlyingIndex.getUpgradeWarning();
+  }
+
   @Override
   public boolean scheduleCompaction() {
     return underlyingIndex.scheduleCompaction();

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -569,13 +569,16 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
   public String getUpgradeWarning() {
     // Built once in the constructor: this is called per index on every schema:indexes / schema:types listing, and the
     // contract on IndexInternal#getUpgradeWarning is that it stays cheap.
-    if (upgradeWarning != null)
-      return upgradeWarning;
+    // The LSM index the cells are stored in is asked FIRST, and deliberately so. A geohash cell is ASCII, so the
+    // key-order mismatch of #5802 should never arise here - but "should never" is the invariant, not the mechanism.
+    // If it ever did arise it would be a correctness fault (lookups under-returning), while the layout advisory
+    // below is about cost, so returning the layout one first would mask the worse of the two - the very hiding this
+    // delegation exists to prevent.
+    final String underlyingWarning = underlyingIndex.getUpgradeWarning();
+    if (underlyingWarning != null)
+      return underlyingWarning;
 
-    // Falling through to the LSM index the cells are stored in rather than stopping at the layout advisory: a
-    // geohash cell is ASCII, so the key-order mismatch of #5802 should never arise here - but "should never" is the
-    // invariant, not the mechanism, and an override that returns early would hide it if the invariant ever broke.
-    return underlyingIndex.getUpgradeWarning();
+    return upgradeWarning;
   }
 
   // ---- Private helpers ----

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -569,7 +569,13 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
   public String getUpgradeWarning() {
     // Built once in the constructor: this is called per index on every schema:indexes / schema:types listing, and the
     // contract on IndexInternal#getUpgradeWarning is that it stays cheap.
-    return upgradeWarning;
+    if (upgradeWarning != null)
+      return upgradeWarning;
+
+    // Falling through to the LSM index the cells are stored in rather than stopping at the layout advisory: a
+    // geohash cell is ASCII, so the key-order mismatch of #5802 should never arise here - but "should never" is the
+    // invariant, not the mechanism, and an override that returns early would hide it if the invariant ever broke.
+    return underlyingIndex.getUpgradeWarning();
   }
 
   // ---- Private helpers ----

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -722,6 +722,24 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
     });
   }
 
+  /**
+   * Reports the verdict of the bounded key-order check the compacted sub-index runs when it is loaded. That check
+   * already logged the offending pages, but only under the sub-index's physical name ({@code Paper_0_84306331895885}),
+   * which is neither what an operator would search for nor what they would rebuild. Answering here instead routes it
+   * through the standard advisory channel: the schema load logs it once per LOGICAL index with the exact
+   * {@code REBUILD INDEX} to run, and {@code schema:indexes} / {@code schema:index:<name>} expose it as
+   * {@code upgradeWarning}, so the affected set is queryable rather than something to grep out of a startup log
+   * (#5802).
+   * <p>
+   * Only the compacted sub-index is covered: verifying the mutable pages means walking all of them, which is what
+   * {@link #checkIntegrity()} does for CHECK DATABASE and what the open path must not do.
+   */
+  @Override
+  public String getUpgradeWarning() {
+    final LSMTreeIndexCompacted subIndex = mutable.getSubIndex();
+    return subIndex != null ? subIndex.getKeyOrderMismatch() : null;
+  }
+
   @Override
   public LSMTreeIndexAbstract.NULL_STRATEGY getNullStrategy() {
     return mutable.nullStrategy;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -736,6 +736,12 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
    * small enough never to have been compacted can be mis-ordered and still answer {@code null} here, and the set this
    * feeds on {@code schema:indexes} is "the affected indexes we can name cheaply", not "every affected index".
    * CHECK DATABASE remains the exhaustive answer.
+   * <p>
+   * <b>Deliberately lock-free</b>, unlike the neighbouring {@link #checkIntegrity()}, which takes the read lock
+   * because it walks pages a concurrent compaction could drop underneath it. This reads one volatile field of
+   * whichever sub-index is published at the time, and a compaction that swaps in a fresh one is harmless: the old
+   * instance's verdict was true of the file it was computed from, and the new one carries its own. Taking the lock
+   * would put a getter that every schema listing calls per index behind the compaction's write lock for nothing.
    */
   @Override
   public String getUpgradeWarning() {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -731,8 +731,11 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
    * {@code upgradeWarning}, so the affected set is queryable rather than something to grep out of a startup log
    * (#5802).
    * <p>
-   * Only the compacted sub-index is covered: verifying the mutable pages means walking all of them, which is what
-   * {@link #checkIntegrity()} does for CHECK DATABASE and what the open path must not do.
+   * <b>Scope.</b> Only the compacted sub-index is covered: verifying the mutable pages means walking all of them,
+   * which is what {@link #checkIntegrity()} does for CHECK DATABASE and what the open path must not do. So an index
+   * small enough never to have been compacted can be mis-ordered and still answer {@code null} here, and the set this
+   * feeds on {@code schema:indexes} is "the affected indexes we can name cheaply", not "every affected index".
+   * CHECK DATABASE remains the exhaustive answer.
    */
   @Override
   public String getUpgradeWarning() {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -738,10 +738,12 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
    * CHECK DATABASE remains the exhaustive answer.
    * <p>
    * <b>Deliberately lock-free</b>, unlike the neighbouring {@link #checkIntegrity()}, which takes the read lock
-   * because it walks pages a concurrent compaction could drop underneath it. This reads one volatile field of
-   * whichever sub-index is published at the time, and a compaction that swaps in a fresh one is harmless: the old
-   * instance's verdict was true of the file it was computed from, and the new one carries its own. Taking the lock
-   * would put a getter that every schema listing calls per index behind the compaction's write lock for nothing.
+   * because it walks pages a concurrent compaction could drop underneath it. Two reads happen here and only the
+   * second is synchronized: the sub-index REFERENCE is a plain field, so racing a compaction's swap is a benign data
+   * race that yields either instance or transiently null; the verdict it then reads is volatile. Every outcome is
+   * sound for an advisory - the old instance's verdict was true of the file it was computed from, the new one
+   * carries its own, and null merely withholds advice for an instant. Taking the lock would put a getter that every
+   * schema listing calls per index behind the compaction's write lock to buy none of that.
    */
   @Override
   public String getUpgradeWarning() {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -762,9 +762,13 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
             problems);
       }
     } catch (final Exception e) {
+      // WARNING, not FINE: the verdict now backs a queryable surface, so a check that could not run leaves
+      // schema:indexes answering "healthy" for an index whose order is in fact UNKNOWN. Say so, or the absence of a
+      // row reads as proof of health.
       LogManager.instance()
-          .log(this, Level.FINE, "Error on checking the key order of index '%s' at load time (%s)", null, getName(),
-              e.getMessage());
+          .log(this, Level.WARNING,
+              "Cannot verify the physical key order of index '%s': it is not covered by the rebuild advice reported on "
+                  + "schema:indexes, run CHECK DATABASE to check it (error=%s)", null, getName(), e.getMessage());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -57,8 +57,22 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
   private static final int MAX_SERIES_CHECKED_ON_LOAD    = 2;
   private static final int MAX_PROBLEMS_REPORTED_ON_LOAD = 3;
 
+  /**
+   * What an operator is told when the load-time check finds this file sorted under a different key order. Phrased as
+   * the {@code getUpgradeWarning()} contract asks: what is wrong and what it costs, not what to type - the schema
+   * load appends the {@code REBUILD INDEX} command naming the logical index.
+   */
+  private static final String KEY_ORDER_MISMATCH_WARNING =
+      "its pages are physically sorted in a different key order than the one lookups apply, which is the state an "
+          + "index written before the string key order was corrected (issue #5321) is left in when its keys hold "
+          + "non-ASCII characters: until it is rebuilt a lookup on it can return fewer records than a scan, or records "
+          + "of unrelated keys";
+
   /** The load-time key-order check runs once per loaded instance, not on every schema change that reloads the index. */
   private volatile boolean keyOrderCheckedOnLoad = false;
+
+  /** Set by {@link #checkKeyOrderOnLoad()} when the check found a mismatch, null otherwise. See {@link #getKeyOrderMismatch()}. */
+  private volatile String keyOrderMismatch = null;
 
   /**
    * The live {@link LSMTreeIndexUnderlyingCompactedSeriesCursor}s over this file, one entry per open cursor. Series
@@ -724,9 +738,15 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
   }
 
   /**
-   * Runs {@link #checkRootPagesKeyOrder(int, int)} once per loaded instance and reports the outcome as a WARNING, so an
-   * index left physically mis-ordered by an older build is reported at startup instead of silently under-returning on
-   * every lookup. Never propagates: a failure to run the check must not stop the database from opening.
+   * Runs {@link #checkRootPagesKeyOrder(int, int)} once per loaded instance and records the outcome, so an index left
+   * physically mis-ordered by an older build is reported at startup instead of silently under-returning on every
+   * lookup. Never propagates: a failure to run the check must not stop the database from opening.
+   * <p>
+   * The operator-facing report is {@link LSMTreeIndex#getUpgradeWarning()}, which the schema load logs once per
+   * LOGICAL index together with the {@code REBUILD INDEX} command that repairs it, and which
+   * {@code schema:indexes} exposes so the affected set can be queried rather than grepped out of a startup log
+   * (#5802). What stays here is the physical evidence - page and entry numbers of THIS bucket sub-index - which is
+   * support detail, not something an operator acts on, so it goes to FINE.
    */
   void checkKeyOrderOnLoad() {
     if (keyOrderCheckedOnLoad)
@@ -735,15 +755,26 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
 
     try {
       final List<String> problems = checkRootPagesKeyOrder(MAX_SERIES_CHECKED_ON_LOAD, MAX_PROBLEMS_REPORTED_ON_LOAD);
-      if (!problems.isEmpty())
-        LogManager.instance().log(this, Level.WARNING,
-            "Index '%s' is physically ordered differently than the current key comparator, so lookups can return fewer (or foreign) records than a scan: run 'REBUILD INDEX %s'. Details: %s",
-            null, getName(), getName(), problems);
+      if (!problems.isEmpty()) {
+        keyOrderMismatch = KEY_ORDER_MISMATCH_WARNING;
+        LogManager.instance().log(this, Level.FINE,
+            "Index '%s' is physically ordered differently than the current key comparator. Details: %s", null, getName(),
+            problems);
+      }
     } catch (final Exception e) {
       LogManager.instance()
           .log(this, Level.FINE, "Error on checking the key order of index '%s' at load time (%s)", null, getName(),
               e.getMessage());
     }
+  }
+
+  /**
+   * The verdict of {@link #checkKeyOrderOnLoad()}, or {@code null} when it found nothing or could not run. Reading a
+   * cached field is what lets {@link LSMTreeIndex#getUpgradeWarning()} honour its "cheap and side-effect free"
+   * contract: it is called per index on every schema listing and must not touch a page to answer.
+   */
+  String getKeyOrderMismatch() {
+    return keyOrderMismatch;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -78,9 +78,9 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
           + "by construction";
 
   /**
-   * The load-time key-order check runs once per loaded instance, not on every schema change that reloads the index.
-   * Set BEFORE the check runs, so a check that throws is not retried on this instance either: it would re-read pages
-   * behind a getter the schema listings call per index, and the failure is already published as a verdict.
+   * Whether the check has COMPLETED for this instance - not merely been attempted. It suppresses a re-run on every
+   * schema change that reloads the index, but a run that threw leaves it false on purpose so the next load tries
+   * again rather than latching a transient I/O failure into permanent advice (see {@link #checkKeyOrderOnLoad()}).
    */
   private volatile boolean keyOrderCheckedOnLoad = false;
 
@@ -764,25 +764,31 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
   void checkKeyOrderOnLoad() {
     if (keyOrderCheckedOnLoad)
       return;
-    keyOrderCheckedOnLoad = true;
 
     try {
       final List<String> problems = checkRootPagesKeyOrder(MAX_SERIES_CHECKED_ON_LOAD, MAX_PROBLEMS_REPORTED_ON_LOAD);
-      if (!problems.isEmpty()) {
-        keyOrderMismatch = KEY_ORDER_MISMATCH_WARNING;
+      // A completed run always publishes the definitive verdict, INCLUDING the clean one: it is what clears a stale
+      // "could not be verified" left by an earlier attempt that failed.
+      keyOrderMismatch = problems.isEmpty() ? null : KEY_ORDER_MISMATCH_WARNING;
+      keyOrderCheckedOnLoad = true;
+      if (!problems.isEmpty())
         LogManager.instance().log(this, Level.FINE,
             "Index '%s' is physically ordered differently than the current key comparator. Details: %s", null, getName(),
             problems);
-      }
     } catch (final Exception e) {
-      // A check that could not run must not be reported as a clean one. Publishing the UNKNOWN verdict through the
-      // same field is what keeps it queryable: leaving it null would send an operator back to grepping the startup
-      // log, which is the problem this whole path exists to remove. Rebuilding is a valid response to "unverifiable"
-      // too - it makes the order correct by construction - so the remedy the advisory names still applies.
+      // A check that could not run must not be reported as a clean one: leaving this null would send an operator back
+      // to grepping the startup log, which is what this path exists to remove. Rebuilding is a valid response to
+      // "unverifiable" too - it makes the order correct by construction - so the remedy the advisory names holds.
+      //
+      // Deliberately WITHOUT setting keyOrderCheckedOnLoad, so the next load of this component retries. This callback
+      // runs on every component load, including the Raft apply path on a replica and a snapshot resync, where a page
+      // read can fail transiently; the component instance is reused across those loads, so latching the failure would
+      // pin false "needs rebuild" advice on a healthy index for the lifetime of the database. The retry costs the
+      // bounded root-page read again and only in the already-failing case, and a later success clears the verdict.
       keyOrderMismatch = KEY_ORDER_UNVERIFIABLE_WARNING;
       LogManager.instance()
-          .log(this, Level.WARNING, "Cannot verify the physical key order of index '%s' (error=%s)", null, getName(),
-              e.getMessage());
+          .log(this, Level.WARNING, "Cannot verify the physical key order of index '%s', retrying on the next load (error=%s)",
+              null, getName(), e.getMessage());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -68,7 +68,20 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
           + "non-ASCII characters: until it is rebuilt a lookup on it can return fewer records than a scan, or records "
           + "of unrelated keys";
 
-  /** The load-time key-order check runs once per loaded instance, not on every schema change that reloads the index. */
+  /**
+   * The other verdict the check can reach: it could not read what it needed. Distinct from silence, which would say
+   * the order was confirmed good - see the catch in {@link #checkKeyOrderOnLoad()}.
+   */
+  private static final String KEY_ORDER_UNVERIFIABLE_WARNING =
+      "its physical key order could not be verified when the database opened, so it is not known whether it matches "
+          + "the order lookups apply; run CHECK DATABASE for the full answer, or rebuild it to make the order correct "
+          + "by construction";
+
+  /**
+   * The load-time key-order check runs once per loaded instance, not on every schema change that reloads the index.
+   * Set BEFORE the check runs, so a check that throws is not retried on this instance either: it would re-read pages
+   * behind a getter the schema listings call per index, and the failure is already published as a verdict.
+   */
   private volatile boolean keyOrderCheckedOnLoad = false;
 
   /** Set by {@link #checkKeyOrderOnLoad()} when the check found a mismatch, null otherwise. See {@link #getKeyOrderMismatch()}. */
@@ -762,13 +775,14 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
             problems);
       }
     } catch (final Exception e) {
-      // WARNING, not FINE: the verdict now backs a queryable surface, so a check that could not run leaves
-      // schema:indexes answering "healthy" for an index whose order is in fact UNKNOWN. Say so, or the absence of a
-      // row reads as proof of health.
+      // A check that could not run must not be reported as a clean one. Publishing the UNKNOWN verdict through the
+      // same field is what keeps it queryable: leaving it null would send an operator back to grepping the startup
+      // log, which is the problem this whole path exists to remove. Rebuilding is a valid response to "unverifiable"
+      // too - it makes the order correct by construction - so the remedy the advisory names still applies.
+      keyOrderMismatch = KEY_ORDER_UNVERIFIABLE_WARNING;
       LogManager.instance()
-          .log(this, Level.WARNING,
-              "Cannot verify the physical key order of index '%s': it is not covered by the rebuild advice reported on "
-                  + "schema:indexes, run CHECK DATABASE to check it (error=%s)", null, getName(), e.getMessage());
+          .log(this, Level.WARNING, "Cannot verify the physical key order of index '%s' (error=%s)", null, getName(),
+              e.getMessage());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -559,6 +559,16 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     return underlyingIndex.isCompacting();
   }
 
+  /**
+   * Delegated rather than left at the interface default: a sparse-vector posting key is a dimension identifier, so
+   * the key-order mismatch of #5802 should never arise here - but that is an invariant about the keys, not a property
+   * of this class, and answering {@code null} unconditionally would hide the mismatch if it ever did.
+   */
+  @Override
+  public String getUpgradeWarning() {
+    return underlyingIndex.getUpgradeWarning();
+  }
+
   @Override
   public boolean scheduleCompaction() {
     return underlyingIndex.scheduleCompaction();

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -2552,10 +2552,12 @@ public class LocalSchema implements Schema {
   }
 
   /**
-   * Logs, once per opened database and per LOGICAL index, the reason an index should be rebuilt. An index whose
-   * on-disk layout predates a change the engine cannot apply in place keeps working exactly as it did, so this is
-   * advice and never an error; it is the only moment an operator would otherwise have no way of learning that a
-   * `REBUILD INDEX` is worth running. The same text reaches Studio through {@code schema:indexes}.
+   * Logs, once per opened database and per LOGICAL index, the reason an index should be rebuilt. How much that
+   * matters is carried by the message itself: an index whose on-disk layout merely predates a change the engine
+   * cannot apply in place keeps working exactly as it did, while one whose physical key order predates #5321 answers
+   * lookups with fewer records than a scan (#5802). Either way this is the only moment an operator would otherwise
+   * have no way of learning that a `REBUILD INDEX` is worth running - and the reason it names the LOGICAL index, not
+   * the bucket sub-index that raised it. The same text reaches Studio through {@code schema:indexes}.
    *
    * @see IndexInternal#getUpgradeWarning()
    */

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue5802KeyOrderUpgradeWarningTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue5802KeyOrderUpgradeWarningTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.arcadedb.database.Binary.INT_SERIALIZED_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5802: an in-place binary upgrade leaves indexes written under the pre-#5321 key order physically sorted the wrong
+ * way. The load-time check reports it, but only as a WARNING naming the physical bucket sub-index
+ * ({@code Paper_0_84306331895885}) - an operator who did not read the startup log has no way to learn which indexes
+ * need a {@code REBUILD INDEX}, and the name in the log is not the one they would act on.
+ * <p>
+ * The outcome of that check is now an {@link IndexInternal#getUpgradeWarning() upgrade warning}, so it reaches the
+ * same surfaces every other "this index should be rebuilt" advisory does: one deduplicated log line per database open
+ * naming the LOGICAL index, and the {@code upgradeWarning} property of {@code schema:indexes} and
+ * {@code schema:index:<name>} - which is what Studio renders and what makes the affected set queryable.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5802KeyOrderUpgradeWarningTest extends TestHelper {
+
+  private static final String TYPE_NAME = "Paper";
+
+  @Override
+  public void beforeTest() {
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+  }
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // Most of these tests deliberately leave a disordered index behind, which the integrity check correctly reports.
+    return false;
+  }
+
+  private void createAndPopulate(final int totalBuckets) {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(totalBuckets)
+        .create();
+    type.createProperty("author", String.class);
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "author" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(false).withPageSize(4096).create();
+
+    // Accented names are the shape #5321 mis-sorted: their UTF-8 lead byte is negative as a Java byte.
+    final String[] authors = { "Á Rodríguez-Lescure", "Àngels Sahuquillo", "Zihao Zou", "Zi-Xuan Guo", "Ziyi Xu",
+        "Zobaida Lahari", "Zuohua Xie", "Muster" };
+    // Per bucket, because a sub-index is only created once its mutable index holds more than one page.
+    final int records = 2_000 * totalBuckets;
+    database.transaction(() -> {
+      for (int i = 0; i < records; i++)
+        database.newDocument(TYPE_NAME).set("author", authors[i % authors.length]).save();
+    });
+  }
+
+  private TypeIndex typeIndex() {
+    return (TypeIndex) database.getSchema().getType(TYPE_NAME).getAllIndexes(false).iterator().next();
+  }
+
+  private List<LSMTreeIndex> bucketIndexes() {
+    final List<LSMTreeIndex> indexes = new ArrayList<>();
+    for (final Index bucketIndex : typeIndex().getIndexesOnBuckets())
+      indexes.add((LSMTreeIndex) bucketIndex);
+    return indexes;
+  }
+
+  /** Compacts every bucket sub-index and returns those that ended up with a compacted sub-index to disorder. */
+  private List<LSMTreeIndex> compactAll() throws Exception {
+    final List<LSMTreeIndex> compacted = new ArrayList<>();
+    for (final LSMTreeIndex index : bucketIndexes()) {
+      if (index.scheduleCompaction())
+        index.compact();
+      if (index.getMutableIndex().getSubIndex() != null)
+        compacted.add(index);
+    }
+    return compacted;
+  }
+
+  /**
+   * Swaps the first two entries of every page holding at least two of them. That is the same physical state an index
+   * written under the pre-#5321 signed byte order ends up in, reproduced without needing the old comparator.
+   */
+  private void disorderPages(final LSMTreeIndexAbstract index) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.transaction(() -> {
+      for (int pageNumber = 0; pageNumber < index.getTotalPages(); ++pageNumber) {
+        try {
+          final MutablePage page = db.getTransaction()
+              .getPageToModify(new PageId(database, index.getFileId(), pageNumber), index.getPageSize(), false);
+
+          if (index.getCount(page) < 2)
+            continue;
+
+          final int startIndexArray = index.getHeaderSize(pageNumber);
+          final int first = page.readInt(startIndexArray);
+          final int second = page.readInt(startIndexArray + INT_SERIALIZED_SIZE);
+          page.writeInt(startIndexArray, second);
+          page.writeInt(startIndexArray + INT_SERIALIZED_SIZE, first);
+        } catch (final Exception e) {
+          throw new IllegalStateException("Cannot alter page " + pageNumber, e);
+        }
+      }
+    });
+  }
+
+  private List<Result> schemaIndexesWithUpgradeWarning() {
+    final List<Result> rows = new ArrayList<>();
+    final ResultSet rs = database.query("sql", "SELECT FROM schema:indexes");
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      if (row.getProperty("upgradeWarning") != null)
+        rows.add(row);
+    }
+    return rows;
+  }
+
+  @Test
+  void aHealthyIndexCarriesNoUpgradeWarning() throws Exception {
+    createAndPopulate(1);
+    compactAll();
+    reopenDatabase();
+
+    assertThat(bucketIndexes().getFirst().getUpgradeWarning()).isNull();
+    assertThat(typeIndex().getUpgradeWarning()).isNull();
+    assertThat(schemaIndexesWithUpgradeWarning()).isEmpty();
+  }
+
+  @Test
+  void aDisorderedCompactedIndexIsReportedAsAnUpgradeWarning() throws Exception {
+    createAndPopulate(1);
+    compactAll();
+    disorderPages(bucketIndexes().getFirst().getMutableIndex().getSubIndex());
+
+    reopenDatabase();
+
+    final String warning = bucketIndexes().getFirst().getUpgradeWarning();
+    assertThat(warning).as("the load-time key-order check is exposed as an upgrade warning").isNotNull();
+    assertThat(warning).containsIgnoringCase("key order");
+  }
+
+  /**
+   * The point of the fix: the affected set is queryable. {@code typeIndexName} carries the name a
+   * {@code REBUILD INDEX} takes, which the physical sub-index name in the log line does not.
+   */
+  @Test
+  void theAffectedIndexesAreDiscoverableFromSchemaIndexes() throws Exception {
+    createAndPopulate(1);
+    compactAll();
+    disorderPages(bucketIndexes().getFirst().getMutableIndex().getSubIndex());
+
+    reopenDatabase();
+
+    // schema:indexes lists both the logical type index and its bucket sub-index, and every flagged row must carry the
+    // name a REBUILD INDEX takes - which the physical sub-index name in the log line is not.
+    final List<Result> flagged = schemaIndexesWithUpgradeWarning();
+    assertThat(flagged).isNotEmpty();
+    assertThat(flagged).allMatch(row -> typeIndex().getName().equals(row.getProperty("typeIndexName")));
+    assertThat(flagged.stream().map(row -> (String) row.getProperty("name")))
+        .contains(typeIndex().getName(), bucketIndexes().getFirst().getName());
+
+    final ResultSet detail = database.query("sql", "SELECT FROM schema:index:`" + typeIndex().getName() + "`");
+    assertThat(detail.hasNext()).isTrue();
+    assertThat((String) detail.next().getProperty("upgradeWarning")).isNotNull();
+  }
+
+  /**
+   * A key-order mismatch is PHYSICAL state, so it can affect any bucket sub-index independently - unlike the
+   * definition-derived warnings the type index used to answer for by asking only its first bucket.
+   */
+  @Test
+  void aTypeIndexReportsAWarningRaisedByANonFirstBucket() throws Exception {
+    createAndPopulate(3);
+
+    final List<LSMTreeIndex> compacted = compactAll();
+    assertThat(compacted).as("more than one bucket sub-index was compacted").hasSizeGreaterThan(1);
+    assertThat(compacted.getLast()).isNotSameAs(bucketIndexes().getFirst());
+    disorderPages(compacted.getLast().getMutableIndex().getSubIndex());
+
+    reopenDatabase();
+
+    assertThat(bucketIndexes().getFirst().getUpgradeWarning()).as("the first bucket is healthy").isNull();
+    assertThat(typeIndex().getUpgradeWarning()).as("the type index answers for every bucket").isNotNull();
+  }
+
+  @Test
+  void rebuildingTheIndexClearsTheWarning() throws Exception {
+    createAndPopulate(1);
+    compactAll();
+    disorderPages(bucketIndexes().getFirst().getMutableIndex().getSubIndex());
+
+    reopenDatabase();
+    assertThat(typeIndex().getUpgradeWarning()).isNotNull();
+
+    database.command("sql", "REBUILD INDEX `" + typeIndex().getName() + "`");
+
+    assertThat(typeIndex().getUpgradeWarning()).isNull();
+    assertThat(schemaIndexesWithUpgradeWarning()).isEmpty();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue5802KeyOrderUpgradeWarningTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue5802KeyOrderUpgradeWarningTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.engine.PageId;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.fulltext.LSMTreeFullTextIndex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
@@ -213,6 +214,58 @@ class Issue5802KeyOrderUpgradeWarningTest extends TestHelper {
 
     assertThat(bucketIndexes().getFirst().getUpgradeWarning()).as("the first bucket is healthy").isNull();
     assertThat(typeIndex().getUpgradeWarning()).as("the type index answers for every bucket").isNotNull();
+  }
+
+  /**
+   * A full-text index reaches {@code IndexInternal} by composition, not inheritance, so before the delegate was added
+   * it silently answered the interface default of {@code null}. Its keys are analyzed user text - the one place
+   * non-ASCII characters are guaranteed to turn up - which makes it the half of the report most likely to be missed.
+   */
+  @Test
+  void aDisorderedFullTextIndexReportsThroughTheCompositionWrapper() throws Exception {
+    final String ftType = "Article";
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(ftType).withTotalBuckets(1).create();
+      database.getSchema().getType(ftType).createProperty("title", String.class);
+      database.getSchema().buildTypeIndex(ftType, new String[] { "title" }).withType(Schema.INDEX_TYPE.FULL_TEXT)
+          .withFullTextType().withPageSize(4096).create();
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < 2_000; i++)
+        database.newDocument(ftType).set("title", "sécurité robuste entropie término " + i).save();
+    });
+
+    final TypeIndex ftIndex = (TypeIndex) database.getSchema().getIndexByName(ftType + "[title]");
+    final IndexInternal ftBucketIndex = ftIndex.getIndexesOnBuckets()[0];
+    assertThat(ftBucketIndex).isInstanceOf(LSMTreeFullTextIndex.class);
+
+    if (ftBucketIndex.scheduleCompaction())
+      ftBucketIndex.compact();
+
+    final LSMTreeIndexCompacted subIndex = compactedSubIndexOf(ftBucketIndex);
+    assertThat(subIndex).as("the full-text index was compacted").isNotNull();
+    disorderPages(subIndex);
+
+    reopenDatabase();
+
+    final TypeIndex reloaded = (TypeIndex) database.getSchema().getIndexByName(ftType + "[title]");
+    assertThat(reloaded.getIndexesOnBuckets()[0].getUpgradeWarning())
+        .as("the wrapper delegates instead of answering the interface default").isNotNull();
+    assertThat(reloaded.getUpgradeWarning()).isNotNull();
+  }
+
+  /**
+   * The compacted component of an index, reached through its file ids rather than a typed accessor, so this works
+   * for a wrapper that holds its LSM index by composition just as well as for a plain one.
+   */
+  private LSMTreeIndexCompacted compactedSubIndexOf(final IndexInternal index) {
+    for (final int fileId : index.getFileIds())
+      if (database.getSchema().getFileById(fileId) instanceof final LSMTreeIndexCompacted compacted)
+        return compacted;
+    return null;
   }
 
   @Test

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -6080,8 +6080,11 @@ function renderIndexUpgradeWarningBanner(needRebuild) {
     if (names.indexOf(name) < 0) names.push(name);
   }
 
+  // No blanket claim about what a rebuild is worth: these messages no longer all describe an index that still answers
+  // correctly. A key-order mismatch left by an upgrade (#5802) makes lookups return fewer records than a scan, so each
+  // message below says what it costs and the reader is not told up front that it is optional.
   var html = "<div><i class='fa fa-exclamation-triangle me-1'></i><strong>Some indexes should be rebuilt.</strong> " +
-    "They keep working as they are - rebuilding is optional and can be done at any time.</div>";
+    "A rebuild can be run at any time.</div>";
 
   for (var message in byMessage) {
     var names = byMessage[message].sort();

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -6080,11 +6080,12 @@ function renderIndexUpgradeWarningBanner(needRebuild) {
     if (names.indexOf(name) < 0) names.push(name);
   }
 
-  // No blanket claim about what a rebuild is worth: these messages no longer all describe an index that still answers
-  // correctly. A key-order mismatch left by an upgrade (#5802) makes lookups return fewer records than a scan, so each
-  // message below says what it costs and the reader is not told up front that it is optional.
-  var html = "<div><i class='fa fa-exclamation-triangle me-1'></i><strong>Some indexes should be rebuilt.</strong> " +
-    "A rebuild can be run at any time.</div>";
+  // The header states no remedy and no severity, because the groups below no longer share either. One index may only
+  // be missing what a newer layout buys, another may be returning fewer records than a scan (#5802), and a third may
+  // simply not have been verifiable at startup. Each message carries its own consequence and its own remedy - saying
+  // "should be rebuilt" up here would overstate the mildest case and understate the worst.
+  var html = "<div><i class='fa fa-exclamation-triangle me-1'></i><strong>Some indexes need attention.</strong> " +
+    "Each note below says what is wrong and what to do about it.</div>";
 
   for (var message in byMessage) {
     var names = byMessage[message].sort();


### PR DESCRIPTION
Closes #5802

## The report is accurate

The disorder is real, not a false positive from the new detector. `BinaryComparator.compareBytes(byte[], Binary)` - the routine the LSM binary search uses to place and to find a `STRING` key - compared bytes as **signed** until #5321 (`02d5800ea`), while every other string comparison in the engine is unsigned. A UTF-8 lead byte is `>= 0x80`, negative as a Java byte, so `Á` sorted before every ASCII letter under the old comparison and after it under the new one.

That is why the reporter's `Author.name` evidence opens with an accented name, and why several of the reported pairs are then pure ASCII: the mutable pages were laid out in signed order, and a compaction reads them with cursors that assume ascending order and merges them with `compareKeys` (object comparison, always unsigned). Once the two orders diverge at one accented key the merge emits a stretch of keys out of order - ASCII neighbours included - and writes them as-is. #5321 did not create the disorder; it made the reader disagree with what an older build had already written.

`REBUILD INDEX` is therefore the right remedy, and it cannot be automatic: rebuilding every index of a multi-million-record database on the open path would turn a restart into an outage.

## What was actually wrong

The reporting. `LSMTreeIndexCompacted.checkKeyOrderOnLoad()` (added in `8489de7fc`) was a dead end for an operator: it named the **physical bucket sub-index** (`Paper_0_84306331895885`) rather than the logical `Paper[title,abstract]` they would rebuild, and it existed only as a log line, so a restart whose logs had rotated away left no trace. `CHECK DATABASE` does report it, but it walks every page of every index - not something to run on the box you are trying to bring back up.

The engine already had the right channel: `IndexInternal.getUpgradeWarning()`. `LocalSchema` logs it once per database open per **logical** index with the `REBUILD INDEX` to run, and it is exposed as `upgradeWarning` on `schema:indexes` and `schema:index:<name>`, which is what Studio renders. The key-order check was simply not wired into it.

## Change

- `LSMTreeIndexCompacted` caches the check's verdict instead of only logging it, so the reader stays cheap and side-effect free as the `getUpgradeWarning()` contract requires. The physical page evidence drops to `FINE` - it is support detail, and emitting it at `WARNING` alongside the new line would restate one finding under two different names.
- `LSMTreeIndex.getUpgradeWarning()` returns it. Only the compacted sub-index is covered; checking the mutable pages means walking all of them, which is `checkIntegrity()`'s job for `CHECK DATABASE`.
- `TypeIndex.getUpgradeWarning()` scans every bucket sub-index rather than answering from the first. The existing shortcut ("every bucket shares one definition") holds for a warning derived from the definition, but a key-order mismatch is physical state one bucket can be in and another not.
- `LSMTreeFullTextIndex` delegates. It implements `IndexInternal` by composition, so it silently answered the interface default of `null` - and its keys are user text, where non-ASCII characters actually live. This is the `Paper[title,abstract]` half of the report.
- The channel's premise had to widen: it was built for an index that still answers correctly and is only missing what a newer layout buys (#5478). Studio's banner said so in as many words - "they keep working as they are - rebuilding is optional" - which would now sit directly above a message explaining that lookups return fewer records than a scan. That claim and the matching wording in the `IndexInternal` / `LocalSchema` contracts are corrected.

`LSMTreeGeoIndex` and `LSMSparseVectorIndex` also wrap an LSM index by composition. Neither should ever be exposed to this - geohash cells and dimension identifiers are ASCII, so no key either stores can be ordered differently by the signed/unsigned change - but they delegate anyway (geo returns its own layout advisory first and falls through; sparse-vector delegates outright). That exemption is a claim about the *keys*, not a property of those classes, and an override returning `null` unconditionally would hide a mismatch if the claim ever stopped holding.

## What an operator gets

One `WARNING` per affected logical index at open, naming the command that repairs it, and - independent of the log - the affected set as a query:

```sql
SELECT name, typeIndexName, upgradeWarning FROM schema:indexes WHERE upgradeWarning IS NOT NULL
```

`typeIndexName` is the name `REBUILD INDEX` takes. Studio needed no change to group the rows and render one ``REBUILD INDEX `Paper[title,abstract]` `` per logical index - it already did.

## Test plan

- [x] `Issue5802KeyOrderUpgradeWarningTest` (engine, 6 tests). The disorder is planted by swapping two pointers of a page's entry array - the physical state an index written under the old comparator ends up in, without needing the old comparator - the technique `LSMTreeIndexKeyOrderCheckTest` established. Each test compacts, disorders and reopens, because the check runs when the sub-index is wired up.
  - `aHealthyIndexCarriesNoUpgradeWarning` - the baseline that lets the others fail
  - `aDisorderedCompactedIndexIsReportedAsAnUpgradeWarning` - the verdict reaches `getUpgradeWarning()`
  - `theAffectedIndexesAreDiscoverableFromSchemaIndexes` - `schema:indexes` and `schema:index:<name>` expose it, with `typeIndexName` carrying the rebuildable name
  - `aTypeIndexReportsAWarningRaisedByANonFirstBucket` - the `TypeIndex` fix
  - `aDisorderedFullTextIndexReportsThroughTheCompositionWrapper` - the `LSMTreeFullTextIndex` delegate, reached through `getFileIds()` / `Schema.getFileById()` so no production accessor was added for the test
  - `rebuildingTheIndexClearsTheWarning` - `REBUILD INDEX` is a real remedy and the advisory does not survive it
- [x] Four of the original five fail before the fix; the healthy baseline passes throughout. The full-text test was separately proven to fail with the delegate stubbed back to `null`.
- [ ] **Untested:** the "could not be verified" branch. Firing it needs a genuine I/O failure - the layer below already turns an unreadable key into a reported problem rather than an exception - so staging it would need mocks or page corruption brittle enough to test the fixture rather than the code.
- [x] `LSMTreeIndexKeyOrderCheckTest` unchanged and still green - it asserts on `checkRootPagesKeyOrder`, `checkIntegrity()` and `CHECK DATABASE`, none of which this touches.
- [x] `mvn -pl engine -am -Dtest='com.arcadedb.index.**.*Test,com.arcadedb.schema.**.*Test' test` - 1486 tests, 0 failures.
- [x] `npm test` in `studio` - 50/50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

