### PR TITLE
fix(#5810): Cartesian-join disconnected MATCH after a relationship pattern

### DIFF
--- a/docs/5810-disconnected-match-after-relationship-null-bind.md
+++ b/docs/5810-disconnected-match-after-relationship-null-bind.md
@@ -125,3 +125,36 @@ developer decision.
   `NoClassDefFoundError` errors in test classes untouched by this change; re-running each of those
   classes in isolation passed cleanly, consistent with a local IDE background-compiler race against
   `target/classes` (IntelliJ IDEA was running concurrently) rather than a regression from this change.
+
+## PR and review history (PR #5888)
+
+- Duplicate discovered: while opening the PR, found PR #5876 (opened earlier the same day) already
+  fixes the identical root cause with a structurally similar approach. Left a cross-reference comment
+  on #5888; both PRs were left open since merge/close is a developer decision this workflow does not
+  make.
+- Cycle 1: head `05c7fe1b2` (initial fix - Cartesian-join disconnected nodes after `buildExpansionChain`,
+  before `AnchorSelector` was touched). `claude[bot]` posted a review as a GitHub **issue comment**
+  (not a PR review or inline comment) identifying one CONFIRMED correctness bug (anchor selection not
+  connectivity-aware - reproduced live), one performance finding (compound WHERE loses anchor pushdown
+  when mixed with a disconnected-node predicate), one minor performance nitpick (disconnected-only
+  filter not pushed into its own scan before the join - left as-is, out of scope), a test-coverage gap
+  list, and a style nit. Addressed the correctness bug and the compound-WHERE performance finding (both
+  verified against a live reproduction and new regression tests before/after); the minor nitpick was
+  intentionally deferred since it is "not incorrect, just more expensive" and outside this issue's
+  scope. Pushed as commit `0558aa581`.
+- Cycle 2: head `0558aa581`. The `claude-review` GitHub Actions check re-ran fresh for this exact
+  commit (a distinct job run, `92832148797`, tied to the new push) and completed successfully (27
+  turns, `is_error: false`) but posted zero comments - no new PR review, no inline comment, no issue
+  comment. Treated as a clean pass: the check is 1:1 with each pushed SHA, and passing with no findings
+  is the review system's way of saying nothing further is actionable. No code changes were needed for
+  this cycle. Final state: **clean-approval**.
+
+## Deferred items
+
+- The minor performance nitpick from cycle 1 (a filter referencing only the disconnected node's own
+  variable is applied as a `FilterOperator` on top of the full `CartesianProduct` rather than pushed
+  into that node's own scan before the join) was consciously left unaddressed - not incorrect, just
+  more expensive for a disconnected label with many rows. No separate follow-up issue was filed by this
+  run; left for the developer to decide whether it merits one.
+- PR #5876 duplicates this PR's fix for the same root cause with an independent, structurally similar
+  implementation. Deciding which PR to carry forward (and closing the other) is left to the developer.

--- a/docs/5810-disconnected-match-after-relationship-null-bind.md
+++ b/docs/5810-disconnected-match-after-relationship-null-bind.md
@@ -75,9 +75,53 @@ All 6 tests were verified to fail without the fix (reverted the `CypherOptimizer
 `git stash`, re-ran the test class: 4 failures + 1 error) and pass with it restored, confirming the
 tests reach and depend on the fixed code path.
 
+## Round 2: fix from the `claude[bot]` PR review (PR #5888)
+
+The bot review found a real, live correctness gap in the round-1 fix: `AnchorSelector.selectAnchor`
+is purely cost-based with no relationship-reachability awareness. If a disconnected node carried its
+own selective filter (e.g. `MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0 {id: 3})`), it could win anchor
+selection outright over the unfiltered `n`/`m`. Reproduced live: the plan picked `x` as anchor and then
+tried to expand the `n-[:E]->m` relationship starting from `x` (not one of its endpoints), returning 0
+rows instead of the correct 1.
+
+Fix:
+- `AnchorSelector` gained a `selectAnchor(LogicalPlan, Set<String> excludedVariables)` overload that
+  skips any node whose variable is in the exclusion set; the original 1-arg method now delegates to it
+  with an empty set.
+- `CypherOptimizer.optimize()` now computes the disconnected-node set **before** calling
+  `selectAnchor`, from `logicalPlan.getRelationships()` alone (not from the chosen anchor), and passes
+  it as the exclusion set - so a disconnected node can never be selected as anchor in the first place.
+- The WHERE-filter split was upgraded from a coarse "does the whole clause touch a disconnected
+  variable" check to a per-conjunct split using the existing
+  `WhereClause.extractForVariables`/`residualForVariables` helpers, so a compound predicate like
+  `WHERE n.id = 1 AND x.id = 2` still lets the connected conjunct (`n.id = 1`) reach anchor pushdown
+  instead of deferring the whole clause because of the disconnected conjunct.
+- Minor style nit from the review (brace-wrapped single-statement `if`) also cleaned up.
+
+New tests added to the same test class:
+- `disconnectedNodeWithOwnIndexedFilterDoesNotHijackAnchorSelection` - the review's exact reproduction.
+- `multipleDisconnectedNodesChainCorrectly` - two disconnected nodes chained (4-row Cartesian product).
+- `mixedConnectedAndDisconnectedWhereClauseAppliesBothParts` / `...ConnectedConjunctCanExcludeAllRows` -
+  compound WHERE clause correctness for the per-conjunct split.
+
+Verified via `git stash` (reverting only `AnchorSelector.java` + `CypherOptimizer.java`, keeping the
+round-1 fix from the initial commit) that the 2 new correctness-targeted tests fail without round 2 and
+pass with it restored.
+
+Independently, PR #5876 (opened earlier the same day, before this PR) fixes the identical root cause
+with a structurally similar approach (excluding isolated nodes from anchor selection). See the PR
+description / PR comment on #5888 for the cross-reference; picking which PR to carry forward is a
+developer decision.
+
 ## Verification run
 
 - `mvn -pl engine -am compile` - clean.
-- `mvn -pl engine -am test -Dtest=Issue5810DisconnectedMatchAfterRelationshipTest` - 6/6 pass.
-- Broader regression pass: `mvn -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**'` (full
-  OpenCypher test package) - see PR/CI for the recorded result.
+- `mvn -pl engine -am test -Dtest=Issue5810DisconnectedMatchAfterRelationshipTest` - 10/10 pass (after
+  round 2).
+- `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.optimizer.**,Issue5117PatternOrderTest,Issue5136MatchMultipleCreateOptimizerTest,Issue5810DisconnectedMatchAfterRelationshipTest'`
+  - all pass, including `AnchorSelectorTest` and `CypherOptimizerIntegrationTest`.
+- Full `com.arcadedb.query.opencypher.**` package after round 2: **8011 tests, 0 failures, 0 errors,
+  98 skipped, BUILD SUCCESS** (3m22s). An earlier bulk run before round 2 showed 21 unrelated
+  `NoClassDefFoundError` errors in test classes untouched by this change; re-running each of those
+  classes in isolation passed cleanly, consistent with a local IDE background-compiler race against
+  `target/classes` (IntelliJ IDEA was running concurrently) rather than a regression from this change.

--- a/docs/5810-disconnected-match-after-relationship-null-bind.md
+++ b/docs/5810-disconnected-match-after-relationship-null-bind.md
@@ -1,0 +1,83 @@
+# Issue #5810: Disconnected MATCH after a relationship pattern binds the new variable to null
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/5810
+
+## Root cause
+
+`CypherOptimizer.optimize()` (the cost-based Cypher optimizer, `com.arcadedb.query.opencypher.optimizer`)
+handles two shapes of multi-`MATCH` query:
+
+- All `MATCH` clauses are relationship-free single nodes → `optimizeMultiMatchIndependent()` builds one
+  scan operator per node and chains them with `CartesianProduct`.
+- Otherwise → a single anchor is selected and `buildExpansionChain()` walks
+  `logicalPlan.getRelationships()` to build the ExpandAll/ExpandInto chain.
+
+A query like:
+
+```cypher
+MATCH (n:A_0)-[:E]->(m:B_0)
+MATCH (x:B_0)
+RETURN m.id, x.id
+```
+
+has a relationship (`n-[:E]->m`), so it falls into the second branch. `x` is a valid node in
+`logicalPlan.getNodes()` but shares no variable with any relationship, so it is never turned into a
+physical operator - it simply falls out of the plan. The `RETURN` projection then reads `x.id` from a
+row where `x` was never bound, silently returning `null` instead of raising an error or expanding one
+row per matching `x`. `count(*)` was correspondingly stuck at 1 instead of 2.
+
+`CypherExecutionPlanner.shouldUseOptimizer()` already special-cases this shape: it allows a
+disconnected pattern into the optimizer specifically when the disconnected component is a single node
+(`path.isSingleNode()`), on the assumption it would be Cartesian-joined like
+`optimizeMultiMatchIndependent()` does - but `optimize()` never actually did that when a relationship
+was present elsewhere in the query.
+
+## Fix
+
+`engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java`, `optimize()`:
+
+- After building the expansion chain, compute the set of "connected" variables (the anchor, plus every
+  relationship's source/target). Any pattern node from `logicalPlan.getPatternNodes()` (named or
+  anonymous) not in that set is a disconnected single-node component.
+- `WHERE` predicates are split: those that reference only connected variables are pushed down as
+  before (so anchor-only pushdown and GAV chain fusion still apply); a predicate mentioning a
+  disconnected node's variable is deferred, since that variable is not bound yet at that point in the
+  plan.
+- After GAV fusion and deferred-vertex-loading (so the connected component keeps its existing
+  optimizations), each disconnected node gets its own anchor operator (`anchorSelector.evaluateNodeDirect`
+  + `createAnchorOperator`, the same helpers `optimizeMultiMatchIndependent` already uses) and is
+  Cartesian-joined onto the plan. The deferred filters are then applied on top, once every variable
+  they reference is bound.
+
+`applyFilterPushdown` was refactored to take an explicit `List<WhereClause>` instead of always reading
+`logicalPlan.getWhereFilters()`, so the two filter buckets (connected / deferred) can be applied at
+their respective points in the plan; both existing call sites (the connected-component path and
+`optimizeMultiMatchIndependent`) keep their original behavior.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue5810DisconnectedMatchAfterRelationshipTest.java`
+(new), using the exact reproduction from the issue plus edge cases:
+
+- `disconnectedMatchAfterRelationshipProducesCartesianProduct` - the reporter's query returns the
+  expected 2-row Cartesian product instead of 1 row with a `null` binding.
+- `countStarReflectsTheCartesianProduct` - `count(*)` returns 2, not 1.
+- `planUsesCartesianProductOperator` - the physical plan actually contains a `CartesianProduct`
+  operator, proving the fixed branch is exercised (not an accidental legacy-path fallback).
+- `disconnectedMatchBeforeRelationshipStillWorks` - control: the already-correct reversed clause order
+  keeps working.
+- `anonymousDisconnectedNodeStillMultipliesRows` - an anonymous disconnected node (no variable) still
+  multiplies the row count, exercising the `getPatternNodes()` (not just named `getNodes()`) choice.
+- `whereFilterOnDisconnectedVariableIsAppliedAfterTheJoin` - a `WHERE` predicate on the disconnected
+  variable is deferred and evaluated correctly once that node is bound.
+
+All 6 tests were verified to fail without the fix (reverted the `CypherOptimizer.java` change via
+`git stash`, re-ran the test class: 4 failures + 1 error) and pass with it restored, confirming the
+tests reach and depend on the fixed code path.
+
+## Verification run
+
+- `mvn -pl engine -am compile` - clean.
+- `mvn -pl engine -am test -Dtest=Issue5810DisconnectedMatchAfterRelationshipTest` - 6/6 pass.
+- Broader regression pass: `mvn -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**'` (full
+  OpenCypher test package) - see PR/CI for the recorded result.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/AnchorSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/AnchorSelector.java
@@ -30,9 +30,11 @@ import com.arcadedb.query.opencypher.optimizer.statistics.StatisticsProvider;
 import com.arcadedb.query.opencypher.optimizer.statistics.TypeStatistics;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Selects the optimal anchor node (starting point) for query execution.
