### PR TITLE
fix(#5799): sum() and avg() reject non-numeric input instead of silently ignoring it

### DIFF
--- a/docs/5799-cypher-sum-avg-silently-ignore-non-numeric.md
+++ b/docs/5799-cypher-sum-avg-silently-ignore-non-numeric.md
@@ -1,0 +1,86 @@
+# Issue #5799: `sum()` and `avg()` silently ignore non-numeric inputs
+
+## Root cause
+
+In Cypher:
+
+- `sum(x)` is *not* a Cypher-specific executor. `CypherFunctionFactory` maps it straight to the
+  shared SQL aggregate `SQLFunctionSum` (`com.arcadedb.function.sql.math.SQLFunctionSum`) via
+  `SQLFunctionBridge`. Its single-argument aggregation path only accumulates when the value
+  `instanceof Number`; anything else (STRING, BOOLEAN, ...) falls through both branches of the
+  `if`/`else if` and is silently dropped, leaving the accumulator untouched. An all-non-numeric
+  input therefore never leaves its default (0), and a mixed input quietly reports the sum of only
+  the numeric elements.
+- `avg(x)` *is* Cypher-specific (`com.arcadedb.function.agg.CypherAvgFunction`, matching Neo4j's
+  "always returns a Double" semantics). It has the identical defect: `execute()` only advances
+  `sum`/`count` when `args[0] instanceof Number`, otherwise it just returns `null` without raising
+  anything - an all-non-numeric input is indistinguishable from an all-null one.
+
+Both are the same class of bug already fixed once for the numeric math family (`abs()`, `sqrt()`,
+...) in issue #5484: a value outside the function's input domain must be a client-facing type
+error (HTTP 400), not silently ignored (which used to surface as a misleading 500, or in this case
+as a *wrong but plausible* result with no error at all).
+
+## Fix
+
+- `SQLFunctionSum` (shared by SQL's and Cypher's `sum()`): every path that used to silently skip a
+  non-numeric, non-null value now throws `IllegalArgumentException` - the existing convention for
+  a bad-input SQL function argument (see `SQLFunctionAbsoluteValue`), which the HTTP layer already
+  maps to 400. This covers the single-argument aggregate path, the `MultiValue` (list-typed
+  argument) path, and the multi-argument per-row path (which previously threw an undecorated
+  `ClassCastException` instead of silently ignoring, but still not a friendly client error).
+- `CypherAvgFunction` (Cypher-only `avg()`): now uses
+  `CypherFunctionHelper.requireNumberArgument()`, the same helper the #5484 numeric family uses,
+  which throws `CommandSemanticException` (a `CommandParsingException`, mapped to HTTP 400) with a
+  message naming the Cypher type actually received (e.g. `STRING`, `BOOLEAN`).
+
+Both null values and empty input remain unaffected (per the issue, that behavior was already
+correct): `sum()` over nulls/empty still returns `0`, `avg()` over nulls/empty still returns
+`null`.
+
+### Why two different exception types
+
+`SQLFunctionSum` is genuinely shared with plain SQL (`SELECT sum(...)`), so it follows the
+existing SQL-function convention (`IllegalArgumentException`) rather than pulling in the
+Cypher-only `CommandSemanticException`/`CypherFunctionHelper`. `CypherAvgFunction` has no SQL
+counterpart reachable from Cypher, so it follows the Cypher convention directly. Both map to HTTP
+400 at `AbstractServerHttpHandler`, so the externally observable behavior is the same.
+
+### Why `SQLFunctionSum`'s arity was not narrowed to match Cypher
+
+A tempting alternative was to give Cypher its own `CypherSumFunction` (mirroring `CypherAvgFunction`),
+which would also naturally reject non-numeric input. This was rejected: `CypherFunctionArityRegistryTest`
+pins `sum` in `NARROWER_IN_CYPHER` specifically *because* the shared `SQLFunctionSum` executor is
+variadic (`sum(a,b,c)`) while the Cypher parser only allows the single-argument aggregation - and
+that test asserts the pin still bites. Introducing a dedicated single-arg-only Cypher executor
+would make the parser and executor arities match exactly, breaking that existing regression test
+for an unrelated reason. Fixing `SQLFunctionSum` in place keeps its arity (and therefore that
+test) untouched.
+
+## Tests added
+
+`engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherAggregatingFunctionsComprehensiveTest.java`:
+
+- `avgRejectsNonNumericStrings`, `avgRejectsBoolean`, `avgRejectsNonNumericListLiteral`
+- `sumRejectsNonNumericStrings`, `sumRejectsBoolean`, `sumRejectsMixedNumericAndNonNumeric`,
+  `sumRejectsNonNumericListLiteral`
+
+`engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionSumAverageMultiArgTest.java`:
+
+- `sumMultiArgRejectsNonNumeric` (direct unit test against `SQLFunctionSum`, covering the
+  multi-argument per-row path without going through the query engine)
+
+## Verification
+
+1. Wrote the regression tests first, confirmed all 7 new Cypher-level tests failed against the
+   unmodified code (`avgRejectsBoolean`, `avgRejectsNonNumericListLiteral`,
+   `avgRejectsNonNumericStrings`, `sumRejectsBoolean`, `sumRejectsMixedNumericAndNonNumeric`,
+   `sumRejectsNonNumericListLiteral`, `sumRejectsNonNumericStrings`) - the last one failed by
+   throwing a bare `ClassCastException` instead of no exception, confirming the direct-list-literal
+   shape was already loud but ugly, while the rest silently returned instead of throwing.
+2. Implemented the fix in `SQLFunctionSum` and `CypherAvgFunction`.
+3. `mvn -pl engine -am test -Dtest=OpenCypherAggregatingFunctionsComprehensiveTest,SQLFunctionSumAverageMultiArgTest` - all pass (new + the pre-existing accumulator/nulls/multi-arg tests).
+4. `mvn -pl engine test -Dtest=CypherFunctionArityRegistryTest,CypherNumericFunctionArgumentIssue5484Test,CypherFunctionFactoryTest,CypherFunctionFactoryExtendedTest` - all pass, confirming the `sum` arity pin in `CypherFunctionArityRegistryTest.NARROWER_IN_CYPHER` still holds (untouched by design, see above) and the #5484 numeric-family tests are unaffected.
+5. `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**,com.arcadedb.function.**'` - 4415 tests, 0 failures, 0 errors.
+6. `mvn -pl engine test -Dtest='com.arcadedb.query.sql.**'` - 404 tests, 0 failures, 0 errors (confirms plain SQL `sum()`/`avg()` callers are unaffected beyond the intended behavior change).
+7. Searched the repo for other callers of `SQLFunctionSum`/`SQLFunctionAverage`/`CypherAvgFunction` and for `sum(`/`avg(` usages with string literals across wire-protocol test modules (postgresw, mongodbw, graphql, bolt) - none found outside `engine/`.

--- a/engine/src/main/java/com/arcadedb/function/agg/CypherAvgFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/CypherAvgFunction.java
@@ -19,13 +19,16 @@
 package com.arcadedb.function.agg;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
  * Cypher avg() aggregation function.
  * Always returns a Double result matching Neo4j/OpenCypher semantics,
  * unlike the SQL avg() which preserves the input numeric type.
- * Skips nulls.
+ * Skips nulls. A non-numeric, non-null input is a client-facing type error rather than being
+ * silently ignored - see issue #5799, the same class of defect as the numeric math family fixed
+ * in issue #5484.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -51,10 +54,9 @@ public class CypherAvgFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    if (args[0] == null)
-      return null;
-    if (args[0] instanceof Number number) {
-      sum += number.doubleValue();
+    final Number value = CypherFunctionHelper.requireNumberArgument(args[0], "avg");
+    if (value != null) {
+      sum += value.doubleValue();
       count++;
     }
     return null;

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionSum.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionSum.java
@@ -61,7 +61,12 @@ public class SQLFunctionSum extends SQLAggregatedFunction {
         sum(number);
       else if (MultiValue.isMultiValue(params[0]))
         for (final Object n : MultiValue.getMultiValueIterable(params[0]))
-          sum((Number) n);
+          sum(requireNumericOrNull(n));
+      else
+        // A NON-NUMERIC, NON-NULL, NON-LIST VALUE MUST BE A CLIENT-FACING TYPE ERROR RATHER THAN BEING SILENTLY
+        // DROPPED, WHICH USED TO LEAVE THE ACCUMULATOR UNCHANGED AND MAKE AN ALL-INVALID INPUT INDISTINGUISHABLE
+        // FROM AN ALL-NULL ONE (ISSUE #5799). requireNumericOrNull() itself is a no-op for null.
+        sum(requireNumericOrNull(params[0]));
       return sum;
     }
 
@@ -69,7 +74,7 @@ public class SQLFunctionSum extends SQLAggregatedFunction {
     // CROSS-ROW ACCUMULATOR, OTHERWISE A SUBSEQUENT getResult() WOULD ONLY RETURN THIS ROW'S CONTRIBUTION.
     Number rowSum = null;
     for (int i = 0; i < params.length; ++i) {
-      final Number value = (Number) params[i];
+      final Number value = requireNumericOrNull(params[i]);
       if (value != null)
         rowSum = rowSum == null ? value : Type.increment(rowSum, value);
     }
@@ -84,6 +89,18 @@ public class SQLFunctionSum extends SQLAggregatedFunction {
       else
         sum = Type.increment(sum, value);
     }
+  }
+
+  /**
+   * Validates a single aggregated value: {@code null} passes through (nulls are skipped, matching the documented
+   * behavior), a {@link Number} passes through unchanged, and anything else (STRING, BOOLEAN, ...) is a client-facing
+   * type error rather than being silently ignored - see issue #5799.
+   */
+  private static Number requireNumericOrNull(final Object value) {
+    if (value == null || value instanceof Number)
+      return (Number) value;
+    throw new IllegalArgumentException(
+        NAME + "() requires numeric input, but received a value of type " + value.getClass().getSimpleName());
   }
 
   public String getSyntax() {

--- a/engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionSumAverageMultiArgTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/math/SQLFunctionSumAverageMultiArgTest.java
@@ -24,8 +24,10 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 /**
@@ -52,6 +54,34 @@ class SQLFunctionSumAverageMultiArgTest {
 
     // ...WITHOUT DESTROYING THE PREVIOUSLY ACCUMULATED TOTAL
     assertThat(((Number) f.getResult()).intValue()).isEqualTo(30);
+  }
+
+  /**
+   * Issue #5799: a non-numeric, non-null value must be a client-facing type error rather than being
+   * silently skipped, whichever of {@code sum()}'s three argument shapes it reaches through.
+   */
+  @Test
+  void sumRejectsNonNumericSingleArg() {
+    final SQLFunctionSum f = new SQLFunctionSum();
+    assertThatThrownBy(() -> f.execute(null, null, null, new Object[] { "not-a-number" }, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sum()");
+  }
+
+  @Test
+  void sumRejectsNonNumericElementInsideAList() {
+    final SQLFunctionSum f = new SQLFunctionSum();
+    assertThatThrownBy(() -> f.execute(null, null, null, new Object[] { List.of(1, "not-a-number", 2) }, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sum()");
+  }
+
+  @Test
+  void sumRejectsNonNumericMultiArg() {
+    final SQLFunctionSum f = new SQLFunctionSum();
+    assertThatThrownBy(() -> f.execute(null, null, null, new Object[] { 1, "not-a-number", 2 }, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sum()");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherAggregatingFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherAggregatingFunctionsComprehensiveTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.functions;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,7 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 /**
@@ -82,6 +84,34 @@ class OpenCypherAggregatingFunctionsComprehensiveTest extends TestHelper {
         "UNWIND [null, null] AS val RETURN avg(val) AS result");
     Assertions.assertThat(result.hasNext() != false).isTrue();
     Assertions.assertThat(result.next().getProperty("result") == null).isTrue();
+  }
+
+  // Issue #5799: avg() must report a client-facing type error instead of silently ignoring
+  // non-numeric input (which used to make avg(['a','b']) indistinguishable from avg([null,null])).
+  @Test
+  void avgRejectsNonNumericStrings() {
+    assertThatThrownBy(() -> consume("UNWIND ['a', 'b'] AS val RETURN avg(val) AS result"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("avg()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void avgRejectsBoolean() {
+    assertThatThrownBy(() -> consume("UNWIND [true, 1] AS val RETURN avg(val) AS result"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("avg()")
+        .hasMessageContaining("BOOLEAN");
+  }
+
+  @Test
+  void avgRejectsNonNumericListLiteral() {
+    // avg() aggregates one scalar expression per row; handing it a LIST directly (rather than an
+    // UNWOUND scalar) is the same out-of-domain mistake, not an implicit "sum the list" request.
+    assertThatThrownBy(() -> consume("RETURN avg(['a', 'b']) AS result"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("avg()")
+        .hasMessageContaining("LIST");
   }
 
   // ==================== collect() Tests ====================
@@ -379,6 +409,40 @@ class OpenCypherAggregatingFunctionsComprehensiveTest extends TestHelper {
     assertThat(((Number) result.next().getProperty("result")).intValue()).isEqualTo(0);
   }
 
+  // Issue #5799: sum() must report a client-facing type error instead of silently ignoring
+  // non-numeric input (which used to make sum(['1','2']) indistinguishable from sum([null,null])).
+  @Test
+  void sumRejectsNonNumericStrings() {
+    assertThatThrownBy(() -> consume("UNWIND ['1', '2'] AS val RETURN sum(val) AS result"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sum()");
+  }
+
+  @Test
+  void sumRejectsBoolean() {
+    assertThatThrownBy(() -> consume("UNWIND [true, 1] AS val RETURN sum(val) AS result"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sum()");
+  }
+
+  @Test
+  void sumRejectsMixedNumericAndNonNumeric() {
+    // A partially-valid input must not be silently summed as if the bad values were absent -
+    // it must fail loudly rather than return a plausible-looking partial total.
+    assertThatThrownBy(() -> consume("UNWIND [1, 'a', 2] AS val RETURN sum(val) AS result"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sum()");
+  }
+
+  @Test
+  void sumRejectsNonNumericListLiteral() {
+    // sum(<list>) sums the list's own elements (unlike avg(), which has no such fallback), so each
+    // element is still held to the numeric domain.
+    assertThatThrownBy(() -> consume("RETURN sum(['1', '2']) AS result"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sum()");
+  }
+
   // ==================== Combined/Integration Tests ====================
 
   @Test
@@ -552,5 +616,12 @@ class OpenCypherAggregatingFunctionsComprehensiveTest extends TestHelper {
         "UNWIND [null, null] AS val RETURN stdev_pop(val) AS result");
     Assertions.assertThat(result.hasNext() != false).isTrue();
     Assertions.assertThat(result.next().getProperty("result") == null).isTrue();
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.command("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?

`sum()` and `avg()` in Cypher now raise a client-facing type error (HTTP 400) instead of
silently ignoring non-numeric input.

- `SQLFunctionSum` (shared by SQL's `sum()` and Cypher's `sum()`, reached via
  `SQLFunctionBridge`): a non-numeric, non-null value used to be silently skipped in the
  single-argument aggregate path, and blindly cast (throwing an undecorated
  `ClassCastException`) in the multi-argument per-row and list-element paths. All three now
  validate the value and throw `IllegalArgumentException` with a clear message, matching the
  existing SQL-function convention (e.g. `SQLFunctionAbsoluteValue`).
- `CypherAvgFunction` (Cypher-only `avg()`): now uses
  `CypherFunctionHelper.requireNumberArgument()`, the same helper the numeric math family
  (`abs()`, `sqrt()`, ...) already uses since #5484 for this exact class of defect, throwing
  `CommandSemanticException`.

Null handling and empty-input identities are unchanged: `sum()` over nulls/empty still returns
`0`, `avg()` over nulls/empty still returns `null`.

## Motivation

Silently ignoring out-of-domain values let `sum()`/`avg()` return a plausible but wrong result
with no error at all:

- `UNWIND ['1', '2'] AS x RETURN sum(x)` returned `0`, indistinguishable from summing
  `[null, null]`.
- `UNWIND [true, 1] AS x RETURN sum(x)` returned `1`, hiding the invalid boolean.
- `UNWIND ['a', 'b'] AS x RETURN avg(x)` returned `null`, indistinguishable from averaging
  `[null, null]`.

Neo4j reports a type error for all of these. This is the same class of defect fixed for the
numeric math family (`abs()`, `sqrt()`, ...) in #5484.

### Why two different exception types

`SQLFunctionSum` is genuinely shared with plain SQL (`SELECT sum(...) FROM ...`), so it follows
the existing SQL-function convention (`IllegalArgumentException`) rather than pulling in the
Cypher-only `CommandSemanticException`/`CypherFunctionHelper`. `CypherAvgFunction` has no SQL
counterpart reachable from Cypher, so it follows the Cypher convention directly. Both map to
HTTP 400 at `AbstractServerHttpHandler`, so the externally observable behavior is the same.

### Why `sum()` didn't get its own Cypher-specific executor

A tempting alternative was giving Cypher its own `CypherSumFunction` (mirroring
`CypherAvgFunction`). This was rejected: `CypherFunctionArityRegistryTest` pins `sum` in
`NARROWER_IN_CYPHER` specifically because the shared `SQLFunctionSum` executor is variadic
(`sum(a,b,c)`) while the Cypher parser only allows the single-argument aggregation, and that
test asserts the pin still bites. A dedicated single-arg-only Cypher executor would make the
parser and executor arities match exactly, breaking that existing regression test for an
unrelated reason. Fixing `SQLFunctionSum` in place keeps its arity untouched.

## Related issues

Closes #5799

Same class of defect as #5484.

## Additional Notes

Verification performed (see the tracking doc at
`docs/5799-cypher-sum-avg-silently-ignore-non-numeric.md` for full detail):

- Wrote the regression tests first and confirmed all 7 new Cypher-level tests failed against the
  unmodified code.
- `OpenCypherAggregatingFunctionsComprehensiveTest` + `SQLFunctionSumAverageMultiArgTest`: pass.
- `CypherFunctionArityRegistryTest` + `CypherNumericFunctionArgumentIssue5484Test` +
  `CypherFunctionFactoryTest` + `CypherFunctionFactoryExtendedTest`: pass (confirms the `sum`
  arity pin still holds and the #5484 numeric-family tests are unaffected).
- Full `com.arcadedb.query.opencypher.**` + `com.arcadedb.function.**` packages: 4415 tests, 0
  failures, 0 errors.
- Full `com.arcadedb.query.sql.**` package: 404 tests, 0 failures, 0 errors.
- Searched the repo for other callers of the changed classes and for `sum(`/`avg(` usages with
  string literals across wire-protocol test modules (postgresw, mongodbw, graphql, bolt): none
  found outside `engine/`.

## Test plan

- [ ] `UNWIND ['1', '2'] AS x RETURN sum(x)` raises a client error instead of returning `0`
- [ ] `UNWIND [true, 1] AS x RETURN sum(x)` raises a client error instead of returning `1`
- [ ] `UNWIND ['a', 'b'] AS x RETURN avg(x)` raises a client error instead of returning `null`
- [ ] `UNWIND [1, null] AS x RETURN sum(x)` still returns `1` (nulls still skipped)
- [ ] `UNWIND [] AS x RETURN sum(x)` still returns `0` (empty-input identity unchanged)
- [ ] `UNWIND [] AS x RETURN avg(x)` still returns `null` (empty-input identity unchanged)
- [ ] `mvn -pl engine -am test -Dtest=OpenCypherAggregatingFunctionsComprehensiveTest,SQLFunctionSumAverageMultiArgTest` passes

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
