### PR TITLE
fix(#5796): Redis and MongoDB plugins honor their configured host/port

### DIFF
--- a/docs/5796-redis-mongodb-plugin-port-ignored.md
+++ b/docs/5796-redis-mongodb-plugin-port-ignored.md
@@ -75,3 +75,31 @@ argument - no changes needed there.
   `ContextConfiguration` falls back to the same static defaults as before.
 - Deployments that DO configure a custom Redis or MongoDB plugin port will now get the port they asked for, instead of a
   silent bind to the default - fixing potential port collisions with a real Redis/MongoDB instance on the same host.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5887
+
+## Review cycles
+
+- **Cycle 1** - head SHA `42b31759d369b609b8a49a539fafae2dad90ab12` (the only commit on the branch).
+  - `claude[bot]` reviewed and posted as a general PR (issue) comment at `2026-08-07T09:15:24Z`, not a formal PR review -
+    the `gh pr view --json reviews` / `pulls/.../comments` (inline, commit-tied) surfaces used by the review-loop's poll
+    stayed empty, so the poll itself timed out at 15 minutes even though the bot had already responded on the third
+    surface (issue comments). Manually checking `gh api repos/.../issues/5887/comments` found the review.
+  - Verdict: correctness, test coverage, style, and security/performance all reviewed with no blocking issues. One
+    non-blocking nit - `isListening(...)` helper duplicated verbatim between `RedisPortConfigurationTest` and
+    `MongoDBPortConfigurationTest` (the two modules don't share a test-util dependency) - the reviewer explicitly called
+    this "a reasonable tradeoff and not worth blocking on." Evaluated against `superpowers:receiving-code-review`
+    principles: the nit is accurate but genuinely low-value to fix given the module boundary, so it was skipped rather
+    than applied. No code changes were made in response to this review.
+  - Working tree stayed empty after the review (no fixes needed) -> **clean-approval**, loop exited after 1 cycle.
+
+## Deferred items
+
+None. The single nit raised (duplicated `isListening` helper across `redisw`/`mongodbw` test modules, no shared
+test-util dependency between them) was evaluated and consciously skipped, not deferred - see Review cycles above.
+
+## Final state
+
+`clean-approval` (1 review cycle). PR left open for the developer to merge.

--- a/docs/5796-redis-mongodb-plugin-port-ignored.md
+++ b/docs/5796-redis-mongodb-plugin-port-ignored.md
@@ -1,0 +1,77 @@
+# Issue #5796: Redis and MongoDB protocol plugins ignore their configured port and bind the default
+
+## Root cause
+
+Both `RedisProtocolPlugin` and `MongoDBProtocolPlugin` implement `ServerPlugin.configure(ArcadeDBServer, ContextConfiguration)`,
+which is the server's per-instance configuration passed by `PluginManager.startPlugins()`. Postgres and Bolt read their
+host/port from this `configuration` argument. Redis and MongoDB did not:
+
+- `RedisProtocolPlugin` stored the `ContextConfiguration` in a field (used it correctly for `REDIS_TLS`), but its
+  `startService()` read the host/port via the static accessors `GlobalConfiguration.REDIS_HOST.getValueAsString()` /
+  `GlobalConfiguration.REDIS_PORT.getValueAsString()`, i.e. the hardcoded defaults, never the value set on the server's
+  `ContextConfiguration`.
+- `MongoDBProtocolPlugin.configure()` dropped the `configuration` argument entirely and `startService()` bound
+  `GlobalConfiguration.MONGO_HOST` / `GlobalConfiguration.MONGO_PORT` directly, same defect.
+
+`BoltProtocolPlugin` had exactly this bug and was fixed in #3809 by reading `BOLT_HOST`/`BOLT_PORT` off the `configuration`
+argument in `configure()` and using the stored fields in `startService()`. This fix mirrors that pattern for Redis and Mongo.
+
+Because `ContextConfiguration` falls back to the `GlobalConfiguration` static default whenever a key is not explicitly set on
+the instance (see `ContextConfiguration` class Javadoc), reading through `configuration.getValueAsString/Integer(...)` is
+strictly more correct and fully backward compatible with every existing test/deployment that never overrode the port.
+
+## Fix
+
+- `redisw/src/main/java/com/arcadedb/redis/RedisProtocolPlugin.java`: `startService()` now reads host/port via
+  `configuration.getValueAsString(GlobalConfiguration.REDIS_HOST)` / `configuration.getValueAsString(GlobalConfiguration.REDIS_PORT)`
+  instead of the static `GlobalConfiguration.REDIS_HOST`/`REDIS_PORT` accessors.
+- `mongodbw/src/main/java/com/arcadedb/mongo/MongoDBProtocolPlugin.java`: `configure()` now captures `host`/`port` fields from
+  the `configuration` argument (mirroring `PostgresProtocolPlugin`/`BoltProtocolPlugin`), and `startService()` binds those
+  fields instead of the static `GlobalConfiguration.MONGO_HOST`/`MONGO_PORT` accessors.
+
+## Tests (TDD)
+
+New regression tests, one per affected module, extending `BaseGraphServerTest` and overriding `onServerConfiguration()` to set
+a custom port (obtained from a `ServerSocket(0)` probe to avoid collisions) on the per-server `ContextConfiguration` - exactly
+the object `PluginManager` hands to `ServerPlugin.configure()`:
+
+- `redisw/src/test/java/com/arcadedb/redis/RedisPortConfigurationTest.java`
+  - Connects a Jedis client to the configured custom port and checks `PING` succeeds.
+  - Asserts the hardcoded default port (6379) is NOT accepting connections.
+- `mongodbw/src/test/java/com/arcadedb/mongo/MongoDBPortConfigurationTest.java`
+  - Connects a Mongo client to the configured custom port and checks a `ping` command succeeds.
+  - Asserts the hardcoded default port (27017) is NOT accepting connections.
+
+Both tests were verified to **fail** against the pre-fix code (proving they exercise the bug) before the fix was applied, then
+verified to pass after the fix:
+
+- Pre-fix `RedisPortConfigurationTest`: `JedisConnectionException: Failed to connect to localhost:<custom>` - the plugin was
+  still bound to the default port.
+- Pre-fix `MongoDBPortConfigurationTest`: `MongoTimeoutException: Timed out after 5000 ms while waiting to connect` to the
+  custom port - same cause.
+
+## Test results
+
+Ran with the fix applied, module-scoped (dependencies installed first via `mvn -pl redisw,mongodbw -am install -DskipTests`,
+then `mvn -pl redisw,mongodbw test`):
+
+- `redisw`: 5 test classes, 46 tests, 0 failures, 0 errors (includes the new `RedisPortConfigurationTest`).
+- `mongodbw`: 13 test classes, 84 tests, 0 failures, 0 errors (includes the new `MongoDBPortConfigurationTest`).
+
+No existing tests were modified or deleted.
+
+## Scope note
+
+The issue also mentions, as a separate "worth considering" suggestion, that a plugin unable to honor a setting should log
+that fact. That is a follow-up UX/observability improvement, not part of this fix, and was left out to keep the change
+minimal and focused on the reported defect (silently binding the wrong port).
+
+`PostgresProtocolPlugin` and `BoltProtocolPlugin` were inspected and already read host/port correctly from the `configuration`
+argument - no changes needed there.
+
+## Impact analysis
+
+- No behavior change for any deployment that does not set `REDIS_PORT`/`REDIS_HOST`/`MONGO_PORT`/`MONGO_HOST` explicitly:
+  `ContextConfiguration` falls back to the same static defaults as before.
+- Deployments that DO configure a custom Redis or MongoDB plugin port will now get the port they asked for, instead of a
+  silent bind to the default - fixing potential port collisions with a real Redis/MongoDB instance on the same host.

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBProtocolPlugin.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBProtocolPlugin.java
@@ -33,18 +33,22 @@ public class MongoDBProtocolPlugin implements ServerPlugin, DatabaseResolver {
   private MongoServer                         mongoDBServer;
   private MongoDBBackend                      mongoDBBackend;
   private ArcadeDBServer                      server;
+  private String                              host;
+  private int                                 port;
   private Map<String, MongoDBDatabaseWrapper> databases = new ConcurrentHashMap<>();
 
   @Override
   public void configure(final ArcadeDBServer arcadeDBServer, final ContextConfiguration configuration) {
     this.server = arcadeDBServer;
+    this.host = configuration.getValueAsString(GlobalConfiguration.MONGO_HOST);
+    this.port = configuration.getValueAsInteger(GlobalConfiguration.MONGO_PORT);
   }
 
   @Override
   public void startService() {
     mongoDBBackend = new MongoDBBackend(server, this);
     mongoDBServer = new MongoServer(mongoDBBackend);
-    mongoDBServer.bind(GlobalConfiguration.MONGO_HOST.getValueAsString(), GlobalConfiguration.MONGO_PORT.getValueAsInteger());
+    mongoDBServer.bind(host, port);
   }
 
   @Override

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBPortConfigurationTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBPortConfigurationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5796: {@link MongoDBProtocolPlugin#configure(com.arcadedb.server.ArcadeDBServer, ContextConfiguration)}
+ * used to drop the server's {@link ContextConfiguration} argument entirely and {@link MongoDBProtocolPlugin#startService()}
+ * bound the static {@link GlobalConfiguration#MONGO_HOST}/{@link GlobalConfiguration#MONGO_PORT} defaults instead. This meant
+ * a custom port configured on the server was silently discarded and the plugin always bound the hardcoded default (27017).
+ */
+public class MongoDBPortConfigurationTest extends BaseGraphServerTest {
+
+  private static int customPort;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin");
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    try (final ServerSocket probe = new ServerSocket(0)) {
+      customPort = probe.getLocalPort();
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+    config.setValue(GlobalConfiguration.MONGO_PORT, customPort);
+  }
+
+  @Test
+  void pluginBindsTheConfiguredPortNotTheDefault() {
+    // The plugin must be reachable on the port configured via ContextConfiguration...
+    try (final MongoClient client = new MongoClient(new ServerAddress("localhost", customPort),
+        MongoCredential.createPlainCredential("root", getDatabaseName(), DEFAULT_PASSWORD_FOR_TESTS.toCharArray()),
+        MongoClientOptions.builder().serverSelectionTimeout(5000).build())) {
+      final Document pingResult = client.getDatabase(getDatabaseName()).runCommand(new Document("ping", 1));
+      assertThat(pingResult.getDouble("ok")).isEqualTo(1.0);
+    }
+
+    // ...and must NOT have silently fallen back to the hardcoded default port.
+    final int defaultPort = GlobalConfiguration.MONGO_PORT.getValueAsInteger();
+    assertThat(isListening(defaultPort))
+        .as("MongoDB plugin must not bind the default port %d when a custom port %d is configured", defaultPort, customPort)
+        .isFalse();
+  }
+
+  private static boolean isListening(final int port) {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("127.0.0.1", port), 500);
+      return true;
+    } catch (final IOException e) {
+      return false;
+    }
+  }
+
+  @Override
+  protected void populateDatabase() {
+    // NO NEED FOR TEST DATA, THIS TEST ONLY EXERCISES THE PLUGIN'S NETWORK BINDING
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+}

--- a/redisw/src/main/java/com/arcadedb/redis/RedisProtocolPlugin.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisProtocolPlugin.java
@@ -42,8 +42,8 @@ public class RedisProtocolPlugin implements ServerPlugin {
         new RedisSslServerSocketFactory(configuration) :
         new DefaultServerSocketFactory();
 
-    listener = new RedisNetworkListener(server, socketFactory, GlobalConfiguration.REDIS_HOST.getValueAsString(),
-        GlobalConfiguration.REDIS_PORT.getValueAsString());
+    listener = new RedisNetworkListener(server, socketFactory, configuration.getValueAsString(GlobalConfiguration.REDIS_HOST),
+        configuration.getValueAsString(GlobalConfiguration.REDIS_PORT));
   }
 
   @Override

--- a/redisw/src/test/java/com/arcadedb/redis/RedisPortConfigurationTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisPortConfigurationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5796: {@link RedisProtocolPlugin#configure(com.arcadedb.server.ArcadeDBServer, ContextConfiguration)}
+ * used to store the server's {@link ContextConfiguration} but then ignore it in {@link RedisProtocolPlugin#startService()},
+ * reading the host/port from the static {@link GlobalConfiguration#REDIS_HOST}/{@link GlobalConfiguration#REDIS_PORT}
+ * defaults instead. This meant a custom port configured on the server was silently discarded and the plugin always bound
+ * the hardcoded default (6379).
+ */
+public class RedisPortConfigurationTest extends BaseGraphServerTest {
+
+  private static int customPort;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Redis Protocol:com.arcadedb.redis.RedisProtocolPlugin");
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    try (final ServerSocket probe = new ServerSocket(0)) {
+      customPort = probe.getLocalPort();
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+    config.setValue(GlobalConfiguration.REDIS_PORT, customPort);
+  }
+
+  @Test
+  void pluginBindsTheConfiguredPortNotTheDefault() {
+    // The plugin must be reachable on the port configured via ContextConfiguration...
+    try (final Jedis jedis = new Jedis("localhost", customPort)) {
+      jedis.auth("root", DEFAULT_PASSWORD_FOR_TESTS);
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+
+    // ...and must NOT have silently fallen back to the hardcoded default port.
+    final int defaultPort = GlobalConfiguration.REDIS_PORT.getValueAsInteger();
+    assertThat(isListening(defaultPort))
+        .as("Redis plugin must not bind the default port %d when a custom port %d is configured", defaultPort, customPort)
+        .isFalse();
+  }
+
+  private static boolean isListening(final int port) {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("127.0.0.1", port), 500);
+      return true;
+    } catch (final IOException e) {
+      return false;
+    }
+  }
+
+  @Override
+  protected void populateDatabase() {
+    // NO NEED FOR TEST DATA, THIS TEST ONLY EXERCISES THE PLUGIN'S NETWORK BINDING
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

`RedisProtocolPlugin` and `MongoDBProtocolPlugin` read their listener host/port from the static `GlobalConfiguration` defaults instead of the server's `ContextConfiguration` passed into `configure()`. A custom `REDIS_PORT`/`REDIS_HOST` or `MONGO_PORT`/`MONGO_HOST` was therefore silently ignored, and the plugin always bound the hardcoded default (6379 / 27017) with no error or log line. Postgres and Bolt already read from the `configuration` argument (Bolt was fixed the same way in #3809); this PR mirrors that pattern for Redis and MongoDB.

- `RedisProtocolPlugin.startService()` now reads host/port via `configuration.getValueAsString(GlobalConfiguration.REDIS_HOST/REDIS_PORT)` instead of the static accessors.
- `MongoDBProtocolPlugin.configure()` now captures `host`/`port` fields from the `configuration` argument (mirroring `PostgresProtocolPlugin`/`BoltProtocolPlugin`), and `startService()` binds those fields.

`ContextConfiguration` falls back to the `GlobalConfiguration` static default whenever a key is not explicitly set on the instance, so this is fully backward compatible with every deployment/test that never overrides the port.

## Motivation

Closes #5796

On a host that already runs a real Redis or MongoDB, the plugin could silently collide with it or attach to the wrong port while the server came up looking healthy, since nothing rejected the setting or logged a warning.

## Related issues

Closes #5796

## Additional Notes

Two new regression tests, one per affected module (`RedisPortConfigurationTest`, `MongoDBPortConfigurationTest`), configure a custom port via `onServerConfiguration()` (obtained from an ephemeral `ServerSocket(0)` probe to avoid collisions) — the exact `ContextConfiguration` object `PluginManager` hands to `ServerPlugin.configure()` — then assert the plugin is reachable on that port and that the hardcoded default port is NOT listening. Both tests were confirmed to fail against the pre-fix code (`JedisConnectionException` / `MongoTimeoutException` connecting to the custom port) before the fix was applied.

`PostgresProtocolPlugin` and `BoltProtocolPlugin` were inspected and already read host/port correctly — no changes needed there.

## Test plan

- [x] `mvn -pl redisw,mongodbw -am install -DskipTests` then `mvn -pl redisw,mongodbw test` — all existing tests pass (redisw: 46 tests / 0 failures; mongodbw: 84 tests / 0 failures), including the two new regression tests.
- [x] Verified both new tests fail against the pre-fix plugin code (stashed the fix, re-ran, confirmed connection failures on the configured custom port), then pass again with the fix restored.
- [x] No existing test was modified or deleted.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios