### PR TITLE
fix(#5835): AND/OR short-circuit instead of evaluating the result-irrelevant operand

### DIFF
--- a/docs/5835-cypher-and-or-short-circuit.md
+++ b/docs/5835-cypher-and-or-short-circuit.md
@@ -1,0 +1,110 @@
+# Issue #5835: AND/OR evaluate result-irrelevant operands instead of short-circuiting
+
+## Root cause
+
+Cypher's `AND`/`OR` are built as one of two independent AST node types depending on where
+the expression appears:
+
+- `TernaryLogicalExpression` (`engine/src/main/java/com/arcadedb/query/opencypher/ast/TernaryLogicalExpression.java`)
+  for `RETURN`/`WITH` projections.
+- `LogicalExpression` (`engine/src/main/java/com/arcadedb/query/opencypher/ast/LogicalExpression.java`)
+  for `WHERE` predicates.
+
+Both `evaluateAnd`/`evaluateOr` methods unconditionally evaluated **both** operands before
+applying the three-valued-logic truth table, even when the left operand alone already
+determined the boolean result (`false AND E`, `true OR E`). If the right operand's
+evaluation raised a runtime error (e.g. `left('abc', -1)`), that error surfaced even though
+the operand's value could not affect the outcome.
+
+The equivalent unreachable branch of a `CASE` expression was already skipped, which made
+the same runtime expression behave inconsistently depending only on which construct wrapped
+it - a boolean guard (`flag AND riskyExpression`) was not safe the way an equivalent `CASE`
+was.
+
+A `WHERE`-clause optimization (`BooleanSimplifier`) already folds *literal* `true`/`false`
+guards (`false AND x -> false`) at rewrite time, which is why the literal-guard `WHERE`
+case looked fine in isolated testing. That rewrite pass does not run for `RETURN`/`WITH`
+projections (`TernaryLogicalExpression`) at all, and even in `WHERE` it does not help when
+the guard is not a literal (e.g. a comparison or a `WITH`-bound variable) - the runtime
+`evaluateAnd`/`evaluateOr` methods still had the bug in the general case.
+
+## Fix
+
+Added true short-circuit evaluation to both `LogicalExpression.evaluateAnd`/`evaluateOr`
+and `TernaryLogicalExpression.evaluateAnd`/`evaluateOr`:
+
+- `AND`: if the left operand evaluates to `false`, return `false` immediately without
+  evaluating the right operand.
+- `OR`: if the left operand evaluates to `true`, return `true` immediately without
+  evaluating the right operand.
+- In every other case (left is `true`/`null` for `AND`, left is `false`/`null` for `OR`),
+  the right operand's value is required to determine the result (including three-valued
+  `null` propagation), so it is still evaluated exactly as before.
+
+This matches Neo4j/Memgraph's observed behavior in the issue's compatibility matrix and
+keeps three-valued (`null`) logic semantics unchanged - the only behavior change is that a
+truly result-irrelevant operand is no longer evaluated (and can no longer throw).
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/query/opencypher/ast/LogicalExpression.java`
+- `engine/src/main/java/com/arcadedb/query/opencypher/ast/TernaryLogicalExpression.java`
+- `engine/src/test/java/com/arcadedb/query/opencypher/Issue5835AndOrShortCircuitTest.java` (new)
+
+## Tests
+
+New regression test `Issue5835AndOrShortCircuitTest` (15 tests), covering both AST paths:
+
+- `RETURN`/`WITH` (`TernaryLogicalExpression`): `false AND (static/runtime-bound error)`,
+  `true OR (static error)` no longer throw.
+- `WHERE` (`LogicalExpression`): `false AND (static/runtime-bound error)`,
+  `true OR (static/runtime-bound error)` no longer throw, including cases where the guard
+  is not a literal (so `BooleanSimplifier` cannot mask the underlying bug).
+- Controls: `true AND (error)`, `false OR (error)` still evaluate the right operand and
+  still throw (its value is required).
+- Control: the unselected `CASE` branch still skips the runtime-bound error (unaffected by
+  this fix).
+- Three-valued logic regression: `null AND false = false`, `true AND null = null`,
+  `null OR true = true`, `false OR null = null` all unaffected by the short-circuit change.
+
+### Before the fix
+
+4 of the 15 tests failed, reproducing the reported bug plus the additional runtime-bound
+`WHERE`-clause case discovered while writing the regression test:
+
+```
+Issue5835AndOrShortCircuitTest.andWithFalseLeftShortCircuitsRuntimeBoundRightError
+Issue5835AndOrShortCircuitTest.andWithFalseLeftShortCircuitsStaticRightError
+Issue5835AndOrShortCircuitTest.orWithTrueLeftShortCircuitsStaticRightError
+Issue5835AndOrShortCircuitTest.whereTrueOrShortCircuitsRuntimeBoundRightError
+```
+
+### After the fix
+
+```
+Tests run: 15, Failures: 0, Errors: 0, Skipped: 0 -- Issue5835AndOrShortCircuitTest
+```
+
+Also re-ran, with no regressions:
+
+- `Issue5383BooleanNullFunctionTest` (8 tests)
+- `com.arcadedb.query.opencypher.rewriter.*` (`BooleanSimplifierTest`, `ConstantFolderTest`,
+  `ComparisonNormalizerTest`, `CompositeRewriterTest`)
+- `com.arcadedb.query.opencypher.ast.*`
+- CASE/WHERE/inline-filter suite: `CypherCaseTest`, `CypherInlinePatternWhereTest`,
+  `CypherInlinePropertyFilterTest`, `CypherLabelCheckInWhereTest`, `CypherLabelFilteringTest`,
+  `Issue5480NodeInlineWhereTest`, `Issue5489NodeInlineWhereRelVariableTest`,
+  `Issue5490VarLengthRelInlineWhereTest`, `OpenCypherWhereClauseTest`,
+  `WhereClauseListPredicateVariablesTest`, `OpenCypherMatchEnhancementsTest`,
+  `OpenCypherOptionalMatchTest`, `Issue5294ToFloatBooleanTest`,
+  `CypherUncorrelatedSubqueryCountPushDownIssue5686Test`
+- NOT/EXISTS/MERGE suite: `CypherDoubleNotIssue5360Test`, `Issue4995ExistsAndNotExistsTest`,
+  `OpenCypherMergeActionsTest`, `OpenCypherMergeTest`
+- `mvn -pl engine -am compile` - full engine module compiles cleanly.
+
+## Impact / recommendations
+
+Boolean guards (`flag AND riskyExpression`, `fallbackAvailable OR riskyExpression`) are now
+safe against the guarded expression raising an error when its value cannot affect the
+result, matching `CASE`'s existing behavior and the observed Neo4j/Memgraph semantics. No
+follow-up work identified.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/LogicalExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/LogicalExpression.java
@@ -66,9 +66,13 @@ public class LogicalExpression implements BooleanExpression {
 
   private Object evaluateAnd(final Result result, final CommandContext context) {
     final Boolean leftBool = toBoolean(left.evaluateTernary(result, context));
-    final Boolean rightBool = toBoolean(right.evaluateTernary(result, context));
 
-    if (Boolean.FALSE.equals(leftBool) || Boolean.FALSE.equals(rightBool))
+    // false AND anything = false: the right operand is result-irrelevant, do not evaluate it.
+    if (Boolean.FALSE.equals(leftBool))
+      return false;
+
+    final Boolean rightBool = toBoolean(right.evaluateTernary(result, context));
+    if (Boolean.FALSE.equals(rightBool))
       return false;
     if (leftBool == null || rightBool == null)
       return null;
@@ -77,9 +81,13 @@ public class LogicalExpression implements BooleanExpression {
 
   private Object evaluateOr(final Result result, final CommandContext context) {
     final Boolean leftBool = toBoolean(left.evaluateTernary(result, context));
-    final Boolean rightBool = toBoolean(right.evaluateTernary(result, context));
 
-    if (Boolean.TRUE.equals(leftBool) || Boolean.TRUE.equals(rightBool))
+    // true OR anything = true: the right operand is result-irrelevant, do not evaluate it.
+    if (Boolean.TRUE.equals(leftBool))
+      return true;
+
+    final Boolean rightBool = toBoolean(right.evaluateTernary(result, context));
+    if (Boolean.TRUE.equals(rightBool))
       return true;
     if (leftBool == null || rightBool == null)
       return null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/TernaryLogicalExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/TernaryLogicalExpression.java
@@ -62,14 +62,16 @@ public class TernaryLogicalExpression implements Expression {
   }
 
   private Object evaluateAnd(final Result result, final CommandContext context) {
-    final Object leftVal = left.evaluate(result, context);
-    final Object rightVal = right.evaluate(result, context);
+    final Boolean leftBool = toBoolean(left.evaluate(result, context));
 
-    final Boolean leftBool = toBoolean(leftVal);
-    final Boolean rightBool = toBoolean(rightVal);
+    // false AND anything = false: the right operand is result-irrelevant, do not evaluate it.
+    if (Boolean.FALSE.equals(leftBool))
+      return false;
+
+    final Boolean rightBool = toBoolean(right.evaluate(result, context));
 
     // false AND anything = false
-    if (Boolean.FALSE.equals(leftBool) || Boolean.FALSE.equals(rightBool))
+    if (Boolean.FALSE.equals(rightBool))
       return false;
 
     // If either is null (unknown), result is null
@@ -81,14 +83,16 @@ public class TernaryLogicalExpression implements Expression {
   }
 
   private Object evaluateOr(final Result result, final CommandContext context) {
-    final Object leftVal = left.evaluate(result, context);
-    final Object rightVal = right.evaluate(result, context);
+    final Boolean leftBool = toBoolean(left.evaluate(result, context));
 
-    final Boolean leftBool = toBoolean(leftVal);
-    final Boolean rightBool = toBoolean(rightVal);
+    // true OR anything = true: the right operand is result-irrelevant, do not evaluate it.
+    if (Boolean.TRUE.equals(leftBool))
+      return true;
+
+    final Boolean rightBool = toBoolean(right.evaluate(result, context));
 
     // true OR anything = true
-    if (Boolean.TRUE.equals(leftBool) || Boolean.TRUE.equals(rightBool))
+    if (Boolean.TRUE.equals(rightBool))
       return true;
 
     // If either is null (unknown), result is null

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5835AndOrShortCircuitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5835AndOrShortCircuitTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5835: {@code AND} and {@code OR} evaluated their result-irrelevant
+ * operand and surfaced its runtime error, even though the boolean result was already determined
+ * by the other operand (e.g. {@code false AND E} or {@code true OR E}). An equivalent unreachable
+ * expression inside {@code CASE} was correctly skipped, which made the same runtime expression
+ * behave differently depending only on which construct wrapped it.
+ * <p>
+ * {@code AND}/{@code OR} are built with two independent AST node types depending on where they
+ * appear: {@code TernaryLogicalExpression} for {@code RETURN}/{@code WITH} projections and
+ * {@code LogicalExpression} for {@code WHERE} predicates. Both need the short-circuit fix.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5835AndOrShortCircuitTest extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (:_Oracle {_id:'n1'}), (:_Oracle {_id:'n2'})");
+  }
+
+  // --- RETURN/WITH projections (TernaryLogicalExpression) ---
+
+  @Test
+  void andWithFalseLeftShortCircuitsStaticRightError() {
+    assertThat(scalar("RETURN false AND (left('abc', -1) = 0) AS x")).isEqualTo(false);
+  }
+
+  @Test
+  void orWithTrueLeftShortCircuitsStaticRightError() {
+    assertThat(scalar("RETURN true OR (left('abc', -1) = 0) AS x")).isEqualTo(true);
+  }
+
+  @Test
+  void andWithFalseLeftShortCircuitsRuntimeBoundRightError() {
+    assertThat(scalar("WITH 2 AS k RETURN false AND (left('abc', 0-k) = 0) AS x")).isEqualTo(false);
+  }
+
+  @Test
+  void andWithTrueLeftStillEvaluatesRightAndThrows() {
+    // Control: the right operand's value is required to determine the result, so it must
+    // still be evaluated and its error must still surface.
+    assertThatThrownBy(() -> scalar("RETURN true AND (left('abc', -1) = 0) AS x"))
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void orWithFalseLeftStillEvaluatesRightAndThrows() {
+    // Control: same reasoning for OR when the left operand is false.
+    assertThatThrownBy(() -> scalar("RETURN false OR (left('abc', -1) = 0) AS x"))
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void unselectedCaseBranchStillSkipsRuntimeBoundError() {
+    // Control: CASE already behaved correctly; must remain unaffected by the AND/OR fix.
+    assertThat(scalar("""
+        WITH 2 AS k \
+        RETURN CASE \
+          WHEN false THEN left('abc', 0-k) \
+          ELSE 1 \
+        END AS x""")).isEqualTo(1L);
+  }
+
+  // --- Three-valued (null) logic must be unaffected by the short-circuit fix ---
+
+  @Test
+  void nullAndFalseIsFalse() {
+    assertThat(scalar("RETURN (null AND false) AS x")).isEqualTo(false);
+  }
+
+  @Test
+  void trueAndNullIsNull() {
+    assertThat(scalar("RETURN (true AND null) AS x")).isNull();
+  }
+
+  @Test
+  void nullOrTrueIsTrue() {
+    assertThat(scalar("RETURN (null OR true) AS x")).isEqualTo(true);
+  }
+
+  @Test
+  void falseOrNullIsNull() {
+    assertThat(scalar("RETURN (false OR null) AS x")).isNull();
+  }
+
+  // --- WHERE predicates (LogicalExpression) ---
+
+  @Test
+  void whereFalseAndShortCircuitsStaticRightError() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:_Oracle) WHERE false AND (left('abc', -1) = 0) RETURN n._id AS id")) {
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void whereFalseAndShortCircuitsRuntimeBoundRightError() {
+    // Left operand is a runtime-evaluated comparison (not a literal), so it cannot be caught
+    // by any compile-time boolean-literal simplification: this exercises LogicalExpression's
+    // own short-circuit, not just a rewrite pass.
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:_Oracle) WHERE (n._id = 'does-not-exist') AND (left('abc', -1) = 0) RETURN n._id AS id")) {
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void whereTrueOrShortCircuitsRuntimeBoundRightError() {
+    // A WITH-bound (non-literal) true flag on the left of OR: cannot be caught by any
+    // compile-time boolean-literal simplification either.
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:_Oracle) WHERE n._id = 'n1' WITH n, true AS flag " +
+            "WHERE flag OR (left('abc', -1) = 0) RETURN n._id AS id")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("id")).isEqualTo("n1");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void whereTrueOrShortCircuitsStaticRightError() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:_Oracle) WHERE true OR (left('abc', -1) = 0) RETURN n._id AS id ORDER BY id")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("id")).isEqualTo("n1");
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("id")).isEqualTo("n2");
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void whereTrueAndStillEvaluatesRightAndThrows() {
+    // Control: the right operand's value is required, so its error must still surface.
+    assertThatThrownBy(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (n:_Oracle) WHERE true AND (left('abc', -1) = 0) RETURN n")) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).isInstanceOf(CommandSemanticException.class);
+  }
+
+  private Object scalar(final String cypher) {
+    try (final ResultSet rs = database.query("opencypher", cypher)) {
+      assertThat(rs.hasNext()).as("query returned no rows: %s", cypher).isTrue();
+      final Result r = rs.next();
+      return r.getProperty("x");
+    }
+  }
+}


### PR DESCRIPTION
Closes #5835

`false AND E` and `true OR E` already determine the boolean result from the left operand, but ArcadeDB's Cypher `AND`/`OR` unconditionally evaluated the right operand too, in both places `AND`/`OR` are built: `LogicalExpression` (used for `WHERE` predicates) and `TernaryLogicalExpression` (used for `RETURN`/`WITH` projections). If the right operand raised a runtime error (e.g. `left('abc', -1)`), the whole query failed even though that operand's value could not affect the result. The same runtime expression was already correctly skipped when placed in an unreachable `CASE` branch, so the same guard failed or succeeded purely depending on which construct wrapped it.

A `WHERE`-clause rewrite pass (`BooleanSimplifier`) already folds *literal* `true`/`false` guards at plan time, which made the literal-guard `WHERE` case look fine in isolated testing, but that rewrite does not run for `RETURN`/`WITH` at all, and even in `WHERE` it can't help when the guard is not a literal (e.g. a comparison, or a `WITH`-bound variable) — the runtime evaluation still had the bug in the general case.

This PR adds real short-circuit evaluation to both `evaluateAnd`/`evaluateOr` pairs:
- `AND`: if the left operand is `false`, return `false` without evaluating the right operand.
- `OR`: if the left operand is `true`, return `true` without evaluating the right operand.
- Otherwise (left is `true`/`null` for `AND`, `false`/`null` for `OR`), the right operand's value is required, so it is still evaluated exactly as before — including three-valued (`null`) logic, which is unchanged.

## Test plan

- [x] New regression test `Issue5835AndOrShortCircuitTest` (15 tests) covering both AST paths: `RETURN`/`WITH` and `WHERE`, static-literal and runtime-bound guards, controls proving the right operand is still evaluated (and still throws) when its value is required, a control proving the unaffected `CASE` behavior, and three-valued-logic regressions (`null AND false`, `true AND null`, `null OR true`, `false OR null`).
- [x] Verified the new test reproduces the bug before the fix (4/15 failing) and passes after (15/15).
- [x] Re-ran `Issue5383BooleanNullFunctionTest`, the `opencypher.rewriter.*` and `opencypher.ast.*` suites, a CASE/WHERE/inline-filter suite (14 classes), and a NOT/EXISTS/MERGE suite (4 classes) — no regressions.
- [x] `mvn -pl engine -am compile` — engine module compiles cleanly.