### PR TITLE
Update Python bindings for 26.8.1: server mode restored, ResultSet.to_arrow(), wire-protocol tests

### DIFF
--- a/.github/workflows/test-python-bindings.yml
+++ b/.github/workflows/test-python-bindings.yml
@@ -122,7 +122,7 @@ jobs:
           for v in $versions; do
             echo "::group::Resolve floors for Python $v"
             uv pip compile pyproject.toml \
-              --extra test --extra vector --extra examples \
+              --extra test --extra vector --extra examples --extra arrow --extra pandas \
               --resolution lowest-direct \
               --python-version "$v" \
               -o "$RUNNER_TEMP/floors-$v.txt"
@@ -327,7 +327,12 @@ jobs:
         shell: bash
         run: |
           cd bindings/python
-          uv pip install --system test-install/*.whl pytest pytest-cov requests numpy
+          # This list is hand-maintained and mirrors the `test` extra. It had
+          # already drifted: pyarrow and pandas were missing, so to_arrow() and
+          # to_dataframe() tests skipped themselves in this job while it
+          # reported green. The guard step below now fails the build if any
+          # test skips for a missing import, so the next drift is loud.
+          uv pip install --system test-install/*.whl pytest pytest-cov requests numpy "psycopg[binary]" redis neo4j pyarrow pandas
 
       - name: Run pytest on host
         id: pytest
@@ -364,6 +369,30 @@ jobs:
             echo "failed=$FAILED" >> $GITHUB_OUTPUT
 
             echo "✅ Test results: $PASSED passed, $SKIPPED skipped, $FAILED failed"
+
+            # A test that skips because a dependency is missing is not a
+            # passing test, and it does not look like a failure either: the
+            # suite goes green having exercised nothing.
+            #
+            # This has now happened three times. pyarrow was dropped by an
+            # install command and the to_arrow() tests skipped; pandas was
+            # never in the `test` extra at all, so to_dataframe() had no
+            # executed coverage in any CI run this package has ever had; and
+            # the hand-written dependency list in this very job was missing
+            # both. Each time the signal was a green build.
+            #
+            # So make it loud. importorskip failures name the module, and a
+            # missing dependency is a CI bug rather than an expected condition.
+            IMPORT_SKIPS=$(grep -oE 'could not import .[a-zA-Z0-9_.]+.' test-results.xml | sort -u || true)
+            if [ -n "$IMPORT_SKIPS" ]; then
+              echo "❌ Tests skipped because dependencies are missing:"
+              echo "$IMPORT_SKIPS" | sed 's/^/     /'
+              echo ""
+              echo "   These tests did not run. Add the module to the 'test' extra in"
+              echo "   bindings/python/pyproject.toml AND to the install step above,"
+              echo "   or delete the test if the integration is no longer supported."
+              exit 1
+            fi
 
             # Force failure if there are failures or errors
             if [ "$FAILED" -gt 0 ] || [ "$ERRORS" -gt 0 ]; then

--- a/.github/workflows/test-python-examples.yml
+++ b/.github/workflows/test-python-examples.yml
@@ -131,6 +131,12 @@ jobs:
     needs: download-jars
     env:
       BUILD_VERSION: ${{ inputs.build-version }}
+      # Pin the Hugging Face cache inside the workspace so it is cacheable with
+      # one path on every platform (the default differs per OS). The examples
+      # embed with sentence-transformers, and this matrix is 20 jobs, so
+      # uncached that is 20 independent model downloads per release and 20
+      # chances for a transient hub outage to fail a release. It has happened.
+      HF_HOME: ${{ github.workspace }}/.hf-cache
     strategy:
       fail-fast: false
       matrix:
@@ -237,6 +243,38 @@ jobs:
             uv pip install --system numpy requests sentence-transformers
           fi
 
+      # Restored before the dataset step, which is what triggers the model
+      # download. Keyed on the model name so bumping the model invalidates it.
+      - name: Cache Hugging Face model
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ github.workspace }}/.hf-cache
+          key: hf-all-MiniLM-L6-v2-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: |
+            hf-all-MiniLM-L6-v2-${{ runner.os }}-
+
+      # Pre-warm with bounded retries, separately from the dataset step, so a
+      # transient hub failure is retried here rather than surfacing mid-example
+      # as an OSError that reads like a bindings bug. Retrying is appropriate
+      # for this step specifically: it exercises third-party I/O, not our code.
+      # Deliberately NOT fail-fast: if the hub is truly down the dataset step
+      # below still runs and fails with its own message, so this cannot turn a
+      # real breakage into a silent skip.
+      - name: Pre-warm embedding model
+        shell: bash
+        continue-on-error: true
+        run: |
+          uv pip install --system sentence-transformers >/dev/null 2>&1 || true
+          for attempt in 1 2 3; do
+            if python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2'); print('model ready')"; then
+              echo "✅ model cached on attempt $attempt"
+              exit 0
+            fi
+            echo "⚠️  model fetch failed (attempt $attempt/3)"
+            [ "$attempt" -lt 3 ] && sleep $((attempt * 20))
+          done
+          echo "::warning::could not pre-warm the embedding model after 3 attempts; the dataset step will retry"
+
       - name: Download datasets
         shell: bash
         run: |
@@ -315,13 +353,17 @@ jobs:
 
             # Set example-specific parameters and timeout
             case "$example" in
-              "21_server_mode_http_access.py")
-                # Example 21 is kept in the repo for local/manual use, but is
-                # excluded from GitHub Actions because it is CI-unstable.
-                echo "⏭️  SKIPPED: $example (excluded from GitHub Actions due to CI instability)" | tee -a $results_file
-                skipped=$((skipped + 1))
-                echo ""
-                continue
+              "21_graph_analytical_view_sql.py")
+                example_args="--base-cities 1200 --stale-growth-cities 300 --sync-growth-cities 200 --regions 12 --batch-size 300 --sample-limit 5"
+                example_name="$example (reduced scale for CI)"
+                timeout_duration=900  # 15 minutes
+                example_jvm_args=""
+                ;;
+              "22_numpy_bulk_io.py")
+                example_args="--rows 50000 --points 100000 --vectors 5000"
+                example_name="$example (reduced scale for CI)"
+                timeout_duration=600  # 10 minutes
+                example_jvm_args=""
                 ;;
               "04_csv_import_documents.py")
                 example_args="--dataset movielens-small --export"
@@ -501,6 +543,10 @@ jobs:
           echo "Detailed Results:"
           cat $results_file
 
+          # Save list of examples for summary (before the failure exit, so
+          # the summary is populated even when some examples fail)
+          echo "$examples" > examples-ran.txt
+
           # Exit with error if any failed
           if [ $failed -gt 0 ]; then
             echo "❌ Some examples failed!"
@@ -508,9 +554,6 @@ jobs:
           else
             echo "✅ All examples passed!"
           fi
-
-          # Save list of examples for summary
-          echo "$examples" > examples-ran.txt
 
       - name: Generate test summary
         if: always()

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -2,7 +2,7 @@
 
 Native Python bindings for ArcadeDB - the multi-model database that supports Graph, Document, Key/Value, Search Engine, Time Series, and Vector models.
 
-**Status**: ✅ Production Ready | **Tests**: 351 Passed | **Platforms**: 4 Supported
+**Status**: ✅ Production Ready | **Tests**: 397 Passed | **Platforms**: 4 Supported
 
 ---
 
@@ -58,10 +58,11 @@ with arcadedb.create_database("./mydb") as db:
 
 - ☕ **No Java Installation Required**: Bundled JRE (~63MB uncompressed)
 - 🌍 **4 Platforms Supported**: Linux (x86_64, ARM64), macOS (ARM64), Windows (x86_64)
-- 🚀 **Embedded Mode**: Direct database access in Python process (no network); for client-server or multi-process deployments, use the official [ArcadeDB server](https://arcadedb.com/) alongside
-- 📦 **Self-contained**: All dependencies bundled (~62MB current Linux wheel)
+- 🚀 **Embedded Mode**: Direct database access in Python process (no network)
+- 🌐 **Server Mode**: Optional in-process HTTP server with the Studio web UI — costs ~8MB of wheel and nothing at runtime until you call `create_server()`
+- 📦 **Self-contained**: All dependencies bundled (~67MB current Linux wheel)
 - 🔄 **Multi-model**: Graph, Document, Key/Value, Vector, Time Series
-- 🔍 **Multiple query languages**: SQL, OpenCypher, MongoDB
+- 🔍 **Multiple query languages**: SQL, OpenCypher
 - ⚡ **High performance**: Direct JVM integration via JPype
 - 🔒 **ACID transactions**: Full transaction support
 - 🎯 **Vector storage**: Store and query vector embeddings with HNSW (JVector) indexing
@@ -75,15 +76,21 @@ The `arcadedb-embedded` package is platform-specific and self-contained:
 
 **Package Contents (current Linux x86_64 dev build; varies by platform and version):**
 
-- **Wheel size (compressed)**: ~62MB
-- **ArcadeDB JARs (uncompressed)**: ~24MB
-- **Bundled JRE (uncompressed)**: ~63MB (platform-specific Java 25 runtime via jlink, 16 modules)
-- **Installed package size**: ~87MB
+- **Wheel size (compressed)**: ~67MB
+- **ArcadeDB JARs (uncompressed)**: ~31MB across 63 JARs
+- **Bundled JRE (uncompressed)**: ~63MB (platform-specific Java 25 runtime via jlink)
+- **Installed package size**: ~94MB
 
 The compressed wheel size is measured from `dist/*.whl`, and the installed package size
 is measured from the extracted `site-packages/arcadedb_embedded/` directory.
 
-**Note**: The package is embedded-only — server/Studio and other unused JARs are excluded to optimize size (e.g., gRPC wire protocol). See [`scripts/jar_exclusions.txt`](https://github.com/humemai/arcadedb-embedded-python/blob/main/bindings/python/scripts/jar_exclusions.txt) for details.
+Of that, the optional **server stack is 12 JARs, 7.65MB uncompressed**, and it adds
+~8MB to the wheel (the extra ~0.8MB beyond the JARs is JRE modules that only the
+server needs). [Server Mode](https://docs.humem.ai/arcadedb/latest/guide/server/)
+breaks the cost down and explains what you pay at runtime (nothing, until you start
+a server).
+
+**Note**: Some JARs are excluded to optimize package size (e.g., gRPC wire protocol). See [`scripts/jar_exclusions.txt`](https://github.com/humemai/arcadedb-embedded-python/blob/main/bindings/python/scripts/jar_exclusions.txt) for details.
 
 Import: `import arcadedb_embedded as arcadedb`
 
@@ -91,7 +98,7 @@ Import: `import arcadedb_embedded as arcadedb`
 
 ## 🧪 Testing
 
-**Status**: 351 passed
+**Status**: 397 passed
 
 Tests run against the built wheel via the uv project at the repo root — no
 virtualenv activation needed, and `uv run` works from anywhere in the repo:
@@ -146,10 +153,14 @@ arcadedb_embedded/
 ├── exceptions.py        # ArcadeDBError exception
 ├── exporter.py          # Data export (JSONL, GraphML, GraphSON, CSV)
 ├── graph.py             # Graph wrappers
+├── graph_batch.py       # GraphBatch high-throughput graph ingest wrapper
+├── importer.py          # Data import (CSV, XML, ArcadeDB JSONL)
 ├── __init__.py          # Public API exports
 ├── jvm.py               # JVM lifecycle management
+├── _logging.py          # Internal logging helpers
 ├── results.py           # ResultSet and Result wrappers
 ├── schema.py            # Schema management API
+├── server.py            # ArcadeDBServer for optional HTTP/Studio mode
 ├── transactions.py      # TransactionContext manager
 ├── type_conversion.py   # Python-Java type conversion utilities
 └── vector.py            # Vector search and HNSW (JVector) indexing

--- a/bindings/python/examples/.gitignore
+++ b/bindings/python/examples/.gitignore
@@ -14,5 +14,12 @@ data/
 benchmark_logs/
 benchmark_work/
 
+# Example exports
+exports/
+
+# Example run logs
+example-results.txt
+examples-ran.txt
+
 # scratch logs (e.g. `... | tee foo`)
 /foo

--- a/bindings/python/examples/02_social_network_graph.py
+++ b/bindings/python/examples/02_social_network_graph.py
@@ -838,11 +838,29 @@ def demonstrate_gremlin_queries(db):
         print("      • Sorting with ORDER BY")
 
     except Exception as e:
-        print(f"    ❌ Error in OpenCypher queries: {e}")
-        print("    💡 Note: OpenCypher support depends on your ArcadeDB build")
-        import traceback
+        # Name the language that actually failed. This block guards Gremlin
+        # queries, but it used to report "Error in OpenCypher queries" and
+        # advise that "OpenCypher support depends on your ArcadeDB build",
+        # which is false and points the reader at the wrong feature: Cypher
+        # and OpenCypher both work in this wheel, and Gremlin is the one that
+        # is absent, because arcadedb-gremlin is excluded to keep the wheel
+        # small (see scripts/jar_exclusions.txt). Reading the old message, a
+        # user would reasonably conclude Cypher was unavailable.
+        if "gremlin" in str(e).lower():
+            print(
+                "    ⏭️  Gremlin is not bundled in this package, so this "
+                "section is skipped."
+            )
+            print(
+                "    💡 arcadedb-gremlin is excluded from the wheel on "
+                "purpose. SQL, Cypher and OpenCypher all work; the Cypher "
+                "section above ran against the same data."
+            )
+        else:
+            print(f"    ❌ Error in Gremlin queries: {e}")
+            import traceback
 
-        traceback.print_exc()
+            traceback.print_exc()
 
 
 def compare_query_languages(db):

--- a/bindings/python/examples/03_vector_search.py
+++ b/bindings/python/examples/03_vector_search.py
@@ -177,7 +177,8 @@ with arcadedb.create_database(db_path) as db:
     print("Step 4: Inserting data...")
     step_start = time.time()
 
-    # Insert in batches for better performance
+    # Per-row inserts inside one transaction; BATCH_SIZE only paces the
+    # progress output (for true batched ingest see example 22 / insert_many)
     BATCH_SIZE = 1000
     total_inserted = 0
 

--- a/bindings/python/examples/12_vector_search.py
+++ b/bindings/python/examples/12_vector_search.py
@@ -1918,6 +1918,30 @@ def run_in_docker(args) -> bool:
             continue
         filtered_args.append(arg)
 
+    # Same host-path translation as 11_vector_index_build.py, and needed for the
+    # same reason: this example re-runs itself in a container with the repo at
+    # /workspace, so a host-absolute --db-path names a directory that does not
+    # exist there. Example 12 is the more certain case of the two, because it is
+    # always handed the absolute path that example 11 wrote.
+    if workspace_mount_dst != workspace_mount_src:
+        src_prefix = workspace_mount_src.rstrip("/")
+
+        def _to_container_path(value: str) -> str:
+            if value == src_prefix:
+                return workspace_mount_dst
+            if value.startswith(src_prefix + "/"):
+                return workspace_mount_dst + value[len(src_prefix) :]
+            return value
+
+        remapped: list[str] = []
+        for arg in filtered_args:
+            if arg.startswith("--") and "=" in arg:
+                flag, _, value = arg.partition("=")
+                remapped.append(f"{flag}={_to_container_path(value)}")
+            else:
+                remapped.append(_to_container_path(arg))
+        filtered_args = remapped
+
     if args.backend == "milvus":
         has_milvus_host = any(
             arg == "--milvus-host" or arg.startswith("--milvus-host=")

--- a/bindings/python/examples/22_numpy_bulk_io.py
+++ b/bindings/python/examples/22_numpy_bulk_io.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Example 22: numpy in, numpy out - bulk I/O paths.
+
+Every path in this example crosses the Python/Java boundary once per BATCH
+instead of once per value, which is what makes them fast: per-row FFI calls
+cap document ingest around 30k rows/s regardless of engine speed, while the
+batched paths below reach hundreds of thousands of rows or points per
+second on the same machine.
+
+Workflow covered:
+- bulk document ingest with Database.insert_many (rows as one JSON batch)
+- the same rows through the async parallel writers (insert_many parallel=True)
+- time-series ingest straight from numpy arrays via
+  AsyncExecutor.append_samples (buffer-protocol bulk copy per column)
+- time-bucketed aggregation over the native TIMESERIES type
+- columnar export with to_columns(): scalar columns as 1-D numpy arrays and
+  embedding columns as a contiguous 2-D array, ready for scikit-learn or
+  faiss without per-row conversion
+- the same export via to_arrow(), which keeps NULLs typed instead of
+  widening a nullable INTEGER to float64/NaN the way numpy must
+
+Requirements:
+- numpy (pip install numpy)
+- pyarrow, optional, only for the to_arrow section
+  (pip install 'arcadedb-embedded[arrow]')
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import time
+from pathlib import Path
+
+import arcadedb_embedded as arcadedb
+import numpy as np
+
+
+def bulk_documents(db, n_rows: int) -> None:
+    print(f"\n=== insert_many: {n_rows:,} order documents ===")
+    db.command("sql", "CREATE DOCUMENT TYPE BulkOrder")
+    rows = [
+        {
+            "oid": i,
+            "customer": f"cust_{i % 997}",
+            "amount": round((i * 37) % 100_000 / 100.0, 2),
+            "status": ("new", "paid", "shipped")[i % 3],
+        }
+        for i in range(n_rows)
+    ]
+    t0 = time.perf_counter()
+    inserted = db.insert_many("BulkOrder", rows, commit_every=10_000)
+    dt = time.perf_counter() - t0
+    print(
+        f"synchronous batches: {inserted:,} rows in {dt:.2f}s "
+        f"({inserted / dt:,.0f} rows/s)"
+    )
+
+    db.command("sql", "CREATE DOCUMENT TYPE BulkOrderP")
+    t0 = time.perf_counter()
+    inserted = db.insert_many("BulkOrderP", rows, parallel=True)
+    dt = time.perf_counter() - t0
+    print(
+        f"async parallel writers: {inserted:,} rows in {dt:.2f}s "
+        f"({inserted / dt:,.0f} rows/s)"
+    )
+
+
+def timeseries_from_numpy(db, n_points: int) -> None:
+    print(f"\n=== append_samples: {n_points:,} sensor points from numpy ===")
+    db.command(
+        "sql",
+        "CREATE TIMESERIES TYPE Sensor TIMESTAMP ts "
+        "TAGS (host STRING) FIELDS (cpu DOUBLE, mem DOUBLE) SHARDS 4",
+    )
+    base_ms = 1_767_225_600_000  # 2026-01-01T00:00:00Z
+    ts = base_ms + np.arange(n_points, dtype=np.int64) * 1_000
+    cpu = 50.0 + 40.0 * np.sin(np.arange(n_points) / 300.0)
+    mem = np.random.default_rng(7).uniform(20.0, 90.0, n_points)
+    hosts = [f"host_{i % 8}" for i in range(n_points)]
+
+    ex = db.async_executor()
+    t0 = time.perf_counter()
+    ex.append_samples("Sensor", ts, hosts, cpu, mem)
+    ex.wait_completion()
+    dt = time.perf_counter() - t0
+    print(f"ingested {n_points:,} points in {dt:.2f}s " f"({n_points / dt:,.0f} pts/s)")
+
+    buckets = db.query(
+        "sql",
+        "SELECT ts.timeBucket('1m', ts) AS minute, avg(cpu) AS cpu "
+        f"FROM Sensor WHERE host = 'host_3' AND ts BETWEEN {base_ms} AND "
+        f"{base_ms + 600_000 - 1} GROUP BY minute ORDER BY minute",
+    ).to_list()
+    print(
+        f"first 10 minutes of host_3, per-minute avg cpu: "
+        f"{[round(float(b['cpu']), 1) for b in buckets]}"
+    )
+
+
+def embeddings_to_numpy(db, n_vectors: int, dim: int) -> None:
+    print(f"\n=== to_columns: {n_vectors:,} x {dim} embeddings out ===")
+    db.command("sql", "CREATE DOCUMENT TYPE Chunk")
+    db.command("sql", "CREATE PROPERTY Chunk.cid INTEGER")
+    db.command("sql", "CREATE PROPERTY Chunk.embedding ARRAY_OF_FLOATS")
+    rng = np.random.default_rng(42)
+    vecs = rng.standard_normal((n_vectors, dim), dtype=np.float32)
+    with db.transaction():
+        for i in range(n_vectors):
+            db.command(
+                "sql",
+                "INSERT INTO Chunk SET cid = :c, embedding = :e",
+                {"c": i, "e": arcadedb.to_java_float_array(vecs[i])},
+            )
+
+    t0 = time.perf_counter()
+    cols = db.query("sql", "SELECT cid, embedding FROM Chunk ORDER BY cid").to_columns()
+    dt = time.perf_counter() - t0
+    emb = cols["embedding"]
+    print(
+        f"exported in {dt:.3f}s: cid -> {cols['cid'].dtype} "
+        f"{cols['cid'].shape}, embedding -> {emb.dtype} {emb.shape}"
+    )
+    # the array is contiguous and immediately usable, e.g. cosine vs a query
+    q = vecs[0]
+    sims = emb @ q / (np.linalg.norm(emb, axis=1) * np.linalg.norm(q))
+    print(f"nearest to chunk 0 by cosine: {np.argsort(-sims)[:5].tolist()}")
+    assert np.allclose(emb[:3], vecs[:3], atol=1e-6)
+
+
+def nulls_to_arrow(db, n_rows: int) -> None:
+    print(f"\n=== to_arrow vs to_columns: {n_rows:,} rows with NULLs ===")
+    db.command("sql", "CREATE DOCUMENT TYPE Reading")
+    db.command("sql", "CREATE PROPERTY Reading.rid INTEGER")
+    db.command("sql", "CREATE PROPERTY Reading.count INTEGER")
+    db.command("sql", "CREATE PROPERTY Reading.ok BOOLEAN")
+    # Every third row leaves count and ok unset, which is the case that
+    # separates the two export paths.
+    rows = [
+        {"rid": i, "count": i * 2, "ok": i % 2 == 0} if i % 3 else {"rid": i}
+        for i in range(n_rows)
+    ]
+    db.insert_many("Reading", rows)
+
+    q = "SELECT rid, count, ok FROM Reading ORDER BY rid"
+
+    # to_columns() has no way to say "missing" inside a plain numpy array, so a
+    # nullable INTEGER widens to float64 with NaN holes and a nullable BOOLEAN
+    # falls back to a Python list. That is a property of numpy, not a defect.
+    cols = db.query("sql", q).to_columns()
+    print(
+        f"to_columns : count -> {cols['count'].dtype}, "
+        f"ok -> {type(cols['ok']).__name__}"
+    )
+
+    table = db.query("sql", q).to_arrow()
+    if table is None:
+        print(
+            "to_arrow   : pyarrow not installed, skipping "
+            "(pip install 'arcadedb-embedded[arrow]')"
+        )
+        return
+
+    print(
+        f"to_arrow   : count -> {table['count'].type}, "
+        f"ok -> {table['ok'].type}, {table.num_rows:,} rows"
+    )
+
+    # The integers stay integers and the nulls stay null, so downstream
+    # arithmetic is not silently done in floating point.
+    assert table["count"].type == "int64"
+    assert table["ok"].type == "bool"
+    expected_nulls = len(range(0, n_rows, 3))
+    assert table["count"].null_count == expected_nulls
+    assert table["ok"].null_count == expected_nulls
+    assert np.isnan(cols["count"]).sum() == expected_nulls
+    print(
+        f"both agree on {expected_nulls:,} missing values; "
+        f"only to_arrow keeps them typed"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", default="./my_test_databases/numpy_bulk_io")
+    parser.add_argument("--rows", type=int, default=200_000)
+    parser.add_argument("--points", type=int, default=500_000)
+    parser.add_argument("--vectors", type=int, default=20_000)
+    parser.add_argument("--dim", type=int, default=64)
+    args = parser.parse_args()
+
+    path = Path(args.db_path)
+    if path.exists():
+        shutil.rmtree(path)
+    db = arcadedb.create_database(str(path))
+    try:
+        bulk_documents(db, args.rows)
+        timeseries_from_numpy(db, args.points)
+        embeddings_to_numpy(db, args.vectors, args.dim)
+        nulls_to_arrow(db, args.rows // 20)
+    finally:
+        db.close()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/python/examples/23_server_mode_http_access.py
+++ b/bindings/python/examples/23_server_mode_http_access.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Example 23: Server Mode And HTTP Access.
+
+This example shows the narrow client-server story that already works in the
+Python bindings today without adding a new remote client abstraction.
+
+Workflow covered:
+- start ArcadeDB server mode from the embedded Python package
+- inspect server metadata over HTTP
+- create a database through the server-managed Java API
+- create schema through the HTTP command endpoint
+- insert records through embedded access in the same Python process
+- log in to the HTTP API and switch to bearer-token authentication
+- query and update the same data over HTTP
+- verify HTTP-side changes back through embedded access
+
+Notes:
+- This repo remains embedded-first. Server mode is an optional access pattern
+  for multi-process or remote HTTP use.
+- The example intentionally uses Python's standard library for HTTP instead of
+  introducing a dedicated remote client layer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import shutil
+import socket
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import arcadedb_embedded as arcadedb
+
+ROOT_PASSWORD = "example23pass"
+ITEMS = [
+    {
+        "sku": "SKU-001",
+        "name": "Arcade Notebook",
+        "category": "office",
+        "stock": 12,
+        "warehouse": "north",
+    },
+    {
+        "sku": "SKU-002",
+        "name": "Graph Whiteboard",
+        "category": "office",
+        "stock": 4,
+        "warehouse": "north",
+    },
+    {
+        "sku": "SKU-003",
+        "name": "Vector GPU Crate",
+        "category": "hardware",
+        "stock": 2,
+        "warehouse": "south",
+    },
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Example 23: server mode and HTTP access workflow"
+    )
+    parser.add_argument(
+        "--server-root",
+        default="./my_test_databases/server_mode_demo_root",
+        help=(
+            "Server root directory "
+            "(default: ./my_test_databases/server_mode_demo_root)"
+        ),
+    )
+    parser.add_argument(
+        "--db-name",
+        default="example23_server_demo",
+        help="Database name to create inside the server root",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="HTTP host to bind the embedded server to (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--http-port",
+        type=int,
+        default=2481,
+        help="HTTP port for the embedded server (default: 2481)",
+    )
+    parser.add_argument(
+        "--wait-for-enter",
+        action="store_true",
+        help=(
+            "Keep the server running after the scripted steps finish until you "
+            "press Enter"
+        ),
+    )
+    return parser.parse_args()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def reset_server_root(server_root: Path) -> None:
+    if server_root.exists():
+        shutil.rmtree(server_root)
+    server_root.parent.mkdir(parents=True, exist_ok=True)
+
+
+def choose_http_port(host: str, requested_port: int) -> tuple[int, bool]:
+    """Return a usable HTTP port for the example.
+
+    Tries the requested port first. If it is unavailable, fall back to an
+    ephemeral free port chosen by the OS.
+    """
+
+    def _can_bind(port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind((host, port))
+            except OSError:
+                return False
+        return True
+
+    if requested_port > 0 and _can_bind(requested_port):
+        return requested_port, False
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        fallback_port = int(sock.getsockname()[1])
+
+    return fallback_port, True
+
+
+def basic_auth_header(username: str, password: str) -> dict[str, str]:
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+def bearer_auth_header(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def http_json_request(
+    url: str,
+    *,
+    method: str = "GET",
+    payload: dict | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict:
+    request_headers = {"Accept": "application/json"}
+    if headers:
+        request_headers.update(headers)
+
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+
+    request = Request(url, data=data, headers=request_headers, method=method)
+    if not request.full_url.startswith(
+        ("http://localhost", "http://127.0.0.1", "https://")
+    ):
+        raise ValueError(f"Refusing to call unexpected URL: {request.full_url!r}")
+    try:
+        with urlopen(request, timeout=timeout) as response:  # nosec B310
+            body = response.read().decode("utf-8")
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code} for {method} {url}: {detail}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"HTTP request failed for {method} {url}: {exc}") from exc
+    except OSError as exc:
+        # A socket timeout raises TimeoutError, which is an OSError but NOT a
+        # URLError, so it escapes the clause above. wait_for_server() retries on
+        # RuntimeError, so leaving this uncaught turned a slow first request into
+        # a hard failure instead of one more poll. Same for ConnectionRefusedError
+        # when the listener is not accepting yet.
+        raise RuntimeError(f"HTTP request failed for {method} {url}: {exc!r}") from exc
+
+    if not body.strip():
+        return {}
+
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Expected JSON from {url}, got: {body}") from exc
+
+
+def wait_for_server(base_url: str, headers: dict[str, str], timeout_sec: float) -> dict:
+    """Poll /api/v1/server until it answers.
+
+    The first HTTP request after start_up is much slower than the rest: measured
+    on one developer machine it took 5.6s, the second 0.7s, and every one after
+    that under 10ms. Undertow and the REST handlers class-load lazily and the
+    root password is verified with a deliberately expensive KDF, and both happen
+    on request one. So the per-attempt timeout here is generous on purpose; a
+    tight one just converts warmup into a failure.
+    """
+    start = time.perf_counter()
+    while True:
+        try:
+            return http_json_request(
+                f"{base_url}/api/v1/server",
+                headers=headers,
+                timeout=30.0,
+            )
+        except RuntimeError:
+            if time.perf_counter() - start > timeout_sec:
+                raise
+            time.sleep(0.25)
+
+
+def print_rows(title: str, rows: list[dict]) -> None:
+    print(title)
+    if not rows:
+        print("  (no rows)")
+        print()
+        return
+    for row in rows:
+        print(f"  - {row}")
+    print()
+
+
+def main() -> int:
+    args = parse_args()
+    server_root = Path(args.server_root)
+    reset_server_root(server_root)
+
+    http_port, used_fallback_port = choose_http_port(args.host, args.http_port)
+
+    base_url = f"http://{args.host}:{http_port}"
+    basic_headers = basic_auth_header("root", ROOT_PASSWORD)
+
+    print("=" * 72)
+    print("ArcadeDB Python - Example 23: Server Mode And HTTP Access")
+    print("=" * 72)
+    print()
+    print("Positioning: embedded-first package, optional server mode when HTTP helps")
+    print(f"Server root: {server_root}")
+    print(f"Database name: {args.db_name}")
+    print(f"Base URL: {base_url}")
+    if used_fallback_port:
+        print(
+            f"Requested HTTP port {args.http_port} was unavailable; "
+            f"using {http_port} instead."
+        )
+    print()
+
+    with arcadedb.create_server(
+        str(server_root),
+        root_password=ROOT_PASSWORD,
+        config={
+            "host": args.host,
+            "http_port": http_port,
+            "mode": "development",
+        },
+    ) as server:
+        print(f"Studio URL: {server.get_studio_url()}")
+
+        server_info = wait_for_server(base_url, basic_headers, timeout_sec=90.0)
+        print_rows(
+            "Server metadata:",
+            [
+                {
+                    "version": server_info.get("version"),
+                    "serverName": server_info.get("serverName"),
+                    "languages": server_info.get("languages"),
+                }
+            ],
+        )
+
+        login_payload = http_json_request(
+            f"{base_url}/api/v1/login",
+            method="POST",
+            headers=basic_headers,
+        )
+        token = login_payload.get("token")
+        require(bool(token), "Expected /api/v1/login to return a bearer token")
+        bearer_headers = bearer_auth_header(token)
+        print("Acquired bearer token via HTTP login.")
+        print()
+
+        db = server.create_database(args.db_name)
+        print("Created database through server-managed Java API.")
+        print()
+
+        for statement in (
+            "CREATE DOCUMENT TYPE InventoryItem",
+            "CREATE PROPERTY InventoryItem.sku STRING",
+            "CREATE PROPERTY InventoryItem.name STRING",
+            "CREATE PROPERTY InventoryItem.category STRING",
+            "CREATE PROPERTY InventoryItem.stock INTEGER",
+            "CREATE PROPERTY InventoryItem.warehouse STRING",
+            "CREATE INDEX ON InventoryItem (sku) UNIQUE_HASH",
+        ):
+            http_json_request(
+                f"{base_url}/api/v1/command/{args.db_name}",
+                method="POST",
+                payload={"language": "sql", "command": statement},
+                headers=bearer_headers,
+            )
+        print("Created schema through the HTTP command endpoint.")
+        print()
+
+        with db.transaction():
+            for item in ITEMS:
+                db.command(
+                    "sql",
+                    "INSERT INTO InventoryItem SET sku = ?, name = ?, category = ?, "
+                    "stock = ?, warehouse = ?",
+                    item["sku"],
+                    item["name"],
+                    item["category"],
+                    item["stock"],
+                    item["warehouse"],
+                )
+        print_rows("Inserted through embedded access:", ITEMS)
+
+        http_list = http_json_request(
+            f"{base_url}/api/v1/query/{args.db_name}",
+            method="POST",
+            payload={
+                "language": "sql",
+                "command": (
+                    "SELECT sku, name, category, stock, warehouse "
+                    "FROM InventoryItem ORDER BY sku"
+                ),
+            },
+            headers=bearer_headers,
+        )
+        remote_rows = http_list.get("result", [])
+        require(len(remote_rows) == len(ITEMS), "Expected HTTP query to see all items")
+        print_rows("Queried through HTTP:", remote_rows)
+
+        http_json_request(
+            f"{base_url}/api/v1/command/{args.db_name}",
+            method="POST",
+            payload={
+                "language": "sql",
+                "command": ("UPDATE InventoryItem SET stock = 9 WHERE sku = 'SKU-002'"),
+            },
+            headers=bearer_headers,
+        )
+        http_json_request(
+            f"{base_url}/api/v1/command/{args.db_name}",
+            method="POST",
+            payload={
+                "language": "sql",
+                "command": (
+                    "INSERT INTO InventoryItem SET sku = 'SKU-004', "
+                    "name = 'Remote Rack', category = 'hardware', "
+                    "stock = 7, warehouse = 'west'"
+                ),
+            },
+            headers=bearer_headers,
+        )
+        print("Applied one HTTP-side update and one HTTP-side insert.")
+        print()
+
+        embedded_rows = [
+            {
+                "sku": row.get("sku"),
+                "name": row.get("name"),
+                "category": row.get("category"),
+                "stock": row.get("stock"),
+                "warehouse": row.get("warehouse"),
+            }
+            for row in db.query(
+                "sql",
+                "SELECT sku, name, category, stock, warehouse "
+                "FROM InventoryItem ORDER BY sku",
+            )
+        ]
+        require(
+            [row["sku"] for row in embedded_rows]
+            == ["SKU-001", "SKU-002", "SKU-003", "SKU-004"],
+            "Expected embedded verification to see all four SKUs",
+        )
+        require(
+            next(row for row in embedded_rows if row["sku"] == "SKU-002")["stock"] == 9,
+            "Expected embedded verification to see the HTTP-side stock update",
+        )
+        print_rows("Verified back through embedded access:", embedded_rows)
+
+        aggregate_payload = http_json_request(
+            f"{base_url}/api/v1/query/{args.db_name}",
+            method="POST",
+            payload={
+                "language": "sql",
+                "command": (
+                    "SELECT category, sum(stock) AS total_stock, count(*) AS items "
+                    "FROM InventoryItem GROUP BY category ORDER BY category"
+                ),
+            },
+            headers=bearer_headers,
+        )
+        aggregate_rows = aggregate_payload.get("result", [])
+        require(len(aggregate_rows) == 2, "Expected two category aggregates")
+        print_rows("HTTP aggregate query:", aggregate_rows)
+
+        if args.wait_for_enter:
+            print(
+                "Server is still running. Open Studio in your browser now if you "
+                "want to inspect the database."
+            )
+            print(f"Studio URL: {server.get_studio_url()}")
+            input("Press Enter to stop the server and exit the example...")
+
+        db.close()
+
+    print("Example 23 completed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bindings/python/examples/README.md
+++ b/bindings/python/examples/README.md
@@ -108,17 +108,27 @@ Building a movie recommendation engine:
 
 ---
 
-### ⏱️ [14_lifecycle_timing.py](./14_lifecycle_timing.py)
-**JVM Startup | DB Create/Open | Transaction Load | Query Phases | Reopen Timing**
+### 🗃️ [07_stackoverflow_tables_oltp.py](./07_stackoverflow_tables_oltp.py)
+**Table OLTP | Mixed CRUD Workload | Cross-DB Benchmarking**
 
-Lifecycle benchmark for embedded ArcadeDB with mixed workloads:
-- Measures JVM startup time in-process
-- Creates schema and loads table/graph/vector data
-- Runs query workload before and after reopen
-- Prints per-run timings and final averages
-- Uses random `/tmp` database path and always cleans up
+Table-oriented Stack Overflow OLTP benchmark:
+- Loads Stack Overflow XML tables and runs a mixed OLTP workload (CRUD)
+- CRUD operations are point-oriented and randomly target one table per operation
+- For cross-database comparability, running with `--threads 1` is recommended
 
-**Learn:** Cold-start behavior, lifecycle costs, and realistic mixed-workload timing patterns
+**Learn:** Table-oriented OLTP benchmarking and cross-database workload fairness
+
+---
+
+### 📉 [08_stackoverflow_tables_olap.py](./08_stackoverflow_tables_olap.py)
+**Table OLAP | Fixed Query Suite | Dockerized Runs**
+
+Table-oriented Stack Overflow OLAP benchmark:
+- Loads all Stack Overflow XML tables and runs a fixed OLAP query suite
+- All work happens inside a Docker container when launched on the host
+- Reports load/index timing and repeated query runs
+
+**Learn:** Analytical query benchmarking over table-shaped data
 
 ---
 
@@ -149,6 +159,30 @@ Fixed query-suite benchmark for Stack Overflow graph analytics:
 
 ---
 
+### 🏗️ [11_vector_index_build.py](./11_vector_index_build.py)
+**Vector Index Build | Build-Only Benchmark | Multi-Backend Comparison**
+
+Build-only vector index benchmark:
+- Backends: ArcadeDB (embedded), pgvector, Qdrant, Milvus, FAISS, LanceDB
+- Datasets: MSMARCO and Stack Overflow embedding vectors
+- For client-server backends, peak RSS combines client process and server process tree
+
+**Learn:** Vector index build cost and memory comparison across backends
+
+---
+
+### 🔎 [12_vector_search.py](./12_vector_search.py)
+**Vector Search | Search-Only Benchmark | ef_search Sweeps**
+
+Search-only vector benchmark that reuses Example 11 output:
+- Backends: ArcadeDB (embedded), FAISS, LanceDB, brute-force NumPy scan, pgvector, Qdrant, Milvus
+- Sweeps explicit `ef_search` values for HNSW-style backends
+- Measures client + server process RSS for client-server backends
+
+**Learn:** Search latency/recall tradeoffs and backend-specific search parameters
+
+---
+
 ### 🔀 [13_stackoverflow_hybrid_queries.py](./13_stackoverflow_hybrid_queries.py)
 **Hybrid SQL + Graph + Vector | Standalone Workflow**
 
@@ -158,6 +192,20 @@ hybrid queries:
 - Graph edge creation uses RID-based directed endpoints
 
 **Learn:** End-to-end hybrid querying across SQL, OpenCypher, and vector search
+
+---
+
+### ⏱️ [14_lifecycle_timing.py](./14_lifecycle_timing.py)
+**JVM Startup | DB Create/Open | Transaction Load | Query Phases | Reopen Timing**
+
+Lifecycle benchmark for embedded ArcadeDB with mixed workloads:
+- Measures JVM startup time in-process
+- Creates schema and loads table/graph/vector data
+- Runs query workload before and after reopen
+- Prints per-run timings and final averages
+- Uses random `/tmp` database path and always cleans up
+
+**Learn:** Cold-start behavior, lifecycle costs, and realistic mixed-workload timing patterns
 
 ---
 
@@ -253,6 +301,33 @@ SQL-first Graph Analytical View workflow:
 - reopens the database to confirm persisted GAV restoration
 
 **Learn:** How to use Graph Analytical Views from Python without introducing a dedicated Python object API
+
+---
+
+### 🔢 [22_numpy_bulk_io.py](./22_numpy_bulk_io.py)
+**numpy Bulk I/O | insert_many | append_samples | Columnar Export**
+
+Batched Python/Java boundary crossings for bulk workloads:
+- Bulk document ingest with `Database.insert_many` (rows as one JSON batch), transactional and `parallel=True`
+- Time-series ingest straight from numpy arrays via `AsyncExecutor.append_samples`
+- Time-bucketed aggregation over the native `TIMESERIES` type
+- Columnar export with `to_columns()`: scalar columns as 1-D numpy arrays and embeddings as a contiguous 2-D array
+
+**Learn:** Why one crossing per batch (not per value) makes bulk ingest and export fast
+
+### 🌐 [23_server_mode_http_access.py](./23_server_mode_http_access.py)
+**Server Mode | HTTP API | Bearer Auth | Mixed Access Pattern**
+
+Embedded-first server workflow, all in one process:
+- starts ArcadeDB server mode from the Python package
+- reads server metadata over HTTP
+- creates a database through the server-managed Java API
+- mixes embedded writes with HTTP queries and updates
+- opens Studio against the same in-process database
+
+**Learn:** How to expose an embedded database over HTTP without running a
+separate container, and when you should reach for the Docker distribution
+instead
 
 ---
 

--- a/bindings/python/examples/download_data.py
+++ b/bindings/python/examples/download_data.py
@@ -564,9 +564,10 @@ def introduce_null_values_movielens(extract_dir):
         # Count total rows for progress bar
         total_rows = sum(1 for _ in open(csv_path, encoding="utf-8")) - 1
 
-        with open(csv_path, "r", encoding="utf-8") as f_in, open(
-            temp_path, "w", encoding="utf-8", newline=""
-        ) as f_out:
+        with (
+            open(csv_path, "r", encoding="utf-8") as f_in,
+            open(temp_path, "w", encoding="utf-8", newline="") as f_out,
+        ):
             reader = csv.DictReader(f_in)
             writer = csv.DictWriter(f_out, fieldnames=reader.fieldnames)
             writer.writeheader()
@@ -922,9 +923,10 @@ def _write_stackoverflow_subset(
     row_count = 0
     closed = False
 
-    with source_path.open(
-        "r", encoding="utf-8", errors="ignore"
-    ) as fin, target_path.open("w", encoding="utf-8") as fout:
+    with (
+        source_path.open("r", encoding="utf-8", errors="ignore") as fin,
+        target_path.open("w", encoding="utf-8") as fout,
+    ):
         for line in fin:
             if root_tag is None:
                 fout.write(line)
@@ -969,9 +971,10 @@ def _write_stackoverflow_subset_by_bytes(
     closed = False
     bytes_written = 0
 
-    with source_path.open(
-        "r", encoding="utf-8", errors="ignore"
-    ) as fin, target_path.open("w", encoding="utf-8") as fout:
+    with (
+        source_path.open("r", encoding="utf-8", errors="ignore") as fin,
+        target_path.open("w", encoding="utf-8") as fout,
+    ):
         for line in fin:
             if root_tag is None:
                 fout.write(line)

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -48,6 +48,20 @@ test = [
     "pytest-cov",
     "numpy>=1.26.4",
     "requests>=2.33.0",  # HTTP API / docs-example tests
+    # Real clients for the bundled wire protocols. Test-only: none of these
+    # reaches an end user's install, and without them three shipped protocols
+    # are covered by nothing but the jars being present in the archive.
+    "psycopg[binary]>=3.1",  # Postgres wire
+    "redis>=5.0",            # Redis wire
+    "neo4j>=5.0",            # Bolt
+    "pyarrow>=23.0.1",       # ResultSet.to_arrow(); <23.0.1 has PYSEC-2026-113
+    # ResultSet.to_dataframe(). Absent until 2026-08-04, which meant its two
+    # tests called importorskip("pandas") and skipped in every CI run this
+    # package has ever had: a public, documented method with no executed
+    # coverage. Same shape as the arrow gap, but in the extras DEFINITION
+    # rather than an install command, so no amount of care at install time
+    # would have caught it.
+    "pandas>=2.2.0",
 ]
 dev = [
     "black",
@@ -60,6 +74,28 @@ dev = [
     "bandit>=1.9.1",
 ]
 vector = [
+    "numpy>=1.26.4",
+]
+# Optional: ResultSet.to_arrow(). The columnar bridge already emits packed
+# columns with a null bitmap, so this adds no Java and no jars to the wheel;
+# pyarrow is only needed to wrap those buffers. Without it to_arrow() returns
+# None and callers fall back to to_columns().
+arrow = [
+    "pyarrow>=23.0.1",
+    "numpy>=1.26.4",
+]
+# Optional: ResultSet.to_dataframe(). Shipped and documented long before this
+# extra existed, so the only way to discover the dependency was to call the
+# method and read the ImportError. `arrow` had an extra and `pandas` did not,
+# for two methods on the same class doing the same kind of thing.
+#
+# Note the two differ in how they FAIL, and that is deliberate on to_arrow's
+# side rather than an oversight here: to_arrow() returns None so callers can
+# fall back to to_columns(), while to_dataframe() raises ImportError. Changing
+# to_dataframe to match would break callers relying on the exception, so it
+# stays as it is and is documented rather than quietly aligned.
+pandas = [
+    "pandas>=2.2.0",
     "numpy>=1.26.4",
 ]
 examples = [
@@ -91,6 +127,8 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
 markers = [
+    "server: tests that require server/studio support",
+    "server_wire: speaks a bundled wire protocol with its real client",
     "integration: tests that require external components",
 ]
 

--- a/bindings/python/scripts/arrow_transport_probe.py
+++ b/bindings/python/scripts/arrow_transport_probe.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Is to_arrow() worth shipping? Measure it against the paths we already have.
+
+The claim to test is not "Arrow is fast". It is that reading the SAME columnar
+buffer into Arrow beats reading it into numpy/pandas, because two things in the
+pandas path cost real work:
+
+  strings   to_columns decodes one Python str per row from the offsets+blob
+            buffer. Arrow's StringArray uses exactly that layout, so the column
+            is wrapped instead of decoded.
+  nullable  to_columns promotes int64+nulls to float64/NaN and degrades
+            bool+nulls to a Python list. Arrow keeps both, with validity.
+
+So the interesting comparison is per column TYPE, not one aggregate number, and
+the honest end-to-end measure is "how long to a pandas DataFrame", since that is
+what the audience actually wants. Arrow can lose that race on numeric-only data
+and still win on strings; reporting a single figure would hide which.
+
+Reports p50 of N reps after warmup, and a correctness check that the two paths
+agree, so a fast wrong answer cannot pass as a win.
+"""
+
+import argparse
+import os
+import statistics
+import sys
+import tempfile
+import time
+
+
+def build(db, n, shape):
+    db.command("sql", "CREATE DOCUMENT TYPE Rec")
+    with db.transaction():
+        for i in range(0, n, 1000):
+            rows = []
+            for j in range(i, min(i + 1000, n)):
+                if shape == "numeric":
+                    rows.append(
+                        f"INSERT INTO Rec SET a = {j}, b = {j * 1.5}, c = {j % 7}"
+                    )
+                elif shape == "strings":
+                    rows.append(
+                        f"INSERT INTO Rec SET s1 = 'value-{j}', "
+                        f"s2 = 'category-{j % 50}', a = {j}"
+                    )
+                else:  # mixed, with nulls in an integer column
+                    if j % 3 == 0:
+                        rows.append(f"INSERT INTO Rec SET s1 = 'v{j}', b = {j * 1.5}")
+                    else:
+                        rows.append(
+                            f"INSERT INTO Rec SET s1 = 'v{j}', a = {j}, b = {j * 1.5}"
+                        )
+            for r in rows:
+                db.command("sql", r)
+
+
+def timeit(fn, reps, warmup):
+    for _ in range(warmup):
+        fn()
+    ts = []
+    for _ in range(reps):
+        t = time.perf_counter()
+        fn()
+        ts.append((time.perf_counter() - t) * 1e3)
+    return statistics.median(ts)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rows", type=int, default=100_000)
+    ap.add_argument("--reps", type=int, default=5)
+    ap.add_argument("--warmup", type=int, default=2)
+    ap.add_argument("--shapes", default="numeric,strings,mixed")
+    args = ap.parse_args()
+
+    import arcadedb_embedded as arcadedb
+    import pandas as pd
+
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError:
+        print("pyarrow not installed; nothing to compare", file=sys.stderr)
+        return 1
+
+    # The engine logs to stdout and does not always terminate its last line, so
+    # a result row printed straight after one gets concatenated onto it and any
+    # log-filtering grep upstream of this script eats the row silently. That
+    # cost a re-run: the numeric row, the one shape where Arrow does NOT win,
+    # was the row that disappeared. Lead every row with a newline and tag it,
+    # so a row can be recovered with `grep -o 'ROW .*'` no matter what shares
+    # the line.
+    def row(*cells):
+        print("\nROW " + "".join(cells), flush=True)
+
+    print(f"\n  rows={args.rows} reps={args.reps} (warmup {args.warmup})")
+    print(f"  arcadedb_embedded {arcadedb.__version__}\n")
+    row(
+        f"{'shape':<10}{'to_columns':>12}{'to_arrow':>11}",
+        f"{'cols->df':>11}{'arrow->df':>11}{'df speedup':>12}",
+    )
+
+    for shape in args.shapes.split(","):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "probe")
+            with arcadedb.create_database(path) as db:
+                build(db, args.rows, shape)
+
+                q = "SELECT FROM Rec"
+                t_cols = timeit(
+                    lambda: db.query("sql", q).to_columns(), args.reps, args.warmup
+                )
+                t_arrow = timeit(
+                    lambda: db.query("sql", q).to_arrow(), args.reps, args.warmup
+                )
+                t_cols_df = timeit(
+                    lambda: pd.DataFrame(db.query("sql", q).to_columns()),
+                    args.reps,
+                    args.warmup,
+                )
+                t_arrow_df = timeit(
+                    lambda: db.query("sql", q).to_arrow().to_pandas(),
+                    args.reps,
+                    args.warmup,
+                )
+
+                # a fast wrong answer is not a win
+                a = db.query("sql", q).to_arrow()
+                c = db.query("sql", q).to_columns()
+                assert a.num_rows == len(next(iter(c.values()))), (
+                    f"{shape}: row count differs, {a.num_rows} vs "
+                    f"{len(next(iter(c.values())))}"
+                )
+
+                sp = t_cols_df / t_arrow_df if t_arrow_df else float("nan")
+                row(
+                    f"  {shape:<10}{t_cols:>12.2f}{t_arrow:>11.2f}",
+                    f"{t_cols_df:>11.2f}{t_arrow_df:>11.2f}{sp:>11.2f}x",
+                )
+
+    print("\n  cols->df and arrow->df are the numbers that matter: they are what")
+    print("  a caller pays to get a DataFrame. A win on strings with a loss on")
+    print("  numeric is a real result, not a reason to average them together.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bindings/python/scripts/build.sh
+++ b/bindings/python/scripts/build.sh
@@ -13,6 +13,13 @@
 
 set -euo pipefail
 
+# Stamped before anything is built, so the wheel check at the end can ask
+# whether an artifact is newer than this run rather than merely present.
+# A marker file rather than an epoch: `test -nt` is portable, while
+# `find -newermt` is GNU-only and this script also runs on macOS hosts.
+BUILD_START_MARKER=$(mktemp -t arcadedb-build-start.XXXXXX)
+trap 'rm -f "$BUILD_START_MARKER"' EXIT
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PY_BINDINGS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
@@ -338,15 +345,40 @@ else
     # Create dist directory if it doesn't exist
     mkdir -p dist
 
+    # Record what was in dist/ BEFORE extracting. The check below used to be
+    # `ls dist/*.whl`, which asks "is there a wheel here?" when the question is
+    # "did THIS build produce one?". Nothing cleans dist/, so a wheel left by
+    # any earlier build satisfied that test: an export stage that yielded
+    # nothing still printed the success banner and exited 0, handing back a
+    # stale wheel that looks like a fresh one. build-native.sh already avoids
+    # this by clearing the directory first; the Docker path had no equivalent.
+    # Compare identities rather than clearing, so deliberately kept wheels for
+    # other platforms survive a build.
+    WHEELS_BEFORE=$(ls -1 dist/*.whl 2> /dev/null | sort || true)
+
     # Extract the wheel from the export container
     echo -e "${CYAN}📋 Extracting wheel file...${NC}"
     CONTAINER_ID=$(docker create arcadedb-python-package-export)
     docker cp ${CONTAINER_ID}:/build/dist/. ./dist/
     docker rm ${CONTAINER_ID}
 
-    # Verify wheel was extracted
-    if ls dist/*.whl 1> /dev/null 2>&1; then
+    # Verify THIS build produced a wheel, not merely that dist/ contains one
+    WHEELS_AFTER=$(ls -1 dist/*.whl 2> /dev/null | sort || true)
+    NEW_WHEELS=$(comm -13 <(echo "$WHEELS_BEFORE") <(echo "$WHEELS_AFTER") || true)
+    if [[ -n "$NEW_WHEELS" ]]; then
         echo -e "${GREEN}✅ Wheel file created successfully!${NC}"
+    elif [[ -n "$WHEELS_AFTER" ]]; then
+        # Same filename as before: only trust it if the export actually rewrote
+        # it. A rebuild of the same version legitimately lands here.
+        NEWEST=$(ls -t dist/*.whl | head -n1)
+        if [[ "$NEWEST" -nt "$BUILD_START_MARKER" ]]; then
+            echo -e "${GREEN}✅ Wheel file created successfully!${NC}"
+        else
+            echo -e "${RED}❌ No wheel was produced by this build${NC}"
+            echo -e "${YELLOW}💡 dist/ still holds only wheels older than this run:${NC}"
+            ls -lh dist/*.whl
+            exit 1
+        fi
     else
         echo -e "${RED}❌ Failed to extract wheel file${NC}"
         exit 1

--- a/bindings/python/scripts/jar_exclusions.txt
+++ b/bindings/python/scripts/jar_exclusions.txt
@@ -15,23 +15,10 @@ regex-*.jar
 arcadedb-ha-raft-*.jar
 arcadedb-metrics-*.jar
 arcadedb-mongodbw-*.jar
-# Embedded-unused (verified 2026-07-05 by quarantine + full suite/examples gate):
+# Embedded-unused (verified 2026-07-05 by quarantine + full suite/examples gate;
+# micrometer must STAY - server startup requires it):
 commons-math3-*.jar
 jackson-*.jar
 snappy-java-*.jar
 arcadedb-tracing-*.jar
 jline-*.jar
-# Server mode removed 2026-07-05 (embedded-only package; use the official
-# ArcadeDB server distribution/Docker image for client-server deployments).
-# micrometer was only kept for server startup, so it goes with the stack.
-# arcadedb-mcp is a server plugin: every class in it references com.arcadedb.server.*, so it is dead
-# weight (and unloadable) once the server jar is gone.
-arcadedb-mcp-*.jar
-arcadedb-server-*.jar
-arcadedb-studio-*.jar
-undertow-*.jar
-xnio-*.jar
-wildfly-*.jar
-jboss-logging-*.jar
-jboss-threads-*.jar
-micrometer-*.jar

--- a/bindings/python/src/arcadedb_embedded/__init__.py
+++ b/bindings/python/src/arcadedb_embedded/__init__.py
@@ -5,12 +5,21 @@ A native Python bindings for ArcadeDB that embeds the Java database engine
 directly in the Python process using JPype.
 """
 
-# Import version from generated _version.py file (created during build).
-# Source checkouts may not have the generated file yet.
+# The installed distribution's version is the single source of truth: the
+# wheel is versioned from the release tag, while the generated _version.py
+# is derived from the Maven pom, so the two disagree on tagged releases
+# (a 26.8.1.dev20 wheel carried __version__ == "26.8.1.dev0"). Fall back to
+# the generated file, then to a placeholder, for source checkouts that were
+# never installed.
 try:
-    from ._version import __version__
-except ModuleNotFoundError:
-    __version__ = "0.0.0"
+    from importlib.metadata import version as _dist_version
+
+    __version__ = _dist_version("arcadedb-embedded")
+except Exception:  # not installed: fall back to the build-time file
+    try:
+        from ._version import __version__
+    except ModuleNotFoundError:
+        __version__ = "0.0.0"
 
 # Import async execution
 from .async_executor import AsyncExecutor
@@ -42,11 +51,18 @@ from .graph_batch import GraphBatch
 # Import importer helpers
 from .importer import ImportResult
 
+# Which engine this install actually carries. __version__ is the PACKAGE
+# version and can disagree with the bundled JARs without any error.
+from .jvm import jar_fingerprint
+
 # Import result classes
 from .results import Result, ResultSet
 
 # Import schema classes
 from .schema import IndexType, PropertyType, Schema
+
+# Import server classes
+from .server import ArcadeDBServer, create_server
 
 # Import transaction management
 from .transactions import TransactionContext
@@ -69,6 +85,14 @@ __all__ = [
     # Core classes
     "Database",
     "DatabaseFactory",
+    # Record wrappers
+    "Document",
+    "Vertex",
+    "Edge",
+    # Citation
+    "cite",
+    # Build provenance
+    "jar_fingerprint",
     "create_database",
     "open_database",
     "database_exists",
@@ -93,6 +117,9 @@ __all__ = [
     "to_java_byte_array",
     "to_java_float_array",
     "to_python_array",
+    # Server classes
+    "ArcadeDBServer",
+    "create_server",
     # Data export
     "export_database",
     "export_to_csv",

--- a/bindings/python/src/arcadedb_embedded/async_executor.py
+++ b/bindings/python/src/arcadedb_embedded/async_executor.py
@@ -36,6 +36,37 @@ if TYPE_CHECKING:
 _LOGGER = get_logger(__name__)
 
 
+def _convert_column(values):
+    """Convert one non-numeric column, reusing the Java object per distinct str.
+
+    TIMESERIES tag columns are strings, so they miss the numeric buffer path
+    and convert one element at a time. Tags are low cardinality by definition,
+    which is the premise the engine's own TAG dictionary rests on (#5574), so
+    almost every one of those conversions repeats work already done: in TSBS
+    `cpu` the ten tag columns hold 233 distinct values across 2,592,000 rows,
+    hostname alone repeating each of 100 values 25,920 times, and `arch`
+    repeating each of 2 values 1,296,000 times.
+
+    Memoising per distinct value turns 25.9M conversions into 233. Restricted
+    to `str` on purpose: a Java String is immutable, so sharing one reference
+    across rows is safe, whereas memoising a converted list or map would alias
+    a mutable object across rows and let a later write show up in earlier ones.
+    Everything else keeps converting per element exactly as before.
+    """
+    out = []
+    seen = {}
+    for value in values:
+        if type(value) is str:
+            java = seen.get(value)
+            if java is None:
+                java = convert_python_to_java(value)
+                seen[value] = java
+            out.append(java)
+        else:
+            out.append(convert_python_to_java(value))
+    return out
+
+
 class AsyncExecutor:
     """
     Wrapper for Java DatabaseAsyncExecutor with Pythonic interface.
@@ -257,6 +288,37 @@ class AsyncExecutor:
 
     # Graph and time-series operations
 
+    def create_record(self, document, callback: Optional[Callable] = None):
+        """Queue a document for asynchronous creation.
+
+        The engine's parallel bucket writers persist it off the calling
+        thread; call :meth:`wait_completion` before relying on visibility.
+        This is the idiomatic bulk-write path for single documents built
+        with ``Database.new_document``; for many uniform rows prefer
+        ``Database.insert_many(..., parallel=True)``, which crosses the
+        FFI boundary once per batch instead of per document.
+
+        Args:
+            document: A ``Document`` (or ``Vertex``/``Edge``) created by
+                ``Database.new_document``/``new_vertex`` (not yet saved).
+            callback: Optional callable invoked with the created record.
+        """
+        java_cb = (
+            self._create_new_record_callback(callback) if callback is not None else None
+        )
+        self._java_async.createRecord(document._java_document, java_cb)
+
+    def _create_new_record_callback(self, python_callback):
+        from .graph import Document
+
+        @jpype.JImplements("com.arcadedb.database.async.NewRecordCallback")
+        class _NewRecordCallback:
+            @jpype.JOverride
+            def call(self, record):
+                python_callback(Document.wrap(record))
+
+        return _NewRecordCallback()
+
     def new_edge(
         self,
         source_vertex,
@@ -361,15 +423,152 @@ class AsyncExecutor:
         type_name: str,
         timestamps: Sequence[int],
         *column_values: Sequence[Any],
+        primitive: bool = False,
     ):
+        """Columnar bulk append into a native TIMESERIES type.
+
+        Columns are positional and must follow the type's declaration order:
+        tags first, then fields. Timestamps are epoch values in the type's
+        precision (milliseconds by default).
+
+        numpy fast path: an ndarray for timestamps or a numeric field column
+        crosses the FFI as one buffer copy (int/uint kinds via boxLongs,
+        float kinds via boxDoubles); other sequences convert per element.
+        Call wait_completion() before relying on visibility.
+
+        primitive=True routes through the engine's TimeSeriesBatch instead,
+        which carries each column as a primitive array and so never boxes a
+        numeric sample (ArcadeDB #5474). It needs an engine that ships that
+        API; the default stays on the Object[] path.
+        """
+        if primitive:
+            return self._append_samples_primitive(type_name, timestamps, *column_values)
+        try:
+            import numpy as _np
+        except ImportError:
+            _np = None
         JLongArray = jpype.JArray(jpype.JLong)
-        timestamps_java = JLongArray([int(value) for value in timestamps])
+        if _np is not None and isinstance(timestamps, _np.ndarray):
+            # buffer-protocol bulk copy: one FFI crossing for the column
+            timestamps_java = JLongArray(
+                _np.ascontiguousarray(timestamps, dtype=_np.int64)
+            )
+        else:
+            timestamps_java = JLongArray([int(value) for value in timestamps])
         JObjectArray = jpype.JArray(jpype.JObject)
-        columns_java = [
-            JObjectArray([convert_python_to_java(value) for value in values])
-            for values in column_values
-        ]
+        boxer = None
+        columns_java = []
+        for values in column_values:
+            if (
+                _np is not None
+                and isinstance(values, _np.ndarray)
+                and values.dtype.kind in "fiu"
+            ):
+                if boxer is None:
+                    boxer = jpype.JClass("com.arcadedb.python.DocumentBatcher")
+                if values.dtype.kind == "f":
+                    col = boxer.boxDoubles(
+                        jpype.JArray(jpype.JDouble)(
+                            _np.ascontiguousarray(values, dtype=_np.float64)
+                        )
+                    )
+                else:
+                    col = boxer.boxLongs(
+                        jpype.JArray(jpype.JLong)(
+                            _np.ascontiguousarray(values, dtype=_np.int64)
+                        )
+                    )
+                columns_java.append(col)
+            else:
+                columns_java.append(JObjectArray(_convert_column(values)))
         self._java_async.appendSamples(type_name, timestamps_java, *columns_java)
+
+    def _append_samples_primitive(
+        self,
+        type_name: str,
+        timestamps: Sequence[int],
+        *column_values: Sequence[Any],
+    ):
+        """append_samples over the engine's primitive TimeSeriesBatch.
+
+        Each column crosses the FFI once as a contiguous primitive array and is
+        written into the batch Java-side. Filling the batch from Python instead
+        would cost one JNI call per value, which is worse than the boxing this
+        replaces, so the per-row loop lives in TimeSeriesBatcher.
+        """
+        try:
+            import numpy as _np
+        except ImportError:
+            _np = None
+
+        if self._owner is None:
+            raise RuntimeError(
+                "primitive append_samples needs the owning Database; "
+                "obtain the executor via Database.async_executor()"
+            )
+
+        batcher = jpype.JClass("com.arcadedb.python.TimeSeriesBatcher")
+        JLongArray = jpype.JArray(jpype.JLong)
+        if _np is not None and isinstance(timestamps, _np.ndarray):
+            timestamps_java = JLongArray(
+                _np.ascontiguousarray(timestamps, dtype=_np.int64)
+            )
+        else:
+            timestamps_java = JLongArray([int(value) for value in timestamps])
+
+        batch = batcher.newBatch(self._owner._java_db, type_name, timestamps_java)
+
+        for index, values in enumerate(column_values):
+            if (
+                _np is not None
+                and isinstance(values, _np.ndarray)
+                and values.dtype.kind == "f"
+            ):
+                batcher.setDoubleColumn(
+                    batch,
+                    index,
+                    jpype.JArray(jpype.JDouble)(
+                        _np.ascontiguousarray(values, dtype=_np.float64)
+                    ),
+                )
+            elif (
+                _np is not None
+                and isinstance(values, _np.ndarray)
+                and values.dtype.kind in "iu"
+            ):
+                batcher.setLongColumn(
+                    batch,
+                    index,
+                    jpype.JArray(jpype.JLong)(
+                        _np.ascontiguousarray(values, dtype=_np.int64)
+                    ),
+                )
+            elif values and all(isinstance(v, str) for v in values):
+                batcher.setStringColumn(
+                    batch, index, jpype.JArray(jpype.JString)(list(values))
+                )
+            elif values and all(isinstance(v, float) for v in values):
+                batcher.setDoubleColumn(
+                    batch,
+                    index,
+                    jpype.JArray(jpype.JDouble)([float(v) for v in values]),
+                )
+            elif values and all(
+                isinstance(v, int) and not isinstance(v, bool) for v in values
+            ):
+                batcher.setLongColumn(
+                    batch, index, jpype.JArray(jpype.JLong)([int(v) for v in values])
+                )
+            else:
+                batcher.setObjectColumn(
+                    batch,
+                    index,
+                    jpype.JArray(jpype.JObject)(
+                        [convert_python_to_java(v) for v in values]
+                    ),
+                )
+
+        self._java_async.appendSamples(type_name, batch)
 
     # Query operations
 

--- a/bindings/python/src/arcadedb_embedded/citation.py
+++ b/bindings/python/src/arcadedb_embedded/citation.py
@@ -10,15 +10,54 @@ except ModuleNotFoundError:
     __version__ = "0.0.0"
 from .exceptions import ArcadeDBError
 
-# Map released package versions to Zenodo version-specific DOIs.
-# Update this mapping on each release.
-_VERSION_DOI_MAP = {
-    "26.1.1.post3": "10.5281/zenodo.18399749",
-}
+# In-process cache of resolved version DOIs. Nothing is hardcoded: every
+# released version resolves live against Zenodo, where each GitHub Release
+# is archived automatically under the concept record below.
+_VERSION_DOI_MAP: dict = {}
+
+# Zenodo concept record grouping every archived release of this package.
+_ZENODO_CONCEPT_RECID = "18399208"
+
+
+def _zenodo_get(url: str):
+    import json
+    import urllib.request
+
+    with urllib.request.urlopen(
+        url, timeout=10
+    ) as resp:  # nosec B310 - fixed https host
+        return json.load(resp)
+
+
+def _zenodo_lookup(version: str) -> Optional[str]:
+    """Resolve a version DOI from Zenodo's API; None if not archived there."""
+    # The concept record resolves to its latest version; that record's
+    # /versions endpoint lists every archived release (25 per page for
+    # unauthenticated requests).
+    latest = _zenodo_get(f"https://zenodo.org/api/records/{_ZENODO_CONCEPT_RECID}")
+    recid = latest.get("id", _ZENODO_CONCEPT_RECID)
+    page = 1
+    while True:
+        data = _zenodo_get(
+            f"https://zenodo.org/api/records/{recid}/versions" f"?size=25&page={page}"
+        )
+        hits = data.get("hits", {}).get("hits", [])
+        if not hits:
+            return None
+        for hit in hits:
+            if hit.get("metadata", {}).get("version") == version:
+                doi = hit.get("doi")
+                if doi:
+                    _VERSION_DOI_MAP[version] = doi  # cache for this process
+                    return doi
+        page += 1
 
 
 def cite(version: Optional[str] = None) -> str:
     """Return the DOI URL for a given ArcadeDB Embedded Python version.
+
+    Resolved live against Zenodo, where every GitHub Release of this
+    package is archived automatically; results are cached per process.
 
     Parameters
     ----------
@@ -33,23 +72,35 @@ def cite(version: Optional[str] = None) -> str:
     Raises
     ------
     ArcadeDBError
-        If the requested version is not found in the citation index.
+        If the version is a dev build, is not archived on Zenodo, or the
+        Zenodo lookup fails (e.g. offline).
 
     Examples
     --------
     >>> import arcadedb_embedded as arcadedb
-    >>> arcadedb.cite("26.1.1.post3")
-    "https://doi.org/10.5281/zenodo.18399749"
+    >>> arcadedb.cite("26.7.2")  # doctest: +SKIP (network)
+    'https://doi.org/10.5281/zenodo.21373842'
     """
 
     if version is None:
         version = __version__
 
-    if version not in _VERSION_DOI_MAP:
-        if "dev" in version:
+    doi = _VERSION_DOI_MAP.get(version)
+    if doi is None:
+        if "dev" in version or version == "0.0.0":
             raise ArcadeDBError(
-                f"Version {version} is not yet released and therefore does not yet have a citable DOI."
+                f"Version {version} is not a release and has no citable DOI."
             )
-        raise ArcadeDBError(f"Version {version} not found in the citation index")
+        try:
+            doi = _zenodo_lookup(version)
+        except Exception as e:
+            raise ArcadeDBError(
+                f"Version {version} is not in the offline citation index and "
+                f"the Zenodo lookup failed: {e}"
+            ) from e
+        if doi is None:
+            raise ArcadeDBError(
+                f"Version {version} not found in the citation index or on Zenodo"
+            )
 
-    return f"https://doi.org/{_VERSION_DOI_MAP[version]}"
+    return f"https://doi.org/{doi}"

--- a/bindings/python/src/arcadedb_embedded/core.py
+++ b/bindings/python/src/arcadedb_embedded/core.py
@@ -219,6 +219,74 @@ class Database:
                 f"Failed to create document of type '{type_name}': {e}"
             ) from e
 
+    def insert_many(
+        self,
+        type_name: str,
+        rows,
+        commit_every: int = 10_000,
+        parallel: bool = False,
+    ) -> int:
+        """Bulk-insert documents with one FFI crossing per batch.
+
+        Rows are serialized to a single JSON string and looped Java-side
+        (``DocumentBatcher``), avoiding the per-row JNI cost that caps
+        ``new_document``-loop ingest. Values must be JSON-representable
+        (str/int/float/bool/None and nested lists/dicts); rows containing
+        other types (e.g. datetime, bytes) fall back transparently to the
+        per-row path.
+
+        Args:
+            type_name: Target document type (must exist).
+            rows: Iterable of dicts, one per document.
+            commit_every: Transaction batch size for the synchronous mode.
+            parallel: If True, route rows through the async executor's
+                parallel bucket writers and wait for completion before
+                returning (higher throughput, out-of-order writes).
+
+        Returns:
+            Number of documents inserted.
+        """
+        self._check_not_closed()
+        import json as _json
+
+        rows = list(rows)
+        if not rows:
+            return 0
+        try:
+            payload = _json.dumps(rows)
+        except (TypeError, ValueError):
+            # Non-JSON-representable values (note: numpy integer scalars land
+            # here too, since json.dumps rejects np.int64): per-row fallback,
+            # honoring commit_every batches like the fast path.
+            n = 0
+            was_active = self.is_transaction_active()
+            if not was_active:
+                self.begin()
+            for row in rows:
+                doc = self.new_document(type_name)
+                for k, v in row.items():
+                    doc.set(k, v)
+                doc.save()
+                n += 1
+                if not was_active and commit_every > 0 and n % commit_every == 0:
+                    self.commit()
+                    self.begin()
+            if not was_active:
+                self.commit()
+            return n
+        try:
+            batcher = _java_class("com.arcadedb.python.DocumentBatcher")
+            count = int(
+                batcher.insertManyJson(
+                    self._java_db, type_name, payload, int(commit_every), bool(parallel)
+                )
+            )
+            if parallel:
+                self._java_db.async_().waitCompletion()
+            return count
+        except Exception as e:
+            raise ArcadeDBError(f"Failed to bulk-insert into '{type_name}': {e}") from e
+
     def close(self):
         """Close the database."""
         if not self._closed and self._java_db is not None:
@@ -227,6 +295,17 @@ class Database:
                 async_close_error = self._close_async_executors()
                 self._java_db.close()
             except Exception as e:
+                # A server-managed database is owned by the server lifecycle,
+                # not by this handle: the engine raises
+                # UnsupportedOperationException rather than closing it. That is
+                # the expected outcome for a Database obtained from
+                # ArcadeDBServer.get_database(), so treat it as closed here and
+                # let the server own the real shutdown.
+                if "cannot be closed" in str(e).lower():
+                    self._closed = True
+                    if async_close_error is not None:
+                        raise async_close_error
+                    return
                 raise ArcadeDBError(f"Failed to close database: {e}") from e
             finally:
                 self._closed = True
@@ -388,14 +467,13 @@ class Database:
                 Use "INT8" when the document property stores pre-quantized bytes in a
                 `BINARY` property. When using INT8 encoding, set quantization to "NONE"
                 to avoid double quantization.
-            location_cache_size: Per-index override for vector location cache size
-                (maps to Java metadata key "locationCacheSize"; uses
-                GlobalConfiguration default if None). Typical ranges by corpus size
-                (vectors):
-                - ~100K: 50k–100k
-                - ~1M: 100k–200k
-                - ~10M: 300k–500k
-                - ~100M: 500k–800k (scale with heap)
+            location_cache_size: REMOVED by the engine (issues #5559, #5568).
+                Passing anything other than None raises ValueError. A vector
+                location is the only mapping from a vector id to its record, so
+                capping it does not spill to disk, it drops vectors from searches
+                and from countEntries(). Size the heap instead. The parameter is
+                kept only so that upgrading callers get this explanation rather
+                than an unexplained TypeError.
             graph_build_cache_size: Per-index override for graph build cache size
                 (maps to Java metadata key "graphBuildCacheSize"; uses
                 GlobalConfiguration default if None). Typical ranges (higher = faster
@@ -432,6 +510,22 @@ class Database:
             VectorIndex object
         """
         self._check_not_closed()
+
+        # The engine removed this in #5559/#5568 and now rejects it in
+        # withMetadata(), so a wheel that still forwards it cannot create an
+        # index at all. Refuse here instead, with the reason: a vector location
+        # is the only mapping from a vector id to its record, so a bound on it
+        # is not a cache eviction, it silently drops vectors from searches and
+        # from countEntries().
+        if location_cache_size is not None:
+            raise ValueError(
+                "location_cache_size is no longer supported (ArcadeDB issues "
+                "#5559 and #5568): a vector location is the only mapping from a "
+                "vector id to its record, so capping the location index drops "
+                "vectors from searches and from countEntries() instead of "
+                "spilling them to disk. Remove the argument and size the heap "
+                "for the live vector set instead."
+            )
 
         # Create the index using the Java Builder API directly to pass configuration
         try:
@@ -508,8 +602,6 @@ class Database:
                 metadata_cfg["storeVectorsInGraph"] = True
             if add_hierarchy is not None:
                 metadata_cfg["addHierarchy"] = bool(add_hierarchy)
-            if location_cache_size is not None:
-                metadata_cfg["locationCacheSize"] = int(location_cache_size)
             if graph_build_cache_size is not None:
                 metadata_cfg["graphBuildCacheSize"] = int(graph_build_cache_size)
             if mutations_before_rebuild is not None:
@@ -690,7 +782,7 @@ class Database:
         """
         Get async executor for parallel operations.
 
-        Experimental: not advised for production use yet.
+        The engine's parallel bulk-write path; insert_many(parallel=True) routes through it.
 
         Returns async executor that enables:
         - Parallel record creation (3-5x faster bulk inserts)
@@ -999,6 +1091,8 @@ class Database:
         interpreter is shutting down and logging may already be unavailable,
         so we narrow the catch to AttributeError/RuntimeError that JPype can
         raise when the JVM has been torn down before this finalizer runs.
+        Server-managed databases raise UnsupportedOperationException on close,
+        which close() handles itself and which is also suppressed here.
         """
         try:
             self.close()

--- a/bindings/python/src/arcadedb_embedded/graph.py
+++ b/bindings/python/src/arcadedb_embedded/graph.py
@@ -185,7 +185,7 @@ class Vertex(Document):
             props.append(k)
             props.append(convert_python_to_java(v))
 
-        # Use non-deprecated Java API (bidirectional is determined by EdgeType schema)
+        # bidirectional is determined by the EdgeType schema
         java_edge = self._java_document.newEdge(label, target_java, *props)
         return Edge(java_edge)
 

--- a/bindings/python/src/arcadedb_embedded/graph_batch.py
+++ b/bindings/python/src/arcadedb_embedded/graph_batch.py
@@ -252,15 +252,12 @@ class GraphBatch:
                 anything else falls back to per-edge buffering.
         """
         self._check_not_closed()
-        import jpype
+        from .results import _bridge_class
 
-        try:
-            edge_batcher = jpype.JClass("com.arcadedb.python.EdgeBatcher")
-        except Exception:
-            edge_batcher = None
-
+        edge_batcher = _bridge_class("EdgeBatcher")
         if edge_batcher is None:
-            # bridge jar unavailable: fall back to the per-edge path
+            # bridge jar unavailable (warned once): per-edge fallback,
+            # documented ~24x slower than the bulk path
             props_iter = properties or [None] * len(source_rids)
             for src, dst, p in zip(source_rids, destination_rids, props_iter):
                 self.new_edge(src, edge_type, dst, **(p or {}))

--- a/bindings/python/src/arcadedb_embedded/jvm.py
+++ b/bindings/python/src/arcadedb_embedded/jvm.py
@@ -8,6 +8,7 @@ import glob
 import os
 import platform
 import shlex
+import sys
 import zipfile
 from pathlib import Path
 from typing import Iterable, Optional, Union
@@ -58,6 +59,120 @@ def get_jar_path() -> str:
     """Get the path to bundled JAR files."""
     jar_dir = _extract_runtime_resource("jars")
     return str(jar_dir)
+
+
+_JAR_FINGERPRINT_CACHE = None
+
+# JARs this project compiles, as opposed to the ArcadeDB engine JARs staged
+# from the image. Excluded from engine_sha256 because they are built here and
+# are not byte-reproducible: the PyPI 26.8.1 wheel and a local build of the
+# same version differ in this JAR alone, at identical size.
+_OUR_JARS = frozenset({"arcadedb-python-bridge.jar"})
+
+
+def jar_fingerprint(per_jar: bool = False) -> dict:
+    """Identify the engine this install actually carries.
+
+    ``__version__`` is a *package* version. It says nothing about which JARs
+    are in the wheel, and the two can disagree without any error: a wheel built
+    from a locally patched Java tree still reports the released version number
+    while carrying a different engine.
+
+    That is not hypothetical. A local build of 26.8.1.dev-something shipped 59
+    JARs instead of 64 and a bt-server-patched engine, and it was caught only
+    because one packaging test happened to count JAR names. Benchmarks run
+    against it would have recorded the released version string beside numbers
+    the release cannot reproduce, which is how a fix gets credited to the wrong
+    commit (see the false null on ArcadeDB #5388).
+
+    So: hash what is actually on disk. Two installs agree iff this agrees.
+
+        >>> import arcadedb_embedded as adb
+        >>> adb.jar_fingerprint()["sha256"][:12]
+        'a3f1c0d8b214'
+
+    Benchmark harnesses should record ``sha256`` next to the engine version, so
+    a results row proves which engine produced it rather than asserting it.
+
+    Args:
+        per_jar: also return the sorted (name, size, sha256) of every JAR, for
+            diffing two installs that disagree.
+
+    Two hashes, because they answer different questions.
+
+    ``sha256`` covers every JAR: "is this the same build?" ``engine_sha256``
+    excludes our own compiled shim: "is this the same ArcadeDB?"
+
+    The distinction is measured, not defensive. Comparing the released 26.8.1
+    wheel from PyPI against a local build of the same version: identical file
+    size, identical JAR count, identical total JAR bytes, and a different
+    ``sha256``. Diffing found 63 of 64 JARs byte-identical, with the only
+    difference in ``arcadedb-python-bridge.jar`` at the *same* 10907 bytes.
+    That JAR is compiled during the build, so it carries timestamps and is not
+    reproducible; the 63 engine JARs come from the ArcadeDB image and are.
+
+    So a bare ``sha256`` comparison would report "different engine" for two
+    builds of the same engine, and anyone using it that way would stop
+    believing it. Use ``engine_sha256`` to ask whether two installs are running
+    the same ArcadeDB.
+
+    Returns:
+        ``{"count", "bytes", "sha256", "engine_sha256", "engine_count",
+        "jar_dir"}``, plus ``"jars"`` when ``per_jar`` is set. Each hash covers
+        the JAR names and contents it spans, so a renamed, added, removed or
+        modified JAR all change it.
+    """
+    global _JAR_FINGERPRINT_CACHE
+    if _JAR_FINGERPRINT_CACHE is not None and not per_jar:
+        return dict(_JAR_FINGERPRINT_CACHE)
+
+    import hashlib
+    import os
+
+    jar_dir = get_jar_path()
+    names = sorted(n for n in os.listdir(jar_dir) if n.endswith(".jar"))
+    combined = hashlib.sha256()
+    engine = hashlib.sha256()
+    total = 0
+    engine_count = 0
+    entries = []
+    for name in names:
+        path = os.path.join(jar_dir, name)
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 20), b""):
+                h.update(chunk)
+        size = os.path.getsize(path)
+        total += size
+        # Name AND digest, so swapping two JARs' contents is not a collision.
+        combined.update(name.encode())
+        combined.update(h.digest())
+        if name not in _OUR_JARS:
+            engine.update(name.encode())
+            engine.update(h.digest())
+            engine_count += 1
+        if per_jar:
+            entries.append(
+                {
+                    "name": name,
+                    "bytes": size,
+                    "sha256": h.hexdigest(),
+                    "engine": name not in _OUR_JARS,
+                }
+            )
+
+    out = {
+        "count": len(names),
+        "bytes": total,
+        "sha256": combined.hexdigest(),
+        "engine_sha256": engine.hexdigest(),
+        "engine_count": engine_count,
+        "jar_dir": jar_dir,
+    }
+    _JAR_FINGERPRINT_CACHE = dict(out)
+    if per_jar:
+        out["jars"] = entries
+    return out
 
 
 def get_bundled_jre_lib_path() -> str:
@@ -179,28 +294,25 @@ def start_jvm(
                 common_pool_parallelism=common_pool_parallelism,
             )
         )
-        if _JVM_CONFIG is not None:
-            if candidate_args != _JVM_CONFIG:
-                raise ArcadeDBError(
-                    "JVM is already started. Configure JVM args/heap before the "
-                    "first database creation."
-                )
-            return
-
         has_overrides = (
             jvm_args is not None
             or (heap_size not in (None, "4g"))
             or (disable_xml_limits is not True)
             or (common_pool_parallelism is not None)
         )
-        if has_overrides:
-            raise ArcadeDBError(
-                "JVM is already started. Configure JVM args/heap before the "
-                "first database creation."
-            )
+        if not has_overrides:
+            # No explicit configuration requested: join the running JVM
+            # (e.g. open_database() after create_database(jvm_kwargs=...)).
+            if _JVM_CONFIG is None:
+                _JVM_CONFIG = candidate_args
+            return
 
-        _JVM_CONFIG = candidate_args
-        return
+        if _JVM_CONFIG is not None and candidate_args == _JVM_CONFIG:
+            return
+        raise ArcadeDBError(
+            "JVM is already started with different settings. Configure JVM "
+            "args/heap before the first database or server creation."
+        )
 
     jar_path = get_jar_path()
     jar_files = glob.glob(os.path.join(jar_path, "*.jar"))
@@ -230,11 +342,41 @@ def start_jvm(
     except Exception as e:
         raise ArcadeDBError(f"Failed to start JVM: {e}") from e
 
-    # NOTE: an atexit hook used to close the engine's PageManager here as a
-    # workaround for ArcadeData/arcadedb#4991 (failed open() leaked a
-    # non-daemon AsyncFlush thread and the process could never exit). The
-    # engine fixed the root cause in 26.7.2; the exit-hang regression test in
-    # tests/test_core.py still guards the behavior.
+    # Registered AFTER JPype's own atexit hook so it runs BEFORE it (atexit
+    # is LIFO): close any Database left open. Engine >= 850ce7c37 (#5418)
+    # also daemonizes its background threads and installs its own JVM
+    # shutdown hook, so this is defense-in-depth for older jars and for
+    # deterministic teardown before JPype detaches.
+    import atexit
+
+    atexit.register(_close_active_databases)
+
+    if sys.platform == "win32":
+        # HotSpot handles SEH access violations internally (safepoint polls,
+        # implicit null checks), but any enabled Python faulthandler prints
+        # them as fake "Windows fatal exception" dumps. Disabling at
+        # configure time is not enough: tools (e.g. pytest's faulthandler
+        # plugin) may re-enable it before the JVM starts, so disable at the
+        # last reliable point, right after JVM start.
+        import faulthandler
+
+        faulthandler.disable()
+
+
+def _close_active_databases():
+    """Close every Database still open so JVM shutdown cannot block."""
+    if not jpype.isJVMStarted():
+        return
+    try:
+        factory = jpype.JClass("com.arcadedb.database.DatabaseFactory")
+        for db in list(factory.getActiveDatabaseInstances()):
+            try:
+                if db.isOpen():
+                    db.close()
+            except Exception:  # nosec B110 - best-effort cleanup at exit
+                pass
+    except Exception:  # nosec B110 - best-effort cleanup at exit
+        pass
 
 
 def _normalize_jvm_args(jvm_args: Optional[Union[Iterable[str], str]]) -> list[str]:
@@ -401,6 +543,7 @@ def shutdown_jvm():
     nothing left for us to do.
     """
     if jpype.isJVMStarted():
+        _close_active_databases()
         try:
             jpype.shutdownJVM()
         except RuntimeError:

--- a/bindings/python/src/arcadedb_embedded/results.py
+++ b/bindings/python/src/arcadedb_embedded/results.py
@@ -6,8 +6,34 @@ ResultSet and Result classes for wrapping query results.
 
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
+from ._logging import get_logger
 from .graph import Document, Edge, Vertex
 from .type_conversion import convert_java_to_python
+
+_logger = get_logger(__name__)
+_BRIDGE_CLASSES: dict = {}
+
+
+def _bridge_class(name):
+    """Cached bridge-class lookup; None (with one warning) if unavailable.
+
+    In an installed wheel the bridge jar is always on the classpath, so the
+    None path only occurs in broken source checkouts."""
+    if name in _BRIDGE_CLASSES:
+        return _BRIDGE_CLASSES[name]
+    import jpype
+
+    try:
+        cls = jpype.JClass(f"com.arcadedb.python.{name}")
+    except Exception:
+        cls = None
+        _logger.warning(
+            "bridge class %s unavailable; falling back to the slow per-row "
+            "path (is the bridge jar missing from this build?)",
+            name,
+        )
+    _BRIDGE_CLASSES[name] = cls
+    return cls
 
 
 def _java_class_name(value: Any) -> str:
@@ -121,11 +147,8 @@ class ResultSet:
         """
         import json
 
-        import jpype
-
-        try:
-            row_batcher = jpype.JClass("com.arcadedb.python.RowBatcher")
-        except Exception:
+        row_batcher = _bridge_class("RowBatcher")
+        if row_batcher is None:
             chunk: List[Dict[str, Any]] = []
             for row in self.iter_dicts():
                 chunk.append(row)
@@ -178,6 +201,12 @@ class ResultSet:
             # row path and ~6x the per-row path on 100k-row scans
             columns = self.to_columns()
             if columns is not None:
+                # pandas rejects 2-D ndarrays as column values; vector
+                # columns (f4v/f8v) become object columns of row slices
+                columns = {
+                    k: (list(v) if getattr(v, "ndim", 1) > 1 else v)
+                    for k, v in columns.items()
+                }
                 return pd.DataFrame(columns)
 
         return pd.DataFrame(self.to_list(convert_types=convert_types))
@@ -203,11 +232,8 @@ class ResultSet:
 
         import json
 
-        import jpype
-
-        try:
-            column_batcher = jpype.JClass("com.arcadedb.python.ColumnBatcher")
-        except Exception:
+        column_batcher = _bridge_class("ColumnBatcher")
+        if column_batcher is None:
             return None
 
         # column order comes from the first row; empty result -> {}
@@ -242,10 +268,8 @@ class ResultSet:
                         arr[mask] = np.nan
                     values = arr
                 elif ctype == "f8":
-                    arr = np.frombuffer(data, dtype="<f8").copy()
-                    if has_nulls:
-                        arr[mask] = np.nan
-                    values = arr
+                    # Java already writes NaN into null slots
+                    values = np.frombuffer(data, dtype="<f8")
                 elif ctype == "dt":
                     arr = np.frombuffer(data, dtype="<i8").astype("datetime64[ms]")
                     if has_nulls:
@@ -259,6 +283,12 @@ class ResultSet:
                         ]
                     else:
                         values = arr
+                elif ctype in ("f4v", "f8v"):
+                    # fixed-dimension vector column -> 2-D array (count, dim);
+                    # Java already writes NaN rows into null slots
+                    dim = col["dim"]
+                    dt = "<f4" if ctype == "f4v" else "<f8"
+                    values = np.frombuffer(data, dtype=dt).reshape(count, dim)
                 elif ctype == "json":
                     values = json.loads(bytes(data))
                 else:  # str
@@ -320,6 +350,131 @@ class ResultSet:
                 column.extend(p if isinstance(p, list) else p.tolist())
             out[name] = column
         return out
+
+    def to_arrow(self, batch_size: int = 25_000):
+        """
+        Bulk-materialize all rows as a ``pyarrow.Table``.
+
+        Reads the same columnar buffer as :meth:`to_columns` (one JSON header
+        plus packed little-endian columns and a null bitmap each), so there is
+        no extra work on the Java side. What differs is what happens to nulls
+        and to strings.
+
+        ``to_columns`` follows pandas conventions, which are lossy in two
+        places: a nullable int64 column is promoted to float64 with NaN, which
+        silently loses precision above 2**53 and loses the type; and a nullable
+        boolean column falls back to a Python list. Arrow carries a validity
+        bitmap alongside the values, so both keep their type here.
+
+        Strings are also cheaper: the buffer already holds int32 offsets
+        followed by a UTF-8 blob, which is exactly Arrow's string layout, so
+        the column is wrapped rather than decoded one Python str at a time.
+
+        Returns None when pyarrow, numpy, or the bridge jar is unavailable, so
+        callers can fall back to :meth:`to_columns` the same way that method
+        falls back to the row-based paths.
+        """
+        try:
+            import numpy as np
+            import pyarrow as pa
+        except ImportError:
+            return None
+
+        import json
+
+        column_batcher = _bridge_class("ColumnBatcher")
+        if column_batcher is None:
+            return None
+
+        first_names: Optional[List[str]] = None
+        chunks: Dict[str, list] = {}
+
+        def validity(null_bits, count, has_nulls):
+            """Arrow validity is 1=valid; the bridge writes 1=null, so invert.
+            Bits past `count` are padding and Arrow ignores them."""
+            if not has_nulls:
+                return None
+            return pa.py_buffer(bytes(np.invert(null_bits).tobytes()))
+
+        def decode_batch(buf):
+            nonlocal first_names
+            hlen = int.from_bytes(buf[:4], "little")
+            header = json.loads(bytes(buf[4 : 4 + hlen]))
+            count = header["count"]
+            if count == 0:
+                return 0
+            pos = 4 + hlen
+            for col in header["cols"]:
+                name, ctype = col["name"], col["type"]
+                nulls_len = col["nulls"]
+                null_bits = np.frombuffer(buf[pos : pos + nulls_len], dtype=np.uint8)
+                has_nulls = bool(null_bits.any())
+                mask = None
+                if has_nulls:
+                    mask = np.unpackbits(null_bits, bitorder="little")[:count].astype(
+                        bool
+                    )
+                pos += nulls_len
+                data = buf[pos : pos + col["bytes"]]
+                pos += col["bytes"]
+
+                if ctype == "i8":
+                    # kept as int64 WITH validity, where to_columns would have
+                    # promoted the whole column to float64/NaN
+                    arr = pa.array(np.frombuffer(data, dtype="<i8"), mask=mask)
+                elif ctype == "f8":
+                    arr = pa.array(np.frombuffer(data, dtype="<f8"), mask=mask)
+                elif ctype == "dt":
+                    ts = np.frombuffer(data, dtype="<i8").astype("datetime64[ms]")
+                    arr = pa.array(ts, type=pa.timestamp("ms"), mask=mask)
+                elif ctype == "b1":
+                    # stays a bool column; to_columns degrades this to a list
+                    vals = np.frombuffer(data, dtype=np.uint8).astype(bool)
+                    arr = pa.array(vals, mask=mask)
+                elif ctype in ("f4v", "f8v"):
+                    dim = col["dim"]
+                    dt = "<f4" if ctype == "f4v" else "<f8"
+                    flat = np.frombuffer(data, dtype=dt)
+                    child = pa.array(flat)
+                    arr = pa.FixedSizeListArray.from_arrays(child, dim)
+                    if mask is not None:
+                        arr = pa.array(arr.to_pylist(), type=arr.type, mask=mask)
+                elif ctype == "json":
+                    arr = pa.array(json.loads(bytes(data)))
+                else:  # str: int32 offsets + utf8 blob IS Arrow's layout
+                    off_bytes = bytes(data[: (count + 1) * 4])
+                    chars = bytes(data[(count + 1) * 4 :])
+                    arr = pa.StringArray.from_buffers(
+                        count,
+                        pa.py_buffer(off_bytes),
+                        pa.py_buffer(chars),
+                        validity(null_bits, count, has_nulls),
+                    )
+                chunks.setdefault(name, []).append(arr)
+            if first_names is None:
+                first_names = [c["name"] for c in header["cols"]]
+            return count
+
+        joined = ""
+        total = 0
+        while True:
+            buf = memoryview(
+                bytes(
+                    column_batcher.nextColumnBatch(
+                        self._java_result_set, int(batch_size), joined
+                    )
+                )
+            )
+            count = decode_batch(buf)
+            if count == 0:
+                break
+            total += count
+            if first_names is not None and not joined:
+                joined = ";".join(first_names)
+
+        if total == 0 or not first_names:
+            return pa.table({})
+        return pa.table({n: pa.chunked_array(chunks[n]) for n in first_names})
 
     def iter_chunks(
         self, size: int = 1000, convert_types: bool = True

--- a/bindings/python/src/arcadedb_embedded/schema.py
+++ b/bindings/python/src/arcadedb_embedded/schema.py
@@ -82,7 +82,7 @@ class Schema:
 
         Args:
             name: Type name
-            buckets: Number of buckets (default: 3)
+            buckets: Number of buckets (default: 1, the engine default)
 
         Returns:
             Java DocumentType object
@@ -109,7 +109,7 @@ class Schema:
 
         Args:
             name: Type name
-            buckets: Number of buckets (default: 3)
+            buckets: Number of buckets (default: 1, the engine default)
 
         Returns:
             Java VertexType object
@@ -137,7 +137,7 @@ class Schema:
 
         Args:
             name: Type name
-            buckets: Number of buckets (default: 3)
+            buckets: Number of buckets (default: 1, the engine default)
 
         Returns:
             Java EdgeType object
@@ -166,7 +166,7 @@ class Schema:
 
         Args:
             name: Type name
-            buckets: Number of buckets (default: 3) if creating new type
+            buckets: Number of buckets (default: 1, the engine default) if creating new type
 
         Returns:
             Java DocumentType object
@@ -188,7 +188,7 @@ class Schema:
 
         Args:
             name: Type name
-            buckets: Number of buckets (default: 3) if creating new type
+            buckets: Number of buckets (default: 1, the engine default) if creating new type
 
         Returns:
             Java VertexType object
@@ -208,7 +208,7 @@ class Schema:
 
         Args:
             name: Type name
-            buckets: Number of buckets (default: 3) if creating new type
+            buckets: Number of buckets (default: 1, the engine default) if creating new type
 
         Returns:
             Java EdgeType object
@@ -229,8 +229,8 @@ class Schema:
         Args:
             name: Type name to drop
 
-        Raises:
-            ArcadeDBError: If type doesn't exist or database is closed
+        Returns:
+            The type, or None if it doesn't exist or database is closed
 
         Example:
             >>> db.schema.drop_type("OldType")
@@ -251,8 +251,8 @@ class Schema:
         Returns:
             Java DocumentType/VertexType/EdgeType object
 
-        Raises:
-            ArcadeDBError: If type doesn't exist
+        Returns:
+            The type, or None if it doesn't exist
 
         Example:
             >>> user_type = db.schema.get_type("User")
@@ -314,8 +314,8 @@ class Schema:
         Returns:
             Java Property object
 
-        Raises:
-            ArcadeDBError: If type doesn't exist or property already exists
+        Returns:
+            The type, or None if it doesn't exist or property already exists
 
         Example:
             >>> db.schema.create_property("User", "email", "STRING")
@@ -462,8 +462,8 @@ class Schema:
         Returns:
             Java Index object
 
-        Raises:
-            ArcadeDBError: If type doesn't exist or index creation fails
+        Returns:
+            The type, or None if it doesn't exist or index creation fails
 
         Example:
             >>> # Simple index

--- a/bindings/python/src/arcadedb_embedded/server.py
+++ b/bindings/python/src/arcadedb_embedded/server.py
@@ -1,0 +1,259 @@
+"""
+ArcadeDB Python Bindings - Server Management
+
+ArcadeDB server for HTTP API and Studio web interface.
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+from .core import Database
+from .exceptions import ArcadeDBError
+from .jvm import start_jvm
+
+
+class ArcadeDBServer:
+    """ArcadeDB Server wrapper for enabling HTTP API and Studio access."""
+
+    def __init__(
+        self,
+        root_path: str = "./databases",
+        root_password: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+        jvm_kwargs: Optional[dict] = None,
+    ):
+        """
+        Initialize ArcadeDB server.
+
+        Args:
+            root_path: Root directory for databases (default: ./databases)
+            root_password: Root user password (optional, recommended for
+                production)
+            config: Optional configuration dictionary with keys like:
+                - http_port: HTTP API port (default: 2480)
+                - host: Host to bind to (default: "localhost"). Pass "0.0.0.0"
+                    explicitly to expose the server on all IPv4 interfaces, or
+                    "::" for all IPv6 interfaces. Earlier versions defaulted to
+                    "0.0.0.0"; the default was tightened to loopback in the
+                    Python bindings v0.x security cleanup.
+                - mode: Server mode (default: development)
+
+                Any other key is forwarded to ArcadeDB as
+                ``arcadedb.<key with _ replaced by .>``, which is how the
+                bundled wire protocols are reached. The wheel ships the
+                Postgres, Redis and Bolt plugins but starts none of them
+                unless asked::
+
+                    create_server(config={
+                        "server_plugins":
+                            "Postgres:com.arcadedb.postgres.PostgresProtocolPlugin",
+                        "postgres_port": 5432,   # -> arcadedb.postgres.port
+                    })
+
+                Redis is ``com.arcadedb.redis.RedisProtocolPlugin`` with
+                ``redis_port``, Bolt is
+                ``com.arcadedb.bolt.BoltProtocolPlugin`` with ``bolt_port``.
+                Mongo, gRPC and Raft replication are NOT bundled: their jars
+                are excluded to keep the wheel installable, so this server is
+                single-node by construction.
+
+                There is deliberately no ``binary_port``. It was documented
+                here until 2026-08-01 and silently discarded, because
+                ArcadeDB has no such setting: its ports are
+                ``httpIncomingPort``, ``httpsIncomingPort`` and the
+                per-protocol ones above. 2424 is OrientDB's legacy binary
+                port and never applied to this engine.
+            jvm_kwargs: Optional JVM args passed to start_jvm()
+                Example: {"heap_size": "8g"}
+        """
+        start_jvm(**(jvm_kwargs or {}))
+        from com.arcadedb import ContextConfiguration
+        from com.arcadedb.server import ArcadeDBServer as JavaArcadeDBServer
+
+        self._config = config or {}
+        self._root_path = root_path
+        self._root_password = root_password
+        self._java_server = None
+        self._started = False
+
+        # Create configuration
+        context_config = ContextConfiguration()
+
+        # Set root path
+        context_config.setValue("arcadedb.server.rootPath", root_path)
+
+        # Set root password if provided
+        if root_password:
+            context_config.setValue("arcadedb.server.rootPassword", root_password)
+
+        # Set common defaults
+        mode = self._config.get("mode", "development")
+        context_config.setValue("arcadedb.server.mode", mode)
+
+        # Default to loopback; callers must opt in to "0.0.0.0" explicitly to
+        # expose the server on all interfaces.
+        host = self._config.get("host", "localhost")
+        context_config.setValue("arcadedb.server.httpIncomingHost", host)
+
+        http_port = self._config.get("http_port", 2480)
+        context_config.setValue("arcadedb.server.httpIncomingPort", http_port)
+
+        # Apply any additional configuration
+        for key, value in self._config.items():
+            # "binary_port" used to be skipped here AND advertised in the
+            # docstring, so it was accepted and dropped without a word. It is
+            # gone from both: ArcadeDB has no binary port to set.
+            if key not in ["mode", "host", "http_port"]:
+                # Convert Python config keys to ArcadeDB config format
+                config_key = f"arcadedb.{key.replace('_', '.')}"
+                context_config.setValue(config_key, value)
+
+        # Create server instance
+        self._java_server = JavaArcadeDBServer(context_config)
+
+    def start(self):
+        """Start the ArcadeDB server."""
+        if self._started:
+            raise ArcadeDBError("Server is already started")
+
+        try:
+            self._java_server.start()
+            self._started = True
+        except Exception as e:
+            raise ArcadeDBError(f"Failed to start server: {e}") from e
+
+    def stop(self):
+        """Stop the ArcadeDB server."""
+        if not self._started:
+            return
+
+        try:
+            self._java_server.stop()
+            self._started = False
+        except Exception as e:
+            raise ArcadeDBError(f"Failed to stop server: {e}") from e
+
+    def __del__(self):
+        """Finalizer - ensure server is stopped.
+
+        See Database.__del__ for rationale on the narrowed except clause.
+        """
+        try:
+            if self._started and self._java_server is not None:
+                self._java_server.stop()
+                self._started = False
+        except (AttributeError, RuntimeError):
+            return
+
+    def get_database(self, name: str) -> Database:
+        """
+        Get a database instance from the server.
+
+        Args:
+            name: Database name
+
+        Returns:
+            Database instance
+        """
+        if not self._started:
+            raise ArcadeDBError("Server is not started")
+
+        try:
+            java_db = self._java_server.getDatabase(name)
+            return Database(java_db)
+        except Exception as e:
+            raise ArcadeDBError(f"Failed to get database '{name}': {e}") from e
+
+    def create_database(self, name: str) -> Database:
+        """
+        Create a new database on the server.
+
+        This uses the server's built-in database management, which properly
+        registers the database and makes it immediately visible in Studio.
+
+        Args:
+            name: Database name
+
+        Returns:
+            Database instance
+        """
+        if not self._started:
+            raise ArcadeDBError("Server is not started")
+
+        try:
+            # Use server's getDatabase with createIfNotExists=True
+            # This properly registers the database with the server
+            java_db = self._java_server.getDatabase(name, True, True)
+            return Database(java_db)
+        except Exception as e:
+            raise ArcadeDBError(f"Failed to create database '{name}': {e}") from e
+
+    def is_started(self) -> bool:
+        """Check if server is running."""
+        return self._started
+
+    def get_http_port(self) -> int:
+        """Get the HTTP port the server is listening on."""
+        return self._config.get("http_port", 2480)
+
+    def get_studio_url(self) -> str:
+        """Get the URL for the Studio web interface."""
+        host = self._config.get("host", "localhost")
+        if host in ("0.0.0.0", "::"):  # nosec B104
+            host = "localhost"
+        port = self.get_http_port()
+        return f"http://{host}:{port}/"
+
+    def __enter__(self):
+        """Context manager entry - starts the server."""
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - stops the server."""
+        self.stop()
+
+
+def create_server(
+    root_path: str = "./databases",
+    root_password: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> ArcadeDBServer:
+    """
+    Create an ArcadeDB server instance.
+
+    Args:
+        root_path: Root directory for databases (default: ./databases)
+        root_password: Root user password (optional, recommended for
+            production)
+        config: Optional configuration dictionary
+
+    Returns:
+        ArcadeDBServer instance
+
+    Note - Log File Locations:
+        ArcadeDB writes logs to multiple locations:
+
+        1. Application logs (arcadedb.log.*):
+           - Location: ./log/ (relative to working directory)
+           - Cannot be changed without modifying Java code
+
+        2. Server event logs (server-event-log-*.jsonl):
+           - Location: {root_path}/log/ (e.g., ./databases/log/)
+           - Keeps event logs with their respective databases
+
+        3. JVM crash logs (hs_err_pid*.log):
+           - Default: ./log/hs_err_pid*.log
+           - Customize with ARCADEDB_JVM_ERROR_FILE before importing
+
+        To customize locations, set environment variables BEFORE importing:
+            os.environ["ARCADEDB_JVM_ERROR_FILE"] = "/custom/path/errors.log"
+            import arcadedb_embedded as arcadedb
+
+        Note: Application log location is hardcoded in ArcadeDB's Java code
+        and cannot be changed via environment variables.
+    """
+    # Normalize to absolute path to avoid path doubling issues
+    abs_root_path = os.path.abspath(root_path)
+
+    return ArcadeDBServer(abs_root_path, root_password, config)

--- a/bindings/python/src/arcadedb_embedded/type_conversion.py
+++ b/bindings/python/src/arcadedb_embedded/type_conversion.py
@@ -289,12 +289,25 @@ def _conv_iter_to_list(value):
 def _conv_primitive_array(value):
     # Bulk copy through the buffer protocol: ~200x faster than per-element
     # recursion for a 384-float vector.
-    return memoryview(value).tolist()
+    mv = memoryview(value)
+    if (
+        mv.format.startswith("=")
+        or mv.format.startswith("<")
+        or mv.format.startswith(">")
+    ):
+        # CPython's memoryview.tolist() rejects standard-size-prefixed
+        # formats ('=i' for int[], '=q' for long[]) with NotImplementedError
+        # (issue #4). Recast through bytes to the native format char.
+        mv = mv.cast("b").cast(mv.format[1:])
+    return mv.tolist()
 
 
 def _register(value, converter):
+    # Convert FIRST: caching before the first successful conversion pins a
+    # broken converter for the process lifetime (issue #4).
+    result = converter(value)
     _CONVERTER_CACHE[type(value)] = converter
-    return converter(value)
+    return result
 
 
 def _convert_and_register(value):

--- a/bindings/python/src/arcadedb_embedded/vector.py
+++ b/bindings/python/src/arcadedb_embedded/vector.py
@@ -511,7 +511,9 @@ class VectorIndex:
                 "max_connections": int(meta.maxConnections),
                 "beam_width": int(meta.beamWidth),
                 "ef_search": int(meta.efSearch),
-                "location_cache_size": int(meta.locationCacheSize),
+                # location_cache_size is absent on purpose: the engine dropped
+                # the field in #5559/#5568, so reading it here would raise on
+                # every get_metadata() call.
                 "graph_build_cache_size": int(meta.graphBuildCacheSize),
                 "mutations_before_rebuild": int(meta.mutationsBeforeRebuild),
                 "store_vectors_in_graph": bool(meta.storeVectorsInGraph),
@@ -524,6 +526,56 @@ class VectorIndex:
             }
         except Exception as e:
             raise ArcadeDBError(f"Failed to read vector index metadata: {e}") from e
+
+    def get_stats(self):
+        """
+        Get live runtime counters for the vector index.
+
+        Unlike :meth:`get_metadata`, which returns the index's stable
+        configuration, this returns counters that change as the index is
+        built and queried: graph state, cache capacities and hit/miss
+        counts, and where vectors were read from (index pages, graph, or
+        the documents themselves). Keys follow the engine and may grow
+        between releases.
+
+        Useful for sizing caches and diagnosing build cost, for example
+        ``vectorFetchFromDocuments`` being non-zero after a build means
+        the build cache did not hold the whole vector set.
+
+        Returns:
+            dict: Counter name to value, for the primary bucket index
+            (see ``get_metadata()["bucket_index_name"]``).
+
+        Examples:
+            >>> stats = index.get_stats()  # doctest: +SKIP
+            >>> stats["vectorCacheHits"], stats["vectorCacheMisses"]
+            (10399017, 1840948)
+        """
+        try:
+            raw = self._get_primary_lsm_index().getStats()
+        except Exception as e:
+            raise ArcadeDBError(f"Failed to read vector index stats: {e}") from e
+
+        stats = {}
+        for java_key in raw.keySet():
+            key = str(java_key)
+            value = raw.get(java_key)
+            if value is None:
+                stats[key] = None
+                continue
+            try:
+                kind = str(value.getClass().getSimpleName())
+            except Exception:
+                kind = ""
+            if kind in ("Long", "Integer", "Short", "Byte", "BigInteger"):
+                stats[key] = int(value)
+            elif kind in ("Double", "Float"):
+                stats[key] = float(value)
+            elif kind == "Boolean":
+                stats[key] = bool(value)
+            else:
+                stats[key] = str(value)
+        return stats
 
     def find_nearest_by_key(
         self,

--- a/bindings/python/src/java/com/arcadedb/python/ColumnBatcher.java
+++ b/bindings/python/src/java/com/arcadedb/python/ColumnBatcher.java
@@ -5,8 +5,7 @@
  * (column names/types/sizes) followed by per-column buffers — fixed-width
  * little-endian for numerics/bools/temporals (epoch millis), offset+UTF-8
  * for strings, plus a null bitmap per column. Columns whose values don't
- * fit those encodings are serialized as a JSON array ("json" type) using
- * RowBatcher's normalization. Python decodes with numpy.frombuffer
+ * fit those encodings are serialized as one JSON array ("json" type). Python decodes with numpy.frombuffer
  * (ResultSet.to_columns / the fast to_dataframe path). Measured ~1.2x of
  * Java-native iteration on 100k-row scans (vs 3.4x for the JSON row path).
  */
