### PR TITLE
fix(#5793): substring() negative start/length returns HTTP 400 not 500

### DIFF
--- a/docs/5793-substring-negative-arg-http500.md
+++ b/docs/5793-substring-negative-arg-http500.md
@@ -1,0 +1,55 @@
+# Issue #5793: `substring()` with a negative start or length returns HTTP 500 instead of HTTP 400
+
+## Root cause
+
+`com.arcadedb.query.opencypher.executor.CypherSubstringFunction` (the implementation the OpenCypher engine
+resolves `substring()` to) threw a plain `CommandExecutionException` when the `start` or `length` argument was
+negative. `AbstractServerHttpHandler` maps `CommandExecutionException` to HTTP 500 - a server-error
+classification for what is really an invalid-argument client error.
+
+The sibling functions `left()` and `right()` (`com.arcadedb.function.text.LeftFunction` /
+`RightFunction`) were already fixed for issue #5296 to throw `CommandSemanticException`, which extends
+`CommandParsingException`. The HTTP handler maps `CommandParsingException` to 400. `substring()`'s two
+negative-argument checks (negative `start`, negative `length`) were never updated the same way.
+
+## Fix
+
+Changed both throw sites in `CypherSubstringFunction.execute()` from `CommandExecutionException` to
+`CommandSemanticException`, mirroring `LeftFunction`'s fix for #5296. Messages were also split to identify
+which argument (start vs. length) was negative, matching the specificity of `LeftFunction`'s message.
+
+## Scope note
+
+A second, structurally similar class - `com.arcadedb.function.text.SubstringFunction` - also throws
+`CommandExecutionException` for a negative length and silently returns `""` for a negative start. That class
+is not registered anywhere in `CypherFunctionFactory` or any other function registry found in `engine/src/main`;
+it is exercised only directly by unit tests (`TextStatelessFunctionsTest`), not reachable through any real
+SQL or Cypher query path. Left untouched: fixing dead code is out of scope for this issue, and changing its
+negative-start behavior (currently returns `""`, not documented as a bug in #5793) would be a separate,
+unrequested behavior change. Noted here in case a future issue asks about it directly.
+
+## Tests
+
+- New regression test: `engine/src/test/java/com/arcadedb/query/opencypher/CypherSubstringNegativeArgumentIssue5793Test.java`
+  - `substringNegativeStartIsAClientError` - `substring('hi', -1)` throws `CommandSemanticException`
+    (and NOT `CommandExecutionException`), matching the issue's exact repro.
+  - `substringNegativeStartWithLengthIsAClientError` - `substring('hi', -3, 2)`.
+  - `substringNegativeLengthIsAClientError` - `substring('hi', 1, -2)`.
+  - `substringNegativeStartAndLengthIsAClientError` - `substring('hi', -1, 2)`.
+  - `substringNonNegativeArgumentsStillWork` - guards against an over-broad fix rejecting legitimate calls.
+- Confirmed the new tests fail against the pre-fix code (4/5 failures, all `CommandExecutionException` instead
+  of `CommandSemanticException`) before applying the fix, then pass after.
+- Ran related existing suites for regressions, all green:
+  - `CypherSubstringNullLengthBoundaryIssue5809Test` (4 tests) - null-length propagation, issues #5193/#5809.
+  - `TextStatelessFunctionsTest` (54 tests) - `left`/`right`/`substring` (function.text package) unit tests.
+  - `OpenCypherFunctionTest` (68 tests) - general Cypher function coverage.
+  - `CypherFunctionSecurityTest` (28 tests, 2 skipped pre-existing) - argument validation / security tests.
+  - `CypherFunctionArityRegistryTest` (5 tests) - arity error classification.
+  - `SQLMethodSubStringTest` (3 tests) - unrelated SQL `.substring()` method syntax, unaffected.
+- `mvn -pl engine -am compile` succeeds with no warnings/errors introduced.
+
+## Impact
+
+Clients calling `substring()` with a negative `start` or `length` via Cypher now receive HTTP 400 with a
+descriptive client-error message, consistent with `left()` and `right()` on the same build. No behavior change
+for valid (non-negative) arguments.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.query.opencypher.executor;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -51,7 +51,9 @@ public class CypherSubstringFunction implements StatelessFunction {
     final String str = args[0].toString();
     final int start = ((Number) args[1]).intValue();
     if (start < 0)
-      throw new CommandExecutionException("Cannot handle negative start index nor negative length");
+      // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching left()/right().
+      // CommandSemanticException extends CommandParsingException, which the HTTP handler maps to 400. See issue #5793/#5296.
+      throw new CommandSemanticException("substring(): negative start index is not supported: " + start);
     // Issue #5193/#5809: an explicitly supplied null length propagates null (as Neo4j does), it must not be
     // treated as an omitted argument. This check must run before the start-past-the-end short-circuit below,
     // otherwise null propagation silently stops once start reaches the length of the string.
@@ -62,7 +64,7 @@ public class CypherSubstringFunction implements StatelessFunction {
     if (args.length == 3) {
       final int length = ((Number) args[2]).intValue();
       if (length < 0)
-        throw new CommandExecutionException("Cannot handle negative start index nor negative length");
+        throw new CommandSemanticException("substring(): negative length is not supported: " + length);
       return str.substring(start, Math.min(start + length, str.length()));
     }
     return str.substring(start);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubstringNegativeArgumentIssue5793Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubstringNegativeArgumentIssue5793Test.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5793: {@code substring()} with a negative start index or a negative length raised a
+ * plain {@code CommandExecutionException}, which the HTTP layer maps to a 500 status - a server-error
+ * classification for what is really an invalid-argument client error. The sibling functions {@code left()} and
+ * {@code right()} were already fixed the same way for issue #5296: they throw {@code CommandSemanticException},
+ * which extends {@code CommandParsingException} and which {@code AbstractServerHttpHandler} maps to 400. This test
+ * pins {@code substring()} to the same classification.
+ */
+class CypherSubstringNegativeArgumentIssue5793Test extends TestHelper {
+
+  @Test
+  void substringNegativeStartIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN substring('hi', -1) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .isInstanceOf(CommandParsingException.class)
+        .isNotInstanceOf(CommandExecutionException.class);
+  }
+
+  @Test
+  void substringNegativeStartWithLengthIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN substring('hi', -3, 2) AS r"))
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void substringNegativeLengthIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN substring('hi', 1, -2) AS r"))
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void substringNegativeStartAndLengthIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN substring('hi', -1, 2) AS r"))
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void substringNonNegativeArgumentsStillWork() {
+    // Guard against an over-broad fix that rejects legitimate calls.
+    assertThat(single("RETURN substring('hello world', 6) AS r")).isEqualTo("world");
+    assertThat(single("RETURN substring('hello world', 0, 5) AS r")).isEqualTo("hello");
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      rs.hasNext();
+    }
+  }
+}


### PR DESCRIPTION
Closes #5793

`substring()` with a negative `start` index or negative `length` argument was raising a plain `CommandExecutionException`, which the HTTP handler maps to a 500 status - a server-error classification for what is really an invalid-argument client error. The sibling functions `left()` and `right()` were already fixed the same way for issue #5296: they throw `CommandSemanticException` (which extends `CommandParsingException`, mapped to HTTP 400). `CypherSubstringFunction`'s two negative-argument checks were never updated to match. This PR changes both throw sites to `CommandSemanticException`, with messages that identify which argument (start vs. length) was negative.

A structurally similar class, `com.arcadedb.function.text.SubstringFunction`, has the same inconsistency but is not registered in `CypherFunctionFactory` or any other function registry - it is unreachable from any real SQL/Cypher query path and is exercised only directly by unit tests. It was left untouched; see the tracking doc for details.

## Test plan

- [x] New regression test `CypherSubstringNegativeArgumentIssue5793Test` reproduces the issue's exact repro cases (`substring('hi', -1)`, `substring('hi', -3, 2)`, `substring('hi', 1, -2)`, `substring('hi', -1, 2)`) and asserts `CommandSemanticException` (not `CommandExecutionException`) is thrown.
- [x] Confirmed the new tests fail against the pre-fix code (4/5 failures) before applying the fix.
- [x] Existing `CypherSubstringNullLengthBoundaryIssue5809Test` (null-length propagation, #5193/#5809) still passes.
- [x] `TextStatelessFunctionsTest`, `OpenCypherFunctionTest`, `CypherFunctionSecurityTest`, `CypherFunctionArityRegistryTest`, `SQLMethodSubStringTest` all pass, no regressions.
- [x] `mvn -pl engine -am compile` succeeds.