### PR TITLE
fix(#5810): disconnected MATCH after a relationship pattern must fan out via Cartesian product

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/AnchorSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/AnchorSelector.java
@@ -30,9 +30,11 @@ import com.arcadedb.query.opencypher.optimizer.statistics.StatisticsProvider;
 import com.arcadedb.query.opencypher.optimizer.statistics.TypeStatistics;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Selects the optimal anchor node (starting point) for query execution.
@@ -66,6 +68,24 @@ public class AnchorSelector {
    * @return anchor selection with the best starting node
    */
   public AnchorSelection selectAnchor(final LogicalPlan plan) {
+    return selectAnchor(plan, Collections.emptySet());
+  }
+
+  /**
+   * Selects the optimal anchor node for the given logical plan, ignoring any node whose variable is
+   * in {@code excludedVariables}.
+   * <p>
+   * A node belonging to a MATCH clause that is disconnected from the relationship pattern (issue
+   * #5810, e.g. {@code MATCH (n)-[:E]->(m) MATCH (x)}) is joined onto the plan separately via a
+   * {@code CartesianProduct} and must never seed the relationship expansion chain itself - an
+   * isolated node has no incident relationship for {@code buildExpansionChain} to walk, so picking it
+   * as the anchor would strand the chain.
+   *
+   * @param plan               the logical plan to analyze
+   * @param excludedVariables  node variables to skip when choosing the anchor
+   * @return anchor selection with the best starting node
+   */
+  public AnchorSelection selectAnchor(final LogicalPlan plan, final Set<String> excludedVariables) {
     if (plan.getNodes().isEmpty()) {
       throw new IllegalArgumentException("Cannot select anchor from empty logical plan");
     }
@@ -85,6 +105,9 @@ public class AnchorSelector {
     // expansion chain already uses. The guard above still keys off the named nodes, so a pattern with
     // no named node at all keeps falling back the way count push-down expects.
     for (final LogicalNode node : plan.getPatternNodes().values()) {
+      if (excludedVariables.contains(node.getVariable()))
+        continue;
+
       final AnchorSelection candidate = evaluateNode(node, plan);
 
       if (candidate.useIndex()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -146,8 +146,25 @@ public class CypherOptimizer {
       return optimizeMultiMatchIndependent(logicalPlan);
     }
 
-    // 3. Select anchor node (best starting point)
-    AnchorSelection anchor = anchorSelector.selectAnchor(logicalPlan);
+    // A later MATCH clause can still be a single, disconnected node pattern even when an earlier
+    // clause has relationships, e.g. "MATCH (n)-[:E]->(m) MATCH (x)" (issue #5810).
+    // shouldUseOptimizer() already admits this shape - a disconnected pattern is only accepted when
+    // it is single-node, on the assumption it is "handled via CartesianProduct" - but until now
+    // nothing here ever built one for it: such a node is a named node absent from every relationship,
+    // so it must be excluded from anchor selection (it cannot seed an expansion chain) and joined back
+    // in explicitly, or it silently disappears from the plan and reads back as an unbound null.
+    final List<LogicalNode> isolatedNodes = new ArrayList<>();
+    if (!logicalPlan.getRelationships().isEmpty())
+      for (final LogicalNode node : logicalPlan.getNodes().values())
+        if (!logicalPlan.isNodeConnected(node.getVariable()))
+          isolatedNodes.add(node);
+
+    final Set<String> isolatedVariables = new HashSet<>();
+    for (final LogicalNode node : isolatedNodes)
+      isolatedVariables.add(node.getVariable());
+
+    // 3. Select anchor node (best starting point) among the relationship-connected nodes only
+    AnchorSelection anchor = anchorSelector.selectAnchor(logicalPlan, isolatedVariables);
 
     // 3a. Validate anchor against UNIDIRECTIONAL edge constraints.
     // UNIDIRECTIONAL edges only store outgoing links on the source vertex,
@@ -164,6 +181,13 @@ public class CypherOptimizer {
     if (!logicalPlan.getRelationships().isEmpty()) {
       rootOperator = buildExpansionChain(logicalPlan, anchor, anchorOperator);
     }
+
+    // 5a. Join in any disconnected single-node MATCH clause pattern via CartesianProduct (#5810).
+    // Must happen before filter pushdown: a disconnected node's own inline-property/WHERE predicate
+    // (lowered into logicalPlan.getWhereFilters()) reads its variable, which is only bound once this
+    // join has run.
+    if (!isolatedNodes.isEmpty())
+      rootOperator = joinIsolatedNodes(rootOperator, isolatedNodes, logicalPlan);
 
     // 6. Apply ExpandInto optimization
     // ExpandInto is detected during expansion chain building (step 5)
@@ -228,6 +252,30 @@ public class CypherOptimizer {
 
     return new PhysicalPlan(logicalPlan, firstAnchor, rootOperator,
         rootOperator.getEstimatedCost(), rootOperator.getEstimatedCardinality());
+  }
+
+  /**
+   * Joins each disconnected, single-node MATCH clause pattern onto {@code rootOperator} via
+   * {@link CartesianProduct}, mirroring the operator-per-node construction
+   * {@link #optimizeMultiMatchIndependent} already uses for the fully-disconnected case (issue #5810).
+   *
+   * @param rootOperator  the physical operator built for the relationship-connected pattern
+   * @param isolatedNodes named nodes not touched by any relationship in the logical plan
+   * @param logicalPlan   the logical plan (for anchor evaluation context)
+   *
+   * @return {@code rootOperator} with one CartesianProduct layer per isolated node
+   */
+  private PhysicalOperator joinIsolatedNodes(PhysicalOperator rootOperator,
+      final List<LogicalNode> isolatedNodes, final LogicalPlan logicalPlan) {
+    for (final LogicalNode node : isolatedNodes) {
+      final AnchorSelection nodeAnchor = anchorSelector.evaluateNodeDirect(node, logicalPlan);
+      final PhysicalOperator nodeOperator = createAnchorOperator(nodeAnchor);
+
+      final long cardinality = Math.max(1, rootOperator.getEstimatedCardinality()) * Math.max(1, nodeAnchor.getEstimatedCardinality());
+      final double cost = rootOperator.getEstimatedCost() + nodeAnchor.getEstimatedCost();
+      rootOperator = new CartesianProduct(rootOperator, nodeOperator, cost, cardinality);
+    }
+    return rootOperator;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMatchEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMatchEnhancementsTest.java
@@ -137,6 +137,50 @@ public class OpenCypherMatchEnhancementsTest {
     assertThat(results.get(3).<String>getProperty("person2")).isEqualTo("Bob");
   }
 
+  // Issue #5810: a disconnected MATCH clause following a relationship pattern must independently
+  // bind its new variable to every match and fan out via Cartesian product, exactly like it does
+  // when the disconnected clause appears first or when both clauses are single-node patterns
+  // (see multipleMatchClausesCartesianProduct above). It must not collapse to a single row with
+  // the new variable bound to null, which is OPTIONAL MATCH behaviour, not plain MATCH.
+  @Test
+  void disconnectedMatchAfterRelationshipPatternProducesCartesianProduct() {
+    // (a:Person)-[:WORKS_FOR]->(c:Company) matches exactly one row: Alice -> TechCorp.
+    // The disconnected MATCH (b:Person) must bind b to both Alice and Bob for that row.
+    final ResultSet result = database.query("opencypher",
+        """
+        MATCH (a:Person)-[:WORKS_FOR]->(c:Company)
+        MATCH (b:Person)
+        RETURN c.name AS company, b.name AS person
+        ORDER BY person""");
+
+    final List<Result> results = new ArrayList<>();
+    while (result.hasNext())
+      results.add(result.next());
+    result.close();
+
+    assertThat(results).as("Expected one row per Person crossed with the single WORKS_FOR match").hasSize(2);
+
+    assertThat(results.get(0).<String>getProperty("company")).isEqualTo("TechCorp");
+    assertThat(results.get(0).<String>getProperty("person")).isEqualTo("Alice");
+
+    assertThat(results.get(1).<String>getProperty("company")).isEqualTo("TechCorp");
+    assertThat(results.get(1).<String>getProperty("person")).isEqualTo("Bob");
+  }
+
+  @Test
+  void disconnectedMatchAfterRelationshipPatternCountMatchesRowCount() {
+    final ResultSet result = database.query("opencypher",
+        """
+        MATCH (a:Person)-[:WORKS_FOR]->(c:Company)
+        MATCH (b:Person)
+        RETURN count(*) AS c""");
+
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<Long>getProperty("c")).isEqualTo(2L);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
   @Test
   void patternWithoutLabel() {
     // MATCH (n) without label should match ALL vertices (Person and Company)

--- a/mcp/src/test/java/com/arcadedb/mcp/GetServerSettingsToolRedactionIT.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/GetServerSettingsToolRedactionIT.java
@@ -23,6 +23,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.mcp.tools.GetServerSettingsTool;
 import com.arcadedb.mcp.tools.SetServerSettingTool;
 import org.junit.jupiter.api.Test;
@@ -79,13 +80,18 @@ class GetServerSettingsToolRedactionIT extends BaseGraphServerTest {
       final MCPConfiguration config = new MCPConfiguration("./target/test");
       config.setAllowAdmin(true);
 
+      // set_server_setting is root-only (GHSA-pff6-hp53-pj54), so the redaction of the echoed previous value can
+      // only be exercised through a root principal. MCPServerAdminAuthorizationIT covers the denial side.
+      final ServerSecurityUser root = getServer(serverIndex).getSecurity()
+          .authenticate("root", DEFAULT_PASSWORD_FOR_TESTS, null);
+
       final JSONObject args = new JSONObject()
           .put("key", "arcadedb.ha.clusterToken")
           .put("value", "replacement-token");
 
       final JSONObject result;
       try {
-        result = SetServerSettingTool.execute(getServer(serverIndex), null, args, config);
+        result = SetServerSettingTool.execute(getServer(serverIndex), root, args, config);
       } finally {
         // This exercises the real setter, so it genuinely replaces the running server's cluster token.
         // Restore it before leaving: the token authenticates cluster-forwarded requests, and a later


### PR DESCRIPTION
## What does this PR do?

Fixes the Cypher cost-based optimizer so a disconnected, single-node `MATCH` clause following a `MATCH` clause containing a relationship pattern correctly binds its new variable to every match and produces a Cartesian product, instead of silently binding it to `null` in a single preserved row.

Example:

```cypher
MATCH (n:A_0)-[:E]->(m:B_0)
MATCH (x:B_0)
RETURN m.id, x.id
```

Before this fix, this returned one row with `x.id = null`. After the fix, it returns one row per `B_0` node, per the Cypher Cartesian-product semantics for disconnected `MATCH` clauses (matching Neo4j/Memgraph/FalkorDB behavior cited in the issue).

## Motivation

`CypherExecutionPlanner.shouldUseOptimizer()` already admits a disconnected single-node `MATCH` clause into the optimizer path, on the documented assumption it is "handled via CartesianProduct". `CypherOptimizer.optimize()`, however, only ever built a `CartesianProduct` chain for the case where *every* `MATCH` clause in the statement is relationship-free (`optimizeMultiMatchIndependent`). As soon as one clause had a relationship, the optimizer fell into the anchor-selection + expansion-chain path, which never accounted for a named node that has no incident relationship: the node was silently absent from the resulting physical plan, and its variable read back as an unbound `null` in the single row the expansion chain produced - an accidental `OPTIONAL MATCH` look-alike, and also a case where `count(*)` under-reported by the missing multiplicity.

## Related issues

Closes #5810

## Changes

- `CypherOptimizer.optimize()`: collects named nodes that are not touched by any relationship in the logical plan ("isolated nodes"), excludes them from anchor selection, and joins each one onto the relationship-connected physical plan via `CartesianProduct` right after the expansion chain is built and before filter pushdown runs (so a predicate reading the isolated variable, e.g. an inline property, evaluates against a row where it is already bound).
- `AnchorSelector`: adds a `selectAnchor(LogicalPlan, Set<String> excludedVariables)` overload so an isolated node can never be selected as the anchor for the relationship expansion chain (which would strand `buildExpansionChain`, since the node has no incident relationship to walk). The original single-argument overload delegates with an empty exclusion set, so no existing call site changes behavior.
- New helper `joinIsolatedNodes` mirrors the operator-per-node + `CartesianProduct` construction that `optimizeMultiMatchIndependent` already uses for the fully-disconnected case.

## Additional Notes

- Root-caused with a targeted investigation confirming (via `EXPLAIN`) that the buggy query shape only reaches the cost-based optimizer path; the "control" queries in the issue that happen to work correctly do so because they fall back to the legacy execution path, not because the optimizer handles them correctly.
- Not related to the `CartesianProductStep` fix in #4543 - that concerned the generic SQL executor's `com.arcadedb.query.sql.executor.CartesianProductStep` (duplicate rows from outer/inner iteration ordering); this bug is entirely in the Cypher-specific optimizer's `com.arcadedb.query.opencypher.executor.operators.CartesianProduct` and its caller, which was never even reached for this query shape.
- Verified no regression: full `com.arcadedb.query.opencypher.**` test package (4309 tests, including the OpenCypher TCK compliance suite and all `CypherOptimizer`/`AnchorSelector` unit tests) passes with zero failures, plus the unrelated `com.arcadedb.query.sql.executor.CartesianProductStepTest` (generic SQL engine) is unaffected.

## Test plan

- [x] New regression test `disconnectedMatchAfterRelationshipPatternProducesCartesianProduct` in `OpenCypherMatchEnhancementsTest` reproduces the issue's query shape and asserts the expected 2-row Cartesian expansion (verified it fails without the fix: `Expected size: 2 but was: 1`, with `person: null`).
- [x] New regression test `disconnectedMatchAfterRelationshipPatternCountMatchesRowCount` asserts `count(*)` matches the row count (verified it fails without the fix: expected `2L` but was `1L`).
- [x] Full `com.arcadedb.query.opencypher.**` package: 4309 tests, 0 failures, 0 errors.
- [x] `com.arcadedb.query.sql.executor.CartesianProductStepTest`: unaffected (unrelated generic SQL step).

## Checklist

- [x] I have run the build using `mvn clean package` command (module-scoped: `mvn -pl engine -am install -DskipTests` plus targeted `mvn -pl engine test`)
- [x] My unit tests cover both failure and success scenarios