### PR TITLE
fix(#5812): make the @props JSON type hint opt-in, off by default

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -73,6 +73,11 @@ public class JsonSerializer {
   private boolean  includeVertexEdges        = true;
   private boolean  useVertexEdgeSize         = true;
   private boolean  useCollectionSizeForEdges = true;
+  // Issue #5812: off by default. The @props type hint only matters to a consumer that must rebuild the exact
+  // Java type of a non-element (projection/aggregate) column - today that is the RemoteDatabase Java driver,
+  // which turns this on explicitly for its own requests. A generic HTTP/JSON client (curl, Postman, another
+  // language) never asked for it and should get plain JSON back.
+  private boolean  includeTypeHints          = false;
   private Database database;
 
   JsonSerializer() {
@@ -154,7 +159,7 @@ public class JsonSerializer {
       }
     }
 
-    final StringBuilder propertyTypes = new StringBuilder();
+    final StringBuilder propertyTypes = includeTypeHints ? new StringBuilder() : null;
 
     for (final String propertyName : result.getPropertyNames()) {
       Object value = result.getProperty(propertyName);
@@ -164,36 +169,39 @@ public class JsonSerializer {
       // only reliable source for column-precision-aware formatting.
       final Type schemaPropertyType =
           type != null && type.existsProperty(propertyName) ? type.getProperty(propertyName).getType() : null;
-      final Type propertyType;
-      if (schemaPropertyType != null)
-        propertyType = schemaPropertyType;
-      else if (value != null)
-        propertyType = Type.getTypeByClass(value.getClass());
-      else
-        propertyType = null;
 
-      if (propertyType != null && !JSON_ROUND_TRIP_FAITHFUL_TYPES.contains(propertyType)) {
-        if (!propertyTypes.isEmpty())
-          propertyTypes.append(",");
-        propertyTypes.append(propertyName).append(":").append(propertyType.getId());
-
-        // Issue #4849: a LIST/MAP column only carries a container hint, so temporal items would reach
-        // the remote client as raw epoch-millis Numbers with no metadata to coerce them back to the
-        // configured Java temporal type (the client returned List<Long>/Map<String,Long> instead of
-        // List<LocalDateTime>/Map<String,LocalDateTime>). When the items share a temporal type, append
-        // the element-type id in parentheses (e.g. "dates:9(6)") so the client can rebuild each item
-        // as the configured temporal implementation.
-        final Collection<?> elements;
-        if (propertyType == Type.LIST && value instanceof Collection<?> collection)
-          elements = collection;
-        else if (propertyType == Type.MAP && value instanceof Map<?, ?> map)
-          elements = map.values();
+      if (includeTypeHints) {
+        final Type propertyType;
+        if (schemaPropertyType != null)
+          propertyType = schemaPropertyType;
+        else if (value != null)
+          propertyType = Type.getTypeByClass(value.getClass());
         else
-          elements = null;
-        if (elements != null) {
-          final Type elementType = detectHomogeneousTemporalElementType(elements);
-          if (elementType != null)
-            propertyTypes.append('(').append(elementType.getId()).append(')');
+          propertyType = null;
+
+        if (propertyType != null && !JSON_ROUND_TRIP_FAITHFUL_TYPES.contains(propertyType)) {
+          if (!propertyTypes.isEmpty())
+            propertyTypes.append(",");
+          propertyTypes.append(propertyName).append(":").append(propertyType.getId());
+
+          // Issue #4849: a LIST/MAP column only carries a container hint, so temporal items would reach
+          // the remote client as raw epoch-millis Numbers with no metadata to coerce them back to the
+          // configured Java temporal type (the client returned List<Long>/Map<String,Long> instead of
+          // List<LocalDateTime>/Map<String,LocalDateTime>). When the items share a temporal type, append
+          // the element-type id in parentheses (e.g. "dates:9(6)") so the client can rebuild each item
+          // as the configured temporal implementation.
+          final Collection<?> elements;
+          if (propertyType == Type.LIST && value instanceof Collection<?> collection)
+            elements = collection;
+          else if (propertyType == Type.MAP && value instanceof Map<?, ?> map)
+            elements = map.values();
+          else
+            elements = null;
+          if (elements != null) {
+            final Type elementType = detectHomogeneousTemporalElementType(elements);
+            if (elementType != null)
+              propertyTypes.append('(').append(elementType.getId()).append(')');
+          }
         }
       }
 
@@ -212,7 +220,8 @@ public class JsonSerializer {
     // clients can restore the original Java type (e.g. count(*) is a long; JSON would otherwise
     // collapse it to Integer when it fits). Element rows already carry their type via @type and
     // the schema, so adding @props there would only change existing JSON shapes without benefit.
-    if (type == null && !propertyTypes.isEmpty())
+    // Issue #5812: gated behind includeTypeHints (off by default) - see the field javadoc.
+    if (type == null && propertyTypes != null && !propertyTypes.isEmpty())
       object.put(Property.PROPERTY_TYPES_PROPERTY, propertyTypes.toString());
 
     return object;
@@ -380,6 +389,19 @@ public class JsonSerializer {
 
   public JsonSerializer setUseCollectionSizeForEdges(final boolean useCollectionSizeForEdges) {
     this.useCollectionSizeForEdges = useCollectionSizeForEdges;
+    return this;
+  }
+
+  public boolean isIncludeTypeHints() {
+    return includeTypeHints;
+  }
+
+  /**
+   * Enables the per-column {@code @props} type hint on non-element (projection/aggregate) result rows -
+   * see the {@link #includeTypeHints} field javadoc for who needs this and why it is off by default.
+   */
+  public JsonSerializer setIncludeTypeHints(final boolean includeTypeHints) {
+    this.includeTypeHints = includeTypeHints;
     return this;
   }
 

--- a/engine/src/test/java/com/arcadedb/serializer/JsonSerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/JsonSerializerTest.java
@@ -47,7 +47,29 @@ class JsonSerializerTest extends TestHelper {
 
   @BeforeEach
   void setUp() {
-    jsonSerializer = JsonSerializer.createJsonSerializer();
+    // Issue #5812: the @props type hint is opt-in (see JsonSerializer#includeTypeHints). Most of the tests
+    // below exercise the type-fidelity logic itself, so the flag is turned on here; propsHintOffByDefault()
+    // below is what pins the off-by-default behavior a generic HTTP/JSON client relies on.
+    jsonSerializer = JsonSerializer.createJsonSerializer().setIncludeTypeHints(true);
+  }
+
+  @Test
+  void propsHintOffByDefault() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("PropsHintOffByDefaultType");
+      database.newDocument("PropsHintOffByDefaultType").save();
+    });
+
+    final JsonSerializer defaultSerializer = JsonSerializer.createJsonSerializer();
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM PropsHintOffByDefaultType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final JSONObject json = defaultSerializer.serializeResult(database, rs.next());
+      // count(*) yields a Long (lossy through JSON), but a JsonSerializer created without
+      // setIncludeTypeHints(true) must never emit the @props hint - a generic HTTP/JSON caller never asked
+      // to rebuild the exact Java type of a projection column.
+      assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isFalse();
+      assertThat(json.getLong("c")).isEqualTo(1L);
+    }
   }
 
   @Test

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -320,6 +320,10 @@ public class RemoteHttpComponent extends RWLockContext {
             jsonRequest.put("language", language);
           jsonRequest.put("command", payloadCommand);
           jsonRequest.put("serializer", "record");
+          // Issue #5812: the @props per-column type hint is off by default on the HTTP surface - a generic
+          // client never asked for it - so this driver, which needs it to rebuild the exact Java type of a
+          // non-element (projection/aggregate) column, opts in explicitly.
+          jsonRequest.put("typeHints", true);
           jsonRequest.put("retries", txRetries);
           if (maxResultRows != null)
             jsonRequest.put("limit", maxResultRows);

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -216,8 +216,14 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
     return command.length() > MAX_LOGGED_COMMAND_CHARS ? result + "..." : result;
   }
 
+  /**
+   * @param includeTypeHints whether to emit the per-column {@code @props} type hint on non-element result rows
+   *                         (issue #5812). Off by default on the HTTP surface: only a caller that must rebuild
+   *                         the exact Java type of a projection/aggregate column - today the RemoteDatabase Java
+   *                         driver - opts in by sending the {@code typeHints} request flag.
+   */
   protected SerializationOutcome serializeResultSet(final Database database, final String serializer, final int limit,
-      final JSONObject response, final ResultSet qResult) {
+      final JSONObject response, final ResultSet qResult, final boolean includeTypeHints) {
     if (qResult == null)
       return SerializationOutcome.EMPTY;
 
@@ -267,6 +273,7 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
           .setExpandVertexEdges(false);
       // Don't use collection size for edges - we want COLLECT(rel) to return edge objects, not counts (issue #3404)
       serializerImpl.setUseCollectionSize(false).setUseCollectionSizeForEdges(false);
+      serializerImpl.setIncludeTypeHints(includeTypeHints);
 
       final Set<RID> includedVertices = new HashSet<>();
       final Set<RID> includedEdges = new HashSet<>();
@@ -352,13 +359,15 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
       return serializeRows(database, qResult, limit, response, JsonSerializer.createJsonSerializer()
           .setIncludeVertexEdges(false)
           .setUseCollectionSize(false)
-          .setUseCollectionSizeForEdges(false));
+          .setUseCollectionSizeForEdges(false)
+          .setIncludeTypeHints(includeTypeHints));
 
     default:
       return serializeRows(database, qResult, limit, response, JsonSerializer.createJsonSerializer()
           .setIncludeVertexEdges(true)
           .setUseCollectionSize(false)
-          .setUseCollectionSizeForEdges(false));
+          .setUseCollectionSizeForEdges(false)
+          .setIncludeTypeHints(includeTypeHints));
     }
     } finally {
       qResult.close();

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
@@ -59,6 +59,9 @@ public class GetQueryHandler extends AbstractQueryHandler {
       if (serializer == null)
         serializer = "record";
 
+      // Issue #5812: off unless the caller explicitly asks for the @props type hint on non-element rows.
+      final boolean includeTypeHints = Boolean.parseBoolean(getQueryParameter(exchange, "typeHints"));
+
       final String limitPar = getQueryParameter(exchange, "limit");
       profile.addDeserializationNanos(System.nanoTime() - deserializationStart);
 
@@ -78,7 +81,7 @@ public class GetQueryHandler extends AbstractQueryHandler {
         profile.addEngineNanos(System.nanoTime() - engineStart);
 
         final long serializationStart = System.nanoTime();
-        final SerializationOutcome outcome = serializeResultSet(database, serializer, limit, response, qResult);
+        final SerializationOutcome outcome = serializeResultSet(database, serializer, limit, response, qResult, includeTypeHints);
         reportLimits(response, limit, outcome);
         logIfTruncatedByDefault(database.getName(), text, limit, requestLimit, planLimit, outcome);
         profile.addSerializationNanos(System.nanoTime() - serializationStart);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -177,6 +177,8 @@ public class PostCommandHandler extends AbstractQueryHandler {
     final Integer requestLimit = optionalIntField(requestMap, "limit");
     final String serializer = requireStringField(requestMap, "serializer", "record");
     final String profileExecution = requireStringField(requestMap, "profileExecution", null);
+    // Issue #5812: off unless the caller explicitly asks for the @props type hint on non-element rows.
+    final boolean includeTypeHints = requestMap.get("typeHints") instanceof Boolean b && b;
 
     if (command == null || command.isEmpty())
       return new ExecutionResponse(400, "{ \"error\" : \"Command text is null\"}");
@@ -269,7 +271,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
           profile.addEngineNanos(System.nanoTime() - engineStart);
 
           final long serializationStart = System.nanoTime();
-          outcome = serializeResultSet(database, serializer, limit, response, qResult);
+          outcome = serializeResultSet(database, serializer, limit, response, qResult, includeTypeHints);
           response.put("explain", explainText);
           response.put("explainPlan", executionPlan.toResult().toJSON());
           profile.addSerializationNanos(System.nanoTime() - serializationStart);
@@ -283,7 +285,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
           profile.addEngineNanos(System.nanoTime() - engineStart);
 
           final long serializationStart = System.nanoTime();
-          outcome = serializeResultSet(database, serializer, limit, response, qResult);
+          outcome = serializeResultSet(database, serializer, limit, response, qResult, includeTypeHints);
 
           if (qResult != null) {
             final var qStats = qResult.getStatistics();

--- a/server/src/test/java/com/arcadedb/server/Issue5812PropsTypeHintHttpIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5812PropsTypeHintHttpIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5812: the {@code @props} per-column type hint leaked into every HTTP JSON response, not just the
+ * RemoteDatabase Java driver requests that actually need it to rebuild the exact Java type of a non-element
+ * (projection/aggregate) column. A plain HTTP caller (curl, wget, a non-Java client) never asked for it and
+ * should get plain JSON back.
+ * <p>
+ * Both reproductions from the issue are covered: a scalar projection on a lossy-typed column (SHORT), and
+ * {@code SELECT FROM schema:types}, whose synthetic rows are not schema-backed elements either. Both are
+ * verified absent by default and present only when the request explicitly opts in with {@code typeHints}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5812PropsTypeHintHttpIT extends BaseGraphServerTest {
+
+  private static final String DATABASE_NAME = "Issue5812PropsTypeHintHttpIT";
+
+  @Override
+  protected String getDatabaseName() {
+    return DATABASE_NAME;
+  }
+
+  @Override
+  protected void populateDatabase() {
+    final Database database = getDatabase(0);
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc").createProperty("num", Type.SHORT);
+      database.newDocument("Doc").set("num", (short) 0).save();
+    });
+  }
+
+  @Test
+  void getQueryOmitsPropsHintByDefault() throws Exception {
+    testEachServer(serverIndex -> {
+      final String response = getQuery(serverIndex, "select num from Doc", null);
+      final JSONObject row = new JSONObject(response).getJSONArray("result").getJSONObject(0);
+      assertThat(row.getInt("num")).isZero();
+      assertThat(row.has("@props")).isFalse();
+    });
+  }
+
+  @Test
+  void getQueryEmitsPropsHintWhenExplicitlyRequested() throws Exception {
+    testEachServer(serverIndex -> {
+      final String response = getQuery(serverIndex, "select num from Doc", "true");
+      final JSONObject row = new JSONObject(response).getJSONArray("result").getJSONObject(0);
+      assertThat(row.has("@props")).isTrue();
+      assertThat(row.getString("@props")).isEqualTo("num:" + Type.SHORT.getId());
+    });
+  }
+
+  @Test
+  void schemaTypesQueryNeverLeaksPropsHintByDefault() throws Exception {
+    testEachServer(serverIndex -> {
+      final String response = getQuery(serverIndex, "select from schema:types", null);
+      assertThat(response).doesNotContain("@props");
+    });
+  }
+
+  @Test
+  void postCommandOmitsPropsHintByDefaultForAggregate() throws Exception {
+    testEachServer(serverIndex -> {
+      final JSONObject payload = new JSONObject()
+          .put("language", "sql")
+          .put("command", "select count(*) as c from Doc")
+          .put("serializer", "record");
+
+      final HttpURLConnection connection = openCommandConnection(serverIndex);
+      formatPayload(connection, payload);
+      connection.connect();
+      try {
+        final JSONObject row = new JSONObject(readResponse(connection)).getJSONArray("result").getJSONObject(0);
+        assertThat(row.getLong("c")).isEqualTo(1L);
+        assertThat(row.has("@props")).isFalse();
+      } finally {
+        connection.disconnect();
+      }
+    });
+  }
+
+  @Test
+  void postCommandEmitsPropsHintWhenExplicitlyRequestedForAggregate() throws Exception {
+    testEachServer(serverIndex -> {
+      final JSONObject payload = new JSONObject()
+          .put("language", "sql")
+          .put("command", "select count(*) as c from Doc")
+          .put("serializer", "record")
+          .put("typeHints", true);
+
+      final HttpURLConnection connection = openCommandConnection(serverIndex);
+      formatPayload(connection, payload);
+      connection.connect();
+      try {
+        final JSONObject row = new JSONObject(readResponse(connection)).getJSONArray("result").getJSONObject(0);
+        assertThat(row.has("@props")).isTrue();
+        assertThat(row.getString("@props")).isEqualTo("c:" + Type.LONG.getId());
+      } finally {
+        connection.disconnect();
+      }
+    });
+  }
+
+  private String getQuery(final int serverIndex, final String sql, final String typeHints) throws IOException {
+    final String encoded = java.net.URLEncoder.encode(sql, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20");
+    String url = "http://localhost:248" + serverIndex + "/api/v1/query/" + DATABASE_NAME + "/sql/" + encoded;
+    if (typeHints != null)
+      url += "?typeHints=" + typeHints;
+
+    final HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    connection.setRequestMethod("GET");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      return readResponse(connection);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private HttpURLConnection openCommandConnection(final int serverIndex) throws IOException {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://localhost:248" + serverIndex + "/api/v1/command/" + DATABASE_NAME).openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    return connection;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5812.

The per-column `@props` type hint (added in #4267/#4849) is meant to let a consumer rebuild the exact Java type of a non-element (projection/aggregate) result column - e.g. `count(*)` yielding a `Long` that plain JSON would otherwise collapse to `Integer`. In practice it was unconditionally emitted on every HTTP response, including plain `SELECT` projections and `SELECT FROM schema:types`, regardless of who was asking. Any HTTP client (curl, wget, another language, Studio) got the extra `@props` field whether it needed it or not, exactly as reported in the issue.

Today the only real consumer of this hint is the `RemoteDatabase` Java driver (`json2Result`/`RemoteImmutableDocument`), and even there only for non-element rows - element/document rows already carry `@type` plus the schema, so they never needed the hint.

## Changes

- `JsonSerializer`: new `includeTypeHints` flag (default `false`) gates `@props` emission in `serializeResult`. Building the per-column type-hint string is now skipped entirely when the flag is off, which also avoids the wasted `StringBuilder`/type lookups on the hot HTTP response path.
- `AbstractQueryHandler` / `GetQueryHandler` / `PostCommandHandler`: a new `typeHints` request flag (query parameter on `GET /query`, JSON field on `POST /command`) is threaded through to `JsonSerializer`, decoupled from the existing `serializer` (record/graph/studio/default) selection - `serializer` controls the response *shape*, `typeHints` controls this specific metadata field. Both default to `false`.
- `RemoteHttpComponent`: the Java driver now sends `typeHints: true` alongside the existing `serializer: record`, so its own type-fidelity behavior (e.g. `count(*)` staying a `Long`, `FLOAT`/`SHORT`/temporal columns) is unaffected.
- `map2json`'s existing `@props` behavior (used when an embedded/document `toJSON(true)` is requested, e.g. for schemaless properties) is left untouched - it's a separate, already-narrower code path not implicated by the reported issue, called out here so it isn't mistaken for an oversight.

## Test plan

- New `Issue5812PropsTypeHintHttpIT` reproduces both repros from the issue against a live server: `SELECT num FROM Doc` (SHORT column) and `SELECT FROM schema:types`, verifying `@props` is absent by default and present only with `typeHints=true`/`"typeHints": true`.
- `JsonSerializerTest` updated: existing type-fidelity tests now opt in via `setIncludeTypeHints(true)`; new `propsHintOffByDefault()` pins the default-off behavior for a plain `JsonSerializer`.
- Ran the existing HTTP handler suite (`AbstractQueryHandlerIT`, `PostCommandHandler*`, `HTTPDocumentIT`, `HTTPGraphIT`) and the driver suite (`RemoteDatabaseIT`, `Issue4267CountTypeIT`, `RemoteGraphBatchIT`) - all pass, confirming the driver's type reconstruction (the original reason `@props` exists) is unaffected.
- [x] `mvn compile test-compile` clean on `engine`, `network`, `server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)