@@ -66,6 +68,28 @@ public class AnchorSelector {
    * @return anchor selection with the best starting node
    */
   public AnchorSelection selectAnchor(final LogicalPlan plan) {
+    return selectAnchor(plan, Collections.emptySet());
+  }
+
+  /**
+   * Selects the optimal anchor node for the given logical plan, ignoring any node whose variable is
+   * in {@code excludedVariables}.
+   * <p>
+   * This is purely a cost-based choice with no relationship-reachability awareness: an indexed or
+   * filtered node is preferred regardless of whether it is actually reachable from the relationship
+   * pattern {@link com.arcadedb.query.opencypher.optimizer.CypherOptimizer#buildExpansionChain} is
+   * about to walk. A node that is disconnected from every relationship (e.g. {@code x} in
+   * {@code MATCH (n)-[:E]->(m) MATCH (x:B {id: 1})}) must therefore be excluded from anchor
+   * candidacy: if it wins purely on cost, the expansion chain would be asked to traverse a
+   * relationship from a node that is not one of its endpoints, which either strands the chain or
+   * returns wrong (empty) results. {@code CypherOptimizer} computes {@code excludedVariables} as
+   * every pattern node not touched by any relationship, before this method ever runs.
+   *
+   * @param plan               the logical plan to analyze
+   * @param excludedVariables  node variables to skip when choosing the anchor
+   * @return anchor selection with the best starting node
+   */
+  public AnchorSelection selectAnchor(final LogicalPlan plan, final Set<String> excludedVariables) {
     if (plan.getNodes().isEmpty()) {
       throw new IllegalArgumentException("Cannot select anchor from empty logical plan");
     }
@@ -85,6 +109,9 @@ public class AnchorSelector {
     // expansion chain already uses. The guard above still keys off the named nodes, so a pattern with
     // no named node at all keeps falling back the way count push-down expects.
     for (final LogicalNode node : plan.getPatternNodes().values()) {
+      if (excludedVariables.contains(node.getVariable()))
+        continue;
+
       final AnchorSelection candidate = evaluateNode(node, plan);
 
       if (candidate.useIndex()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -146,8 +146,41 @@ public class CypherOptimizer {
       return optimizeMultiMatchIndependent(logicalPlan);
     }
 
-    // 3. Select anchor node (best starting point)
-    AnchorSelection anchor = anchorSelector.selectAnchor(logicalPlan);
+    // A later MATCH clause can introduce a node that shares no variable with any relationship in the
+    // pattern (e.g. "MATCH (n)-[:E]->(m) MATCH (x)"). shouldUseOptimizer() only lets such a query
+    // reach the optimizer when every disconnected component is a single, standalone node, so any
+    // pattern node not touched by a relationship is exactly that: an independent scan that must
+    // Cartesian-join with the rest, the same way optimizeMultiMatchIndependent handles a query with no
+    // relationships at all. This is computed BEFORE anchor selection (not after, keyed off the chosen
+    // anchor) because AnchorSelector.selectAnchor is purely cost-based with no relationship-
+    // reachability awareness: a disconnected node with its own selective filter can otherwise outrank
+    // the real relationship-connected nodes and get selected as the anchor itself, and
+    // buildExpansionChain would then try to expand a relationship from a node that is not one of its
+    // endpoints - silently returning wrong (often empty) results rather than the correct Cartesian
+    // product (#5810). getPatternNodes() (rather than the named-only getNodes()) is used so an
+    // anonymous disconnected node, e.g. "MATCH (n)-[:E]->(m) MATCH (:Label)", is caught too - it still
+    // multiplies the row count even though nothing reads its variable.
+    final Set<String> relationshipVariables = new HashSet<>();
+    for (final LogicalRelationship rel : logicalPlan.getRelationships()) {
+      relationshipVariables.add(rel.getSourceVariable());
+      relationshipVariables.add(rel.getTargetVariable());
+    }
+    final List<LogicalNode> disconnectedNodes = new ArrayList<>();
+    final Set<String> disconnectedVariables = new HashSet<>();
+    if (!relationshipVariables.isEmpty()) {
+      // Only exclude nodes from anchor candidacy when there IS a relationship pattern to be
+      // disconnected from - with no relationships at all this loop would otherwise treat every node
+      // (including the only candidate) as "disconnected" and starve anchor selection.
+      for (final LogicalNode node : logicalPlan.getPatternNodes().values())
+        if (!relationshipVariables.contains(node.getVariable())) {
+          disconnectedNodes.add(node);
+          disconnectedVariables.add(node.getVariable());
+        }
+    }
+
+    // 3. Select anchor node (best starting point), excluding any node disconnected from the
+    // relationship pattern - it cannot seed buildExpansionChain and is joined in separately below.
+    AnchorSelection anchor = anchorSelector.selectAnchor(logicalPlan, disconnectedVariables);
 
     // 3a. Validate anchor against UNIDIRECTIONAL edge constraints.
     // UNIDIRECTIONAL edges only store outgoing links on the source vertex,
@@ -165,56 +198,36 @@ public class CypherOptimizer {
       rootOperator = buildExpansionChain(logicalPlan, anchor, anchorOperator);
     }
 
-    // 5a. A later MATCH clause can introduce a node that shares no variable with the relationship
-    // pattern above (e.g. "MATCH (n)-[:E]->(m) MATCH (x)"). shouldUseOptimizer() only lets such a
-    // query reach the optimizer when every disconnected component is a single, standalone node, so
-    // any pattern node not reachable from the anchor via a relationship is exactly that: an
-    // independent scan that must Cartesian-join with the rest, the same way optimizeMultiMatchIndependent
-    // handles a query with no relationships at all. Without this, the node is silently dropped from the
-    // plan and its variable resolves to null downstream instead of expanding one row per match (#5810).
-    // getPatternNodes() (rather than the named-only getNodes()) is used so an anonymous disconnected
-    // node, e.g. "MATCH (n)-[:E]->(m) MATCH (:Label)", is caught too - it still multiplies the row
-    // count even though nothing reads its variable.
-    final Set<String> connectedVariables = new HashSet<>();
-    connectedVariables.add(anchor.getVariable());
-    for (final LogicalRelationship rel : logicalPlan.getRelationships()) {
-      connectedVariables.add(rel.getSourceVariable());
-      connectedVariables.add(rel.getTargetVariable());
-    }
-    final List<LogicalNode> disconnectedNodes = new ArrayList<>();
-    for (final LogicalNode node : logicalPlan.getPatternNodes().values())
-      if (!connectedVariables.contains(node.getVariable()))
-        disconnectedNodes.add(node);
-
     // 6. Apply ExpandInto optimization
     // ExpandInto is detected during expansion chain building (step 5)
     // and applied automatically when both endpoints are bound
 
-    // 7. Push down filters. A filter that reads a disconnected node's variable can only be evaluated
-    // once that node has been Cartesian-joined in, so it is deferred to step 9a; every other filter
-    // is applied here as before, so it still benefits from anchor pushdown and GAV fusion below.
+    // 7. Push down filters. A conjunct that reads a disconnected node's variable can only be
+    // evaluated once that node has been Cartesian-joined in, so it is deferred to step 9a; a
+    // compound predicate like "WHERE n.id = 1 AND x.id = 2" (n connected, x disconnected) is split
+    // per-conjunct via the existing extractForVariables/residualForVariables helpers so the connected
+    // conjunct still reaches anchor pushdown and GAV fusion below instead of the whole clause being
+    // deferred just because one AND-ed conjunct touches a disconnected variable.
     final List<WhereClause> connectedFilters;
     final List<WhereClause> deferredFilters;
     if (disconnectedNodes.isEmpty()) {
       connectedFilters = logicalPlan.getWhereFilters();
       deferredFilters = Collections.emptyList();
     } else {
-      final Set<String> disconnectedVariables = new HashSet<>();
-      for (final LogicalNode node : disconnectedNodes)
-        disconnectedVariables.add(node.getVariable());
       connectedFilters = new ArrayList<>();
       deferredFilters = new ArrayList<>();
       for (final WhereClause whereClause : logicalPlan.getWhereFilters()) {
-        final Set<String> vars = WhereClause.collectVariables(whereClause.getConditionExpression());
-        if (Collections.disjoint(vars, disconnectedVariables))
-          connectedFilters.add(whereClause);
-        else
-          deferredFilters.add(whereClause);
+        final BooleanExpression condition = whereClause.getConditionExpression();
+        final BooleanExpression connectedPart = WhereClause.extractForVariables(condition, relationshipVariables);
+        final BooleanExpression residualPart = WhereClause.residualForVariables(condition, relationshipVariables);
+        if (connectedPart != null)
+          connectedFilters.add(new WhereClause(connectedPart));
+        if (residualPart != null)
+          deferredFilters.add(new WhereClause(residualPart));
       }
     }
-    if (!connectedFilters.isEmpty()) {
+    if (!connectedFilters.isEmpty())
       rootOperator = applyFilterPushdown(connectedFilters, logicalPlan, rootOperator, anchor.getVariable(), anchorOperator);
-    }
 
     // 8. Fuse consecutive GAVExpandAll operators into a single GAVFusedChainOperator
     // This eliminates ALL intermediate ResultInternal/HashMap/Vertex allocations
@@ -232,9 +245,8 @@ public class CypherOptimizer {
       final long cardinality = rootOperator.getEstimatedCardinality() * Math.max(1, nodeAnchor.getEstimatedCardinality());
       rootOperator = new CartesianProduct(rootOperator, nodeOperator, cost, cardinality);
     }
-    if (!deferredFilters.isEmpty()) {
+    if (!deferredFilters.isEmpty())
       rootOperator = applyFilterPushdown(deferredFilters, logicalPlan, rootOperator, null, null);
-    }
 
     // 10. Calculate total cost and cardinality
     final double totalCost = rootOperator.getEstimatedCost();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -165,13 +165,55 @@ public class CypherOptimizer {
       rootOperator = buildExpansionChain(logicalPlan, anchor, anchorOperator);
     }
 
+    // 5a. A later MATCH clause can introduce a node that shares no variable with the relationship
+    // pattern above (e.g. "MATCH (n)-[:E]->(m) MATCH (x)"). shouldUseOptimizer() only lets such a
+    // query reach the optimizer when every disconnected component is a single, standalone node, so
+    // any pattern node not reachable from the anchor via a relationship is exactly that: an
+    // independent scan that must Cartesian-join with the rest, the same way optimizeMultiMatchIndependent
+    // handles a query with no relationships at all. Without this, the node is silently dropped from the
+    // plan and its variable resolves to null downstream instead of expanding one row per match (#5810).
+    // getPatternNodes() (rather than the named-only getNodes()) is used so an anonymous disconnected
+    // node, e.g. "MATCH (n)-[:E]->(m) MATCH (:Label)", is caught too - it still multiplies the row
+    // count even though nothing reads its variable.
+    final Set<String> connectedVariables = new HashSet<>();
+    connectedVariables.add(anchor.getVariable());
+    for (final LogicalRelationship rel : logicalPlan.getRelationships()) {
+      connectedVariables.add(rel.getSourceVariable());
+      connectedVariables.add(rel.getTargetVariable());
+    }
+    final List<LogicalNode> disconnectedNodes = new ArrayList<>();
+    for (final LogicalNode node : logicalPlan.getPatternNodes().values())
+      if (!connectedVariables.contains(node.getVariable()))
+        disconnectedNodes.add(node);
+
     // 6. Apply ExpandInto optimization
     // ExpandInto is detected during expansion chain building (step 5)
     // and applied automatically when both endpoints are bound
 
-    // 7. Push down filters
-    if (!logicalPlan.getWhereFilters().isEmpty()) {
-      rootOperator = applyFilterPushdown(logicalPlan, rootOperator, anchor.getVariable(), anchorOperator);
+    // 7. Push down filters. A filter that reads a disconnected node's variable can only be evaluated
+    // once that node has been Cartesian-joined in, so it is deferred to step 9a; every other filter
+    // is applied here as before, so it still benefits from anchor pushdown and GAV fusion below.
+    final List<WhereClause> connectedFilters;
+    final List<WhereClause> deferredFilters;
+    if (disconnectedNodes.isEmpty()) {
+      connectedFilters = logicalPlan.getWhereFilters();
+      deferredFilters = Collections.emptyList();
+    } else {
+      final Set<String> disconnectedVariables = new HashSet<>();
+      for (final LogicalNode node : disconnectedNodes)
+        disconnectedVariables.add(node.getVariable());
+      connectedFilters = new ArrayList<>();
+      deferredFilters = new ArrayList<>();
+      for (final WhereClause whereClause : logicalPlan.getWhereFilters()) {
+        final Set<String> vars = WhereClause.collectVariables(whereClause.getConditionExpression());
+        if (Collections.disjoint(vars, disconnectedVariables))
+          connectedFilters.add(whereClause);
+        else
+          deferredFilters.add(whereClause);
+      }
+    }
+    if (!connectedFilters.isEmpty()) {
+      rootOperator = applyFilterPushdown(connectedFilters, logicalPlan, rootOperator, anchor.getVariable(), anchorOperator);
     }
 
     // 8. Fuse consecutive GAVExpandAll operators into a single GAVFusedChainOperator
@@ -180,6 +222,19 @@ public class CypherOptimizer {
 
     // 9. Defer vertex loading for remaining (non-fused) intermediate GAVExpandAll hops
     applyDeferredVertexLoading(rootOperator);
+
+    // 9a. Cartesian-join every disconnected single-node component, then apply any filter that
+    // needed one of them bound first.
+    for (final LogicalNode node : disconnectedNodes) {
+      final AnchorSelection nodeAnchor = anchorSelector.evaluateNodeDirect(node, logicalPlan);
+      final PhysicalOperator nodeOperator = createAnchorOperator(nodeAnchor);
+      final double cost = rootOperator.getEstimatedCost() + nodeAnchor.getEstimatedCost();
+      final long cardinality = rootOperator.getEstimatedCardinality() * Math.max(1, nodeAnchor.getEstimatedCardinality());
+      rootOperator = new CartesianProduct(rootOperator, nodeOperator, cost, cardinality);
+    }
+    if (!deferredFilters.isEmpty()) {
+      rootOperator = applyFilterPushdown(deferredFilters, logicalPlan, rootOperator, null, null);
+    }
 
     // 10. Calculate total cost and cardinality
     final double totalCost = rootOperator.getEstimatedCost();
@@ -731,7 +786,7 @@ public class CypherOptimizer {
    */
   private PhysicalOperator applyFilterPushdown(final LogicalPlan logicalPlan,
       final PhysicalOperator rootOperator) {
-    return applyFilterPushdown(logicalPlan, rootOperator, null, null);
+    return applyFilterPushdown(logicalPlan.getWhereFilters(), logicalPlan, rootOperator, null, null);
   }
 
   /**
@@ -741,8 +796,12 @@ public class CypherOptimizer {
    * A predicate that reads only the anchor variable answers "is this row worth expanding at all", so
    * evaluating it at the scan drops the row before the expansion multiplies it. Left at the top, the
    * plan expanded every vertex of the label and threw most of the rows away afterwards.
+   *
+   * @param filters the WHERE predicates to apply (a subset of {@code logicalPlan.getWhereFilters()}
+   *                when the caller has already routed some elsewhere, e.g. filters referencing a
+   *                Cartesian-joined disconnected node that is not bound yet at this point in the plan)
    */
-  private PhysicalOperator applyFilterPushdown(final LogicalPlan logicalPlan,
+  private PhysicalOperator applyFilterPushdown(final List<WhereClause> filters, final LogicalPlan logicalPlan,
       final PhysicalOperator rootOperator, final String anchorVariable, final PhysicalOperator anchorOperator) {
     // Wrap the root operator with a FilterOperator for each WHERE clause
     // In a full implementation, we would analyze which filters can be pushed down
@@ -751,7 +810,7 @@ public class CypherOptimizer {
 
     PhysicalOperator currentOp = rootOperator;
 
-    for (final WhereClause whereClause : logicalPlan.getWhereFilters()) {
+    for (final WhereClause whereClause : filters) {
       BooleanExpression filterExpression = whereClause.getConditionExpression();
 
       if (anchorOperator instanceof NodeByLabelScan scan && anchorVariable != null)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5810DisconnectedMatchAfterRelationshipTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5810DisconnectedMatchAfterRelationshipTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5810: a disconnected {@code MATCH} that follows a relationship
+ * pattern must independently bind its new variable to every match, producing a Cartesian product,
+ * not preserve a single row with the new variable bound to {@code null}.
+ * <p>
+ * The cost-based optimizer's {@code optimize()} builds a single anchor + expansion chain from
+ * {@code logicalPlan.getRelationships()}. A node introduced by a later, disconnected {@code MATCH}
+ * (e.g. {@code x} in {@code MATCH (n)-[:E]->(m) MATCH (x)}) shares no variable with any relationship,
+ * so it was never turned into a physical operator at all: it silently fell out of the plan and its
+ * variable resolved to {@code null} downstream, without eliminating the row the way {@code OPTIONAL
+ * MATCH} would. The fix Cartesian-joins every such disconnected single-node component into the plan,
+ * the same way {@code optimizeMultiMatchIndependent} already does when a query has no relationships
+ * at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5810DisconnectedMatchAfterRelationshipTest extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.command("sql", "CREATE VERTEX TYPE A_0 IF NOT EXISTS");
+    database.command("sql", "CREATE VERTEX TYPE B_0 IF NOT EXISTS");
+    database.command("sql", "CREATE EDGE TYPE E IF NOT EXISTS");
+
+    database.command("opencypher", "CREATE (:A_0 {id: 1})");
+    database.command("opencypher", "CREATE (:B_0 {id: 2})");
+    database.command("opencypher", "CREATE (:B_0 {id: 3})");
+    database.command("opencypher", "MATCH (a:A_0 {id: 1}), (b:B_0 {id: 2}) CREATE (a)-[:E]->(b)");
+  }
+
+  /**
+   * The reporter's exact query. The relationship MATCH produces one row (n=1, m=2); the disconnected
+   * MATCH (x:B_0) must independently bind x to both B_0 nodes, producing 2 rows: (2,2) and (2,3).
+   */
+  @Test
+  void disconnectedMatchAfterRelationshipProducesCartesianProduct() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0) RETURN m.id AS m, x.id AS x ORDER BY x");
+
+    final List<String> rows = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      rows.add(r.<Integer>getProperty("m") + "|" + r.<Integer>getProperty("x"));
+    }
+    rs.close();
+
+    assertThat(rows).containsExactly("2|2", "2|3");
+  }
+
+  /** Same query via count(*): must count 2 rows, not 1. */
+  @Test
+  void countStarReflectsTheCartesianProduct() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0) RETURN count(*) AS c");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(2L);
+    rs.close();
+  }
+
+  /** The fix must exercise the CartesianProduct operator, not silently fall back to the legacy path. */
+  @Test
+  void planUsesCartesianProductOperator() {
+    final ResultSet rs = database.query("opencypher",
+        "PROFILE MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0) RETURN m.id AS m, x.id AS x");
+    while (rs.hasNext())
+      rs.next();
+    final String plan = rs.getExecutionPlan().orElseThrow().prettyPrint(0, 2);
+    rs.close();
+
+    assertThat(plan).contains("CartesianProduct");
+  }
+
+  /** Control: reversing clause order already worked before the fix and must keep working. */
+  @Test
+  void disconnectedMatchBeforeRelationshipStillWorks() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (x:B_0) MATCH (n:A_0)-[:E]->(m:B_0) RETURN count(*) AS c");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(2L);
+    rs.close();
+  }
+
+  /**
+   * The disconnected node does not even need a variable to affect the row count: an anonymous
+   * standalone node in a later MATCH clause must still multiply the rows, not vanish from the plan.
+   */
+  @Test
+  void anonymousDisconnectedNodeStillMultipliesRows() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A_0)-[:E]->(m:B_0) MATCH (:B_0) RETURN count(*) AS c");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(2L);
+    rs.close();
+  }
+
+  /**
+   * A WHERE predicate that reads only the disconnected variable must still be evaluated correctly
+   * once that variable is bound by the Cartesian join, not before (when it would not resolve at all).
+   */
+  @Test
+  void whereFilterOnDisconnectedVariableIsAppliedAfterTheJoin() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0) WHERE x.id > 2 RETURN m.id AS m, x.id AS x");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Integer>getProperty("m")).isEqualTo(2);
+    assertThat(row.<Integer>getProperty("x")).isEqualTo(3);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5810DisconnectedMatchAfterRelationshipTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5810DisconnectedMatchAfterRelationshipTest.java
@@ -50,6 +50,10 @@ class Issue5810DisconnectedMatchAfterRelationshipTest extends TestHelper {
     database.command("sql", "CREATE VERTEX TYPE A_0 IF NOT EXISTS");
     database.command("sql", "CREATE VERTEX TYPE B_0 IF NOT EXISTS");
     database.command("sql", "CREATE EDGE TYPE E IF NOT EXISTS");
+    database.command("sql", "CREATE PROPERTY A_0.id IF NOT EXISTS INTEGER");
+    database.command("sql", "CREATE PROPERTY B_0.id IF NOT EXISTS INTEGER");
+    database.command("sql", "CREATE INDEX IF NOT EXISTS ON A_0 (id) UNIQUE");
+    database.command("sql", "CREATE INDEX IF NOT EXISTS ON B_0 (id) UNIQUE");
 
     database.command("opencypher", "CREATE (:A_0 {id: 1})");
     database.command("opencypher", "CREATE (:B_0 {id: 2})");
@@ -135,6 +139,65 @@ class Issue5810DisconnectedMatchAfterRelationshipTest extends TestHelper {
     final Result row = rs.next();
     assertThat(row.<Integer>getProperty("m")).isEqualTo(2);
     assertThat(row.<Integer>getProperty("x")).isEqualTo(3);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  /**
+   * Review finding: {@link com.arcadedb.query.opencypher.optimizer.AnchorSelector#selectAnchor} is
+   * purely cost-based with no relationship-reachability awareness. Before the fix, a disconnected
+   * node with its own indexed equality filter (cheaper than either endpoint of the unfiltered
+   * relationship pattern) could win anchor selection outright; {@code buildExpansionChain} would then
+   * try to expand the {@code n-[:E]->m} relationship starting from {@code x}, which is not one of its
+   * endpoints, silently returning 0 rows instead of the correct single row.
+   */
+  @Test
+  void disconnectedNodeWithOwnIndexedFilterDoesNotHijackAnchorSelection() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0 {id: 3}) RETURN m.id AS m, x.id AS x");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Integer>getProperty("m")).isEqualTo(2);
+    assertThat(row.<Integer>getProperty("x")).isEqualTo(3);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  /** Two disconnected single-node MATCH clauses after a relationship pattern must both fan out. */
+  @Test
+  void multipleDisconnectedNodesChainCorrectly() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0) MATCH (y:B_0) RETURN count(*) AS c");
+    assertThat(rs.hasNext()).isTrue();
+    // 1 relationship row x 2 B_0 nodes (x) x 2 B_0 nodes (y) = 4
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(4L);
+    rs.close();
+  }
+
+  /**
+   * A compound WHERE mixing a connected conjunct (n.id = 1, always true here) and a disconnected
+   * conjunct (x.id = 3) must apply both correctly: the connected conjunct is safe to push down
+   * alongside anchor selection, the disconnected one only after the Cartesian join binds x.
+   */
+  @Test
+  void mixedConnectedAndDisconnectedWhereClauseAppliesBothParts() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0) WHERE n.id = 1 AND x.id = 3 RETURN m.id AS m, x.id AS x");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Integer>getProperty("m")).isEqualTo(2);
+    assertThat(row.<Integer>getProperty("x")).isEqualTo(3);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  /** Same mixed clause, but the connected conjunct excludes the only row: must return nothing. */
+  @Test
+  void mixedConnectedAndDisconnectedWhereClauseConnectedConjunctCanExcludeAllRows() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A_0)-[:E]->(m:B_0) MATCH (x:B_0) WHERE n.id = 999 AND x.id = 3 RETURN m.id AS m, x.id AS x");
     assertThat(rs.hasNext()).isFalse();
     rs.close();
   }


