### PR TITLE
fix(#5809): substring() propagates null length at/past the string-length boundary

### DIFF
--- a/docs/5809-substring-null-length-boundary.md
+++ b/docs/5809-substring-null-length-boundary.md
@@ -49,3 +49,24 @@ Also re-ran the related existing suites to confirm no regression:
 - `SQLMethodSubStringTest` (3 tests) - the separate SQL-side substring implementation, unaffected.
 
 All 136 tests pass with 0 failures.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5882
+
+## Review cycles
+
+### Cycle 1 - `b9664b2d5`
+
+`claude[bot]` posted a review as an issue comment (not a formal PR review) verifying the fix's
+control-flow ordering line by line and confirming it is correct and minimal. It flagged one
+non-blocking consistency suggestion: reuse `CypherFunctionHelper.isExplicitNull(args, position)`
+- the codebase's canonical helper for exactly this check, already used by `RoundFunction`,
+`NormalizeFunction`, `FormatFunction`, the `*TruncateFunction` family, `VectorDistanceFunction`,
+and the sibling `com.arcadedb.function.text.SubstringFunction` - instead of the hand-rolled
+`args.length == 3 && args[2] == null`.
+
+Applied: replaced the hand-rolled check with `CypherFunctionHelper.isExplicitNull(args, 2)` and
+added the import. Re-ran the same 136-test suite; all pass with 0 failures.
+
+No deferred items from this cycle.

--- a/docs/5809-substring-null-length-boundary.md
+++ b/docs/5809-substring-null-length-boundary.md
@@ -70,3 +70,29 @@ Applied: replaced the hand-rolled check with `CypherFunctionHelper.isExplicitNul
 added the import. Re-ran the same 136-test suite; all pass with 0 failures.
 
 No deferred items from this cycle.
+
+### Cycle 2 - `42aab29a1`
+
+`claude[bot]` re-reviewed after the cycle 1 push (issue comment, not a formal PR review).
+Confirmed the fix and the `isExplicitNull` refactor are correct by tracing all four cases by
+hand and cross-checking against the sibling `com.arcadedb.function.text.SubstringFunction`
+implementation. Raised one non-blocking observation, explicitly marked pre-existing and out of
+scope: `CypherSubstringFunction`'s `length < 0` check only runs inside the `args.length == 3`
+branch, which is unreachable once `start >= str.length()` has already returned `""`, so
+`substring('ab', 5, -1)` returns `""` instead of throwing. This predates this PR (the old code
+had the same gap before either fix) and was suggested only as a possible follow-up issue, not a
+change to make here.
+
+No actionable items, no code changes required, working tree clean. Treated as a clean approval -
+loop exited after 2 cycles.
+
+### Deferred items
+
+None. The one non-blocking observation from cycle 2 (pre-existing negative-length validation
+gap in `CypherSubstringFunction`, unrelated to this PR's fix) was intentionally left for a
+possible separate follow-up issue rather than filed here, since it predates this change and
+touches a different code path (`length < 0` validation, not null propagation).
+
+### Final state
+
+`clean-approval`

--- a/docs/5809-substring-null-length-boundary.md
+++ b/docs/5809-substring-null-length-boundary.md
@@ -1,0 +1,51 @@
+# Issue #5809 - substring() skips null propagation when the start index is at or beyond the string length
+
+## Problem
+
+`CypherSubstringFunction.execute()` checked `start >= str.length()` and returned `""` before
+checking whether the explicit three-argument `length` was `null`. This meant:
+
+- `substring('ab', 1, null)` correctly returned `null` (the fix for #5193 - `start < length`).
+- `substring('ab', 2, null)` and `substring('ab', 3, null)` incorrectly returned `""` instead of
+  `null`, because `start >= str.length()` was true and the method returned before ever reaching
+  the `args[2] == null` check.
+
+This violated the null-propagation rule settled in #5629/#5699: an explicit `null` in an optional
+argument position is never "argument omitted" and must propagate, regardless of what the other
+arguments are. The boundary-dependent behavior meant the same explicit `null` length propagated
+or didn't depending on where `start` landed relative to the string length, which no
+null-propagation rule depends on.
+
+## Fix
+
+`engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java`
+
+Moved the `args.length == 3 && args[2] == null` check ahead of the `start >= str.length()`
+short-circuit, so the explicit-null-length propagation is decided before the two-argument
+"empty tail" boundary behavior can intercept it. The two-argument (length omitted) form is
+untouched - it still legitimately returns `""` at and past the boundary.
+
+## Tests
+
+New regression test:
+`engine/src/test/java/com/arcadedb/query/opencypher/CypherSubstringNullLengthBoundaryIssue5809Test.java`
+
+- `substringPropagatesNullLengthWhenStartIsBeforeTheEnd` - pins the #5193 witness so it can't
+  regress alongside this fix.
+- `substringPropagatesNullLengthWhenStartIsAtTheEnd` - the exact #5809 repro (`start == length`).
+- `substringPropagatesNullLengthWhenStartIsPastTheEnd` - the exact #5809 repro (`start > length`).
+- `substringStillReturnsTheEmptyTailWhenLengthIsOmittedAtOrPastTheEnd` - pins that the two-argument
+  form's boundary behavior is unchanged.
+
+Confirmed the new test fails against the pre-fix code (2/4 failures, matching the two out-of-range
+cases from the issue) before applying the fix, then passes after.
+
+Also re-ran the related existing suites to confirm no regression:
+- `CypherOptionalArgumentNullIssue5629Test` (17 tests) - the #5629/#5699 null-propagation rule
+  test suite, including its existing substring coverage.
+- `OpenCypherStringFunctionsComprehensiveTest` (77 tests)
+- `CypherFunctionFactoryExtendedTest` (30 tests)
+- `CypherFunctionArityRegistryTest` (5 tests)
+- `SQLMethodSubStringTest` (3 tests) - the separate SQL-side substring implementation, unaffected.
+
+All 136 tests pass with 0 failures.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -54,7 +55,7 @@ public class CypherSubstringFunction implements StatelessFunction {
     // Issue #5193/#5809: an explicitly supplied null length propagates null (as Neo4j does), it must not be
     // treated as an omitted argument. This check must run before the start-past-the-end short-circuit below,
     // otherwise null propagation silently stops once start reaches the length of the string.
-    if (args.length == 3 && args[2] == null)
+    if (CypherFunctionHelper.isExplicitNull(args, 2))
       return null;
     if (start >= str.length())
       return "";

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
@@ -51,13 +51,14 @@ public class CypherSubstringFunction implements StatelessFunction {
     final int start = ((Number) args[1]).intValue();
     if (start < 0)
       throw new CommandExecutionException("Cannot handle negative start index nor negative length");
+    // Issue #5193/#5809: an explicitly supplied null length propagates null (as Neo4j does), it must not be
+    // treated as an omitted argument. This check must run before the start-past-the-end short-circuit below,
+    // otherwise null propagation silently stops once start reaches the length of the string.
+    if (args.length == 3 && args[2] == null)
+      return null;
     if (start >= str.length())
       return "";
     if (args.length == 3) {
-      // Issue #5193: an explicitly supplied null length propagates null (as Neo4j does),
-      // it must not be treated as an omitted argument.
-      if (args[2] == null)
-        return null;
       final int length = ((Number) args[2]).intValue();
       if (length < 0)
         throw new CommandExecutionException("Cannot handle negative start index nor negative length");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubstringNullLengthBoundaryIssue5809Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubstringNullLengthBoundaryIssue5809Test.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5809: {@code substring(original, start, null)} correctly propagated {@code null} (the
+ * fix for #5193) as long as {@code start < length(original)}, but fell through to the two-argument "empty tail"
+ * behavior and returned {@code ""} once {@code start} reached or passed the end of the string. Null propagation
+ * for an explicit {@code null} length argument must not depend on where the start index lands - the boundary check
+ * that returns {@code ""} for the omitted-length form must not run before the explicit-null check for the
+ * three-argument form.
+ */
+class CypherSubstringNullLengthBoundaryIssue5809Test extends TestHelper {
+
+  @Test
+  void substringPropagatesNullLengthWhenStartIsBeforeTheEnd() {
+    // The #5193 witness - already correct before this fix, pinned here so a regression is caught alongside the
+    // boundary cases below.
+    assertThat(single("RETURN substring('ab', 1, null) AS r")).isNull();
+  }
+
+  @Test
+  void substringPropagatesNullLengthWhenStartIsAtTheEnd() {
+    assertThat(single("RETURN substring('ab', 2, null) AS r")).isNull();
+  }
+
+  @Test
+  void substringPropagatesNullLengthWhenStartIsPastTheEnd() {
+    assertThat(single("RETURN substring('ab', 3, null) AS r")).isNull();
+  }
+
+  @Test
+  void substringStillReturnsTheEmptyTailWhenLengthIsOmittedAtOrPastTheEnd() {
+    // The two-argument (length omitted) form legitimately returns the empty tail at and past the boundary - this
+    // is the behavior that must not be disturbed by the null-length fix above.
+    assertThat(single("RETURN substring('ab', 2) AS r")).isEqualTo("");
+    assertThat(single("RETURN substring('ab', 3) AS r")).isEqualTo("");
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes `substring(original, start, null)` in the OpenCypher engine so it consistently returns
`null` when the length argument is explicitly `null`, regardless of where `start` falls relative
to the length of the original string.

`CypherSubstringFunction.execute()` checked `start >= str.length()` and returned `""` before
checking whether the explicit three-argument `length` was `null`. That meant
`substring('ab', 1, null)` correctly propagated `null` (`start < length`), but
`substring('ab', 2, null)` and `substring('ab', 3, null)` fell through to the two-argument
"empty tail" behavior and returned `""` instead, because the boundary short-circuit ran first.

The fix moves the `args[2] == null` check ahead of the `start >= str.length()` short-circuit, so
explicit-null propagation is decided before the two-argument boundary behavior can intercept it.
The two-argument (length omitted) form is untouched - it still legitimately returns `""` at and
past the boundary.

Closes #5809

## Motivation

Under ArcadeDB's adopted explicit-null contract (settled in #5629/#5699), an explicit `null` in an
optional argument position is never "argument omitted" - it must propagate, the same as it already
does for `round()`, `ltrim()`, and `normalize()`. `substring()` violated that rule only at the
string-length boundary, which no null-propagation rule depends on: the same explicit `null` length
propagated at `start = 1` but stopped at `start = 2`. Queries that pass a possibly-null computed
`length` get a silently wrong `""` instead of `null` exactly when `start` sits at or past the end
of the string, which can flip downstream `IS NULL` / `coalesce` / `WHERE` branches.

## Related issues

Closes #5809. Residual boundary case left after the fix for #5193 ("substring() treats an explicit
null length as an omitted argument"), whose exact witness (`substring('hello', 1, null)` ->
`'ello'`) remains correct and is pinned by a new test alongside the boundary cases.

## Additional Notes

None.

## Test plan

- [x] New regression test `CypherSubstringNullLengthBoundaryIssue5809Test` (4 tests):
  - `substring('ab', 1, null)` -> `null` (the #5193 witness, pinned against regression)
  - `substring('ab', 2, null)` -> `null` (start == length, the exact #5809 repro)
  - `substring('ab', 3, null)` -> `null` (start > length, the exact #5809 repro)
  - `substring('ab', 2)` / `substring('ab', 3)` (length omitted) -> `""` unchanged
- [x] Confirmed the new test fails against the pre-fix code (2/4 failures, matching the two
      out-of-range cases from the issue) before applying the fix, then passes after.
- [x] Re-ran related existing suites with no regressions (136 tests total, 0 failures):
  `CypherOptionalArgumentNullIssue5629Test` (17), `OpenCypherStringFunctionsComprehensiveTest`
  (77), `CypherFunctionFactoryExtendedTest` (30), `CypherFunctionArityRegistryTest` (5),
  `SQLMethodSubStringTest` (3, the separate SQL-side implementation, unaffected).

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
