### PR TITLE
fix(#5788): let database open() optionally await restored Graph Analytical Views

### DIFF
--- a/docs/5788-gav-restore-await-timeout.md
+++ b/docs/5788-gav-restore-await-timeout.md
@@ -1,0 +1,96 @@
+# Issue #5788: Graph Analytical View is never READY in time to serve the query that triggered it
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5788
+
+## Root cause / analysis
+
+`LocalDatabase.open()` calls `GraphAnalyticalViewPersistence.restoreAll(database)` after
+`openInternal()`. `restoreAll()` reads each persisted GAV definition and calls
+`builder.skipPersistence().buildAsync()`, which fires the CSR rebuild on the shared
+`gav-worker-` virtual-thread executor and returns immediately - the method does not wait for
+any of the triggered builds to reach `READY`.
+
+The reporter measured (26.8.1.dev23, 10k/100k/1M/5M-vertex graphs) that a query issued right
+after `open()` always beats the background rebuild, always falls back to the unaccelerated OLTP
+path, and at 3 of the 4 sizes the "cold" session (view present, still building) is *slower*
+end-to-end than a database with no view configured at all, because the query competes with the
+background scan for CPU.
+
+The issue frames this as an open question rather than a bug report and proposes a much larger
+change (persisting the CSR itself to disk, so a reopen loads it instead of rebuilding it) but
+explicitly declines to prototype it ("I did not want to write several hundred lines of new
+on-disk format against a guess"). Persisting the derived CSR structure is a large, high-risk
+undertaking (new on-disk paginated format, staleness handling, a format review) that does not
+belong in an unattended single-issue fix.
+
+The `GraphAnalyticalView` class already has the building block the issue's ask actually needs:
+`awaitReady(timeout, unit)`, plus `GraphAnalyticalViewRegistry.getAll()`/`getReady()`. What is
+missing is a *supported, opt-in* way to make `open()` itself wait for restored views, so that
+for callers who choose it, the session that pays for the rebuild is once again the session that
+benefits - without inventing a new persistence format.
+
+## Fix
+
+Add a new `SCOPE.DATABASE` setting, `GAV_RESTORE_AWAIT_TIMEOUT`
+(`arcadedb.gavRestoreAwaitTimeout`, `Long`, default `0`). When `0` (the default), behavior is
+byte-for-byte unchanged: `restoreAll()` triggers the async rebuild and returns immediately, same
+as today. When set to a positive number of milliseconds, `restoreAll()` still triggers every
+build asynchronously (so a single stuck/slow view cannot block the others beyond the shared
+budget), then blocks the calling `open()` for up to that many milliseconds total, waiting for
+each triggered view to reach `READY` (or fail/go `STALE`) via the existing `awaitReady()`.
+
+This is scoped to the actual reproducible defect (the session that rebuilds is never the one
+that benefits) without taking on CSR-to-disk persistence, which remains open ground for a
+follow-up if the maintainers want it (tracked by the issue's own text, and related issue #5747).
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/GlobalConfiguration.java` - new `GAV_RESTORE_AWAIT_TIMEOUT` setting.
+- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java` - `restoreAll()` optionally awaits restored views up to the configured budget.
+- `engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java` - regression test.
+
+## Test plan
+
+- New test reproducing the issue: reopen a database with a persisted GAV and
+  `GAV_RESTORE_AWAIT_TIMEOUT` set to a positive value - the view must be `READY` with the correct
+  node/edge counts *immediately* after `open()` returns, with no additional `awaitReady()` call
+  from the test.
+- Existing `gavRestoredOnDatabaseReopen` test continues to prove the default (`0`, non-blocking)
+  behavior is unchanged.
+- Full `GraphAnalyticalViewTest` suite run to check for regressions.
+
+## Results
+
+- TDD: the new test (`gavRestoreAwaitTimeoutBlocksOpenUntilViewsAreReady`) was first proven unable
+  to compile without `GAV_RESTORE_AWAIT_TIMEOUT` (the setting did not exist), then, once the
+  setting existed but the wait logic in `restoreAll()` was stubbed out (`if (false && ...)`),
+  proven to fail with `Expecting value to be true but was false` - confirming the assertion
+  actually exercises the fix rather than passing vacuously. Restoring the real wait logic turns it
+  green.
+- `mvn -pl engine -am test -Dtest=GraphAnalyticalViewTest`: **133/133 passed**, 0 failures, 0
+  errors (11.74s). No regressions in any existing GAV persistence/reopen/incremental-update test.
+- `mvn -pl engine -am test -Dtest=GlobalConfigurationTest,ContextConfigurationTest,ConfigurationTest`:
+  all passed (10 + 30 + 4 tests).
+- `mvn -pl engine -am compile`: clean.
+
+## Impact analysis
+
+- **Default behavior is unchanged.** `GAV_RESTORE_AWAIT_TIMEOUT` defaults to `0`, so
+  `restoreAll()` triggers the async rebuild and returns immediately exactly as before; existing
+  deployments see no behavior change and no performance cost unless they opt in.
+- **Opt-in cost is a slower `open()`.** Setting the timeout trades `open()` latency for the
+  restored GAV being immediately usable, bounded by the configured budget (shared across all
+  restored views in that database, not per-view) so one slow/stuck view cannot block the others
+  beyond the configured total.
+- Does not address CSR-to-disk persistence (the issue's larger, explicitly-speculative ask);
+  the async rebuild itself is unchanged, only whether `open()` waits for it.
+
+## Recommendations / follow-up
+
+- Persisting the CSR itself to disk (issue's original ask) remains open ground for a dedicated,
+  reviewed follow-up if the maintainers want it - the issue explicitly frames that as a design
+  question, and #5747 is called out as a cautionary precedent for a persisted-vs-rebuilt check
+  the load path.
+- Consider surfacing `GAV_RESTORE_AWAIT_TIMEOUT` in the embedded-deployment docs alongside
+  `GAV_USE_WHEN_STALE`, since both trade correctness/latency in the same "read-mostly analytics"
+  use case the issue describes.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1658,6 +1658,14 @@ public enum GlobalConfiguration {
       """
       When true, the query planner uses stale Graph Analytical Views (GAV/CSR) for traversals instead of falling back to OLTP. \
       Stale data is faster but may not reflect the latest committed changes""", Boolean.class, false),
+
+  GAV_RESTORE_AWAIT_TIMEOUT("arcadedb.gavRestoreAwaitTimeout", SCOPE.DATABASE,
+      """
+      Milliseconds database open() blocks waiting for Graph Analytical Views (GAV/CSR) restored from persisted \
+      definitions to reach READY before returning. 0 (default) does not wait: the async rebuild is still triggered, \
+      but open() returns immediately and queries issued right after it run unaccelerated until the rebuild completes. \
+      A positive value trades a slower open() for the restored view being usable by the query that triggered the reopen""",
+      Long.class, 0L),
   ;
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.graph.olap;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
@@ -26,6 +27,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 /**
@@ -41,7 +43,10 @@ import java.util.logging.Level;
  *   // After opening a database, restore all previously saved GAVs:
  *   GraphAnalyticalViewPersistence.restoreAll(database);
  *
- *   // This rebuilds all GAVs asynchronously from their saved definitions.
+ *   // This rebuilds all GAVs asynchronously from their saved definitions. By default the call
+ *   // returns as soon as the rebuilds are triggered, before any of them reach READY - see
+ *   // {@link com.arcadedb.GlobalConfiguration#GAV_RESTORE_AWAIT_TIMEOUT} to instead block the
+ *   // caller (bounded by a configurable timeout) until the restored views are ready.
  * </pre>
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -82,6 +87,10 @@ public class GraphAnalyticalViewPersistence {
   /**
    * Restores all GAV definitions from the schema and rebuilds them asynchronously.
    * Call this after opening a database to restore previously saved GAVs.
+   * <p>
+   * By default this returns as soon as every rebuild is triggered, without waiting for any of
+   * them to reach READY (see {@link com.arcadedb.GlobalConfiguration#GAV_RESTORE_AWAIT_TIMEOUT}
+   * to instead block, bounded by a configurable timeout, until the restored views are ready).
    *
    * @return the number of GAVs being restored
    */
@@ -95,6 +104,7 @@ public class GraphAnalyticalViewPersistence {
 
     int count = 0;
     List<String> failedKeys = null;
+    final List<GraphAnalyticalView> restoredViews = new ArrayList<>();
     for (final String gavName : allGavs.keySet()) {
       try {
         final JSONObject gavDef = allGavs.getJSONObject(gavName);
@@ -137,7 +147,7 @@ public class GraphAnalyticalViewPersistence {
         final int ct = gavDef.getInt("compactionThreshold", -1);
         if (ct >= 0)
           builder.withCompactionThreshold(ct);
-        builder.skipPersistence().buildAsync();
+        restoredViews.add(builder.skipPersistence().buildAsync());
         count++;
 
         LogManager.instance().log(GraphAnalyticalViewPersistence.class, Level.INFO,
@@ -170,6 +180,22 @@ public class GraphAnalyticalViewPersistence {
     if (count > 0)
       LogManager.instance().log(GraphAnalyticalViewPersistence.class, Level.INFO,
           "Restoring %d Graph Analytical View(s) asynchronously on database open", count);
+
+    // #5788: by default restoreAll() returns as soon as every rebuild is triggered, so the query
+    // that reopened the database always races the background rebuild and loses. When opted in via
+    // GAV_RESTORE_AWAIT_TIMEOUT, block here (bounded by the configured budget, shared across every
+    // restored view) until each triggered build reaches READY, so the session that pays for the
+    // rebuild is the session that benefits from it.
+    final long awaitTimeoutMs = database.getConfiguration().getValueAsLong(GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT);
+    if (awaitTimeoutMs > 0 && !restoredViews.isEmpty()) {
+      final long deadline = System.currentTimeMillis() + awaitTimeoutMs;
+      for (final GraphAnalyticalView view : restoredViews) {
+        final long remainingMs = deadline - System.currentTimeMillis();
+        if (remainingMs <= 0)
+          break;
+        view.awaitReady(remainingMs, TimeUnit.MILLISECONDS);
+      }
+    }
 
     return count;
   }

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.graph.olap;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
@@ -2147,6 +2148,58 @@ class GraphAnalyticalViewTest extends TestHelper {
     }
 
     // Reopen database with the original factory for TestHelper cleanup
+    database = new DatabaseFactory(dbPath).open();
+  }
+
+  /**
+   * Regression for issue #5788: by default, {@code restoreAll()} triggers the async rebuild of a
+   * persisted GAV and returns immediately - the query that reopened the database races the
+   * background rebuild and always loses, so it never benefits from the view it paid to restore.
+   * <p>
+   * Setting {@link GlobalConfiguration#GAV_RESTORE_AWAIT_TIMEOUT} makes {@code open()} block,
+   * bounded by the configured budget, until every restored GAV reaches {@code READY} - so the
+   * session that pays for the rebuild is the session that benefits from it.
+   */
+  @Test
+  void gavRestoreAwaitTimeoutBlocksOpenUntilViewsAreReady() {
+    database.getSchema().createVertexType("City");
+    database.getSchema().createEdgeType("ROAD");
+    database.begin();
+    final List<RID> ids = new ArrayList<>();
+    for (int i = 0; i < 300; i++)
+      ids.add(database.newVertex("City").set("name", "C" + i).save().getIdentity());
+    for (int i = 0; i < ids.size() - 1; i++)
+      ids.get(i).asVertex().modify().newEdge("ROAD", ids.get(i + 1).asVertex());
+    database.commit();
+
+    database.command("sql", "CREATE GRAPH ANALYTICAL VIEW cityRoadsAwait VERTEX TYPES (City) EDGE TYPES (ROAD)");
+
+    final String dbPath = database.getDatabasePath();
+    database.close();
+
+    final Object defaultTimeout = GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT.getValue();
+    GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT.setValue(10_000L);
+    try {
+      final DatabaseFactory factory2 = new DatabaseFactory(dbPath);
+      final Database db2 = factory2.open();
+      try {
+        // No awaitReady() call here: open() must already have blocked until the restore finished.
+        final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(db2, "cityRoadsAwait");
+        assertThat(restored).isNotNull();
+        assertThat(restored.isReady())
+            .as("open() should block until the restored GAV is READY when GAV_RESTORE_AWAIT_TIMEOUT > 0")
+            .isTrue();
+        assertThat(restored.getNodeCount()).isEqualTo(300);
+        assertThat(restored.getEdgeCount()).isEqualTo(299);
+
+        db2.command("sql", "DROP GRAPH ANALYTICAL VIEW cityRoadsAwait");
+      } finally {
+        db2.close();
+      }
+    } finally {
+      GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT.setValue(defaultTimeout);
+    }
+
     database = new DatabaseFactory(dbPath).open();
   }
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `GAV_RESTORE_AWAIT_TIMEOUT` setting (`arcadedb.gavRestoreAwaitTimeout`, `SCOPE.DATABASE`, default `0`). When a database with persisted Graph Analytical Views is reopened, `GraphAnalyticalViewPersistence.restoreAll()` triggers every view's async CSR rebuild as before, but if this timeout is set to a positive number of milliseconds, `open()` now blocks (bounded by that shared budget) until each restored view reaches `READY` before returning, using the existing `GraphAnalyticalView.awaitReady()`.

Default behavior (`0`) is unchanged: `restoreAll()` still returns as soon as the rebuilds are triggered, with no wait.

Closes #5788

## Motivation

The issue measured that a Graph Analytical View's CSR is always rebuilt by a full graph scan on reopen, and that the query issued right after `open()` always beats that background rebuild - the session that pays for the rebuild is never the session that benefits from it. At several graph sizes the reporter also measured the "cold" session (view present, still building) running *slower* end-to-end than a database with no view configured at all, because the query competes with the background scan for CPU.

The issue's own proposed fix (persisting the CSR itself to disk, so a reopen loads it instead of rebuilding it) is explicitly framed as an open design question rather than a concrete ask - the reporter deliberately did not attempt it ("I did not want to write several hundred lines of new on-disk format against a guess"), and it would need a new on-disk paginated format plus staleness handling that deserves its own dedicated review.

`GraphAnalyticalView` already has the building block this actually needs: `awaitReady(timeout, unit)`. What was missing is a supported way to make `open()` itself use it, so a caller who wants the "warm" behavior from the issue's benchmarks can opt in without any new persistence format. This directly fixes the core reproducible defect (the session that rebuilds is never the one that benefits) at a fraction of the risk.

## Related issues

Closes #5788. Related to #5747 (same GAV persistence family, different mechanism - there the structure IS on disk and gets rebuilt anyway; here there is nothing on disk to load, which is why this PR doesn't attempt CSR-to-disk persistence).

## Additional Notes

- Persisting the CSR to disk remains open ground for a follow-up if maintainers want to take it on; this PR intentionally does not attempt it.
- The wait budget is a single deadline shared across all views restored in that `open()` call (not per-view), so one slow or stuck view cannot block the others beyond the configured total.
- Tracking doc with the full analysis: `docs/5788-gav-restore-await-timeout.md`.

## Test plan

- [x] New regression test `gavRestoreAwaitTimeoutBlocksOpenUntilViewsAreReady`: reopens a database with a persisted GAV and `GAV_RESTORE_AWAIT_TIMEOUT` set to a positive value; asserts the view is `READY` with the correct node/edge counts *immediately* after `open()` returns, with no additional `awaitReady()` call from the test.
  - Confirmed the test fails without `GAV_RESTORE_AWAIT_TIMEOUT` existing (compile error), and again fails with the setting present but the wait logic stubbed out (`Expecting value to be true but was false`), before passing with the real fix.
- [x] Existing `gavRestoredOnDatabaseReopen` test continues to pass, proving the default (`0`, non-blocking) behavior is unchanged.
- [x] Full `GraphAnalyticalViewTest` suite: 133/133 passed.
- [x] `GlobalConfigurationTest`, `ContextConfigurationTest`, `ConfigurationTest`: all passed.
- [x] `mvn -pl engine -am compile`: clean.

## Checklist

- [x] I have run the build using `mvn clean package` command (module-scoped: `mvn -pl engine -am compile` + targeted test runs; see Test plan)
- [x] My unit tests cover both failure and success scenarios
