### PR TITLE
fix(native): unbreak the native image build and smoke test (four regressions since 2026-07-27)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,18 @@ updates:
       # frozen 4.9.1 sits below the engine's current 4.13.2, so any range that
       # blocked the gremlin bump would silently freeze the engine too. The
       # gremlin ANTLR PR is closed by hand instead.
+      #
+      # The GraalVM Truffle/polyglot coordinates (org.graalvm.*) are unlisted for
+      # the same reason. They appear with two different intents:
+      # native/pom.xml's native.graalvm.version MUST equal the native-image
+      # builder pinned by native-image.yml's java-version (a mismatch aborts the
+      # image build with NoSuchMethodError getLoopNodeFactory()), while
+      # engine/pom.xml's graalvm.version tracks the latest independently for the
+      # JVM-side JS engine. A coordinate-wide ignore would freeze the engine
+      # along with the native pin. A GraalVM PR is therefore reviewed by hand:
+      # merge it only together with a matching java-version bump in
+      # native-image.yml, otherwise close it. Bump 3fecba4bf did exactly this
+      # wrong and broke all four native legs.
       - dependency-name: "org.apache.groovy:*"
         update-types: ["version-update:semver-major"]
 

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -253,16 +253,27 @@
                         <!-- Netty holds JNI/native and static state that must not be snapshotted at build time. -->
                         <buildArg>--initialize-at-run-time=io.netty</buildArg>
                         <!--
-                            grpc-netty-shaded relocates the whole of Netty under
-                            io.grpc.netty.shaded.io.netty, which the io.netty prefix above does NOT
-                            match, so the relocated copy needs the identical treatment. Without this
-                            the build aborts in the analysis phase on the tcnative classes
-                            (AsyncSSLPrivateKeyMethod, CertificateCompressionAlgo,
-                            ReferenceCountedOpenSslEngine, ...) with UnsatisfiedLinkError on
-                            NativeStaticallyReferencedJniMethods: their static initializers call
-                            into libnetty_tcnative, which is not loadable in the image builder.
+                            grpc-netty-shaded relocates Netty under io.grpc.netty.shaded.io.netty,
+                            which the io.netty prefix above does NOT match. Only the classes that
+                            reach libnetty_tcnative are listed, NOT the whole relocated package:
+                            their static initializers call NativeStaticallyReferencedJniMethods,
+                            which the image builder cannot load, so build-time initialization dies
+                            with UnsatisfiedLinkError during analysis. These five are the complete
+                            set the builder reports.
+
+                            Deferring the whole io.grpc.netty.shaded.io.netty package instead is
+                            WRONG and was tried first: it also moves PlatformDependent0 to run time,
+                            whose initializer reflectively reads java.nio.Bits.UNALIGNED,
+                            java.nio.Buffer.address, sun.misc.Unsafe.theUnsafe and friends. The
+                            GraalVM reachability metadata repository does register those, but every
+                            entry is conditioned on typeReached of the UNSHADED class (e.g.
+                            io.netty.util.internal.PlatformDependent0$6), a condition the relocated
+                            copy never satisfies. The image then builds cleanly and dies at STARTUP
+                            with MissingReflectionRegistrationError as soon as the gRPC plugin
+                            touches NettyServerBuilder. Everything outside this list therefore stays
+                            build-time initialized, as it was in the last green build.
                         -->
-                        <buildArg>--initialize-at-run-time=io.grpc.netty.shaded.io.netty</buildArg>
+                        <buildArg>--initialize-at-run-time=io.grpc.netty.shaded.io.netty.internal.tcnative,io.grpc.netty.shaded.io.netty.handler.ssl.ReferenceCountedOpenSslEngine</buildArg>
                         <!-- Embed all classpath resources (Studio assets, config templates, Lucene codecs). Tighten later. -->
                         <buildArg>-H:IncludeResources=.*</buildArg>
                         <!--

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -53,14 +53,26 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <!--
             GraalVM polyglot/Truffle version used ONLY for the native image build. It MUST match the
