### PR TITLE
chore(ci): update Claude Code workflows to sonnet-5, restore CI-read permission

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,4 +53,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,6 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
 
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 


### PR DESCRIPTION
## Summary
- `claude-code-review.yml`: switch model from `claude-opus-4-8` to `claude-sonnet-5`, matching `claude.yml`.
- `claude.yml`: restore the `additional_permissions: | actions: read` block, which had been dropped in an uncommitted local edit alongside the new `claude_args` line. This input is distinct from the job-level `permissions:` block and is required for Claude to read CI results on PRs (per the action's own docs); losing it would silently break CI-log analysis in `@claude`-triggered runs.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both files - valid YAML
- [x] Pre-commit hooks (yaml check, whitespace, etc.) passed on commit
- [ ] Verify the `@claude` workflow can still read CI results on a live PR after merge