@@ -90,10 +89,14 @@ public final class ColumnBatcher {
           t = "b1";
         else if (v instanceof java.util.Date || v instanceof java.time.LocalDateTime
             || v instanceof java.time.LocalDate || v instanceof java.time.Instant
-            || v instanceof java.time.ZonedDateTime)
+            || v instanceof java.time.ZonedDateTime || v instanceof java.time.OffsetDateTime)
           t = "dt";
         else if (v instanceof String || v instanceof Character)
           t = "str";
+        else if (v instanceof float[])
+          t = "f4v";
+        else if (v instanceof double[])
+          t = "f8v";
         else
           t = "json";
         if (type == null)
@@ -110,6 +113,23 @@ public final class ColumnBatcher {
       }
       if (type == null)
         type = "str"; // all-null column
+
+      int vdim = -1;
+      if (type.equals("f4v") || type.equals("f8v")) {
+        // vector columns must be uniform-length; ragged degrades to json
+        for (int r = 0; r < count && vdim != -2; r++) {
+          final Object v = rows.get(r)[c];
+          if (v == null)
+            continue;
+          final int len = type.equals("f4v") ? ((float[]) v).length : ((double[]) v).length;
+          if (vdim == -1)
+            vdim = len;
+          else if (vdim != len)
+            vdim = -2;
+        }
+        if (vdim < 0)
+          type = "json";
+      }
 
       byte[] colBuf;
       if (type.equals("i8") || type.equals("dt")) {
@@ -145,6 +165,32 @@ public final class ColumnBatcher {
             bb.put((byte) 0);
           } else
             bb.put((byte) (((Boolean) v) ? 1 : 0));
+        }
+        colBuf = bb.array();
+      } else if (type.equals("f4v")) {
+        final ByteBuffer bb = ByteBuffer.allocate(count * vdim * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (int r = 0; r < count; r++) {
+          final Object v = rows.get(r)[c];
+          if (v == null) {
+            nulls[r >> 3] |= (1 << (r & 7));
+            for (int k = 0; k < vdim; k++)
+              bb.putFloat(Float.NaN);
+          } else
+            for (final float x : (float[]) v)
+              bb.putFloat(x);
+        }
+        colBuf = bb.array();
+      } else if (type.equals("f8v")) {
+        final ByteBuffer bb = ByteBuffer.allocate(count * vdim * 8).order(ByteOrder.LITTLE_ENDIAN);
+        for (int r = 0; r < count; r++) {
+          final Object v = rows.get(r)[c];
+          if (v == null) {
+            nulls[r >> 3] |= (1 << (r & 7));
+            for (int k = 0; k < vdim; k++)
+              bb.putDouble(Double.NaN);
+          } else
+            for (final double x : (double[]) v)
+              bb.putDouble(x);
         }
         colBuf = bb.array();
       } else if (type.equals("json")) {
@@ -184,7 +230,10 @@ public final class ColumnBatcher {
       if (c > 0)
         header.append(',');
       header.append("{\"name\":\"").append(columns[c]).append("\",\"type\":\"").append(type)
-          .append("\",\"nulls\":").append(nulls.length).append(",\"bytes\":").append(colBuf.length).append('}');
+          .append("\",\"nulls\":").append(nulls.length).append(",\"bytes\":").append(colBuf.length);
+      if (vdim > 0 && (type.equals("f4v") || type.equals("f8v")))
+        header.append(",\"dim\":").append(vdim);
+      header.append('}');
       body.write(nulls, 0, nulls.length);
       body.write(colBuf, 0, colBuf.length);
     }

--- a/bindings/python/src/java/com/arcadedb/python/DocumentBatcher.java
+++ b/bindings/python/src/java/com/arcadedb/python/DocumentBatcher.java
@@ -1,0 +1,81 @@
+/*
+ * Python-bindings bridge: bulk document insertion.
+ *
+ * Database.insert_many() from Python would otherwise pay ~5 JNI calls per
+ * row (newDocument + set per property + save), which caps ingest around
+ * 30-130k rows/s regardless of engine speed. This helper accepts the rows
+ * as ONE JSON string and loops Java-side, so the whole batch costs one bulk
+ * string copy plus the engine's own write path.
+ *
+ * Two modes: transactional batches on the calling thread (commitEvery), or
+ * the async executor's parallel bucket writers (parallel=true; the Python
+ * insert_many wrapper waits for completion itself). The boxDoubles/boxLongs
+ * helpers below serve AsyncExecutor.append_samples' numpy fast path.
+ *
+ * JSON-representable property values only (str/int/float/bool/null and
+ * nested lists/maps thereof) — the Python side falls back to the per-row
+ * new_document path for anything else (e.g. datetime, bytes).
+ */
+package com.arcadedb.python;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+
+public final class DocumentBatcher {
+
+  private DocumentBatcher() {
+  }
+
+  public static long insertManyJson(final Database db, final String typeName, final String jsonRows,
+      final int commitEvery, final boolean parallel) {
+    final JSONArray rows = new JSONArray(jsonRows);
+    final int n = rows.length();
+    if (parallel) {
+      for (int i = 0; i < n; i++) {
+        final MutableDocument doc = db.newDocument(typeName);
+        fill(doc, rows.getJSONObject(i));
+        db.async().createRecord(doc, null);
+      }
+      return n;
+    }
+    final boolean wasActive = db.isTransactionActive();
+    if (!wasActive)
+      db.begin();
+    for (int i = 0; i < n; i++) {
+      final MutableDocument doc = db.newDocument(typeName);
+      fill(doc, rows.getJSONObject(i));
+      doc.save();
+      if (commitEvery > 0 && (i + 1) % commitEvery == 0) {
+        db.commit();
+        db.begin();
+      }
+    }
+    if (!wasActive)
+      db.commit();
+    return n;
+  }
+
+  /** Box primitive columns Java-side so numpy arrays can cross the FFI as
+   * one buffer copy and still feed Object[]-typed engine APIs (e.g.
+   * TimeSeriesEngine.appendSamples). */
+  public static Object[] boxDoubles(final double[] a) {
+    final Object[] out = new Object[a.length];
+    for (int i = 0; i < a.length; i++)
+      out[i] = a[i];
+    return out;
+  }
+
+  public static Object[] boxLongs(final long[] a) {
+    final Object[] out = new Object[a.length];
+    for (int i = 0; i < a.length; i++)
+      out[i] = a[i];
+    return out;
+  }
+
+  private static void fill(final MutableDocument doc, final JSONObject row) {
+    for (final String key : row.keySet())
+      doc.set(key, row.isNull(key) ? null : row.get(key));
+  }
+}

--- a/bindings/python/src/java/com/arcadedb/python/TimeSeriesBatcher.java
+++ b/bindings/python/src/java/com/arcadedb/python/TimeSeriesBatcher.java
@@ -1,0 +1,64 @@
+/*
+ * Python-bindings bridge: primitive columnar append into a native TIMESERIES type.
+ *
+ * AsyncExecutor.append_samples' original path hands the engine Object[] columns, so every
+ * numeric sample is boxed once on the way in and unboxed immediately on the way out
+ * (ArcadeDB issue #5474: 7.8M dead Double allocations per TSBS ingest). The engine now
+ * accepts a TimeSeriesBatch of primitive columns instead.
+ *
+ * Filling that batch row-by-row from Python would cost one JNI call per value, which is far
+ * worse than the boxing it replaces. These helpers move the loop to the Java side: one FFI
+ * crossing per column, each carrying a contiguous primitive array copied straight out of the
+ * caller's numpy buffer.
+ */
+package com.arcadedb.python;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.engine.timeseries.ColumnDefinition;
+import com.arcadedb.engine.timeseries.TimeSeriesBatch;
+import com.arcadedb.schema.LocalTimeSeriesType;
+
+import java.util.List;
+
+public final class TimeSeriesBatcher {
+
+  private TimeSeriesBatcher() {
+  }
+
+  /**
+   * Allocates a batch for the type and opens one row per timestamp. Column values are filled
+   * afterwards by the setters below, which is why the rows must exist first.
+   */
+  public static TimeSeriesBatch newBatch(final Database db, final String typeName, final long[] timestamps) {
+    final LocalTimeSeriesType type = (LocalTimeSeriesType) db.getSchema().getType(typeName);
+    final List<ColumnDefinition> columns = type.getTsColumns();
+    final TimeSeriesBatch batch = new TimeSeriesBatch(columns, timestamps.length);
+    for (final long ts : timestamps)
+      batch.addRow(ts);
+    return batch;
+  }
+
+  public static void setDoubleColumn(final TimeSeriesBatch batch, final int columnIndex, final double[] values) {
+    for (int row = 0; row < values.length; row++)
+      batch.setDouble(row, columnIndex, values[row]);
+  }
+
+  public static void setLongColumn(final TimeSeriesBatch batch, final int columnIndex, final long[] values) {
+    for (int row = 0; row < values.length; row++)
+      batch.setLong(row, columnIndex, values[row]);
+  }
+
+  public static void setStringColumn(final TimeSeriesBatch batch, final int columnIndex, final String[] values) {
+    for (int row = 0; row < values.length; row++)
+      batch.setString(row, columnIndex, values[row]);
+  }
+
+  /**
+   * Fallback for a column whose Python values are not a single primitive kind (mixed types, or a
+   * declared type the batch stores as text). Values arrive already converted to Java objects.
+   */
+  public static void setObjectColumn(final TimeSeriesBatch batch, final int columnIndex, final Object[] values) {
+    for (int row = 0; row < values.length; row++)
+      batch.setValue(row, columnIndex, values[row]);
+  }
+}

--- a/bindings/python/tests/README.md
+++ b/bindings/python/tests/README.md
@@ -7,7 +7,8 @@ For detailed test documentation, examples, and best practices, see the **[Testin
 ## Quick Stats
 
 - Current bindings suite
-- Package includes the embedded ArcadeDB features (SQL, OpenCypher, vectors, graphs)
+- Package includes the embedded ArcadeDB features (SQL, OpenCypher, vectors,
+  graphs) **and** the optional in-process HTTP server with Studio
 
 ## Running Tests
 
@@ -30,16 +31,35 @@ pytest -k "transaction" -v
 | File | Coverage |
 |------|----------|
 | `test_core.py` | Core CRUD, transactions, queries, graphs, vectors |
+| `test_server.py` | Server lifecycle, HTTP API, Studio, configuration |
+| `test_server_packaging.py` | The server stack is really in the wheel (fails, never skips) |
+| `test_server_patterns.py` | Embedded, server-managed, and HTTP access patterns |
 | `test_concurrency.py` | File locking, thread safety, multi-process |
 | `test_import_database.py` | SQL `IMPORT DATABASE`, CSV/XML/Neo4j and restore flows |
-| `test_docs_examples.py` | Validates runnable Python snippets from installation, quickstart, query, and graph docs |
+| `test_docs_examples.py` | Validates runnable Python snippets from installation, quickstart, query, graph, and API-access docs |
 | `test_cypher.py` | OpenCypher query language, path modes, and planner regressions |
+
+### A note on the server tests
+
+`test_server.py` and `test_server_patterns.py` skip themselves when server
+support is absent, which is convenient but has a failure mode: in 26.7.2 the
+server JARs were dropped from the wheel and those tests **skipped instead of
+failing**, so the suite stayed green while the feature was gone. That is what
+`test_server_packaging.py` is for. It never skips. If you deliberately want a
+slim wheel, delete that file on purpose rather than letting the suite go quiet.
+
+```bash
+uv run pytest -m server -v      # only the server tests
+uv run pytest -m "not server"   # skip them (they start a real HTTP listener)
+```
 
 ## Documentation Links
 
 - **[Testing Overview](https://docs.humem.ai/arcadedb/latest/development/testing/overview/)** - Quick start guide
 - **[Core Tests](https://docs.humem.ai/arcadedb/latest/development/testing/test-core/)** - Database operations
+- **[Server Tests](https://docs.humem.ai/arcadedb/latest/development/testing/test-server/)** - HTTP API
 - **[Concurrency Tests](https://docs.humem.ai/arcadedb/latest/development/testing/test-concurrency/)** - Multi-process, threads
+- **[Server Patterns](https://docs.humem.ai/arcadedb/latest/development/testing/test-server-patterns/)** - Best practices
 - **[Data Import Tests](https://docs.humem.ai/arcadedb/latest/development/testing/test-importer/)** - SQL import workflows and format coverage
 - **[OpenCypher Tests](https://docs.humem.ai/arcadedb/latest/development/testing/test-opencypher/)** - Graph queries
 - **[Best Practices](https://docs.humem.ai/arcadedb/latest/development/testing/best-practices/)** - Summary checklist
@@ -61,13 +81,24 @@ for t in threads: t.start()
 for t in threads: t.join()
 ```
 
-### Multi-Process ❌
+### Multi-Process ❌ → ✅
 ```python
-# Multiple processes CANNOT access the same database file (file lock).
-# This package is embedded-only: for multi-process/client-server access,
-# run the official ArcadeDB server (e.g. the arcadedata/arcadedb Docker
-# image) and connect over HTTP.
+# Multiple processes CANNOT open the same database file (file lock).
+# Server mode is the in-process answer: one process holds the database and
+# serves HTTP, everyone else connects over it.
+
+server = arcadedb.create_server("./databases", root_password="...")
+server.start()
+# "mydb" is created at ./databases/databases/mydb
+db = server.create_database("mydb")
+
+# The owning process keeps embedded (in-JVM) access to db, and HTTP clients
+# in other processes reach the same data through the server.
 ```
+
+For a database whose lifetime should outlive your Python process, or for
+HA/TLS, run the official ArcadeDB server distribution instead. See
+[Server Mode](https://docs.humem.ai/arcadedb/latest/guide/server/).
 
 ## Need Help?
 

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -9,6 +9,53 @@ import tempfile
 import pytest
 
 
+def pytest_configure(config):
+    # HotSpot routinely raises access violations it handles itself
+    # (safepoints, implicit null checks). On Windows, pytest's faulthandler
+    # prints a fatal-looking Python stack for each one even though nothing
+    # crashed. Disable it there; real crashes still fail the run.
+    import sys
+
+    if sys.platform == "win32":
+        import faulthandler
+
+        if faulthandler.is_enabled():
+            faulthandler.disable()
+
+
+# Shared test password used by server-mode tests. ArcadeDB requires >= 8 chars.
+# Hardcoded test fixture, not a real credential.
+TEST_PASSWORD = "test12345"  # nosec B105
+
+
+@pytest.fixture
+def temp_server_root():
+    """Create a temporary server root directory."""
+    temp_dir = tempfile.mkdtemp(prefix="arcadedb_test_server_")
+    yield temp_dir
+    if os.path.exists(temp_dir):
+        shutil.rmtree(temp_dir)
+
+
+def has_server_support():
+    """Is the server stack bundled in this wheel?
+
+    The server JARs (arcadedb-server, studio, undertow, xnio, wildfly, jboss,
+    micrometer) are shipped by default, but a slim build can exclude them via
+    scripts/jar_exclusions.txt. Probing for the studio JAR keeps the suite
+    honest either way: server tests skip rather than fail on a slim wheel.
+    """
+    try:
+        from arcadedb_embedded.jvm import get_jar_path
+
+        jar_dir = get_jar_path()
+        if not os.path.exists(jar_dir):
+            return False
+        return any("studio" in j.lower() for j in os.listdir(jar_dir))
+    except Exception:
+        return False
+
+
 @pytest.fixture
 def temp_db_path():
     """Create a temporary database path."""
@@ -114,6 +161,10 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "graph_export: tests that require GraphML/GraphSON support",
+    )
+    config.addinivalue_line(
+        "markers",
+        "server: tests that require server support (available in base package)",
     )
 
 

--- a/bindings/python/tests/test_bulk_insert.py
+++ b/bindings/python/tests/test_bulk_insert.py
@@ -1,0 +1,268 @@
+"""Tests for Database.insert_many and AsyncExecutor.create_record."""
+
+import datetime
+
+import pytest
+
+
+def _count(db, type_name):
+    q = f"SELECT count(*) AS n FROM {type_name}"  # nosec B608 - test-controlled
+    return int(db.query("sql", q).to_list()[0]["n"])
+
+
+class TestInsertMany:
+    def test_basic_roundtrip(self, temp_db):
+        temp_db.command("sql", "CREATE DOCUMENT TYPE Item")
+        rows = [
+            {
+                "k": i,
+                "name": f"item_{i}",
+                "price": i * 1.5,
+                "active": i % 2 == 0,
+                "tags": ["a", "b"],
+                "meta": {"x": i},
+            }
+            for i in range(500)
+        ]
+        n = temp_db.insert_many("Item", rows, commit_every=100)
+        assert n == 500
+        assert _count(temp_db, "Item") == 500
+        got = temp_db.query("sql", "SELECT FROM Item WHERE k = 7").to_list()[0]
+        assert got["name"] == "item_7"
+        assert got["price"] == pytest.approx(10.5)
+        assert got["active"] is False
+        assert list(got["tags"]) == ["a", "b"]
+
+    def test_null_values(self, temp_db):
+        temp_db.command("sql", "CREATE DOCUMENT TYPE Nul")
+        n = temp_db.insert_many("Nul", [{"a": 1, "b": None}, {"a": None}])
+        assert n == 2
+        assert _count(temp_db, "Nul") == 2
+
+    def test_empty(self, temp_db):
+        temp_db.command("sql", "CREATE DOCUMENT TYPE Empty")
+        assert temp_db.insert_many("Empty", []) == 0
+
+    def test_parallel(self, temp_db):
+        temp_db.command("sql", "CREATE DOCUMENT TYPE Par")
+        rows = [{"k": i} for i in range(2000)]
+        n = temp_db.insert_many("Par", rows, parallel=True)
+        assert n == 2000
+        assert _count(temp_db, "Par") == 2000
+
+    def test_non_json_fallback(self, temp_db):
+        temp_db.command("sql", "CREATE DOCUMENT TYPE Dated")
+        rows = [
+            {"k": i, "when": datetime.datetime(2026, 7, 25, 12, 0, i)} for i in range(3)
+        ]
+        n = temp_db.insert_many("Dated", rows)
+        assert n == 3
+        assert _count(temp_db, "Dated") == 3
+
+    def test_inside_open_transaction(self, temp_db):
+        temp_db.command("sql", "CREATE DOCUMENT TYPE Tx")
+        temp_db.begin()
+        temp_db.insert_many("Tx", [{"k": 1}, {"k": 2}], commit_every=0)
+        temp_db.commit()
+        assert _count(temp_db, "Tx") == 2
+
+
+class TestAsyncCreateRecord:
+    def test_create_and_wait(self, temp_db):
+        temp_db.command("sql", "CREATE DOCUMENT TYPE ARec")
+        ex = temp_db.async_executor()
+        for i in range(100):
+            doc = temp_db.new_document("ARec")
+            doc.set("k", i)
+            ex.create_record(doc)
+        ex.wait_completion()
+        assert _count(temp_db, "ARec") == 100
+
+    def test_callback(self, temp_db):
+        temp_db.command("sql", "CREATE DOCUMENT TYPE CRec")
+        seen = []
+        ex = temp_db.async_executor()
+        doc = temp_db.new_document("CRec")
+        doc.set("k", 1)
+        ex.create_record(doc, callback=lambda rec: seen.append(rec))
+        ex.wait_completion()
+        assert _count(temp_db, "CRec") == 1
+        assert len(seen) == 1
+
+
+class TestVectorColumns:
+    """f4v/f8v columnar export: embedding columns as 2-D numpy arrays."""
+
+    def test_float_array_column_to_columns(self, temp_db):
+        import arcadedb_embedded as arcadedb
+        import numpy as np
+
+        temp_db.command("sql", "CREATE DOCUMENT TYPE Emb")
+        temp_db.command("sql", "CREATE PROPERTY Emb.vid INTEGER")
+        temp_db.command("sql", "CREATE PROPERTY Emb.v ARRAY_OF_FLOATS")
+        with temp_db.transaction():
+            for i in range(50):
+                temp_db.command(
+                    "sql",
+                    "INSERT INTO Emb SET vid = :i, v = :v",
+                    {"i": i, "v": arcadedb.to_java_float_array([i, i + 0.5, i + 0.25])},
+                )
+        cols = temp_db.query("sql", "SELECT vid, v FROM Emb ORDER BY vid").to_columns()
+        assert cols is not None
+        arr = cols["v"]
+        assert isinstance(arr, np.ndarray) and arr.shape == (50, 3)
+        assert arr[10][1] == np.float32(10.5)
+
+
+class TestAppendSamplesNumpy:
+    def test_numpy_columns(self, temp_db):
+        import numpy as np
+
+        temp_db.command(
+            "sql",
+            "CREATE TIMESERIES TYPE NpTs TIMESTAMP ts "
+            "TAGS (host STRING) FIELDS (val DOUBLE) SHARDS 2",
+        )
+        n = 10_000
+        ts = np.arange(n, dtype=np.int64) * 1000
+        vals = np.linspace(0.0, 1.0, n)
+        hosts = [f"h{i % 4}" for i in range(n)]
+        ex = temp_db.async_executor()
+        ex.append_samples("NpTs", ts, hosts, vals)
+        ex.wait_completion()
+        got = temp_db.query("sql", "SELECT count(*) AS n FROM NpTs").to_list()[0]["n"]
+        assert int(got) == n
+
+    def test_primitive_batch_matches_object_path(self, temp_db):
+        """primitive=True must store exactly what the Object[] path stores.
+
+        The primitive path exists to skip boxing (engine issue #5474), so the
+        only thing that makes it worth having is that the samples it writes are
+        indistinguishable from the path it replaces.
+        """
+        import numpy as np
+
+        for type_name in ("PrimA", "PrimB"):
+            temp_db.command(
+                "sql",
+                f"CREATE TIMESERIES TYPE {type_name} TIMESTAMP ts "
+                "TAGS (host STRING) FIELDS (val DOUBLE, cnt LONG) SHARDS 2",
+            )
+
+        n = 5_000
+        ts = np.arange(n, dtype=np.int64) * 1000 + 1_700_000_000_000
+        vals = np.linspace(-5.0, 5.0, n)
+        cnts = np.arange(n, dtype=np.int64) % 7
+        hosts = [f"h{i % 4}" for i in range(n)]
+
+        ex = temp_db.async_executor()
+        ex.append_samples("PrimA", ts, hosts, vals, cnts)
+        ex.append_samples("PrimB", ts, hosts, vals, cnts, primitive=True)
+        ex.wait_completion()
+
+        def rows(type_name):
+            return temp_db.query(
+                "sql",
+                f"SELECT ts, host, val, cnt FROM {type_name} WHERE host = 'h2' "
+                f"AND ts BETWEEN {int(ts[0])} AND {int(ts[0]) + 200_000} "
+                "ORDER BY ts",  # nosec B608 - test-owned type name
+            ).to_list()
+
+        boxed, primitive = rows("PrimA"), rows("PrimB")
+        assert len(boxed) == len(primitive) and len(boxed) > 0
+        for row_boxed, row_primitive in zip(boxed, primitive):
+            for key in ("ts", "host", "val", "cnt"):
+                assert row_boxed.get(key) == row_primitive.get(key), key
+
+        counts = [
+            int(
+                temp_db.query(
+                    "sql",
+                    f"SELECT count(*) AS n FROM {t}",  # nosec B608 - test-owned type name
+                ).to_list()[0]["n"]
+            )
+            for t in ("PrimA", "PrimB")
+        ]
+        assert counts == [n, n]
+
+    def test_repeated_tag_values_are_stored_distinctly(self, temp_db):
+        """Memoised string conversion must not conflate or alias tag values.
+
+        append_samples reuses one converted Java object per distinct str,
+        because tag columns are low cardinality by design and converting each
+        of 2.59M elements separately dominated ten-tag TSBS ingest. Sharing an
+        immutable String across rows is safe, but only if the cache is keyed
+        correctly, so this checks the two ways it could go wrong: a value must
+        not leak into rows that had a different one, and a column mixing
+        strings with non-strings must still round-trip.
+        """
+        temp_db.command(
+            "sql",
+            "CREATE TIMESERIES TYPE TagMemo TIMESTAMP ts "
+            "TAGS (host STRING, region STRING) FIELDS (val DOUBLE) SHARDS 2",
+        )
+        n = 600
+        base = 1_700_000_000_000
+        ts = [base + i * 1000 for i in range(n)]
+        # Heavy repetition with interleaving, so an off-by-one in the cache
+        # would show up as a wrong pairing rather than a wrong count.
+        hosts = [f"h{i % 3}" for i in range(n)]
+        regions = [f"r{(i // 7) % 5}" for i in range(n)]
+        vals = [float(i) for i in range(n)]
+
+        ex = temp_db.async_executor()
+        ex.append_samples("TagMemo", ts, hosts, regions, vals)
+        ex.wait_completion()
+
+        rows = temp_db.query(
+            "sql", "SELECT ts, host, region, val FROM TagMemo ORDER BY ts"
+        ).to_list()
+        assert len(rows) == n
+        for i, row in enumerate(rows):
+            assert row["host"] == hosts[i], f"host mismatch at {i}"
+            assert row["region"] == regions[i], f"region mismatch at {i}"
+            assert float(row["val"]) == vals[i], f"val mismatch at {i}"
+        # Every distinct value survived, so the cache did not collapse them.
+        assert {r["host"] for r in rows} == set(hosts)
+        assert {r["region"] for r in rows} == set(regions)
+
+    def test_primitive_batch_accepts_plain_sequences(self, temp_db):
+        """Lists, not just ndarrays: the batch path types each column itself."""
+        temp_db.command(
+            "sql",
+            "CREATE TIMESERIES TYPE PrimList TIMESTAMP ts "
+            "TAGS (host STRING) FIELDS (val DOUBLE) SHARDS 1",
+        )
+        n = 500
+        ex = temp_db.async_executor()
+        ex.append_samples(
+            "PrimList",
+            [1_700_000_000_000 + i * 1000 for i in range(n)],
+            [f"h{i % 3}" for i in range(n)],
+            [float(i) / 4 for i in range(n)],
+            primitive=True,
+        )
+        ex.wait_completion()
+        got = temp_db.query("sql", "SELECT count(*) AS n FROM PrimList").to_list()[0][
+            "n"
+        ]
+        assert int(got) == n
+
+
+class TestVectorColumnsDataFrame:
+    def test_vector_column_to_dataframe(self, temp_db):
+        import arcadedb_embedded as arcadedb
+
+        pd = __import__("pytest").importorskip("pandas")
+        temp_db.command("sql", "CREATE DOCUMENT TYPE EmbDf")
+        temp_db.command("sql", "CREATE PROPERTY EmbDf.v ARRAY_OF_FLOATS")
+        with temp_db.transaction():
+            for i in range(10):
+                temp_db.command(
+                    "sql",
+                    "INSERT INTO EmbDf SET v = :v",
+                    {"v": arcadedb.to_java_float_array([i, i + 1.0])},
+                )
+        df = temp_db.query("sql", "SELECT v FROM EmbDf").to_dataframe()
+        assert len(df) == 10
+        assert len(df["v"].iloc[3]) == 2

--- a/bindings/python/tests/test_citation.py
+++ b/bindings/python/tests/test_citation.py
@@ -1,0 +1,66 @@
+"""Tests for the citation helper (offline: Zenodo access is mocked)."""
+
+import pytest
+from arcadedb_embedded import citation
+from arcadedb_embedded.exceptions import ArcadeDBError
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    """Fail loudly if a test reaches for the real Zenodo API."""
+
+    def boom(url):
+        raise AssertionError(f"unexpected network call: {url}")
+
+    monkeypatch.setattr(citation, "_zenodo_get", boom)
+
+
+def test_cached_version_no_network(monkeypatch):
+    monkeypatch.setitem(
+        citation._VERSION_DOI_MAP, "26.1.1.post3", "10.5281/zenodo.18399749"
+    )
+    assert citation.cite("26.1.1.post3") == "https://doi.org/10.5281/zenodo.18399749"
+
+
+def test_dev_version_rejected_without_network():
+    with pytest.raises(ArcadeDBError, match="not a release"):
+        citation.cite("26.8.1.dev0")
+
+
+def test_live_lookup_mocked(monkeypatch):
+    pages = {
+        1: {
+            "hits": {
+                "hits": [
+                    {
+                        "metadata": {"version": "26.6.1"},
+                        "doi": "10.5281/zenodo.20708871",
+                    }
+                ]
+            }
+        },
+        2: {"hits": {"hits": []}},
+    }
+
+    def fake_get(url):
+        if url.endswith(f"/records/{citation._ZENODO_CONCEPT_RECID}"):
+            return {"id": "99999"}
+        page = int(url.rsplit("page=", 1)[1])
+        return pages[page]
+
+    monkeypatch.setattr(citation, "_zenodo_get", fake_get)
+    monkeypatch.delitem(citation._VERSION_DOI_MAP, "26.6.1", raising=False)
+    assert citation.cite("26.6.1") == "https://doi.org/10.5281/zenodo.20708871"
+    # resolved DOI is cached for the process
+    assert citation._VERSION_DOI_MAP["26.6.1"] == "10.5281/zenodo.20708871"
+
+
+def test_unknown_version_not_on_zenodo(monkeypatch):
+    def fake_get(url):
+        if url.endswith(f"/records/{citation._ZENODO_CONCEPT_RECID}"):
+            return {"id": "99999"}
+        return {"hits": {"hits": []}}
+
+    monkeypatch.setattr(citation, "_zenodo_get", fake_get)
+    with pytest.raises(ArcadeDBError, match="not found"):
+        citation.cite("99.9.9")

--- a/bindings/python/tests/test_core.py
+++ b/bindings/python/tests/test_core.py
@@ -1,6 +1,6 @@
 """
 Core functionality tests for ArcadeDB Python bindings.
-These tests work with our base package (includes SQL and OpenCypher).
+These tests work with our base package (includes SQL, OpenCypher, Studio).
 """
 
 import json

--- a/bindings/python/tests/test_docs_examples.py
+++ b/bindings/python/tests/test_docs_examples.py
@@ -7,6 +7,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from tests.conftest import has_server_support
 
 DOCS_ROOT = Path(__file__).resolve().parents[1] / "docs"
 PYTHON_BLOCK_RE = re.compile(r"```python\n(.*?)```", re.DOTALL)
@@ -367,6 +368,41 @@ def test_docs_index_and_quickstart_examples(temp_dir_factory):
             '        db.command("sql", "CREATE DOCUMENT TYPE User")'
         ),
         base_dir / "error_handling",
+    )
+
+
+@pytest.mark.server
+@pytest.mark.skipif(not has_server_support(), reason="Requires server support")
+def test_docs_api_access_examples(temp_dir_factory):
+    """Every access path documented in api-access-methods.md actually runs.
+
+    The doc claims embedded, server-managed, HTTP, and hybrid access all work
+    against the same store, so each of its four blocks is executed rather than
+    read. Note this test skips without server support; the guard that fails
+    instead of skipping lives in test_server_packaging.py.
+    """
+    pytest.importorskip("requests")
+    base_dir = Path(temp_dir_factory("docs_api_access_"))
+
+    _run_doc_block(
+        "api-access-methods.md",
+        "# Direct database access - NO server needed",
+        base_dir / "embedded",
+    )
+    _run_doc_block(
+        "api-access-methods.md",
+        '# "mydb" will be created at ./server_data/databases/mydb',
+        base_dir / "server_managed",
+    )
+    _run_doc_block(
+        "api-access-methods.md",
+        "# Get server details",
+        base_dir / "http_api",
+    )
+    _run_doc_block(
+        "api-access-methods.md",
+        "# Create database using Java API (fastest)",
+        base_dir / "hybrid",
     )
 
 

--- a/bindings/python/tests/test_import_database.py
+++ b/bindings/python/tests/test_import_database.py
@@ -333,29 +333,33 @@ def test_import_database_into_timeseries_type(temp_db_path, sample_timeseries_cs
                 pytest.skip(f"Timeseries not available in current runtime: {e}")
             raise
 
-        try:
-            result = db.command(
+        # IMPORT DATABASE cannot target a TIMESERIES type, and this asserts that
+        # rather than skipping past it.
+        #
+        # The importer builds plain documents and persists them through
+        # MutableDocument.save() -> LocalDatabase.createRecord() ->
+        # LocalDocumentType.getBucketIdByRecord(), but a TIMESERIES type owns no
+        # document buckets, so the save cannot place the record. The importer
+        # reports "Parsed lines: 2 / Total documents: 0" and then fails. That is
+        # structural, not a property of the runtime.
+        #
+        # This previously called pytest.skip() when the message matched
+        # "error on importing database", a generic top-level error, which would
+        # equally have swallowed a genuine regression in CSV import. If the
+        # engine ever grows a timeseries import path, this test fails and says so.
+        with pytest.raises(arcadedb.ArcadeDBError) as exc_info:
+            db.command(
                 "sql",
                 (
                     f"IMPORT DATABASE {_file_url(sample_timeseries_csv_path)} WITH "
                     "documentType = 'Telemetry'"
                 ),
             )
-        except arcadedb.ArcadeDBError as e:
-            message = str(e).lower()
-            if (
-                "no buckets associated" in message
-                or "timeseries" in message
-                or "error on importing database" in message
-            ):
-                pytest.skip(
-                    f"Timeseries import path not available in current runtime: {e}"
-                )
-            raise
-        _import_result_ok(result)
+        assert "importing database" in str(exc_info.value).lower()
 
+        # Nothing was written, and the type is still queryable afterwards.
         count = db.query("sql", "SELECT count(*) as c FROM Telemetry").one().get("c")
-        assert count == 2
+        assert count == 0
 
 
 def test_import_database_with_missing_file_fails(temp_db_path):

--- a/bindings/python/tests/test_jar_provenance.py
+++ b/bindings/python/tests/test_jar_provenance.py
@@ -1,0 +1,148 @@
+"""The wheel can say which engine it carries, not just which version it is.
+
+`__version__` is the package version. It is baked from the pom and says
+nothing about the JARs that ended up in the wheel, so a build from a locally
+patched Java tree reports the released version while shipping a different
+engine. That happened: a local build shipped 59 JARs instead of 64 with a
+bt-server-patched engine, and only a packaging test that counted JAR names
+noticed. Benchmarks against such a wheel record the released version string
+beside numbers the release cannot reproduce.
+
+`jar_fingerprint()` hashes what is actually on disk, so two installs agree iff
+their engines agree. These tests check the hash covers what it claims rather
+than merely returning a string, because a fingerprint nobody can trust is worse
+than none: it invites exactly the assumption it was added to prevent.
+"""
+
+import hashlib
+import os
+
+import arcadedb_embedded as adb
+
+
+def test_fingerprint_is_deterministic():
+    """Same install, same answer. Otherwise it cannot compare two installs."""
+    a = adb.jar_fingerprint()
+    b = adb.jar_fingerprint()
+    assert a["sha256"] == b["sha256"]
+    assert a["count"] == b["count"]
+    assert len(a["sha256"]) == 64, "expected a hex sha256"
+
+
+def test_fingerprint_matches_what_is_on_disk():
+    """count and bytes are read from the filesystem, not asserted."""
+    fp = adb.jar_fingerprint()
+    names = [n for n in os.listdir(fp["jar_dir"]) if n.endswith(".jar")]
+    assert fp["count"] == len(
+        names
+    ), f"fingerprint claims {fp['count']} JARs, directory has {len(names)}"
+    total = sum(os.path.getsize(os.path.join(fp["jar_dir"], n)) for n in names)
+    assert fp["bytes"] == total
+    assert fp["count"] > 0, "a wheel with no JARs is not a working install"
+
+
+def test_hash_actually_covers_every_jar_name_and_content():
+    """Recompute the combined hash from the per-JAR digests.
+
+    This is the test that makes the fingerprint worth trusting. Without it,
+    sha256 could be a hash of the count, or of one JAR, or of nothing, and
+    every other assertion here would still pass.
+    """
+    fp = adb.jar_fingerprint(per_jar=True)
+    combined = hashlib.sha256()
+    for entry in fp["jars"]:
+        combined.update(entry["name"].encode())
+        combined.update(bytes.fromhex(entry["sha256"]))
+    assert combined.hexdigest() == fp["sha256"], (
+        "combined hash is not the hash of the per-JAR (name, digest) pairs, so "
+        "it does not mean what the docstring says it means"
+    )
+
+
+def test_per_jar_digests_are_the_real_file_digests():
+    """Spot-check against the bytes on disk, so the per-JAR list is evidence."""
+    fp = adb.jar_fingerprint(per_jar=True)
+    # The largest JAR: most likely to catch a truncated or streamed-wrong read.
+    biggest = max(fp["jars"], key=lambda e: e["bytes"])
+    path = os.path.join(fp["jar_dir"], biggest["name"])
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    assert h.hexdigest() == biggest["sha256"], f"digest wrong for {biggest['name']}"
+    assert os.path.getsize(path) == biggest["bytes"]
+
+
+def test_renaming_a_jar_would_change_the_fingerprint():
+    """Name is hashed, not only content.
+
+    Two JARs swapping filenames leaves the multiset of contents identical. If
+    only contents were hashed, that swap would be invisible, and it is exactly
+    what a mis-staged JAR_LIB_DIR can produce.
+    """
+    fp = adb.jar_fingerprint(per_jar=True)
+    jars = fp["jars"]
+    if len(jars) < 2:
+        # Not a skip in disguise: with one JAR the property is vacuous, and
+        # test_fingerprint_matches_what_is_on_disk already asserts count > 0.
+        return
+    swapped = hashlib.sha256()
+    order = [jars[1], jars[0]] + jars[2:]
+    for name_entry, digest_entry in zip(jars, order):
+        swapped.update(name_entry["name"].encode())
+        swapped.update(bytes.fromhex(digest_entry["sha256"]))
+    assert (
+        swapped.hexdigest() != fp["sha256"]
+    ), "swapping two JARs' contents does not change the fingerprint"
+
+
+def test_engine_hash_excludes_our_own_jar():
+    """engine_sha256 answers "same ArcadeDB?", sha256 answers "same build?".
+
+    Measured 2026-08-04: the PyPI 26.8.1 wheel and a local build of the same
+    version have identical size, identical JAR count, identical total JAR
+    bytes, and different sha256. 63 of 64 JARs are byte-identical; the only
+    difference is arcadedb-python-bridge.jar, at the same 10907 bytes, because
+    it is compiled during the build and carries timestamps.
+
+    So the two hashes must actually differ in coverage, or engine_sha256 is
+    decoration and someone will compare the wrong one.
+    """
+    fp = adb.jar_fingerprint(per_jar=True)
+    ours = [j for j in fp["jars"] if not j["engine"]]
+    assert ours, "no JAR is marked as ours; _OUR_JARS is stale against the wheel"
+    assert fp["engine_count"] == fp["count"] - len(ours)
+    assert (
+        fp["engine_sha256"] != fp["sha256"]
+    ), "engine hash equals the full hash, so it is not excluding anything"
+
+    combined = hashlib.sha256()
+    for entry in fp["jars"]:
+        if entry["engine"]:
+            combined.update(entry["name"].encode())
+            combined.update(bytes.fromhex(entry["sha256"]))
+    assert (
+        combined.hexdigest() == fp["engine_sha256"]
+    ), "engine_sha256 is not the hash of exactly the engine JARs"
+
+
+def test_our_jar_list_still_matches_the_wheel():
+    """_OUR_JARS names a JAR that exists.
+
+    If the bridge JAR is ever renamed, every engine comparison silently starts
+    including a non-reproducible JAR again and stops meaning what it says.
+    """
+    from arcadedb_embedded.jvm import _OUR_JARS
+
+    names = {j["name"] for j in adb.jar_fingerprint(per_jar=True)["jars"]}
+    missing = _OUR_JARS - names
+    assert not missing, (
+        f"_OUR_JARS lists {sorted(missing)}, absent from the wheel. Renamed? "
+        f"engine_sha256 is now hashing a JAR we build."
+    )
+
+
+def test_exported_from_the_package_root():
+    """Harnesses record this next to engine_version, so it must be public."""
+    assert "jar_fingerprint" in adb.__all__
+    assert callable(adb.jar_fingerprint)

--- a/bindings/python/tests/test_jvm.py
+++ b/bindings/python/tests/test_jvm.py
@@ -1,0 +1,83 @@
+"""Tests for start_jvm() re-entry behavior once the JVM is running."""
+
+import arcadedb_embedded as arcadedb
+import jpype
+import pytest
+from arcadedb_embedded import jvm
+from arcadedb_embedded.exceptions import ArcadeDBError
+
+
+@pytest.fixture(autouse=True)
+def _jvm_running(tmp_path):
+    """All tests here assume a started JVM (any earlier DB use starts it)."""
+    if not jpype.isJVMStarted():
+        db = arcadedb.create_database(str(tmp_path / "jvm_boot"))
+        db.close()
+    assert jpype.isJVMStarted()
+
+
+def test_bare_start_jvm_joins_running_jvm(monkeypatch):
+    # Regression: create_database(jvm_kwargs={"heap_size": "6g"}) followed by
+    # open_database() raised, because the default-built args were compared
+    # against the stored custom config instead of noticing no override was
+    # requested.
+    monkeypatch.setattr(jvm, "_JVM_CONFIG", ("-Xmx6g", "-Xms6g"))
+    jvm.start_jvm()  # must not raise
+
+
+def test_identical_config_is_idempotent(monkeypatch):
+    args = tuple(
+        jvm._build_jvm_args(
+            heap_size="6g",
+            disable_xml_limits=True,
+            jvm_args="-Xms6g",
+            common_pool_parallelism=None,
+        )
+    )
+    monkeypatch.setattr(jvm, "_JVM_CONFIG", args)
+    jvm.start_jvm(heap_size="6g", jvm_args="-Xms6g")  # must not raise
+
+
+def test_conflicting_override_raises(monkeypatch):
+    monkeypatch.setattr(jvm, "_JVM_CONFIG", ("-Xmx4g",))
+    with pytest.raises(ArcadeDBError, match="already started"):
+        jvm.start_jvm(heap_size="99g")
+
+
+def test_create_close_reopen_same_process(tmp_path):
+    path = str(tmp_path / "reopen_db")
+    db = arcadedb.create_database(path)
+    db.command("sql", "CREATE DOCUMENT TYPE Doc")
+    with db.transaction():
+        db.command("sql", "INSERT INTO Doc SET k = 1")
+    db.close()
+    db2 = arcadedb.open_database(path)
+    rows = db2.query("sql", "SELECT k FROM Doc").to_list()
+    db2.close()
+    assert rows == [{"k": 1}]
+
+
+def test_interpreter_exits_with_unclosed_database(tmp_path):
+    """A leaked (unclosed) Database must not hang interpreter exit.
+
+    The engine's non-daemon background threads (e.g. AsyncFlush) keep the
+    JVM alive; the bindings close active databases from an atexit hook so
+    JPype's shutdown can complete. Without the hook this hangs forever.
+    """
+    import subprocess  # nosec B404 - test-controlled child process
+    import sys as _sys
+
+    script = (
+        "import arcadedb_embedded as a\n"
+        f"db = a.create_database({str(tmp_path / 'leak_db')!r})\n"
+        "db.command('sql', 'CREATE DOCUMENT TYPE Doc')\n"
+        "print('OK', flush=True)\n"
+    )
+    proc = subprocess.run(  # nosec B603 - fixed argv, no shell, test-owned
+        [_sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert "OK" in proc.stdout
+    assert proc.returncode == 0

--- a/bindings/python/tests/test_resultset_arrow.py
+++ b/bindings/python/tests/test_resultset_arrow.py
@@ -1,0 +1,138 @@
+"""Tests for ResultSet.to_arrow().
+
+The point of this path is not only speed. `to_columns` follows pandas
+conventions, and two of them are lossy: a nullable int64 column is promoted to
+float64 with NaN, which loses the type and loses precision above 2**53; and a
+nullable boolean column degrades to a Python list. Arrow carries a validity
+bitmap next to the values, so both keep their type.
+
+The lossiness tests below are therefore the reason this method exists, and they
+assert against `to_columns` directly so the difference cannot quietly go away.
+"""
+
+import arcadedb_embedded as arcadedb
+import pytest
+
+pa = pytest.importorskip("pyarrow", reason="to_arrow() requires pyarrow")
+
+
+def test_to_arrow_basic_types(temp_db_path):
+    """Ints, floats, strings and bools survive the round trip with types."""
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Rec")
+        with db.transaction():
+            db.command(
+                "sql", "INSERT INTO Rec SET name = 'a', n = 1, x = 1.5, ok = true"
+            )
+            db.command(
+                "sql", "INSERT INTO Rec SET name = 'b', n = 2, x = 2.5, ok = false"
+            )
+
+        table = db.query(
+            "sql", "SELECT name, n, x, ok FROM Rec ORDER BY name"
+        ).to_arrow()
+
+        assert table is not None, "pyarrow present, so to_arrow must not return None"
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 2
+        assert table.column("name").to_pylist() == ["a", "b"]
+        assert table.column("n").to_pylist() == [1, 2]
+        assert pa.types.is_integer(table.schema.field("n").type)
+        assert pa.types.is_floating(table.schema.field("x").type)
+        assert pa.types.is_string(table.schema.field("name").type)
+
+
+def test_to_arrow_keeps_int64_with_nulls(temp_db_path):
+    """A nullable integer stays an integer here; to_columns turns it into float64.
+
+    This is the concrete reason to prefer Arrow for anything that will be
+    checked against the stored value: once the column is float64, an id larger
+    than 2**53 no longer round-trips.
+    """
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Rec")
+        with db.transaction():
+            db.command("sql", "INSERT INTO Rec SET k = 'has', n = 7")
+            db.command("sql", "INSERT INTO Rec SET k = 'none'")  # n missing -> null
+
+        arrow_tbl = db.query("sql", "SELECT k, n FROM Rec ORDER BY k").to_arrow()
+        cols = db.query("sql", "SELECT k, n FROM Rec ORDER BY k").to_columns()
+
+        assert pa.types.is_integer(
+            arrow_tbl.schema.field("n").type
+        ), "nullable int must stay an integer in Arrow"
+        assert arrow_tbl.column("n").to_pylist() == [7, None]
+
+        # and record what the pandas-convention path does with the same data,
+        # so a future change to either is visible here
+        import numpy as np
+
+        assert cols["n"].dtype == np.float64
+        assert np.isnan(cols["n"][1])
+
+
+def test_to_arrow_keeps_bool_with_nulls(temp_db_path):
+    """A nullable boolean stays a bool column rather than becoming a list."""
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Rec")
+        with db.transaction():
+            db.command("sql", "INSERT INTO Rec SET k = 'a', ok = true")
+            db.command("sql", "INSERT INTO Rec SET k = 'b'")  # ok missing -> null
+
+        table = db.query("sql", "SELECT k, ok FROM Rec ORDER BY k").to_arrow()
+
+        assert pa.types.is_boolean(table.schema.field("ok").type)
+        assert table.column("ok").to_pylist() == [True, None]
+
+
+def test_to_arrow_nullable_strings(temp_db_path):
+    """Strings are wrapped from the offsets+blob buffer, nulls included."""
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Rec")
+        with db.transaction():
+            db.command("sql", "INSERT INTO Rec SET k = 'a', s = 'hello'")
+            db.command("sql", "INSERT INTO Rec SET k = 'b'")  # s missing -> null
+            db.command("sql", "INSERT INTO Rec SET k = 'c', s = 'wörld'")  # non-ascii
+
+        table = db.query("sql", "SELECT k, s FROM Rec ORDER BY k").to_arrow()
+
+        assert table.column("s").to_pylist() == ["hello", None, "wörld"]
+
+
+def test_to_arrow_multi_batch(temp_db_path):
+    """More rows than one batch: chunks must concatenate, not truncate."""
+    n = 300
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Rec")
+        with db.transaction():
+            for i in range(n):
+                db.command("sql", f"INSERT INTO Rec SET n = {i}")
+
+        table = db.query("sql", "SELECT n FROM Rec").to_arrow(batch_size=64)
+
+        assert table.num_rows == n
+        assert sorted(table.column("n").to_pylist()) == list(range(n))
+
+
+def test_to_arrow_empty(temp_db_path):
+    """An empty result is an empty table, not None and not an error."""
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Rec")
+        table = db.query("sql", "SELECT FROM Rec").to_arrow()
+        assert table is not None
+        assert table.num_rows == 0
+
+
+def test_to_arrow_matches_to_columns_when_not_null(temp_db_path):
+    """With no nulls the two paths must agree; only null handling differs."""
+    with arcadedb.create_database(temp_db_path) as db:
+        db.command("sql", "CREATE DOCUMENT TYPE Rec")
+        with db.transaction():
+            for i in range(50):
+                db.command("sql", f"INSERT INTO Rec SET n = {i}, s = 'v{i}'")
+
+        arrow_tbl = db.query("sql", "SELECT n, s FROM Rec ORDER BY n").to_arrow()
+        cols = db.query("sql", "SELECT n, s FROM Rec ORDER BY n").to_columns()
+
+        assert arrow_tbl.column("n").to_pylist() == list(cols["n"])
+        assert arrow_tbl.column("s").to_pylist() == list(cols["s"])

--- a/bindings/python/tests/test_server.py
+++ b/bindings/python/tests/test_server.py
@@ -1,0 +1,135 @@
+"""
+Server and Studio tests for ArcadeDB Python bindings.
+
+These tests use the JAVA API for server operations:
+- Server creation and management via ArcadeDBServer class
+- Database operations via direct JVM method calls (db.command, db.query)
+- All operations happen within the same Python process (embedded mode)
+
+Note: These tests do NOT test HTTP API access patterns.
+For HTTP API testing, see test_server_patterns.py
+
+These tests require server support (available in our base package).
+"""
+
+import time
+
+import pytest
+from arcadedb_embedded import ArcadeDBServer
+from tests.conftest import TEST_PASSWORD, has_server_support
+
+
+@pytest.mark.server
+@pytest.mark.skipif(not has_server_support(), reason="Requires server support")
+def test_server_creation(temp_server_root):
+    """Test creating and starting a server."""
+    server = ArcadeDBServer(
+        root_path=temp_server_root,
+        root_password=TEST_PASSWORD,
+        config={"http_port": 2480},
+    )
+
+    assert not server.is_started()
+    server.start()
+    assert server.is_started()
+
+    # Give server a moment to start
+    time.sleep(1)
+
+    assert server.get_http_port() == 2480
+    studio_url = server.get_studio_url()
+    assert "http://" in studio_url
+    assert "2480" in studio_url
+
+    server.stop()
+    assert not server.is_started()
+
+
+@pytest.mark.server
+@pytest.mark.skipif(not has_server_support(), reason="Requires server support")
+def test_server_database_operations(temp_server_root):
+    """
+    Test database operations through server using Java API.
+
+    This test demonstrates:
+    - Server-managed database creation via Java API
+    - Direct JVM method calls (db.command, db.query)
+    - Operations within same Python process (embedded access)
+    """
+    with ArcadeDBServer(
+        root_path=temp_server_root, root_password=TEST_PASSWORD
+    ) as server:
+        # Server auto-starts in context manager
+        time.sleep(1)
+
+        # Create database through server
+        db = server.create_database("testdb")
+        assert db.is_open()
+
+        # Use database
+        # Schema operations are auto-transactional
+        db.command("sql", "CREATE DOCUMENT TYPE Person")
+
+        with db.transaction():
+            db.command("sql", "INSERT INTO Person SET name = 'Alice', age = 30")
+
+        # Query
+        result = db.query("sql", "SELECT FROM Person")
+        records = list(result)
+        assert len(records) == 1
+        assert records[0].get("name") == "Alice"
+
+        # Close database
+        db.close()
+
+
+@pytest.mark.server
+@pytest.mark.skipif(not has_server_support(), reason="Requires server support")
+def test_server_custom_config(temp_server_root):
+    """Test server with custom configuration."""
+    config = {"http_port": 8080, "host": "127.0.0.1", "mode": "production"}
+
+    server = ArcadeDBServer(
+        root_path=temp_server_root, root_password=TEST_PASSWORD, config=config
+    )
+    server.start()
+    time.sleep(1)
+
+    assert server.get_http_port() == 8080
+
+    server.stop()
+
+
+@pytest.mark.server
+@pytest.mark.skipif(not has_server_support(), reason="Requires server support")
+def test_server_context_manager(temp_server_root):
+    """Test server context manager."""
+    with ArcadeDBServer(
+        root_path=temp_server_root, root_password=TEST_PASSWORD
+    ) as server:
+        # Server auto-starts in context manager
+        time.sleep(1)
+
+        assert server.is_started()
+
+        # Server should auto-stop when exiting context
+
+    # Note: We can't easily test if stopped after context exit
+    # because the server object is out of scope
+
+
+def test_default_host_is_localhost(temp_server_root):
+    """Default host should be localhost; binding to all interfaces must be opt-in.
+
+    Asserts on the publicly-observable Studio URL composition; we do not
+    start the server here because that requires a real JVM. The same default
+    host feeds both ``get_studio_url()`` and the underlying ContextConfiguration,
+    so the URL is a faithful proxy for the configured host.
+    """
+    from arcadedb_embedded.server import ArcadeDBServer
+
+    server = ArcadeDBServer(
+        root_path=temp_server_root,
+        root_password=TEST_PASSWORD,
+    )
+    assert server.get_studio_url().startswith("http://localhost:")

--- a/bindings/python/tests/test_server_packaging.py
+++ b/bindings/python/tests/test_server_packaging.py
@@ -1,0 +1,143 @@
+"""The server stack is actually IN the wheel, and the API is reachable.
+
+This file exists because of a specific failure. On 2026-07-05 commit cfcde0c2
+excluded the server JARs and deleted ``server.py`` to save ~7 MB, that shipped
+in stable 26.7.2 on 2026-07-09, and nobody noticed for three weeks until a
+downstream user said so on the commit itself. Every other server test in this
+suite is guarded by ``has_server_support()``, so when the JARs vanished those
+tests did not fail. **They skipped, silently, and the suite stayed green.**
+
+A guard that skips when the thing it guards is missing cannot detect the thing
+going missing. So these tests deliberately do NOT skip: if the server stack is
+absent, they fail.
+
+If a future build genuinely wants a slim wheel, that is a decision to make on
+purpose, by deleting this file with a commit message that says why, not by
+letting a packaging change quietly turn a suite green.
+"""
+
+import os
+import zipfile
+
+import pytest
+
+# The JAR families that make server mode work. Sizes as measured on the
+# 26.8.1-SNAPSHOT image (uncompressed, MB) are in docs/guide/server.md; the
+# whole set is ~7.65 MB uncompressed and ~7.3 MB on the wheel.
+REQUIRED_JAR_PREFIXES = [
+    "arcadedb-server",  # the server itself, 0.66 MB
+    "arcadedb-studio",  # web UI assets, 2.60 MB, contains zero .class files
+    "undertow-core",  # HTTP server, 2.21 MB
+    "xnio-api",  # undertow's IO layer
+    "xnio-nio",
+    "wildfly-common",
+    "jboss-logging",
+    "jboss-threads",
+    "micrometer-core",  # required at server startup, not optional
+]
+
+
+def _jar_names():
+    from arcadedb_embedded.jvm import get_jar_path
+
+    jar_dir = get_jar_path()
+    assert os.path.isdir(jar_dir), f"jar directory missing: {jar_dir}"
+    return sorted(os.listdir(jar_dir))
+
+
+def test_server_jars_are_bundled():
+    """Every JAR server mode needs is present. Fails, never skips."""
+    names = _jar_names()
+    missing = [
+        p for p in REQUIRED_JAR_PREFIXES if not any(n.startswith(p) for n in names)
+    ]
+    assert not missing, (
+        f"server JARs missing from the wheel: {missing}\n"
+        f"This is how server mode was lost in 26.7.2. If the removal is "
+        f"deliberate, delete this test explicitly rather than leaving the "
+        f"server tests to skip themselves into a green suite.\n"
+        f"jars present: {names}"
+    )
+
+
+def test_server_api_is_importable_and_exported():
+    """create_server / ArcadeDBServer are importable AND in __all__.
+
+    Both halves matter: the classes existing but not being exported is the
+    same breakage from a user's point of view, since the documented import is
+    ``from arcadedb_embedded import create_server``.
+    """
+    import arcadedb_embedded as adb
+
+    assert hasattr(adb, "ArcadeDBServer"), "ArcadeDBServer not importable"
+    assert hasattr(adb, "create_server"), "create_server not importable"
+    assert "ArcadeDBServer" in adb.__all__, "ArcadeDBServer missing from __all__"
+    assert "create_server" in adb.__all__, "create_server missing from __all__"
+
+
+def test_has_server_support_agrees_with_reality():
+    """The skip-guard other server tests rely on must not lie.
+
+    If ``has_server_support()`` returned False while the JARs are present,
+    every server test would skip and the suite would look fine while covering
+    nothing. That is precisely the failure mode this file exists to close, so
+    the guard itself is checked against the JARs it claims to detect.
+    """
+    from tests.conftest import has_server_support
+
+    names = _jar_names()
+    jars_present = any(n.startswith("arcadedb-studio") for n in names)
+    assert has_server_support() == jars_present, (
+        f"has_server_support() returned {has_server_support()} but studio JAR "
+        f"present={jars_present}. The guard and the wheel disagree, so server "
+        f"tests are skipping or running for the wrong reason."
+    )
+
+
+def test_studio_jar_carries_no_classes():
+    """Studio is static assets only, which is why bundling it is cheap.
+
+    docs/guide/server.md tells users Studio costs disk and nothing else,
+    on the grounds that a JAR with no ``.class`` entries cannot execute. If a
+    future Studio release starts shipping code, that claim stops being true
+    and the documentation needs revisiting, so assert the premise rather than
+    trusting it.
+    """
+    from arcadedb_embedded.jvm import get_jar_path
+
+    jar_dir = get_jar_path()
+    studio = [n for n in os.listdir(jar_dir) if n.startswith("arcadedb-studio")]
+    assert studio, "studio JAR missing (see test_server_jars_are_bundled)"
+
+    with zipfile.ZipFile(os.path.join(jar_dir, studio[0])) as z:
+        classes = [n for n in z.namelist() if n.endswith(".class")]
+    assert not classes, (
+        f"arcadedb-studio now ships {len(classes)} .class files. "
+        f"docs/guide/server.md claims Studio costs disk only because it "
+        f"contains no executable code; update that claim."
+    )
+
+
+@pytest.mark.server
+def test_server_starts_and_serves_http(temp_server_root):
+    """End-to-end: the bundled stack actually starts and answers.
+
+    The packaging tests above prove the files are present. This proves they
+    work together, which is the claim a user actually cares about.
+    """
+    requests = pytest.importorskip("requests")
+    from arcadedb_embedded import create_server
+    from tests.conftest import TEST_PASSWORD
+
+    with create_server(
+        root_path=temp_server_root, root_password=TEST_PASSWORD
+    ) as server:
+        assert server.is_started()
+        port = server.get_http_port()
+        r = requests.get(
+            f"http://localhost:{port}/api/v1/server",
+            auth=("root", TEST_PASSWORD),
+            timeout=30,
+        )
+        assert r.status_code == 200, f"server returned {r.status_code}"
+        assert "version" in r.json()

--- a/bindings/python/tests/test_server_patterns.py
+++ b/bindings/python/tests/test_server_patterns.py
@@ -1,0 +1,763 @@
+"""
+Tests for ArcadeDB server access patterns.
+
+Tests three main access patterns:
+1. Java API Standalone: Direct database access (no server)
+2. Java API Server-managed: Access via server (embedded)
+3. HTTP API: REST requests to server (remote access)
+
+Key insight: Server supports BOTH Java API (embedded) and HTTP API (remote)
+simultaneously.
+"""
+
+import os
+import shutil
+import threading
+import time
+
+import arcadedb_embedded as arcadedb
+import pytest
+from tests.conftest import TEST_PASSWORD
+
+
+@pytest.fixture
+def cleanup_test_dirs():
+    """Fixture to clean up test directories and servers."""
+    import tempfile
+
+    dirs = []
+    servers = []
+
+    def _create_temp_dir(prefix="arcadedb_test_"):
+        """Create a temporary directory and register it for cleanup."""
+        temp_dir = tempfile.mkdtemp(prefix=prefix)
+        dirs.append(temp_dir)
+        return temp_dir
+
+    def _register_server(server):
+        servers.append(server)
+
+    yield _create_temp_dir, _register_server
+
+    # Cleanup after test
+    for server in servers:
+        try:
+            if server.is_started():
+                server.stop()
+        except Exception:
+            pass  # nosec B110
+
+    # Give servers time to release locks
+    time.sleep(0.5)
+
+    for path in dirs:
+        if os.path.exists(path):
+            try:
+                shutil.rmtree(path, ignore_errors=True)
+            except Exception:
+                pass  # nosec B110
+
+
+def test_server_pattern_recommended(cleanup_test_dirs):
+    """
+    Recommended Pattern: Start server first, create database through server.
+
+    Benefits:
+    - Embedded access for the Python process that started the server
+    - HTTP access available for other processes
+    - No need to close database before server access
+    """
+    create_temp_dir, register_server = cleanup_test_dirs
+
+    print("\n" + "=" * 70)
+    print("TEST: Recommended Pattern - Server First")
+    print("=" * 70)
+
+    root_path = create_temp_dir("server_first_")
+
+    # Step 1: Start server first
+    print("\n1. Starting ArcadeDB server...")
+    server = arcadedb.create_server(root_path=root_path, root_password=TEST_PASSWORD)
+    register_server(server)
+    server.start()
+    print(f"   ✅ Server started on port {server.get_http_port()}")
+    print(f"   📊 Studio URL: {server.get_studio_url()}")
+
+    # Step 2: Create database through server
+    print("\n2. Creating database through server...")
+    db = server.create_database("mydb")
+
+    db.command("sql", "CREATE DOCUMENT TYPE Product")
+
+    with db.transaction():
+        db.command("sql", "INSERT INTO Product SET name = 'Laptop', price = 999")
+        db.command("sql", "INSERT INTO Product SET name = 'Mouse', price = 29")
+
+    print("   ✅ Database created and populated")
+
+    # Step 3: Query via embedded access
+    print("\n3. Querying via embedded access...")
+    result = db.query("sql", "SELECT FROM Product WHERE name = 'Laptop'")
+    record = list(result)[0]
+    name = record.get("name")
+    price = record.get("price")
+    print(f"   ✅ Found: {name} costs ${price}")
+
+    # Step 4: HTTP access would work here too
+    print("\n4. HTTP API is now available...")
+    print(
+        f"   💡 Other processes can connect to: http://localhost:{server.get_http_port()}"
+    )
+    print("   💡 Both embedded AND HTTP access work simultaneously!")
+
+    db.close()
+    server.stop()
+    print("\n✅ Recommended Pattern Complete!\n")
+
+
+def test_server_thread_safety(cleanup_test_dirs):
+    """
+    Test that server-managed database handles concurrent thread access.
+
+    Multiple threads can safely access the same database through the server.
+    """
+    create_temp_dir, register_server = cleanup_test_dirs
+
+    print("\n" + "=" * 70)
+    print("TEST: Server Thread Safety")
+    print("=" * 70)
+
+    root_path = create_temp_dir("thread_safety_")
+
+    # Start server and create database
+    print("\n1. Setting up server and database...")
+    server = arcadedb.create_server(root_path=root_path, root_password=TEST_PASSWORD)
+    register_server(server)
+    server.start()
+
+    db = server.create_database("testdb")
+
+    db.command("sql", "CREATE DOCUMENT TYPE `Item`")
+
+    with db.transaction():
+        for i in range(20):
+            db.command("sql", f"INSERT INTO `Item` SET id = {i}, value = {i * 10}")
+
+    print("   ✅ Created 20 items")
+
+    # Test concurrent thread access
+    print("\n2. Running 5 threads concurrently...")
+    results = []
+    errors = []
+
+    def thread_query(thread_id):
+        """Each thread queries the database."""
+        try:
+            # Query a range of items
+            start = thread_id * 4
+            end = start + 4
+            result = db.query(
+                "sql",
+                f"SELECT FROM `Item` WHERE id >= {start} AND id < {end}",  # nosec B608
+            )
+            count = len(list(result))
+            results.append(f"   Thread {thread_id}: Found {count} items")
+        except Exception as e:
+            errors.append(f"   Thread {thread_id}: Error - {e}")
+
+    threads = []
+    for i in range(5):
+        thread = threading.Thread(target=thread_query, args=(i,))
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    for result_msg in results:
+        print(result_msg)
+
+    if errors:
+        for error_msg in errors:
+            print(error_msg)
+        pytest.fail("Concurrent thread access failed")
+
+    print("   ✅ All threads accessed database successfully!")
+
+    db.close()
+    server.stop()
+    print("\n✅ Thread Safety Test Complete!\n")
+
+
+def test_server_context_manager(cleanup_test_dirs):
+    """Test using server with context manager for automatic cleanup."""
+    create_temp_dir, register_server = cleanup_test_dirs
+
+    print("\n" + "=" * 70)
+    print("TEST: Server Context Manager")
+    print("=" * 70)
+
+    root_path = create_temp_dir("context_")
+
+    print("\n1. Using server with context manager...")
+
+    # Server automatically starts and stops
+    with arcadedb.create_server(
+        root_path=root_path, root_password=TEST_PASSWORD
+    ) as server:
+        print("   ✅ Server started (automatic)")
+
+        db = server.create_database("contextdb")
+
+        db.command("sql", "CREATE DOCUMENT TYPE Note")
+
+        with db.transaction():
+            db.command("sql", "INSERT INTO Note SET text = 'Test'")
+
+        result = db.query("sql", "SELECT count(*) as count FROM Note")
+        count = list(result)[0].get("count")
+        print(f"   ✅ Created {count} notes")
+
+        db.close()
+
+    # Server automatically stopped when exiting context
+    print("   ✅ Server stopped (automatic)")
+    print("\n✅ Context Manager Test Complete!\n")
+
+
+def test_pattern1_embedded_first_requires_close(cleanup_test_dirs):
+    """
+    Pattern 1: Create database in embedded mode first, then start server.
+
+    IMPORTANT: Must close the database before starting server, otherwise
+    the file lock prevents server access.
+
+    This test shows you MUST close the embedded database before the
+    server can access it.
+    """
+    create_temp_dir, register_server = cleanup_test_dirs
+
+    print("\n" + "=" * 70)
+    print("TEST: Pattern 1 - Embedded First (Requires Close)")
+    print("=" * 70)
+
+    root_path = create_temp_dir("pattern1_")
+    db_name = "mydb"
+    db_path = os.path.join(root_path, db_name)
+
+    # Step 1: Create database in embedded mode
+    print("\n1. Creating database in embedded mode...")
+    db = arcadedb.create_database(db_path)
+
+    db.command("sql", "CREATE DOCUMENT TYPE Person")
+
+    with db.transaction():
+        db.command("sql", "INSERT INTO Person SET name = 'Alice', age = 30")
+        db.command("sql", "INSERT INTO Person SET name = 'Bob', age = 25")
+
+    result = db.query("sql", "SELECT count(*) as count FROM Person")
+    count = list(result)[0].get("count")
+    print(f"   ✅ Created database with {count} records")
+
+    # Step 2: MUST close database to release file lock
+    print("\n2. Closing database to release file lock...")
+    db.close()
+    print("   ✅ Database closed, lock released")
+
+    # Step 3: Now move database to where server expects it
+    print("\n3. Moving database to server's databases directory...")
+    server_db_dir = os.path.join(root_path, "databases")
+    os.makedirs(server_db_dir, exist_ok=True)
+    server_db_path = os.path.join(server_db_dir, db_name)
+
+    if os.path.exists(server_db_path):
+        shutil.rmtree(server_db_path)
+    shutil.move(db_path, server_db_path)
+    print(f"   ✅ Database moved to {server_db_path}")
+
+    # Step 4: Start server
+    print("\n4. Starting ArcadeDB server...")
+    server = arcadedb.create_server(root_path=root_path, root_password=TEST_PASSWORD)
+    register_server(server)
+    server.start()
+    print(f"   ✅ Server started on port {server.get_http_port()}")
+
+    # Step 5: Access database through server
+    print("\n5. Accessing database through server...")
+    db = server.get_database(db_name)
+
+    result = db.query("sql", "SELECT FROM Person WHERE name = 'Alice'")
+    record = list(result)[0]
+    name = record.get("name")
+    age = record.get("age")
+    print(f"   ✅ Retrieved via server: {name}, age {age}")
+
+    # Step 6: Add more data through server
+    print("\n6. Adding data through server...")
+    with db.transaction():
+        db.command("sql", "INSERT INTO Person SET name = 'Charlie', age = 35")
+
+    result = db.query("sql", "SELECT count(*) as count FROM Person")
+    count = list(result)[0].get("count")
+    print(f"   ✅ Total records now: {count}")
+
+    # Step 7: Both embedded and HTTP access now available
+    print("\n7. Dual access now available...")
+    print(f"   💡 Embedded access: db.query() works")
+    print(f"   💡 HTTP access: http://localhost:{server.get_http_port()} works")
+    print("   💡 Note: Server-managed databases are closed by server.stop()")
+
+    # Don't close db - server-managed databases are shared and closed by server
+    server.stop()
+    print("\n✅ Pattern 1 Complete: Embedded → Close → Server works!\n")
+    print("⚠️  Key Requirement: Must close() the embedded database first!")
+    print("⚠️  Note: Don't close server-managed databases - server handles it!")
+
+
+def test_embedded_performance_comparison(cleanup_test_dirs):
+    """
+    Demonstrate that Pattern 2 embedded access is just as fast as standalone.
+
+    Key insight: When you access a server-managed database from the same
+    Python process, it's a direct JVM call - NO HTTP overhead!
+
+    HTTP access is only for OTHER processes/clients.
+    """
+    create_temp_dir, register_server = cleanup_test_dirs
+
+    print("\n" + "=" * 70)
+    print("TEST: Embedded Performance - Server vs Standalone")
+    print("=" * 70)
+
+    # Setup test data size - increased for more reliable benchmarks
+    num_records = 500
+    num_queries = 100
+
+    # Test 1: Standalone embedded (no server)
+    print("\n1. Standalone Embedded Mode...")
+    standalone_path = create_temp_dir("standalone_perf_")
+
+    db_standalone = arcadedb.create_database(standalone_path)
+
+    # Create document type (schema-less by design)
+    db_standalone.command("sql", "CREATE DOCUMENT TYPE PerfTest")
+
+    # Create indexes for better query performance
+    # Will be created implicitly when we insert data with these fields
+
+    # Insert complex data with various data types
+    categories = ["Electronics", "Books", "Clothing", "Home", "Sports"]
+    import random  # nosec B311
+    from datetime import datetime, timedelta
+
+    with db_standalone.transaction():
+
+        for i in range(num_records):
+            category = categories[i % len(categories)]
+            price = round(random.uniform(10.0, 999.99), 2)  # nosec B311
+            created_date = datetime.now() - timedelta(
+                days=random.randint(0, 365)  # nosec B311
+            )
+            is_active = random.choice([True, False])  # nosec B311
+            tags = ",".join(
+                random.choices(
+                    ["new", "sale", "popular", "limited", "premium"], k=2
+                )  # nosec B311
+            )
+
+            db_standalone.command(
+                "sql",
+                f"""
+                INSERT INTO PerfTest SET
+                    id = {i},
+                    name = 'Product {i}',
+                    description = 'Product {i} with detailed description',
+                    price = {price},
+                    category = '{category}',
+                    tags = '{tags}',
+                    created_date = '{created_date.strftime('%Y-%m-%d')}',
+                    is_active = {str(is_active).lower()}
+            """,
+            )
+
+    print(f"   ✅ Created {num_records} complex records")
+
+    # Time standalone queries with complex operations
+    import time
+
+    query_types = [
+        "SELECT FROM PerfTest WHERE price > 100 ORDER BY price LIMIT 10",
+        "SELECT category, avg(price) as avg_price FROM PerfTest GROUP BY category",
+        "SELECT FROM PerfTest WHERE category = 'Electronics' AND is_active = true",
+        "SELECT FROM PerfTest WHERE tags LIKE '%sale%' ORDER BY created_date DESC",
+        "SELECT FROM PerfTest WHERE id BETWEEN 100 AND 200 AND price < 500",
+    ]
+
+    start = time.time()
+    for i in range(num_queries):
+        query = query_types[i % len(query_types)]
+        result = db_standalone.query("sql", query)
+        list(result)  # Consume results
+    standalone_time = time.time() - start
+
+    print(f"   ⚡ {num_queries} complex queries in {standalone_time:.3f}s")
+    print(f"   ⚡ {num_queries/standalone_time:.1f} queries/sec")
+
+    db_standalone.close()
+
+    # Test 2: Server-managed embedded access (same process)
+    print("\n2. Server-Managed Embedded Mode (same process)...")
+    server_path = create_temp_dir("server_perf_")
+
+    server = arcadedb.create_server(root_path=server_path, root_password=TEST_PASSWORD)
+    register_server(server)
+    server.start()
+
+    db_server = server.create_database("perfdb")
+
+    # Create document type (schema-less by design)
+    db_server.command("sql", "CREATE DOCUMENT TYPE PerfTest")
+
+    with db_server.transaction():
+        for i in range(num_records):
+            category = categories[i % len(categories)]
+            price = round(random.uniform(10.0, 999.99), 2)  # nosec B311
+            created_date = datetime.now() - timedelta(
+                days=random.randint(0, 365)  # nosec B311
+            )
+            is_active = random.choice([True, False])  # nosec B311
+            tags = ",".join(
+                random.choices(
+                    ["new", "sale", "popular", "limited", "premium"], k=2
+                )  # nosec B311
+            )
+
+            db_server.command(
+                "sql",
+                f"""
+                INSERT INTO PerfTest SET
+                    id = {i},
+                    name = 'Product {i}',
+                    description = 'Product {i} with detailed description',
+                    price = {price},
+                    category = '{category}',
+                    tags = '{tags}',
+                    created_date = '{created_date.strftime('%Y-%m-%d')}',
+                    is_active = {str(is_active).lower()}
+            """,
+            )
+
+    print(f"   ✅ Created {num_records} complex records")
+
+    # Time server-managed queries (embedded access) - same complex queries
+    start = time.time()
+    for i in range(num_queries):
+        query = query_types[i % len(query_types)]
+        result = db_server.query("sql", query)
+        list(result)  # Consume results
+    server_time = time.time() - start
+
+    print(f"   ⚡ {num_queries} complex queries in {server_time:.3f}s")
+    print(f"   ⚡ {num_queries/server_time:.1f} queries/sec")
+
+    # Compare
+    print("\n3. Performance Comparison...")
+    ratio = server_time / standalone_time
+    print(f"   📊 Standalone: {standalone_time:.3f}s")
+    print(f"   📊 Server (embedded): {server_time:.3f}s")
+    print(f"   📊 Ratio: {ratio:.2f}x")
+
+    if ratio < 1.5:  # Within 50% is essentially same performance
+        print("   ✅ Performance is SIMILAR - direct JVM calls in both cases!")
+    else:
+        print("   ℹ️  Some overhead from server management")
+
+    print("\n4. Key Insights:")
+    print("   💡 Server-managed embedded access = Direct JVM call")
+    print("   💡 NO HTTP overhead when accessing from same process")
+    print("   💡 HTTP is only for OTHER processes/clients")
+    print("   💡 HTTP would add ~5-50ms per request (network + JSON)")
+
+    server.stop()
+    print("\n✅ Performance Test Complete!\n")
+
+
+def test_http_api_access_pattern(cleanup_test_dirs):
+    """
+    Test HTTP API access pattern - REST requests to server.
+
+    This demonstrates the third access pattern: HTTP API for remote access.
+    Shows how HTTP API differs from Java API in terms of usage and performance.
+
+    Includes realistic CRUD operations benchmark with proper connection pooling.
+    """
+    create_temp_dir, register_server = cleanup_test_dirs
+
+    print("\n" + "=" * 70)
+    print("TEST: HTTP API Access Pattern")
+    print("=" * 70)
+
+    # Import requests here to avoid dependency for non-HTTP tests
+    try:
+        import requests
+        from requests.auth import HTTPBasicAuth
+    except ImportError:
+        pytest.skip("requests library not available for HTTP API testing")
+
+    root_path = create_temp_dir("http_api_")
+
+    # Step 1: Start server (required for HTTP API)
+    print("\n1. Starting ArcadeDB server...")
+    server = arcadedb.create_server(root_path=root_path, root_password=TEST_PASSWORD)
+    register_server(server)
+    server.start()
+    time.sleep(1)  # Give server time to fully start
+
+    base_url = f"http://localhost:{server.get_http_port()}"
+
+    # Use session for connection pooling (more realistic)
+    session = requests.Session()
+    session.auth = HTTPBasicAuth("root", "test12345")
+
+    print(f"   ✅ Server started on port {server.get_http_port()}")
+    print(f"   📡 HTTP API base URL: {base_url}")
+
+    # Step 2: Create database via Java API
+    # (HTTP API doesn't have database creation endpoint)
+    print("\n2. Creating database via Java API (both APIs need this)...")
+    server.create_database("httpdb")  # Use Java API for database creation
+    print("   ✅ Database created via Java API")
+
+    # Step 3: Create schema via HTTP API
+    print("\n3. Creating schema via HTTP API...")
+    response = session.post(
+        f"{base_url}/api/v1/command/httpdb",
+        json={"language": "sql", "command": "CREATE DOCUMENT TYPE Product"},
+        timeout=30,
+    )
+    assert response.status_code == 200, f"Schema creation failed: {response.text}"
+    print("   ✅ Schema created via HTTP request")
+
+    # Step 4: Insert initial data via HTTP API
+    print("\n4. Inserting sample data via HTTP API...")
+    products = [
+        ("Laptop", 999, "Electronics"),
+        ("Mouse", 29, "Electronics"),
+        ("Keyboard", 79, "Electronics"),
+        ("Desk", 299, "Furniture"),
+        ("Chair", 199, "Furniture"),
+    ]
+
+    for name, price, category in products:
+        response = session.post(
+            f"{base_url}/api/v1/command/httpdb",
+            json={
+                "language": "sql",
+                "command": (
+                    f"INSERT INTO Product SET name = '{name}', "
+                    f"price = {price}, category = '{category}'"
+                ),
+            },
+            timeout=30,
+        )
+        assert response.status_code == 200
+
+    print(f"   ✅ Inserted {len(products)} products via HTTP requests")
+
+    # Step 5: Query data via HTTP API
+    print("\n5. Querying data via HTTP API...")
+    response = session.post(
+        f"{base_url}/api/v1/query/httpdb",
+        json={"language": "sql", "command": "SELECT FROM Product ORDER BY price"},
+        timeout=30,
+    )
+    assert response.status_code == 200
+    result = response.json()
+
+    print("   ✅ Query results via HTTP:")
+    for record in result["result"]:
+        print(f"     - {record['name']}: ${record['price']} ({record['category']})")
+
+    # Step 6: Comprehensive Performance Comparison - Full CRUD Operations
+    print("\n6. Comprehensive Performance Test: HTTP vs Java API...")
+    print("   Testing schema creation, inserts, queries, updates, and deletes")
+
+    # Access same database via Java API for comparison
+    db = server.get_database("httpdb")
+
+    # Benchmark parameters
+    num_operations = 100  # Reduced from 1000 for more realistic mixed operations
+    import random  # nosec B311
+
+    # --- HTTP API Full CRUD Benchmark ---
+    print("\n   6a. HTTP API - Full CRUD operations...")
+
+    start = time.time()
+
+    # Create a test type
+    session.post(
+        f"{base_url}/api/v1/command/httpdb",
+        json={"language": "sql", "command": "CREATE DOCUMENT TYPE BenchItem"},
+        timeout=30,
+    )
+
+    # Mixed operations
+    for i in range(num_operations):
+        op_type = i % 5  # Cycle through 5 operation types
+
+        if op_type == 0:  # Insert
+            response = session.post(
+                f"{base_url}/api/v1/command/httpdb",
+                json={
+                    "language": "sql",
+                    "command": (
+                        f"INSERT INTO BenchItem SET id = {i}, "
+                        f"value = {random.randint(1, 1000)}, name = 'Item {i}'"  # nosec B311
+                    ),
+                },
+                timeout=30,
+            )
+        elif op_type == 1:  # Query with filter
+            response = session.post(
+                f"{base_url}/api/v1/query/httpdb",
+                json={
+                    "language": "sql",
+                    "command": (
+                        f"SELECT FROM BenchItem WHERE "  # nosec B608
+                        f"value > {random.randint(1, 500)} LIMIT 10"  # nosec B311
+                    ),
+                },
+                timeout=30,
+            )
+        elif op_type == 2:  # Update
+            response = session.post(
+                f"{base_url}/api/v1/command/httpdb",
+                json={
+                    "language": "sql",
+                    "command": (
+                        f"UPDATE BenchItem SET value = {random.randint(1, 1000)} "  # nosec B608 B311
+                        f"WHERE id = {random.randint(0, max(1, i-1))}"  # nosec B311
+                    ),
+                },
+                timeout=30,
+            )
+        elif op_type == 3:  # Aggregation query
+            response = session.post(
+                f"{base_url}/api/v1/query/httpdb",
+                json={
+                    "language": "sql",
+                    "command": (
+                        "SELECT avg(value) as avg_val, "
+                        "count(*) as total FROM BenchItem"
+                    ),
+                },
+                timeout=30,
+            )
+        else:  # Complex query
+            response = session.post(
+                f"{base_url}/api/v1/query/httpdb",
+                json={
+                    "language": "sql",
+                    "command": (
+                        f"SELECT FROM BenchItem WHERE name LIKE "  # nosec B608
+                        f"'%{random.randint(0, 9)}%' ORDER BY value DESC LIMIT 5"  # nosec B311
+                    ),
+                },
+                timeout=30,
+            )
+
+        assert response.status_code == 200
+
+    http_time = time.time() - start
+    print(f"   ⏱️  HTTP API: {num_operations} operations in {http_time:.3f}s")
+    print(f"   📊 {num_operations/http_time:.1f} ops/sec")
+
+    # --- Java API Full CRUD Benchmark ---
+    print("\n   6b. Java API - Same CRUD operations...")
+
+    # Clean up from HTTP test
+    with db.transaction():
+        db.command("sql", "DELETE FROM BenchItem")
+
+    start = time.time()
+
+    # Create same test type (already exists, but included for fair comparison)
+    try:
+        db.command("sql", "CREATE DOCUMENT TYPE BenchItem")
+    except Exception:
+        pass  # nosec B110
+
+    # Same mixed operations
+    for i in range(num_operations):
+        op_type = i % 5
+
+        if op_type == 0:  # Insert
+            with db.transaction():
+                db.command(
+                    "sql",
+                    f"INSERT INTO BenchItem SET id = {i}, "
+                    f"value = {random.randint(1, 1000)}, name = 'Item {i}'",  # nosec B311
+                )
+        elif op_type == 1:  # Query with filter
+            result = db.query(
+                "sql",
+                f"SELECT FROM BenchItem WHERE "  # nosec B608
+                f"value > {random.randint(1, 500)} LIMIT 10",  # nosec B311
+            )
+            list(result)  # Consume results
+        elif op_type == 2:  # Update
+            with db.transaction():
+                db.command(
+                    "sql",
+                    f"UPDATE BenchItem SET value = {random.randint(1, 1000)} "  # nosec B608 B311
+                    f"WHERE id = {random.randint(0, max(1, i-1))}",  # nosec B311
+                )
+        elif op_type == 3:  # Aggregation query
+            result = db.query(
+                "sql",
+                "SELECT avg(value) as avg_val, count(*) as total FROM BenchItem",
+            )
+            list(result)
+        else:  # Complex query
+            result = db.query(
+                "sql",
+                f"SELECT FROM BenchItem WHERE name LIKE "  # nosec B608
+                f"'%{random.randint(0, 9)}%' ORDER BY value DESC LIMIT 5",  # nosec B311
+            )
+            list(result)
+
+    java_time = time.time() - start
+    print(f"   ⏱️  Java API: {num_operations} operations in {java_time:.3f}s")
+    print(f"   📊 {num_operations/java_time:.1f} ops/sec")
+
+    # --- Comparison ---
+    print("\n   6c. Performance Comparison:")
+    ratio = http_time / java_time
+    overhead_ms = (http_time - java_time) / num_operations * 1000
+    print(f"   📊 HTTP API: {http_time:.3f}s ({num_operations/http_time:.1f} ops/sec)")
+    print(f"   📊 Java API: {java_time:.3f}s ({num_operations/java_time:.1f} ops/sec)")
+    print(f"   📊 Ratio: HTTP is {ratio:.1f}x slower")
+    print(f"   💡 Per-operation overhead: ~{overhead_ms:.1f}ms")
+
+    if ratio < 10:
+        print("   ✅ Reasonable overhead for network/HTTP layer")
+    else:
+        print(
+            "   ⚠️  Significant overhead - "
+            "Java API strongly preferred for performance"
+        )
+
+    # Step 7: Summary of access patterns
+    print("\n7. Access Pattern Summary:")
+    print("   🔧 Java API (Standalone): arcadedb.create_database()")
+    print("   🔧 Java API (Server): server.create_database() → db.command()")
+    print("   🔧 HTTP API (Remote): requests.Session() → JSON responses")
+    print("   💡 Database creation requires Java API")
+    print("   💡 HTTP API adds network + JSON overhead (~1-10ms per operation)")
+    print("   💡 Java API provides maximum performance for Python processes")
+    print("   💡 HTTP API essential for other languages/remote clients")
+    print("   💡 Both can be used simultaneously on same server!")
+
+    session.close()
+    server.stop()
+    print("\n✅ HTTP API Test Complete!\n")

--- a/bindings/python/tests/test_server_wire_protocols.py
+++ b/bindings/python/tests/test_server_wire_protocols.py
@@ -1,0 +1,185 @@
+"""The wire protocols the wheel bundles are actually reachable.
+
+The wheel ships arcadedb-postgresw, arcadedb-redisw and arcadedb-bolt as
+shaded jars. Until 2026-08-01 nothing connected over any of them: the server
+suite covered lifecycle, threading, jar presence and HTTP/Studio, so three
+bundled protocols rested on the jars being in the archive. That is the same
+shape as shipping a feature and testing that its file exists.
+
+Each test speaks the real protocol with the real client, because the failure
+these guard against is not "the port is closed" but "the plugin loaded and
+then disagreed with its own client". A socket probe would pass on a half-built
+plugin.
+
+The plugins are opt-in, which is itself worth pinning: a default install
+starts HTTP only, and a test that assumed otherwise would quietly stop testing
+anything the day the default changed.
+"""
+
+import socket
+import time
+
+import pytest
+
+pytestmark = pytest.mark.server_wire
+
+PG_PLUGIN = "Postgres:com.arcadedb.postgres.PostgresProtocolPlugin"
+REDIS_PLUGIN = "Redis:com.arcadedb.redis.RedisProtocolPlugin"
+BOLT_PLUGIN = "Bolt:com.arcadedb.bolt.BoltProtocolPlugin"
+
+# The shared fixture password, not a second hardcoded one. Defining our own
+# tripped bandit B105 and, worse, diverged from what every other server test
+# already imports.
+from tests.conftest import TEST_PASSWORD as ROOT_PASSWORD  # noqa: E402
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait(port, timeout=60.0):
+    """Wait for a listener, then give the plugin a moment to finish binding."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.25)
+    return False
+
+
+@pytest.fixture
+def wire_server(tmp_path):
+    """A server with all three bundled wire plugins enabled."""
+    from arcadedb_embedded import create_server
+
+    ports = {k: _free_port() for k in ("http", "postgres", "redis", "bolt")}
+    server = create_server(
+        root_path=str(tmp_path / "databases"),
+        root_password=ROOT_PASSWORD,
+        config={
+            "http_port": ports["http"],
+            "server_plugins": ",".join([PG_PLUGIN, REDIS_PLUGIN, BOLT_PLUGIN]),
+            "postgres_port": ports["postgres"],
+            "redis_port": ports["redis"],
+            "bolt_port": ports["bolt"],
+        },
+    )
+    server.start()
+    db = server.create_database("wiretest")
+    # VERTEX, not DOCUMENT: Cypher's MATCH (i:Item) matches vertices, so a
+    # document type makes the Bolt test return [] while SQL still works. That
+    # is a property of the query language, not of the wire protocol, and it
+    # cost a debugging round to see. A vertex is a record, so the SQL and
+    # Postgres paths read it the same either way.
+    db.command("sql", "CREATE VERTEX TYPE Item")
+    with db.transaction():
+        db.command("sql", "INSERT INTO Item SET id = 1, name = 'alpha'")
+    try:
+        yield server, ports
+    finally:
+        server.stop()
+
+
+def test_plugins_are_opt_in(tmp_path):
+    """A default server starts HTTP and nothing else.
+
+    Checked against the REAL default ports rather than a random unused one:
+    an earlier version of this test bound a free port and asserted it was
+    closed, which would have passed whether or not the plugins were running.
+    Verified 2026-08-01 that a default server logs
+    "with plugins [AutoBackupSchedulerPlugin]" and leaves 5432/6379/7687 shut.
+
+    Pinned because the other tests only mean something if enabling the
+    plugins is what turns them on.
+    """
+    from arcadedb_embedded import create_server
+
+    http = _free_port()
+    server = create_server(
+        root_path=str(tmp_path / "default"),
+        root_password=ROOT_PASSWORD,
+        config={"http_port": http},
+    )
+    server.start()
+    try:
+        assert _wait(http), "HTTP should serve on a default server"
+        for name, port in (("postgres", 5432), ("redis", 6379), ("bolt", 7687)):
+            with pytest.raises(OSError):
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
+                    pass
+    finally:
+        server.stop()
+
+
+def test_postgres_wire_answers_a_query(wire_server):
+    """Postgres wire is the binary protocol the wheel actually ships."""
+    psycopg = pytest.importorskip("psycopg")
+    _, ports = wire_server
+    assert _wait(ports["postgres"]), "postgres plugin never bound its port"
+
+    with psycopg.connect(
+        host="127.0.0.1",
+        port=ports["postgres"],
+        dbname="wiretest",
+        user="root",
+        password=ROOT_PASSWORD,
+        connect_timeout=15,
+    ) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT name FROM Item")
+            rows = cur.fetchall()
+    assert any("alpha" in str(r) for r in rows), rows
+
+
+@pytest.mark.xfail(
+    reason="engine ignores arcadedb.redis.port; binds 6379 (ArcadeDB #5796)",
+    strict=True,
+)
+def test_redis_port_setting_is_honored(wire_server):
+    """arcadedb.redis.port is accepted and ignored.
+
+    Measured 2026-08-01 on 26.8.1.dev24. With all three plugins enabled and a
+    distinct port passed to each, the startup log reads:
+
+        [PostgresNetworkListener] Listening ... on 0.0.0.0:56857   <- ours
+        [BoltNetworkListener]     Listening ... on 0.0.0.0:38377   <- ours
+        [RedisNetworkListener]    Listening ... on 0.0.0.0:6379    <- default
+
+    So the setting reaches the engine (Postgres and Bolt honour theirs by the
+    same passthrough) and the Redis listener does not read it. xfail(strict)
+    so this turns into a failure the day it is fixed, rather than sitting here
+    as a permanently green skip.
+
+    Root-caused and filed as ArcadeDB #5796 on 2026-08-03. ServerPlugin
+    .configure() is handed the server's ContextConfiguration; Postgres and
+    Bolt read the port from it, while Redis drops the argument and reads the
+    static GlobalConfiguration default at startService(). MongoDB has the same
+    shape (untested here, that jar is excluded from the wheel). Bolt carried
+    the identical bug until #3809 fixed it, so two plugins were converted and
+    two were left behind.
+    """
+    _, ports = wire_server
+    assert _wait(
+        ports["redis"], timeout=20
+    ), f"redis did not bind the requested port {ports['redis']}"
+
+
+def test_bolt_wire_answers_a_cypher_query(wire_server):
+    neo4j = pytest.importorskip("neo4j")
+    _, ports = wire_server
+    assert _wait(ports["bolt"]), "bolt plugin never bound its port"
+
+    driver = neo4j.GraphDatabase.driver(
+        f"bolt://127.0.0.1:{ports['bolt']}",
+        auth=("root", ROOT_PASSWORD),
+    )
+    try:
+        with driver.session(database="wiretest") as session:
+            got = session.run("MATCH (i:Item) RETURN i.name AS name").data()
+    finally:
+        driver.close()
+    assert any(r.get("name") == "alpha" for r in got), got

--- a/bindings/python/tests/test_type_conversion.py
+++ b/bindings/python/tests/test_type_conversion.py
@@ -398,3 +398,42 @@ def test_array_conversion(temp_db_path):
         assert len(names) == 3
         assert "Alice" in names
         assert "Charlie" in names
+
+
+class TestPrimitiveArrayFormats:
+    """Regression tests for issue #4: int[]/long[] buffer formats ('=i'/'=q')
+    crashed memoryview.tolist() and poisoned the converter cache."""
+
+    def test_int_array(self):
+        import jpype
+        from arcadedb_embedded.type_conversion import convert_java_to_python
+
+        assert convert_java_to_python(jpype.JArray(jpype.JInt)([1, 2, 3])) == [1, 2, 3]
+        # second conversion exercises the cached converter
+        assert convert_java_to_python(jpype.JArray(jpype.JInt)([4, 5])) == [4, 5]
+
+    def test_long_array(self):
+        import jpype
+        from arcadedb_embedded.type_conversion import convert_java_to_python
+
+        big = 2**40
+        assert convert_java_to_python(jpype.JArray(jpype.JLong)([big, -big])) == [
+            big,
+            -big,
+        ]
+
+    def test_cache_not_poisoned_by_failure(self):
+        from arcadedb_embedded import type_conversion as tc
+
+        class Boom:
+            pass
+
+        def bad_converter(v):
+            raise RuntimeError("first call fails")
+
+        b = Boom()
+        try:
+            tc._register(b, bad_converter)
+        except RuntimeError:
+            pass
+        assert type(b) not in tc._CONVERTER_CACHE

--- a/bindings/python/tests/test_vector.py
+++ b/bindings/python/tests/test_vector.py
@@ -19,7 +19,29 @@ def test_db(tmp_path):
     db.drop()
 
 
-def test_to_java_byte_array_accepts_bytes_like_fast_paths():
+@pytest.fixture
+def jvm(tmp_path):
+    """Guarantee a running JVM for tests that touch the array converters.
+
+    to_java_byte_array and to_java_float_array go straight to jpype.JArray,
+    which raises JVMNotRunning unless something has already started the JVM.
+    The two tests below have no database fixture, so running this FILE on its
+    own failed both of them while the full suite passed, because some earlier
+    module happened to boot the JVM first.
+
+    That is a test-isolation defect rather than a product one, and it matters
+    more than it looks: running one file in isolation is the first thing
+    anybody does when chasing a flake in it (see upstream #5615, which is
+    about this very file).
+    """
+    import jpype
+
+    if not jpype.isJVMStarted():
+        arcadedb.create_database(str(tmp_path / "_jvm_boot")).close()
+    yield
+
+
+def test_to_java_byte_array_accepts_bytes_like_fast_paths(jvm):
     """to_java_byte_array should preserve signed byte semantics for bytes-like
     inputs."""
     np = pytest.importorskip("numpy")
@@ -36,7 +58,7 @@ def test_to_java_byte_array_accepts_bytes_like_fast_paths():
     ) == [0, 127, -1]
 
 
-def test_to_java_float_array_accepts_numpy_directly():
+def test_to_java_float_array_accepts_numpy_directly(jvm):
     """to_java_float_array should accept NumPy arrays without Python-list copies."""
     np = pytest.importorskip("numpy")
 
@@ -294,7 +316,6 @@ class TestLSMVectorIndex:
             quantization="INT8",
             store_vectors_in_graph=True,
             add_hierarchy=True,
-            location_cache_size=123,
             graph_build_cache_size=456,
             mutations_before_rebuild=789,
         )
@@ -309,7 +330,10 @@ class TestLSMVectorIndex:
         assert metadata["similarity_function"] == "EUCLIDEAN"
         assert metadata["id_property"] == "slug"
         assert metadata["quantization"] == "INT8"
-        assert metadata["location_cache_size"] == 123
+        # The engine removed locationCacheSize in #5559/#5568, so the key must
+        # no longer be reported. Asserting its absence keeps a silent
+        # reintroduction (which would raise on every metadata read) visible.
+        assert "location_cache_size" not in metadata
         assert metadata["graph_build_cache_size"] == 456
         assert metadata["mutations_before_rebuild"] == 789
         assert metadata["store_vectors_in_graph"] is True
@@ -514,12 +538,21 @@ class TestLSMVectorIndex:
             index.build_graph_now()
 
         with arcadedb.open_database(db_path) as db:
-            rs = db.query(
-                "sql",
-                "SELECT vectorNeighbors('Doc[embedding]', [1.0, 0.0, 0.0], 1) as res",
-            ).to_list()
-            assert len(rs) == 1
-            neighbors = rs[0].get("res")
+            # The ANN graph loads asynchronously after reopen; poll briefly
+            # so slow CI runners (Windows especially) don't race it.
+            import time as _time
+
+            neighbors = []
+            for _ in range(50):
+                rs = db.query(
+                    "sql",
+                    "SELECT vectorNeighbors('Doc[embedding]', [1.0, 0.0, 0.0], 1) as res",
+                ).to_list()
+                assert len(rs) == 1
+                neighbors = rs[0].get("res")
+                if neighbors:
+                    break
+                _time.sleep(0.1)
             assert len(neighbors) == 1
             vertex = neighbors[0]
             assert vertex is not None
@@ -711,9 +744,6 @@ class TestLSMVectorIndex:
         assert rid_conversion_calls[: len(allowed_rids)] == allowed_rids
         assert len(rid_conversion_calls) >= len(allowed_rids)
 
-    @pytest.mark.skip(
-        reason="Known upstream bug: Vector deletions cause index corruption"
-    )
     def test_lsm_vector_delete_and_search_others(self, test_db):
         """Test deleting vertices in a larger dataset and ensuring others are still found."""
         import random  # nosec B311
@@ -733,7 +763,6 @@ class TestLSMVectorIndex:
         # Generate 100 random vectors
         num_vectors = 100
         vectors = []
-        rids = []
 
         # Use fixed seed for reproducibility
         random.seed(42)
@@ -750,7 +779,6 @@ class TestLSMVectorIndex:
                     arcadedb.to_java_float_array(vec),
                     i,
                 )
-                rids.append(str(i))
 
         # Create index now (Bulk load)
         # We disable store_vectors_in_graph to avoid "Invalid position" errors when checking mutable pages
@@ -767,39 +795,34 @@ class TestLSMVectorIndex:
             for idx in sorted(list(deleted_indices)):
                 test_db.command("sql", "DELETE FROM Doc WHERE id = ?", idx)
 
-        # Verify deletions and existence
+        # Verify deletions and existence.
+        #
+        # Compare the `id` PROPERTY, not the record identity. An earlier version
+        # of this test compared str(get_identity()), a RID like "#1:1", against
+        # the integer i. "#1:1" != 1 is always true, so the deleted-vector check
+        # could never fail, and "#1:1" == 1 is always false, so the surviving-
+        # vector check could never pass. That made the test fail unconditionally
+        # and it was skipped as "Known upstream bug: Vector deletions cause index
+        # corruption". The engine was never at fault: it reports
+        # "110 total entries, 10 deleted, 90 active" and validates 90/90, and the
+        # query for a surviving vector returns it ranked first.
         for i in range(num_vectors):
             vec = vectors[i]
-            rid = i
 
-            # Search for the vector
-            # Increase k to 10 to handle slight variations in ANN recall or score normalization
-            # especially on Windows/CI environments where the graph structure might be slightly different
+            # k=10 absorbs small variations in ANN recall across platforms.
             results = index.find_nearest(vec, k=10)
+            found_ids = [int(vertex.get("id")) for vertex, _ in results]
 
             if i in deleted_indices:
-                # If deleted, we should NOT find this specific RID
-                if len(results) > 0:
-                    for found_vertex, _ in results:
-                        found_rid = str(found_vertex.get_identity())
-                        assert (
-                            found_rid != rid
-                        ), f"Deleted vector at index {i} (RID {rid}) was found!"
+                assert i not in found_ids, (
+                    f"Deleted vector id={i} was still returned.\n"
+                    f"Found ids: {found_ids}"
+                )
             else:
-                # If not deleted, we SHOULD find this specific RID among top matches
-                found = False
-                found_rids = []
-                for found_vertex, _ in results:
-                    found_rid = str(found_vertex.get_identity())
-                    found_rids.append(found_rid)
-                    if found_rid == rid:
-                        found = True
-                        break
-
-                assert found, (
-                    f"Existing vector at index {i} (RID {rid}) not found in top 10 results.\n"
-                    f"Found RIDs: {found_rids}\n"
-                    f"Deleted indices: {sorted(list(deleted_indices))}"
+                assert i in found_ids, (
+                    f"Surviving vector id={i} not in the top 10.\n"
+                    f"Found ids: {found_ids}\n"
+                    f"Deleted ids: {sorted(deleted_indices)}"
                 )
 
     def test_lsm_vector_search_ef_search(self, test_db):
@@ -891,6 +914,36 @@ class TestLSMVectorIndex:
 
         # Size should be 2
         assert index.get_size() == 2
+
+    def test_lsm_index_stats(self, test_db):
+        """Live counters are readable and track index activity."""
+        test_db.command("sql", "CREATE VERTEX TYPE Doc")
+        test_db.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS")
+
+        index = test_db.create_vector_index("Doc", "embedding", dimensions=3)
+
+        stats = index.get_stats()
+        assert isinstance(stats, dict) and stats
+        # Counters the engine has reported since vector indexes existed;
+        # the key set may grow, so only these are asserted.
+        assert stats["totalVectors"] == 0
+        assert isinstance(stats["dimensions"], int)
+        assert stats["vectorFetchFromDocuments"] >= 0
+
+        with test_db.transaction():
+            for vec in ([1.0, 0.0, 0.0], [0.0, 1.0, 0.0]):
+                test_db.command(
+                    "sql",
+                    "INSERT INTO Doc SET embedding = ?",
+                    arcadedb.to_java_float_array(vec),
+                )
+
+        assert index.get_stats()["totalVectors"] == 2
+        # values are plain Python scalars, not Java objects
+        assert all(
+            v is None or isinstance(v, (int, float, bool, str))
+            for v in index.get_stats().values()
+        )
 
     def test_lsm_persistence(self, temp_db_path):
         """Test that LSM index persists across database restarts."""

--- a/bindings/python/tests/test_vector_params_verification.py
+++ b/bindings/python/tests/test_vector_params_verification.py
@@ -202,11 +202,18 @@ class TestVectorParams:
         test_db.command("sql", "CREATE VERTEX TYPE CacheDoc")
         test_db.command("sql", "CREATE PROPERTY CacheDoc.embedding ARRAY_OF_FLOATS")
 
+        # location_cache_size was removed by the engine (#5559, #5568). The
+        # binding must reject it with an explanation rather than forward it and
+        # let index creation blow up inside withMetadata().
+        with pytest.raises(ValueError, match="no longer supported"):
+            test_db.create_vector_index(
+                "CacheDoc", "embedding", dimensions=4, location_cache_size=123
+            )
+
         index = test_db.create_vector_index(
             "CacheDoc",
             "embedding",
             dimensions=4,
-            location_cache_size=123,
             graph_build_cache_size=456,
             mutations_before_rebuild=789,
         )
@@ -220,15 +227,10 @@ class TestVectorParams:
 
         # Direct field access is available on LSMVectorIndexMetadata; fall back to string inspection if not.
         try:
-            assert metadata.locationCacheSize == 123
             assert metadata.graphBuildCacheSize == 456
             assert metadata.mutationsBeforeRebuild == 789
         except AttributeError:
             meta_str = metadata.toString()
-            assert (
-                "locationCacheSize=123" in meta_str
-                or "locationCacheSize: 123" in meta_str
-            )
             assert (
                 "graphBuildCacheSize=456" in meta_str
                 or "graphBuildCacheSize: 456" in meta_str

--- a/bindings/python/tests/test_vector_sql.py
+++ b/bindings/python/tests/test_vector_sql.py
@@ -599,7 +599,6 @@ class TestVectorSQL:
                 "idPropertyName": "slug",
                 "storeVectorsInGraph": true,
                 "addHierarchy": true,
-                "locationCacheSize": 123,
                 "graphBuildCacheSize": 456,
                 "mutationsBeforeRebuild": 789
             }
@@ -615,9 +614,25 @@ class TestVectorSQL:
         assert metadata.idPropertyName == "slug"
         assert metadata.storeVectorsInGraph is True
         assert metadata.addHierarchy is True
-        assert metadata.locationCacheSize == 123
         assert metadata.graphBuildCacheSize == 456
         assert metadata.mutationsBeforeRebuild == 789
+
+        # locationCacheSize was removed in #5559/#5568 and the engine now
+        # rejects it outright, so a SQL METADATA block that still carries it
+        # fails index creation rather than ignoring the key. Asserting the
+        # rejection (not the field's absence) is the durable check: hasattr on
+        # a JPype proxy answers True for names the Java class does not define.
+        test_db.command("sql", "CREATE VERTEX TYPE SqlMetaRejectDoc")
+        test_db.command("sql", "CREATE PROPERTY SqlMetaRejectDoc.vec ARRAY_OF_FLOATS")
+        with pytest.raises(Exception, match="locationCacheSize"):
+            test_db.command(
+                "sql",
+                """
+                CREATE INDEX ON SqlMetaRejectDoc (vec)
+                LSM_VECTOR
+                METADATA { "dimensions": 4, "locationCacheSize": 123 }
+                """,
+            )
 
     def test_vector_neighbors_by_key_sql(self, test_db):
         """SQL vector.neighbors should search from an existing record key."""

--- a/bindings/python/tests/test_wheel_platform_tag.py
+++ b/bindings/python/tests/test_wheel_platform_tag.py
@@ -134,3 +134,24 @@ def test_module_exposes_public_api() -> None:
     assert hasattr(verifier, "max_glibc_in_dir")
     assert hasattr(verifier, "parse_wheel_tag")
     assert hasattr(verifier, "main")
+
+
+def test_dunder_version_matches_distribution_metadata():
+    """__version__ must equal the installed distribution version.
+
+    Regression: _version.py is generated from the Maven pom (26.8.1-SNAPSHOT
+    -> 26.8.1.dev0) while the wheel is versioned from the release tag, so a
+    published 26.8.1.dev20 wheel reported __version__ == "26.8.1.dev0".
+    Anything reading the version programmatically (our own benchmark
+    provenance did) recorded the wrong build.
+    """
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as dist_version
+
+    import arcadedb_embedded
+
+    try:
+        expected = dist_version("arcadedb-embedded")
+    except PackageNotFoundError:  # source checkout, nothing to compare against
+        return
+    assert arcadedb_embedded.__version__ == expected


### PR DESCRIPTION
Periodic update of `bindings/python` from the downstream packaging fork
(humemai/arcadedb-embedded-python), rebased on current `main`. No engine code.

Everything here has been shipping on PyPI as `arcadedb-embedded`, most recently
`26.8.1`, so it is running against the released engine rather than proposed
against it.

## Two files outside bindings/python, and why

Both python workflows. They are in this repo because we sent them, and both
have been frozen at whatever we sent last while our copies kept gaining fixes.
Shipping tests without the workflows that run them ships tests that do not
execute.

### `test-python-examples.yml` (+53/-10)

- `HF_HOME` pinned into the workspace plus `actions/cache`. This matrix is 20
  jobs and the examples embed with sentence-transformers, so today it does 20
  independent model downloads per release.
- Pre-warm with three bounded retries, `continue-on-error`, run separately from
  the dataset step. A transient hub outage currently fails the release, and it
  surfaces mid-example as an `OSError` that reads like a bindings bug. Not
  fail-fast: if the hub is genuinely down the dataset step still fails with its
  own message, so this cannot turn a real breakage into a silent skip.
- Drops the `21_server_mode_http_access.py` exclusion. That example is now
  `23_server_mode_http_access.py` and the CI instability it was skipped for is
  fixed, so the exclusion targets a filename that no longer exists.

### `test-python-bindings.yml` (+31/-2)

Without it several tests in this PR do not run on your CI.

On the first push of this PR, linux/amd64 + Python 3.12 reported **405 passed,
15 skipped**. The same cell on the fork reports 423 passed, 2 skipped. The
difference is the install step:

```
uv pip install --system test-install/*.whl pytest pytest-cov requests numpy
```

No psycopg, neo4j, redis, pyarrow or pandas, so every test that
`importorskip`s one of them skips. **That included both wire-protocol tests**,
which are the main thing this PR adds: `test_postgres_wire_answers_a_query`
and `test_bolt_wire_answers_a_cypher_query` both skipped, so the bundled
Postgres and Bolt plugins still had no client-level coverage here.

The change is three things:

1. the five packages added to that install line
2. `--extra arrow --extra pandas` on the dependency floor audit
3. a guard that fails the build if any test skips for a missing import

The guard exists because this failure mode is silent by construction: a test
that skips on a missing dependency is not a pass and does not look like a
failure, so the suite goes green having exercised nothing. It matches only
`could not import`, so skips you legitimately expect are unaffected. Verified
against the two that remain: `bindings/python/docs is not present on this
branch` and `Requires GraphML/GraphSON support`.

Happy to drop either file if you would rather own those changes separately. The
rest of the PR stands without them; those tests will just keep skipping.

## Server mode is back in the wheel

`create_server()` / `ArcadeDBServer`, the HTTP API and the Studio UI ship
again, reversing the removal in 26.7.2. A downstream user reported the loss on
the removal commit itself, three weeks after it went out in a stable release,
and pinning 26.7.1 was the only way back.

Measured cost, one Linux x86_64 build of the same commit:

| | wheel | jars | bundled JRE |
| --- | --- | --- | --- |
| without server | 59.06 MiB | 20.70 MiB | 38.30 MiB |
| with server | 67.08 MiB | 27.87 MiB | 39.10 MiB |
| delta | **+8.02 MiB** | +7.17 MiB | +0.80 MiB |

Only 7.17 MiB of that is the 12 server JARs. The other 0.80 MiB is the JRE:
the build `jlink`s a runtime from what the shipped JARs need, and the server
pulls in `java.naming`, `java.security.jgss` and `java.security.sasl`.

## The bundled wire protocols now have tests that speak them

`arcadedb-postgresw`, `arcadedb-redisw` and `arcadedb-bolt` were in the wheel
with nothing connecting over any of them. The suite covered lifecycle,
threading and JAR presence, which is the same shape as shipping a feature and
testing that its file exists.

`tests/test_server_wire_protocols.py` connects with the real clients
(`psycopg`, `neo4j`), because the failure worth catching is not "the port is
closed" but "the plugin loaded and then disagreed with its own client". It
also pins that the plugins are opt-in, so the other tests keep meaning
something if that default ever changes.

Writing it found #5796: `arcadedb.redis.port` is accepted and ignored. Redis
binds 6379 whatever you configure, while Postgres and Bolt honour theirs
through the same passthrough. `ServerPlugin.configure()` receives the server's
`ContextConfiguration`, and the Redis plugin drops the argument and reads the
static `GlobalConfiguration` at `startService()`. Bolt had the identical bug
until #3809. The test is `xfail(strict=True)`, so it turns into a failure the
day it is fixed rather than sitting here as a permanently green skip.

## New in the Python surface

- **`ResultSet.to_arrow()`** returns a `pyarrow.Table` from the same columnar
  bridge buffer `to_columns()` already uses, so it adds no Java and no JARs.
  It preserves validity bitmaps instead of widening nullable integers to
  `float64`/NaN the way `to_columns()` must. Optional `arrow` extra; without
  pyarrow it returns `None` so callers can fall back.
- **`jar_fingerprint()`** reports which engine an install actually carries.
  `__version__` comes from the pom and says nothing about the JARs in the
  wheel, and the two can disagree with no error at all. It returns both a
  build hash and an `engine_sha256` that excludes the bridge JAR we compile,
  since that one is not byte reproducible.
- **`DocumentBatcher` / `TimeSeriesBatcher`** under `src/java`, for bulk paths
  that would otherwise cross the boundary per row.

## Binding changes the engine required

- `location_cache_size` now raises `ValueError` rather than failing inside the
  Java builder, following #5559 and #5568. Since the engine rejects the key,
  a wheel that still forwarded it could not create a vector index at all.
- Tests updated for #5501: a Cypher query referencing an unbound parameter
  raises instead of returning `NULL`.
- Example 2 named OpenCypher in an error path that only Gremlin can reach.
  Verified on the shipped wheel: `opencypher` works, `cypher` works, `gremlin`
  fails because that JAR is excluded by design. It now says so.

## Testing

`423 passed, 2 skipped, 1 xfailed` on linux/amd64, Python 3.12, against a wheel
built from this tree. The two skips are GraphML/GraphSON, genuinely absent
because the Gremlin JAR is excluded; the xfail is #5796 above.

Optional test dependencies are named explicitly in the `test` extra now.
`pandas` had never been there, so both `to_dataframe()` tests called
`importorskip` and skipped in every CI run this package has had, for a public
documented method. They pass once pandas is installed, so it was a coverage
gap rather than a bug, which is also why nobody noticed.
