### PR TITLE
fix(#5801): reverse() rejects unsupported scalar types instead of silently returning null

### DIFF
--- a/docs/5801-reverse-type-mismatch.md
+++ b/docs/5801-reverse-type-mismatch.md
@@ -1,0 +1,39 @@
+# Issue #5801: `reverse()` silently returns null for unsupported non-null scalar inputs
+
+## Problem
+
+`reverse()` in the OpenCypher engine (`com.arcadedb.function.misc.ReverseFunction`) returns
+`null` when handed a scalar value outside its input domain (e.g. `reverse(5)`, `reverse(true)`).
+This is indistinguishable from legal null propagation (`reverse(null)` also returns `null`),
+so a type error in the client's query silently produces a wrong-but-plausible result instead of
+a client-facing error.
+
+Neo4j documents `reverse()`'s input as `STRING | LIST` and raises a type error for anything else
+(except explicit `null`, which still propagates).
+
+This is the same class of defect as #5477 (`size()`) and #5476 (`head()`/`last()`/`tail()`), both
+already fixed by raising `CommandSemanticException` (HTTP 400) via
+`CypherFunctionHelper.typeMismatch()`. `isEmpty()` (sibling of #5477) got the identical runtime-only
+treatment without an additional static (parse-time) check, since its type is not always known until
+the query runs. This fix mirrors `isEmpty()`'s precedent for `reverse()`.
+
+## Fix
+
+`ReverseFunction.execute()`: when the argument is not `null`, not a `String`, and not resolvable via
+`MultiValue.getMultiValueAsList()` (covers `List`/`Collection`/array), throw
+`CypherFunctionHelper.typeMismatch("reverse", "a STRING or a LIST<ANY>", args[0])` instead of
+returning `null`.
+
+## Tests
+
+New file `engine/src/test/java/com/arcadedb/query/opencypher/CypherReverseArgumentIssue5801Test.java`:
+
+- `reverse(5)`, `reverse(3.14)`, `reverse(true)` each throw `CommandSemanticException` mentioning
+  `reverse()` and the offending Cypher type name.
+- `reverse(null)` still answers `null` (no regression in null propagation).
+- `reverse('abc')` and `reverse([1,2,3])` still work as before (no regression on the supported domain).
+- A node argument (`reverse(n)`) is also a type error.
+
+## Status
+
+Implemented, tests written and passing. See PR for review history.

--- a/engine/src/main/java/com/arcadedb/function/misc/ReverseFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/misc/ReverseFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.misc;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 
@@ -61,6 +62,9 @@ public class ReverseFunction implements StatelessFunction {
       Collections.reverse(reversed);
       return reversed;
     }
-    return null;
+    // An argument outside the input domain (e.g. reverse(5), reverse(true)) used to answer null, which is
+    // indistinguishable from legal reverse(null) propagation. That hides a type error as a plausible result, so it
+    // must be a CommandSemanticException (HTTP 400), not a silent null. See issue #5801, sibling of #5477/#5476.
+    throw CypherFunctionHelper.typeMismatch("reverse", "a STRING or a LIST<ANY>", args[0]);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherReverseArgumentIssue5801Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherReverseArgumentIssue5801Test.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5801: {@code reverse()} answered {@code null} for a scalar argument outside its
+ * input domain ({@code reverse(5)}, {@code reverse(true)}), which a client cannot tell apart from legal Cypher
+ * null propagation ({@code reverse(null)}), so a type violation looked like a successful null result. Same class
+ * of defect as #5477 ({@code size()}) and #5476 ({@code head()}/{@code last()}/{@code tail()}); this fix follows
+ * their sibling {@code isEmpty()}'s precedent of a runtime-only check via {@link
+ * com.arcadedb.function.cypher.CypherFunctionHelper#typeMismatch}.
+ *
+ * <p>Input domain: {@code reverse()} accepts a {@code STRING} or a {@code LIST<ANY>}, matching Neo4j.
+ * {@code reverse(null)} still answers {@code null}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherReverseArgumentIssue5801Test extends TestHelper {
+
+  // ===================== arguments outside the input domain =====================
+
+  @Test
+  void reverseOfIntegerIsATypeError() {
+    // The reproducer from the issue: RETURN reverse(5) used to answer {"value": null}.
+    assertThatThrownBy(() -> consume("RETURN reverse(5) AS value"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("reverse()")
+        .hasMessageContaining("INTEGER");
+  }
+
+  @Test
+  void reverseOfFloatIsATypeError() {
+    assertThatThrownBy(() -> consume("RETURN reverse(3.14) AS value"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("reverse()")
+        .hasMessageContaining("FLOAT");
+  }
+
+  @Test
+  void reverseOfBooleanIsATypeError() {
+    assertThatThrownBy(() -> consume("RETURN reverse(true) AS value"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("reverse()")
+        .hasMessageContaining("BOOLEAN");
+  }
+
+  @Test
+  void reverseOfNodeIsATypeError() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Issue5801 {name: 'a'})"));
+    assertThatThrownBy(() -> consume("MATCH (n:Issue5801) RETURN reverse(n) AS value"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("reverse()");
+  }
+
+  @Test
+  void reverseOfIntegerPropertyIsRejectedAtRuntime() {
+    // The type is known only while the query runs, so this exercises ReverseFunction itself rather than any
+    // parse-time literal check.
+    database.transaction(() -> database.command("opencypher", "CREATE (:Issue5801 {name: 'a', age: 42})"));
+    assertThatThrownBy(() -> consume("MATCH (n:Issue5801) RETURN reverse(n.age) AS value"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("reverse()")
+        .hasMessageContaining("INTEGER");
+  }
+
+  // ===================== arguments that remain valid =====================
+
+  @Test
+  void reverseOfNullStaysNull() {
+    // Null propagation is legal Cypher and must not be turned into an error.
+    assertThat(single("RETURN reverse(null) AS value")).isNull();
+  }
+
+  @Test
+  void reverseOfStringStillWorks() {
+    assertThat(single("RETURN reverse('palindrome') AS value")).isEqualTo("emordnilap");
+    assertThat(single("RETURN reverse('') AS value")).isEqualTo("");
+  }
+
+  @Test
+  void reverseOfListStillWorks() {
+    assertThat(single("RETURN reverse([1, 2, 3]) AS value")).isEqualTo(List.of(3L, 2L, 1L));
+    assertThat(single("RETURN reverse([]) AS value")).isEqualTo(List.of());
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("value");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Makes Cypher's `reverse()` raise a client-facing type error (`CommandSemanticException`, HTTP 400) when given a scalar argument outside its input domain, instead of silently returning `null`.

`reverse()` accepts a `STRING` or a `LIST<ANY>` (matching Neo4j). Before this change, `reverse(5)` and `reverse(true)` answered `null`, which is indistinguishable from legal `reverse(null)` propagation, so a type violation in the client's query looked like a successful null result.

## Motivation

Closes #5801

`reverse()` silently returning `null` for unsupported non-null scalar inputs hides genuine type errors and lets unexpected nulls flow into downstream filters, comparisons and aggregations without any signal that something went wrong.

This is the same class of defect already fixed for `size()` (#5477) and `head()`/`last()`/`tail()` (#5476). `isEmpty()`, the sibling of #5477, received the identical runtime-only treatment (no separate parse-time literal check), and this PR follows that same precedent for `reverse()`.

## Related issues

Closes #5801

## Additional Notes

- `reverse(null)` is unchanged and still legally propagates `null`.
- `reverse('abc')` and `reverse([1, 2, 3])` are unchanged.
- The error message follows the existing `CypherFunctionHelper.typeMismatch()` helper, so the wording and exception type match `size()`/`isEmpty()`/`head()`/`last()`/`tail()`.

## Test plan

- [x] New regression test `engine/src/test/java/com/arcadedb/query/opencypher/CypherReverseArgumentIssue5801Test.java`:
  - `reverse(5)`, `reverse(3.14)`, `reverse(true)`, and `reverse(n)` (a node) each throw `CommandSemanticException` naming `reverse()` and the offending Cypher type.
  - `reverse(n.age)` (an `INTEGER` property, type known only at runtime) is rejected the same way.
  - `reverse(null)` still returns `null`.
  - `reverse('palindrome')`, `reverse('')`, `reverse([1,2,3])`, `reverse([])` are unchanged.
- [x] `mvn -pl engine -am test -Dtest=CypherReverseArgumentIssue5801Test` - 8/8 pass.
- [x] Ran the broader OpenCypher function suites for regressions: `OpenCypherStringFunctionsComprehensiveTest`, `OpenCypherListFunctionsComprehensiveTest`, `OpenCypherAdvancedFunctionTest`, `CypherArrayParameterTest`, `CypherRangeHeapExhaustionTest`, `CypherFunctionFactoryExtendedTest`, `CypherSizeArgumentIssue5477Test`, `CypherListFunctionArgumentIssue5476Test` - 247/247 pass, 1 pre-existing skip.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
