### PR TITLE
fix(#5789): make Cypher DISTINCT/UNION consistent with numeric equality

### DIFF
--- a/docs/5789-distinct-union-numeric-type-equality.md
+++ b/docs/5789-distinct-union-numeric-type-equality.md
@@ -1,0 +1,87 @@
+# Issue #5789: DISTINCT and UNION treat `1` and `1.0` as distinct
+
+## Root cause
+
+ArcadeDB's Cypher `=` operator correctly evaluates `1 = 1.0` as `true` (see
+`ComparisonExpression.evaluateTernary`, which compares `Number` operands via `longValue()` when
+both sides are `Integer`/`Long`, and via `doubleValue()` otherwise). But every duplicate-elimination
+path built its hash key from the raw boxed value instead of a value consistent with that equality:
+
+- `ProjectReturnStep` (`RETURN DISTINCT`) built a `String` key via `StringBuilder.append(Object)`,
+  which calls `Object.toString()`. `Integer.valueOf(1).toString()` is `"1"`, `Double.valueOf(1.0).toString()`
+  is `"1.0"` - different strings, so the two rows were kept as distinct.
+- `UnionStep` (`UNION`) built the same kind of `String` key, with the same bug.
+- `DistinctAggregationWrapper` (`count(DISTINCT ...)`, `min/max/avg(DISTINCT ...)`, and any
+  SQL-bridged aggregate function used with `DISTINCT`) tracked seen argument tuples in a
+  `HashSet<List<Object>>`. `Integer.valueOf(1).equals(Double.valueOf(1.0))` is `false` in Java (boxed
+  numeric types never compare equal across type), so the two values were never recognized as
+  duplicates.
+- `CollectDistinctFunction` (`collect(DISTINCT ...)`) had the identical `HashSet<Object>` bug.
+
+## Fix
+
+Added a small canonicalization utility, `com.arcadedb.function.DistinctNumericKey`, that maps any
+`Number` to a canonical `Long` (when it represents a finite integer within the range a `double`
+represents integers exactly, i.e. `|value| <= 2^53`) or canonical `Double` otherwise. This mirrors
+`ComparisonExpression`'s numeric-equality rule closely enough that `Integer`, `Long`, `Float`,
+`Double`, and `BigDecimal` values representing the same number all canonicalize to the same key,
+while non-numeric values pass through unchanged.
+
+Applied it at all four duplicate-elimination sites:
+
+- `ProjectReturnStep`: the DISTINCT key builder now canonicalizes each returned value before
+  appending it to the composite string key.
+- `UnionStep`: same change to `buildResultKey`.
+- `DistinctAggregationWrapper`: the seen-arguments key is now built from canonicalized arguments;
+  the wrapped aggregation function still executes on the original, uncanonicalized arguments.
+- `CollectDistinctFunction`: numeric values are now wrapped in a new
+  `com.arcadedb.function.DistinctNumberWrapper` (analogous to the existing `IdentifiableWrapper`
+  used for RID-based dedup of graph elements) that hashes/compares on the canonical numeric key
+  while preserving the original boxed value for the output list, so `collect(DISTINCT [1, 1.0])`
+  returns a single value of whichever boxed type was encountered first.
+
+### Scope note: `EagerDistinctCollectOptionalMatchStep`
+
+This class implements the identical `collect(DISTINCT ...)` deduplication pattern (a raw
+`HashSet<Object>` per variable) for an OPTIONAL MATCH optimization, but a repo-wide search found
+no call site constructing it anywhere in `src/main/java` - it is currently dead code, unreachable
+from the planner. Left unchanged since no test can exercise it and touching unreachable code adds
+risk without verifiable benefit; flagged here in case a future planner change wires it up, since it
+would need the same fix.
+
+## Tests
+
+New file: `engine/src/test/java/com/arcadedb/query/opencypher/Issue5789NumericDistinctEqualityTest.java`
+
+Covers, on an UNWIND-generated `[1, 1.0]` (and `[1, 2.0]` as a negative control):
+
+- `UNION` collapses `1` and `1.0` to one row; `UNION ALL` still keeps both; same-type `UNION` still
+  dedupes.
+- `RETURN DISTINCT` collapses `1`/`1.0` to one row, still keeps numerically-different values apart.
+- `count(DISTINCT x)` returns `1` (was `2`).
+- `collect(DISTINCT x)` returns a single-element list (was `[1, 1.0]`).
+- `min(DISTINCT x)`, `max(DISTINCT x)`, `avg(DISTINCT x)` (shared `DistinctAggregationWrapper` path)
+  treat `1` and `1.0` as one value when computing the aggregate.
+- Sanity check that `1 = 1.0` still evaluates to `true` (unchanged baseline).
+
+TDD: all 5 tests that assert the fixed behavior were confirmed to fail against the pre-fix code
+(reproducing the bug 1:1 with the issue's reported symptoms), then pass after the fix.
+
+## Test results
+
+- New regression test class: 9/9 passing.
+- Pre-existing DISTINCT/UNION/aggregation-adjacent test classes re-run for regressions (27 classes,
+  252 total test methods including `@Nested` classes): 0 failures, 0 errors.
+
+## Impact analysis
+
+The change only affects the *hash key* used for duplicate elimination; it never changes what value
+is returned to the caller (the original boxed value is always preserved/returned). Risk is limited
+to the four call sites touched, all scoped to the Cypher engine's optimizer execution path
+(`com.arcadedb.query.opencypher.executor.steps`) and its Cypher-only aggregation function package
+(`com.arcadedb.function.agg`); neither is used by the SQL engine.
+
+## Recommendations
+
+- If `EagerDistinctCollectOptionalMatchStep` is ever wired into the planner, apply the same
+  `DistinctNumberWrapper` fix there before it becomes reachable.

--- a/engine/src/main/java/com/arcadedb/function/DistinctNumberWrapper.java
+++ b/engine/src/main/java/com/arcadedb/function/DistinctNumberWrapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function;
+
+/**
+ * Wraps a {@link Number} for insertion into a {@link java.util.Set} used to eliminate duplicates
+ * (e.g. {@code collect(DISTINCT ...)}), keying membership on {@link DistinctNumericKey#canonicalize}
+ * while preserving the original value for retrieval. This keeps the first-encountered boxed numeric
+ * type (e.g. an {@code Integer} vs. a {@code Double}) in the output, while still deduplicating
+ * against later numerically-equal values of a different boxed type. See issue #5789.
+ */
+public final class DistinctNumberWrapper {
+  private final Object original;
+  private final Object canonicalKey;
+
+  public DistinctNumberWrapper(final Object original) {
+    this.original = original;
+    this.canonicalKey = DistinctNumericKey.canonicalize(original);
+  }
+
+  public Object getOriginal() {
+    return original;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (!(obj instanceof DistinctNumberWrapper other))
+      return false;
+    return canonicalKey.equals(other.canonicalKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return canonicalKey.hashCode();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
+++ b/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function;
+
+/**
+ * Canonicalizes numeric values for duplicate-elimination purposes (Cypher {@code UNION},
+ * {@code RETURN DISTINCT}, {@code count(DISTINCT ...)}, {@code collect(DISTINCT ...)}) so that
+ * finite numeric values which compare equal under Cypher's {@code =} operator (e.g. {@code 1 = 1.0})
+ * also collapse to the same key. Without this, duplicate-elimination paths that key a
+ * {@link java.util.HashSet} / {@link java.util.HashMap} directly on the boxed value see
+ * {@code Integer.valueOf(1)}, {@code Long.valueOf(1)} and {@code Double.valueOf(1.0)} as distinct,
+ * because Java's per-type {@code equals()}/{@code hashCode()} never compares across boxed numeric
+ * types. See issue #5789.
+ * <p>
+ * A value that is an exact-integer Java numeric type ({@link Long}, {@link Integer}, {@link Short},
+ * {@link Byte}) canonicalizes to its {@code long} value, which is always exact. Any other
+ * {@link Number} (typically {@link Double}, {@link Float}, or {@link java.math.BigDecimal})
+ * canonicalizes to the same {@code long} value when it represents a finite integer within the range
+ * a {@code double} represents integers exactly (|value| &lt;= 2^53), so it lines up with the
+ * exact-integer-type canonicalization above; otherwise it canonicalizes to its {@code double} value.
+ * Non-numeric values pass through unchanged.
+ */
+public final class DistinctNumericKey {
+  /** 2^53: the largest integer magnitude a double represents exactly. */
+  private static final long MAX_EXACT_DOUBLE_INTEGER = 1L << 53;
+
+  private DistinctNumericKey() {
+  }
+
+  /**
+   * Returns a canonical key for {@code value} suitable for use in a hash-based set/map so that
+   * numerically equal finite values, regardless of their boxed numeric type, hash and compare equal.
+   * Non-{@link Number} values are returned unchanged.
+   */
+  public static Object canonicalize(final Object value) {
+    if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte)
+      return ((Number) value).longValue();
+
+    if (value instanceof Number number) {
+      final double d = number.doubleValue();
+      if (!Double.isNaN(d) && !Double.isInfinite(d) && d == Math.rint(d) && Math.abs(d) <= MAX_EXACT_DOUBLE_INTEGER)
+        return (long) d;
+      return d;
+    }
+
+    return value;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/agg/CollectDistinctFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/CollectDistinctFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.agg;
 
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.function.DistinctNumberWrapper;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
 
@@ -59,6 +60,10 @@ public class CollectDistinctFunction implements StatelessFunction {
       if (value instanceof Identifiable)
         // Use RID as the key for deduplication to handle proxies and loaded records
         distinctValues.add(new IdentifiableWrapper((Identifiable) value));
+      else if (value instanceof Number)
+        // Canonicalize cross-type numeric equality (e.g. INTEGER 1 vs FLOAT 1.0) so DISTINCT stays
+        // consistent with Cypher's `=` operator (issue #5789).
+        distinctValues.add(new DistinctNumberWrapper(value));
       else
         distinctValues.add(value);
     }
@@ -77,6 +82,8 @@ public class CollectDistinctFunction implements StatelessFunction {
     for (final Object value : distinctValues) {
       if (value instanceof IdentifiableWrapper)
         result.add(((IdentifiableWrapper) value).getIdentifiable());
+      else if (value instanceof DistinctNumberWrapper)
+        result.add(((DistinctNumberWrapper) value).getOriginal());
       else
         result.add(value);
     }

--- a/engine/src/main/java/com/arcadedb/function/agg/DistinctAggregationWrapper.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/DistinctAggregationWrapper.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.agg;
 
+import com.arcadedb.function.DistinctNumericKey;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
 
@@ -58,7 +59,13 @@ public class DistinctAggregationWrapper implements StatelessFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (!seenValues.add(Arrays.asList(args)))
+    // Canonicalize cross-type numeric equality (e.g. INTEGER 1 vs FLOAT 1.0) so DISTINCT stays
+    // consistent with Cypher's `=` operator (issue #5789). The delegate still executes on the
+    // original, uncanonicalized arguments.
+    final Object[] key = new Object[args.length];
+    for (int i = 0; i < args.length; i++)
+      key[i] = DistinctNumericKey.canonicalize(args[i]);
+    if (!seenValues.add(Arrays.asList(key)))
       return null;
     return delegate.execute(args, context);
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ProjectReturnStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ProjectReturnStep.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.database.Document;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.function.DistinctNumericKey;
 import com.arcadedb.query.opencypher.InternalVariables;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
@@ -135,14 +136,16 @@ public class ProjectReturnStep extends AbstractExecutionStep {
                   if (InternalVariables.isInternal(name))
                     continue;
                   final Object val = projectedResult.getProperty(name);
-                  keyBuilder.append(name).append('=').append(val).append('|');
+                  // Canonicalize numeric values so DISTINCT treats e.g. INTEGER 1 and FLOAT 1.0 as
+                  // the same value, consistent with Cypher's `=` operator (issue #5789).
+                  keyBuilder.append(name).append('=').append(DistinctNumericKey.canonicalize(val)).append('|');
                 }
               } else {
                 for (final ReturnClause.ReturnItem item : returnClause.getReturnItems()) {
                   final String outputName = item.getOutputName();
                   keyBuilder.append(outputName).append('=');
                   final Object val = projectedResult.getProperty(outputName);
-                  keyBuilder.append(val).append('|');
+                  keyBuilder.append(DistinctNumericKey.canonicalize(val)).append('|');
                 }
               }
               if (!seenResults.add(keyBuilder.toString()))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.function.DistinctNumericKey;
 import com.arcadedb.query.opencypher.executor.CypherExecutionPlan;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -153,7 +154,9 @@ public class UnionStep extends AbstractExecutionStep {
         for (final String prop : result.getPropertyNames()) {
           sb.append(prop).append("=");
           final Object value = result.getProperty(prop);
-          sb.append(value == null ? "null" : value.toString());
+          // Canonicalize numeric values so UNION treats e.g. INTEGER 1 and FLOAT 1.0 as the same
+          // value, consistent with Cypher's `=` operator (issue #5789).
+          sb.append(value == null ? "null" : DistinctNumericKey.canonicalize(value));
           sb.append("|");
         }
         return sb.toString();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue5789NumericDistinctEqualityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue5789NumericDistinctEqualityTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5789: ArcadeDB evaluates {@code 1 = 1.0} as {@code true}, but its duplicate-elimination
+ * paths (UNION, RETURN DISTINCT, count(DISTINCT ...), collect(DISTINCT ...)) treated the same
+ * finite, non-null numeric values as distinct when they had different boxed numeric types
+ * (INTEGER vs FLOAT). This left UNION and DISTINCT out of sync with expression equality.
+ */
+class Issue5789NumericDistinctEqualityTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue5789-numeric-distinct").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void unionCollapsesNumericallyEqualCrossTypeValues() {
+    try (final ResultSet rs = database.query("opencypher", "RETURN 1 AS x UNION RETURN 1.0 AS x")) {
+      assertThat(rs.stream().count()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void unionStillDeduplicatesSameTypeValues() {
+    try (final ResultSet rs = database.query("opencypher", "RETURN 1 AS x UNION RETURN 1 AS x")) {
+      assertThat(rs.stream().count()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void unionAllStillPreservesCrossTypeDuplicates() {
+    try (final ResultSet rs = database.query("opencypher", "RETURN 1 AS x UNION ALL RETURN 1.0 AS x")) {
+      assertThat(rs.stream().count()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void returnDistinctCollapsesNumericallyEqualCrossTypeValues() {
+    try (final ResultSet rs = database.query("opencypher", "UNWIND [1, 1.0] AS x RETURN DISTINCT x")) {
+      assertThat(rs.stream().count()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void returnDistinctStillKeepsNumericallyDifferentValues() {
+    try (final ResultSet rs = database.query("opencypher", "UNWIND [1, 2.0] AS x RETURN DISTINCT x")) {
+      assertThat(rs.stream().count()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void countDistinctCollapsesNumericallyEqualCrossTypeValues() {
+    try (final ResultSet rs = database.query("opencypher", "UNWIND [1, 1.0] AS x RETURN count(DISTINCT x) AS c")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(1L);
+    }
+  }
+
+  @Test
+  void collectDistinctCollapsesNumericallyEqualCrossTypeValues() {
+    try (final ResultSet rs = database.query("opencypher", "UNWIND [1, 1.0] AS x RETURN collect(DISTINCT x) AS c")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      @SuppressWarnings("unchecked")
+      final List<Object> collected = (List<Object>) row.getProperty("c");
+      assertThat(collected).hasSize(1);
+    }
+  }
+
+  @Test
+  void minDistinctAndMaxDistinctCollapseNumericallyEqualCrossTypeValues() {
+    // A regression guard for the shared DistinctAggregationWrapper used by min/max/avg DISTINCT.
+    try (final ResultSet rs = database.query("opencypher",
+        "UNWIND [1, 1.0, 2] AS x RETURN min(DISTINCT x) AS mn, max(DISTINCT x) AS mx, avg(DISTINCT x) AS av")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("mn")).doubleValue()).isEqualTo(1.0);
+      assertThat(((Number) row.getProperty("mx")).doubleValue()).isEqualTo(2.0);
+      // Only two distinct values (1 and 2) should be averaged: (1 + 2) / 2 = 1.5
+      assertThat(((Number) row.getProperty("av")).doubleValue()).isEqualTo(1.5);
+    }
+  }
+
+  @Test
+  void equalityOperatorAndDistinctPathsAgree() {
+    try (final ResultSet rs = database.query("opencypher", "RETURN 1 = 1.0 AS eq")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat((Boolean) row.getProperty("eq")).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Makes Cypher's duplicate-elimination paths (`UNION`, `RETURN DISTINCT`, `count(DISTINCT ...)`,
`collect(DISTINCT ...)`, and the shared `min/max/avg(DISTINCT ...)` wrapper) consistent with
Cypher's `=` operator for finite, non-null numeric values of different boxed types (e.g. `INTEGER 1`
vs `FLOAT 1.0`).

Closes #5789

## Motivation

ArcadeDB already evaluates `1 = 1.0` as `true`, but every duplicate-elimination path built its hash
key from the raw boxed value (or its `toString()`), and Java's boxed numeric types never compare
equal across type (`Integer.valueOf(1).equals(Double.valueOf(1.0))` is `false`). This left `UNION`
and `DISTINCT` internally inconsistent with expression equality, producing duplicate rows whenever
values computed via different paths (aggregation, arithmetic, property reads) landed on the same
number with different numeric types.

Added `com.arcadedb.function.DistinctNumericKey`, a small canonicalization helper mirroring the
numeric-equality rule already used by `ComparisonExpression` (long-value comparison when both
operands are exact-integer types, double-value comparison otherwise), and applied it at all four
duplicate-elimination sites:

- `ProjectReturnStep` (`RETURN DISTINCT`)
- `UnionStep` (`UNION`)
- `DistinctAggregationWrapper` (`count(DISTINCT ...)`, `min/max/avg(DISTINCT ...)`, and any other
  SQL-bridged aggregate used with `DISTINCT`)
- `CollectDistinctFunction` (`collect(DISTINCT ...)`), via a new `DistinctNumberWrapper` that
  dedups on the canonical key while preserving the original boxed value in the output list

`UNION ALL` and same-type dedup are unaffected; the canonicalization only changes the *hash key*,
never the value returned to the caller.

One dead-code call site with the identical bug pattern, `EagerDistinctCollectOptionalMatchStep`
(an OPTIONAL MATCH optimizer step for `collect(DISTINCT ...)`), was found unreachable from the
planner - no test can currently exercise it, so it was left unchanged and flagged in the tracking
doc for whoever wires it up.

## Related issues

Closes #5789

## Additional Notes

Tracking doc with full root-cause analysis: `docs/5789-distinct-union-numeric-type-equality.md`

## Test plan

- [x] New regression test `engine/src/test/java/com/arcadedb/query/opencypher/Issue5789NumericDistinctEqualityTest.java`
      (9 tests) covering all four reported duplicate-elimination paths plus `min/max/avg(DISTINCT)`,
      with negative controls (`UNION ALL`, same-type dedup, numerically-different values) confirming
      unrelated behavior is unchanged.
- [x] TDD: the 5 tests asserting the fixed behavior were confirmed to fail against the pre-fix code,
      reproducing the issue's reported symptoms 1:1, then pass after the fix.
- [x] Re-ran 27 pre-existing DISTINCT/UNION/aggregation-adjacent test classes (252 test methods
      including `@Nested` classes) for regressions: 0 failures, 0 errors.
- [x] `mvn -pl engine -am test-compile` passes.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
