### PR TITLE
fix(#5838): Gremlin parse() checks TinkerPop step contracts, not concrete classes, for OperationType

### DIFF
--- a/docs/5838-gremlin-parse-over-widens-operationtype.md
+++ b/docs/5838-gremlin-parse-over-widens-operationtype.md
@@ -103,4 +103,57 @@ skips, unrelated to this change)**.
   still exist and are still implemented by both the placeholder and concrete step for
   addV/addE/property, and that `DropStep` still has no placeholder variant - the test
   `mutatingStepsSeenByAnalysisArePlaceholdersNotResolvedSteps` in `ArcadeGremlinAnalyzeTest` pins
-  the current placeholder class names and will fail loudly if TinkerPop changes this shape.
+  the current placeholder class names and will fail loudly if TinkerPop changes this shape. A
+  cross-reference comment was added next to `gremlin.version` in the root `pom.xml` pointing back
+  here (see cycle 1 below).
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/5903
+
+## Review cycles
+
+### Cycle 1 - `5046a7958`
+
+`claude[bot]` posted a review as an issue comment confirming the root-cause analysis by tracing
+`ExecuteCommandTool.checkPermission()` and verifying it really does deny on any missing
+permission bit across the whole `OperationType` set. Confirmed the `*StepContract` fix is the
+right shape and that HA routing (`isIdempotent()`/`isDDL()`) is untouched. Raised one actionable,
+non-blocking suggestion: add a one-line cross-reference comment near the `gremlin.version`
+property in the root `pom.xml` pointing at the doc/test, mirroring the existing `#5535` antlr
+cross-reference comment in `gremlin/pom.xml`.
+
+Applied: added a comment block above `<gremlin.version>3.8.1</gremlin.version>` in the root
+`pom.xml` explaining the `*StepContract` requirement and cross-referencing this doc, the
+regression test, and the `#5535` antlr-pairing comment. Validated with `mvn -N validate`.
+
+No deferred items from this cycle.
+
+### Cycle 2 - `9d0a3a7f1`
+
+`claude[bot]` re-reviewed after the cycle 1 push. Independently re-confirmed the root cause
+against `ExecuteCommandTool.checkPermission()`, confirmed the fix doesn't touch `isIdempotent()`
+(HA routing unaffected), and noted it could not itself run `javap` against `gremlin-core:3.8.1`
+in its sandbox but that the PR's claim is backed by a regression test
+(`mutatingStepsSeenByAnalysisArePlaceholdersNotResolvedSteps`) that pins the exact placeholder
+class names, so a future TinkerPop upgrade that changes the shape fails loudly rather than
+regressing silently. Explicitly called out the new `pom.xml` cross-reference comment as a "nice
+touch."
+
+One optional, explicitly-non-blocking note: "consider trimming some of the very verbose in-code
+comments if the team wants `docs/5838-*.md` to be the single source of truth." Framed as "my only
+optional ask" - a style nitpick, not a defect. Skipped: the inline comments explain a genuinely
+version-sensitive TinkerPop internal (placeholder vs. concrete step, contract interface, the
+`DropStep` exception) at the exact point a future reader needs it, which is more discoverable
+than requiring a jump to `docs/`; the first review round explicitly praised the same level of
+detail. No code changes required, working tree clean. Treated as a clean approval - loop exited
+after 2 cycles.
+
+### Deferred items
+
+None. The one optional nit from cycle 2 (trim in-code comment verbosity) was evaluated and
+intentionally skipped with rationale recorded above, not deferred for developer follow-up.
+
+### Final state
+
+`clean-approval`

