### PR TITLE
fix(#5845): RemoteDatabase commit()/begin()/rollback() capture the commit-index bookmark

### DIFF
--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -326,6 +326,7 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
         throw new TransactionException("Error on transaction begin", detail);
       }
 
+      captureCommitIndexHeader(response);
       setSessionId(response.headers().firstValue(ARCADEDB_SESSION_ID).orElse(null));
     } catch (final Exception e) {
       throw new TransactionException("Error on transaction begin", e);
@@ -365,6 +366,7 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
 
         throw new TransactionException("Error on transaction commit", detail);
       }
+      captureCommitIndexHeader(response);
       committed = true;
     } catch (final DuplicatedKeyException | ConcurrentModificationException e) {
       throw e;
@@ -399,12 +401,30 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
         final Exception detail = manageException(response, "rollback transaction");
         throw new TransactionException("Error on transaction rollback", detail);
       }
+      captureCommitIndexHeader(response);
     } catch (final Exception e) {
       throw new TransactionException("Error on transaction rollback", e);
     } finally {
       resetCreatedRecordsIdentity();
       setSessionId(null);
     }
+  }
+
+  /**
+   * Captures the {@code X-ArcadeDB-Commit-Index} response header on raw {@link #begin()}/{@link #commit()}/
+   * {@link #rollback()} sends, which bypass {@link RemoteHttpComponent#httpCommand} and its bookmark capture
+   * (issue #5845). The server emits this header on every begin/commit/rollback response once the database
+   * has an applied index, so all three call sites can carry the just-committed bookmark forward for the next
+   * {@link ReadConsistency#READ_YOUR_WRITES} read.
+   */
+  void captureCommitIndexHeader(final HttpResponse<String> response) {
+    response.headers().firstValue("X-ArcadeDB-Commit-Index").ifPresent(val -> {
+      try {
+        updateLastCommitIndex(Long.parseLong(val));
+      } catch (final NumberFormatException ignored) {
+        // server sent an invalid header; ignore
+      }
+    });
   }
 
   /**

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -345,15 +345,8 @@ public class RemoteHttpComponent extends RWLockContext {
         HttpResponse<String> response = sendWithWatchdog(request);
 
         // Capture commit-index from response for read-your-writes consistency.
-        if (this instanceof RemoteDatabase remoteDb) {
-          response.headers().firstValue("X-ArcadeDB-Commit-Index").ifPresent(val -> {
-            try {
-              remoteDb.updateLastCommitIndex(Long.parseLong(val));
-            } catch (final NumberFormatException ignored) {
-              // server sent an invalid header; ignore
-            }
-          });
-        }
+        if (this instanceof RemoteDatabase remoteDb)
+          remoteDb.captureCommitIndexHeader(response);
 
         if (response.statusCode() != 200) {
           lastException = manageException(response, payloadCommand != null ? payloadCommand : operation);

--- a/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
@@ -408,6 +408,9 @@ class RemoteDatabaseTest {
             final InputStream in = client.getInputStream();
             final byte[] buf = new byte[8192];
             int total = 0;
+            // Stops at the header terminator without draining a request body (begin() sends one): safe here
+            // because the client never reuses the connection (Connection: close) and does not wait for us to
+            // read the body before it reads our response.
             while (total < buf.length) {
               final int n = in.read(buf, total, buf.length - total);
               if (n < 0)

--- a/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
@@ -27,8 +27,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStream;
 import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -316,6 +320,53 @@ class RemoteDatabaseTest {
     }
   }
 
+  // commit-index bookmark capture tests, regression for issue #5845
+
+  @Test
+  void commitCapturesCommitIndexHeaderForReadYourWrites() throws Exception {
+    withHttpServer(List.of(
+        new StubResponse(204, "", Map.of(RemoteDatabase.ARCADEDB_SESSION_ID, "test-session")),
+        new StubResponse(204, "", Map.of("X-ArcadeDB-Commit-Index", "42"))
+    ), port -> {
+      final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", port, "testdb", "root", "test");
+      try {
+        db.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+        db.begin();
+        db.commit();
+
+        // The X-ArcadeDB-Commit-Index header on the commit response is the only place the server
+        // publishes the bookmark for the just-committed transaction: a raw commit() that ignores it
+        // silently degrades READ_YOUR_WRITES to EVENTUAL for the next read.
+        assertThat(db.getLastCommitIndex())
+            .as("commit() must capture the X-ArcadeDB-Commit-Index response header")
+            .isEqualTo(42);
+      } finally {
+        db.close();
+      }
+    });
+  }
+
+  @Test
+  void commitWithoutCommitIndexHeaderLeavesLastCommitIndexUnchanged() throws Exception {
+    withHttpServer(List.of(
+        new StubResponse(204, "", Map.of(RemoteDatabase.ARCADEDB_SESSION_ID, "test-session")),
+        new StubResponse(204, "", Map.of())
+    ), port -> {
+      final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", port, "testdb", "root", "test");
+      try {
+        db.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+        db.begin();
+        db.commit();
+
+        assertThat(db.getLastCommitIndex()).isEqualTo(-1L);
+      } finally {
+        db.close();
+      }
+    });
+  }
+
   /**
    * Testable subclass that injects a fake leader address via the cluster-configuration hook.
    */
