### PR TITLE
fix(engine) #5613: a whole-vertex Cypher projection no longer emits the type properties as null columns

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -361,6 +361,11 @@ public class ResultInternal implements Result {
 
   @Override
   public Map<String, Object> toMap() {
+    // Deliberately element-first, which is the opposite precedence to getProperty()/getPropertyNames().
+    // The JSON flattening of a whole-entity projection depends on it: a Cypher `RETURN f` row carries
+    // content {f: vertex} plus the vertex as element, and JsonSerializer flattens it through this map.
+    // Do not "align" this with getPropertyNames() - that would nest the vertex under its alias and
+    // reintroduce the null columns of issue #5613 from the other side.
     if (element == null)
       return content;
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -321,6 +321,13 @@ public class ResultInternal implements Result {
     return result;
   }
 
+  /**
+   * Deliberately the union of both stores, so it stays broader than {@link #getPropertyNames()}: for a
+   * whole-entity projection this answers {@code true} for a name that is not listed as a column and that
+   * {@link #getProperty(String)} resolves to {@code null}. FinalProjectionStep uses it to decide which
+   * requested properties to project, not to describe columns, so narrowing it here would change
+   * projection selection rather than the reported column list. See the note on {@link #toMap()}.
+   */
   public boolean hasProperty(final String propName) {
     // $score is always available as a special property
     if ("$score".equals(propName))

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -228,6 +228,13 @@ public class ResultInternal implements Result {
     return result;
   }
 
+  /**
+   * Unlike the single-argument {@link #getProperty(String)}, this falls back to the element when content
+   * lacks the key, so it can answer a name that {@link #getPropertyNames()} does not list. Pairing a
+   * {@code getPropertyNames()} loop with this getter therefore reads values for columns nobody announced -
+   * the mismatch that made the Postgres wire depend on the pre-#5613 union. Iterate with the single-argument
+   * getter, or collect the names from the element too, as {@code PostgresNetworkExecutor} now does.
+   */
   public <T> T getProperty(final String name, final Object defaultValue) {
     T result;
     if (tombstones != null && tombstones.contains(name))
@@ -244,6 +251,10 @@ public class ResultInternal implements Result {
     return result;
   }
 
+  /**
+   * Falls back to the element when content lacks the key, so the same caveat as
+   * {@link #getProperty(String, Object)} applies: it can resolve a name {@link #getPropertyNames()} omits.
+   */
   @Override
   public Record getElementProperty(final String name) {
     Object result = null;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -303,7 +303,11 @@ public class ResultInternal implements Result {
     if (similarity > 0)
       result.add("$similarity");
 
-    if (element != null) {
+    // Mirror getProperty()'s precedence: once content is present the element is never consulted, so
+    // merging the element's names here would advertise columns that can only ever resolve to null
+    // (issue #5613: a Cypher `RETURN n` row carries content {n: vertex} plus the vertex as element,
+    // and every declared property of the vertex's type surfaced as an extra null column).
+    if (element != null && (content == null || content.isEmpty())) {
       if (tombstones == null || tombstones.isEmpty())
         result.addAll(element.getPropertyNames());
       else

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5613WholeVertexNullColumnsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5613WholeVertexNullColumnsTest.java
@@ -20,7 +20,9 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.serializer.JsonSerializer;
 import com.arcadedb.serializer.json.JSONObject;
@@ -44,7 +46,11 @@ class Issue5613WholeVertexNullColumnsTest {
 
   @BeforeEach
   void setUp() {
-    database = new DatabaseFactory("./target/databases/testissue5613").create();
+    // create() throws when the directory survives, so a crash before tearDown would break every later run.
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/testissue5613");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
     database.command("sql", "CREATE VERTEX TYPE Person");
     database.command("sql", "CREATE PROPERTY Person.id LONG");
     database.command("sql", "CREATE PROPERTY Person.name STRING");
@@ -124,6 +130,25 @@ class Issue5613WholeVertexNullColumnsTest {
     // The vertex is flattened, never nested under the alias, so no stray column survives on the
     // surfaces that build their columns from the row itself (Postgres, gRPC, Bolt).
     assertThat(json.has("f")).isFalse();
+  }
+
+  /**
+   * The invariant the fix establishes, asserted directly on {@link ResultInternal} so it holds
+   * independently of the Cypher engine: {@code getPropertyNames()} must never advertise a column that
+   * {@code getProperty()} cannot resolve. Its guard is the exact complement of the content-precedence
+   * branch in {@code getProperty()}, and this test fails if a future edit desyncs the two.
+   */
+  @Test
+  void everyListedColumnIsResolvableByGetProperty() {
+    final Document person = database.query("sql", "SELECT FROM Person WHERE id = 1").next().getElement().get();
+
+    final ResultInternal row = new ResultInternal();
+    row.setProperty("f", person);
+    row.setElement(person);
+
+    assertThat(row.getPropertyNames()).containsExactly("f");
+    for (final String name : row.getPropertyNames())
+      assertThat(row.<Object>getProperty(name)).as("column %s is listed so it must resolve", name).isNotNull();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5613WholeVertexNullColumnsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5613WholeVertexNullColumnsTest.java
@@ -121,6 +121,9 @@ class Issue5613WholeVertexNullColumnsTest {
     assertThat(json.getLong("id")).isEqualTo(1L);
     assertThat(json.getInt("age")).isEqualTo(21);
     assertThat(json.getString("city")).isEqualTo("c1");
+    // The vertex is flattened, never nested under the alias, so no stray column survives on the
+    // surfaces that build their columns from the row itself (Postgres, gRPC, Bolt).
+    assertThat(json.has("f")).isFalse();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5613WholeVertexNullColumnsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5613WholeVertexNullColumnsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.JsonSerializer;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces issue #5613: returning a whole vertex from openCypher also emitted every declared
+ * property of the vertex's type as a top-level column, always null. `RETURN f` yielded five columns
+ * where four were null, while the equivalent SQL MATCH yielded one.
+ * <p>
+ * The row carried both a backing element (the vertex) and content ({@code {"f": vertex}}).
+ * {@code getPropertyNames()} returned the union of both, while {@code getProperty()} deliberately
+ * ignores the element once content is present, so every element-only name resolved to null.
+ */
+class Issue5613WholeVertexNullColumnsTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testissue5613").create();
+    database.command("sql", "CREATE VERTEX TYPE Person");
+    database.command("sql", "CREATE PROPERTY Person.id LONG");
+    database.command("sql", "CREATE PROPERTY Person.name STRING");
+    database.command("sql", "CREATE PROPERTY Person.age INTEGER");
+    database.command("sql", "CREATE PROPERTY Person.city STRING");
+    database.command("sql", "CREATE INDEX ON Person (id) UNIQUE");
+    database.command("sql", "CREATE EDGE TYPE KNOWS");
+
+    database.transaction(() -> {
+      for (int i = 1; i <= 3; i++)
+        database.command("sql", "INSERT INTO Person SET id = ?, name = ?, age = ?, city = ?", i, "n" + i, 20 + i, "c" + i);
+      database.command("sql", "CREATE EDGE KNOWS FROM (SELECT FROM Person WHERE id = 1) TO (SELECT FROM Person WHERE id = 2)");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void returningWholeVertexEmitsOnlyTheAliasColumn() {
+    final ResultSet rs = database.query("opencypher", "MATCH (f:Person) WHERE f.id = 1 RETURN f");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result result = rs.next();
+
+    assertThat(result.getPropertyNames()).containsExactly("f");
+    assertThat(result.<Object>getProperty("f")).isNotNull();
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
+  void returningWholeVertexOverATraversalEmitsOnlyTheAliasColumn() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (p:Person)-[:KNOWS]->(f:Person) WHERE p.id = 1 RETURN DISTINCT f");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result result = rs.next();
+
+    assertThat(result.getPropertyNames()).containsExactly("f");
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
+  void returningAScalarProjectionStaysClean() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (p:Person)-[:KNOWS]->(f:Person) WHERE p.id = 1 RETURN f.name");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result result = rs.next();
+
+    assertThat(result.getPropertyNames()).containsExactly("f.name");
+    assertThat(result.<String>getProperty("f.name")).isEqualTo("n2");
+  }
+
+  /**
+   * The whole-vertex row keeps its backing element so {@code isElement()} / {@code toElement()} and
+   * the JSON flattening added for issue #3391 keep working.
+   */
+  @Test
+  void wholeVertexRowStillExposesTheBackingElement() {
+    final ResultSet rs = database.query("opencypher", "MATCH (f:Person) WHERE f.id = 1 RETURN f");
+    final Result result = rs.next();
+
+    assertThat(result.isElement()).isTrue();
+    assertThat(result.toElement().getString("name")).isEqualTo("n1");
+
+    final JSONObject json = JsonSerializer.createJsonSerializer().serializeResult(database, result);
+    assertThat(json.getString("name")).isEqualTo("n1");
+    assertThat(json.getLong("id")).isEqualTo(1L);
+    assertThat(json.getInt("age")).isEqualTo(21);
+    assertThat(json.getString("city")).isEqualTo("c1");
+  }
+
+  /**
+   * The point of the issue: openCypher and the equivalent SQL MATCH must describe the same answer
+   * with the same columns.
+   */
+  @Test
+  void openCypherAndSqlMatchAgreeOnTheColumnList() {
+    final Result cypher = database.query("opencypher",
+        "MATCH (p:Person)-[:KNOWS]->(f:Person) WHERE p.id = 1 RETURN DISTINCT f").next();
+    final Result sql = database.query("sql",
+        "MATCH {type: Person, as: p, where: (id = 1)}.out('KNOWS'){as: f} RETURN DISTINCT f").next();
+
+    assertThat(cypher.getPropertyNames()).isEqualTo(sql.getPropertyNames());
+  }
+
+  /**
+   * The fix narrows {@code ResultInternal.getPropertyNames()}, which SQL shares. A plain SELECT *
+   * seeds content with every element property, so its column list must be unaffected.
+   */
+  @Test
+  void sqlSelectStarStillListsEveryColumn() {
+    final Result result = database.query("sql", "SELECT * FROM Person WHERE id = 1").next();
+
+    assertThat(result.getPropertyNames()).contains("id", "name", "age", "city");
+    assertThat(result.<String>getProperty("name")).isEqualTo("n1");
+    assertThat(result.<Integer>getProperty("age")).isEqualTo(21);
+  }
+
+  /**
+   * RETURN * takes the sibling branch in FinalProjectionStep and must not leak the columns either.
+   */
+  @Test
+  void returnStarOverAWholeVertexEmitsOnlyTheAliasColumn() {
+    final ResultSet rs = database.query("opencypher", "MATCH (f:Person) WHERE f.id = 1 RETURN *");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result result = rs.next();
+
+    assertThat(result.getPropertyNames()).containsExactly("f");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5613WholeVertexNullColumnsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5613WholeVertexNullColumnsTest.java
@@ -127,6 +127,20 @@ class Issue5613WholeVertexNullColumnsTest {
   }
 
   /**
+   * {@code toMap()} keeps the opposite (element-first) precedence on purpose: the JSON flattening of a
+   * whole-entity projection goes through it. Aligning it with {@code getPropertyNames()} would nest the
+   * vertex under its alias and bring the null columns back from the other side.
+   */
+  @Test
+  void wholeVertexRowStillFlattensThroughToMap() {
+    final Result result = database.query("opencypher", "MATCH (f:Person) WHERE f.id = 1 RETURN f").next();
+
+    assertThat(result.getPropertyNames()).containsExactly("f");
+    assertThat(result.toMap()).containsKeys("id", "name", "age", "city").doesNotContainKey("f");
+    assertThat(result.toMap()).containsEntry("name", "n1");
+  }
+
+  /**
    * The point of the issue: openCypher and the equivalent SQL MATCH must describe the same answer
    * with the same columns.
    */

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -74,6 +74,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -779,6 +780,25 @@ public class PostgresNetworkExecutor extends Thread {
     return Collections.emptyList();
   }
 
+  /**
+   * Column names advertised for a row, kept deliberately independent of {@code Result.getPropertyNames()}.
+   * <p>
+   * A whole-entity projection (OpenCypher {@code RETURN n}) yields a row whose content holds only the
+   * variable while the record's own properties live on the backing element. This surface flattens such a
+   * row: {@code writeDataRows} reads those values straight off the element, so the names have to be
+   * collected from the element as well. Relying on {@code getPropertyNames()} tied the announced columns
+   * to that accessor's element/content precedence, and narrowing it for issue #5613 silently dropped every
+   * flattened column here. Element names come first so the column order matches what this surface has
+   * always emitted.
+   */
+  private Set<String> columnNamesOf(final Result row) {
+    final Set<String> names = new LinkedHashSet<>();
+    if (row.isElement())
+      names.addAll(row.getElement().get().getPropertyNames());
+    names.addAll(row.getPropertyNames());
+    return names;
+  }
+
   private Map<String, PostgresType> getColumns(final List<Result> resultSet) {
     final Map<String, PostgresType> columns = new LinkedHashMap<>();
 
@@ -787,8 +807,7 @@ public class PostgresNetworkExecutor extends Thread {
       if (row.isElement())
         atLeastOneElement = true;
 
-      final Set<String> propertyNames = row.getPropertyNames();
-      for (final String p : propertyNames) {
+      for (final String p : columnNamesOf(row)) {
         if (!columns.containsKey(p)) {
           // Determine the PostgreSQL type based on the actual value.
           // Arrays/collections use proper array type codes; native scalar types (numeric, boolean,

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -1241,6 +1241,37 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
     }
   }
 
+  /**
+   * A whole-entity Cypher projection is flattened on this wire: the record's own properties are
+   * advertised as columns and read off the backing element, alongside the variable column itself.
+   * The column names must NOT be taken from {@code Result.getPropertyNames()}, whose element/content
+   * precedence was narrowed for issue #5613 - doing so silently dropped every flattened column here.
+   */
+  @Test
+  void wholeVertexCypherProjectionFlattensItsColumns() throws Exception {
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("create vertex type Town");
+        st.execute("{opencypher} CREATE (n:Town {code: 'T1', label: 'Springfield'})");
+      }
+
+      try (var st = conn.createStatement();
+          var rs = st.executeQuery("{opencypher} MATCH (n:Town) WHERE n.code = 'T1' RETURN n")) {
+        assertThat(rs.next()).isTrue();
+
+        final var metaData = rs.getMetaData();
+        final List<String> columns = new ArrayList<>();
+        for (int i = 1; i <= metaData.getColumnCount(); i++)
+          columns.add(metaData.getColumnName(i));
+
+        assertThat(columns).contains("code", "label", "n");
+        assertThat(rs.getString("code")).isEqualTo("T1");
+        assertThat(rs.getString("label")).isEqualTo("Springfield");
+        assertThat(rs.next()).isFalse();
+      }
+    }
+  }
+
   @Test
   void createVertexCypherQueryParams() throws Exception {
     try (var conn = getConnection()) {


### PR DESCRIPTION
Closes #5613

Returning a whole vertex from openCypher emitted every declared property of that vertex's type as an extra top-level column, always null: `RETURN f` produced `{"id": null, "name": null, "age": null, "city": null, "f": {...}}` where the equivalent SQL `MATCH` produced `{"f": {...}}`. The reporter measured this at 1.6x the JSON bytes of the identical SQL answer on an LDBC SF1 corpus, paid on every returned row and scaling with the number of properties *declared* on the type rather than with the result.

## Root cause

Not the result schema being seeded from the type, as the issue guessed. `ResultInternal` has two backing stores, a `Document element` and a `Map content`, and three of its accessors disagreed about their precedence:

- `getProperty()` reads **only** `content` once content is non-empty ("IF CONTENT IS PRESENT SKIP CHECKING FOR ELEMENT (PROJECTIONS USED)").
- `getPropertyNames()` returned the **union** of the element's property names and the content keys.
- `toMap()` returns only `element.toMap()`.

`FinalProjectionStep.filterResult()` builds a `RETURN f` row with `content = {"f": vertex}` and additionally calls `setElement(vertex)` so `isElement()` / `toElement()` keep working. That dual state made `getPropertyNames()` advertise the vertex's own field names, every one of which `getProperty()` could only ever answer `null` for. `RETURN f.name` was clean because a scalar projection never attaches an element.

## Fix

One guard in `ResultInternal.getPropertyNames()` so the listing honours the precedence `getProperty()` already documents: the element's names are merged only when `content` is null or empty. The element itself is still attached, so `isElement()`, `toElement()` and the `_projectionName` JSON flattening from #3391 are unchanged.

This also fixes the leak for embedded callers that iterate `getPropertyNames()` directly and therefore never saw the `_projectionName` short-circuit, such as the reporter's Python client.

### Correction: the wire protocols were NOT leaking

An earlier revision of this description claimed the fix also cleaned up Postgres, gRPC and Bolt. That was wrong, and it broke the Postgres surface:

- **Bolt** resolves field names from the `_projectionName` metadata before ever reading `getPropertyNames()`, so it already answered `[n]`.
- **gRPC** branches on `isElement()` and converts the element directly, only using `getPropertyNames()` for non-element rows.
- **Postgres** took column *names* from `getPropertyNames()` but read the *values* off the backing element (`writeDataRows`, the `default` branch: `if (v == null && row.isElement()) v = row.getElement().get().get(propertyName)`). It was therefore flattening whole-entity projections correctly, with real values - the union in `getPropertyNames()` was load-bearing for it. Narrowing the accessor deleted the names, and every flattened column vanished: `The column name id was not found in this ResultSet` in `PostgresWJdbcIT.createVertexCypherQueryParams` and in the java/python e2e suites.

The second commit fixes this by having `PostgresNetworkExecutor` collect its column names the same element-first way it already reads values, so that surface owns its shape instead of inheriting an engine accessor's precedence. Verified red/green: with the engine change alone the IT fails with the exact error above; with the Postgres change it passes 42/42.

## Blast radius

Every producer of a row carrying both an element and non-empty content was audited. The element-taking constructor leaves `content` null and `setProperty()` then throws, so such rows can only originate from an explicit `setElement()` call - 10 sites, all in `engine/`:

- `Projection.calculateSingle` (`SELECT *`): content is seeded with every element property plus `@rid`/`@type` in the same order, a superset, so the column list and its ordering are byte-identical. With `!exclusions` or `HIDDEN` properties content is a strict subset, and those columns previously showed up as null; they are now correctly absent.
- `ExpandStep`, `UnwindStep`, and the four UPDATE-pipeline steps leave content empty or seed it from `getPropertyNames()`, so they are unaffected.
- `ScanWithFilterStep`'s projection-pushdown branch is a strict subset, but is unreachable today (`computeProjectedProperties` returns null whenever a WHERE clause is present, which is the only branch that constructs this step).

`hasProperty()` is deliberately left alone: it is used by `FinalProjectionStep` to decide which requested properties to project, and narrowing it would change projection selection rather than just the reported column list.

## Test plan

- [x] New `Issue5613WholeVertexNullColumnsTest` (7 tests) fails on unfixed main with exactly `["id", "name", "age", "city", "f"]` vs the expected `["f"]`, and passes with the fix.
- [x] Covers `RETURN f`, `RETURN DISTINCT f` over a traversal, and `RETURN *`; asserts openCypher and SQL `MATCH` now report an identical column list.
- [x] Guards the behaviour that must not change: `RETURN f.name` stays clean, `isElement()`/`toElement()` still work, the JSON serializer still flattens the vertex, and SQL `SELECT *` still lists every column.
- [x] Full openCypher package plus the SQL suites that assert on projected column lists (`QueryTest`, `SelectStatementExecutionTest`, `MatchStatementExecutionTest`, `MemoryOptimizationTest`, `DistinctExecutionStepTest`, `ExpandStepTest`, `ExpandParseTest`, `BacktickProjectionAliasTest`, `OLAPOptimizationsTest`, `DDLTest`, `ResultInternalTest`, `ResultInternalScoreTest`): **4421 tests, 0 failures**.
- [x] `postgresw` `PostgresWJdbcIT` **42 tests green**, and proven to FAIL (`The column name id was not found in this ResultSet`) when the Postgres change is reverted, so it genuinely covers this regression.
- [x] `bolt` + `grpcw` full suites: 739 tests, 0 failures - confirming neither surface was affected.
- [x] Counts reconciled against the same selection run on unfixed main (4410 green): 4410 − 13 (`JsonSerializerTest`, dropped from the selection) + 8 + 9 (`ResultInternal*`, added) + 7 (new tests) = 4421, so no pre-existing test silently dropped out of the run.

