### PR TITLE
fix(#5862): PostBatchHandler emits the X-ArcadeDB-Commit-Index bookmark for GraphBatch imports

### DIFF
--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftRemoteReadYourWritesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftRemoteReadYourWritesIT.java
@@ -21,6 +21,7 @@ package com.arcadedb.server.ha.raft;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.remote.ReadConsistency;
 import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.remote.RemoteGraphBatch;
 import com.arcadedb.server.BaseGraphServerTest;
 
 import org.junit.jupiter.api.Test;
@@ -137,6 +138,112 @@ class RaftRemoteReadYourWritesIT extends BaseRaftHATest {
             .as("Reader's lastCommitIndex must advance after querying the follower")
             .isGreaterThanOrEqualTo(finalWriterIndex);
       }
+    }
+  }
+
+  /**
+   * Regression test for issue #5862: {@code RemoteGraphBatch} imports go through
+   * {@code RemoteDatabase.sendBatch()} / the server's {@code PostBatchHandler}, a write path that bypasses
+   * {@code DatabaseAbstractHandler} entirely (GraphBatch commits internally, one Raft entry per
+   * {@code commitEvery} chunk). Before the fix neither side of that path touched the
+   * {@code X-ArcadeDB-Commit-Index} bookmark, so a client importing through {@code RemoteGraphBatch} had no
+   * bookmark to carry into a follower read - unlike the {@code writer.command(...)} path exercised by
+   * {@link #remoteClientSeesWriteOnFollowerWithReadYourWrites()} above.
+   * <p>
+   * {@code writer} is a connection dedicated to the batch call and nothing else: its {@code lastCommitIndex}
+   * starts at the documented sentinel {@code -1} and the ONLY request it ever issues is the GraphBatch
+   * import, so an unchanged {@code -1} afterward can only mean {@code sendBatch()} failed to capture the
+   * response header. A shared connection that had already run a prior command (whose own response also
+   * carries the header) would leave that question ambiguous - a stale-but-non-negative index looks
+   * identical to a freshly captured one.
+   */
+  @Test
+  void remoteClientSeesGraphBatchWriteOnFollowerWithReadYourWrites() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final int followerIndex = leaderIndex == 0 ? 1 : 0;
+    final int leaderPort = 2480 + leaderIndex;
+    final int followerPort = 2480 + followerIndex;
+    final String dbName = getDatabaseName();
+    final String password = BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+    final String vertexType = "RywBatchVertex";
+
+    // Dedicated connection, used only to create the vertex type: kept separate from "writer" below so the
+    // regression assertion is not muddied by an earlier response's bookmark.
+    try (final RemoteDatabase setup = new RemoteDatabase("127.0.0.1", leaderPort, dbName, "root", password)) {
+      setup.command("sql", "CREATE VERTEX TYPE " + vertexType);
+    }
+
+    try (final RemoteDatabase writer = new RemoteDatabase("127.0.0.1", leaderPort, dbName, "root", password)) {
+      writer.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+      assertThat(writer.getLastCommitIndex()).as("Fresh connection must start with no bookmark captured").isEqualTo(-1L);
+
+      try (final RemoteGraphBatch batch = writer.batch().build()) {
+        batch.createVertex(vertexType, "id", "v1");
+        batch.createVertex(vertexType, "id", "v2");
+      }
+
+      final long writerIndex = writer.getLastCommitIndex();
+      assertThat(writerIndex)
+          .as("sendBatch() must capture the X-ArcadeDB-Commit-Index header from the PostBatchHandler response")
+          .isGreaterThanOrEqualTo(0);
+
+      try (final RemoteDatabase reader = new RemoteDatabase("127.0.0.1", followerPort, dbName, "root", password)) {
+        reader.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+        // Seed the reader with the writer's commit index via reflection, since
+        // updateLastCommitIndex is package-private in com.arcadedb.remote.
+        final var updateMethod = RemoteDatabase.class.getDeclaredMethod("updateLastCommitIndex", long.class);
+        updateMethod.setAccessible(true);
+        updateMethod.invoke(reader, writerIndex);
+
+        final ResultSet rs = reader.query("sql", "SELECT FROM " + vertexType);
+        final long count = rs.stream().count();
+        assertThat(count)
+            .as("Follower must see the vertices batch-imported on the leader when using READ_YOUR_WRITES")
+            .isEqualTo(2);
+      }
+    }
+  }
+
+  /**
+   * Regression test for issue #5862's forwarding half: a batch request that lands on a follower is
+   * relayed to the leader by {@code PostBatchHandler.forwardBatchToLeader}, and {@code ExecutionResponse}
+   * carries only status + body - so the leader's {@code X-ArcadeDB-Commit-Index} header has to be copied
+   * onto the follower's own response explicitly, or a client that happened to connect to a follower would
+   * never see the bookmark despite the leader having just emitted it.
+   */
+  @Test
+  void remoteClientOnFollowerCapturesCommitIndexForwardedFromLeaderOnGraphBatch() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final int followerIndex = leaderIndex == 0 ? 1 : 0;
+    final int leaderPort = 2480 + leaderIndex;
+    final int followerPort = 2480 + followerIndex;
+    final String dbName = getDatabaseName();
+    final String password = BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+    final String vertexType = "RywBatchForwardedVertex";
+
+    try (final RemoteDatabase setup = new RemoteDatabase("127.0.0.1", leaderPort, dbName, "root", password)) {
+      setup.command("sql", "CREATE VERTEX TYPE " + vertexType);
+    }
+
+    // Connected directly to the FOLLOWER: PostBatchHandler on this node sees ha.isLeader() == false and
+    // forwards the request to the leader instead of running GraphBatch locally.
+    try (final RemoteDatabase writer = new RemoteDatabase("127.0.0.1", followerPort, dbName, "root", password)) {
+      writer.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+      assertThat(writer.getLastCommitIndex()).as("Fresh connection must start with no bookmark captured").isEqualTo(-1L);
+
+      try (final RemoteGraphBatch batch = writer.batch().build()) {
+        batch.createVertex(vertexType, "id", "v1");
+      }
+
+      assertThat(writer.getLastCommitIndex())
+          .as("The follower must relay the leader's X-ArcadeDB-Commit-Index header back to the client, "
+              + "not just the status code and body of the forwarded response")
+          .isGreaterThanOrEqualTo(0);
     }
   }
 }

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -756,6 +756,12 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
 
       final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
