### PR TITLE
fix(#5894): bound Bolt WebSocket frame length and Postgres bind-parameter length before allocation

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -334,7 +334,8 @@ public class BoltNetworkExecutor extends Thread {
         completeWebSocketUpgrade(headers);
 
         // Reinitialize I/O with WebSocket framing and read Bolt magic from WebSocket stream
-        input = new BoltChunkedInput(new BoltWebSocketInputStream(socket.getInputStream()));
+        input = new BoltChunkedInput(
+            new BoltWebSocketInputStream(socket.getInputStream(), GlobalConfiguration.BOLT_WEBSOCKET_MAX_FRAME_SIZE.getValueAsInteger()));
         output = new BoltChunkedOutput(new BoltWebSocketOutputStream(socket.getOutputStream()));
         try {
           magic = input.readRaw(4);

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltWebSocketInputStream.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltWebSocketInputStream.java
@@ -30,13 +30,15 @@ import java.io.InputStream;
  */
 class BoltWebSocketInputStream extends InputStream {
   private final DataInputStream in;
+  private final long    maxFrameSize;
   private byte[]  buffer;
   private int     bufferPos;
   private int     bufferLen;
   private boolean closed;
 
-  BoltWebSocketInputStream(final InputStream in) {
+  BoltWebSocketInputStream(final InputStream in, final long maxFrameSize) {
     this.in = new DataInputStream(in);
+    this.maxFrameSize = maxFrameSize;
   }
 
   @Override
@@ -82,6 +84,9 @@ class BoltWebSocketInputStream extends InputStream {
         payloadLen = in.readUnsignedShort();
       else if (payloadLen == 127)
         payloadLen = in.readLong();
+
+      if (payloadLen < 0 || payloadLen > maxFrameSize)
+        throw new IOException("BOLT WebSocket frame too large: " + payloadLen + " bytes (max " + maxFrameSize + ")");
 
       byte[] maskKey = null;
       if (masked) {

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltWebSocketInputStreamTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltWebSocketInputStreamTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5894: a BOLT WebSocket frame with an unbounded, unauthenticated
+ * client-supplied length must never be allowed to drive a byte-array allocation.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BoltWebSocketInputStreamTest {
+
+  private static final long MAX_FRAME_SIZE = 1024; // small cap so tests stay fast
+
+  private static byte[] maskedFrame(final byte[] payload) {
+    final byte[] mask = { 0x01, 0x02, 0x03, 0x04 };
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(0x82); // FIN + binary opcode
+    if (payload.length < 126) {
+      out.write(0x80 | payload.length); // masked + 7-bit length
+    } else {
+      out.write(0x80 | 127); // masked + 64-bit length marker
+      for (int shift = 56; shift >= 0; shift -= 8)
+        out.write((int) (payload.length >>> shift) & 0xFF);
+    }
+    out.writeBytes(mask);
+    for (int i = 0; i < payload.length; i++)
+      out.write(payload[i] ^ mask[i % 4]);
+    return out.toByteArray();
+  }
+
+  /**
+   * Frame header declares a huge extended length, then the socket never delivers the payload
+   * (or the mask) - mirrors the 14-byte attack in the report. The stream must reject the frame
+   * from the length field alone, without allocating and without blocking on the missing bytes.
+   */
+  @Test
+  void rejectsOversizedFrameBeforeAllocating() throws Exception {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(0x82); // FIN + binary opcode
+    out.write(0x80 | 127); // masked + 64-bit length marker
+    final long declaredLength = 0x7FFFFFFFL; // ~2GB
+    for (int shift = 56; shift >= 0; shift -= 8)
+      out.write((int) (declaredLength >>> shift) & 0xFF);
+    // no mask key, no payload follows - attacker stops here
+
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(new ByteArrayInputStream(out.toByteArray()), MAX_FRAME_SIZE);
+
+    assertThatThrownBy(() -> stream.read()).isInstanceOf(IOException.class).hasMessageContaining("too large");
+  }
+
+  @Test
+  void rejectsNegativeExtendedLength() throws Exception {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(0x82);
+    out.write(0x80 | 127);
+    // 0x8000000000000000 decodes as a negative long when read with readLong()
+    out.write(0x80);
+    for (int i = 0; i < 7; i++)
+      out.write(0x00);
+
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(new ByteArrayInputStream(out.toByteArray()), MAX_FRAME_SIZE);
+
+    assertThatThrownBy(() -> stream.read()).isInstanceOf(IOException.class).hasMessageContaining("too large");
+  }
+
+  @Test
+  void acceptsFrameWithinLimit() throws Exception {
+    final byte[] payload = "hello bolt".getBytes();
+    final byte[] frame = maskedFrame(payload);
+
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(new ByteArrayInputStream(frame), MAX_FRAME_SIZE);
+
+    final byte[] read = new byte[payload.length];
+    final int n = stream.read(read, 0, read.length);
+
+    assertThat(n).isEqualTo(payload.length);
+    assertThat(read).isEqualTo(payload);
+  }
+
+  @Test
+  void rejectsFrameJustOverLimit() throws Exception {
+    final byte[] payload = new byte[(int) MAX_FRAME_SIZE + 1];
+    final byte[] frame = maskedFrame(payload);
+
+    final BoltWebSocketInputStream stream = new BoltWebSocketInputStream(new ByteArrayInputStream(frame), MAX_FRAME_SIZE);
+
+    assertThatThrownBy(() -> stream.read()).isInstanceOf(IOException.class).hasMessageContaining("too large");
+  }
+}

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1610,6 +1610,10 @@ public enum GlobalConfiguration {
       PostgreSQL and the SQL standard mandate, instead of as string literals. Set to false to restore the legacy \
       behaviour where a double-quoted token is a string literal. Default is true""", Boolean.class, true),
 
+  POSTGRES_MAX_PARAM_SIZE("arcadedb.postgres.maxParamSize", SCOPE.SERVER,
+      "Maximum size in bytes accepted for a single bind-message parameter value on the Postgres wire protocol. Values declaring a larger size are rejected before allocation. Default is 16MB",
+      Integer.class, 16 * 1024 * 1024),
+
   // BOLT (Neo4j)
   BOLT_PORT("arcadedb.bolt.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for BOLT plugin. Default is 7687", Integer.class, 7687),
@@ -1632,6 +1636,11 @@ public enum GlobalConfiguration {
   BOLT_SSL("arcadedb.bolt.ssl", SCOPE.SERVER,
       "TLS mode for BOLT connections: DISABLED (no TLS, default), OPTIONAL (auto-detect TLS or plaintext), REQUIRED (TLS only)",
       String.class, "DISABLED"),
+
+  BOLT_WEBSOCKET_MAX_FRAME_SIZE("arcadedb.bolt.websocket.maxFrameSize", SCOPE.SERVER,
+      "Maximum payload size in bytes accepted for a single BOLT WebSocket frame. Frames declaring a larger size are rejected before allocation, "
+          + "since the length is read off the wire before authentication. Default is 16MB",
+      Integer.class, 16 * 1024 * 1024),
 
   // REDIS
   REDIS_PORT("arcadedb.redis.port", SCOPE.SERVER,

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -102,8 +102,10 @@ public class PostgresNetworkExecutor extends Thread {
 
   public static final String PG_SERVER_VERSION = "12.0";
 
-  private static final int                                            BUFFER_LENGTH   = 32 * 1024;
-  private static final Map<Long, Pair<Long, PostgresNetworkExecutor>> ACTIVE_SESSIONS = new ConcurrentHashMap<>();
+  private static final int                                            BUFFER_LENGTH    = 32 * 1024;
+  private static final Map<Long, Pair<Long, PostgresNetworkExecutor>> ACTIVE_SESSIONS  = new ConcurrentHashMap<>();
+  /** Bind-message parameter length denoting a NULL value (wire value -1, read unsigned). */
+  private static final long                                           NULL_PARAM_LENGTH = 0xFFFFFFFFL;
 
   private final ArcadeDBServer              server;
   private final ChannelBinaryServer         channel;
@@ -1289,6 +1291,16 @@ public class PostgresNetworkExecutor extends Thread {
           final long paramSize = channel.readUnsignedInt();
           if (DEBUG)
             LogManager.instance().log(this, Level.INFO, "PSQL: bind param %d size=%d (thread=%s)", i, paramSize, Thread.currentThread().threadId());
+
+          if (paramSize == NULL_PARAM_LENGTH) {
+            // Postgres protocol NULL sentinel: a declared length of -1 (0xFFFFFFFF unsigned), with no
+            // value bytes following. Must be checked before the max-size guard below, since the unsigned
+            // reading of -1 is far larger than any realistic configured limit.
+            portal.parameterValues.add(null);
+            paramsConsumed = i + 1;
+            continue;
+          }
+
           if (paramSize > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger())
             throw new IOException("Postgres bind parameter too large: " + paramSize + " bytes (max "
                 + GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger() + ")");
@@ -1361,8 +1373,11 @@ public class PostgresNetworkExecutor extends Thread {
       try {
         for (int i = paramsConsumed; i < totalParamValues; i++) {
           final long sz = channel.readUnsignedInt();
+          if (sz == NULL_PARAM_LENGTH)
+            continue;
           if (sz > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger())
-            throw new IOException("Postgres bind parameter too large: " + sz + " bytes");
+            throw new IOException("Postgres bind parameter too large: " + sz + " bytes (max "
+                + GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger() + ")");
           if (sz > 0)
             channel.readBytes(new byte[(int) sz]);
         }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -1289,6 +1289,9 @@ public class PostgresNetworkExecutor extends Thread {
           final long paramSize = channel.readUnsignedInt();
           if (DEBUG)
             LogManager.instance().log(this, Level.INFO, "PSQL: bind param %d size=%d (thread=%s)", i, paramSize, Thread.currentThread().threadId());
+          if (paramSize > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger())
+            throw new IOException("Postgres bind parameter too large: " + paramSize + " bytes (max "
+                + GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger() + ")");
           final byte[] paramValue = new byte[(int) paramSize];
           channel.readBytes(paramValue);
           if (DEBUG)
@@ -1358,6 +1361,8 @@ public class PostgresNetworkExecutor extends Thread {
       try {
         for (int i = paramsConsumed; i < totalParamValues; i++) {
           final long sz = channel.readUnsignedInt();
+          if (sz > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger())
+            throw new IOException("Postgres bind parameter too large: " + sz + " bytes");
           if (sz > 0)
             channel.readBytes(new byte[(int) sz]);
         }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -1301,9 +1301,18 @@ public class PostgresNetworkExecutor extends Thread {
             continue;
           }
 
-          if (paramSize > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger())
-            throw new IOException("Postgres bind parameter too large: " + paramSize + " bytes (max "
-                + GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger() + ")");
+          if (paramSize > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger()) {
+            // The value bytes for this parameter were never read, so the channel cannot be safely
+            // resynchronized without draining a client(attacker)-controlled amount of data - that would
+            // either reintroduce an unbounded read or block the connection thread indefinitely if the
+            // declared bytes never arrive. Tell the client why, then close the connection outright
+            // rather than gamble on realigning the stream.
+            setErrorInTx();
+            writeError(ERROR_SEVERITY.FATAL, "Postgres bind parameter too large: " + paramSize + " bytes (max "
+                + GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger() + ")", "08P01");
+            shutdown = true;
+            return;
+          }
           final byte[] paramValue = new byte[(int) paramSize];
           channel.readBytes(paramValue);
           if (DEBUG)
@@ -1370,18 +1379,22 @@ public class PostgresNetworkExecutor extends Thread {
     } catch (final Exception e) {
       // Best-effort drain of the remaining Bind message so the channel stays aligned
       // for the next message in the pipelined client request (Describe, Execute, Sync).
+      boolean drainedCleanly = true;
       try {
         for (int i = paramsConsumed; i < totalParamValues; i++) {
           final long sz = channel.readUnsignedInt();
           if (sz == NULL_PARAM_LENGTH)
             continue;
-          if (sz > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger())
-            throw new IOException("Postgres bind parameter too large: " + sz + " bytes (max "
-                + GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger() + ")");
+          if (sz > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger()) {
+            // Same reasoning as the main loop's guard: draining a declared-but-undelivered amount of
+            // data risks an unbounded/blocking read, so give up on resyncing rather than attempt it.
+            drainedCleanly = false;
+            break;
+          }
           if (sz > 0)
             channel.readBytes(new byte[(int) sz]);
         }
-        if (!resultFormatSectionRead) {
+        if (drainedCleanly && !resultFormatSectionRead) {
           final int resultFormatCount = channel.readShort();
           for (int i = 0; i < resultFormatCount; i++)
             channel.readUnsignedShort();
@@ -1389,9 +1402,12 @@ public class PostgresNetworkExecutor extends Thread {
       } catch (final Exception ignored) {
         // If even the drain fails the channel is unrecoverable; the error response below
         // still goes out and the client will see the failure.
+        drainedCleanly = false;
       }
       setErrorInTx();
       writeError(ERROR_SEVERITY.ERROR, "Error on parsing bind message: " + e.getMessage(), sqlStateFor(e));
+      if (!drainedCleanly)
+        shutdown = true;
     }
   }
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresBindParamBoundIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresBindParamBoundIT.java
@@ -83,24 +83,42 @@ class PostgresBindParamBoundIT extends BaseGraphServerTest {
       sendParse(out, "SELECT 1");
       readMessage(in); // ParseComplete
 
-      // Bind message declaring a single parameter whose 32-bit length claims ~2GB, then filler bytes that
-      // let the server's own drain-on-error recovery finish without blocking on bytes we never send: a
-      // zero-length slot for the failed parameter, then a zero result-format-code count (the drain also
-      // consumes the Bind message's trailing section). The attacker never sends anything resembling a
-      // 2GB payload - only the declared length.
+      // Bind message declaring a single parameter whose 32-bit length claims ~2GB. The attacker never
+      // sends anything resembling a 2GB payload - only the declared length - mirroring the report's
+      // "declare a huge length, don't follow through" shape.
       sendMaliciousBind(out, 0x7FFFFFFF);
-      out.writeInt(0);   // filler: post-error drain loop reads this as the failed slot's zero length
-      out.writeShort(0); // filler: post-error drain also reads the result-format-code count
       out.flush();
 
       // Without a bound check, the server allocates `new byte[0x7FFFFFFF]`, which throws OutOfMemoryError
       // (an Error, not an Exception) - it is never caught by bindCommand's `catch (Exception e)`, so the
       // connection thread dies silently and the client never gets a response, hanging here. With the
-      // bound check the oversized length is rejected as a plain (caught) IOException and the server
-      // replies with a normal ErrorResponse ('E') well within the timeout.
+      // bound check, the value bytes were never read (so the channel cannot be safely resynchronized
+      // without risking the same unbounded/blocking read this fix closes), so the server replies with a
+      // normal ErrorResponse ('E') and then closes the connection outright, well within the timeout.
       final int responseType = assertTimeoutPreemptively(Duration.ofSeconds(10), () -> readMessageType(in));
       org.assertj.core.api.Assertions.assertThat((char) responseType).isEqualTo('E');
+
+      // The connection is not left half-aligned or hanging: the server closes it after the error, so a
+      // further read reaches EOF (rather than blocking or returning garbage from a desynced channel).
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> in.readUnsignedByte())
+            .isInstanceOf(java.io.EOFException.class);
+      });
     }
+
+    // The rejected connection must not have wedged the shared listener/thread pool: a fresh,
+    // well-behaved client is still served promptly right after.
+    assertTimeoutPreemptively(Duration.ofSeconds(15), () -> {
+      try (final Socket client = new Socket()) {
+        client.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+        final DataOutputStream out = new DataOutputStream(client.getOutputStream());
+        final DataInputStream in = new DataInputStream(client.getInputStream());
+        sendStartupMessage(out, "root", getDatabaseName());
+        readMessage(in); // AuthenticationCleartextPassword
+        sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+        readMessageOfType(in, 'Z'); // AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+      }
+    });
   }
 
   private static void sendStartupMessage(final DataOutputStream out, final String user, final String database) throws Exception {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresBindParamBoundIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresBindParamBoundIT.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression test for issue #5894: the Postgres wire-protocol Bind message reads a client-supplied,
+ * unbounded parameter length and allocated a byte array sized by it with no upper bound. An authenticated
+ * client declaring a multi-gigabyte parameter could OOM or thrash the server before any payload byte
+ * arrives. {@code arcadedb.postgres.maxParamSize} now rejects an oversized declared length before the
+ * allocation happens.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresBindParamBoundIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Postgres:com.arcadedb.postgres.PostgresProtocolPlugin");
+    GlobalConfiguration.POSTGRES_DEBUG.setValue("false");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    GlobalConfiguration.POSTGRES_DEBUG.setValue("false");
+    super.endTest();
+  }
+
+  @Override
+  protected String getDatabaseName() {
+    return "postgresdb";
+  }
+
+  @Test
+  @DisplayName("[#5894] Oversized Bind parameter length is rejected before allocation, with a graceful error instead of an OOM'd thread")
+  void oversizedBindParameterIsRejectedGracefully() throws Exception {
+    try (final Socket attacker = new Socket()) {
+      attacker.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(attacker.getOutputStream());
+      final DataInputStream in = new DataInputStream(attacker.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+
+      sendParse(out, "SELECT 1");
+      readMessage(in); // ParseComplete
+
+      // Bind message declaring a single parameter whose 32-bit length claims ~2GB, then filler bytes that
+      // let the server's own drain-on-error recovery finish without blocking on bytes we never send: a
+      // zero-length slot for the failed parameter, then a zero result-format-code count (the drain also
+      // consumes the Bind message's trailing section). The attacker never sends anything resembling a
+      // 2GB payload - only the declared length.
+      sendMaliciousBind(out, 0x7FFFFFFF);
+      out.writeInt(0);   // filler: post-error drain loop reads this as the failed slot's zero length
+      out.writeShort(0); // filler: post-error drain also reads the result-format-code count
+      out.flush();
+
+      // Without a bound check, the server allocates `new byte[0x7FFFFFFF]`, which throws OutOfMemoryError
+      // (an Error, not an Exception) - it is never caught by bindCommand's `catch (Exception e)`, so the
+      // connection thread dies silently and the client never gets a response, hanging here. With the
+      // bound check the oversized length is rejected as a plain (caught) IOException and the server
+      // replies with a normal ErrorResponse ('E') well within the timeout.
+      final int responseType = assertTimeoutPreemptively(Duration.ofSeconds(10), () -> readMessageType(in));
+      org.assertj.core.api.Assertions.assertThat((char) responseType).isEqualTo('E');
+    }
+  }
+
+  private static void sendStartupMessage(final DataOutputStream out, final String user, final String database) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, "user");
+    writeCString(body, user);
+    writeCString(body, "database");
+    writeCString(body, database);
+    body.write(0);
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeInt(4 + 4 + bodyBytes.length);
+    out.writeInt(196608); // protocol version 3.0
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendPasswordMessage(final DataOutputStream out, final String password) throws Exception {
+    final byte[] pwBytes = password.getBytes(StandardCharsets.UTF_8);
+    out.writeByte('p');
+    out.writeInt(4 + pwBytes.length + 1);
+    out.write(pwBytes);
+    out.writeByte(0);
+    out.flush();
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // unnamed statement
+    writeCString(body, query);
+    body.write(0);
+    body.write(0); // int16 numParamDataTypes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('P');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  /**
+   * Bind message for the unnamed portal/statement, declaring one parameter with the given (attacker
+   * controlled) 32-bit length, then stopping - no payload bytes follow.
+   */
+  private static void sendMaliciousBind(final DataOutputStream out, final int declaredParamLength) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    writeCString(body, ""); // statement name
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0
+    body.write(0);
+    body.write(1); // int16 numParamValues = 1
+    body.write((declaredParamLength >>> 24) & 0xFF);
+    body.write((declaredParamLength >>> 16) & 0xFF);
+    body.write((declaredParamLength >>> 8) & 0xFF);
+    body.write(declaredParamLength & 0xFF);
+    // no payload follows
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('B');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void writeCString(final ByteArrayOutputStream out, final String s) {
+    out.writeBytes(s.getBytes(StandardCharsets.UTF_8));
+    out.write(0);
+  }
+
+  private static void readMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    in.skipNBytes(length - 4);
+  }
+
+  private static void readMessageOfType(final DataInputStream in, final char expectedType) throws Exception {
+    while (true) {
+      final int type = in.readUnsignedByte();
+      final int length = in.readInt();
+      in.skipNBytes(length - 4);
+      if (type == expectedType)
+        return;
+    }
+  }
+
+  private static int readMessageType(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    in.skipNBytes(length - 4);
+    return type;
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
@@ -317,6 +317,41 @@ class PostgresProtocolIT extends BaseGraphServerTest {
     }
   }
 
+  // Issue #5894 follow-up: the Postgres Bind message encodes a NULL parameter value as a 32-bit
+  // length of -1 with no bytes following, not as a small/zero declared length. Binding an actual
+  // NULL value (java.sql.Types.VARCHAR / setObject(null)) must not be mistaken for an oversized
+  // declared length.
+  @Test
+  void preparedStatementBindsActualNullValue() throws Exception {
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("CREATE DOCUMENT TYPE NullBindTest IF NOT EXISTS");
+      }
+
+      try (var pst = conn.prepareStatement("INSERT INTO NullBindTest SET id = ?, name = ?")) {
+        pst.setInt(1, 1);
+        pst.setNull(2, java.sql.Types.VARCHAR);
+        pst.execute();
+      }
+
+      try (var pst = conn.prepareStatement("INSERT INTO NullBindTest SET id = ?, name = ?")) {
+        pst.setInt(1, 2);
+        pst.setObject(2, null);
+        pst.execute();
+      }
+
+      try (var st = conn.createStatement()) {
+        ResultSet rs = st.executeQuery("SELECT FROM NullBindTest ORDER BY id");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("name")).isNull();
+        assertThat(rs.wasNull()).isTrue();
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("name")).isNull();
+        assertThat(rs.wasNull()).isTrue();
+      }
+    }
+  }
+
   // ==================== Error Handling Tests ====================
 
   @Test


### PR DESCRIPTION
## Summary
- `BoltWebSocketInputStream` now rejects a frame whose decoded length is negative or exceeds `arcadedb.bolt.websocket.maxFrameSize` (new config, default 16MB) before allocating the payload array or reading the mask key. Closes the pre-auth path where ~14 bytes declaring a multi-gigabyte length could OOM the server before the Bolt handshake or authentication.
- `PostgresNetworkExecutor.bindCommand()` applies the same bound via `arcadedb.postgres.maxParamSize` (new config, default 16MB) to a Bind message's declared parameter length, in both the normal parse path and the error-recovery drain path, before any allocation.

Fixes #5894.

## Test plan
- [x] `BoltWebSocketInputStreamTest`: attack-shaped oversized frame, negative extended length, and the accept/reject boundary.
- [x] `PostgresBindParamBoundIT`: raw-socket regression test; verified it fails against the unpatched code (reproduces the actual `OutOfMemoryError`) and passes with the fix.
- [x] Full `PostgresProtocolIT` + `PostgresPortalTest` + Bolt suites pass (no regressions).