### PR TITLE
fix(#5790): guard undeclared edge type in count(*) OPTIONAL MATCH push-down

### DIFF
--- a/docs/5790-optional-match-count-star-undeclared-rel.md
+++ b/docs/5790-optional-match-count-star-undeclared-rel.md
@@ -93,7 +93,38 @@ New file: `engine/src/test/java/com/arcadedb/query/opencypher/Issue5790OptionalM
    - all pass.
 5. Ran the full `com.arcadedb.query.opencypher.**` test package: 4540 tests, 0 failures, 0 errors.
 
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/5914
+
+## Review cycles
+
+Zero review cycles completed. The `claude` bot's review job (`claude-review`,
+https://github.com/ArcadeData/arcadedb/actions/runs/31181968311) ran to completion
+against head SHA `aea666bd26097c3c451f677c2a0609350a831119` (41 turns, reported
+`permission_denials_count: 14`, "No buffered inline comments") but posted **no**
+review, review comment, or issue comment anywhere on the PR - verified across all
+three surfaces (`gh api .../pulls/5914/reviews`, `.../pulls/5914/comments`,
+`.../issues/5914/comments`) after the job's CI check itself showed `pass` (5m1s).
+All other CI checks passed (CodeQL, Codacy, Meterian, language analyzers,
+`build-and-package`).
+
+This looks like the known MCP-tool-over-denial infrastructure issue tracked
+separately (not part of this issue's scope) rather than anything about this PR's
+diff - the job's own permission-denial counter is consistent with it being unable
+to call whatever tool it needed to post a review/comment.
+
+## Deferred items
+
+None from code review (none was received). The PR is left open for the developer
+to either re-trigger `claude-review` (e.g. by pushing a no-op commit) or review and
+merge manually.
+
 ## Status
 
-Fix implemented and verified. Proceeding to PR + automated review loop via
-`resolve-issue-with-review`.
+**timeout** - the review loop's 15-minute wait window closed with the `claude`
+bot's workflow having already run to completion and posted nothing. Per this
+skill's constraints, the loop stops here; merge remains the developer's
+responsibility. Fix and regression test are implemented, verified locally
+(target-package test run: 4540 tests, 0 failures, 0 errors), and pushed to the PR
+branch.

--- a/docs/5790-optional-match-count-star-undeclared-rel.md
+++ b/docs/5790-optional-match-count-star-undeclared-rel.md
@@ -1,0 +1,99 @@
+# Issue #5790: count(*) after OPTIONAL MATCH over an undeclared relationship type causes HTTP 500
+
+https://github.com/ArcadeData/arcadedb/issues/5790
+
+## Root cause
+
+`CypherExecutionPlan.tryDetectStarCountStar()` is one of the `count(*)` push-down detectors
+tried by `tryOptimizeCountStar()`. It is the only detector among the five (`tryDetectChainCountStar`,
+`tryDetectAntiJoinChainCountStar`, `tryDetectStarCountStar`, `tryDetectTriangleCountStar`,
+`tryDetectPairJoinCountStar`) that accepts `OPTIONAL MATCH` clauses - the other four all require
+exactly one non-optional `MATCH` clause and bail out otherwise. For a query like
+
+```cypher
+MATCH (n:T_0) OPTIONAL MATCH (n)-[:NO_SUCH]->(m:T_0) RETURN count(*) AS c
+```
+
+`tryDetectStarCountStar()` finds `n` as the central variable shared by the two `MATCH` clauses and
+builds a `DegreeProductOp` with one `Arm` per relationship, marking the arm built from the
+`OPTIONAL MATCH` clause as `optional = true`.
+
+`DegreeProductOp.execute()` falls back to the OLTP path whenever there is no mandatory arm (a
+correctness requirement documented in issue #5094 - a purely optional star has no degree filter
+to exclude zero-degree central nodes, and those nodes must still contribute one null-preserving
+row each). The OLTP path, for a single-hop arm, calls `executeOLTPDegreeMap()`, which iterated the
+arm's edge type via `Database.iterateType(edgeType, true)` **unconditionally**. `iterateType`
+resolves the type name through `Schema.getType()`, which throws `SchemaException("Type with name
+'X' was not found")` for an undeclared name.
+
+Every other way of asking the same question - no aggregation, `count(m)`, `sum(1)`, `collect(m)`,
+or declaring the relationship type first - either never reaches `DegreeProductOp` at all (the
+push-down detectors require `count(*)` specifically) or reaches the ordinary materialization
+pipeline, whose `MatchRelationshipStep` already tolerates an undeclared type via vertex-local
+edge-list filtering (`EdgeLinkedList.count()`, fixed for issue #4199). Only the `count(*)`
+degree-product fast path skipped that guard.
+
+A mandatory (non-optional) arm over an undeclared type never reaches `DegreeProductOp` in the
+first place - `tryOptimizeCountStar()` calls `mandatoryPatternElementIsEmpty()` first, which
+short-circuits to `ConstantCountStep(0L)` for any *non-optional* `MATCH` clause whose relationship
+type set is entirely undeclared. That check deliberately skips `OPTIONAL MATCH` clauses (an
+optional arm that matches nothing still contributes its anchor row), which is exactly the gap this
+issue falls into.
+
+The multi-hop OLTP fallback (`executeOLTPPerVertex`, used when an arm spans 2+ relationship types)
+was already safe: it goes through `Vertex.countEdges()` / `Vertex.getVertices()`, which resolve
+edge types via the vertex's own edge-list segments (`EdgeLinkedList.count()`), not via
+`Schema.getType()`. Verified with a dedicated reproduction before writing the fix - no additional
+guard was needed there.
+
+## Fix
+
+`DegreeProductOp.executeOLTPDegreeMap()` now checks `db.getSchema().existsType(edgeType)` before
+calling `db.iterateType(edgeType, true)` for each arm. An undeclared edge type is skipped entirely
+for that arm: it contributes no entries to the per-vertex degree map, which is exactly equivalent
+to "degree 0 for every vertex" - the same fallback already used to answer this correctly through
+the ordinary pipeline.
+
+- A **mandatory** arm over an undeclared type never reaches this code (already short-circuited to
+  `ConstantCountStep(0L)` upstream), so the guard only changes behavior for optional arms.
+- An **optional** arm with degree 0 (now including "the type doesn't exist") contributes a
+  `max(1, 0) = 1` multiplier, per the pre-existing OPTIONAL MATCH semantics of this operator - i.e.
+  the anchor row is preserved.
+
+File changed: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOp.java`
+(+10 lines, a guard clause and its comment - no other files touched).
+
+## Test plan
+
+New file: `engine/src/test/java/com/arcadedb/query/opencypher/Issue5790OptionalMatchCountStarUndeclaredRelTypeTest.java`
+
+- `countStarAfterOptionalMatchOverUndeclaredRelTypeCountsAnchorRow` - one anchor vertex, `count(*)`
+  over `OPTIONAL MATCH` on an undeclared type returns `1` instead of throwing.
+- `countStarAfterOptionalMatchOverUndeclaredRelTypeOnEmptyGraphIsZero` - empty graph returns `0`
+  (already worked before the fix, via the mandatory-arm-is-empty short-circuit on the anchor label;
+  kept as a regression guard).
+- `countStarAfterOptionalMatchOverUndeclaredRelTypeWithMultipleAnchors` - three anchor vertices,
+  `count(*)` returns `3`.
+- `controlFormsAlreadyWorkedAndKeepWorking` - `count(m)`, `sum(1)`, and the unaggregated
+  `RETURN n.id` forms from the issue's "Controls (work correctly)" table still work after the fix.
+- `countStarWithOneDeclaredAndOneUndeclaredOptionalArm` - a star with two `OPTIONAL MATCH` arms,
+  one over a declared type with real edges and one over an undeclared type, to confirm the
+  undeclared arm's `max(1, 0)` fallback does not disturb the declared arm's real degree count.
+
+### Verification performed
+
+1. TDD: wrote the regression test first, confirmed all `count(*)` scenarios failed with the exact
+   `SchemaException`/HTTP-500-shaped `CommandExecutionException` reported in the issue (4 of 5
+   tests errored; the empty-graph case already passed via the pre-existing short-circuit).
+2. Applied the one-guard fix in `DegreeProductOp.executeOLTPDegreeMap()`.
+3. Re-ran the regression test: all 5 pass.
+4. Ran the closely related existing tests for regressions: `Issue5094OptionalMatchCountStarTest`,
+   `CypherCountPushDownPreconditionsIssue5715Test`, `CypherSubqueryBodyIssue5656Test`,
+   `CypherUncorrelatedSubqueryCountPushDownIssue5686Test`, `Issue4199NonExistentEdgeTypeWithRangeTest`
+   - all pass.
+5. Ran the full `com.arcadedb.query.opencypher.**` test package: 4540 tests, 0 failures, 0 errors.
+
+## Status
+
+Fix implemented and verified. Proceeding to PR + automated review loop via
+`resolve-issue-with-review`.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DegreeProductOp.java
@@ -255,6 +255,16 @@ public final class DegreeProductOp implements CountOp {
       final String edgeType = arms[a].edgeTypes[0];
       final Vertex.DIRECTION dir = arms[a].directions[0];
 
+      // An undeclared edge type has no edges by definition. db.iterateType() resolves the type
+      // via Schema#getType() and throws for a name the schema does not know, unlike the vertex-local
+      // edge-list filtering the ordinary pipeline uses (EdgeLinkedList#count, fixed for issue #4199).
+      // A mandatory arm over an undeclared type is already short-circuited to a constant 0 before
+      // this operator is even built (see mandatoryPatternElementIsEmpty()), but an OPTIONAL MATCH
+      // arm reaches here and must simply contribute degree 0 to every central vertex rather than
+      // throw (issue #5790).
+      if (!db.getSchema().existsType(edgeType))
+        continue;
+
       for (final Iterator<? extends Identifiable> it = db.iterateType(edgeType, true); it.hasNext(); ) {
         final Edge edge = it.next().asEdge();
         // The central vertex is the vertex on the "source" side of the arm direction:

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5790OptionalMatchCountStarUndeclaredRelTypeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5790OptionalMatchCountStarUndeclaredRelTypeTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces issue #5790: {@code count(*)} after an {@code OPTIONAL MATCH} over a relationship
+ * type that is not declared in the schema returned HTTP 500 ({@code SchemaException: Type with
+ * name '...' was not found}) instead of the correct aggregated count.
+ * <p>
+ * Root cause: the star-join count-push-down ({@code CypherExecutionPlan#tryDetectStarCountStar})
+ * builds a {@code DegreeProductOp} arm for the OPTIONAL MATCH relationship without checking
+ * whether the schema actually declares that edge type. {@code DegreeProductOp#executeOLTPDegreeMap}
+ * then called {@code Database#iterateType(String, boolean)} unconditionally, which resolves the
+ * type via {@code Schema#getType(String)} and throws for an undeclared name. Every other
+ * aggregation form ({@code count(m)}, {@code sum(1)}, {@code collect(m)}) and the un-aggregated
+ * query are answered by the ordinary materialization pipeline, which already tolerates an
+ * undeclared relationship type via vertex-local edge-list filtering ({@code EdgeLinkedList#count},
+ * fixed for issue #4199) - only the {@code count(*)} degree-product fast path skipped that guard.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/5790">Issue #5790</a>
+ */
+class Issue5790OptionalMatchCountStarUndeclaredRelTypeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testissue5790").create();
+    database.getSchema().createVertexType("T");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void countStarAfterOptionalMatchOverUndeclaredRelTypeCountsAnchorRow() {
+    database.transaction(() -> database.newVertex("T").set("id", 1).save());
+
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:T) OPTIONAL MATCH (n)-[:NO_SUCH]->(m:T) RETURN count(*) AS c");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(1L);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void countStarAfterOptionalMatchOverUndeclaredRelTypeOnEmptyGraphIsZero() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:T) OPTIONAL MATCH (n)-[:NO_SUCH]->(m:T) RETURN count(*) AS c");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(0L);
+    rs.close();
+  }
+
+  @Test
+  void countStarAfterOptionalMatchOverUndeclaredRelTypeWithMultipleAnchors() {
+    database.transaction(() -> {
+      database.newVertex("T").set("id", 1).save();
+      database.newVertex("T").set("id", 2).save();
+      database.newVertex("T").set("id", 3).save();
+    });
+
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:T) OPTIONAL MATCH (n)-[:NO_SUCH]->(m:T) RETURN count(*) AS c");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(3L);
+    rs.close();
+  }
+
+  @Test
+  void controlFormsAlreadyWorkedAndKeepWorking() {
+    database.transaction(() -> database.newVertex("T").set("id", 1).save());
+
+    try (ResultSet rs = database.query("opencypher",
+        "MATCH (n:T) OPTIONAL MATCH (n)-[:NO_SUCH]->(m:T) RETURN count(m) AS c")) {
+      assertThat(rs.next().<Long>getProperty("c")).isEqualTo(0L);
+    }
+
+    try (ResultSet rs = database.query("opencypher",
+        "MATCH (n:T) OPTIONAL MATCH (n)-[:NO_SUCH]->(m:T) RETURN sum(1) AS c")) {
+      assertThat(rs.next().<Number>getProperty("c").longValue()).isEqualTo(1L);
+    }
+
+    try (ResultSet rs = database.query("opencypher",
+        "MATCH (n:T) OPTIONAL MATCH (n)-[:NO_SUCH]->(m:T) RETURN n.id AS id")) {
+      assertThat(rs.next().<Number>getProperty("id").longValue()).isEqualTo(1L);
+    }
+  }
+
+  @Test
+  void countStarWithOneDeclaredAndOneUndeclaredOptionalArm() {
+    // Star-join with two arms sharing the central variable n: a declared LINK arm and an
+    // undeclared NO_SUCH arm. Only the undeclared arm's degree must be treated as always 0
+    // (max(1, 0) = 1 multiplier), the declared arm must still be counted correctly.
+    database.getSchema().createEdgeType("LINK");
+    database.transaction(() -> {
+      final MutableVertex n1 = database.newVertex("T").set("id", 1).save();
+      final MutableVertex n2 = database.newVertex("T").set("id", 2).save();
+      n1.newEdge("LINK", n2);
+    });
+
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:T) OPTIONAL MATCH (n)-[:LINK]->(x:T) OPTIONAL MATCH (n)-[:NO_SUCH]->(y:T) RETURN count(*) AS c");
+
+    // n1 contributes 1 row (LINK degree 1 * NO_SUCH max(1,0)=1), n2 contributes 1 row
+    // (LINK degree 0 -> optional null row * NO_SUCH max(1,0)=1) = 2 total.
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Long>getProperty("c")).isEqualTo(2L);
+    rs.close();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes `count(*)` throwing an HTTP 500 when it follows an `OPTIONAL MATCH` over a relationship type
that is not declared in the schema. `MATCH (n:T) OPTIONAL MATCH (n)-[:NO_SUCH]->(m:T) RETURN
count(*) AS c` now returns the correct count instead of `SchemaException: Type with name 'NO_SUCH'
was not found`.

## Motivation

Closes #5790.

The `count(*)` star-join push-down (`CypherExecutionPlan.tryDetectStarCountStar` ->
`DegreeProductOp`) is the only one of the five `count(*)` push-down detectors that accepts
`OPTIONAL MATCH` clauses. Its OLTP execution path (`DegreeProductOp.executeOLTPDegreeMap`)
iterated an arm's edge type via `Database.iterateType(edgeType, true)` unconditionally.
`iterateType` resolves the type name through `Schema.getType()`, which throws for a name the
schema does not know.

Every other way of asking the same question - no aggregation, `count(m)`, `sum(1)`, `collect(m)`,
or declaring the relationship type first - either never reaches this push-down (the detectors are
`count(*)`-specific) or goes through the ordinary materialization pipeline, which already tolerates
an undeclared relationship type via vertex-local edge-list filtering (`EdgeLinkedList.count()`,
fixed for issue #4199). Only this fast path skipped that guard.

A **mandatory** (non-optional) arm over an undeclared type never reaches this code in the first
place - it is already short-circuited to a constant `0` upstream by
`CypherExecutionPlan.mandatoryPatternElementIsEmpty()`, which deliberately does not read `OPTIONAL
MATCH` clauses (an optional arm that matches nothing still contributes its anchor row). That is
exactly the gap an **optional** arm with an undeclared type falls into.

## Related issues

Closes #5790.

## Additional Notes

Fix: `DegreeProductOp.executeOLTPDegreeMap()` now skips an arm's edge-type iteration when
`Schema.existsType()` says the type is undeclared, letting that arm contribute degree `0` to every
vertex - which is exactly the pre-existing `OPTIONAL MATCH` fallback (`max(1, degree)`) this
operator already uses for a real zero-degree arm. One file, one guard clause (+10 lines, all
comment + guard).

The multi-hop OLTP fallback (`executeOLTPPerVertex`, used when an arm spans 2+ hops) was already
safe - verified with a dedicated reproduction before writing the fix - because it goes through
`Vertex.countEdges()` / `Vertex.getVertices()`, which resolve types via the vertex's own edge-list
segments rather than `Schema.getType()`.

## Test plan

New test file: `Issue5790OptionalMatchCountStarUndeclaredRelTypeTest`

- [x] `count(*)` after `OPTIONAL MATCH` over an undeclared type, with one anchor vertex, returns `1`
      (was: HTTP 500 / `SchemaException`)
- [x] Same query on an empty graph returns `0`
- [x] Same query with 3 anchor vertices returns `3`
- [x] The issue's "controls" table (`count(m)`, `sum(1)`, unaggregated `RETURN n.id`) still work
- [x] A star with one declared-type optional arm (real edges) and one undeclared-type optional arm
      computes the correct count, confirming the undeclared arm's `max(1, 0)` fallback does not
      disturb the declared arm's real degree
- [x] TDD: reproduced the exact `SchemaException` first, confirmed 4/5 new tests failed before the
      fix, then confirmed all 5 pass after
- [x] Regression: `Issue5094OptionalMatchCountStarTest`, `CypherCountPushDownPreconditionsIssue5715Test`,
      `CypherSubqueryBodyIssue5656Test`, `CypherUncorrelatedSubqueryCountPushDownIssue5686Test`,
      `Issue4199NonExistentEdgeTypeWithRangeTest` all still pass
- [x] Full `com.arcadedb.query.opencypher.**` package: 4540 tests, 0 failures, 0 errors

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