@@ -331,6 +382,57 @@ class RemoteDatabaseTest {
     @Override
     Pair<String, Integer> getLeaderServer() {
       return fakeLeader;
+    }
+  }
+
+  private record StubResponse(int statusCode, String body, Map<String, String> headers) {
+  }
+
+  @FunctionalInterface
+  private interface ServerAction {
+    void run(int port) throws Exception;
+  }
+
+  /**
+   * Starts a loopback HTTP server that answers the given responses in order, one per connection, then runs
+   * {@code action} against its port. Used to test raw-send call sites (begin/commit/rollback) that bypass
+   * httpCommand() and must capture response headers on their own.
+   */
+  private void withHttpServer(final List<StubResponse> responses, final ServerAction action) throws Exception {
+    try (final ServerSocket serverSocket = new ServerSocket(0)) {
+      final int port = serverSocket.getLocalPort();
+
+      final Thread serverThread = new Thread(() -> {
+        for (final StubResponse stub : responses) {
+          try (final Socket client = serverSocket.accept()) {
+            final InputStream in = client.getInputStream();
+            final byte[] buf = new byte[8192];
+            int total = 0;
+            while (total < buf.length) {
+              final int n = in.read(buf, total, buf.length - total);
+              if (n < 0)
+                break;
+              total += n;
+              if (new String(buf, 0, total, StandardCharsets.ISO_8859_1).contains("\r\n\r\n"))
+                break;
+            }
+            final byte[] body = stub.body().getBytes(StandardCharsets.UTF_8);
+            final StringBuilder header = new StringBuilder("HTTP/1.1 " + stub.statusCode() + " \r\nContent-Type: application/json\r\n");
+            for (final Map.Entry<String, String> h : stub.headers().entrySet())
+              header.append(h.getKey()).append(": ").append(h.getValue()).append("\r\n");
+            header.append("Content-Length: ").append(body.length).append("\r\nConnection: close\r\n\r\n");
+            client.getOutputStream().write(header.toString().getBytes(StandardCharsets.ISO_8859_1));
+            client.getOutputStream().write(body);
+            client.getOutputStream().flush();
+          } catch (final Exception ignored) {
+            // best-effort: the test assertions cover the client side
+          }
+        }
+      });
+      serverThread.setDaemon(true);
+      serverThread.start();
+
+      action.run(port);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #5845. With `ReadConsistency.READ_YOUR_WRITES`, a read issued right after an explicit transaction `commit()` could be served by a follower that had not yet applied that commit, with no error or warning.

`RemoteDatabase.begin()`, `commit()`, and `rollback()` build their own HTTP request and send it with the raw `httpClient`, bypassing `RemoteHttpComponent.httpCommand()`, which is where the `X-ArcadeDB-Commit-Index` response header is normally parsed into `lastCommitIndex`. `commit()` is the one that matters for correctness: without capturing it, `lastCommitIndex` still holds whatever the last `command()` response carried (or `-1` if none did), so the very next `X-ArcadeDB-Read-After` bookmark sent to the server is stale or missing, and the read silently degrades to `EVENTUAL`.

The server already emits `X-ArcadeDB-Commit-Index` on begin/commit/rollback responses too (`DatabaseAbstractHandler` emits it whenever the wrapped database is HA and has an applied index), so all three call sites now go through a shared `captureCommitIndexHeader()` helper. `RemoteHttpComponent.httpCommand()` was refactored to reuse the same helper instead of duplicating the parsing logic.

## Changes

- `network/src/main/java/com/arcadedb/remote/RemoteDatabase.java`: added `captureCommitIndexHeader()`, called from `begin()`, `commit()`, `rollback()` after a successful (204) response.
- `network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java`: `httpCommand()` now calls the shared helper instead of inlining the same header-parsing logic.
- `network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java`: two regression tests using a loopback HTTP test double (matching the existing pattern in `RemoteHttpComponentTest`) that assert `commit()` captures `X-ArcadeDB-Commit-Index` when present, and leaves `lastCommitIndex` unchanged when absent.

## Test plan

- [x] New unit tests fail before the fix (reproduces the bug exactly as described in the issue) and pass after.
- [x] Full `network` module unit test suite: 405 tests, 0 failures.
- [x] `ha-raft` module's existing `RaftRemoteReadYourWritesIT` (real 3-node Raft cluster, end-to-end read-your-writes): 2/2 tests pass, no regression.