### PR DESCRIPTION
## What does this PR do?

Fixes the Cypher cost-based optimizer so a `MATCH` clause that is disconnected from (shares no
variable with) a preceding relationship pattern is correctly Cartesian-joined into the plan, instead
of being silently dropped so its variable resolves to `null`.

`CypherOptimizer.optimize()` built its single anchor + expansion chain from
`logicalPlan.getRelationships()` only. A node introduced by a later, disconnected `MATCH` (e.g. `x` in
`MATCH (n)-[:E]->(m) MATCH (x)`) shares no variable with any relationship, so it was never turned into
a physical operator at all — it fell out of the plan, and `RETURN`/`count(*)` read it as unbound
instead of expanding one row per match. This is the same shape `optimizeMultiMatchIndependent()`
already handles correctly when a query has *no* relationships at all; this PR extends that same
Cartesian-join treatment to a disconnected node that appears alongside a relationship pattern.

The fix computes, after the connected component's expansion chain (and its GAV fusion / deferred
vertex loading) is built, which pattern nodes are *not* reachable from the anchor via a relationship,
and Cartesian-joins each of them onto the plan using the same anchor-selection helpers
`optimizeMultiMatchIndependent` already uses. `WHERE` predicates that reference a disconnected node's
variable are deferred until after that join (they cannot be evaluated before the variable is bound);
every other predicate keeps going through the existing anchor-pushdown/filter path unchanged.

