### PR TITLE
fix(#5798): Cypher string functions reject non-STRING arguments

### DIFF
--- a/docs/5798-string-function-strict-string-args.md
+++ b/docs/5798-string-function-strict-string-args.md
@@ -62,7 +62,9 @@ New test class
 
 ## Results
 
-- New test class `CypherStringFunctionArgumentIssue5798Test`: 14/14 pass.
+- New test class `CypherStringFunctionArgumentIssue5798Test`: 14/14 pass as of the original PR
+  (grew to 17/17 after the alias-spelling and 3-arg-trim tests added during review cycles 2-3; see
+  "Review cycles" below).
 - Confirmed TDD red-green: before the fix, 11 of the 14 tests failed (the reproducers, the runtime
   property-read check and the parse-time literal check); after the fix, all 14 pass.
 - Targeted regression classes (numeric family #5484, list family #5476, string-function comprehensive
@@ -151,3 +153,34 @@ char FROM string)` path too, finding it correct but untested:
 Outcome: one actionable-and-clear code/test item applied (3-arg trim test); one out-of-scope
 follow-up noted in the PR description rather than fixed; one optional consistency-test suggestion
 skipped as explicitly non-urgent; PR description updated per the reviewer's process suggestion.
+
+### Cycle 4 - head `4c4b6606` (final cycle, `--max-cycles=4`)
+
+Claude's bot review re-verified the cycle-1 ordering fix and the cycle-3 3-arg-trim path against the
+grammar/parser directly (confirmed `CypherExpressionBuilder`'s trim-function builder produces
+`[mode, trimChar, source]`), found no bugs ("no gaps found" in test coverage, "no concerns" on
+security/performance), and raised four minor/non-blocking observations:
+
+- `CypherTrimFunction`'s 3-arg branch could collapse the redundant `args[2] == null` check into
+  `requireStringArgument()`'s own null handling, matching the style of the 1-arg/2-arg branches
+  above it. **Applied**: simplified to `final String source = requireStringArgument(args[2], ...); if
+  (source == null || trimChar == null) return null;`.
+- The tracking doc's "Results" section still said "14/14 pass" after later commits grew the test
+  class to 17 tests. **Applied**: corrected the line to note the growth across cycles.
+- Scope boundary (secondary STRING-typed arguments, `left()`/`right()` follow-up) is clearly
+  documented - no action needed, reviewer confirms it reads as "a reasonable, well-communicated scope
+  boundary rather than an oversight."
+- Suggested confirming whether the project tracks a CHANGELOG/release-notes entry for breaking
+  changes. **Checked and skipped**: no `CHANGELOG` file exists at the repo root: the project has no
+  such convention to update.
+
+Outcome: two small, safe touch-ups applied (readability simplification, stale doc line); two
+informational items require no code change. Re-ran the new test class plus
+`CypherOptionalArgumentNullIssue5629Test`, `OpenCypherMissingFunctionsTest`,
+`OpenCypherStringFunctionsComprehensiveTest` and `CypherFunctionArityRegistryTest` after the
+simplification: all pass.
+
+This was the fourth and final review cycle allowed by `--max-cycles=4`. No further review round was
+requested after this push; the review itself was a clean approval in substance ("Nice work - this
+closes the gap cleanly and consistently with the established pattern") with only optional polish
+items, none of which is a deferred/blocking item for the developer.

--- a/docs/5798-string-function-strict-string-args.md
+++ b/docs/5798-string-function-strict-string-args.md
@@ -100,3 +100,25 @@ Confirmed red (via `git stash` of only the reordering) before the fix, green aft
 class (15/15) and the same targeted regression suites re-run clean after the fix.
 
 Outcome: actionable and clear, applied. No deferred items from this cycle.
+
+### Cycle 2 - head `55fb0ca9`
+
+Claude's bot review (again a PR issue comment) confirmed the cycle-1 fix is correct and covered by a
+regression test, and found no further bugs. It raised three non-blocking observations:
+
+- `btrim(5, null)` reports a message naming `trim()` rather than `btrim()`, because
+  `CypherTrimFunction.getName()` returns `"trim"` unconditionally - pre-existing behavior, not
+  introduced by this PR, and internally consistent between the parse-time and runtime paths (the new
+  test already asserts this exact spelling). **Skipped**: out of scope for this PR, asked only to
+  "confirm this is intentional" rather than requesting a change.
+- The parse-time static check accepts any `CharSequence` literal while the runtime check requires
+  `instanceof String`; the reviewer notes this is not a real gap today since literals and STRING
+  properties are always plain `String`. **Skipped**: informational only, no requested change.
+- The new `docs/` tracking file follows the existing convention - no concern raised.
+- Optional: add test coverage for the alias spellings (`upper`, `lower`, `ltrim`, `rtrim`) directly,
+  since `canonicalStringFunctionName()`'s alias mapping was previously exercised only implicitly.
+  **Applied**: added `theAliasSpellingsRejectANonStringArgumentToo()` covering all four aliases.
+
+Outcome: one actionable-and-clear item applied (alias test coverage); two informational observations
+skipped with rationale above (both explicitly non-blocking and either pre-existing or already-covered
+behavior, not requests for a code change).

--- a/docs/5798-string-function-strict-string-args.md
+++ b/docs/5798-string-function-strict-string-args.md
@@ -184,3 +184,10 @@ This was the fourth and final review cycle allowed by `--max-cycles=4`. No furth
 requested after this push; the review itself was a clean approval in substance ("Nice work - this
 closes the gap cleanly and consistently with the established pattern") with only optional polish
 items, none of which is a deferred/blocking item for the developer.
+
+## Final state
+
+`max-cycles-reached` (4/4 cycles run; each cycle's feedback was applied or explicitly and
+transparently skipped with rationale - no unresolved blocking feedback and no deferred-items file was
+produced in any cycle). PR #5901 is open, mergeable, and unmerged. Merge remains the developer's
+decision.

--- a/docs/5798-string-function-strict-string-args.md
+++ b/docs/5798-string-function-strict-string-args.md
@@ -71,3 +71,32 @@ New test class
   `OpenCypherFunctionTest`, `OpenCypherExpressionTest`, `CypherFollowUpsIssue5602Test`): all pass.
 - Full `com.arcadedb.query.opencypher.**` package (337 test classes, 7652 tests, includes the OpenCypher
   TCK suite): 0 failures, 0 errors.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5901
+
+## Review cycles
+
+### Cycle 1 - head `019f4352`
+
+Claude's bot review (posted as a PR issue comment, not a formal review) found one correctness gap:
+`replace()`, `split()`, and the 2-argument forms of `lTrim()`/`rTrim()`/`trim()`/`btrim()` checked
+`args[0] == null || args[1] == null || ...` for `null` *before* calling `requireStringArgument()` on
+the primary argument, so an out-of-domain primary argument (e.g. `replace(5, null, 'b')`) silently
+returned `null` instead of raising the type error whenever a *secondary* argument happened to be
+`null` too. This contradicted the ordering convention already established in #5484
+(`MathBinaryFunction`/`RoundFunction` type-check every argument before null propagation decides the
+answer). The reviewer also confirmed `CypherTrimFunction`'s 3-argument SQL-style form did not have
+this problem, and that the parse-time static check, the alias-name mapping and the test structure
+were all correct.
+
+Fix applied: reordered the five affected call sites so `requireStringArgument()` on the primary
+argument runs first, and the null check on the remaining arguments runs after, mirroring the #5484
+convention. Added a new test
+(`thePrimaryArgumentIsCheckedEvenWhenASecondaryArgumentIsNull`) covering
+`replace(5, null, 'b')`, `split(5, null)`, `lTrim(5, null)`, `rTrim(5, null)` and `btrim(5, null)`.
+Confirmed red (via `git stash` of only the reordering) before the fix, green after. Full new test
+class (15/15) and the same targeted regression suites re-run clean after the fix.
+
+Outcome: actionable and clear, applied. No deferred items from this cycle.

--- a/docs/5798-string-function-strict-string-args.md
+++ b/docs/5798-string-function-strict-string-args.md
@@ -1,0 +1,73 @@
+# Issue #5798 - String functions silently coerce non-STRING inputs
+
+https://github.com/ArcadeData/arcadedb/issues/5798
+
+## Root cause
+
+Several OpenCypher string functions declare a `STRING` input domain but implement it by calling
+`args[0].toString()` (or the equivalent for a later argument) without checking the runtime type of
+the value first. Any value - `INTEGER`, `FLOAT`, `BOOLEAN`, `LIST<ANY>`, ... - is therefore silently
+turned into text instead of being rejected, making `toUpper(5)` observationally identical to the
+explicit conversion `toUpper(toString(5))`.
+
+Affected functions (as reported):
+
+- `toUpper()` - `com.arcadedb.function.text.ToUpperFunction`
+- `toLower()` - `com.arcadedb.function.text.ToLowerFunction`
+- `trim()` / `btrim()` - `com.arcadedb.query.opencypher.executor.CypherTrimFunction`
+- `lTrim()` - `com.arcadedb.function.text.LTrimFunction`
+- `rTrim()` - `com.arcadedb.function.text.RTrimFunction`
+- `split()` - `com.arcadedb.query.opencypher.executor.CypherSplitFunction`
+- `replace()` - `com.arcadedb.function.text.ReplaceFunction`
+
+This is the same class of defect already fixed for the numeric family in issue #5484 (a
+`CommandExecutionException`/500 vs. a client-facing `CommandSemanticException`/400 distinction), and
+for `head()`/`last()`/`tail()`/`size()` in #5476/#5477: a function's declared input domain must be
+enforced, not silently widened by `Object.toString()`.
+
+## Fix
+
+- Added `CypherFunctionHelper.requireStringArgument(Object, String)` (mirrors the existing
+  `requireNumberArgument`/`requireListArgument` helpers): returns the value as a `String` when it is
+  one, returns `null` when the value is `null` (Cypher null propagation), and otherwise throws a
+  `CommandSemanticException` via the shared `typeMismatch()` builder so the HTTP layer answers 400,
+  not 500.
+- `ToUpperFunction`, `ToLowerFunction`, `LTrimFunction`, `RTrimFunction`, `CypherTrimFunction`,
+  `CypherSplitFunction` and `ReplaceFunction` now call `requireStringArgument()` on their primary
+  text argument(s) instead of blindly calling `.toString()`.
+- `CypherSemanticValidator.checkStaticallyKnownArgType()` (the parse-time check that already covers
+  `size()`/`head()`/`last()`/`tail()`) was extended to reject a statically-known non-STRING literal
+  for the single-argument spellings of `toUpper`/`upper`, `toLower`/`lower`, `trim`/`btrim`,
+  `lTrim`/`ltrim` and `rTrim`/`rtrim` too, so `MATCH (n) WHERE false RETURN toUpper(5)` fails before
+  the query runs, matching Neo4j and the existing #5484/#5477/#5476 precedent.
+
+`toString()` conversion is still available explicitly via `toString()`, and `null` still propagates
+to `null` per Cypher semantics.
+
+## Test plan
+
+New test class
+`engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java`:
+
+- Each of the seven functions rejects a non-STRING argument (`INTEGER`) with a `CommandSemanticException`
+  naming the function and `STRING`; `toUpper()` additionally covers `BOOLEAN` and `LIST<ANY>` as
+  representative extra cases of the same input-domain check shared by all seven.
+- `null` still propagates to `null` for every affected function.
+- A valid `STRING` argument still works as before (regression guard).
+- `toUpper(toString(5))` still returns `"5"` (explicit conversion keeps working).
+- The parse-time static check rejects a literal even when no row would reach the projection, for the
+  single-argument spellings.
+- A property read whose runtime value is a non-STRING type is rejected too (exercises the runtime
+  path, not just the parse-time literal check).
+
+## Results
+
+- New test class `CypherStringFunctionArgumentIssue5798Test`: 14/14 pass.
+- Confirmed TDD red-green: before the fix, 11 of the 14 tests failed (the reproducers, the runtime
+  property-read check and the parse-time literal check); after the fix, all 14 pass.
+- Targeted regression classes (numeric family #5484, list family #5476, string-function comprehensive
+  suite, optional-argument-null #5629, `OpenCypherMissingFunctionsTest`, `OpenCypherAdvancedFunctionTest`,
+  `CypherFunctionFactoryExtendedTest`, `CypherMissingFunctionsTest`, `Issue5383BooleanNullFunctionTest`,
+  `OpenCypherFunctionTest`, `OpenCypherExpressionTest`, `CypherFollowUpsIssue5602Test`): all pass.
+- Full `com.arcadedb.query.opencypher.**` package (337 test classes, 7652 tests, includes the OpenCypher
+  TCK suite): 0 failures, 0 errors.

--- a/docs/5798-string-function-strict-string-args.md
+++ b/docs/5798-string-function-strict-string-args.md
@@ -122,3 +122,32 @@ regression test, and found no further bugs. It raised three non-blocking observa
 Outcome: one actionable-and-clear item applied (alias test coverage); two informational observations
 skipped with rationale above (both explicitly non-blocking and either pre-existing or already-covered
 behavior, not requests for a code change).
+
+### Cycle 3 - head `cbdc82da`
+
+Claude's bot review (again a PR issue comment) confirmed the cycle-1 null-ordering fix is correct
+across all five affected call sites and traced the 3-argument SQL-style `trim(BOTH/LEADING/TRAILING
+char FROM string)` path too, finding it correct but untested:
+
+- **Applied**: added `theSqlStyleThreeArgumentTrimFormRejectsANonStringSource()` covering
+  `trim(BOTH 'x' FROM 5)`, since this branch of `CypherTrimFunction` was directly modified in cycle 1
+  (the `source` computation moved after the `args[2] == null` check) but had no dedicated regression
+  test.
+- `left()`/`right()` have the same class of defect (no type check on their primary argument) but
+  were not named in #5798. **Skipped/deferred**: explicitly called out by the reviewer as "out of
+  scope here since #5798 didn't name them" - noted as a follow-up in the PR's Additional Notes
+  section rather than fixed in this PR.
+- A dedicated consistency test between `canonicalStringFunctionName()`'s alias mapping and
+  `CypherFunctionFactory`, mirroring the numeric family's `everyNumericFunctionNameResolvesToA...`
+  test. **Skipped**: reviewer explicitly says "not urgent given the alias tests added in cycle 3
+  exercise it end-to-end."
+- Two previously-raised informational points (btrim() message naming, CharSequence/String asymmetry)
+  reiterated as fine to leave as documented.
+- Suggested calling out the behavior change (`toUpper(5)` now throws instead of returning `"5"`)
+  explicitly as a breaking change in the PR description. **Applied**: added a "Breaking change" note
+  and a mention of the `left()`/`right()` follow-up to the PR body (not a tracking-doc-only change,
+  since it needed to be visible on the PR itself).
+
+Outcome: one actionable-and-clear code/test item applied (3-arg trim test); one out-of-scope
+follow-up noted in the PR description rather than fixed; one optional consistency-test suggestion
+skipped as explicitly non-urgent; PR description updated per the reviewer's process suggestion.

--- a/engine/src/main/java/com/arcadedb/function/cypher/CypherFunctionHelper.java
+++ b/engine/src/main/java/com/arcadedb/function/cypher/CypherFunctionHelper.java
@@ -58,6 +58,11 @@ public final class CypherFunctionHelper {
   public static final String NUMERIC_DOMAIN = "an INTEGER or a FLOAT";
 
   /**
+   * Input domain shared by every function declared as {@code f(input :: STRING)}, phrased for error messages.
+   */
+  public static final String STRING_DOMAIN = "a STRING";
+
+  /**
    * Value of {@link NumericSignature#numericArgs()} meaning "every argument this function takes is numeric", which is the
    * case for the whole family except {@code round()}.
    */
@@ -195,6 +200,28 @@ public final class CypherFunctionHelper {
       return number;
 
     throw typeMismatch(functionName, NUMERIC_DOMAIN, value);
+  }
+
+  /**
+   * Resolves the primary text argument of a STRING-only Cypher function - {@code toUpper()}, {@code toLower()},
+   * {@code trim()}/{@code btrim()}, {@code lTrim()}, {@code rTrim()}, {@code split()}, {@code replace()} - to a String.
+   * <p>
+   * Cypher declares those functions as {@code f(input :: STRING)}, so silently converting any other value via
+   * {@code Object.toString()} made {@code toUpper(5)} and the explicit conversion {@code toUpper(toString(5))}
+   * observationally identical, hiding an invalid type usage as a "successful" result (issue #5798). {@code null} is
+   * the one exception, because Cypher null semantics propagate it through every function.
+   *
+   * @return the argument as a String, or {@code null} when the argument itself is {@code null}
+   *
+   * @throws CommandSemanticException when the argument is neither {@code null} nor a String
+   */
+  public static String requireStringArgument(final Object value, final String functionName) {
+    if (value == null)
+      return null;
+    if (value instanceof String s)
+      return s;
+
+    throw typeMismatch(functionName, STRING_DOMAIN, value);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/text/LTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/LTrimFunction.java
@@ -52,9 +52,12 @@ public class LTrimFunction implements StatelessFunction {
       return source.stripLeading();
     }
     if (args.length == 2) {
-      if (args[0] == null || args[1] == null)
-        return null;
+      // The primary argument is type-checked before a null trim character decides the answer, so an
+      // out-of-domain primary argument is still reported even when args[1] happens to be null (issue
+      // #5798 review: lTrim(5, null) must still be a type error, not a silent null).
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+      if (source == null || args[1] == null)
+        return null;
       final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.stripLeading();

--- a/engine/src/main/java/com/arcadedb/function/text/LTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/LTrimFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.text;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -45,14 +46,15 @@ public class LTrimFunction implements StatelessFunction {
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
     if (args.length == 1) {
-      if (args[0] == null)
+      final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+      if (source == null)
         return null;
-      return args[0].toString().stripLeading();
+      return source.stripLeading();
     }
     if (args.length == 2) {
       if (args[0] == null || args[1] == null)
         return null;
-      final String source = args[0].toString();
+      final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
       final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.stripLeading();

--- a/engine/src/main/java/com/arcadedb/function/text/RTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/RTrimFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.text;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -45,14 +46,15 @@ public class RTrimFunction implements StatelessFunction {
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
     if (args.length == 1) {
-      if (args[0] == null)
+      final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+      if (source == null)
         return null;
-      return args[0].toString().stripTrailing();
+      return source.stripTrailing();
     }
     if (args.length == 2) {
       if (args[0] == null || args[1] == null)
         return null;
-      final String source = args[0].toString();
+      final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
       final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.stripTrailing();

--- a/engine/src/main/java/com/arcadedb/function/text/RTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/RTrimFunction.java
@@ -52,9 +52,12 @@ public class RTrimFunction implements StatelessFunction {
       return source.stripTrailing();
     }
     if (args.length == 2) {
-      if (args[0] == null || args[1] == null)
-        return null;
+      // The primary argument is type-checked before a null trim character decides the answer, so an
+      // out-of-domain primary argument is still reported even when args[1] happens to be null (issue
+      // #5798 review: rTrim(5, null) must still be a type error, not a silent null).
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+      if (source == null || args[1] == null)
+        return null;
       final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.stripTrailing();

--- a/engine/src/main/java/com/arcadedb/function/text/ReplaceFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/ReplaceFunction.java
@@ -47,9 +47,12 @@ public class ReplaceFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    if (args[0] == null || args[1] == null || args[2] == null)
-      return null;
+    // The primary argument is type-checked before a null secondary argument decides the answer, so an
+    // out-of-domain primary argument is still reported even when args[1] or args[2] happens to be null
+    // (issue #5798 review: replace(5, null, 'b') must still be a type error, not a silent null).
     final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+    if (source == null || args[1] == null || args[2] == null)
+      return null;
     return source.replace(args[1].toString(), args[2].toString());
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/text/ReplaceFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/ReplaceFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.text;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -48,6 +49,7 @@ public class ReplaceFunction implements StatelessFunction {
     checkArity(args);
     if (args[0] == null || args[1] == null || args[2] == null)
       return null;
-    return args[0].toString().replace(args[1].toString(), args[2].toString());
+    final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+    return source.replace(args[1].toString(), args[2].toString());
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/text/ToLowerFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/ToLowerFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.text;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.Locale;
@@ -45,8 +46,9 @@ public class ToLowerFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    if (args[0] == null)
+    final String value = CypherFunctionHelper.requireStringArgument(args[0], getName());
+    if (value == null)
       return null;
-    return args[0].toString().toLowerCase(Locale.ROOT);
+    return value.toLowerCase(Locale.ROOT);
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/text/ToUpperFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/ToUpperFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.text;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.Locale;
@@ -45,8 +46,9 @@ public class ToUpperFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    if (args[0] == null)
+    final String value = CypherFunctionHelper.requireStringArgument(args[0], getName());
+    if (value == null)
       return null;
-    return args[0].toString().toUpperCase(Locale.ROOT);
+    return value.toUpperCase(Locale.ROOT);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSplitFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSplitFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
@@ -50,7 +51,7 @@ public class CypherSplitFunction implements StatelessFunction {
     checkArity(args);
     if (args[0] == null || args[1] == null)
       return null;
-    final String str = args[0].toString();
+    final String str = CypherFunctionHelper.requireStringArgument(args[0], getName());
     final String delimiter = args[1].toString();
 
     // An empty delimiter splits the string into its individual characters (Neo4j/Memgraph semantics).

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSplitFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSplitFunction.java
@@ -49,9 +49,12 @@ public class CypherSplitFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    if (args[0] == null || args[1] == null)
-      return null;
+    // The primary argument is type-checked before a null delimiter decides the answer, so an out-of-domain
+    // primary argument is still reported even when args[1] happens to be null (issue #5798 review:
+    // split(5, null) must still be a type error, not a silent null).
     final String str = CypherFunctionHelper.requireStringArgument(args[0], getName());
+    if (str == null || args[1] == null)
+      return null;
     final String delimiter = args[1].toString();
 
     // An empty delimiter splits the string into its individual characters (Neo4j/Memgraph semantics).

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
@@ -59,10 +59,13 @@ public class CypherTrimFunction implements StatelessFunction {
     }
 
     if (args.length == 2) {
-      // 2-arg form: btrim(source, trimCharacter)
-      if (args[0] == null || args[1] == null)
-        return null;
+      // 2-arg form: btrim(source, trimCharacter). The primary argument is type-checked before a null
+      // trim character decides the answer, so an out-of-domain primary argument is still reported even
+      // when args[1] happens to be null (issue #5798 review: btrim(5, null) must still be a type error,
+      // not a silent null).
       final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+      if (source == null || args[1] == null)
+        return null;
       final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.strip();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
@@ -77,10 +77,8 @@ public class CypherTrimFunction implements StatelessFunction {
       final String mode = args[0] != null ? args[0].toString() : null;
       final String trimChar = args[1] != null ? args[1].toString() : null;
 
-      if (args[2] == null)
-        return null;
       final String source = CypherFunctionHelper.requireStringArgument(args[2], getName());
-      if (trimChar == null)
+      if (source == null || trimChar == null)
         return null;
       if (trimChar.isEmpty()) {
         return switch (mode) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherTrimFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -51,16 +52,17 @@ public class CypherTrimFunction implements StatelessFunction {
     checkArity(args);
     if (args.length == 1) {
       // Simple form: trim(source) or btrim(source)
-      if (args[0] == null)
+      final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
+      if (source == null)
         return null;
-      return args[0].toString().strip();
+      return source.strip();
     }
 
     if (args.length == 2) {
       // 2-arg form: btrim(source, trimCharacter)
       if (args[0] == null || args[1] == null)
         return null;
-      final String source = args[0].toString();
+      final String source = CypherFunctionHelper.requireStringArgument(args[0], getName());
       final String trimChar = args[1].toString();
       if (trimChar.isEmpty())
         return source.strip();
@@ -71,10 +73,10 @@ public class CypherTrimFunction implements StatelessFunction {
       // SQL-style: trim(BOTH/LEADING/TRAILING char FROM string)
       final String mode = args[0] != null ? args[0].toString() : null;
       final String trimChar = args[1] != null ? args[1].toString() : null;
-      final String source = args[2] != null ? args[2].toString() : null;
 
-      if (source == null)
+      if (args[2] == null)
         return null;
+      final String source = CypherFunctionHelper.requireStringArgument(args[2], getName());
       if (trimChar == null)
         return null;
       if (trimChar.isEmpty()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -2141,7 +2141,9 @@ public class CypherSemanticValidator {
    * outside the function's input domain. The functions repeat the check at runtime for values known only then; doing it here
    * as well matches Neo4j, which fails {@code MATCH (n:Nothing) RETURN size(42)} even though the query matches no row and the
    * function would never run. Same message and same exception as the runtime check, so the client sees one behaviour.
-   * See issues #5477 (size) and #5476 (head, last, tail). The numeric family is handled by
+   * See issues #5477 (size), #5476 (head, last, tail) and #5798 (toUpper, toLower, trim, lTrim, rTrim - their
+   * single-argument spelling; split() and replace() are never called with one argument, so they rely on the runtime
+   * check in {@link CypherFunctionHelper#requireStringArgument} alone). The numeric family is handled by
    * {@link #checkStaticallyKnownNumericArgs}, which covers every argument rather than only a single one.
    */
   private void checkStaticallyKnownArgType(final String functionName, final Expression arg) {
@@ -2166,9 +2168,41 @@ public class CypherSemanticValidator {
       case "tail":
         // LIST-only: even a string literal is a type error.
         throw CypherFunctionHelper.typeMismatch(functionName, "a LIST<ANY>", isMap ? Map.of() : literal);
+      case "toupper":
+      case "upper":
+      case "tolower":
+      case "lower":
+      case "trim":
+      case "btrim":
+      case "ltrim":
+      case "rtrim":
+        // STRING-only primary argument (issue #5798): neither a MAP nor any other non-STRING literal is in domain.
+        // Named after the executor's own getName() (e.g. "toUpper", not the parsed-and-lower-cased "toupper"), the
+        // same spelling the runtime check in CypherFunctionHelper#requireStringArgument uses, so the client sees one
+        // message whichever path caught the mistake.
+        if (isMap || !(literal instanceof CharSequence))
+          throw CypherFunctionHelper.typeMismatch(canonicalStringFunctionName(functionName), CypherFunctionHelper.STRING_DOMAIN,
+              isMap ? Map.of() : literal);
+        break;
       default:
         break;
     }
+  }
+
+  /**
+   * Maps the parsed-and-lower-cased name of a STRING-only function (and its aliases) to the spelling its executor's
+   * {@code getName()} reports, so {@link #checkStaticallyKnownArgType}'s message matches the runtime check in
+   * {@link CypherFunctionHelper#requireStringArgument} regardless of which one caught the mistake (issue #5798).
+   */
+  private static String canonicalStringFunctionName(final String functionName) {
+    return switch (functionName) {
+      case "toupper", "upper" -> "toUpper";
+      case "tolower", "lower" -> "toLower";
+      case "ltrim" -> "lTrim";
+      case "rtrim" -> "rTrim";
+      case "btrim" -> "trim";
+      default -> functionName;
+    };
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5798: {@code toUpper()}, {@code toLower()}, {@code trim()}, {@code lTrim()},
+ * {@code rTrim()}, {@code split()} and {@code replace()} declare a {@code STRING} input domain but silently
+ * converted any value via {@code Object.toString()} instead of rejecting it, so {@code toUpper(5)} and
+ * {@code toUpper(toString(5))} were observationally identical. Handing a non-STRING value to one of these
+ * functions is the client's mistake and must be a {@link CommandSemanticException} (400), not a silently
+ * "successful" textual conversion. Same class of fix as issues #5484 (numeric family) and #5476/#5477
+ * (head/last/tail/size).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherStringFunctionArgumentIssue5798Test extends TestHelper {
+
+  // ===================== the reproducers from the issue =====================
+
+  @Test
+  void toUpperOfIntegerIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN toUpper(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toUpper()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void toUpperOfBooleanIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN toUpper(true) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toUpper()")
+        .hasMessageContaining("BOOLEAN");
+  }
+
+  @Test
+  void toUpperOfListIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN toUpper([1,2]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toUpper()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void splitOfNonStringFirstArgumentIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN split(5, ',') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("split()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void toLowerOfIntegerIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN toLower(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toLower()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void trimOfIntegerIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN trim(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void lTrimOfIntegerIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN lTrim(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("lTrim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void rTrimOfIntegerIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN rTrim(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("rTrim()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void replaceOfNonStringFirstArgumentIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN replace(5, 'a', 'b') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()")
+        .hasMessageContaining("STRING");
+  }
+
+  // ===================== explicit conversion still works =====================
+
+  @Test
+  void explicitToStringConversionStillWorks() {
+    // The distinction the issue is about: an explicit conversion is a valid STRING argument.
+    assertThat(single("RETURN toUpper(toString(5)) AS r")).isEqualTo("5");
+  }
+
+  // ===================== null propagation is not a type error =====================
+
+  @Test
+  void nullPropagationIsNotATypeError() {
+    assertThat(single("RETURN toUpper(null) AS r")).isNull();
+    assertThat(single("RETURN toLower(null) AS r")).isNull();
+    assertThat(single("RETURN trim(null) AS r")).isNull();
+    assertThat(single("RETURN lTrim(null) AS r")).isNull();
+    assertThat(single("RETURN rTrim(null) AS r")).isNull();
+    assertThat(single("RETURN split(null, ',') AS r")).isNull();
+    assertThat(single("RETURN replace(null, 'a', 'b') AS r")).isNull();
+  }
+
+  // ===================== valid STRING arguments still work =====================
+
+  @Test
+  void validStringArgumentsStillWork() {
+    assertThat(single("RETURN toUpper('abc') AS r")).isEqualTo("ABC");
+    assertThat(single("RETURN toLower('ABC') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN trim('  abc  ') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN lTrim('  abc') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN rTrim('abc  ') AS r")).isEqualTo("abc");
+    assertThat(single("RETURN split('a,b', ',') AS r").toString()).isEqualTo("[a, b]");
+    assertThat(single("RETURN replace('abc', 'b', 'x') AS r")).isEqualTo("axc");
+  }
+
+  // ===================== the runtime path, exercised through a property =====================
+
+  @Test
+  void aPropertyHoldingAnIntegerIsRejectedAtRuntime() {
+    // The type is known only while the query runs, so this exercises the executor itself rather than the
+    // statically-known-argument check in the validator.
+    database.transaction(() -> database.command("opencypher", "CREATE (:Issue5798 {name: 'a', age: 42})"));
+    assertThatThrownBy(() -> consume("MATCH (n:Issue5798) RETURN toUpper(n.age) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toUpper()")
+        .hasMessageContaining("STRING");
+  }
+
+  // ===================== the parse-time literal check =====================
+
+  @Test
+  void aLiteralArgumentFailsEvenWhenNoRowMatches() {
+    // Neo4j rejects an out-of-domain literal before running the query, so it fails even where the function
+    // would never be called. Same behaviour as the numeric family (#5484).
+    database.transaction(() -> database.command("opencypher", "CREATE (:Issue5798 {name: 'a'})"));
+    assertThatThrownBy(() -> consume("MATCH (n:Issue5798) WHERE n.name = 'nobody' RETURN toUpper(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toUpper()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("MATCH (n:Issue5798) WHERE n.name = 'nobody' RETURN toLower(true) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toLower()")
+        .hasMessageContaining("BOOLEAN");
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java
@@ -113,6 +113,36 @@ class CypherStringFunctionArgumentIssue5798Test extends TestHelper {
         .hasMessageContaining("STRING");
   }
 
+  // ===================== the primary argument is checked independent of a null secondary one =====================
+
+  @Test
+  void thePrimaryArgumentIsCheckedEvenWhenASecondaryArgumentIsNull() {
+    // A null secondary argument (delimiter, search text, trim character) must not let an out-of-domain
+    // primary argument slip through as a silent null: the type check on the primary argument must run
+    // before null propagation decides the answer, mirroring the #5484 convention for MathBinaryFunction
+    // and RoundFunction.
+    assertThatThrownBy(() -> consume("RETURN replace(5, null, 'b') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("replace()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN split(5, null) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("split()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN lTrim(5, null) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("lTrim()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN rTrim(5, null) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("rTrim()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN btrim(5, null) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()")
+        .hasMessageContaining("STRING");
+  }
+
   // ===================== explicit conversion still works =====================
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java
@@ -113,6 +113,30 @@ class CypherStringFunctionArgumentIssue5798Test extends TestHelper {
         .hasMessageContaining("STRING");
   }
 
+  // ===================== the alias spellings share the same check =====================
+
+  @Test
+  void theAliasSpellingsRejectANonStringArgumentToo() {
+    // canonicalStringFunctionName() maps the parser's lower-cased alias to the same spelling the runtime
+    // check uses; exercise the aliases directly rather than only through their canonical name.
+    assertThatThrownBy(() -> consume("RETURN upper(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toUpper()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN lower(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("toLower()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN ltrim(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("lTrim()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> consume("RETURN rtrim(5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("rTrim()")
+        .hasMessageContaining("STRING");
+  }
+
   // ===================== the primary argument is checked independent of a null secondary one =====================
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStringFunctionArgumentIssue5798Test.java
@@ -113,6 +113,17 @@ class CypherStringFunctionArgumentIssue5798Test extends TestHelper {
         .hasMessageContaining("STRING");
   }
 
+  @Test
+  void theSqlStyleThreeArgumentTrimFormRejectsANonStringSource() {
+    // trim(BOTH/LEADING/TRAILING char FROM string) is a separate code path from the 1- and 2-argument
+    // forms above (CypherTrimFunction's args.length == 3 branch); exercise it directly since it is not
+    // reachable through the 1-argument parse-time static check.
+    assertThatThrownBy(() -> consume("RETURN trim(BOTH 'x' FROM 5) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("trim()")
+        .hasMessageContaining("STRING");
+  }
+
   // ===================== the alias spellings share the same check =====================
 
   @Test


### PR DESCRIPTION
## What does this PR do?

Makes `toUpper()`, `toLower()`, `trim()`/`btrim()`, `lTrim()`, `rTrim()`, `split()` and `replace()`
reject arguments outside their declared `STRING` input domain with a client-facing
`CommandSemanticException` (400) instead of silently converting any value - `INTEGER`, `BOOLEAN`,
`LIST<ANY>`, ... - to text via `Object.toString()`.

Closes #5798

## Motivation

These functions declare a `STRING` input domain, but their implementation called `.toString()` on
the argument without checking its runtime type first. That made `toUpper(5)` observationally
identical to the explicit conversion `toUpper(toString(5))`, hiding an invalid type usage as an
apparently successful result and diverging from Neo4j, which rejects the non-`STRING` input as a
type error.

This is the same class of defect already fixed for the numeric family in #5484 and for
`head()`/`last()`/`tail()`/`size()` in #5476/#5477.

## Related issues

Closes #5798. Same class of fix as #5484, #5476 and #5477.

## What changed

- Added `CypherFunctionHelper.requireStringArgument(Object, String)`, mirroring the existing
  `requireNumberArgument`/`requireListArgument` helpers: returns the value as a `String`, returns
  `null` for a `null` argument (Cypher null propagation), or throws a `CommandSemanticException` via
  the shared `typeMismatch()` builder.
- `ToUpperFunction`, `ToLowerFunction`, `LTrimFunction`, `RTrimFunction`, `CypherTrimFunction`,
  `CypherSplitFunction` and `ReplaceFunction` now call `requireStringArgument()` on their primary
  text argument instead of blindly calling `.toString()`.
- Extended the parse-time static check in `CypherSemanticValidator.checkStaticallyKnownArgType()`
  (already covering `size()`/`head()`/`last()`/`tail()`) to reject a statically-known non-STRING
  literal for the single-argument spellings of `toUpper`/`upper`, `toLower`/`lower`, `trim`/`btrim`,
  `lTrim`/`ltrim` and `rTrim`/`rtrim`, so `MATCH (n) WHERE false RETURN toUpper(5)` fails before the
  query runs, matching Neo4j and the existing #5484/#5477/#5476 precedent.

`toString()` conversion is still available explicitly, and `null` still propagates to `null` per
Cypher semantics.

## Test plan

New test class `CypherStringFunctionArgumentIssue5798Test`:

- [x] Each of the seven functions rejects a non-STRING `INTEGER` argument with a
      `CommandSemanticException` naming the function and `STRING`; `toUpper()` additionally covers
      `BOOLEAN` and `LIST<ANY>`.
- [x] `null` still propagates to `null` for every affected function.
- [x] A valid `STRING` argument still works as before (regression guard).
- [x] `toUpper(toString(5))` still returns `"5"` (explicit conversion keeps working).
- [x] The parse-time static check rejects a literal even when no row would reach the projection.
- [x] A property read whose runtime value is a non-STRING type is rejected too (runtime path).
- [x] The primary argument is still rejected even when a secondary argument is `null` (e.g.
      `replace(5, null, 'b')`), so a `null` secondary argument cannot mask an out-of-domain primary
      one.
- [x] The alias spellings (`upper`, `lower`, `ltrim`, `rtrim`) reject a non-STRING argument too.
- [x] The 3-argument SQL-style `trim(BOTH/LEADING/TRAILING char FROM string)` form rejects a
      non-STRING source.

Verified with (see `docs/5798-string-function-strict-string-args.md` for full detail):

- New test class: 14/14 pass; confirmed red before the fix (11/14 failing), green after.
- Targeted regression suites (numeric #5484, list #5476, string-function comprehensive,
  optional-argument-null #5629, and several other Cypher function test classes): all pass.
- Full `com.arcadedb.query.opencypher.**` package (337 test classes, 7652 tests, including the
  OpenCypher TCK suite): 0 failures, 0 errors.

## Additional Notes

**Breaking change:** queries that relied on the old implicit `toString()` coercion now get a
`CommandSemanticException` (400) instead of a silently converted string, e.g. `RETURN toUpper(5)`
used to return `"5"` and now throws. This is intentional and matches the precedent already set by
#5484 for the numeric family; callers who need the old behavior can request it explicitly with
`toString()`, e.g. `toUpper(toString(5))`.

Scope is limited to the primary text argument of each of the seven functions, matching what the
issue reports. Secondary STRING-typed arguments (e.g. `split()`'s delimiter, `replace()`'s search
and replacement text) are unchanged and out of scope for this fix. `left()` and `right()`
(`com.arcadedb.function.text.LeftFunction`/`RightFunction`) have the same class of defect but were
not named in #5798 and are left for a follow-up.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

