### PR TITLE
fix(sql): plan WHERE @rid = / IN [RIDs] as a direct RID fetch, not a full type scan

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -53,6 +53,7 @@ import com.arcadedb.query.sql.parser.GeOperator;
 import com.arcadedb.query.sql.parser.GroupBy;
 import com.arcadedb.query.sql.parser.GtOperator;
 import com.arcadedb.query.sql.parser.Identifier;
+import com.arcadedb.query.sql.parser.InCondition;
 import com.arcadedb.query.sql.parser.IndexIdentifier;
 import com.arcadedb.query.sql.parser.InputParameter;
 import com.arcadedb.query.sql.parser.IsNullCondition;
@@ -104,6 +105,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1847,6 +1849,13 @@ public class SelectExecutionPlanner {
       return;
     }
 
+    // RID-address optimization: for queries like SELECT FROM Type WHERE @rid = <RID> or
+    // WHERE @rid IN [<RID list>], fetch the records directly by RID address instead of
+    // scanning the whole type. This is always cheaper than an index lookup, so it is checked
+    // before the index-based paths below. See issue #5824.
+    if (handleTypeWithRidFilter(plan, identifier, info, context))
+      return;
+
     if (handleTypeAsTargetWithIndexedFunction(plan, effectiveClusters, identifier, info, context)) {
       plan.chain(new FilterByTypeStep(identifier, context));
       return;
@@ -1980,6 +1989,138 @@ public class SelectExecutionPlanner {
     final String exprStr = expr.toString().trim();
     if (exprStr.startsWith("@"))
       return exprStr;
+    return null;
+  }
+
+  /**
+   * RID-address optimization: rewrites {@code WHERE @rid = <RID>} or {@code WHERE @rid IN [<RID list>]}
+   * on a type target into a direct {@link FetchFromRidsStep} instead of a full type scan with a
+   * per-record filter. The address-based fetch is O(k) in the number of RIDs, while the scan it
+   * replaces is O(n) in the size of the type. Only applies to a single AND-block (no OR at the top
+   * level, mirroring {@link #handleEdgeTypeWithVertexRidFilter}) so every surviving branch of the
+   * WHERE clause is guaranteed to still require these RIDs. See issue #5824.
+   *
+   * @return true if the optimization was applied
+   */
+  private boolean handleTypeWithRidFilter(final SelectExecutionPlan plan, final Identifier identifier, final QueryPlanningInfo info,
+      final CommandContext context) {
+    if (info.flattenedWhereClause == null || info.flattenedWhereClause.size() != 1)
+      return false; // OR at the top level: other branches may match records outside this RID set
+
+    // A remaining (non-@rid) condition that references a per-record LET variable can't be
+    // evaluated here: LET is computed after the fetch step, in handleLet(), which runs after this
+    // method. Chaining it into a FilterStep on the fetch-side plan would evaluate it before LET
+    // populates the variable. Defer to the normal scan path, which applies WHERE only after LET.
+    if (info.perRecordLetClause != null && info.whereClause != null && info.whereClause.toString().contains("$"))
+      return false;
+
+    final AndBlock andBlock = info.flattenedWhereClause.getFirst();
+
+    for (int i = 0; i < andBlock.getSubBlocks().size(); i++) {
+      final BooleanExpression expr = andBlock.getSubBlocks().get(i);
+      final List<RID> rids = extractRidEqualityOrInList(expr, context);
+      if (rids == null)
+        continue;
+
+      if (rids.isEmpty()) {
+        // The RID list is definitely empty (e.g. an empty IN-list or a null bind parameter):
+        // no record can match, whatever the remaining conditions are.
+        plan.chain(new EmptyStep(context));
+        info.whereClause = null;
+        info.flattenedWhereClause = null;
+        return true;
+      }
+
+      plan.chain(new FetchFromRidsStep(rids, context));
+      plan.chain(new FilterByTypeStep(identifier, context));
+
+      final List<BooleanExpression> remaining = new ArrayList<>(andBlock.getSubBlocks());
+      remaining.remove(i);
+      if (!remaining.isEmpty()) {
+        final AndBlock remainingBlock = new AndBlock(-1);
+        remainingBlock.getSubBlocks().addAll(remaining);
+        final WhereClause remainingWhere = new WhereClause(-1);
+        remainingWhere.setBaseExpression(remainingBlock);
+        plan.chain(new FilterStep(remainingWhere, context));
+      }
+
+      info.whereClause = null;
+      info.flattenedWhereClause = null;
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Recognizes {@code @rid = <RID>} and {@code @rid IN [<RID list>]} (also {@code IN (<RID list>)}
+   * and {@code IN <bind parameter>}) and resolves the RID(s) at plan time. Returns {@code null} if
+   * {@code expr} isn't one of these shapes, or if any element can't be resolved to a RID at plan
+   * time (e.g. it's computed from a per-record field) - the caller falls back to the normal scan
+   * in that case, which still evaluates correctly. Returns an empty list if the condition can
+   * never match any record (empty IN-list, or a bind parameter bound to null) so the caller can
+   * short-circuit to no results. {@code @rid NOT IN [...]} is deliberately not handled here:
+   * excluding a RID set still requires scanning every other record of the type, which this
+   * optimization cannot help with.
+   */
+  private static List<RID> extractRidEqualityOrInList(final BooleanExpression expr, final CommandContext context) {
+    if (expr instanceof BinaryCondition bc && bc.getOperator() instanceof EqualsCompareOperator
+        && RID_PROPERTY.equalsIgnoreCase(bc.getLeft().toString())) {
+      final RID rid = extractRidValue(bc.getRight(), context);
+      return rid == null ? null : List.of(rid);
+    }
+
+    if (!(expr instanceof InCondition in) || in.not || !RID_PROPERTY.equalsIgnoreCase(in.getLeft().toString()))
+      return null;
+
+    final Object rawValue;
+    if (in.right instanceof List<?> list) {
+      final List<Object> values = new ArrayList<>(list.size());
+      for (final Object item : list)
+        values.add(item instanceof Expression itemExpr ? extractRidValue(itemExpr, context) : item);
+      rawValue = values;
+    } else if (in.getRightMathExpression() != null) {
+      try {
+        rawValue = in.getRightMathExpression().execute((Result) null, context);
+      } catch (final Exception e) {
+        return null; // not resolvable at plan time (e.g. references a per-record field)
+      }
+    } else if (in.getRightParam() != null) {
+      rawValue = in.getRightParam().getValue(context.getInputParameters());
+    } else
+      return null; // subquery on the right: not a plan-time-resolvable RID list
+
+    if (rawValue == null)
+      return List.of(); // WHERE @rid IN <null> matches nothing
+
+    // A scan evaluates the IN-list as a per-record membership test, so a duplicate RID in the
+    // list must not multiply the matching record into duplicate rows: dedupe with a Set.
+    final Set<RID> rids = new LinkedHashSet<>();
+    if (rawValue instanceof Iterable<?> iterable) {
+      for (final Object item : iterable) {
+        final RID rid = toRid(item, context);
+        if (rid == null)
+          return null;
+        rids.add(rid);
+      }
+    } else {
+      final RID rid = toRid(rawValue, context);
+      if (rid == null)
+        return null;
+      rids.add(rid);
+    }
+    return new ArrayList<>(rids);
+  }
+
+  private static RID toRid(final Object value, final CommandContext context) {
+    if (value instanceof RID rid)
+      return rid;
+    if (value instanceof Identifiable identifiable)
+      return identifiable.getIdentity();
+    if (value instanceof Result result && result.getIdentity().isPresent())
+      return result.getIdentity().get();
+    if (value instanceof String s && RID.is(s))
+      return context.getDatabase().newRID(s);
     return null;
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RidInScanOptimizationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RidInScanOptimizationTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.partitioning.PartitioningTestFixture;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the planner rewrite that recognizes {@code WHERE @rid = <RID>} and
+ * {@code WHERE @rid IN [<RID list>]} on a type target and plans them as a direct
+ * {@link FetchFromRidsStep} (address-based, O(k)) instead of a {@link FetchFromTypeWithFilterStep}
+ * full type scan with a per-record filter (O(n) in the size of the type). Issue #5824.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class RidInScanOptimizationTest extends TestHelper {
+
+  private RID doc0Rid;
+  private RID doc1Rid;
+  private RID doc2Rid;
+  private RID otherTypeRid;
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Doc");
+    database.getSchema().createDocumentType("Other");
+
+    database.transaction(() -> {
+      final MutableDocument doc0 = database.newDocument("Doc").set("name", "doc0").set("active", true).save();
+      final MutableDocument doc1 = database.newDocument("Doc").set("name", "doc1").set("active", false).save();
+      final MutableDocument doc2 = database.newDocument("Doc").set("name", "doc2").set("active", true).save();
+
+      doc0Rid = doc0.getIdentity();
+      doc1Rid = doc1.getIdentity();
+      doc2Rid = doc2.getIdentity();
+
+      otherTypeRid = database.newDocument("Other").set("name", "other0").save().getIdentity();
+    });
+  }
+
+  @Test
+  void planUsesFetchFromRidsStepForEquality() {
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid = " + doc1Rid);
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(findStep(plan, FetchFromRidsStep.class)).as("@rid = <RID> must use FetchFromRidsStep").isNotNull();
+    assertThat(findStep(plan, FetchFromTypeWithFilterStep.class)).as("must not fall back to a full scan").isNull();
+    assertThat(findStep(plan, FetchFromTypeExecutionStep.class)).as("must not fall back to a full scan").isNull();
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("name")).isEqualTo("doc1");
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void planUsesFetchFromRidsStepForBracketInList() {
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN [" + doc0Rid + ", " + doc2Rid + "]");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(findStep(plan, FetchFromRidsStep.class)).as("@rid IN [...] must use FetchFromRidsStep").isNotNull();
+    assertThat(findStep(plan, FetchFromTypeWithFilterStep.class)).isNull();
+
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("doc0", "doc2");
+  }
+
+  @Test
+  void planUsesFetchFromRidsStepForParenthesizedInList() {
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN (" + doc0Rid + ", " + doc2Rid + ")");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(findStep(plan, FetchFromRidsStep.class)).as("@rid IN (...) must use FetchFromRidsStep").isNotNull();
+
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("doc0", "doc2");
+  }
+
+  @Test
+  void planUsesFetchFromRidsStepForBoundParameterList() {
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN ?", List.of(doc0Rid, doc1Rid));
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(findStep(plan, FetchFromRidsStep.class)).as("@rid IN ? bound to a RID list must use FetchFromRidsStep").isNotNull();
+
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("doc0", "doc1");
+  }
+
+  @Test
+  void ridInListCombinesWithAdditionalFilter() {
+    final ResultSet rs = database.query("sql",
+        "SELECT FROM Doc WHERE @rid IN [" + doc0Rid + ", " + doc1Rid + ", " + doc2Rid + "] AND active = true");
+
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("doc0", "doc2");
+  }
+
+  @Test
+  void ridInListWithDuplicateRidDoesNotDuplicateTheRow() {
+    // A scan evaluates "@rid IN [...]" as a per-record membership test: a repeated value in the
+    // list must not visit the matching record twice.
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN [" + doc0Rid + ", " + doc0Rid + "]");
+
+    assertThat(collectNames(rs)).containsExactly("doc0");
+  }
+
+  @Test
+  void ridInListExcludesRidsOfAnotherType() {
+    // otherTypeRid belongs to type "Other": the FilterByTypeStep chained after FetchFromRidsStep
+    // must drop it, matching what a plain type scan would have returned.
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN [" + doc0Rid + ", " + otherTypeRid + "]");
+
+    assertThat(collectNames(rs)).containsExactly("doc0");
+  }
+
+  @Test
+  void ridInListSkipsNonExistentRidsWithoutError() {
+    final RID deleted = doc1Rid;
+    database.transaction(() -> database.lookupByRID(deleted, true).asDocument().delete());
+
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN [" + doc0Rid + ", " + deleted + ", " + doc2Rid + "]");
+
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("doc0", "doc2");
+  }
+
+  @Test
+  void ridInEmptyBoundParameterListReturnsNoRows() {
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN ?", List.of());
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void ridInNullBoundParameterReturnsNoRows() {
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN ?", new Object[] { null });
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void ridWithOrConditionFallsBackToScanButStaysCorrect() {
+    // The optimization only applies to a single AND-block; an OR at the top level must still be
+    // answered correctly by the regular scan path.
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid IN [" + doc0Rid + "] OR name = 'doc2'");
+
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("doc0", "doc2");
+  }
+
+  @Test
+  void ridNotInFallsBackToScanButStaysCorrect() {
+    final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE @rid NOT IN [" + doc1Rid + "]");
+
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("doc0", "doc2");
+  }
+
+  @Test
+  void ridInListWithRemainingLetReferencingConditionStaysCorrect() {
+    // The remaining (non-@rid) AND condition references a per-record LET variable, which is only
+    // computed after the fetch. A rewrite that pushes this remaining condition into the fetch-side
+    // plan (ahead of LET) would silently drop every row - see LetWherePredicatePushdownTest for the
+    // same hazard on the generic predicate-pushdown path.
+    final ResultSet rs = database.query("sql",
+        "SELECT name, $flag AS flag FROM Doc LET $flag = (active = true) WHERE @rid IN ["
+            + doc0Rid + ", " + doc1Rid + ", " + doc2Rid + "] AND $flag = true");
+
+    assertThat(collectNames(rs)).containsExactlyInAnyOrder("doc0", "doc2");
+  }
+
+  @Test
+  void ridInListIgnoresPartitionPruningAndReturnsRidsFromAnyBucket() {
+    // RID-address fetch bypasses the partition-pruning bucket narrowing entirely (it doesn't need
+    // it: the RID already encodes its physical bucket). Confirm records from different partitions
+    // are all still resolved correctly when named directly by RID.
+    PartitioningTestFixture.createPartitionedDocType(database, "PartDoc", 4, false);
+    PartitioningTestFixture.populateDocs(database, "PartDoc", false);
+
+    final List<RID> allRids = new java.util.ArrayList<>();
+    final ResultSet all = database.query("sql", "SELECT @rid AS r FROM PartDoc");
+    while (all.hasNext())
+      allRids.add(all.next().<RID>getProperty("r"));
+    all.close();
+    assertThat(allRids).hasSize(4); // one per tenant, spread across the 4 partitioned buckets
+
+    final String ridList = allRids.stream().map(RID::toString).reduce((a, b) -> a + ", " + b).orElseThrow();
+    final ResultSet rs = database.query("sql", "SELECT tenant_id FROM PartDoc WHERE @rid IN [" + ridList + "]");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+    assertThat(findStep(plan, FetchFromRidsStep.class)).isNotNull();
+
+    int count = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      count++;
+    }
+    rs.close();
+    assertThat(count).isEqualTo(4);
+  }
+
+  private static List<String> collectNames(final ResultSet rs) {
+    final List<String> names = new java.util.ArrayList<>();
+    while (rs.hasNext())
+      names.add(rs.next().getProperty("name"));
+    rs.close();
+    return names;
+  }
+
+  private static <T extends ExecutionStep> T findStep(final ExecutionPlan plan, final Class<T> type) {
+    for (final ExecutionStep step : plan.getSteps())
+      if (type.isInstance(step))
+        return type.cast(step);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

`SELECT ... FROM <Type> WHERE @rid IN [...]` (and `WHERE @rid = <RID>`) was falling through to the generic predicate-pushdown path and planning as `FETCH FROM TYPE ... WITH FILTER`, i.e. a full scan of every record of the type with a per-record filter. Cost was O(n) in the size of the type and independent of how many RIDs were being looked up, even though the equivalent RID-as-target form (`SELECT ... FROM [...]`) already resolves the same RIDs in O(k) via `FetchFromRidsStep`.

`SelectExecutionPlanner.handleTypeAsTarget` now recognizes a single-AND-block WHERE clause containing `@rid = <RID>` or `@rid IN [<RID list>]` on a type target (bracket list, parenthesized list, or a bind parameter bound to a RID / collection of RIDs), resolves the RID(s) at plan time, and rewrites the fetch to `FetchFromRidsStep` + `FilterByTypeStep` (to preserve the "only this type" semantics of the original scan), keeping any remaining AND-ed conditions as a `FilterStep`. This mirrors the existing `@out`/`@in` equality → vertex-centric-fetch rewrite already in the planner for edge types.

The rewrite deliberately backs off (falls back to the ordinary scan) when:
- the WHERE clause has a top-level `OR` (another branch could match records outside this RID set),
- a remaining AND-ed condition references a per-record `LET` variable (LET is only populated after this fetch step runs — pushing such a condition down here would silently drop every row; see `LetWherePredicatePushdownTest` for the existing precedent of this hazard),
- `@rid NOT IN [...]` (exclusion still requires scanning everything else in the type).

A duplicate RID in the `IN` list is deduped before building `FetchFromRidsStep`, since a scan evaluates `IN` as a per-record membership test and must not visit the same record twice for a repeated list value.

Fixes #5824.

## Test plan

- [x] New `RidInScanOptimizationTest` (14 cases): plan-shape assertions (`FetchFromRidsStep` used, not `FetchFromTypeWithFilterStep`/`FetchFromTypeExecutionStep`) for `=`, bracket `IN [...]`, parenthesized `IN (...)`, and bind-parameter `IN ?`; correctness for combined AND conditions, RIDs of another type being filtered out, non-existent RIDs being skipped without error, empty/null bind-parameter lists, duplicate RIDs not duplicating rows, `OR`/`NOT IN` still falling back to a correct scan, a per-record-LET-referencing remaining condition staying correct, and a partitioned type ignoring bucket pruning correctly.
- [x] `mvn -o compile` clean.
- [x] Full targeted regression pass, 0 failures across 498 tests: `SelectStatementExecutionTest`, `EdgeTypeVertexRidOptimizationTest` (the closest existing precedent), `PartitionPruningPlannerTest`, `MatchStatementExecutionTest`, `DeleteExecutionStepTest`, `UpdateStatementExecutionTest`, `Issue5505BoundRidCollectionTargetTest`, `MatchRidFilterTest`, `RidSetTest`, `FetchFromTypeExecutionStepTest`, `SelectStatementTest`, `SQLGrammarRegressionTest`, `ExplicitLockingTransactionTest`, `LetWherePredicatePushdownTest`, `LetDivisionBugTest`, `ScriptExecutionTest`, plus the new test class.