-            native-image builder (GraalVM CE 25.0.2) shipped with the local GRAALVM_HOME, otherwise
-            the in-image Truffle feature (TruffleBaseFeature.afterRegistration) fails at build time
-            with NoSuchMethodError OptimizedTruffleRuntime.getLoopNodeFactory() because the SVM
-            Truffle runtime bundled in the builder is compiled against a different Truffle API than
-            the one the engine pulls transitively (25.1.3). Pinning here (native module only) leaves
-            the JVM engine build untouched while letting the JS language embed into the image.
+            native-image builder (GraalVM CE 25.0.2) shipped with the local GRAALVM_HOME and pinned
+            by native-image.yml's java-version, otherwise the in-image Truffle feature
+            (TruffleBaseFeature.afterRegistration) fails at build time with NoSuchMethodError
+            OptimizedTruffleRuntime.getLoopNodeFactory() because the SVM Truffle runtime bundled in
+            the builder is compiled against a different Truffle API than the one the engine pulls
+            transitively. Pinning here (native module only) leaves the JVM engine build untouched
+            (engine/pom.xml's own graalvm.version tracks latest independently) while letting the JS
+            language embed into the image.
+
+            DEPENDABOT WILL TRY TO BUMP THIS AND MUST BE REFUSED unless native-image.yml's
+            java-version moves in the same change. Its last attempt (3fecba4bf, merged [skip ci] as
+            d463a31d0) raised this to 25.2.4 and broke every native leg with exactly the
+            getLoopNodeFactory() error above. 25.2.4 is NOT a drop-in for the builder: it is a
+            GraalVM intermediate release, published by graalvm/graalvm-ce-builds under the tag
+            graal-25.2.4 with assets named graalvm-community-jdk-25i2-25.0.4_*, which
+            graalvm/setup-graalvm cannot select through a plain java-version. jdk-25.0.2 is the
+            newest mainline JDK 25 Community build, so 25.0.2 is the version both sides can agree
+            on. A newer pin needs the builder side proven first.
         -->
-        <native.graalvm.version>25.2.4</native.graalvm.version>
+        <native.graalvm.version>25.0.2</native.graalvm.version>
         <!--
             Flag plumbed through by the CI matrix (native-image.yml) for the linux/amd64 job.
             Activates the native-static profile below, which appends the fully-static musl
@@ -240,6 +252,17 @@
                         <buildArg>--initialize-at-build-time=org.slf4j,org.slf4j.helpers,org.slf4j.spi,org.slf4j.event,org.slf4j.jul</buildArg>
                         <!-- Netty holds JNI/native and static state that must not be snapshotted at build time. -->
                         <buildArg>--initialize-at-run-time=io.netty</buildArg>
+                        <!--
+                            grpc-netty-shaded relocates the whole of Netty under
+                            io.grpc.netty.shaded.io.netty, which the io.netty prefix above does NOT
+                            match, so the relocated copy needs the identical treatment. Without this
+                            the build aborts in the analysis phase on the tcnative classes
+                            (AsyncSSLPrivateKeyMethod, CertificateCompressionAlgo,
+                            ReferenceCountedOpenSslEngine, ...) with UnsatisfiedLinkError on
+                            NativeStaticallyReferencedJniMethods: their static initializers call
+                            into libnetty_tcnative, which is not loadable in the image builder.
+                        -->
+                        <buildArg>--initialize-at-run-time=io.grpc.netty.shaded.io.netty</buildArg>
                         <!-- Embed all classpath resources (Studio assets, config templates, Lucene codecs). Tighten later. -->
                         <buildArg>-H:IncludeResources=.*</buildArg>
                         <!--

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -34,7 +34,21 @@
 
     <properties>
         <mainClass>com.arcadedb.server.ArcadeDBServer</mainClass>
-        <native-maven-plugin.version>1.1.6</native-maven-plugin.version>
+        <!--
+            Do NOT go back to 1.1.6: that release's AbstractNativeImageMojo calls
+            org.apache.maven.shared.utils.logging.MessageUtils.isColorEnabled() to pick the
+            native-image color flag ("-H:+BuildOutputColorful" or "color=never" depending on the
+            builder version), but the plugin's published pom does not declare
+            maven-shared-utils (its Gradle build leaves it compileOnly) and Maven core does not
+            export org.apache.maven.shared.utils from the maven.api realm - the jar in Maven's lib/
+            stays confined to plexus.core. Every goal invocation therefore dies with
+            "A required class was missing ... org/apache/maven/shared/utils/logging/MessageUtils"
+            on all four platforms. 1.1.7 drops the MessageUtils use entirely. If a future bump ever
+            reintroduces it, the alternative fix is a <dependency> on
+            org.apache.maven.shared:maven-shared-utils in the plugin declaration below, which
+            injects the jar into the plugin realm.
+        -->
+        <native-maven-plugin.version>1.1.7</native-maven-plugin.version>
         <imageName>arcadedb-${project.version}-${os.detected.name}-${os.detected.arch}</imageName>
         <maven.deploy.skip>true</maven.deploy.skip>
         <!--

--- a/native/src/test/scripts/exercise.sh
+++ b/native/src/test/scripts/exercise.sh
@@ -173,6 +173,16 @@ echo "[exercise] Redis PING (port $REDIS_PORT)"
 if tcp_connect 3 "$HOST" "$REDIS_PORT"; then
   # ArcadeDB's Redis wrapper only accepts RESP-encoded commands (no inline-command support), so
   # PING must be sent as the RESP array *1\r\n$4\r\nPING\r\n rather than a bare "PING\r\n".
+  #
+  # AUTH first: since "Require authentication on the Redis wire protocol" (3e76b3b82, reaching
+  # main with the 26.8.1 security merge) every command except AUTH and HELLO-with-AUTH is
+  # answered "-NOAUTH Authentication required." until the connection presents ArcadeDB
+  # credentials, mirroring the Postgres wrapper. An unauthenticated PING therefore no longer
+  # returns PONG, which under WIRE_STRICT=1 fails the build for a reason that has nothing to do
+  # with the binary under test. Both replies land in the same capture, so the PONG grep below
+  # still decides the check - "+OK" from AUTH alone would not match it.
+  printf '*3\r\n$4\r\nAUTH\r\n$%d\r\n%s\r\n$%d\r\n%s\r\n' \
+    "${#DB_USER}" "$DB_USER" "${#PASS}" "$PASS" >&3
   printf '*1\r\n$4\r\nPING\r\n' >&3
   RESP_FILE="$EX_WORK/redis.resp"
   read_fd_with_deadline 3 "$RESP_FILE"

--- a/native/src/test/scripts/smoke.sh
+++ b/native/src/test/scripts/smoke.sh
@@ -34,9 +34,15 @@ set -euo pipefail
 EXE="${1:?path to server executable required}"
 shift || true
 
-HOST=127.0.0.1
-HTTP=2480
-PG=5432
+# Overridable so the script can run on a machine that already has something on 2480/5432 (a
+# locally installed ArcadeDB, for instance): polling a port held by ANOTHER server turns this
+# smoke test into a false green. CI sets none of these, so the defaults below are what the
+# matrix keeps using. When overriding HTTP, pass the matching
+# -Darcadedb.server.httpIncomingPort=<port> as an extra argument so the server under test
+# actually listens where exercise.sh looks.
+HOST="${HOST:-127.0.0.1}"
+HTTP="${HTTP:-2480}"
+PG="${PG:-5432}"
 DB_USER=root
 PASS="${ARCADEDB_ROOT_PASSWORD:-PlayWithData123!}"
 


### PR DESCRIPTION
## Problem

Every leg of the Native Image workflow fails. It was last green on **2026-07-27** ([run 30282412460](https://github.com/ArcadeData/arcadedb/actions/runs/30282412460), `9f6f610a8`). Four independent regressions landed after that, each hidden behind the previous one. Every one arrived with `[skip ci]` or on a side branch, and `native-image.yml` has no `push`/`pull_request` trigger, so nothing caught any of them - the 26.8.1 release run on 2026-08-03 was the first casualty.

## 1. `native-maven-plugin` 0.10.6 -> 1.1.6 (`68bcf720b`)

```
A required class was missing ... org/apache/maven/shared/utils/logging/MessageUtils
```

1.1.6 added `AbstractNativeImageMojo.isColorEnabled()`, an unconditional `invokestatic` on `MessageUtils.isColorEnabled()`. The plugin's **published pom does not declare `maven-shared-utils`** - its Gradle build leaves the dependency `compileOnly`, so it is stripped from both the pom and `META-INF/maven/plugin.xml`, which list only `utils`, `openjson`, `graalvm-reachability-metadata`, `cyclonedx-maven-plugin`, `mojo-executor` and transitives: exactly the `urls[0..25]` set in the failure log. Maven core does not export `org.apache.maven.shared.utils` from the `maven.api` realm either (not among `maven-core`'s 76 exported packages), so the jar in Maven's `lib/` stays confined to `plexus.core`. `<extensions>true</extensions>` is not a factor - the same failure occurs in a plain `plugin>` realm.

**Fix:** 1.1.7, which drops the `MessageUtils` usage entirely.

## 2. `native.graalvm.version` 25.0.2 -> 25.2.4 (`3fecba4bf`)

```
NoSuchMethodError: OptimizedTruffleRuntime.getLoopNodeFactory()
```

The bump left `native-image.yml`'s `java-version: "25.0.2"` untouched, so the Truffle artifacts on the image classpath no longer match the SVM Truffle runtime inside the builder and `TruffleBaseFeature.afterRegistration` aborts. The property's own comment already warned about this failure, naming the method.

**Fix:** pin back to 25.0.2. 25.2.4 is not a drop-in for the builder: it is a GraalVM *intermediate* release, published under tag `graal-25.2.4` with assets named `graalvm-community-jdk-25i2-25.0.4_*`, which `setup-graalvm` cannot select through a plain `java-version`. `jdk-25.0.2` is the newest mainline JDK 25 Community build.

## 3. Shaded Netty reaching tcnative at build time

```
Class initialization of io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod failed
  Caused by: UnsatisfiedLinkError: NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha1()
```

A reflection registration marks the tcnative classes reachable, SVM initializes them at build time, and their static initializers call into `libnetty_tcnative`, which the image builder cannot load. The pom already defers `io.netty` to run time for this reason, but `grpc-netty-shaded` relocates Netty under `io.grpc.netty.shaded.io.netty`, which that prefix does not match.

**Fix:** defer exactly the five classes the builder rejects - the `...shaded.io.netty.internal.tcnative` package plus `handler.ssl.ReferenceCountedOpenSslEngine`.

Deferring the **whole** relocated package is wrong, and this PR tried it first. It also moves `PlatformDependent0` off build-time init, and its initializer reflectively reads `java.nio.Bits.UNALIGNED`, `java.nio.Buffer.address` and `sun.misc.Unsafe.theUnsafe`. The reachability metadata repository does register those, but every entry is conditioned on `typeReached` of the **unshaded** class (`UNALIGNED` hangs off `io.netty.util.internal.PlatformDependent0$6`) - a condition the relocated copy can never satisfy. The image then builds cleanly and dies at startup as soon as the gRPC plugin touches `NettyServerBuilder`:

```
MissingReflectionRegistrationError: Cannot reflectively read or write
field 'private static boolean java.nio.Bits.UNALIGNED'
  at io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0$6.run
```

Mirroring ~40 metadata entries under the shaded names would trade a build-time failure for a class of startup failures only a smoke test can catch. Keeping everything else build-time initialized reproduces the last green build's behavior. One consequence worth knowing: `OpenSsl`'s initializer probes for tcnative inside a try/catch, so it stays build-time initialized with "unavailable" frozen in - gRPC without TLS is unaffected, and TLS falls back to the JDK SSL provider.

## 4. Redis smoke check never authenticates

```
[exercise] WARN: Redis PING did not return PONG (got: -NOAUTH Authentication required.)
```

Not an image problem. "Require authentication on the Redis wire protocol" (`3e76b3b82`) reached main with the 26.8.1 security merge, after the last green run: every command other than `AUTH` and `HELLO`-with-`AUTH` now answers `-NOAUTH`. `exercise.sh` still sent a bare `PING`. It warn-skips by default but is a **hard failure under `WIRE_STRICT=1`**, which both Linux legs set - so the build would have gone red for a reason unrelated to the binary.

**Fix:** send RESP `AUTH` before `PING`. The Postgres check already authenticates via `PGPASSWORD`/`-U` and needed no change.

## Verification

Built and smoke-tested on macOS/arm64 with GraalVM CE 25.0.2 - the exact builder CI pins:

```
mvn -Pnative -pl native -am -DskipTests package    ->  BUILD SUCCESS
Finished generating 'arcadedb-26.9.1-SNAPSHOT-osx-aarch_64' in 2m 54s
```

Then the **actual CI smoke script**, with the full Linux wire-protocol plugin list (this is what exercises the gRPC path that crashed):

```
[exercise] Studio index / create DB / SQL / Cypher / JS round-trips
[exercise] Redis PING -> PONG
[exercise] Bolt negotiated version bytes: 00000405
[exercise] Mongo hello -> reply received
[exercise] gRPC services: com.arcadedb.grpc.ArcadeDbAdminService com.arcadedb.grpc.ArcadeDbService
           grpc.health.v1.Health grpc.reflection.v1alpha.ServerReflection
[smoke] PASS                                       ->  exit 0
```

The gRPC reflection listing is the meaningful line: it can only be produced by a `GrpcServerPlugin` that got past `NettyServerBuilder`, which is precisely where the Linux legs died. The JS round-trip proves Truffle is genuinely functional in the image, not merely past the version check from #2.

For #1 specifically, a minimal standalone project (hello-world + the plugin) isolated it from ArcadeDB entirely: 1.1.6 with `extensions` -> byte-identical error and realm listing to CI; 1.1.6 without -> same error, `plugin>` realm; 1.1.6 + an explicit `maven-shared-utils` plugin dependency -> passes; 1.1.7 unchanged -> passes.

**Not verified:** the Postgres-wire assertion warn-skips locally (no `psql` here; CI installs `postgresql-client` and asserts it). The three Linux/Windows legs are unverified, in particular the two static-link modes (`-Dnative.static=true` musl, `-Dnative.mostlystatic=true`), which cannot be exercised on macOS. Dispatch the workflow against this branch before merging.

## Also in this PR

- `smoke.sh` - `HOST`/`HTTP`/`PG` become environment-overridable. Hardcoded ports mean that on a machine already running something on 2480 the script polls **that** server and passes without ever touching the binary under test, which is a false green. CI sets none of them and keeps the current defaults.
- `.github/dependabot.yml` - a note that GraalVM PRs must be hand-reviewed and merged only alongside a matching `java-version` bump. Deliberately **not** an ignore rule: `org.graalvm.*` also appears in `engine/pom.xml`, which should keep tracking latest, and ignore rules match coordinates rather than modules - the same trap already documented there for ANTLR.

## Follow-up worth considering (not in this PR)

`native-image.yml` triggers only on `workflow_dispatch` and `release: published`, and `native/pom.xml` sits outside the default reactor (`-Pnative`). That is why four separate breakages accumulated undetected and surfaced during a release. A `pull_request` trigger scoped to `native/**` plus the plugin/GraalVM properties (build-only, no release upload) would have caught all four. Note that #4 came from a change to `redisw`, so a path filter narrow enough to only watch `native/**` would still have missed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)