### PR TITLE
fix(#5895): bound RESP array nesting depth and element count in the Redis wrapper

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -181,4 +181,13 @@ Both are now bounded by two new settings mirroring Redis' own protocol limits: `
 a RESP `-ERR Protocol error: ...` reply and the connection is closed, since the stream position past a rejected
 message can no longer be trusted to resynchronize on.
 
+Code review on the fix caught the same bug class one level down: the RESP bulk-string (`$`) length was equally
+unbounded, and unlike the array case it sits on the hot path of essentially every command (the command name and
+every argument, including `GET`/`SET`'s own payloads, are bulk strings), so it was arguably the bigger exposure
+of the two. A `$2000000000\r\n` header could tie up a connection thread the same way, or grow the parse buffer
+without bound if the client actually sent the declared bytes. It is now capped by a third setting,
+`arcadedb.redis.maxBulkLength` (default 512MB, matching Redis' own `proto-max-bulk-len`). Malformed, non-numeric
+lengths (e.g. `$abc\r\n`) also used to throw an uncaught `NumberFormatException` that killed the connection
+thread outright; they now get the same clean error-reply-and-close treatment as an oversized length.
+
 [#5588](https://github.com/ArcadeData/arcadedb/issues/5588)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -165,4 +165,20 @@ garbage collector no longer traces one object graph per indexed vector.
   constructors: the two roles now take the same argument types and differ only in whether the reader may
   short-circuit to the vectors persisted inline in the graph file.
 
+## Redis wire protocol: an unauthenticated RESP array could overflow the connection thread's stack (#5895)
+
+`RedisNetworkExecutor.parseNext()` decoded RESP arrays recursively, once per nesting level, with no bound
+on either the nesting depth or the client-declared element count - and it runs before the `NOAUTH` check,
+since the whole message has to be parsed before a command exists to reject. On the default JVM stack, about
+47KB of `*1\r\n` repeated ~11,860 times was enough to overflow the connection thread with an uncaught
+`StackOverflowError`, reachable by anyone who can open the Redis port, no credentials required. Separately,
+an unbounded array-length header such as `*2000000000\r\n` started a parse loop the client could keep alive
+indefinitely just by trickling bytes, tying up a connection thread for as long as it liked.
+
+Both are now bounded by two new settings mirroring Redis' own protocol limits: `arcadedb.redis.maxMultiBulkDepth`
+(default 32 - no real command nests anywhere close to that) and `arcadedb.redis.maxMultiBulkLength` (default
+1,048,576, the same hard cap Redis itself enforces on multibulk requests). Either violation now fails fast with
+a RESP `-ERR Protocol error: ...` reply and the connection is closed, since the stream position past a rejected
+message can no longer be trusted to resynchronize on.
+
 [#5588](https://github.com/ArcadeData/arcadedb/issues/5588)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -165,6 +165,8 @@ garbage collector no longer traces one object graph per indexed vector.
   constructors: the two roles now take the same argument types and differ only in whether the reader may
   short-circuit to the vectors persisted inline in the graph file.
 
+[#5588](https://github.com/ArcadeData/arcadedb/issues/5588)
+
 ## Redis wire protocol: an unauthenticated RESP array could overflow the connection thread's stack (#5895)
 
 `RedisNetworkExecutor.parseNext()` decoded RESP arrays recursively, once per nesting level, with no bound
@@ -189,5 +191,3 @@ without bound if the client actually sent the declared bytes. It is now capped b
 `arcadedb.redis.maxBulkLength` (default 512MB, matching Redis' own `proto-max-bulk-len`). Malformed, non-numeric
 lengths (e.g. `$abc\r\n`) also used to throw an uncaught `NumberFormatException` that killed the connection
 thread outright; they now get the same clean error-reply-and-close treatment as an oversized length.
-
-[#5588](https://github.com/ArcadeData/arcadedb/issues/5588)

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1660,6 +1660,13 @@ public enum GlobalConfiguration {
       *2000000000\\r\\n) starting a parse loop with billions of iterations. Default is 1048576.""",
       Integer.class, 1_048_576),
 
+  REDIS_MAX_BULK_LENGTH("arcadedb.redis.maxBulkLength", SCOPE.SERVER, """
+      Maximum length in bytes accepted for a single RESP bulk string ($) by the Redis wire-protocol listener, \
+      matching Redis' own proto-max-bulk-len. Without a bound, a client-declared length (e.g. $2000000000\\r\\n) \
+      can tie up a connection thread indefinitely by trickling bytes, or grow the parse buffer unbounded if the \
+      declared bytes are actually sent. Default is 536870912 (512MB).""",
+      Integer.class, 536_870_912),
+
   // MONGO
   MONGO_PORT("arcadedb.mongo.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for Mongo plugin. Default is 27017", Integer.class, 27017),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1647,6 +1647,19 @@ public enum GlobalConfiguration {
       "When true, the Redis wire-protocol listener accepts only TLS connections, using the shared SSL key/trust store settings (arcadedb.ssl.*). The AUTH credentials are then encrypted in transit. Default is false",
       Boolean.class, false),
 
+  REDIS_MAX_MULTIBULK_DEPTH("arcadedb.redis.maxMultiBulkDepth", SCOPE.SERVER, """
+      Maximum nesting depth of a RESP array accepted by the Redis wire-protocol listener. A RESP array element can \
+      itself be an array, and the parser recurses once per nesting level, so an unbounded value lets an \
+      unauthenticated client overflow the connection thread's JVM stack with a few tens of KB of input. Default is \
+      32, generous for any real command.""",
+      Integer.class, 32),
+
+  REDIS_MAX_MULTIBULK_LENGTH("arcadedb.redis.maxMultiBulkLength", SCOPE.SERVER, """
+      Maximum number of elements accepted in a single RESP array by the Redis wire-protocol listener, matching \
+      Redis' own hard limit on multibulk requests. Guards against a client-declared array length (e.g. \
+      *2000000000\\r\\n) starting a parse loop with billions of iterations. Default is 1048576.""",
+      Integer.class, 1_048_576),
+
   // MONGO
   MONGO_PORT("arcadedb.mongo.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for Mongo plugin. Default is 27017", Integer.class, 27017),

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
@@ -65,6 +66,11 @@ public class RedisNetworkExecutor extends Thread {
   private final    int                 maxMultiBulkDepth;
   private final    int                 maxMultiBulkLength;
   private final    int                 maxBulkLength;
+
+  // A misconfigured protocol-limit setting is re-read (and re-validated) on every new connection, since the
+  // value can change at runtime; this only bounds the WARNING about it to once per setting per JVM, so a busy
+  // server churning through connections against a static bad value does not flood the log.
+  private static final Set<GlobalConfiguration> WARNED_MISCONFIGURED_LIMITS = ConcurrentHashMap.newKeySet();
 
   /**
    * Holds the resolved key and database from key resolution.
@@ -102,9 +108,10 @@ public class RedisNetworkExecutor extends Thread {
     final int configured = setting.getValueAsInteger();
     if (configured < floor) {
       final int fallback = ((Number) setting.getDefValue()).intValue();
-      LogManager.instance().log(this, Level.WARNING,
-          "Redis wrapper: '%s' is set to %d, below the minimum usable value (%d); falling back to the default (%d)",
-          setting.getKey(), configured, floor, fallback);
+      if (WARNED_MISCONFIGURED_LIMITS.add(setting))
+        LogManager.instance().log(this, Level.WARNING,
+            "Redis wrapper: '%s' is set to %d, below the minimum usable value (%d); falling back to the default (%d)",
+            setting.getKey(), configured, floor, fallback);
       return fallback;
     }
     return configured;

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -72,6 +72,13 @@ public class RedisNetworkExecutor extends Thread {
   // server churning through connections against a static bad value does not flood the log.
   private static final Set<GlobalConfiguration> WARNED_MISCONFIGURED_LIMITS = ConcurrentHashMap.newKeySet();
 
+  // parseValueUntilLF() reads every RESP length/integer token (*, $, :) and simple-string reply value; all of
+  // them are always short (a signed 64-bit decimal has at most 20 characters). Without a bound, a client that
+  // never sends a terminating CRLF - e.g. "$" followed by megabytes of digits - grows this buffer unboundedly
+  // and holds the thread before parseLength()/maxBulkLength/maxMultiBulkLength ever get a value to check,
+  // since those only fire once a token has actually been parsed (issue #5895 review, round 6).
+  private static final int MAX_TOKEN_LENGTH = 64;
+
   /**
    * Holds the resolved key and database from key resolution.
    */
@@ -882,8 +889,11 @@ public class RedisNetworkExecutor extends Thread {
       if (!slashR) {
         if (b == '\r')
           slashR = true;
-        else
+        else {
+          if (value.length() >= MAX_TOKEN_LENGTH)
+            throw new RedisProtocolLimitException("Protocol error: token exceeds the maximum allowed length (" + MAX_TOKEN_LENGTH + ") without a terminating CRLF");
           value.append((char) b);
+        }
       } else {
         if (b == '\n')
           break;

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -62,6 +62,8 @@ public class RedisNetworkExecutor extends Thread {
   private final    Map<String, Object> defaultBucket    = new ConcurrentHashMap<>();
   private          String              selectedDatabaseName = null;
   private          ServerSecurityUser  authenticatedUser    = null;
+  private final    int                 maxMultiBulkDepth;
+  private final    int                 maxMultiBulkLength;
 
   /**
    * Holds the resolved key and database from key resolution.
@@ -73,6 +75,8 @@ public class RedisNetworkExecutor extends Thread {
     setName(Constants.PRODUCT + "-redis/" + socket.getInetAddress());
     this.server = server;
     this.channel = new ChannelBinaryServer(socket, server.getConfiguration());
+    this.maxMultiBulkDepth = GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH.getValueAsInteger();
+    this.maxMultiBulkLength = GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH.getValueAsInteger();
 
     // Initialize default database from configuration if set. The database access is authorized lazily,
     // once the connection has authenticated (see getAuthorizedDatabase), so here we only record the name.
@@ -101,6 +105,19 @@ public class RedisNetworkExecutor extends Thread {
           close();
         } catch (final SocketTimeoutException e) {
           // IGNORE IT
+        } catch (final RedisProtocolLimitException e) {
+          // The message violates a configured protocol limit (issue #5895): the stream position can no
+          // longer be trusted, so report the error and close rather than trying to resync and continue.
+          LogManager.instance().log(this, Level.WARNING, "Redis wrapper: %s, closing connection", e.getMessage());
+          try {
+            value.setLength(0);
+            value.append("-ERR ").append(e.getMessage());
+            appendCrLf();
+            replyToClient(value);
+          } catch (final IOException ignored) {
+            // the connection is already gone; nothing left to notify
+          }
+          close();
         } catch (final IOException e) {
           LogManager.instance().log(this, Level.SEVERE, "Redis wrapper: Error on reading request", e);
         }
@@ -736,6 +753,20 @@ public class RedisNetworkExecutor extends Thread {
   }
 
   private Object parseNext() throws IOException {
+    return parseNext(0);
+  }
+
+  /**
+   * Parses the next RESP value from the wire. {@code depth} counts RESP array nesting: a RESP array
+   * element can itself be an array, so without a bound a maliciously deep, unauthenticated client payload
+   * recurses once per nesting level and overflows the connection thread's JVM stack (issue #5895). The
+   * array element count is bounded the same way, so a single client-declared length like
+   * {@code *2000000000\r\n} cannot start a parse loop with billions of iterations.
+   */
+  private Object parseNext(final int depth) throws IOException {
+    if (depth > maxMultiBulkDepth)
+      throw new RedisProtocolLimitException("Protocol error: RESP array nesting exceeds the maximum allowed depth (" + maxMultiBulkDepth + ")");
+
     final byte b = readNext();
 
     if (b == '+')
@@ -751,10 +782,17 @@ public class RedisNetworkExecutor extends Thread {
       return value;
     } else if (b == '*') {
       // ARRAY
-      final List<Object> array = new ArrayList<>();
       final int arraySize = Integer.parseInt(parseValueUntilLF());
+      if (arraySize <= 0)
+        // RESP2 null array (*-1) or an explicit empty array (*0): nothing to read.
+        return new ArrayList<>();
+      if (arraySize > maxMultiBulkLength)
+        throw new RedisProtocolLimitException(
+            "Protocol error: invalid multibulk length " + arraySize + " (maximum allowed is " + maxMultiBulkLength + ")");
+
+      final List<Object> array = new ArrayList<>();
       for (int i = 0; i < arraySize; ++i)
-        array.add(parseNext());
+        array.add(parseNext(depth + 1));
       return array;
     } else {
       LogManager.instance().log(this, Level.SEVERE, "Redis wrapper: Invalid character '%s'", (char) b);

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -64,6 +64,7 @@ public class RedisNetworkExecutor extends Thread {
   private          ServerSecurityUser  authenticatedUser    = null;
   private final    int                 maxMultiBulkDepth;
   private final    int                 maxMultiBulkLength;
+  private final    int                 maxBulkLength;
 
   /**
    * Holds the resolved key and database from key resolution.
@@ -75,8 +76,9 @@ public class RedisNetworkExecutor extends Thread {
     setName(Constants.PRODUCT + "-redis/" + socket.getInetAddress());
     this.server = server;
     this.channel = new ChannelBinaryServer(socket, server.getConfiguration());
-    this.maxMultiBulkDepth = GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH.getValueAsInteger();
-    this.maxMultiBulkLength = GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH.getValueAsInteger();
+    this.maxMultiBulkDepth = sanitizedLimit(GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH, 1);
+    this.maxMultiBulkLength = sanitizedLimit(GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH, 1);
+    this.maxBulkLength = sanitizedLimit(GlobalConfiguration.REDIS_MAX_BULK_LENGTH, 1);
 
     // Initialize default database from configuration if set. The database access is authorized lazily,
     // once the connection has authenticated (see getAuthorizedDatabase), so here we only record the name.
@@ -88,6 +90,24 @@ public class RedisNetworkExecutor extends Thread {
         LogManager.instance().log(this, Level.WARNING,
             "Redis wrapper: Default database '%s' not found, will use connection-local storage", defaultDbName);
     }
+  }
+
+  /**
+   * Reads a protocol-limit setting, falling back to its built-in default (with a warning) if configured below
+   * {@code floor}. A value that low would reject every command outright - e.g. a max nesting depth of 0 rejects
+   * even a flat {@code PING}, whose single argument is already one level of RESP array nesting deep - so it is
+   * treated as a misconfiguration rather than an intentional (if impractical) lockdown.
+   */
+  private int sanitizedLimit(final GlobalConfiguration setting, final int floor) {
+    final int configured = setting.getValueAsInteger();
+    if (configured < floor) {
+      final int fallback = ((Number) setting.getDefValue()).intValue();
+      LogManager.instance().log(this, Level.WARNING,
+          "Redis wrapper: '%s' is set to %d, below the minimum usable value (%d); falling back to the default (%d)",
+          setting.getKey(), configured, floor, fallback);
+      return fallback;
+    }
+    return configured;
   }
 
   @Override
@@ -760,8 +780,9 @@ public class RedisNetworkExecutor extends Thread {
    * Parses the next RESP value from the wire. {@code depth} counts RESP array nesting: a RESP array
    * element can itself be an array, so without a bound a maliciously deep, unauthenticated client payload
    * recurses once per nesting level and overflows the connection thread's JVM stack (issue #5895). The
-   * array element count is bounded the same way, so a single client-declared length like
-   * {@code *2000000000\r\n} cannot start a parse loop with billions of iterations.
+   * array element count and the bulk-string byte length are bounded the same way, so a single
+   * client-declared length like {@code *2000000000\r\n} or {@code $2000000000\r\n} cannot start a parse
+   * loop (or a buffer growth) that runs for as long as the client is willing to trickle bytes.
    */
   private Object parseNext(final int depth) throws IOException {
     if (depth > maxMultiBulkDepth)
@@ -774,15 +795,20 @@ public class RedisNetworkExecutor extends Thread {
       return parseValueUntilLF();
     else if (b == ':')
       // INTEGER
-      return Integer.parseInt(parseValueUntilLF());
+      return parseLength(parseValueUntilLF(), "integer");
     else if (b == '$') {
       // BATCH STRING
-      final String value = parseChars(Integer.parseInt(parseValueUntilLF()));
+      final int size = parseLength(parseValueUntilLF(), "bulk length");
+      if (size > maxBulkLength)
+        throw new RedisProtocolLimitException(
+            "Protocol error: invalid bulk length " + size + " (maximum allowed is " + maxBulkLength + ")");
+
+      final String value = parseChars(size);
       skipLF();
       return value;
     } else if (b == '*') {
       // ARRAY
-      final int arraySize = Integer.parseInt(parseValueUntilLF());
+      final int arraySize = parseLength(parseValueUntilLF(), "multibulk length");
       if (arraySize <= 0)
         // RESP2 null array (*-1) or an explicit empty array (*0): nothing to read.
         return new ArrayList<>();
@@ -797,6 +823,21 @@ public class RedisNetworkExecutor extends Thread {
     } else {
       LogManager.instance().log(this, Level.SEVERE, "Redis wrapper: Invalid character '%s'", (char) b);
       return null;
+    }
+  }
+
+  /**
+   * Parses a RESP length/integer token as a plain {@code int}, wrapping a malformed (non-numeric) value in
+   * {@link RedisProtocolLimitException} instead of letting {@link NumberFormatException} escape uncaught: a
+   * bare {@code NumberFormatException} is not an {@link IOException}, so it would kill the connection thread
+   * outright rather than getting the same clean {@code -ERR Protocol error} reply and close that {@link #run()}
+   * already gives every other malformed-input case.
+   */
+  private int parseLength(final String raw, final String what) throws RedisProtocolLimitException {
+    try {
+      return Integer.parseInt(raw);
+    } catch (final NumberFormatException e) {
+      throw new RedisProtocolLimitException("Protocol error: invalid " + what + " '" + raw + "'");
     }
   }
 

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -102,7 +102,11 @@ public class RedisNetworkExecutor extends Thread {
    * Reads a protocol-limit setting, falling back to its built-in default (with a warning) if configured below
    * {@code floor}. A value that low would reject every command outright - e.g. a max nesting depth of 0 rejects
    * even a flat {@code PING}, whose single argument is already one level of RESP array nesting deep - so it is
-   * treated as a misconfiguration rather than an intentional (if impractical) lockdown.
+   * treated as a misconfiguration rather than an intentional (if impractical) lockdown. "Usable" here means
+   * "a connection can still parse a command at all", not "usable for real traffic": the floor of 1 used for
+   * {@code maxMultiBulkLength}/{@code maxBulkLength} still lets a configured value through that is far too low
+   * for any real command (e.g. a 1-byte max bulk length rejects even the shortest command name) - that is an
+   * intentionally low, if impractical, configuration rather than the 0-or-negative case this guards against.
    */
   private int sanitizedLimit(final GlobalConfiguration setting, final int floor) {
     final int configured = setting.getValueAsInteger();
@@ -138,7 +142,10 @@ public class RedisNetworkExecutor extends Thread {
           LogManager.instance().log(this, Level.WARNING, "Redis wrapper: %s, closing connection", e.getMessage());
           try {
             value.setLength(0);
-            value.append("-ERR ").append(e.getMessage());
+            // respErrorMessage() strips embedded \r/\n: the malformed-length message embeds the raw
+            // client-supplied token verbatim, and a bare \n (no preceding \r) survives parseValueUntilLF()
+            // uncaught, so without this an adversarial token could break a RESP reply across two lines.
+            value.append("-ERR ").append(respErrorMessage(e));
             appendCrLf();
             replyToClient(value);
           } catch (final IOException ignored) {

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -82,7 +82,7 @@ public class RedisNetworkExecutor extends Thread {
     setName(Constants.PRODUCT + "-redis/" + socket.getInetAddress());
     this.server = server;
     this.channel = new ChannelBinaryServer(socket, server.getConfiguration());
-    this.maxMultiBulkDepth = sanitizedLimit(GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH, 1);
+    this.maxMultiBulkDepth = sanitizedLimit(GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH, 2);
     this.maxMultiBulkLength = sanitizedLimit(GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH, 1);
     this.maxBulkLength = sanitizedLimit(GlobalConfiguration.REDIS_MAX_BULK_LENGTH, 1);
 
@@ -100,9 +100,10 @@ public class RedisNetworkExecutor extends Thread {
 
   /**
    * Reads a protocol-limit setting, falling back to its built-in default (with a warning) if configured below
-   * {@code floor}. A value that low would reject every command outright - e.g. a max nesting depth of 0 rejects
-   * even a flat {@code PING}, whose single argument is already one level of RESP array nesting deep - so it is
-   * treated as a misconfiguration rather than an intentional (if impractical) lockdown. "Usable" here means
+   * {@code floor}. A value that low would reject every command outright - e.g. {@code parseNext}'s depth check
+   * is {@code depth >= maxMultiBulkDepth} (depth starts at 0 for the top-level array, so a flat command's single
+   * argument is already parsed at depth 1), so a configured depth below 2 rejects even a flat {@code PING} - so
+   * it is treated as a misconfiguration rather than an intentional (if impractical) lockdown. "Usable" here means
    * "a connection can still parse a command at all", not "usable for real traffic": the floor of 1 used for
    * {@code maxMultiBulkLength}/{@code maxBulkLength} still lets a configured value through that is far too low
    * for any real command (e.g. a 1-byte max bulk length rejects even the shortest command name) - that is an
@@ -799,7 +800,9 @@ public class RedisNetworkExecutor extends Thread {
    * loop (or a buffer growth) that runs for as long as the client is willing to trickle bytes.
    */
   private Object parseNext(final int depth) throws IOException {
-    if (depth > maxMultiBulkDepth)
+    // depth starts at 0 for the top-level call, so ">=" (not ">") admits exactly maxMultiBulkDepth nested
+    // levels (0 .. maxMultiBulkDepth-1) before rejecting - matching the setting's documented default.
+    if (depth >= maxMultiBulkDepth)
       throw new RedisProtocolLimitException("Protocol error: RESP array nesting exceeds the maximum allowed depth (" + maxMultiBulkDepth + ")");
 
     final byte b = readNext();

--- a/redisw/src/main/java/com/arcadedb/redis/RedisProtocolLimitException.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisProtocolLimitException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import java.io.IOException;
+
+/**
+ * Thrown by {@link RedisNetworkExecutor#parseNext(int)} when an incoming RESP message violates a
+ * configured protocol limit (array nesting depth or array element count). It extends {@link IOException},
+ * not {@link RedisException}, because the violation is detected while decoding the message itself, before
+ * {@code executeCommand} has a command to run: the parser has no reliable way to know where the malformed
+ * structure ends, so the only safe response is to report the error and close the connection, exactly as
+ * {@link RedisNetworkExecutor#run()} already does for other transport-level {@link IOException}s.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class RedisProtocolLimitException extends IOException {
+  public RedisProtocolLimitException(final String message) {
+    super(message);
+  }
+}

--- a/redisw/src/main/java/com/arcadedb/redis/RedisProtocolLimitException.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisProtocolLimitException.java
@@ -21,12 +21,13 @@ package com.arcadedb.redis;
 import java.io.IOException;
 
 /**
- * Thrown by {@link RedisNetworkExecutor#parseNext(int)} when an incoming RESP message violates a
- * configured protocol limit (array nesting depth or array element count). It extends {@link IOException},
- * not {@link RedisException}, because the violation is detected while decoding the message itself, before
- * {@code executeCommand} has a command to run: the parser has no reliable way to know where the malformed
- * structure ends, so the only safe response is to report the error and close the connection, exactly as
- * {@link RedisNetworkExecutor#run()} already does for other transport-level {@link IOException}s.
+ * Thrown by {@code RedisNetworkExecutor.parseNext(int)} when an incoming RESP message violates a configured
+ * protocol limit (array/bulk-string length, array nesting depth, or a malformed non-numeric length). It
+ * extends {@link IOException}, not {@link RedisException}, because the violation is detected while decoding
+ * the message itself, before {@code executeCommand} has a command to run: the parser has no reliable way to
+ * know where the malformed structure ends, so the only safe response is to report the error and close the
+ * connection, exactly as {@code RedisNetworkExecutor.run()} already does for other transport-level
+ * {@link IOException}s.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
@@ -104,6 +104,94 @@ public class RedisProtocolLimitsTest extends BaseGraphServerTest {
     }
   }
 
+  @Test
+  void oversizedBulkStringLengthIsRejectedImmediately() throws IOException {
+    // Same DoS class as the array-length case above, but on the $ path every command actually uses (the
+    // command name and every argument, including GET/SET's own payloads, are RESP bulk strings). A header
+    // this large would previously tie up the connection thread indefinitely and, if the client actually sent
+    // the declared bytes, grow the parse buffer without bound.
+    final String payload = "$2000000000\r\n";
+
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+      socket.getOutputStream().write(payload.getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      final byte[] buffer = new byte[512];
+      final int    read   = socket.getInputStream().read(buffer);
+      assertThat(read).isGreaterThan(0);
+      final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("bulk length");
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+  }
+
+  @Test
+  void malformedLengthClosesCleanlyInsteadOfCrashingTheThread() throws IOException {
+    // A non-numeric length used to throw an uncaught NumberFormatException, killing the connection thread
+    // outright instead of getting the same -ERR Protocol error + close treatment as the size-related cases.
+    final String payload = "$abc\r\n";
+
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+      socket.getOutputStream().write(payload.getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      final byte[] buffer = new byte[512];
+      final int    read   = socket.getInputStream().read(buffer);
+      assertThat(read).isGreaterThan(0);
+      final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("bulk length");
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+  }
+
+  @Test
+  void configuredDepthLimitIsHonored() throws IOException {
+    // Confirms arcadedb.redis.maxMultiBulkDepth is actually wired end to end, rather than the tests above
+    // only ever exercising the (also never-directly-asserted) built-in default.
+    GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH.setValue(3);
+    try {
+      final StringBuilder payload = new StringBuilder();
+      for (int i = 0; i < 5; i++)
+        payload.append("*1\r\n");
+      payload.append("$1\r\nx\r\n");
+
+      try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+        socket.setSoTimeout(10_000);
+        socket.getOutputStream().write(payload.toString().getBytes(StandardCharsets.US_ASCII));
+        socket.getOutputStream().flush();
+
+        final byte[] buffer = new byte[512];
+        final int    read   = socket.getInputStream().read(buffer);
+        assertThat(read).isGreaterThan(0);
+        final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+        assertThat(reply).startsWith("-ERR");
+        assertThat(reply).contains("maximum allowed depth (3)");
+      }
+
+      // A flat command (depth 1) must still be accepted at the lowered limit.
+      try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+        assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+        assertThat(jedis.ping()).isEqualTo("PONG");
+      }
+    } finally {
+      GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH.reset();
+    }
+  }
+
   @Override
   protected void populateDatabase() {
   }

--- a/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
@@ -159,6 +159,36 @@ public class RedisProtocolLimitsTest extends BaseGraphServerTest {
   }
 
   @Test
+  void malformedLengthReplyDoesNotEmbedRawNewline() throws IOException {
+    // parseValueUntilLF() only treats \r as the start of the CRLF terminator, so a malformed length token
+    // can itself contain a bare \n; that used to be echoed verbatim into the RESP -ERR reply instead of
+    // going through respErrorMessage()'s \r/\n sanitization, breaking the single-line contract every other
+    // RESP error reply relies on.
+    final String payload = "$1\nA\r\n";
+
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+      socket.getOutputStream().write(payload.getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      final byte[] buffer = new byte[512];
+      final int    read   = socket.getInputStream().read(buffer);
+      assertThat(read).isGreaterThan(0);
+      final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).endsWith("\r\n");
+      final String body = reply.substring(0, reply.length() - 2);
+      assertThat(body).doesNotContain("\r").doesNotContain("\n");
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+  }
+
+  @Test
   void configuredDepthLimitIsHonored() throws IOException {
     // Confirms arcadedb.redis.maxMultiBulkDepth is actually wired end to end, rather than the tests above
     // only ever exercising the (also never-directly-asserted) built-in default.

--- a/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
@@ -223,6 +223,40 @@ public class RedisProtocolLimitsTest extends BaseGraphServerTest {
   }
 
   @Test
+  void misconfiguredDepthLimitFallsBackToDefault() throws IOException {
+    // Below sanitizedLimit's floor (2, since depth >= maxMultiBulkDepth would otherwise reject even a flat
+    // command's single argument): must fall back to the built-in default (32) rather than locking every
+    // connection out.
+    GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH.setValue(1);
+    try {
+      final StringBuilder payload = new StringBuilder();
+      for (int i = 0; i < 10; i++)
+        payload.append("*1\r\n");
+      payload.append("$1\r\nx\r\n");
+      // Followed, on the SAME connection, by a normal PING - which needs depth 1 to parse its single
+      // argument. If the broken value of 1 were used verbatim (no fallback), PING itself would be rejected
+      // with "maximum allowed depth (1)"; if the fallback to 32 took effect, it parses normally and gets
+      // as far as the pre-auth NOAUTH check.
+      payload.append("*1\r\n$4\r\nPING\r\n");
+
+      try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+        socket.setSoTimeout(10_000);
+        socket.getOutputStream().write(payload.toString().getBytes(StandardCharsets.US_ASCII));
+        socket.getOutputStream().flush();
+
+        final byte[] buffer = new byte[512];
+        final int    read   = socket.getInputStream().read(buffer);
+        assertThat(read).isGreaterThan(0);
+        final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+        assertThat(reply).doesNotContain("maximum allowed depth");
+        assertThat(reply).contains("NOAUTH");
+      }
+    } finally {
+      GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH.reset();
+    }
+  }
+
+  @Test
   void configuredMultiBulkLengthLimitIsHonored() throws IOException {
     // Confirms arcadedb.redis.maxMultiBulkLength is actually wired end to end, not just the built-in default.
     GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH.setValue(5);

--- a/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5895: the Redis wire-protocol listener parsed RESP arrays with unbounded
+ * recursion, so a small ({@code ~47 KB}) deeply-nested payload overflowed the connection thread's JVM
+ * stack before authentication ran. A client-supplied array-length header was equally unbounded, letting a
+ * single {@code *2000000000\r\n} header set up a two-billion-iteration parse loop. Both are reachable
+ * pre-auth by anyone who can open the Redis port.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class RedisProtocolLimitsTest extends BaseGraphServerTest {
+
+  private static final int    DEF_PORT = GlobalConfiguration.REDIS_PORT.getValueAsInteger();
+  private static final String USER     = "root";
+  private static final String PASSWORD = DEFAULT_PASSWORD_FOR_TESTS;
+
+  @Test
+  void deeplyNestedArrayIsRejectedInsteadOfOverflowingTheStack() throws IOException {
+    // Well beyond both the configured nesting cap and the depth that used to overflow the default JVM
+    // stack (~11,861 levels / ~47 KB in the original report), so the fix is exercised either way.
+    final int          depth   = 50_000;
+    final StringBuilder payload = new StringBuilder();
+    for (int i = 0; i < depth; i++)
+      payload.append("*1\r\n");
+    payload.append("$1\r\nx\r\n");
+
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+      socket.getOutputStream().write(payload.toString().getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      // The server must reject the oversized nesting and close the connection instead of dying with an
+      // uncaught StackOverflowError: reading from the socket returns a diagnostic error reply (or at
+      // least EOF), never a hang and never a raw crash.
+      final byte[] buffer = new byte[512];
+      final int    read   = socket.getInputStream().read(buffer);
+      if (read > 0) {
+        final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+        assertThat(reply).startsWith("-ERR");
+      }
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+  }
+
+  @Test
+  void oversizedArrayLengthIsRejectedImmediately() throws IOException {
+    // A header this large would previously start a two-billion-iteration parse loop, tying up the
+    // connection thread for as long as the client trickles bytes.
+    final String payload = "*2000000000\r\n";
+
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+      socket.getOutputStream().write(payload.getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      final byte[] buffer = new byte[512];
+      final int    read   = socket.getInputStream().read(buffer);
+      assertThat(read).isGreaterThan(0);
+      final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("multibulk length");
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Redis Protocol:com.arcadedb.redis.RedisProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+}

--- a/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
@@ -192,6 +192,68 @@ public class RedisProtocolLimitsTest extends BaseGraphServerTest {
     }
   }
 
+  @Test
+  void configuredMultiBulkLengthLimitIsHonored() throws IOException {
+    // Confirms arcadedb.redis.maxMultiBulkLength is actually wired end to end, not just the built-in default.
+    GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH.setValue(5);
+    try {
+      final String payload = "*6\r\n";
+
+      try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+        socket.setSoTimeout(10_000);
+        socket.getOutputStream().write(payload.getBytes(StandardCharsets.US_ASCII));
+        socket.getOutputStream().flush();
+
+        final byte[] buffer = new byte[512];
+        final int    read   = socket.getInputStream().read(buffer);
+        assertThat(read).isGreaterThan(0);
+        final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+        assertThat(reply).startsWith("-ERR");
+        assertThat(reply).contains("maximum allowed is 5");
+      }
+
+      // Ordinary traffic (AUTH's 3 elements, PING's 1) is well under the lowered limit and must still work.
+      try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+        assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+        assertThat(jedis.ping()).isEqualTo("PONG");
+      }
+    } finally {
+      GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH.reset();
+    }
+  }
+
+  @Test
+  void configuredBulkLengthLimitIsHonored() throws IOException {
+    // Confirms arcadedb.redis.maxBulkLength is actually wired end to end, not just the built-in default.
+    // 64 comfortably fits every bulk string AUTH/PING send (including the test password), while still being
+    // a small, clearly non-default value to prove the setting is honored rather than ignored.
+    GlobalConfiguration.REDIS_MAX_BULK_LENGTH.setValue(64);
+    try {
+      final String payload = "$100\r\n";
+
+      try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+        socket.setSoTimeout(10_000);
+        socket.getOutputStream().write(payload.getBytes(StandardCharsets.US_ASCII));
+        socket.getOutputStream().flush();
+
+        final byte[] buffer = new byte[512];
+        final int    read   = socket.getInputStream().read(buffer);
+        assertThat(read).isGreaterThan(0);
+        final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+        assertThat(reply).startsWith("-ERR");
+        assertThat(reply).contains("maximum allowed is 64");
+      }
+
+      // Ordinary traffic well under the lowered limit must still be accepted.
+      try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+        assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+        assertThat(jedis.ping()).isEqualTo("PONG");
+      }
+    } finally {
+      GlobalConfiguration.REDIS_MAX_BULK_LENGTH.reset();
+    }
+  }
+
   @Override
   protected void populateDatabase() {
   }

--- a/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisProtocolLimitsTest.java
@@ -189,6 +189,34 @@ public class RedisProtocolLimitsTest extends BaseGraphServerTest {
   }
 
   @Test
+  void unterminatedTokenIsRejectedInsteadOfGrowingUnbounded() throws IOException {
+    // The new size/depth checks only fire once parseValueUntilLF() has actually produced a token (it looks
+    // for a terminating CRLF), so a client that never sends one - e.g. "$" followed by a very long run of
+    // digits with no \r\n - grows that buffer unbounded and holds the thread before maxBulkLength ever gets
+    // a value to check against. A real RESP length token is always short, so it must be rejected on its own.
+    final String payload = "$" + "9".repeat(1000);
+
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+      socket.getOutputStream().write(payload.getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      final byte[] buffer = new byte[512];
+      final int    read   = socket.getInputStream().read(buffer);
+      assertThat(read).isGreaterThan(0);
+      final String reply = new String(buffer, 0, read, StandardCharsets.US_ASCII);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("maximum allowed length");
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+  }
+
+  @Test
   void configuredDepthLimitIsHonored() throws IOException {
     // Confirms arcadedb.redis.maxMultiBulkDepth is actually wired end to end, rather than the tests above
     // only ever exercising the (also never-directly-asserted) built-in default.


### PR DESCRIPTION
## Summary
- `RedisNetworkExecutor.parseNext()` decoded RESP arrays recursively with no bound on nesting depth. A ~47 KB payload of deeply nested arrays (`*1\r\n` repeated ~11,860 times) overflowed the connection thread's JVM stack with an uncaught `StackOverflowError`, reachable pre-authentication by anyone who can open the Redis port, since the whole message must be parsed before the `NOAUTH` check runs.
- The client-declared array length (`arraySize`) was also unbounded: a single `*2000000000\r\n` header started a parse loop the client could keep alive indefinitely by trickling bytes, tying up a connection thread.
- Both are now bounded by two new configurable settings mirroring Redis' own protocol limits: `arcadedb.redis.maxMultiBulkDepth` (default 32) and `arcadedb.redis.maxMultiBulkLength` (default 1,048,576, matching Redis' own hard cap on multibulk requests). A violation of either fails fast with a RESP `-ERR Protocol error: ...` reply, and the connection is closed rather than attempting to resynchronize on an untrusted stream position.

## Test plan
- [x] New regression test `RedisProtocolLimitsTest` (raw-socket, modeled on `RedisAuthenticationTest`) reproduces both issues against unpatched code (`StackOverflowError` for the nesting case, `SocketTimeoutException`/hang for the oversized-length case) and passes against the fix.
- [x] Full `redisw` module test suite passes (48 tests, 0 failures).
- [x] Full project compiles (`mvn compile`).

Closes #5895

🤖 Generated with [Claude Code](https://claude.com/claude-code)