### PR TITLE
fix(sql): guard @out/@in vertex-centric edge rewrite against LET-referencing conditions

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -1924,6 +1924,14 @@ public class SelectExecutionPlanner {
     if (info.flattenedWhereClause == null || info.flattenedWhereClause.size() != 1)
       return false; // only handle simple AND conditions (single flattened block, no OR)
 
+    // A remaining (non-@out/@in) condition that references a per-record LET variable can't be
+    // evaluated here: LET is computed after the fetch step, in handleLet(), which runs after this
+    // method (called from handleFetchFromTarget). Chaining it into a FilterStep on the fetch-side
+    // plan would evaluate it before LET populates the variable, silently dropping every row. Defer
+    // to the normal scan path, which applies WHERE only after LET. See issue #5856.
+    if (info.perRecordLetClause != null && info.whereClause != null && info.whereClause.toString().contains("$"))
+      return false;
+
     final AndBlock andBlock = info.flattenedWhereClause.getFirst();
     final String edgeTypeName = docType.getName();
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/EdgeTypeVertexRidOptimizationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/EdgeTypeVertexRidOptimizationTest.java
@@ -151,6 +151,31 @@ class EdgeTypeVertexRidOptimizationTest extends TestHelper {
   }
 
   @Test
+  void selectFromEdgeWhereOutEqualsRidWithRemainingLetReferencingConditionStaysCorrect() {
+    // The remaining (non-@out/@in) AND condition references a per-record LET variable, which is
+    // only computed after the fetch step runs. A rewrite that pushes this remaining condition into
+    // the fetch-side plan (ahead of LET) would silently drop every row - see
+    // LetWherePredicatePushdownTest and RidInScanOptimizationTest for the same hazard on the
+    // generic predicate-pushdown and @rid IN [...] paths. Issue #5856.
+    database.transaction(() -> {
+      final ResultSet result = database.query("sql",
+          "SELECT since, $recent AS recent FROM Knows LET $recent = (since > 2020) WHERE @out = "
+              + v1Rid + " AND $recent = true");
+
+      int count = 0;
+      while (result.hasNext()) {
+        final Result r = result.next();
+        final int since = r.getProperty("since");
+        final boolean recent = r.getProperty("recent");
+        assertThat(recent).isTrue();
+        assertThat(since).isGreaterThan(2020);
+        count++;
+      }
+      assertThat(count).isEqualTo(1); // Only Alice->Charlie (since=2021)
+    });
+  }
+
+  @Test
   void executionPlanUsesVertexFetch() {
     database.transaction(() -> {
       final ResultSet result = database.query("sql",


### PR DESCRIPTION
## Summary

`handleEdgeTypeWithVertexRidFilter` rewrites `WHERE @out = <RID>` / `WHERE @in = <RID>` on an edge type into a vertex-centric `FetchEdgesFromVertexStep`, chaining any remaining AND-ed conditions as a `FilterStep` on the fetch-side plan (`info.fetchExecutionPlan`). That plan is assembled during `handleFetchFromTarget`, which runs *before* `handleLet()` chains the per-record LET evaluation step. So a remaining condition that references a `$letVar` was being evaluated before LET populated the variable, silently dropping every row.

This is the same hazard already fixed for the `@rid = <RID>` / `@rid IN [<RID list>]` rewrite in #5854 (issue #5824), and the one `LetWherePredicatePushdownTest` documents for the generic predicate-pushdown path. It was flagged during review of #5854 as a suspected pre-existing gap in the precedent that rewrite was modeled on: https://github.com/ArcadeData/arcadedb/pull/5854#issuecomment-5208380568. Filed as #5856, fixed here.

Fix applies the identical guard used in #5854: skip the rewrite when a per-record LET clause is present and the WHERE clause text references a `$` variable, deferring to the normal scan path (which applies WHERE only after LET runs).

Fixes #5856.

## Test plan

- [x] Added `EdgeTypeVertexRidOptimizationTest#selectFromEdgeWhereOutEqualsRidWithRemainingLetReferencingConditionStaysCorrect`, confirmed it reproduces the bug against unfixed code (0 rows instead of 1), then confirmed it passes after the fix.
- [x] `mvn -o compile` clean.
- [x] Full `EdgeTypeVertexRidOptimizationTest` (7 cases) passes.
- [x] Broader regression pass, 0 failures across 354 tests: `EdgeTypeVertexRidOptimizationTest`, `LetWherePredicatePushdownTest`, `LetDivisionBugTest`, `MatchStatementExecutionTest`, `SelectStatementExecutionTest`, `PartitionPruningPlannerTest`, `RidInScanOptimizationTest`, `ScriptExecutionTest`, `SQLGrammarRegressionTest`.