--- a/docs/5838-gremlin-parse-over-widens-operationtype.md
+++ b/docs/5838-gremlin-parse-over-widens-operationtype.md
@@ -1,0 +1,106 @@
+# Issue #5838 - Gremlin parse() over-widens OperationType, causing MCP to deny legitimate insert operations
+
+## Problem
+
+`ArcadeGremlin.parse()` classifies each mutating step in a traversal by `instanceof`-checking it
+against the concrete TinkerPop step classes (`AddVertexStep`, `AddVertexStartStep`, `AddEdgeStep`,
+`AddEdgeStartStep`, `AddPropertyStep`). TinkerPop 3.8.1's gremlin-lang parser, however, hands
+`parse()` GValue-based *placeholder* step types for `addV`/`addE`/`property`
+(`AddVertexStartStepPlaceholder`, `AddEdgeStepPlaceholder`, `AddPropertyStepPlaceholder`, etc.) -
+these are only resolved into the concrete classes by TinkerPop's `GValueReductionStrategy`, which
+`parse()` never runs (it reads `getSteps()` straight after `eval()`).
+
+None of the placeholder classes is a subtype of the concrete classes the `instanceof` chain
+checks for, so every addV/addE/property query falls into the "unknown mutating step" catch-all,
+which unions all three write `OperationType`s (`CREATE`, `UPDATE`, `DELETE`) instead of the single
+one that actually applies.
+
+`ExecuteCommandTool.execute()` (MCP) calls `GremlinQueryEngine.analyze()`, which delegates to this
+`parse()`, then `checkPermission(Set<OperationType>, MCPPermissions)` rejects the whole command if
+**any** `OperationType` present lacks its matching permission bit. Concrete effect: an MCP
+`execute_command` call with language `"gremlin"` and command `g.addV('Person')`, against a profile
+with `allowInsert=true` but `allowUpdate=false` (a realistic, supported profile), is wrongly
+rejected with "Update operations are not allowed by MCP configuration" even though the query is a
+pure insert.
+
+This is fail-closed over-denial, not privilege escalation, and does not depend on HA. HA follower
+routing is unaffected: the placeholders DO implement `Mutating` transitively (via `Writing`/
+`Deleting`, javap-verified), so `isIdempotent()` correctly returns `false`, and
+`RaftReplicatedDatabase` consults only `isIdempotent()`/`isDDL()`, never `getOperationTypes()`.
+
+`DropStep` has no placeholder variant in gremlin-core 3.8.1, so `drop()` alone reached `parse()`
+already resolved and was classified correctly before this fix.
+
+## Fix
+
+`gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java` - `parse()`
+
+TinkerPop 3.8.1 introduced `AddVertexStepContract`, `AddEdgeStepContract`, and
+`AddPropertyStepContract` interfaces (verified via `javap` against `gremlin-core-3.8.1.jar`) that
+are implemented by **both** the placeholder step and its resolved concrete counterpart:
+
+| Concrete class | Placeholder class | Shared contract |
+| --- | --- | --- |
+| `AddVertexStep`, `AddVertexStartStep` | `AddVertexStepPlaceholder`, `AddVertexStartStepPlaceholder` | `AddVertexStepContract` |
+| `AddEdgeStep`, `AddEdgeStartStep` | `AddEdgeStepPlaceholder`, `AddEdgeStartStepPlaceholder` | `AddEdgeStepContract` |
+| `AddPropertyStep` | `AddPropertyStepPlaceholder` | `AddPropertyStepContract` |
+
+Changed the `instanceof` chain in `parse()` to check against these contract interfaces instead of
+the concrete classes, so classification is correct regardless of whether `parse()` sees the
+placeholder or the already-resolved step. `DropStep` (no placeholder variant) keeps its direct
+`instanceof DropStep` check.
+
+```java
+if (step instanceof AddVertexStepContract || step instanceof AddEdgeStepContract)
+  ops.add(OperationType.CREATE);
+else if (step instanceof DropStep)
+  ops.add(OperationType.DELETE);
+else if (step instanceof AddPropertyStepContract)
+  ops.add(OperationType.UPDATE);
+else {
+  // Unknown mutating step: assume all write types
+  ...
+}
+```
+
+## Tests
+
+`gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGremlinAnalyzeTest.java`
+
+The issue's three `@Disabled` tests pinning the correct narrow expectations were enabled (no logic
+changes to the assertions themselves, since they already documented the exact expected fix):
+
+- `addVertexOperationTypeIsExactlyCreate` - `g.addV('Person')` -> `containsExactly(CREATE)`
+- `addEdgeOperationTypeIsExactlyCreate` - `addE('KNOWS')` -> `containsExactly(CREATE)`
+- `addPropertyOperationTypeIsExactlyUpdate` - `property('age', 30)` -> `containsExactly(UPDATE)`
+
+Confirmed regression-proof before committing: stashed the source fix, reinstalled
+`arcadedb-gremlin`, and reran the test class through `gremlin-it` (gremlin's own tests are
+`skipTests=true` and only execute against the shaded jar in the `gremlin-it` module, per its
+surefire `dependenciesToScan` config) - exactly the 3 enabled tests failed
+(`Tests run: 13, Failures: 3`), matching the issue's predicted symptom. Restored the fix,
+reinstalled, reran - all 13 pass.
+
+Also ran the full `arcadedb-gremlin-it` module (`mvn -pl gremlin-it test`, 344 tests including the
+TinkerPop structure/process conformance suite, `GremlinParameterizedAnalyzeTest` (#5187 regression
+coverage, includes a mixed `addV().property()` case asserting `.contains(CREATE)`), and all other
+gremlin/server-gremlin unit tests): **344 tests, 0 failures, 0 errors, 43 skipped (pre-existing
+skips, unrelated to this change)**.
+
+## Impact analysis
+
+- Scope: `ArcadeGremlin.parse()` only, used by MCP's `execute_command` permission check and any
+  other caller of `QueryEngine.analyze()` for the gremlin engine that inspects
+  `getOperationTypes()`.
+- HA follower routing: unaffected (confirmed above; `isIdempotent()`/`isDDL()` are untouched by
+  this change).
+- No new dependency; no public API change; `OperationType` set semantics unchanged - only which
+  types are added for a given step is corrected.
+
+## Recommendations
+
+- If TinkerPop is upgraded past 3.8.1, re-verify (via `javap`) that `*StepContract` interfaces
+  still exist and are still implemented by both the placeholder and concrete step for
+  addV/addE/property, and that `DropStep` still has no placeholder variant - the test
+  `mutatingStepsSeenByAnalysisArePlaceholdersNotResolvedSteps` in `ArcadeGremlinAnalyzeTest` pins
+  the current placeholder class names and will fail loudly if TinkerPop changes this shape.

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
@@ -41,11 +41,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTrav
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DropStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStartStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStepContract;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStepContract;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStepContract;
 
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
@@ -204,12 +202,17 @@ public class ArcadeGremlin extends ArcadeQuery {
       for (final Object step : resultSet.getSteps()) {
         if (step instanceof Mutating) {
           idempotent = false;
-          if (step instanceof AddVertexStep || step instanceof AddVertexStartStep
-              || step instanceof AddEdgeStep || step instanceof AddEdgeStartStep)
+          // TinkerPop 3.8.1's gremlin-lang parser hands parse() GValue-based placeholder step types for
+          // addV/addE/property (e.g. AddVertexStartStepPlaceholder) instead of the concrete step classes
+          // (AddVertexStep, AddEdgeStep, AddPropertyStep) - those are only resolved by GValueReductionStrategy,
+          // which parse() never runs. Both the placeholder and the concrete step implement the *StepContract
+          // interface TinkerPop introduced for exactly this purpose, so check against the contract rather than
+          // the concrete class. See #5838. DropStep has no placeholder variant in 3.8.1, so it stays a direct check.
+          if (step instanceof AddVertexStepContract || step instanceof AddEdgeStepContract)
             ops.add(OperationType.CREATE);
           else if (step instanceof DropStep)
             ops.add(OperationType.DELETE);
-          else if (step instanceof AddPropertyStep)
+          else if (step instanceof AddPropertyStepContract)
             ops.add(OperationType.UPDATE);
           else {
             // Unknown mutating step: assume all write types

--- a/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGremlinAnalyzeTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGremlinAnalyzeTest.java
@@ -23,7 +23,6 @@ import com.arcadedb.query.QueryEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
@@ -36,10 +35,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Covers ArcadeGremlin.parse(). Its isIdempotent() verdict drives HA follower routing
  * (RaftReplicatedDatabase consults only isIdempotent()/isDDL(), never getOperationTypes()); the
  * placeholder step types gremlin-lang hands to parse() DO implement Mutating (via Writing/Deleting,
- * javap-verified), so isIdempotent() is correct and HA routing is unaffected. getOperationTypes() is a
- * separate story: it over-widens for addV/addE/property (see
- * mutatingStepsSeenByAnalysisArePlaceholdersNotResolvedSteps and the @Disabled tests below), and the
- * confirmed impact of that is MCP permission over-denial, not HA misrouting.
+ * javap-verified), so isIdempotent() is correct and HA routing is unaffected. getOperationTypes() used to
+ * be a separate story: it over-widened for addV/addE/property because the placeholder step types are not
+ * subtypes of the concrete step classes parse() checked for (see
+ * mutatingStepsSeenByAnalysisArePlaceholdersNotResolvedSteps) - fixed in #5838 by checking the
+ * AddVertexStepContract/AddEdgeStepContract/AddPropertyStepContract interfaces both the placeholder and the
+ * concrete steps implement, instead of the concrete classes alone.
  */
 class ArcadeGremlinAnalyzeTest {
 
@@ -67,14 +68,12 @@ class ArcadeGremlinAnalyzeTest {
    * Reflects into the private {@code ArcadeGremlin.executeStatement(boolean)} to inspect exactly what
    * step types reach {@code parse()}'s instanceof checks, without triggering iteration (parse() itself
    * never calls hasNext()/next() before reading getSteps(), so this mirrors it precisely). This directly
-   * answers whether TinkerPop 3.8.1's gremlin-lang parser hands parse() placeholder step types (e.g.
-   * AddVertexStartStepPlaceholder, which does NOT extend AddVertexStep) that would be missed by the
-   * instanceof checks in ArcadeGremlin.parse(). Confirmed impact: the placeholders DO implement
-   * Mutating (via Writing/Deleting, javap-verified), so isIdempotent() still comes back correctly false
-   * and HA routing is unaffected; what actually breaks is getOperationTypes(), which falls into the
-   * "unknown mutating step" branch and widens to all three write types instead of the one that
-   * actually applies - see mutatingStepsSeenByAnalysisArePlaceholdersNotResolvedSteps below and the
-   * MCP permission over-denial impact documented on the @Disabled tests.
+   * confirms TinkerPop 3.8.1's gremlin-lang parser hands parse() placeholder step types (e.g.
+   * AddVertexStartStepPlaceholder, which does NOT extend AddVertexStep) rather than the concrete classes.
+   * The placeholders DO implement Mutating (via Writing/Deleting, javap-verified), so isIdempotent() is
+   * correct and HA routing is unaffected; getOperationTypes() is fixed by checking against the
+   * AddVertexStepContract/AddEdgeStepContract/AddPropertyStepContract interfaces the placeholders
+   * implement (see addVertexOperationTypeIsExactlyCreate and siblings, and #5838).
    */
   private List<String> analysisStepClassNames(final String query) throws Exception {
     final ArcadeGremlin gremlin = graph.gremlin(query);
@@ -101,7 +100,7 @@ class ArcadeGremlinAnalyzeTest {
 
   @Test
   // NOTE: .contains() cannot distinguish this from the widened [CREATE,UPDATE,DELETE] fallback;
-  // see addVertexOperationTypeIsExactlyCreate (disabled).
+  // see addVertexOperationTypeIsExactlyCreate for the narrow assertion.
   void addVertexIsNotIdempotentAndIsACreate() {
     final QueryEngine.AnalyzedQuery analyzed = analyze("g.addV('Person')");
     assertThat(analyzed.isIdempotent()).isFalse();
@@ -111,7 +110,7 @@ class ArcadeGremlinAnalyzeTest {
 
   @Test
   // NOTE: .contains() cannot distinguish this from the widened [CREATE,UPDATE,DELETE] fallback;
-  // see addEdgeOperationTypeIsExactlyCreate (disabled).
+  // see addEdgeOperationTypeIsExactlyCreate for the narrow assertion.
   void addEdgeIsACreate() {
     final QueryEngine.AnalyzedQuery analyzed =
         analyze("g.V().hasLabel('Person').as('a').addE('KNOWS').to('a')");
@@ -128,7 +127,7 @@ class ArcadeGremlinAnalyzeTest {
 
   @Test
   // NOTE: .contains() cannot distinguish this from the widened [CREATE,UPDATE,DELETE] fallback;
-  // see addPropertyOperationTypeIsExactlyUpdate (disabled).
+  // see addPropertyOperationTypeIsExactlyUpdate for the narrow assertion.
   void addPropertyIsAnUpdate() {
     final QueryEngine.AnalyzedQuery analyzed =
         analyze("g.V().hasLabel('Person').property('age', 30)");
@@ -177,55 +176,23 @@ class ArcadeGremlinAnalyzeTest {
   }
 
   @Test
-  @Disabled("""
-      BUG (test-coverage finding): OperationType over-widening defect. getOperationTypes() only - \
-      isIdempotent() is correct and HA routing (RaftReplicatedDatabase, which consults only isIdempotent()/ \
-      isDDL(), never getOperationTypes()) is unaffected. The real, confirmed impact is MCP permission \
-      over-denial: ExecuteCommandTool.execute() calls GremlinQueryEngine.analyze(), which delegates \
-      straight to this parse() method, then checkPermission(Set<OperationType>, MCPPermissions) rejects \
-      the whole command if ANY OperationType present lacks its matching permission bit (CREATE needs \
-      isAllowInsert(), UPDATE needs isAllowUpdate(), DELETE needs isAllowDelete() - independent booleans \
-      on MCPPermissions). Concrete effect: an MCP execute_command call with language "gremlin" and \
-      command "g.addV('Person')", against a profile with allowInsert=true but allowUpdate=false (a \
-      realistic, supported profile), is wrongly rejected with "Update operations are not allowed by MCP \
-      configuration" even though the query is a pure insert. Tracked as issue #5838; full writeup: PR #5829. \
-      Root cause: parse() sees AddVertexStartStepPlaceholder for 'g.addV(\\'Person\\')', not the \
-      AddVertexStartStep its instanceof check tests for (TinkerPop 3.8.1's gremlin-lang parser builds a \
-      GValue placeholder that GValueReductionStrategy - which parse() never runs - would normally resolve). \
-      The instanceof chain in ArcadeGremlin.parse() misses it and falls into the 'unknown mutating step' \
-      branch, which adds ALL THREE write OperationTypes. Query: g.addV('Person'). Expected \
-      getOperationTypes(): [CREATE]. Actual: [CREATE, UPDATE, DELETE].""")
+  // FIXED (#5838): parse() now checks the AddVertexStepContract/AddEdgeStepContract/AddPropertyStepContract
+  // interfaces, which both the GValue placeholder steps and the resolved concrete steps implement, instead of
+  // the concrete classes alone. See the comment in ArcadeGremlin.parse() for the full explanation.
   void addVertexOperationTypeIsExactlyCreate() {
     assertThat(analyze("g.addV('Person')").getOperationTypes())
         .containsExactly(OperationType.CREATE);
   }
 
   @Test
-  @Disabled("""
-      BUG (test-coverage finding): OperationType over-widening defect. getOperationTypes() only - \
-      isIdempotent() is correct and HA routing is unaffected (see the sibling addVertexOperationTypeIsExactlyCreate \
-      for the full HA-routing analysis and the confirmed, already-shipping MCP permission over-denial \
-      this causes; tracked as issue #5838, full writeup: PR #5829). Root cause: parse() sees \
-      AddEdgeStepPlaceholder for \"g.V().hasLabel('Person').as('a').addE('KNOWS').to('a')\", not the \
-      AddEdgeStep its instanceof check tests for, same GValue-placeholder reason as addV (see \
-      mutatingStepsSeenByAnalysisArePlaceholdersNotResolvedSteps). Falls into the 'unknown mutating step' \
-      branch, which adds ALL THREE write OperationTypes. Expected getOperationTypes(): [CREATE]. Actual: \
-      [CREATE, UPDATE, DELETE].""")
+  // FIXED (#5838): see addVertexOperationTypeIsExactlyCreate above.
   void addEdgeOperationTypeIsExactlyCreate() {
     assertThat(analyze("g.V().hasLabel('Person').as('a').addE('KNOWS').to('a')").getOperationTypes())
         .containsExactly(OperationType.CREATE);
   }
 
   @Test
-  @Disabled("""
-      BUG (test-coverage finding): OperationType over-widening defect. getOperationTypes() only - \
-      isIdempotent() is correct and HA routing is unaffected (see the sibling addVertexOperationTypeIsExactlyCreate \
-      for the full HA-routing analysis and the confirmed, already-shipping MCP permission over-denial \
-      this causes; tracked as issue #5838, full writeup: PR #5829). Root cause: parse() sees \
-      AddPropertyStepPlaceholder for \"g.V().hasLabel('Person').property('age', 30)\", not the \
-      AddPropertyStep its instanceof check tests for, same GValue-placeholder reason as addV/addE. Falls \
-      into the 'unknown mutating step' branch, which adds ALL THREE write OperationTypes. Expected \
-      getOperationTypes(): [UPDATE]. Actual: [CREATE, UPDATE, DELETE].""")
+  // FIXED (#5838): see addVertexOperationTypeIsExactlyCreate above.
   void addPropertyOperationTypeIsExactlyUpdate() {
     assertThat(analyze("g.V().hasLabel('Person').property('age', 30)").getOperationTypes())
         .containsExactly(OperationType.UPDATE);

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,15 @@
         <mockito-core.version>5.23.0</mockito-core.version>
         <neo4j-driver.version>6.2.0</neo4j-driver.version>
         <byte-buddy.version>1.17.7</byte-buddy.version>
+        <!-- ArcadeGremlin.parse() instanceof-checks TinkerPop's AddVertexStepContract/AddEdgeStepContract/
+             AddPropertyStepContract interfaces (not the concrete step classes) to classify OperationType,
+             because 3.8.1's gremlin-lang parser hands it GValue placeholder steps that only these contract
+             interfaces - not the concrete classes - cover (issue #5838). A version bump must re-verify via
+             javap that those contracts still exist and are still implemented by both the placeholder and the
+             concrete step for addV/addE/property, or the widened-OperationType bug silently comes back; see
+             docs/5838-gremlin-parse-over-widens-operationtype.md and
+             gremlin/src/test/java/com/arcadedb/gremlin/ArcadeGremlinAnalyzeTest.java. See also gremlin/pom.xml's
+             own comment on the paired antlr version (issue #5535). -->
         <gremlin.version>3.8.1</gremlin.version>
 
 


### PR DESCRIPTION
Closes #5838

## Summary

`ArcadeGremlin.parse()` classified mutating steps by `instanceof`-checking the concrete TinkerPop step classes (`AddVertexStep`, `AddEdgeStep`, `AddPropertyStep`, ...). TinkerPop 3.8.1's gremlin-lang parser, however, hands `parse()` GValue-based *placeholder* step types for `addV`/`addE`/`property` (e.g. `AddVertexStartStepPlaceholder`) that are only resolved into the concrete classes by `GValueReductionStrategy`, which `parse()` never runs. None of the placeholders is a subtype of the concrete classes, so every such query fell into the "unknown mutating step" fallback, which unions all three write `OperationType`s (`CREATE`, `UPDATE`, `DELETE`) instead of the single one that actually applies.

MCP's `execute_command` permission check denies a command if **any** `OperationType` it sees lacks its matching permission bit, so a caller with `allowInsert=true, allowUpdate=false` running `g.addV('Person')` was wrongly rejected with "Update operations are not allowed" - fail-closed over-denial, not privilege escalation, and independent of HA (HA follower routing only consults `isIdempotent()`/`isDDL()`, never `getOperationTypes()`, and remains correct throughout).

The fix switches the `instanceof` checks to the `AddVertexStepContract`/`AddEdgeStepContract`/`AddPropertyStepContract` interfaces TinkerPop 3.8.1 introduced, which both the placeholder and the resolved concrete step implement (verified via `javap` against `gremlin-core-3.8.1.jar`). `DropStep` has no placeholder variant in 3.8.1, so its direct check is unchanged.

## Test plan

- [x] Enabled the three `@Disabled` tests in `ArcadeGremlinAnalyzeTest` that pinned the correct narrow expectations (`addVertexOperationTypeIsExactlyCreate`, `addEdgeOperationTypeIsExactlyCreate`, `addPropertyOperationTypeIsExactlyUpdate`)
- [x] Confirmed regression-proof: reverted the source fix, reinstalled `arcadedb-gremlin`, reran `ArcadeGremlinAnalyzeTest` via `gremlin-it` - exactly the 3 target tests failed (`Tests run: 13, Failures: 3`)
- [x] Restored the fix, reran - all 13 tests pass
- [x] Ran the full `arcadedb-gremlin-it` module (`mvn -pl gremlin-it test`, includes the TinkerPop structure/process conformance suite and `GremlinParameterizedAnalyzeTest`'s mixed `addV().property()` case) - 344 tests, 0 failures, 0 errors
- [x] `mvn -pl gremlin -am compile` - clean compile, verified via `javap` that the compiled bytecode references the new `*StepContract` interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)