### PR TITLE
fix(#5841): ArcadeTraversalStrategy declares CountStrategy ordering to stop non-deterministic install

### DIFF
--- a/docs/5841-arcadeedgecountfilterstep-nondeterministic-install.md
+++ b/docs/5841-arcadeedgecountfilterstep-nondeterministic-install.md
@@ -1,0 +1,102 @@
+# Issue #5841 - ArcadeEdgeCountFilterStep installs non-deterministically across JVM runs
+
+## Problem
+
+`ArcadeTraversalStrategy.applyEdgeCountFilterOptimization()` rewrites the pattern
+`where(outE('X').count().is(predicate))` into an O(1) degree check
+(`ArcadeEdgeCountFilterStep`) by matching an exact 3-substep shape inside the `where`-child:
+`VertexStep(edge) -> CountGlobalStep -> IsStep`.
+
+TinkerPop's own `CountStrategy` also rewrites `count().is(predicate)` patterns: for a bounded
+predicate such as `is(gt(1))` it computes a `highRangeCandidate` and inserts a
+`RangeGlobalStep(0, 2)` ahead of the `CountGlobalStep`, growing the where-child to 4 substeps.
+That permanently defeats the exact-3-substep match.
+
+`ArcadeTraversalStrategy.applyPrior()` declared an ordering relationship only with
+`InlineFilterStrategy` - nothing about `CountStrategy`. With no declared edge between the two
+strategies, TinkerPop's `TraversalStrategies.sortStrategies()` topological sort ties are broken by
+iterating a `HashSet<Class<?>>`. `Class` does not override `hashCode()`, so the iteration order
+follows the JVM's identity hash codes, which are seeded per-JVM-invocation and not stable across
+JVM processes.
+
+`ArcadeGraph` computes and registers the strategy set exactly once in a `static` block, so
+whichever order a given JVM process happens to produce is frozen for that JVM's entire lifetime:
+deterministic within one Surefire fork, but flips depending on which JVM process (fork) runs the
+query - for byte-identical code and unchanged test order.
+
+## Fix
+
+`gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalStrategy.java`
+
+Added an `applyPost()` override declaring `CountStrategy.class` (in addition to the
+`OptimizationStrategy` default of `GValueReductionStrategy.class`, which would otherwise be
+silently dropped by overriding the method). This forces TinkerPop's topological sort to always
+place `ArcadeTraversalStrategy` before `CountStrategy`, regardless of JVM identity-hash iteration
+order, so `applyEdgeCountFilterOptimization()` always sees the traversal in its pre-`CountStrategy`
+shape before deciding whether the O(1) rewrite applies.
+
+## Tests
+
+`gremlin/src/test/java/com/arcadedb/gremlin/ArcadeEdgeCountFilterStepTest.java`
+
+- Removed the `@Disabled` annotation (and its long explanatory Javadoc, now folded into this
+  tracking doc and the fix's Javadoc) from `theDegreeFilterStepIsInstalled`, which pins that
+  `ArcadeEdgeCountFilterStep` installs for `g.V().where(outE("KNOWS").count().is(P.gt(1)))`. This
+  is the exact bounded-predicate shape that triggered TinkerPop's `CountStrategy` interference.
+  Removed the now-unused `Disabled` import.
+- Left `whenTheRewriteDoesNotInstallTinkerPopsCountStrategyExplainsWhy` untouched: it is written to
+  hold under either outcome (if the rewrite doesn't install, it must be because of
+  `CountStrategy`'s `RangeGlobalStep`), so it stays meaningful as a belt-and-suspenders check even
+  though the `if (!installed)` branch is now unreachable.
+
+### Verification that the test can actually fail (pre-fix)
+
+Per project practice, proved the un-disabled test both fails against the original code and passes
+against the fix, rather than trusting a newly-enabled assertion at face value:
+
+1. Stashed just the production change (`ArcadeTraversalStrategy.java`), keeping the un-disabled
+   test. Rebuilt (`./mvnw -pl gremlin install -DskipTests -q`) and ran
+   `./mvnw -pl gremlin-it test -Dtest=ArcadeEdgeCountFilterStepTest` across 6 separate JVM forks:
+   all 6 failed `theDegreeFilterStepIsInstalled` with
+   `plan was: GraphStep -> TraversalFilterStep` / `Expecting value to be true but was false` -
+   confirming `CountStrategy` wins the tie-break deterministically in this environment (illustrating
+   the "frozen per-JVM, but the JVM you get is arbitrary" nature of the bug - a different developer
+   machine or CI runner could just as easily freeze the other way).
+2. Restored the fix (`git stash pop`), rebuilt, and re-ran the same test across 3 separate JVM
+   forks plus the original single run: all 9 tests in the class passed every time (`Failures: 0,
+   Errors: 0`), including `theDegreeFilterStepIsInstalled`.
+
+### Regression coverage
+
+- `ArcadeEdgeCountFilterStepTest` (9 tests) - all pass, including the un-disabled test, across
+  multiple JVM forks.
+- `ArcadeGAVStepsTest` (12 tests), `ArcadeFilterByTypeStepTest` (13 tests), `GremlinGAVTest` (9
+  tests) - all pass, covering other `ArcadeTraversalStrategy` rewrite paths that share the same
+  `apply()`/`applyPrior()`/`applyPost()` machinery.
+- Full `gremlin-it` unit test module (152 tests total across all classes, run via
+  `./mvnw -pl gremlin-it test`) - 0 failures, 0 errors.
+
+Build note: per the module's own test-execution quirk, `gremlin`'s tests are compiled into a
+test-jar but only actually executed from `gremlin-it` against the shaded/relocated jar
+(`gremlin/pom.xml` sets `skipTests=true` for both surefire and failsafe). Every verification run
+above was preceded by `./mvnw -pl gremlin install -DskipTests -q` so `gremlin-it` picked up the
+current working-tree code rather than a stale `~/.m2` artifact.
+
+## Impact analysis
+
+Scope is limited to `ArcadeTraversalStrategy`'s ordering relative to `CountStrategy`; no change to
+`apply()`'s rewrite logic itself, and no other `OptimizationStrategy` ordering is touched. The fix
+makes an existing optimization's applicability deterministic - it does not change result semantics
+in either the optimized or unoptimized path (both paths call the same predicate/count logic;
+`ArcadeEdgeCountFilterStepTest`'s six `DifferentialTraversal`-based tests confirm the optimized and
+unoptimized paths agree).
+
+## Recommendations
+
+- No further action needed for this issue. The companion issues #5838, #5840, #5842 (also found in
+  PR #5829, tracked separately) are unrelated defects in different code paths and are out of scope
+  here.
+- If a similar "silent HashSet-tie-break" class of bug is suspected elsewhere in
+  `ArcadeTraversalStrategy` or other custom `TraversalStrategy` implementations, the fix pattern
+  (declare the missing `applyPrior()`/`applyPost()` edge against the specific TinkerPop strategy
+  class involved) generalizes directly.

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalStrategy.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalStrategy.java
@@ -43,6 +43,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.CountStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.GValueReductionStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.InlineFilterStrategy;
 
 import java.util.ArrayList;
@@ -307,5 +309,28 @@ public class ArcadeTraversalStrategy extends AbstractTraversalStrategy<Traversal
     return Stream.of(
         //Inline must happen first as it sometimes removes the need for a TraversalFilterStep
         InlineFilterStrategy.class).collect(Collectors.toSet());
+  }
+
+  /**
+   * Declares that TinkerPop's {@link CountStrategy} must run AFTER this strategy, so that
+   * {@code applyEdgeCountFilterOptimization}'s exact-3-substep {@code where(outE(X).count().is(predicate))}
+   * pattern match sees the traversal before {@code CountStrategy} inserts a {@code RangeGlobalStep} for
+   * bounded predicates (e.g. {@code is(gt(1))} triggers a {@code highRangeCandidate} rewrite), which would
+   * otherwise grow the pattern to 4 sub-steps and defeat the match.
+   * <p>
+   * Without this explicit edge, TinkerPop's {@code TraversalStrategies.sortStrategies()} has no declared
+   * ordering between the two strategies and falls back to iterating an unordered {@code HashSet<Class<?>>},
+   * whose order follows JVM identity hash codes - stable within one JVM process but not predictable or
+   * reproducible across JVM invocations (see issue #5841).
+   * <p>
+   * {@link GValueReductionStrategy} is preserved here because it is the default {@code applyPost()} for
+   * {@link OptimizationStrategy} (see {@link OptimizationStrategy#applyPost()}); overriding this method
+   * would otherwise silently drop that requirement.
+   */
+  @Override
+  public Set<Class<? extends OptimizationStrategy>> applyPost() {
+    return Stream.of(
+        GValueReductionStrategy.class,
+        CountStrategy.class).collect(Collectors.toSet());
   }
 }

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeEdgeCountFilterStepTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeEdgeCountFilterStepTest.java
@@ -30,7 +30,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javax.script.SimpleBindings;
@@ -80,31 +79,6 @@ class ArcadeEdgeCountFilterStepTest {
   }
 
   @Test
-  @Disabled("""
-      Whether ArcadeEdgeCountFilterStep installs for this exact traversal is NOT stable across JVMs, \
-      even for byte-identical code and unchanged test-method order. Captured failing plan (top-level \
-      only; TraversalPlans.describe() does not recurse into children):
-        plan was: GraphStep -> TraversalFilterStep
-      Verified mechanism (see the companion test \
-      whenTheRewriteDoesNotInstallTinkerPopsCountStrategyExplainsWhy below, which is written to hold \
-      under either outcome instead of asserting one): TinkerPop's own CountStrategy is not declared in \
-      ArcadeTraversalStrategy.applyPrior() (only InlineFilterStrategy is), so their relative application \
-      order is left to TinkerPop's TraversalStrategies.sortStrategies() tie-break, which resolves ties \
-      via a HashSet<Class<?>>. Class does not override hashCode(), so iteration order follows JVM \
-      identity hashes - arbitrary per JVM process, not per test-method order. ArcadeGraph's static block \
-      registers the strategy set exactly once, freezing that arbitrary order for the JVM's lifetime: \
-      within a single Surefire fork the outcome is fully deterministic, but it flips depending on WHICH \
-      Surefire fork (i.e. which JVM process, seeded with its own identity hashes) runs the test - not on \
-      the presence/order of unrelated methods and not on which traversal happens to run first. When \
-      CountStrategy wins that race for a bounded predicate such as gt(1), it rewrites the where-child from
-        VertexStep(OUT,[KNOWS],edge), CountGlobalStep, IsStep(gt(1))            (3 steps - matches)
-      to
-        VertexStep(OUT,[KNOWS],edge), RangeGlobalStep(0,2), CountGlobalStep, IsStep(gt(1))  (4 steps)
-      which permanently defeats applyEdgeCountFilterOptimization's exact-3-substep check, so the O(1) \
-      GAV path silently does not fire for this query shape on that JVM - a genuine, \
-      JVM-identity-hash-dependent "sometimes unreachable in normal use" defect in ArcadeTraversalStrategy, \
-      not merely an untested branch. Tracked as issue #5841; full writeup: PR #5829.
-      """)
   void theDegreeFilterStepIsInstalled() {
     assertThat(TraversalPlans.hasStepOfType(
         graph.traversal().V().where(outE("KNOWS").count().is(P.gt(1))), ArcadeEdgeCountFilterStep.class))


### PR DESCRIPTION
## What does this PR do?

Declares an explicit `applyPost()` ordering edge from `ArcadeTraversalStrategy` to TinkerPop's
`CountStrategy`, so `ArcadeTraversalStrategy` always applies before `CountStrategy`, regardless of
JVM.

## Motivation

`ArcadeEdgeCountFilterStep` accelerates `where(outE('X').count().is(predicate))` into an O(1)
degree check by matching an exact 3-substep shape (`VertexStep(edge) -> CountGlobalStep ->
IsStep`). TinkerPop's own `CountStrategy` also rewrites `count().is(predicate)`: for a bounded
predicate such as `is(gt(1))` it inserts a `RangeGlobalStep` ahead of the `CountGlobalStep`,
growing the shape to 4 substeps and permanently defeating the match.

`ArcadeTraversalStrategy.applyPrior()` declared an ordering only against `InlineFilterStrategy` -
nothing against `CountStrategy`. With no declared edge, TinkerPop's
`TraversalStrategies.sortStrategies()` topological-sort tie-break falls through to iterating a
`HashSet<Class<?>>`. `Class` does not override `hashCode()`, so iteration order follows the JVM's
identity hash codes - frozen for a given JVM process's lifetime (`ArcadeGraph` registers the
strategy set once, in a `static` block), but arbitrary across JVM processes. Same query, same
code, different outcome depending on which JVM happened to run it.

## Related issues

Closes #5841

Found in PR #5829 (companion defects #5838, #5840, #5842 are tracked separately and out of scope
here).

