### PR TITLE
fix(engine) #5873: keep the graph search's answer instead of replacing it with a resume that returns nothing

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3937,9 +3937,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
             final int effectiveEfSearch = Math.max(k, metadata.efSearch);
             searchResult = searcher.search(ssp, k, effectiveEfSearch, 0.0f, 0.0f, bitsFilter);
           } else {
-            // Adaptive efSearch with resume for insufficient results (issue #3722).
-            // Both small and large graphs use the same two-pass strategy: search first,
-            // resume with wider beam if too few results are returned.
+            // Adaptive efSearch (issue #3722): size the beam to the graph and keep whatever it finds.
+            //
+            // There used to be a second pass here - `if (firstPass.getNodes().length < k) searchResult =
+            // searcher.resume(...)` - meant to widen the beam when the search came up short. It could only ever
+            // make things worse, and issue #5873 is what it cost. A short first pass means the result queue never
+            // reached rerankK, and JVector's searchOneLayer breaks early *only* once the queue is that full, so the
+            // loop must instead have run its candidate queue dry - having expanded every node reachable from the
+            // entry point. resume() pushes the (empty) evicted pile back onto that same empty queue and returns
+            // zero nodes, so the assignment threw the first pass away and handed the caller nothing. Width was
+            // never what ran out either, so a wider fresh search would have visited exactly the same nodes.
+            //
+            // What is actually left unreached at that point is whatever the graph cannot walk to, and the only
+            // thing that finds it is the brute-force scan below - which is already there, already gated on the
+            // shortfall, and now starts from the rows the graph did find instead of from nothing.
             final int graphSize = graphIndex.size();
             final int initialEfSearch;
             if (graphSize < 10_000)
@@ -3947,13 +3958,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             else
               initialEfSearch = Math.max(k * 2, 20);
 
-            final SearchResult firstPass = searcher.search(ssp, k, initialEfSearch, 0.0f, 0.0f, bitsFilter);
-            if (firstPass.getNodes().length < k && graphSize >= k) {
-              // Graph has enough nodes but beam search found too few - widen the beam
-              searchResult = searcher.resume(k, Math.max(k * 10, 100));
-            } else {
-              searchResult = firstPass;
-            }
+            searchResult = searcher.search(ssp, k, initialEfSearch, 0.0f, 0.0f, bitsFilter);
           }
         } finally {
           pool.release(searcher, pooledGraph, poolEpoch);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue5873AdaptiveResumeFirstPassTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue5873AdaptiveResumeFirstPassTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.utility.Pair;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5873: the adaptive-{@code efSearch} branch of {@code findNeighborsFromVector} answered a short first pass by
+ * replacing it with {@code searcher.resume(...)} rather than adding to it, and the resume could only ever return
+ * nothing.
+ * <p>
+ * The branch is gated on {@code firstPass.getNodes().length < k}. JVector's {@code searchOneLayer} breaks early only
+ * when its result queue has reached {@code rerankK} candidates, and {@code rerankK >= k} here, so a first pass that
+ * came back with fewer than {@code k} cannot have stopped early: it ran its candidate queue dry, having expanded
+ * every node reachable from the entry point. {@code resume} pushes the (empty) evicted pile back onto that same empty
+ * queue and returns immediately with zero nodes - and for the same reason a wider beam would not have helped either,
+ * because width is not what ran out. So the branch threw away a correct partial answer, and the brute-force fallback
+ * then walked every ordinal in the index to reconstruct what the graph had already found.
+ * <p>
+ * The fixture is a graph whose live vectors are far fewer than {@code k}: 1500 vectors with all but four deleted, and
+ * rebuilds frozen so the tombstones stay in the graph. That is the shape the branch needs - plenty of graph, almost
+ * nothing admissible - and it is the shape a tombstone-heavy index has between rebuilds.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5873AdaptiveResumeFirstPassTest extends TestHelper {
+
+  private static final int DIMENSIONS = 8;
+  private static final int VERTICES   = 1500;
+  private static final int SURVIVORS  = 4;
+  private static final int K          = 10;
+
+  @BeforeEach
+  void freezeTheGraph() {
+    // Keep the deleted vectors in the graph: a rebuild would drop them, the graph would shrink below k and the
+    // branch under test would never be reached. This is what an index looks like between rebuilds.
+    GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.setValue(1_000_000);
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO.setValue(0f);
+    GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS.setValue(0);
+  }
+
+  @AfterEach
+  void thawTheGraph() {
+    GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.reset();
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO.reset();
+    GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS.reset();
+  }
+
+  /**
+   * What the graph search found has to reach the caller, and the brute-force scan must not be asked to find it again.
+   * The scan walks every ordinal in the index - the most expensive thing this index does - so firing it to recover
+   * rows the search had already produced is pure waste, and it also makes {@code bruteForceScans} report a degraded
+   * graph when the graph did its job.
+   */
+  @Test
+  void aShortFirstPassIsKeptInsteadOfBeingScannedForAgain() {
+    createSchema();
+    insertVertices();
+    final List<RID> survivors = deleteAllButTheSurvivors();
+
+    // Preconditions: without these the test would pass without ever reaching the branch it is about.
+    assertThat(vectorIndex().getStats().get("graphNodeCount"))
+        .as("the graph has to hold at least k nodes, or the branch's own gate is not met").isGreaterThanOrEqualTo(K);
+    assertThat(vectorIndex().getStats().get("activeVectors"))
+        .as("and fewer than k of them may be live, or the first pass would not come back short")
+        .isEqualTo(SURVIVORS).isLessThan(K);
+
+    final long scansBefore = vectorIndex().getStats().get("bruteForceScans");
+    final List<Pair<RID, Float>> neighbors = vectorIndex().findNeighborsFromVector(embedding(0), K);
+
+    assertThat(ridsOf(neighbors)).as("every live vector is reachable and has to come back, got %s", neighbors)
+        .containsExactlyInAnyOrderElementsOf(survivors);
+    assertThat(vectorIndex().getStats().get("bruteForceScans"))
+        .as("the graph search already had the whole answer, so nothing may walk the index to find it again")
+        .isEqualTo(scansBefore);
+  }
+
+  /** Distances still come back ascending, and no row is duplicated by the path that keeps the first pass. */
+  @Test
+  void theKeptFirstPassIsStillARankedAnswer() {
+    createSchema();
+    insertVertices();
+    deleteAllButTheSurvivors();
+
+    final List<Pair<RID, Float>> neighbors = vectorIndex().findNeighborsFromVector(embedding(0), K);
+
+    assertThat(ridsOf(neighbors)).as("a row kept from the first pass must not also be added by anything downstream")
+        .doesNotHaveDuplicates();
+    for (int i = 1; i < neighbors.size(); i++)
+      assertThat(neighbors.get(i).getSecond()).as("row %d is nearer than row %d, so the answer is not sorted", i, i - 1)
+          .isGreaterThanOrEqualTo(neighbors.get(i - 1).getSecond());
+  }
+
+  /**
+   * The healthy case has to be untouched: with every vector live, a query for k gets k, and still no scan. This is
+   * what pins the change to the short-answer branch rather than to the search as a whole.
+   */
+  @Test
+  void aFullyLiveIndexIsUnaffected() {
+    createSchema();
+    insertVertices();
+
+    final long scansBefore = vectorIndex().getStats().get("bruteForceScans");
+    final List<Pair<RID, Float>> neighbors = vectorIndex().findNeighborsFromVector(embedding(0), K);
+
+    assertThat(neighbors).as("a healthy graph answers a k-NN query in full").hasSize(K);
+    assertThat(vectorIndex().getStats().get("bruteForceScans")).as("and does not fall back").isEqualTo(scansBefore);
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private List<RID> ridsOf(final List<Pair<RID, Float>> neighbors) {
+    final List<RID> rids = new ArrayList<>(neighbors.size());
+    for (final Pair<RID, Float> neighbor : neighbors)
+      rids.add(neighbor.getFirst().getIdentity());
+    return rids;
+  }
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON Doc (id) UNIQUE");
+      database.getSchema().buildTypeIndex("Doc", new String[] { "embedding" }).withLSMVectorType()
+          .withDimensions(DIMENSIONS).withSimilarity("COSINE").create();
+    });
+  }
+
+  private void insertVertices() {
+    database.transaction(() -> {
+      for (int i = 0; i < VERTICES; i++)
+        database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + i, embedding(i));
+    });
+    // The graph is built on the first search, and only above ASYNC_REBUILD_MIN_GRAPH_SIZE - below it every query is
+    // answered by the delta scan and the graph search this test is about never runs at all.
+    vectorIndex().findNeighborsFromVector(embedding(0), 1);
+  }
+
+  private List<RID> deleteAllButTheSurvivors() {
+    final List<RID> survivors = new ArrayList<>(SURVIVORS);
+    database.transaction(() -> {
+      for (int i = 0; i < SURVIVORS; i++)
+        survivors.add(ridOf("doc" + i));
+      for (int i = SURVIVORS; i < VERTICES; i++)
+        database.command("sql", "DELETE FROM Doc WHERE id = ?", "doc" + i);
+    });
+    return survivors;
+  }
+
+  private RID ridOf(final String id) {
+    try (final var rs = database.query("sql", "SELECT FROM Doc WHERE id = ?", id)) {
+      return rs.next().getIdentity().orElseThrow();
+    }
+  }
+
+  /** Points on an arc, so "nearest" is decidable and the survivors are the four closest to the query at vertex 0. */
+  private float[] embedding(final int vertex) {
+    final float[] v = new float[DIMENSIONS];
+    final double theta = vertex * 0.001;
+    for (int m = 1; m <= DIMENSIONS / 2; m++) {
+      v[(m - 1) * 2] = (float) (Math.cos(m * theta) / m);
+      v[(m - 1) * 2 + 1] = (float) (Math.sin(m * theta) / m);
+    }
+    return v;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return (LSMVectorIndex) ((TypeIndex) database.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBruteForceScanTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBruteForceScanTest.java
@@ -127,7 +127,8 @@ class LSMVectorIndexBruteForceScanTest extends TestHelper {
     for (int i = total - kept; i < total; i++)
       keptRids.add(ridByIndex[i]);
 
-    // Capture WARNING logs to confirm the brute-force fallback actually fires.
+    // Capture WARNING logs to see whether the brute-force fallback fires. Since #5873 it must NOT: the graph
+    // search answers this fixture in full on its own, and the assertion at the bottom pins that.
     final List<String> captured = new CopyOnWriteArrayList<>();
     // #5773: getLogger(), not reflection on the private field - the accessor exists for exactly this
     // save-and-restore, and a field rename would break the reflective form with no compile error. NOTE that
@@ -142,9 +143,9 @@ class LSMVectorIndexBruteForceScanTest extends TestHelper {
       // match would neither rank first nor have a near-zero distance.
       for (int probe = total - kept; probe < total; probe++) {
         final RID expected = ridByIndex[probe];
-        // Request k = total: the stale graph still exposes all `total` ordinals (the deleted ones were
-        // not rebuilt away), so `expectedResults` is `total` while graph search can only surface the
-        // `kept` survivors. That gap (results < 80% of available) is what triggers the brute-force scan.
+        // Request k = total. The stale graph still exposes all `total` ordinals, but only the `kept` survivors
+        // are admissible, so the search walks a graph mostly made of tombstones to find them - which is the
+        // degraded shape this test is about, whether or not anything falls back afterwards.
         final List<Result> results = executeVectorSearch(vectorByIndex[probe], total);
 
         assertThat(results)
@@ -171,9 +172,85 @@ class LSMVectorIndexBruteForceScanTest extends TestHelper {
             .isLessThan(1e-3f);
       }
 
+      // Issue #5873. This assertion used to read the other way round, and it passed for the wrong reason: the
+      // adaptive branch replaced its short first pass with `searcher.resume(...)`, which on a dry candidate queue
+      // returns nothing, so the answer above arrived empty at the fallback and the scan rebuilt it from all 1200
+      // ordinals - 50 times over, once per probe. The graph search had already found all 50 survivors. Now that
+      // the first pass is kept, `expectedResults` is the live count, the answer already meets it, and no scan
+      // runs. Everything asserted above still holds, which is the point: the scan was never adding anything.
       assertThat(captured)
-          .as("The brute-force fallback WARNING must fire, proving the scan path is exercised")
+          .as("the graph search found every survivor, so nothing may walk 1200 ordinals to find them again")
+          .noneMatch(m -> m != null && m.contains("falling back to brute-force scan"));
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
+  }
+
+  /**
+   * The end-to-end route into the brute-force fallback that survives #5873, so the "a real query reaches the scan
+   * and the scan pairs each RID with its own score" claim keeps a test.
+   * <p>
+   * An allow-list narrower than {@code k} is the case: the graph can only ever answer with the allowed rows, which
+   * is fewer than the {@code k} the caller asked for, so {@code expectedResults} stays above what the search returns
+   * and the fallback fires every time (issue #5748). Unlike the stale-graph fixture above, that shortfall is real -
+   * the answer genuinely cannot be filled from the graph - so the scan has something to do.
+   */
+  @Test
+  void aNarrowAllowListStillReachesTheFallbackEndToEnd() {
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, 100_000);
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, -1);
+
+    final int total = 1200;
+    final int allowed = 3;
+
+    final RID[] ridByIndex = new RID[total];
+    final float[][] vectorByIndex = new float[total][];
+    database.transaction(() -> {
+      final VertexType type = database.getSchema().createVertexType("BFVec");
+      type.createProperty("name", Type.STRING);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      database.getSchema().buildTypeIndex("BFVec", new String[] { "vector" }).withLSMVectorType()
+          .withDimensions(DIMENSIONS).withSimilarity("EUCLIDEAN").withMaxConnections(16).withBeamWidth(100).create();
+    });
+    database.transaction(() -> {
+      for (int i = 0; i < total; i++) {
+        final float[] vec = createDeterministicVector(i, DIMENSIONS);
+        final MutableVertex v = database.newVertex("BFVec").set("name", "v" + i).set("vector", vec);
+        v.save();
+        ridByIndex[i] = v.getIdentity();
+        vectorByIndex[i] = vec;
+      }
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("BFVec[vector]");
+    final LSMVectorIndex index = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+    index.buildVectorGraphNow();
+
+    // Three RIDs scattered across the index, none of them adjacent to the others in the graph.
+    final Set<RID> whitelist = new HashSet<>();
+    for (int i = 0; i < allowed; i++)
+      whitelist.add(ridByIndex[i * (total / allowed)]);
+
+    final List<String> captured = new CopyOnWriteArrayList<>();
+    final Logger originalLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(new CapturingLogger(captured, originalLogger));
+    try {
+      // Probe with one whitelisted vertex's own vector: it has to rank first at ~0 distance, which is exactly the
+      // RID-to-score pairing issue #4581 was about, now observed through a real query rather than by reflection.
+      final int probe = total / allowed;
+      final List<Pair<RID, Float>> results = index.findNeighborsFromVector(vectorByIndex[probe], 10, whitelist);
+
+      assertThat(captured).as("an allow-list narrower than k cannot be filled from the graph, so the scan must run")
           .anyMatch(m -> m != null && m.contains("falling back to brute-force scan"));
+      assertThat(results).as("and it answers with the whitelisted rows, and only those").hasSize(allowed);
+      for (final Pair<RID, Float> r : results)
+        assertThat(whitelist).as("a row outside the allow-list must not survive the scan").contains(
+            r.getFirst().getIdentity());
+      assertThat(results.getFirst().getFirst().getIdentity())
+          .as("a self-query must rank its own vertex first, or a RID was paired with another vector's score")
+          .isEqualTo(ridByIndex[probe]);
+      assertThat(results.getFirst().getSecond())
+          .as("at ~0 distance, for the same reason").isLessThan(1e-3f);
     } finally {
       LogManager.instance().setLogger(originalLogger);
     }


### PR DESCRIPTION
Fixes #5873.

### The defect

The adaptive-`efSearch` branch of `findNeighborsFromVector` answered a short first pass with `searchResult = searcher.resume(...)`, which replaces rather than adds to it - and the resume could not return anything, so the assignment threw the answer away. The brute-force fallback then walked every ordinal in the index to reconstruct what the graph had already found.

### Why resume was always empty

The branch is gated on `firstPass.getNodes().length < k`. JVector's `searchOneLayer` breaks early only once its result queue holds `rerankK` candidates, and `rerankK >= k` here, so a first pass that came back short cannot have stopped early: it ran its candidate queue dry, having expanded every node reachable from the entry point. `resume()` pushes the (empty) evicted pile back onto that same empty queue and returns zero nodes.

Width was never what ran out either, so the wider fresh search the comment was reaching for would have visited exactly the same nodes. The second pass is therefore removed rather than repaired.

### What replaces it

Nothing new. What is genuinely unreached at that point is whatever the graph cannot walk to, and the only thing that finds it is the brute-force scan - already there, already gated on the shortfall, and now starting from the rows the graph did find instead of from nothing. On the issue's reproduction (1500 vectors, all but four deleted, rebuilds frozen, k=10) the scan stops running entirely: the four survivors are the whole live population, so the answer already meets `expectedResults`.

This also stops `bruteForceScans` counting a shortfall the code manufactured. The metric exists to say the graph is degraded and needs rebuilding; here the graph had done its job.

### A test that was passing for the wrong reason

`LSMVectorIndexBruteForceScanTest.bruteForceFallbackPairsRidWithItsOwnScore` was reaching the fallback *only* through this defect - 50 full scans of 1200 ordinals per run, to recover 50 survivors the graph search had already returned. Every substantive assertion in it still passes; only the "the fallback WARNING must fire" one does not, and it is inverted here into a second regression test for #5873 on a different fixture.

With a healthy graph the fallback can now only fire on a genuinely degraded graph or a narrow `allowedRIDs` list, so that test's lost coverage is replaced by a new sibling taking the allow-list route (#5748) end-to-end, re-checking the #4581 RID-to-score pairing through a real query rather than by reflection.

### Verification

`Issue5873AdaptiveResumeFirstPassTest` - survivors returned with no scan, the kept answer still sorted and duplicate-free, a fully live index unaffected; preconditions assert the branch's own gate (graph >= k nodes, live < k) so it cannot pass vacuously. Mutation-checked by restoring the old branch: both #5873 assertions go red.

553 tests across `com.arcadedb.index.vector` and `com.arcadedb.function.sql.vector` green, plus `Issue5639IndexMetadataKeysTest` and `SQLVectorDatabaseFunctionsTest`.