### PR TITLE
fix(query): close chain-length gap in Cypher and add matching guard for SQL (#5851 follow-up)

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -26,3 +26,36 @@ converting either crash into a `CommandParsingException` that names the limit an
 legitimate query needs it. Real-world queries essentially never nest this deep, so the default leaves a
 wide margin; the SQL parser was never at risk from the same input because its hand-written recursive-descent
 implementation costs far fewer stack frames per nesting level, not because it enforces a limit of its own.
+
+### Follow-up: the chain-length gap, and a matching guard for SQL
+
+Two things turned out to be wrong in the paragraph above, found while auditing for the same class of bug
+elsewhere in both engines.
+
+First, the Cypher fix was incomplete. `ExpressionRewriter`'s guard only fires from
+`CypherASTBuilder#visitWhereClause`, so a long OR/AND/NOT/comparison/arithmetic chain written anywhere
+*other* than a top-level `WHERE` condition - a `RETURN` projection, an `ORDER BY` item, a function
+argument - was never rewritten and so never hit that guard. A 30000-term OR chain in a `RETURN` projection
+still overflowed the stack, this time inside `CypherSemanticValidator#checkExpressionScope` - a completely
+different recursive walker from `ExpressionRewriter`, invoked during semantic validation on every clause.
+Chasing down and patching every such walker individually is exactly the kind of fragile, incomplete-prone
+fix that let this one through in the first place, so `CypherExpressionDepthGuard` (the same `ParseTreeListener`
+already attached to the parser for nesting depth) now also bounds the term count of every `(OP operand)*`-shaped
+grammar rule directly - OR, XOR, AND, `NOT*`, chained comparisons, and the three arithmetic precedence
+levels - using each rule's own generated accessor, exactly as every AST builder does. This rejects an
+oversized chain during parsing, before any tree is built, regardless of which clause it is in and regardless
+of which pass would eventually have walked it.
+
+Second, "the SQL parser was never at risk... not because it enforces a limit of its own" undersold the
+actual risk: it isn't at risk of a `StackOverflowError` from nested parentheses (confirmed - its grammar
+costs far fewer Java stack frames per nesting level, exactly as claimed), but it is at risk of something
+worse. The production SQL parser is `SQLAntlrParser` (ANTLR4-based, like Cypher's), which resolves the
+ambiguity between the several grammar rules that all start with a bare `(` - a parenthesized expression,
+condition, or sub-statement - by trying a fast SLL prediction first and falling back to full ALL(*)
+prediction on failure. For deeply nested parentheses that fallback's cost grows steeply enough that a query
+of only a few KB (about 6000 nested parentheses) tied up a worker thread for well over two minutes of CPU
+without ever crashing - worse than a fast error, since a slow hang is not distinguishable from a legitimately
+slow query. `SQLAntlrParser` now counts parenthesis nesting on the token stream before attempting any parse,
+rejecting a query past `arcadedb.sql.maxExpressionDepth` (default 200) in O(n) time - the same depth that
+previously burned minutes of CPU is now rejected in single-digit milliseconds. Counting on the token stream
+rather than raw characters means a `(` inside a string literal or comment is not miscounted.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -501,6 +501,20 @@ public enum GlobalConfiguration {
       "Deprecated, has no effect. The ANTLR4-based SQL parser is always used.",
       String.class, "antlr"),
 
+  SQL_MAX_EXPRESSION_DEPTH("arcadedb.sql.maxExpressionDepth", SCOPE.DATABASE,
+      """
+      Maximum nesting depth allowed for parentheses in a single SQL statement (WHERE conditions, sub-expressions, \
+      nested function/statement calls, ...). The ANTLR-generated SQL parser resolves ambiguity between several \
+      grammar rules that all start with '(' (a parenthesized expression, condition, or sub-statement) by first \
+      trying a fast SLL prediction and falling back to full ALL(*) prediction on failure; for a query with enough \
+      nested parentheses that fallback's cost grows so steeply that a query of only a few KB can tie up a worker \
+      thread for minutes without ever crashing, which is worse than a fast failure since it is not distinguishable \
+      from a slow legitimate query. This is checked on the token stream before any parse is attempted, so a query \
+      past the limit is rejected in O(n) time with a normal parse error. Real-world queries rarely nest more than a \
+      handful of parentheses, so the default is deliberately generous. Raise it only if a legitimate, deeply-nested \
+      or generated query needs it.""",
+      Integer.class, 200),
+
   // OPENCYPHER
   OPENCYPHER_STATEMENT_CACHE("arcadedb.opencypher.statementCache", SCOPE.DATABASE,
       "Maximum number of parsed OpenCypher statements to keep in cache", Integer.class, 300),

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionDepthGuard.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionDepthGuard.java
@@ -26,23 +26,39 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 /**
- * Bounds how deeply the {@code expression} grammar rule may re-enter itself while parsing a single
- * Cypher query, so that a pathologically nested or long input (thousands of nested parentheses, list/map
- * literals or function arguments) is rejected as a normal {@link CommandParsingException} instead of
- * crashing the calling thread with a {@link StackOverflowError}.
- * <p>
- * Every nested sub-expression, regardless of the syntax that introduces it, re-enters
- * {@code Cypher25Parser.RULE_expression} exactly once: {@code parenthesizedExpression: LPAREN expression
- * RPAREN}, function call arguments, list/map literal values, {@code CASE} branches and comprehensions all
- * funnel back through the same rule. The generated parser walks its full operator-precedence cascade
- * (roughly ten Java stack frames) for every such re-entry, so counting re-entries is a precise, allocation-free
- * proxy for the additional native stack consumed by one more nesting level - see issue #5851.
- * <p>
+ * Bounds two independent sources of unbounded depth while parsing a single Cypher query, so that a
+ * pathologically nested or long input is rejected as a normal {@link CommandParsingException} instead of
+ * crashing the calling thread (or a later pass) with a {@link StackOverflowError}. See issue #5851 and its
+ * follow-up.
+ * <ol>
+ *   <li><b>Nesting.</b> How deeply the {@code expression} grammar rule re-enters itself. Every nested
+ *   sub-expression, regardless of the syntax that introduces it, re-enters {@code
+ *   Cypher25Parser.RULE_expression} exactly once: {@code parenthesizedExpression: LPAREN expression
+ *   RPAREN}, function call arguments, list/map literal values, {@code CASE} branches and comprehensions
+ *   all funnel back through the same rule. The generated parser walks its full operator-precedence cascade
+ *   (roughly ten Java stack frames) for every such re-entry, so counting re-entries is a precise,
+ *   allocation-free proxy for the additional native stack consumed by one more nesting level - this is
+ *   what the original issue reports and reproduces with 1001 nested parentheses.</li>
+ *   <li><b>Chain length.</b> How many terms a flat {@code (OP operand)*} repetition matches - {@code
+ *   expression: expression11 (OR expression11)*} and the seven other precedence levels shaped the same
+ *   way (XOR, AND, {@code NOT*}, chained comparisons, {@code +}/{@code -}/{@code ||}, {@code *}/{@code /}/
+ *   {@code %}, {@code ^}). ANTLR compiles a quantifier as a loop, not recursion, so the parser itself
+ *   handles tens of thousands of chained terms without trouble - the issue's own diagnosis stopped there
+ *   and assumed this shape was safe. It is not: every AST builder in this package folds such a list into a
+ *   left-associative <em>binary tree</em> exactly as deep as the term count, and that tree is then walked
+ *   recursively by several independent, unrelated passes - {@code ExpressionRewriter} (WHERE-clause
+ *   normalization), {@code CypherExpressionWalker} (generic visitor, semantic validation and more) and
+ *   {@code CypherSemanticValidator#checkExpressionScope} were all confirmed to overflow on a long enough
+ *   chain, each on its own call stack shape. Rejecting an oversized chain here, at the one place its length
+ *   is known before any tree gets built, protects all of them at once - including any future or
+ *   undiscovered walker - without touching a single one of them.
+ * </ol>
  * This is attached to the parser with {@link org.antlr.v4.runtime.Parser#addParseListener}, which ANTLR calls
- * synchronously from {@code enterRule}/{@code exitRule} before descending into any nested rule. Throwing from
- * {@link #enterEveryRule} therefore aborts the recursion before it goes one level deeper, unwinding cleanly
- * through the generated rule methods' {@code finally} blocks; {@link Cypher25AntlrParser#parseQuery} then
- * lets the {@link CommandParsingException} surface as-is.
+ * synchronously from {@code enterRule}/{@code exitRule} before descending into any nested rule and after a
+ * rule's children (including every match of a repeated sub-rule) are attached to its context. Throwing from
+ * {@link #enterEveryRule} or {@link #exitEveryRule} therefore aborts the parse before any further work is
+ * done, unwinding cleanly through the generated rule methods' {@code finally} blocks; {@link
+ * Cypher25AntlrParser#parseQuery} then lets the {@link CommandParsingException} surface as-is.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -58,17 +74,45 @@ final class CypherExpressionDepthGuard implements ParseTreeListener {
   @Override
   public void enterEveryRule(final ParserRuleContext ctx) {
     if (ctx.getRuleIndex() == Cypher25Parser.RULE_expression && ++depth > maxDepth)
-      throw new CommandParsingException(
-          "Expression nesting exceeds the maximum allowed depth of " + maxDepth
-              + " (parentheses, list/map literals and function arguments nested inside one another). "
-              + "This protects the server against a stack overflow from pathologically nested queries; "
-              + "raise 'arcadedb.cypher.maxExpressionDepth' if this is a legitimate query.");
+      throw tooDeep("nested (parentheses, list/map literals and function arguments nested inside one another)");
   }
 
   @Override
   public void exitEveryRule(final ParserRuleContext ctx) {
     if (ctx.getRuleIndex() == Cypher25Parser.RULE_expression)
       --depth;
+    checkChainLength(ctx); // no-op for any rule index not covered below
+  }
+
+  /**
+   * Checks the term count of every {@code (OP operand)*}-shaped rule, using each rule's own generated
+   * accessor - the same one every AST builder in this package calls - so the count is exact and never
+   * drifts from what would actually be folded into a tree. Dispatches on {@link
+   * ParserRuleContext#getRuleIndex()} rather than the context's runtime type: this fires on every rule
+   * exit in the entire query, so an int switch (one comparison against a dense set of constants) is cheaper
+   * on that hot path than a chain of {@code instanceof} checks that misses for every irrelevant rule.
+   */
+  private void checkChainLength(final ParserRuleContext ctx) {
+    final int termCount = switch (ctx.getRuleIndex()) {
+      case Cypher25Parser.RULE_expression -> ((Cypher25Parser.ExpressionContext) ctx).expression11().size();    // OR
+      case Cypher25Parser.RULE_expression11 -> ((Cypher25Parser.Expression11Context) ctx).expression10().size(); // XOR
+      case Cypher25Parser.RULE_expression10 -> ((Cypher25Parser.Expression10Context) ctx).expression9().size();  // AND
+      case Cypher25Parser.RULE_expression9 -> ((Cypher25Parser.Expression9Context) ctx).NOT().size() + 1;         // NOT*
+      case Cypher25Parser.RULE_expression8 -> ((Cypher25Parser.Expression8Context) ctx).expression7().size();    // chained comparisons
+      case Cypher25Parser.RULE_expression6 -> ((Cypher25Parser.Expression6Context) ctx).expression5().size();    // + - ||
+      case Cypher25Parser.RULE_expression5 -> ((Cypher25Parser.Expression5Context) ctx).expression4().size();    // * / %
+      case Cypher25Parser.RULE_expression4 -> ((Cypher25Parser.Expression4Context) ctx).expression3().size();    // ^
+      default -> 1;
+    };
+    if (termCount - 1 > maxDepth)
+      throw tooDeep("chained (a run of AND/OR/XOR/NOT/comparison/arithmetic terms)");
+  }
+
+  private CommandParsingException tooDeep(final String shape) {
+    return new CommandParsingException(
+        "Expression is too deeply " + shape + " - exceeds the maximum allowed depth of " + maxDepth + ". "
+            + "This protects the server against a stack overflow from a pathologically nested or long query; "
+            + "raise 'arcadedb.cypher.maxExpressionDepth' if this is a legitimate query.");
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLAntlrParser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLAntlrParser.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.sql.antlr;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.grammar.SQLLexer;
@@ -30,6 +31,7 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
@@ -74,7 +76,7 @@ public record SQLAntlrParser(Database database) {
       final SQLLexer lexer = new SQLLexer(input);
 
       // Create token stream
-      final CommonTokenStream tokens = new CommonTokenStream(lexer);
+      final CommonTokenStream tokens = tokenize(lexer);
 
       // Create parser
       final SQLParser parser = new SQLParser(tokens);
@@ -139,7 +141,7 @@ public record SQLAntlrParser(Database database) {
       final SQLLexer lexer = new SQLLexer(input);
 
       // Create token stream
-      final CommonTokenStream tokens = new CommonTokenStream(lexer);
+      final CommonTokenStream tokens = tokenize(lexer);
 
       // Create parser
       final SQLParser parser = new SQLParser(tokens);
@@ -203,7 +205,7 @@ public record SQLAntlrParser(Database database) {
       final SQLLexer lexer = new SQLLexer(input);
 
       // Create token stream
-      final CommonTokenStream tokens = new CommonTokenStream(lexer);
+      final CommonTokenStream tokens = tokenize(lexer);
 
       // Create parser
       final SQLParser parser = new SQLParser(tokens);
@@ -257,7 +259,7 @@ public record SQLAntlrParser(Database database) {
       final SQLLexer lexer = new SQLLexer(input);
 
       // Create token stream
-      final CommonTokenStream tokens = new CommonTokenStream(lexer);
+      final CommonTokenStream tokens = tokenize(lexer);
 
       // Create parser
       final SQLParser parser = new SQLParser(tokens);
@@ -305,5 +307,43 @@ public record SQLAntlrParser(Database database) {
   @Override
   public Database database() {
     return database;
+  }
+
+  /**
+   * Builds the token stream and bounds its parenthesis nesting depth before any parse is attempted.
+   * <p>
+   * The grammar resolves the ambiguity between the several rules that all start with a bare '(' - a
+   * parenthesized expression, condition, or sub-statement - by trying a fast SLL prediction first and
+   * falling back to full ALL(*) prediction on failure. For deeply nested parentheses that fallback's cost
+   * grows steeply enough that a query of only a few KB can tie up a worker thread for minutes without ever
+   * crashing (issue #5851's follow-up: unlike the OpenCypher parser, this one is not at risk of a
+   * StackOverflowError from the same input - it costs far fewer Java stack frames per nesting level - but it
+   * is at risk of this far worse failure mode, an unbounded hang rather than a fast error). Counting on the
+   * token stream rather than raw characters means a '(' inside a string literal or comment - already lexed
+   * as part of that token, never as a standalone LPAREN - is not miscounted.
+   */
+  private static CommonTokenStream tokenize(final SQLLexer lexer) {
+    final CommonTokenStream tokens = new CommonTokenStream(lexer);
+    tokens.fill(); // the parser reuses this same fully-buffered stream
+    checkExpressionDepth(tokens);
+    return tokens;
+  }
+
+  private static void checkExpressionDepth(final CommonTokenStream tokens) {
+    final int maxDepth = GlobalConfiguration.SQL_MAX_EXPRESSION_DEPTH.getValueAsInteger();
+    int depth = 0;
+    for (final Token token : tokens.getTokens()) {
+      if (token.getChannel() != Token.DEFAULT_CHANNEL)
+        continue;
+      if (token.getType() == SQLLexer.LPAREN) {
+        if (++depth > maxDepth)
+          throw new CommandSQLParsingException(
+              "Expression nesting exceeds the maximum allowed depth of " + maxDepth
+                  + " (parentheses nested inside one another). This protects the server from a query that ties up "
+                  + "a worker thread for a very long time without crashing; raise 'arcadedb.sql.maxExpressionDepth' "
+                  + "if this is a legitimate query.");
+      } else if (token.getType() == SQLLexer.RPAREN && depth > 0)
+        --depth;
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherChainLengthGuardIssue5851FollowupTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherChainLengthGuardIssue5851FollowupTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.query.opencypher.parser.Cypher25AntlrParser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Follow-up to issue #5851 / PR #5859: {@code ExpressionRewriter}'s recursion guard only fires from
+ * {@code CypherASTBuilder#visitWhereClause}, so a long OR/AND/NOT/comparison/arithmetic chain written
+ * anywhere <em>other</em> than a top-level {@code WHERE} condition - a {@code RETURN} projection, an
+ * {@code ORDER BY} item, a function argument, inside a list literal, ... - was never rewritten and so never
+ * hit that guard either. Confirmed to still crash after PR #5859: a 30000-term OR chain in a {@code RETURN}
+ * projection overflowed {@code CypherSemanticValidator#checkExpressionScope} (a completely different
+ * recursive walker from {@code ExpressionRewriter}, invoked during semantic validation on every clause).
+ * <p>
+ * Rather than chase down and patch every such walker individually - which is exactly the kind of fragile,
+ * incomplete-prone fix that let this gap through PR #5859 in the first place - {@code
+ * CypherExpressionDepthGuard} (already attached to the parser for nesting depth) now also bounds the term
+ * count of every {@code (OP operand)*}-shaped grammar rule directly, using each rule's own generated
+ * accessor. This rejects an oversized chain during parsing, before any AST tree is built, regardless of
+ * which clause it appears in and regardless of which pass would eventually have walked it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherChainLengthGuardIssue5851FollowupTest extends TestHelper {
+
+  @AfterEach
+  void resetConfig() {
+    GlobalConfiguration.CYPHER_MAX_EXPRESSION_DEPTH.setValue(GlobalConfiguration.CYPHER_MAX_EXPRESSION_DEPTH.getDefValue());
+  }
+
+  // ===================== the confirmed gap: a chain outside WHERE =====================
+
+  @Test
+  void longOrChainInAReturnProjectionIsRejectedNotAStackOverflow() {
+    final StringBuilder cypher = new StringBuilder("MATCH (n) RETURN n, (a=1");
+    for (int i = 0; i < 30_000; i++)
+      cypher.append(" OR a=1");
+    cypher.append(") AS r");
+
+    assertThatThrownBy(() -> new Cypher25AntlrParser().parse(cypher.toString()))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("chained")
+        .hasMessageContaining("arcadedb.cypher.maxExpressionDepth");
+  }
+
+  @Test
+  void longAndChainInAnOrderByItemIsRejectedNotAStackOverflow() {
+    final StringBuilder cypher = new StringBuilder("MATCH (n) RETURN n ORDER BY (n.a=1");
+    for (int i = 0; i < 30_000; i++)
+      cypher.append(" AND n.a=1");
+    cypher.append(")");
+
+    assertThatThrownBy(() -> new Cypher25AntlrParser().parse(cypher.toString()))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("arcadedb.cypher.maxExpressionDepth");
+  }
+
+  @Test
+  void aFewOrTermsInAReturnProjectionStillParseFine() {
+    final String cypher = "MATCH (n) RETURN n, (n.a=1 OR n.a=2 OR n.a=3) AS r";
+
+    assertThatCode(() -> new Cypher25AntlrParser().parse(cypher)).doesNotThrowAnyException();
+  }
+
+  // ===================== chained comparisons (a < b < c < ...) and arithmetic chains =====================
+
+  @Test
+  void longChainedComparisonIsRejectedNotAStackOverflow() {
+    final StringBuilder cypher = new StringBuilder("MATCH (n) WHERE 0");
+    for (int i = 0; i < 30_000; i++)
+      cypher.append(" < ").append(i + 1);
+    cypher.append(" RETURN n");
+
+    assertThatThrownBy(() -> new Cypher25AntlrParser().parse(cypher.toString()))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("arcadedb.cypher.maxExpressionDepth");
+  }
+
+  /** A short chained comparison (issue #5284: {@code a < b < c} means {@code a < b AND b < c}) still parses. */
+  @Test
+  void aShortChainedComparisonStillParsesFine() {
+    final String cypher = "MATCH (n) WHERE 1 < 2 < 3 RETURN n";
+
+    assertThatCode(() -> new Cypher25AntlrParser().parse(cypher)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void longMultiplicationChainIsRejectedNotAStackOverflow() {
+    final StringBuilder cypher = new StringBuilder("MATCH (n) WHERE (1");
+    for (int i = 0; i < 30_000; i++)
+      cypher.append("*2");
+    cypher.append(") = 0 RETURN n");
+
+    assertThatThrownBy(() -> new Cypher25AntlrParser().parse(cypher.toString()))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("arcadedb.cypher.maxExpressionDepth");
+  }
+
+  @Test
+  void longPowerChainIsRejectedNotAStackOverflow() {
+    final StringBuilder cypher = new StringBuilder("MATCH (n) WHERE (1");
+    for (int i = 0; i < 30_000; i++)
+      cypher.append("^2");
+    cypher.append(") = 0 RETURN n");
+
+    assertThatThrownBy(() -> new Cypher25AntlrParser().parse(cypher.toString()))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("arcadedb.cypher.maxExpressionDepth");
+  }
+
+  @Test
+  void aFewArithmeticTermsStillParseFine() {
+    final String cypher = "MATCH (n) WHERE (1*2*3*4) = 24 RETURN n";
+
+    assertThatCode(() -> new Cypher25AntlrParser().parse(cypher)).doesNotThrowAnyException();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherExpressionDepthGuardIssue5851Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherExpressionDepthGuardIssue5851Test.java
@@ -35,25 +35,33 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * inputs without trouble because its hand-written recursive-descent implementation costs far fewer Java
  * stack frames per nesting level than the ANTLR4-generated Cypher parser's operator-precedence cascade.
  * <p>
- * Investigation found two independent recursion sites, not one:
+ * Investigation found two independent problems, not one:
  * <ul>
- *   <li>The ANTLR-generated parser itself, which re-enters its {@code expression} rule (and walks the full
- *   ~10-level precedence cascade) once per nesting nesting level for parentheses, list/map literals and
+ *   <li><b>Nesting.</b> The ANTLR-generated parser itself re-enters its {@code expression} rule (and walks
+ *   the full ~10-level precedence cascade) once per nesting level for parentheses, list/map literals and
  *   function arguments - the shape the issue reports and reproduces with 1001 nested parentheses.</li>
- *   <li>{@code ExpressionRewriter.rewrite()}, ArcadeDB's own post-parse AST rewrite visitor used to
- *   normalize/fold/simplify every {@code WHERE} condition. The grammar's {@code (OR expression11)*} and
- *   {@code (PLUS expression5)*} loops do <em>not</em> recurse in the parser (they are ANTLR quantifiers,
- *   not self-referencing rules), so a long flat chain of OR/AND/string-concatenation terms parses fine and
- *   only overflows afterwards, while this shared, statically-cached rewriter instance recursively walks the
- *   resulting deep expression tree. This is a distinct bug the issue's own diagnosis did not isolate: its
- *   captured stack trace was for the parentheses case only. Its "NOT NOT NOT ... true" shape is a
- *   Kleene-star loop in the grammar (not recursion), so it never reproduces in the parser at the depth the
- *   issue reports - but a long enough NOT chain still builds a deeply nested AST and is still caught, by
- *   this same rewriter-side guard - see {@link #longNotChainIsRejectedAsAParseErrorNotAStackOverflow()}.
+ *   <li><b>Chain length.</b> The grammar's {@code (OR expression11)*}, {@code (PLUS expression5)*} and
+ *   similar loops do <em>not</em> recurse in the parser (they are ANTLR quantifiers, not self-referencing
+ *   rules), so a long flat chain of OR/AND/NOT/string-concatenation terms parses fine on its own - the
+ *   issue's own diagnosis stopped there and assumed this shape was safe. It is not: every AST builder folds
+ *   such a chain into a left-associative binary tree exactly as deep as the term count, and that tree is
+ *   then walked recursively by several independent passes - {@code ExpressionRewriter} (WHERE-clause
+ *   normalization - fixed first, see below), {@code CypherExpressionWalker} and {@code
+ *   CypherSemanticValidator#checkExpressionScope} (both reachable from <em>any</em> clause, not just WHERE)
+ *   were all confirmed to overflow independently, each on its own call stack shape.</li>
  * </ul>
- * Both sites are bounded by {@link GlobalConfiguration#CYPHER_MAX_EXPRESSION_DEPTH}, converting the crash
- * into a {@link CommandParsingException} (an ordinary client/parse error, HTTP 400) with a message that
- * names the limit and the config key to raise it.
+ * {@link com.arcadedb.query.opencypher.parser.CypherExpressionDepthGuard}, the same {@code
+ * ParseTreeListener} that bounds nesting, also bounds chain length directly on the grammar's own
+ * {@code (OP operand)*} term counts (using each rule's generated accessor, exactly as every AST builder
+ * would) - this rejects an oversized chain during parsing itself, before any tree is built, which protects
+ * every downstream walker at once rather than requiring each one to be found and patched individually.
+ * {@code ExpressionRewriter.rewrite()} carries its own, narrower {@code ThreadLocal} depth guard as
+ * defense-in-depth for the WHERE-clause tree shape specifically, in case something ever builds one without
+ * going through the guarded grammar rules.
+ * <p>
+ * Both mechanisms are bounded by {@link GlobalConfiguration#CYPHER_MAX_EXPRESSION_DEPTH}, converting the
+ * crash into a {@link CommandParsingException} (an ordinary client/parse error, HTTP 400) with a message
+ * that names the limit and the config key to raise it.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -109,7 +117,7 @@ class CypherExpressionDepthGuardIssue5851Test extends TestHelper {
 
     assertThatThrownBy(() -> new Cypher25AntlrParser().parse(cypher.toString()))
         .isInstanceOf(CommandParsingException.class)
-        .hasMessageContaining("deeply nested or chained")
+        .hasMessageContaining("chained")
         .hasMessageContaining("arcadedb.cypher.maxExpressionDepth");
   }
 
@@ -135,11 +143,10 @@ class CypherExpressionDepthGuardIssue5851Test extends TestHelper {
   /**
    * {@code NOT*} is a Kleene-star quantifier in the grammar ({@code expression9: NOT* expression8}), not a
    * self-referencing rule, so a chain of {@code NOT}s does not re-enter {@code expression} and never trips
-   * the parser-side guard - confirmed here by an input depth (2000) at which the un-guarded parser is
-   * already known not to overflow. It does, however, get built into a chain of nested {@code
-   * LogicalExpression(NOT, ...)} AST nodes, which {@code ExpressionRewriter} then walks recursively, so a
-   * long enough chain is still caught by the rewriter-side guard - a strictly wider protection than the
-   * issue's own diagnosis asked for.
+   * the parser's nesting guard on its own. It does get built into a chain of nested AST nodes exactly as
+   * deep as the NOT count, which the parser's chain-length guard now catches directly (by counting {@code
+   * NOT} tokens on the {@code expression9} context) - a strictly wider protection than the issue's own
+   * diagnosis asked for.
    */
   @Test
   void moderateNotChainStillParsesFine() {

--- a/engine/src/test/java/com/arcadedb/query/sql/antlr/SqlExpressionDepthGuardIssue5851FollowupTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/antlr/SqlExpressionDepthGuardIssue5851FollowupTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.antlr;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.query.sql.parser.Statement;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Follow-up to issue #5851: unlike the OpenCypher parser, the ANTLR-based SQL parser is not at risk of a
+ * {@link StackOverflowError} from deeply nested parentheses - its recursive-descent grammar costs far fewer
+ * Java stack frames per nesting level. It is, however, at risk of a worse failure: {@link SQLAntlrParser}
+ * resolves the ambiguity between the several grammar rules that all start with a bare '(' (a parenthesized
+ * expression, condition, or sub-statement) by trying a fast SLL prediction first and falling back to full
+ * ALL(*) prediction on failure. That fallback's cost grows steeply enough with nesting depth that a query of
+ * only a few KB can tie up a worker thread for minutes without ever crashing - confirmed here by timing a
+ * depth (6000) that previously took well over two minutes of CPU before being interrupted; a legitimate,
+ * merely-slow query is not distinguishable from that hang from the outside, which is what makes it worse
+ * than a fast StackOverflowError.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SqlExpressionDepthGuardIssue5851FollowupTest {
+
+  @AfterEach
+  void resetConfig() {
+    GlobalConfiguration.SQL_MAX_EXPRESSION_DEPTH.setValue(GlobalConfiguration.SQL_MAX_EXPRESSION_DEPTH.getDefValue());
+  }
+
+  @Test
+  void deeplyNestedParenthesesAreRejectedFastRatherThanHanging() {
+    final SQLAntlrParser parser = new SQLAntlrParser(null);
+    final String sql = "SELECT FROM V WHERE " + "(".repeat(6000) + "1=1" + ")".repeat(6000);
+
+    final long start = System.currentTimeMillis();
+    assertThatThrownBy(() -> parser.parse(sql))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("nest")
+        .hasMessageContaining("arcadedb.sql.maxExpressionDepth");
+    final long elapsed = System.currentTimeMillis() - start;
+
+    // Rejected on the O(n) token-stream pre-scan, well before any ANTLR prediction work: previously this
+    // exact input burned well over two minutes of CPU before being forcibly interrupted.
+    assertThat(elapsed).as("expected a fast rejection").isLessThan(5000);
+  }
+
+  @Test
+  void moderatelyNestedParenthesesStillParseFine() {
+    final SQLAntlrParser parser = new SQLAntlrParser(null);
+    final String sql = "SELECT FROM V WHERE " + "(".repeat(50) + "1=1" + ")".repeat(50);
+
+    assertThatCode(() -> parser.parse(sql)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void nestedFunctionCallsAndSubSelectsStillParseFine() {
+    final SQLAntlrParser parser = new SQLAntlrParser(null);
+    final Statement stmt = parser.parse(
+        "SELECT FROM V WHERE ((a = 1) AND (b = 2)) OR (c IN (SELECT FROM V2 WHERE (d > 0)))");
+    assertThat(stmt).isNotNull();
+  }
+
+  /** A '(' inside a string literal must not count toward the nesting depth. */
+  @Test
+  void parenthesesInsideAStringLiteralAreNotCounted() {
+    final SQLAntlrParser parser = new SQLAntlrParser(null);
+    final String literalFullOfParens = "(".repeat(6000);
+    final String sql = "SELECT FROM V WHERE name = '" + literalFullOfParens + "'";
+
+    assertThatCode(() -> parser.parse(sql)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void raisingTheConfiguredLimitAllowsADeeperQueryThatWasPreviouslyRejected() {
+    final SQLAntlrParser parser = new SQLAntlrParser(null);
+    final String sql = "SELECT FROM V WHERE " + "(".repeat(300) + "1=1" + ")".repeat(300);
+
+    // Rejected at the default (200)
+    assertThatThrownBy(() -> parser.parse(sql)).isInstanceOf(CommandSQLParsingException.class);
+
+    // Accepted once the operator raises the knob
+    GlobalConfiguration.SQL_MAX_EXPRESSION_DEPTH.setValue(500);
+    assertThatCode(() -> parser.parse(sql)).doesNotThrowAnyException();
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #5851 / PR #5859, requested after that PR merged: extend the same investigation to SQL, and audit other recursive Cypher AST walkers for the same failure class. Both turned up real, confirmed gaps.

### Cypher: the chain-length guard only covered `WHERE`

`ExpressionRewriter`'s recursion guard (added in #5859) only fires from `CypherASTBuilder#visitWhereClause`. A long OR/AND/NOT/comparison/arithmetic chain written anywhere *other* than a top-level `WHERE` condition - a `RETURN` projection, an `ORDER BY` item, a function argument - was never rewritten and so never hit that guard. Confirmed with a real repro: a 30000-term OR chain in a `RETURN` projection still produced a `StackOverflowError`, this time inside `CypherSemanticValidator#checkExpressionScope` - a completely different, independent recursive walker from `ExpressionRewriter`.

Patching that one walker would just repeat the mistake with a new blind spot the next time some other pass (`CypherExpressionWalker`, execution-time evaluation, anything not yet written) walks such a tree. Instead, `CypherExpressionDepthGuard` - the same `ParseTreeListener` already attached to the parser for nesting depth - now also bounds the term count of every `(OP operand)*`-shaped grammar rule directly: OR, XOR, AND, `NOT*`, chained comparisons, and the three arithmetic precedence levels. Each check uses that rule's own generated accessor (`ctx.expression11()`, `ctx.NOT()`, ...) - the exact same one every AST builder in the package calls - so the count can never drift from what would actually be folded into a tree. This rejects an oversized chain during parsing, before any tree is built, regardless of clause or which pass would eventually have walked it.

### SQL: not at risk of a stack overflow, but at risk of something worse

The production SQL parser is `SQLAntlrParser` (ANTLR4-based, like Cypher's - the legacy hand-maintained JavaCC `SqlParser` is dead code, unreferenced anywhere). It genuinely isn't at risk of the parenthesis-nesting `StackOverflowError` (confirmed - its grammar's left-recursion elimination costs far fewer Java stack frames per nesting level than Cypher's precedence cascade). It is, however, at risk of something arguably worse: it resolves the ambiguity between several grammar rules that all start with a bare `(` (a parenthesized expression, condition, or sub-statement) by trying a fast SLL prediction first and falling back to full ALL(*) prediction on failure. For deeply nested parentheses that fallback's cost grows steeply enough that ~6000 nested parens (a few KB) tied up a worker thread for **well over two minutes of CPU** without ever crashing - measured directly, and worse than a fast error since a slow hang isn't distinguishable from a legitimately slow query from the outside.

`SQLAntlrParser` now counts parenthesis nesting on the token stream (reusing the already-buffered `CommonTokenStream`, same technique the Cypher parser already used for its deprecated-syntax pre-check) before attempting any parse, rejecting past `arcadedb.sql.maxExpressionDepth` (default 200) in O(n) time. The same depth that previously burned 2+ minutes of CPU is now rejected in ~4ms. Counting on the token stream rather than raw characters means a `(` inside a string literal or comment - already lexed as part of that token - is never miscounted (covered by a test).

## Test plan

- [x] New `CypherChainLengthGuardIssue5851FollowupTest` (8 tests): long OR chain in `RETURN`, long AND chain in `ORDER BY`, long chained-comparison (`a<b<c<...`), long multiplication and power chains all now fail with `CommandParsingException` instead of `StackOverflowError`; short/legitimate versions of each still parse fine.
- [x] New `SqlExpressionDepthGuardIssue5851FollowupTest` (5 tests): the 6000-paren hang is now rejected in single-digit ms; moderate nesting, nested function calls/sub-selects, and parens inside a string literal all still parse fine; the config is a real, effective knob.
- [x] Updated `CypherExpressionDepthGuardIssue5851Test` (9 tests, from #5859) - the OR-chain and NOT-chain cases are now caught earlier (by the parser's chain-length check rather than `ExpressionRewriter`), message assertions and doc comments updated accordingly; all still pass.
- [x] `mvn -pl engine test` across the full opencypher top-level/parser/rewriter suite and the full SQL parser/antlr suite: 2744 tests, 0 failures, 0 errors.
- [x] `mvn -pl engine -am compile` clean.

## Known residual (not fixed here, flagged for visibility)

The two guards (parser nesting ≤200, chain length ≤200 per level) compose: a deliberately-crafted input nesting many parenthesized groups, each containing its own near-limit chain, could in principle reach an AST depth well past either individual limit along one root-to-leaf path. This wasn't reproduced (it requires a much larger, more deliberately-constructed payload than either bug reported here), and closing it properly needs a running depth budget threaded through AST construction rather than two independent local checks - a larger change than this fix warrants. Noting it rather than quietly leaving it undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)