## Additional Notes

`gremlin/src/test/java/com/arcadedb/gremlin/ArcadeEdgeCountFilterStepTest.java`:
`theDegreeFilterStepIsInstalled` was `@Disabled`, pinning this exact bug with a detailed writeup of
the mechanism. Removed the `@Disabled` (and now-unused `Disabled` import) since the fix makes the
outcome deterministic. Verified this by reverting only the production change (`git stash`) and
running the un-disabled test across 6 separate JVM forks: all 6 failed identically
(`plan was: GraphStep -> TraversalFilterStep`), confirming the test can fail and that this
particular JVM/build environment happens to freeze the "wrong" order. Restored the fix and re-ran
across multiple fresh JVM forks: all passed every time.

Full writeup, including the differential/regression coverage that was run, in
`docs/5841-arcadeedgecountfilterstep-nondeterministic-install.md`.

## Test plan

- [x] `./mvnw -pl gremlin install -DskipTests -q` then
      `./mvnw -pl gremlin-it test -Dtest=ArcadeEdgeCountFilterStepTest` - 9/9 pass, across multiple
      separate JVM forks (this module's tests only execute against the shaded jar from
      `gremlin-it`; see `gremlin/pom.xml`'s `skipTests` comment).
- [x] `./mvnw -pl gremlin-it test -Dtest='ArcadeGAVStepsTest,ArcadeEdgeCountFilterStepTest,ArcadeFilterByTypeStepTest,GremlinGAVTest'` -
      43/43 pass (other rewrite paths sharing `ArcadeTraversalStrategy.apply()`).
- [x] Full `gremlin-it` unit-test module (`./mvnw -pl gremlin-it test`) - 152/152 pass, 0 failures,
      0 errors.
- [x] Confirmed the un-disabled test fails deterministically against the pre-fix code (6/6 JVM
      forks) and passes deterministically against the fix (multiple JVM forks).

## Checklist

- [x] I have run the build using `mvn clean package` command (via `-pl gremlin install` +
      `-pl gremlin-it test`, per this module's documented build quirk)
- [x] My unit tests cover both failure and success scenarios