### PR TITLE
fix(#5745): cache resolved column in ColumnStore to cut per-row hashing

### DIFF
--- a/docs/5745-gav-far-endpoint-property-access.md
+++ b/docs/5745-gav-far-endpoint-property-access.md
@@ -1,0 +1,118 @@
+# Issue #5745: GAV far-endpoint property access is dominated by HashMap probing
+
+## Root cause
+
+`GraphAnalyticalView.getProperty(nodeId, propertyName)` resolves every single
+property read through `ColumnStore.getValue()`, which did:
+
+```java
+final Column column = columns.get(propertyName);   // HashMap<String, Column>.get()
+```
+
+on **every call**, i.e. once per traversed edge for a far-endpoint property
+read such as `MATCH (p:Person)-[:KNOWS]->(f:Person) RETURN f.city`. The
+issue's profile (`dst_prop_only`, GAV-ON) shows `HashMap.getNode` at 32.09%
+self time and `ColumnStore.getValue` at 18.85% inclusive - roughly 46% of the
+profile is this repeated hashing of the *same* property name across rows,
+because a query loop calls `getValue(nodeId, "city")` with a constant
+`propertyName` thousands of times in a row.
+
+The issue's author had already ruled out two adjacent micro-optimizations
+(`ResultInternal.getProperty`'s redundant `containsKey`, and hoisting
+`getPropertyNames()` in `GAVExpandAll`) by measuring them as noise, and
+correctly pointed at the column-name hashing itself as the real cost.
+
+## Fix
+
+Added a single-slot memoization cache to `ColumnStore`: the last resolved
+`(propertyName, Column)` pair is kept behind one `volatile` field
+(`CachedColumn`, a record pairing both fields so a racing reader can never
+observe a torn combination of an old name with a new column, or vice versa).
+`getColumn(name)` checks the cached name first (a `String#equals`, no
+hashing) and only falls back to the `HashMap` probe on a cache miss;
+`getValue()` was refactored to go through `getColumn()` so both call sites
+share the cache.
+
+This is correctness-preserving because `ColumnStore.columns` is populated
+exclusively during CSR build (`CSRBuilder`, single property name only ever
+`createColumn`'d once per store — verified by tracing every call site) and is
+never mutated once the `GraphAnalyticalView` snapshot is published, so a
+cached entry can never go stale for the query-time lifetime of the store.
+
+Query loops (Cypher property expressions such as `f.city` evaluated via
+`GAVVertex.get()` -> `GraphAnalyticalView.getProperty()` ->
+`ColumnStore.getValue()`) repeat the *same* property name across every row of
+an expansion, which is exactly the pattern this single-slot cache turns from
+an O(1)-amortized-but-still-hashing `HashMap.get` into a plain reference
+compare + `String#equals`.
+
+### Scope note
+
+The issue's "structural observation" section flags
+`GraphAnalyticalView.getBucketColumnStore(int)` as dead code with zero
+callers, and speculates that a fuller fix would route Cypher operators through
+bulk/vectorized column access instead of per-row `getProperty()` calls. That
+is a materially larger change (touching the Cypher expression evaluator and/or
+`GAVExpandAll`'s per-row result construction) that the issue explicitly did
+not propose or measure a patch for ("we are not proposing a specific patch
+for that ... the two we did measure taught us not to guess"). This PR fixes
+the measured, profiled bottleneck (the redundant per-row hashing) with a
+minimal, safe, well-tested change; wiring a vectorized/batched consumer onto
+`getBucketColumnStore` remains a separate, larger follow-up and is out of
+scope here.
+
+## Changes
+
+- `engine/src/main/java/com/arcadedb/graph/olap/ColumnStore.java`: single-slot
+  `(name, Column)` cache shared by `getColumn()` and `getValue()`.
+- `engine/src/test/java/com/arcadedb/graph/olap/ColumnStoreTest.java` (new):
+  regression tests for the cache — repeated same-property access, alternating
+  between two properties (would expose a torn/stale entry), a missing
+  property not poisoning a subsequent valid lookup, repeated misses staying
+  null, a null value on an existing column vs. a missing column, and the
+  empty-store case.
+
+## Test results
+
+```
+mvn -pl engine -am test -Dtest=ColumnStoreTest
+Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
+
+mvn -pl engine -am test -Dtest='ColumnStoreTest,GraphAnalyticalViewTest,GraphAnalyticalViewRegistryTest,DeltaOverlayTest,DeltaOverlayCompactionDedupTest,GraphAlgorithmsTest,GraphAlgorithmsInterruptTest,CSRPerformanceTest'
+Tests run: 173, Failures: 0, Errors: 0, Skipped: 0
+
+mvn -pl engine -am test -Dtest='CypherGAVBoundTargetCardinalityTest,CypherGAVFusedChainIssue5746Test,GAVEligibilityTest,CypherExpandIntoUnreadEdgeVariableTest,CypherExpandIntoMultiplicityCardinalityTest,AlgoPageRankTest'
+Tests run: 70, Failures: 0, Errors: 0, Skipped: 0
+```
+
+All green, no regressions in the GAV/Cypher-GAV suites.
+
+## Impact analysis
+
+- Correctness: unchanged behavior for every existing caller of
+  `ColumnStore.getColumn()` / `getValue()`; the cache is purely an
+  optimization layered on top of the same lookup semantics.
+- Performance: eliminates the per-row `HashMap` probe on the property name
+  for the dominant access pattern (same property name read across many
+  rows), which the issue's profiling identified as ~46% of CPU time on the
+  far-endpoint-property benchmark queries.
+- Concurrency: the cache field is `volatile` and the cached name/column pair
+  is read and written atomically as one object reference, so concurrent
+  readers across multiple query threads sharing one `ColumnStore` can only
+  ever observe a fully-formed `(name, column)` pair — never a torn one. In
+  the worst case (concurrent queries alternating different property names on
+  the same store) the cache simply thrashes back to hashmap-lookup-per-call
+  behavior; it is never wrong.
+
+## Recommendations for future improvements
+
+- A fuller fix per the issue's structural observation would give
+  `GAVExpandAll` (or the Cypher property-expression evaluator) a bulk/batched
+  path onto `GraphAnalyticalView.getBucketColumnStore()` instead of one
+  `getProperty()` call per row. That is a larger, separate change and was
+  explicitly out of scope for this fix.
+- If a follow-up benchmark shows the single-slot cache thrashing under mixed
+  concurrent multi-property workloads sharing one `ColumnStore`, a small
+  N-way (e.g. 2-4 slot) cache could be considered, but the profile in this
+  issue is dominated by single-property repeated access, so a single slot
+  matches the reported workload.

--- a/engine/src/main/java/com/arcadedb/graph/olap/ColumnStore.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/ColumnStore.java
@@ -45,6 +45,20 @@ public class ColumnStore {
   private final Map<String, Column> columns;
   private final int                 nodeCount;
 
+  // Single-slot memoization of the last resolved (name, column) pair. Query loops
+  // (e.g. GAVExpandAll reading a far-endpoint property once per traversed edge) call
+  // getColumn()/getValue() with the SAME propertyName across many rows in a row, so
+  // caching the last resolution turns a HashMap probe per row into a String#equals
+  // check. `columns` is only ever populated during CSR build (see CSRBuilder), never
+  // mutated afterward, so a cached entry can never go stale; and since both the name
+  // and the column travel together inside one record referenced through a single
+  // volatile field, a racing reader can only ever see a fully-formed pair, never one
+  // field from an older resolution and the other from a newer one.
+  private volatile CachedColumn lastResolved;
+
+  private record CachedColumn(String name, Column column) {
+  }
+
   public ColumnStore(final int nodeCount) {
     this.nodeCount = nodeCount;
     this.columns = new HashMap<>();
@@ -63,14 +77,20 @@ public class ColumnStore {
    * Returns the column for the given property name, or null if not present.
    */
   public Column getColumn(final String name) {
-    return columns.get(name);
+    final CachedColumn cached = lastResolved;
+    if (cached != null && cached.name().equals(name))
+      return cached.column();
+
+    final Column column = columns.get(name);
+    lastResolved = new CachedColumn(name, column);
+    return column;
   }
 
   /**
    * Returns the property value for a given node, or null if not set or column doesn't exist.
    */
   public Object getValue(final int nodeId, final String propertyName) {
-    final Column column = columns.get(propertyName);
+    final Column column = getColumn(propertyName);
     if (column == null || column.isNull(nodeId))
       return null;
 

--- a/engine/src/test/java/com/arcadedb/graph/olap/ColumnStoreTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/ColumnStoreTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for {@link ColumnStore}'s single-slot column-resolution cache
+ * (issue #5745): {@code getColumn()}/{@code getValue()} are called with the same
+ * property name across many rows in query loops, so the last-resolved column is
+ * memoized to avoid a repeated {@code HashMap} probe on the property name. These
+ * tests exercise the cache under access patterns that would expose a torn or
+ * stale entry: alternating between properties, repeating the same property,
+ * probing a missing property, and probing the empty store.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ColumnStoreTest {
+
+  @Test
+  void repeatedAccessToSamePropertyReturnsCorrectValues() {
+    final ColumnStore store = new ColumnStore(3);
+    final Column city = store.createColumn("city", Column.Type.STRING);
+    city.setString(0, "Rome");
+    city.setString(1, "Milan");
+    city.setString(2, "Turin");
+
+    // Same property name probed repeatedly (the hot-loop pattern the cache targets).
+    for (int i = 0; i < 5; i++) {
+      assertThat(store.getValue(0, "city")).isEqualTo("Rome");
+      assertThat(store.getValue(1, "city")).isEqualTo("Milan");
+      assertThat(store.getValue(2, "city")).isEqualTo("Turin");
+    }
+  }
+
+  @Test
+  void alternatingPropertiesResolveIndependently() {
+    final ColumnStore store = new ColumnStore(2);
+    final Column name = store.createColumn("name", Column.Type.STRING);
+    name.setString(0, "Alice");
+    name.setString(1, "Bob");
+    final Column age = store.createColumn("age", Column.Type.INT);
+    age.setInt(0, 30);
+    age.setInt(1, 40);
+
+    // Alternate property names on every call so the cache slot is invalidated and
+    // re-resolved each time; must never leak the wrong column's value across the switch.
+    for (int i = 0; i < 10; i++) {
+      assertThat(store.getValue(0, "name")).isEqualTo("Alice");
+      assertThat(store.getValue(0, "age")).isEqualTo(30);
+      assertThat(store.getValue(1, "name")).isEqualTo("Bob");
+      assertThat(store.getValue(1, "age")).isEqualTo(40);
+    }
+  }
+
+  @Test
+  void missingPropertyDoesNotPoisonSubsequentLookups() {
+    final ColumnStore store = new ColumnStore(2);
+    final Column name = store.createColumn("name", Column.Type.STRING);
+    name.setString(0, "Alice");
+
+    // Probe an absent property first (caches a null column), then a real one with a
+    // DIFFERENT name, then the absent one again — none of these should observe the
+    // other's cached entry.
+    assertThat(store.getValue(0, "missing")).isNull();
+    assertThat(store.getValue(0, "name")).isEqualTo("Alice");
+    assertThat(store.getValue(0, "missing")).isNull();
+    assertThat(store.getColumn("missing")).isNull();
+    assertThat(store.getColumn("name")).isSameAs(name);
+  }
+
+  @Test
+  void repeatedMissingPropertyLookupStaysNull() {
+    final ColumnStore store = new ColumnStore(1);
+    store.createColumn("name", Column.Type.STRING);
+
+    for (int i = 0; i < 5; i++)
+      assertThat(store.getValue(0, "doesNotExist")).isNull();
+  }
+
+  @Test
+  void nullValueWithinExistingColumnIsDistinctFromMissingColumn() {
+    final ColumnStore store = new ColumnStore(2);
+    final Column age = store.createColumn("age", Column.Type.INT);
+    age.setInt(0, 25); // node 1 left unset -> null bit stays set
+
+    assertThat(store.getValue(0, "age")).isEqualTo(25);
+    assertThat(store.getValue(1, "age")).isNull();
+    // Re-probe node 0 right after a null read on the SAME column/property to confirm
+    // the cache (keyed on name, not on null-ness) still resolves the right column.
+    assertThat(store.getValue(0, "age")).isEqualTo(25);
+  }
+
+  @Test
+  void getColumnOnEmptyStoreReturnsNull() {
+    final ColumnStore store = new ColumnStore(0);
+    assertThat(store.getColumn("anything")).isNull();
+    assertThat(store.getValue(0, "anything")).isNull();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a single-slot `(propertyName, Column)` cache to `ColumnStore`, shared by
`getColumn()` and `getValue()`, so a property name that repeats across many
rows in a query loop (the common case for a Graph Analytical View traversal
reading a far-endpoint property) resolves via a `String#equals` check instead
of a fresh `HashMap` probe on every row.

Closes #5745

## Motivation

The issue's profiling (async-profiler, `dst_prop_only` query, GAV-ON) showed
`HashMap.getNode` at 32.09% self time with `ColumnStore.getValue` at 18.85%
inclusive — roughly 46% of CPU time spent re-hashing the *same* property
name (`"city"`) on every traversed edge. `ColumnStore.getValue()` did
`columns.get(propertyName)` unconditionally on every call, even though the
calling loop (`GAVVertex.get()` -> `GraphAnalyticalView.getProperty()` ->
`ColumnStore.getValue()`) passes the same `propertyName` thousands of times
in a row for a query like:

```cypher
MATCH (p:Person)-[:KNOWS]->(f:Person) RETURN f.city AS c, count(*) AS n
```

The issue's author had already ruled out two adjacent micro-optimizations
(a redundant `containsKey` in `ResultInternal.getProperty`, and hoisting
`getPropertyNames()` in `GAVExpandAll`) by measuring them as noise, and
pointed at the column-name hashing itself as the real cost — this PR
addresses exactly that, profiled bottleneck.

The fix is correctness-preserving because `ColumnStore.columns` is populated
exclusively during CSR build (every call site in `CSRBuilder` creates a given
column name at most once per store) and is never mutated once the
`GraphAnalyticalView` snapshot is published — so a cached entry can never go
stale for the query-time lifetime of the store. The cached `(name, column)`
pair is read/written as one object behind a single `volatile` field, so a
racing reader on a `ColumnStore` shared across concurrent query threads can
only ever observe a fully-formed pair, never a torn one; in the worst case
(concurrent queries alternating different property names on one store) the
cache just thrashes back to hashmap-lookup-per-call, it is never wrong.

### Scope note

The issue also flags `GraphAnalyticalView.getBucketColumnStore(int)` as dead
code and speculates that a fuller fix would route Cypher operators through
bulk/vectorized column access instead of per-row `getProperty()` calls. That
is a materially larger change (Cypher expression evaluator and/or
`GAVExpandAll`'s per-row result construction) that the issue explicitly did
not propose or measure a patch for. This PR fixes the measured bottleneck
with a minimal, well-tested change; wiring a vectorized/batched consumer onto
`getBucketColumnStore` remains a separate follow-up.

## Related issues

Closes #5745

## Additional Notes

Tracking doc with full analysis: `docs/5745-gav-far-endpoint-property-access.md`

## Test plan

- [x] New unit tests in `engine/src/test/java/com/arcadedb/graph/olap/ColumnStoreTest.java`:
      repeated same-property access, alternating between two properties (would
      expose a torn/stale cache entry), a missing property not poisoning a
      subsequent valid lookup, repeated misses staying null, a null value on an
      existing column vs. a missing column, and the empty-store case.
- [x] `mvn -pl engine -am test -Dtest=ColumnStoreTest` — 6/6 pass
- [x] `mvn -pl engine -am test -Dtest='ColumnStoreTest,GraphAnalyticalViewTest,GraphAnalyticalViewRegistryTest,DeltaOverlayTest,DeltaOverlayCompactionDedupTest,GraphAlgorithmsTest,GraphAlgorithmsInterruptTest,CSRPerformanceTest'` — 173/173 pass
- [x] `mvn -pl engine -am test -Dtest='CypherGAVBoundTargetCardinalityTest,CypherGAVFusedChainIssue5746Test,GAVEligibilityTest,CypherExpandIntoUnreadEdgeVariableTest,CypherExpandIntoMultiplicityCardinalityTest,AlgoPageRankTest'` — 70/70 pass

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios