### PR TITLE
test(mcp): authenticate root in the set_server_setting redaction IT

### DIFF
--- a/mcp/src/test/java/com/arcadedb/mcp/GetServerSettingsToolRedactionIT.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/GetServerSettingsToolRedactionIT.java
@@ -23,6 +23,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.mcp.tools.GetServerSettingsTool;
 import com.arcadedb.mcp.tools.SetServerSettingTool;
 import org.junit.jupiter.api.Test;
@@ -79,13 +80,18 @@ class GetServerSettingsToolRedactionIT extends BaseGraphServerTest {
       final MCPConfiguration config = new MCPConfiguration("./target/test");
       config.setAllowAdmin(true);
 
+      // set_server_setting is root-only (GHSA-pff6-hp53-pj54), so the redaction of the echoed previous value can
+      // only be exercised through a root principal. MCPServerAdminAuthorizationIT covers the denial side.
+      final ServerSecurityUser root = getServer(serverIndex).getSecurity()
+          .authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
+
       final JSONObject args = new JSONObject()
           .put("key", "arcadedb.ha.clusterToken")
           .put("value", "replacement-token");
 
       final JSONObject result;
       try {
-        result = SetServerSettingTool.execute(getServer(serverIndex), null, args, config);
+        result = SetServerSettingTool.execute(getServer(serverIndex), root, args, config);
       } finally {
         // This exercises the real setter, so it genuinely replaces the running server's cluster token.
         // Restore it before leaving: the token authenticates cluster-forwarded requests, and a later


### PR DESCRIPTION
## Problem

`GetServerSettingsToolRedactionIT.clusterTokenIsRedactedInMcpSetServerSetting` fails on `main`:

```
java.lang.SecurityException: Only the root user is authorized to execute the server administration operation 'set_server_setting'
    at com.arcadedb.mcp.tools.MCPToolUtils.checkServerAdmin(MCPToolUtils.java:119)
    at com.arcadedb.mcp.tools.SetServerSettingTool.execute(SetServerSettingTool.java:61)
    at com.arcadedb.mcp.GetServerSettingsToolRedactionIT.lambda$clusterTokenIsRedactedInMcpSetServerSetting$1(...:88)
```

## Cause

The test is stale, not the production code. Two security fixes were developed independently and collided in merge `f6517187a` (`26.8.1-security` -> `main`):

| Fix | What it introduced |
| --- | --- |
| GHSA-p9wc-4fhr-78wm | This test, calling `SetServerSettingTool.execute(server, null, args, config)` |
| GHSA-pff6-hp53-pj54 | `MCPToolUtils.checkServerAdmin`, which rejects `user == null` outright |

The root gate at `SetServerSettingTool.java:61` runs before any of the masking logic, so the redaction assertion the test exists to make became unreachable and the test failed on the gate instead.

Its sibling `clusterTokenIsRedactedInMcpServerSettings` keeps passing because `GetServerSettingsTool` is read-gated and never dereferences its `user` argument at all, which is why only one of the two methods went red.

## Fix

Authenticate a real root principal, the same way every other MCP test obtains a user (`MCPTransportConformanceTest:548`, `MCPResourcesTest:119`). This was the only test call site in the module still passing `null`.

The denial path stays covered by `MCPServerAdminAuthorizationIT.readerCannotInvokeServerAdminTools`, which asserts a non-root reader is refused `set_server_setting` and the other three server-admin tools, so routing this test through root loses no coverage. What it restores is the redaction assertion: `previousValue` must be `*****` rather than the cluster token it just replaced.

The test still exercises the real setter against the running server and still restores `HA_CLUSTER_TOKEN` in a `finally`, with the restore itself pinned by an assertion.

## Verification

```
mvn -pl mcp -am verify -DskipITs=false -Dit.test=GetServerSettingsToolRedactionIT
[INFO] Running com.arcadedb.mcp.GetServerSettingsToolRedactionIT
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Confirmed against `mcp/target/failsafe-reports/com.arcadedb.mcp.GetServerSettingsToolRedactionIT.txt`, not just the build status, so the green result is not a case of zero tests having matched.

Scope note: only this IT was run. The change is confined to one test file with no production code touched. Given the failure sat on `main` undetected since the merge, the module's remaining ITs may be worth a full pass separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)