## Motivation

Reported in #5810: a plain `MATCH` clause that scans a disconnected node after a relationship pattern
produced `OPTIONAL MATCH`-like behavior (a preserved row with a `null` binding) instead of Cypher's
required Cartesian-product semantics, and `count(*)` undercounted the resulting rows. Cross-engine
comparison against Neo4j, Memgraph, and FalkorDB in the issue confirms the expected behavior.

## Related issues

Closes #5810

## Additional Notes

- `applyFilterPushdown` was refactored to take an explicit `List<WhereClause>` parameter instead of
  always reading `logicalPlan.getWhereFilters()`, so the connected-component and deferred filter
  buckets can each be applied at the right point in the plan. Both existing call sites (the
  single-anchor path and `optimizeMultiMatchIndependent`) keep their original behavior.
- The disconnected-node scan is built from `logicalPlan.getPatternNodes()` (not just the named-only
  `getNodes()`), so an *anonymous* disconnected node (e.g. `MATCH (n)-[:E]->(m) MATCH (:Label)`) is
  also caught — it still has to multiply the row count even though nothing reads its variable.
- Verified the new tests fail without the fix (4 failures/1 error reverting just
  `CypherOptimizer.java`) and pass with it restored, confirming they reach the fixed code path.
- Ran the full `com.arcadedb.query.opencypher.**` test package (8006 tests) after the fix: 0 failures.
  A batch of 21 `NoClassDefFoundError` errors surfaced only in that bulk run and only in test classes
  untouched by this change (`CypherRangeIndexTest`, `Issue5444CompositeIndexSeekTest`,
  `OpenCypherStackOverflowWorkloadTest`, etc.); re-running each of those classes in isolation passed
  cleanly, consistent with a local IDE background-compiler race against `target/classes` rather than a
  regression from this change.

## Test plan

- [x] `mvn -pl engine -am compile` — clean compile.
- [x] `mvn -pl engine -am test -Dtest=Issue5810DisconnectedMatchAfterRelationshipTest` — new regression
      test (6 cases): the reporter's exact query, `count(*)`, an assertion that the plan actually uses
      `CartesianProduct`, the already-correct reversed-clause-order control, an anonymous disconnected
      node, and a `WHERE` filter on the disconnected variable. All pass.
- [x] `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.optimizer.**,Issue5117PatternOrderTest,Issue5136MatchMultipleCreateOptimizerTest,Issue5810DisconnectedMatchAfterRelationshipTest'`
      — optimizer unit tests plus the two closest-related existing regression tests (disconnected
      comma-separated patterns in one `MATCH`, and multi-`MATCH` + `CREATE`). All pass.
- [x] Full `com.arcadedb.query.opencypher.**` package (8006 tests) — 0 failures (see note above on
      unrelated, isolation-confirmed environmental errors).

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
