### PR TITLE
fix(#5794): range() zero step, invalid date()/datetime(), non-numeric point() coordinates return HTTP 400

### DIFF
--- a/docs/5794-cypher-function-arg-validation-500.md
+++ b/docs/5794-cypher-function-arg-validation-500.md
@@ -94,3 +94,28 @@ removed a now-unused `CommandExecutionException` import in
   (`localdatetime()`, `localtime()`, `time()`) and the remaining
   `CypherPointFunction` structural-validation branches, which have the
   identical defect class but were not part of this issue's named repro.
+  Done: filed as #5910.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5909
+
+## Review cycles
+
+- **Cycle 1** - head `d40023d05a4fcc639965a6ef4cf4a832e7441c91` (the fix
+  commit). `claude[bot]` posted its review as a PR issue comment (not a
+  formal GitHub review) ~4 minutes after the push: "Didn't find any
+  bugs... LGTM pending the tracking-issue note above." The one suggestion
+  (link a tracking issue for the documented out-of-scope follow-up) was
+  actioned without a code change: filed #5910 and linked it from a PR
+  comment. Working tree stayed clean, so the loop exited on a
+  clean-approval after cycle 1 with no further push needed.
+
+## Deferred items
+
+None. The single review suggestion was actionable-and-clear and was
+resolved by filing #5910, not by deferring to the developer.
+
+## Final state
+
+`clean-approval` after 1 review cycle.

--- a/docs/5794-cypher-function-arg-validation-500.md
+++ b/docs/5794-cypher-function-arg-validation-500.md
@@ -1,0 +1,96 @@
+# Issue #5794: Cypher argument-validation errors surfaced as HTTP 500
+
+## Root cause
+
+Four argument-validation paths in Cypher functions threw a bare
+`com.arcadedb.exception.CommandExecutionException`, which
+`AbstractServerHttpHandler` maps to HTTP 500 ("internal server error").
+`CommandSemanticException` (a subclass of `CommandParsingException`) is the
+class the HTTP layer maps to HTTP 400 for deterministic, client-caused
+argument errors — the pattern already established for `abs()` (#5484),
+`left()`/`right()` (#5296), and arithmetic errors (#5545).
+
+Each of the four failures below is determined entirely by the supplied query
+arguments and cannot succeed when retried unchanged, so it belongs to the
+same class of client error, not a server fault.
+
+## Affected components
+
+- `engine/src/main/java/com/arcadedb/function/coll/RangeFunction.java`
+  - `range()` with a zero step.
+- `engine/src/main/java/com/arcadedb/function/temporal/DateConstructorFunction.java`
+  - `date()` with a string that parses as neither a date nor a timezone.
+- `engine/src/main/java/com/arcadedb/function/temporal/DateTimeConstructorFunction.java`
+  - `datetime()` with a string that parses as neither a datetime nor a timezone.
+- `engine/src/main/java/com/arcadedb/function/geo/CypherPointFunction.java`
+  - `point()` with a non-numeric coordinate, in `coerceCoordinate()`. Both
+    branches were fixed (a non-numeric `String` and a value that is neither a
+    `Number` nor a numeric-looking `String`), since they are the same
+    validation guard for the same class of error.
+
+## Expected vs actual behavior
+
+| Query | Before | After |
+| --- | --- | --- |
+| `RETURN range(1, 5, 0)` | HTTP 500 `CommandExecutionException` | HTTP 400 `CommandSemanticException` |
+| `RETURN date('not-a-date')` | HTTP 500 `CommandExecutionException` | HTTP 400 `CommandSemanticException` |
+| `RETURN datetime('not-a-date')` | HTTP 500 `CommandExecutionException` | HTTP 400 `CommandSemanticException` |
+| `RETURN point({x: 'a', y: 1})` | HTTP 500 `CommandExecutionException` | HTTP 400 `CommandSemanticException` |
+
+## Fix
+
+Changed the four throw sites (five call sites counting both branches of
+`coerceCoordinate()`) from `CommandExecutionException` to
+`CommandSemanticException`, keeping the existing descriptive messages
+unchanged. Updated the class-level Javadoc on `CypherPointFunction` and
+removed a now-unused `CommandExecutionException` import in
+`RangeFunction.java`.
+
+## TDD approach
+
+1. Wrote `engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionArgumentValidationIssue5794Test.java`
+   reproducing all four named paths (plus the second `coerceCoordinate`
+   branch) and asserting `CommandSemanticException`, plus a
+   `validInputsStillSucceed()` control.
+2. Confirmed all 5 reproducer tests failed against `main` (asserting
+   `CommandExecutionException` was thrown instead), proving the bug.
+3. Applied the minimal fix (exception class swap only, no behavior/message
+   change).
+4. Re-ran the same test class: all 6 tests pass.
+5. Ran a broader related-test pass (numeric-function argument validation
+   #5484, optional-argument-null #5629, spatial functions comprehensive
+   test, function-factory extended test, function-arity registry test):
+   all pass, no regressions.
+
+## Test results
+
+- `CypherFunctionArgumentValidationIssue5794Test`: 6/6 pass (was 1/6 before
+  the fix, with the 5 reproducer tests failing as expected).
+- Broader related suite (`CypherNumericFunctionArgumentIssue5484Test`,
+  `CypherFollowUpsIssue5602Test`, `CypherOptionalArgumentNullIssue5629Test`,
+  `OpenCypherSpatialFunctionsComprehensiveTest`,
+  `CypherFunctionFactoryExtendedTest`, `CypherFunctionArityRegistryTest`):
+  all pass, no regressions.
+
+## Impact analysis
+
+- Client-facing: the four listed queries now report a descriptive HTTP 400
+  instead of a misleading HTTP 500, matching the behavior already shipped
+  for the neighboring numeric/string/arithmetic argument-validation fixes.
+- No change to error message text, so no downstream string-matching client
+  code is affected beyond the (already-desired) HTTP status code and
+  exception class.
+- Scope: limited to the four paths named in the issue's reproduction steps.
+  Sibling constructors (`localdatetime()`, `localtime()`, `time()`) and a
+  few other structural `point()` validation branches (missing `x`/`y` or
+  `longitude`/`latitude`, non-map argument, non-numeric `srid`) share the
+  same `CommandExecutionException`-for-a-client-error defect but were left
+  untouched, being outside this issue's reported repro steps. Recommended
+  as a follow-up issue for the same systematic scan.
+
+## Recommendations for monitoring or future improvements
+
+- File a follow-up issue for the sibling temporal constructors
+  (`localdatetime()`, `localtime()`, `time()`) and the remaining
+  `CypherPointFunction` structural-validation branches, which have the
+  identical defect class but were not part of this issue's named repro.

--- a/engine/src/main/java/com/arcadedb/function/coll/RangeFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/RangeFunction.java
@@ -20,7 +20,6 @@ package com.arcadedb.function.coll;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
@@ -67,8 +66,10 @@ public class RangeFunction implements StatelessFunction {
     final long end = ((Number) args[1]).longValue();
     final long step = args.length == 3 ? ((Number) args[2]).longValue() : 1L;
 
+    // A zero step is determined entirely by the supplied argument, so it is a client error (HTTP 400) rather
+    // than a CommandExecutionException (HTTP 500). See issue #5794.
     if (step == 0)
-      throw new CommandExecutionException("range() step cannot be zero");
+      throw new CommandSemanticException("range() step cannot be zero");
 
     final long cardinality = LongRangeList.cardinality(start, end, step);
     final long maxAllowed = maxRangeSize(context);

--- a/engine/src/main/java/com/arcadedb/function/geo/CypherPointFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/geo/CypherPointFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.geo;
 
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
 
@@ -43,8 +44,9 @@ import java.util.Map;
  * <p>Numeric coordinate keys that resolve to a {@link String} are coerced to {@link Number}
  * when the string parses cleanly as a decimal (e.g. a node whose {@code lat} property was
  * declared as {@link com.arcadedb.schema.Type#STRING}). When coercion is impossible the
- * function raises a {@link CommandExecutionException} naming the offending key and value
- * rather than leaking a raw {@link ClassCastException} (issue #4305).</p>
+ * function raises a {@link CommandSemanticException} naming the offending key and value
+ * rather than leaking a raw {@link ClassCastException} (issue #4305) or reporting a client
+ * argument error as an internal server fault (issue #5794).</p>
  */
 public class CypherPointFunction implements StatelessFunction {
   @Override
@@ -154,9 +156,11 @@ public class CypherPointFunction implements StatelessFunction {
   /**
    * Returns the numeric value of {@code value}, coercing a numeric {@link String} when the
    * underlying property is typed as STRING but the contents are a clean decimal literal.
-   * Throws a {@link CommandExecutionException} that names {@code key} and {@code value}
-   * when coercion is impossible, so the user sees a clear error instead of a raw
-   * {@link ClassCastException} (issue #4305).
+   * Throws a {@link CommandSemanticException} that names {@code key} and {@code value}
+   * when coercion is impossible, so the user sees a clear client-facing error (HTTP 400)
+   * instead of a raw {@link ClassCastException} (issue #4305) or an internal-fault-looking
+   * {@link CommandExecutionException} (HTTP 500, issue #5794): a non-numeric coordinate is
+   * determined entirely by the supplied argument, so it is a client error either way.
    */
   private static double coerceCoordinate(final String key, final Object value) {
     if (value instanceof Number n)
@@ -165,11 +169,11 @@ public class CypherPointFunction implements StatelessFunction {
       try {
         return Double.parseDouble(s.trim());
       } catch (final NumberFormatException ignored) {
-        throw new CommandExecutionException(
+        throw new CommandSemanticException(
             "point() '" + key + "' must be numeric, found String value '" + s + "'");
       }
     }
-    throw new CommandExecutionException(
+    throw new CommandSemanticException(
         "point() '" + key + "' must be numeric, found " + describe(value));
   }
 

--- a/engine/src/main/java/com/arcadedb/function/temporal/DateConstructorFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/temporal/DateConstructorFunction.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.temporal;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.opencypher.temporal.CypherDate;
 import com.arcadedb.query.opencypher.temporal.CypherDateTime;
@@ -70,7 +71,9 @@ public class DateConstructorFunction implements StatelessFunction {
         try {
           return new CypherDate(LocalDate.now(ZoneId.of(str)));
         } catch (final Exception e2) {
-          throw new CommandExecutionException("date() cannot parse '" + str + "' as a date or timezone");
+          // Neither a valid date nor a valid timezone: determined entirely by the supplied string, so it is a
+          // client error (HTTP 400) rather than a CommandExecutionException (HTTP 500). See issue #5794.
+          throw new CommandSemanticException("date() cannot parse '" + str + "' as a date or timezone");
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/temporal/DateTimeConstructorFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/temporal/DateTimeConstructorFunction.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.temporal;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.opencypher.temporal.CypherDate;
 import com.arcadedb.query.opencypher.temporal.CypherDateTime;
@@ -71,7 +72,9 @@ public class DateTimeConstructorFunction implements StatelessFunction {
         try {
           return new CypherDateTime(ZonedDateTime.now(ZoneId.of(str)));
         } catch (final Exception e2) {
-          throw new CommandExecutionException("datetime() cannot parse '" + str + "' as a datetime or timezone");
+          // Neither a valid datetime nor a valid timezone: determined entirely by the supplied string, so it is a
+          // client error (HTTP 400) rather than a CommandExecutionException (HTTP 500). See issue #5794.
+          throw new CommandSemanticException("datetime() cannot parse '" + str + "' as a datetime or timezone");
         }
       }
     }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionArgumentValidationIssue5794Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionArgumentValidationIssue5794Test.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5794: a systematic function x invalid-input scan found four argument-validation
+ * paths that still threw a bare {@link com.arcadedb.exception.CommandExecutionException}, which the HTTP layer
+ * turns into a misleading 500 "internal server error" instead of a 400 client error. Every failure below is
+ * determined entirely by the supplied query arguments and cannot succeed when retried unchanged, so it belongs
+ * to the same class of client-caused failure fixed for the neighboring functions in issues #5484 (abs()), #5296
+ * (left()/right()) and #5545 (arithmetic errors).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherFunctionArgumentValidationIssue5794Test extends TestHelper {
+
+  @Test
+  void rangeWithZeroStepIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN range(1, 5, 0) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("range()")
+        .hasMessageContaining("zero");
+  }
+
+  @Test
+  void dateWithAnInvalidStringIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN date('not-a-date') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("date()")
+        .hasMessageContaining("not-a-date");
+  }
+
+  @Test
+  void datetimeWithAnInvalidStringIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN datetime('not-a-date') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("datetime()")
+        .hasMessageContaining("not-a-date");
+  }
+
+  @Test
+  void pointWithANonNumericStringCoordinateIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN point({x: 'a', y: 1}) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("point()")
+        .hasMessageContaining("x");
+  }
+
+  @Test
+  void pointWithANonNumericNonStringCoordinateIsAClientError() {
+    // Same coerceCoordinate() guard, the other branch: a value that is neither a Number nor a numeric-looking
+    // String (e.g. a boolean) must be reported the same way as the string case above.
+    assertThatThrownBy(() -> consume("RETURN point({x: true, y: 1}) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("point()")
+        .hasMessageContaining("x");
+  }
+
+  // ===================== valid-input controls: confirm the fix does not disturb success paths =====================
+
+  @Test
+  void validInputsStillSucceed() {
+    assertThat(single("RETURN range(1, 5, 1) AS r").toString()).contains("1", "5");
+    assertThat(single("RETURN date('2026-08-03') AS r")).isNotNull();
+    assertThat(single("RETURN datetime('2026-08-03T12:00:00Z') AS r")).isNotNull();
+    assertThat(single("RETURN point({x: 1, y: 1}).x AS r")).isEqualTo(1.0d);
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes four Cypher argument-validation paths that returned HTTP 500 (`CommandExecutionException`) instead of a client-facing HTTP 400 (`CommandSemanticException`):

- `range()` with a zero step
- `date()` with a string that parses as neither a date nor a timezone
- `datetime()` with a string that parses as neither a datetime nor a timezone
- `point()` with a non-numeric coordinate (both branches of the shared `coerceCoordinate()` guard: a non-numeric `String` and a value that is neither a `Number` nor a numeric-looking `String`)

Each failure is determined entirely by the supplied query arguments and cannot succeed when retried unchanged, so it belongs to the same class of client-caused error already fixed for the neighboring functions in #5484 (`abs()`), #5296 (`left()`/`right()`) and #5545 (arithmetic errors). Only the exception class changes; the existing descriptive messages are unchanged.

Closes #5794

## Motivation

A systematic function x invalid-input scan (reported in #5794) found these four paths still reaching the unclassified HTTP 500 path, causing clients to see a misleading internal-server-error status for a deterministic input mistake, which may trigger unnecessary retries or false operational alerts.

## Related issues

Closes #5794

Same class of fix as #5484, #5296, #5545.

## Additional Notes

Scope is intentionally limited to the four paths named in the issue's reproduction steps. While reproducing the bug I found the same `CommandExecutionException`-for-a-client-error defect in three sibling temporal constructors (`localdatetime()`, `localtime()`, `time()`) and in a few other `point()` structural-validation branches (missing `x`/`y` or `longitude`/`latitude`, non-map argument, non-numeric `srid`). Those are out of scope for this issue and are recommended as a follow-up.

## Test plan

- [ ] New regression test `engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionArgumentValidationIssue5794Test.java` reproduces all four named paths (five call sites) and asserts `CommandSemanticException`, plus a valid-input control test.
- [ ] Confirmed all five reproducer tests failed against `main` before the fix (asserting `CommandExecutionException` was thrown instead), proving the bug.
- [ ] `mvn -pl engine -am test -Dtest=CypherFunctionArgumentValidationIssue5794Test` passes (6/6) after the fix.
- [ ] Broader related-test pass with no regressions: `CypherNumericFunctionArgumentIssue5484Test`, `CypherFollowUpsIssue5602Test`, `CypherOptionalArgumentNullIssue5629Test`, `OpenCypherSpatialFunctionsComprehensiveTest`, `CypherFunctionFactoryExtendedTest`, `CypherFunctionArityRegistryTest`.
- [ ] `mvn -pl engine -am compile` succeeds.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