+      // GraphBatch commits internally every commitEvery records (issue #5862), so unlike a single
+      // begin/commit/rollback a non-200 response here can still carry chunks the server already made
+      // durable (see PostBatchHandler's partialCommit responses): the bookmark is captured unconditionally,
+      // not only on success, or a READ_YOUR_WRITES client would silently miss the records that did commit.
+      captureCommitIndexHeader(response);
+
       if (response.statusCode() != 200) {
         final Exception detail = manageException(response, "batch import");
         throw new DatabaseOperationException("Error on batch import", detail);

--- a/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.remote;
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.DatabaseIsClosedException;
+import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.utility.Pair;
 import org.junit.jupiter.api.AfterEach;
@@ -359,6 +360,73 @@ class RemoteDatabaseTest {
 
         db.begin();
         db.commit();
+
+        assertThat(db.getLastCommitIndex()).isEqualTo(-1L);
+      } finally {
+        db.close();
+      }
+    });
+  }
+
+  // commit-index bookmark capture tests, regression for issue #5862
+
+  @Test
+  void sendBatchCapturesCommitIndexHeaderForReadYourWrites() throws Exception {
+    withHttpServer(List.of(
+        new StubResponse(200, "{\"verticesCreated\":1,\"edgesCreated\":0}", Map.of("X-ArcadeDB-Commit-Index", "42"))
+    ), port -> {
+      final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", port, "testdb", "root", "test");
+      try {
+        db.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+        db.sendBatch("{\"@type\":\"V\",\"@id\":\"v1\"}\n", Map.of());
+
+        // PostBatchHandler bypasses DatabaseAbstractHandler and commits internally (commitEvery), so the
+        // bookmark it publishes on the response is the only place a READ_YOUR_WRITES client can learn how
+        // far a bulk import got - without capturing it here the next read is silently served at EVENTUAL
+        // consistency (issue #5862).
+        assertThat(db.getLastCommitIndex())
+            .as("sendBatch() must capture the X-ArcadeDB-Commit-Index response header")
+            .isEqualTo(42);
+      } finally {
+        db.close();
+      }
+    });
+  }
+
+  @Test
+  void sendBatchCapturesCommitIndexHeaderEvenOnPartialCommitFailure() throws Exception {
+    // GraphBatch is NOT atomic: a non-200 response mid-stream can still carry chunks committed before the
+    // failure (PostBatchHandler's partialCommit response), so the bookmark must be captured regardless of
+    // the HTTP status code, not only on success.
+    withHttpServer(List.of(
+        new StubResponse(400, "{\"error\":\"boom\",\"verticesCreated\":1,\"edgesCreated\":0,\"partialCommit\":true}",
+            Map.of("X-ArcadeDB-Commit-Index", "7"))
+    ), port -> {
+      final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", port, "testdb", "root", "test");
+      try {
+        db.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+        assertThatThrownBy(() -> db.sendBatch("bad-line\n", Map.of()))
+            .isInstanceOf(DatabaseOperationException.class);
+
+        assertThat(db.getLastCommitIndex()).isEqualTo(7);
+      } finally {
+        db.close();
+      }
+    });
+  }
+
+  @Test
+  void sendBatchWithoutCommitIndexHeaderLeavesLastCommitIndexUnchanged() throws Exception {
+    withHttpServer(List.of(
+        new StubResponse(200, "{\"verticesCreated\":1,\"edgesCreated\":0}", Map.of())
+    ), port -> {
+      final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", port, "testdb", "root", "test");
+      try {
+        db.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+        db.sendBatch("{\"@type\":\"V\",\"@id\":\"v1\"}\n", Map.of());
 
         assertThat(db.getLastCommitIndex()).isEqualTo(-1L);
       } finally {

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -28,6 +28,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.HttpSessionException;
@@ -994,6 +995,37 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       if (user == null || user.canAccessToDatabase(databaseName))
         authorized.add(databaseName);
     return authorized;
+  }
+
+  /**
+   * Resolves the {@link HAReplicatedDatabase} backing {@code database}, either directly or through
+   * {@link DatabaseInternal#getWrappedDatabaseInstance()}, or {@code null} on a standalone (non-HA)
+   * database. Shared by {@link DatabaseAbstractHandler} and {@link PostBatchHandler} so the
+   * wrapper-unwrapping rule for HA read-your-writes support (bookmark header, read-consistency context)
+   * lives in one place.
+   */
+  protected static HAReplicatedDatabase resolveHAReplicatedDatabase(final DatabaseInternal database) {
+    if (database == null)
+      return null;
+    if (database instanceof HAReplicatedDatabase haDb)
+      return haDb;
+    return database.getWrappedDatabaseInstance() instanceof HAReplicatedDatabase haDb ? haDb : null;
+  }
+
+  /**
+   * Emits the {@code X-ArcadeDB-Commit-Index} response header, the read-your-writes bookmark a
+   * {@code READ_YOUR_WRITES} client captures and carries into its next read. A no-op when {@code haDb} is
+   * {@code null} (standalone database) or has not applied anything yet. Shared by
+   * {@link DatabaseAbstractHandler} (issue #5845) and {@link PostBatchHandler} (issue #5862), the only two
+   * write paths whose commit happens outside, or beyond, the generic per-request wrapper in
+   * {@link #handleRequest}.
+   */
+  protected static void emitCommitIndexBookmark(final HttpServerExchange exchange, final HAReplicatedDatabase haDb) {
+    if (haDb == null)
+      return;
+    final long lastApplied = haDb.getLastAppliedIndex();
+    if (lastApplied >= 0)
+      exchange.getResponseHeaders().put(new HttpString("X-ArcadeDB-Commit-Index"), String.valueOf(lastApplied));
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
@@ -114,8 +114,7 @@ public abstract class DatabaseAbstractHandler extends AbstractServerHttpHandler 
     final int retries = payload != null && !payload.isNull("retries") ? payload.getInt("retries") : 1;
 
     // Resolve HA database for read consistency (may be wrapped inside ServerDatabase).
-    final HAReplicatedDatabase haDbForRead = database instanceof HAReplicatedDatabase h ? h
-        : (database != null && database.getWrappedDatabaseInstance() instanceof HAReplicatedDatabase h2 ? h2 : null);
+    final HAReplicatedDatabase haDbForRead = resolveHAReplicatedDatabase(database);
 
     final AtomicReference<ExecutionResponse> response = new AtomicReference<>();
     try {
@@ -183,11 +182,7 @@ public abstract class DatabaseAbstractHandler extends AbstractServerHttpHandler 
         database.commit();
 
       // Emit bookmark header for read-your-writes consistency
-      if (haDbForRead != null) {
-        final long lastApplied = haDbForRead.getLastAppliedIndex();
-        if (lastApplied >= 0)
-          exchange.getResponseHeaders().put(new HttpString("X-ArcadeDB-Commit-Index"), String.valueOf(lastApplied));
-      }
+      emitCommitIndexBookmark(exchange, haDbForRead);
 
     } finally {
       // Clear read consistency context

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.graph.GraphBatch;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.batch.BatchRecord;
@@ -38,6 +39,7 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.ServerConnection;
 import io.undertow.util.HeaderValues;
+import io.undertow.util.HttpString;
 import org.xnio.Options;
 
 import java.io.FilterInputStream;
@@ -242,8 +244,17 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       final GraphBatch.Builder builder = database.batch();
       configureBuilder(exchange, builder);
 
-      return streamRecords(exchange, databaseName, isCsv, builder, inputStream, newVertexRefResolver(exchange),
-          System.currentTimeMillis(), parseVertexBatchSize(exchange), parseExpectedRecords(exchange));
+      // GraphBatch commits incrementally (commitEvery), so unlike every other write endpoint the
+      // READ_YOUR_WRITES bookmark has to be emitted even when the load ends in a partial-commit error
+      // (408/400): whatever chunk got through is already durable, and a client must be able to read it
+      // back regardless of how the request itself was answered (issue #5862).
+      final HAReplicatedDatabase haDb = resolveHAReplicatedDatabase(database);
+      try {
+        return streamRecords(exchange, databaseName, isCsv, builder, inputStream, newVertexRefResolver(exchange),
+            System.currentTimeMillis(), parseVertexBatchSize(exchange), parseExpectedRecords(exchange));
+      } finally {
+        emitCommitIndexBookmark(exchange, haDb);
+      }
     } finally {
       restoreConnectionReadTimeout(exchange, previousReadTimeout);
     }
@@ -966,6 +977,13 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
 
     try {
       final HttpResponse<String> response = HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+
+      // ExecutionResponse carries only status + body, so the leader's X-ArcadeDB-Commit-Index bookmark
+      // (issue #5862) has to be copied onto this exchange explicitly, or a READ_YOUR_WRITES client that
+      // landed on a follower would never see it despite the leader having just emitted it.
+      response.headers().firstValue("X-ArcadeDB-Commit-Index")
+          .ifPresent(val -> exchange.getResponseHeaders().put(new HttpString("X-ArcadeDB-Commit-Index"), val));
+
       return new ExecutionResponse(response.statusCode(), response.body());
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();


### PR DESCRIPTION
## Summary

Follow-up to #5845 (fixed in #5858). That fix made `RemoteDatabase.begin()`/`commit()`/`rollback()` capture the `X-ArcadeDB-Commit-Index` bookmark, but it only covered the explicit-transaction path. Bulk imports via `RemoteGraphBatch` (`RemoteDatabase.sendBatch()`) go through `PostBatchHandler`, which doesn't extend `DatabaseAbstractHandler` and never emitted the header, so a `READ_YOUR_WRITES` client had no bookmark to carry forward after a batch import, on any code path (direct or forwarded through a follower).

## Changes

- Extracted `resolveHAReplicatedDatabase()` / `emitCommitIndexBookmark()` as shared helpers on `AbstractServerHttpHandler` (the common ancestor of both `DatabaseAbstractHandler` and `PostBatchHandler`), reused by `DatabaseAbstractHandler` to remove the duplicated resolution/emission logic
- `PostBatchHandler` now emits the bookmark once the batch finishes - **even on a partial-commit error (400/408)**: `GraphBatch` commits every `commitEvery` records, so a failure mid-stream can still leave earlier chunks durably committed and readable
- `forwardBatchToLeader` (follower → leader relay) copies the header onto its own response: `ExecutionResponse` only carries status + body, so without this a client that happened to land on a follower would never see the bookmark the leader just emitted
- `RemoteDatabase.sendBatch()` captures the header unconditionally (not only on HTTP 200), mirroring the partial-commit reasoning on the client side

## Test plan

- [x] `RemoteDatabaseTest` (network module): 3 new deterministic unit tests using a loopback HTTP stub - `sendBatch()` captures the header on success, on a partial-commit failure (400), and leaves the bookmark unchanged when the header is absent. Verified each fails without the client-side fix and passes with it.
- [x] `RaftRemoteReadYourWritesIT` (ha-raft module, real 3-node Raft cluster): 2 new end-to-end tests -
  - a fresh `RemoteDatabase` connection whose only request is a `RemoteGraphBatch` import must go from the documented `-1` sentinel to a captured non-negative bookmark, and a follower seeded with that bookmark must see the imported vertices
  - a batch sent directly to a **follower** (forwarded to the leader) must relay the leader's header back to the client
  - Verified both fail without the corresponding fix (confirmed by reverting main-source changes and re-running against a correctly rebuilt reactor)
- [x] Existing suites unaffected: `PostBatchHandlerIT` (26), `Issue5470BatchErrorDeliveryIT` (12), `Issue5470BatchStreamStallIT` (3), `Issue5064CommittedRemotelyHttpStatusTest` (5), `DatabaseAbstractHandlerBookmarkParseTest` (3), `RemoteGraphBatchIT` (12), `RemoteHttpComponentTest` (68) - all green
- [x] Full reactor `mvn compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)