### PR TITLE
fix(#5919): widen numeric narrowing at LIMIT/SKIP, map2json, and DOUBLE MIN/MAX validation

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
@@ -121,7 +121,7 @@ public class DocumentValidator {
     }
     case DOUBLE -> {
       final double maxAsDouble = Double.parseDouble(max);
-      if (((Number) fieldValue).floatValue() > maxAsDouble)
+      if (((Number) fieldValue).doubleValue() > maxAsDouble)
         throwValidationException(document.getType(), p, "value " + fieldValue + " is greater than " + max);
     }
     case DECIMAL -> {
@@ -200,7 +200,7 @@ public class DocumentValidator {
       }
       case DOUBLE -> {
         final double minAsDouble = Double.parseDouble(min);
-        if (((Number) fieldValue).floatValue() < minAsDouble)
+        if (((Number) fieldValue).doubleValue() < minAsDouble)
           yield new ValidationResult(true, "value " + fieldValue + " is less than " + min);
         yield new ValidationResult(false, null);
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Limit.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Limit.java
@@ -52,12 +52,12 @@ public class Limit extends SimpleNode {
 
   public int getValue(final CommandContext context) {
     if (num != null)
-      return num.getValue().intValue();
+      return saturateToInt(num.getValue());
 
     if (inputParam != null) {
       final Object paramValue = inputParam.getValue(context.getInputParameters());
       if (paramValue instanceof Number number)
-        return number.intValue();
+        return saturateToInt(number);
       else
         throw new CommandExecutionException("Invalid value for LIMIT: " + paramValue);
     }
@@ -65,12 +65,27 @@ public class Limit extends SimpleNode {
     if (expression != null) {
       final Object exprValue = expression.execute((Result) null, context);
       if (exprValue instanceof Number number)
-        return number.intValue();
+        return saturateToInt(number);
       else
         throw new CommandExecutionException("Invalid value for LIMIT: " + exprValue);
     }
 
     throw new CommandExecutionException("No value for LIMIT");
+  }
+
+  /**
+   * Narrows a numeric LIMIT to an int without wrapping: a value outside the int range saturates to the
+   * nearest int bound instead of overflowing into an unrelated (and often negative, hence
+   * silently-zero-rows) value. `Integer.MIN_VALUE` is used as the negative saturation bound (rather than -1)
+   * because -1 is the sentinel `LimitExecutionStep` reads as "unlimited".
+   */
+  private static int saturateToInt(final Number value) {
+    final long longValue = value.longValue();
+    if (longValue > Integer.MAX_VALUE)
+      return Integer.MAX_VALUE;
+    if (longValue < Integer.MIN_VALUE)
+      return Integer.MIN_VALUE;
+    return (int) longValue;
   }
 
   public Limit setValue(final int value) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Limit.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Limit.java
@@ -23,6 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.Map;
 import java.util.Objects;
@@ -50,14 +51,20 @@ public class Limit extends SimpleNode {
 
   }
 
+  /**
+   * A value outside the int range is narrowed with {@link NumberUtils#saturateToInt(Number)} rather than a
+   * plain narrowing cast, so it saturates instead of wrapping into an unrelated (and often negative, hence
+   * silently-zero-rows) value. Saturating negative lands on `Integer.MIN_VALUE`, not `-1`, because `-1` is
+   * the sentinel `LimitExecutionStep` reads as "unlimited".
+   */
   public int getValue(final CommandContext context) {
     if (num != null)
-      return saturateToInt(num.getValue());
+      return NumberUtils.saturateToInt(num.getValue());
 
     if (inputParam != null) {
       final Object paramValue = inputParam.getValue(context.getInputParameters());
       if (paramValue instanceof Number number)
-        return saturateToInt(number);
+        return NumberUtils.saturateToInt(number);
       else
         throw new CommandExecutionException("Invalid value for LIMIT: " + paramValue);
     }
@@ -65,27 +72,12 @@ public class Limit extends SimpleNode {
     if (expression != null) {
       final Object exprValue = expression.execute((Result) null, context);
       if (exprValue instanceof Number number)
-        return saturateToInt(number);
+        return NumberUtils.saturateToInt(number);
       else
         throw new CommandExecutionException("Invalid value for LIMIT: " + exprValue);
     }
 
     throw new CommandExecutionException("No value for LIMIT");
-  }
-
-  /**
-   * Narrows a numeric LIMIT to an int without wrapping: a value outside the int range saturates to the
-   * nearest int bound instead of overflowing into an unrelated (and often negative, hence
-   * silently-zero-rows) value. `Integer.MIN_VALUE` is used as the negative saturation bound (rather than -1)
-   * because -1 is the sentinel `LimitExecutionStep` reads as "unlimited".
-   */
-  private static int saturateToInt(final Number value) {
-    final long longValue = value.longValue();
-    if (longValue > Integer.MAX_VALUE)
-      return Integer.MAX_VALUE;
-    if (longValue < Integer.MIN_VALUE)
-      return Integer.MIN_VALUE;
-    return (int) longValue;
   }
 
   public Limit setValue(final int value) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Skip.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Skip.java
@@ -23,6 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.Map;
 
@@ -48,14 +49,19 @@ public class Skip extends SimpleNode {
       expression.toString(params, builder);
   }
 
+  /**
+   * A value outside the int range is narrowed with {@link NumberUtils#saturateToInt(Number)} rather than a
+   * plain narrowing cast, so it saturates instead of wrapping into an unrelated (and often negative, hence
+   * silently-skip-nothing) value.
+   */
   public int getValue(final CommandContext context) {
     if (num != null)
-      return saturateToInt(num.getValue());
+      return NumberUtils.saturateToInt(num.getValue());
 
     if (inputParam != null) {
       final Object paramValue = inputParam.getValue(context.getInputParameters());
       if (paramValue instanceof Number number)
-        return saturateToInt(number);
+        return NumberUtils.saturateToInt(number);
       else
         throw new CommandExecutionException("Invalid value for SKIP: " + paramValue);
     }
@@ -63,26 +69,12 @@ public class Skip extends SimpleNode {
     if (expression != null) {
       final Object exprValue = expression.execute((Result) null, context);
       if (exprValue instanceof Number number)
-        return saturateToInt(number);
+        return NumberUtils.saturateToInt(number);
       else
         throw new CommandExecutionException("Invalid value for SKIP: " + exprValue);
     }
 
     throw new CommandExecutionException("No value for SKIP");
-  }
-
-  /**
-   * Narrows a numeric SKIP to an int without wrapping: a value outside the int range saturates to the
-   * nearest int bound instead of overflowing into an unrelated (and often negative, hence
-   * silently-skip-nothing) value.
-   */
-  private static int saturateToInt(final Number value) {
-    final long longValue = value.longValue();
-    if (longValue > Integer.MAX_VALUE)
-      return Integer.MAX_VALUE;
-    if (longValue < Integer.MIN_VALUE)
-      return Integer.MIN_VALUE;
-    return (int) longValue;
   }
 
   public Skip copy() {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Skip.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Skip.java
@@ -50,12 +50,12 @@ public class Skip extends SimpleNode {
 
   public int getValue(final CommandContext context) {
     if (num != null)
-      return num.getValue().intValue();
+      return saturateToInt(num.getValue());
 
     if (inputParam != null) {
       final Object paramValue = inputParam.getValue(context.getInputParameters());
       if (paramValue instanceof Number number)
-        return number.intValue();
+        return saturateToInt(number);
       else
         throw new CommandExecutionException("Invalid value for SKIP: " + paramValue);
     }
@@ -63,12 +63,26 @@ public class Skip extends SimpleNode {
     if (expression != null) {
       final Object exprValue = expression.execute((Result) null, context);
       if (exprValue instanceof Number number)
-        return number.intValue();
+        return saturateToInt(number);
       else
         throw new CommandExecutionException("Invalid value for SKIP: " + exprValue);
     }
 
     throw new CommandExecutionException("No value for SKIP");
+  }
+
+  /**
+   * Narrows a numeric SKIP to an int without wrapping: a value outside the int range saturates to the
+   * nearest int bound instead of overflowing into an unrelated (and often negative, hence
+   * silently-skip-nothing) value.
+   */
+  private static int saturateToInt(final Number value) {
+    final long longValue = value.longValue();
+    if (longValue > Integer.MAX_VALUE)
+      return Integer.MAX_VALUE;
+    if (longValue < Integer.MIN_VALUE)
+      return Integer.MIN_VALUE;
+    return (int) longValue;
   }
 
   public Skip copy() {

--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -268,7 +268,7 @@ public class JsonSerializer {
 
       value = convertToJSONType(value, propertyType);
 
-      if (value instanceof Number number && !Float.isFinite(number.floatValue())) {
+      if (value instanceof Number number && !Double.isFinite(number.doubleValue())) {
         LogManager.instance()
             .log(this, Level.SEVERE, """
                     Found non finite number in map with key '%s', ignore this entry in the \

--- a/engine/src/main/java/com/arcadedb/utility/NumberUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/NumberUtils.java
@@ -18,7 +18,15 @@
  */
 package com.arcadedb.utility;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 public class NumberUtils {
+
+  private static final BigInteger BIGINTEGER_MAX_INT = BigInteger.valueOf(Integer.MAX_VALUE);
+  private static final BigInteger BIGINTEGER_MIN_INT = BigInteger.valueOf(Integer.MIN_VALUE);
+  private static final BigDecimal BIGDECIMAL_MAX_INT = BigDecimal.valueOf(Integer.MAX_VALUE);
+  private static final BigDecimal BIGDECIMAL_MIN_INT = BigDecimal.valueOf(Integer.MIN_VALUE);
 
   public static Integer parsePositiveInteger(final String s) {
     for (int i = 0; i < s.length(); i++) {
@@ -35,5 +43,36 @@ public class NumberUtils {
         return false;
     }
     return true;
+  }
+
+  /**
+   * Narrows a numeric value to an int without wrapping: a value outside the int range saturates to
+   * the nearest int bound instead of overflowing into an unrelated value. `BigInteger`/`BigDecimal`
+   * are compared by magnitude directly, because `Number.longValue()` on one of those far outside the
+   * `Long` range is documented as lossy in an unspecified way (it can even flip sign).
+   */
+  public static int saturateToInt(final Number value) {
+    if (value instanceof BigInteger bigInteger) {
+      if (bigInteger.compareTo(BIGINTEGER_MAX_INT) > 0)
+        return Integer.MAX_VALUE;
+      if (bigInteger.compareTo(BIGINTEGER_MIN_INT) < 0)
+        return Integer.MIN_VALUE;
+      return bigInteger.intValue();
+    }
+
+    if (value instanceof BigDecimal bigDecimal) {
+      if (bigDecimal.compareTo(BIGDECIMAL_MAX_INT) > 0)
+        return Integer.MAX_VALUE;
+      if (bigDecimal.compareTo(BIGDECIMAL_MIN_INT) < 0)
+        return Integer.MIN_VALUE;
+      return bigDecimal.intValue();
+    }
+
+    final long longValue = value.longValue();
+    if (longValue > Integer.MAX_VALUE)
+      return Integer.MAX_VALUE;
+    if (longValue < Integer.MIN_VALUE)
+      return Integer.MIN_VALUE;
+    return (int) longValue;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/LimitExecutionStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/LimitExecutionStepTest.java
@@ -205,6 +205,30 @@ class LimitExecutionStepTest extends TestHelper {
   }
 
   @Test
+  void shouldLimitAboveIntRangeReturnsAllRows() {
+    // Issue #5919 - Site A: a LIMIT value above Integer.MAX_VALUE used to narrow with
+    // intValue(), wrapping to a negative int and returning 0 rows instead of the whole result.
+    database.getSchema().createDocumentType("LimitOverflow");
+
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++) {
+        database.newDocument("LimitOverflow").set("value", i).save();
+      }
+    });
+
+    final ResultSet result = database.query("sql", "SELECT FROM LimitOverflow LIMIT 2147483648");
+
+    int count = 0;
+    while (result.hasNext()) {
+      result.next();
+      count++;
+    }
+
+    assertThat(count).isEqualTo(5);
+    result.close();
+  }
+
+  @Test
   void shouldLimitLargeDataset() {
     database.getSchema().createDocumentType("BigData");
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/LimitSkipStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/LimitSkipStepTest.java
@@ -227,6 +227,26 @@ class LimitSkipStepTest extends TestHelper {
   }
 
   @Test
+  void shouldSkipAboveIntRangeSkipsEverything() {
+    // Issue #5919 - Site A follow-up: SKIP shares the same intValue() narrowing as LIMIT. A SKIP
+    // above Integer.MAX_VALUE used to wrap to a negative int, which SkipExecutionStep's
+    // "while (skipped < skipValue)" then evaluates as false, silently returning ALL rows instead
+    // of skipping past a result set that can never reach 2^31 rows.
+    database.getSchema().createDocumentType("TestSkipOverflow");
+
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++) {
+        database.newDocument("TestSkipOverflow").set("value", i).save();
+      }
+    });
+
+    final ResultSet result = database.query("sql", "SELECT FROM TestSkipOverflow SKIP 2147483648");
+
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
   void shouldHandleLimitOne() {
     database.getSchema().createDocumentType("TestLimitOne");
 

--- a/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
@@ -536,6 +536,40 @@ class DocumentValidationTest extends TestHelper {
   }
 
   @Test
+  void maxValidationDoubleBeyondFloatRange() {
+    // Issue #5919 - Site C: the DOUBLE arm of validateMaxValue() compared fieldValue.floatValue()
+    // against the double bound. A value beyond Float.MAX_VALUE (~3.4e38) narrows to
+    // Float.POSITIVE_INFINITY, which is always > any finite bound, so a value that is actually
+    // well within range was falsely rejected.
+    final DocumentType clazz = database.getSchema().createDocumentType("MaxDoubleBeyondFloat");
+    clazz.createProperty("value", Type.DOUBLE).setMax("1e300");
+
+    final MutableDocument d = database.newDocument(clazz.getName());
+    d.set("value", 5e250d); // finite, way beyond Float.MAX_VALUE, but well below the 1e300 max
+    d.validate();
+
+    d.set("value", 2e300d); // genuinely above the max
+    assertThatThrownBy(d::validate).isInstanceOf(ValidationException.class);
+  }
+
+  @Test
+  void minValidationDoubleBeyondFloatRange() {
+    // Issue #5919 - Site C: the DOUBLE arm of validateMinValue() compared fieldValue.floatValue()
+    // against the double bound. A value beyond -Float.MAX_VALUE narrows to
+    // Float.NEGATIVE_INFINITY, which is always < any finite bound, so a value that is actually
+    // well within range was falsely rejected.
+    final DocumentType clazz = database.getSchema().createDocumentType("MinDoubleBeyondFloat");
+    clazz.createProperty("value", Type.DOUBLE).setMin("-1e300");
+
+    final MutableDocument d = database.newDocument(clazz.getName());
+    d.set("value", -5e250d); // finite, way beyond -Float.MAX_VALUE, but well above the -1e300 min
+    d.validate();
+
+    d.set("value", -2e300d); // genuinely below the min
+    assertThatThrownBy(d::validate).isInstanceOf(ValidationException.class);
+  }
+
+  @Test
   void notNullValidation() {
     database.getSchema().createDocumentType("EmbeddedValidation");
 

--- a/engine/src/test/java/com/arcadedb/serializer/json/JSONSerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/json/JSONSerializerTest.java
@@ -106,6 +106,22 @@ class JSONSerializerTest extends TestHelper {
   }
 
   @Test
+  void map2jsonKeepsFiniteDoubleBeyondFloatRange() {
+    // Issue #5919 - Site B: the finiteness guard in map2json() narrowed to float before checking
+    // Float.isFinite(), so a finite double above Float.MAX_VALUE (~3.4e38) was misclassified as
+    // non-finite and silently dropped from the serialized map.
+    final Map<String, Object> map = new HashMap<>();
+    map.put("big", 1e300);
+    map.put("small", 1.5);
+
+    final JSONObject json = jsonSerializer.map2json(map, null, false);
+
+    assertThat(json.has("big")).isTrue();
+    assertThat(json.getDouble("big")).isEqualTo(1e300);
+    assertThat(json.getDouble("small")).isEqualTo(1.5);
+  }
+
+  @Test
   void json2map() {
     JSONObject json = new JSONObject();
     json.put("key1", "value1");

--- a/engine/src/test/java/com/arcadedb/utility/NumberUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/NumberUtilsTest.java
@@ -20,6 +20,9 @@ package com.arcadedb.utility;
 
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -90,5 +93,49 @@ class NumberUtilsTest {
   void parsePositiveIntegerWithMaxValue() {
     assertThat(NumberUtils.parsePositiveInteger(String.valueOf(Integer.MAX_VALUE)))
         .isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  void saturateToIntWithValueInRangeIsUnchanged() {
+    assertThat(NumberUtils.saturateToInt(42)).isEqualTo(42);
+    assertThat(NumberUtils.saturateToInt(-42)).isEqualTo(-42);
+    assertThat(NumberUtils.saturateToInt(0)).isEqualTo(0);
+    assertThat(NumberUtils.saturateToInt(Integer.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(NumberUtils.saturateToInt(Integer.MIN_VALUE)).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test
+  void saturateToIntWithLongBeyondIntRangeSaturates() {
+    // Issue #5919 - Site A: a Long above Integer.MAX_VALUE (e.g. LIMIT 2147483648) must not wrap
+    // to a negative int via a plain narrowing cast.
+    assertThat(NumberUtils.saturateToInt(Integer.MAX_VALUE + 1L)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(NumberUtils.saturateToInt(Long.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(NumberUtils.saturateToInt(Integer.MIN_VALUE - 1L)).isEqualTo(Integer.MIN_VALUE);
+    assertThat(NumberUtils.saturateToInt(Long.MIN_VALUE)).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test
+  void saturateToIntWithBigIntegerBeyondLongRangeSaturates() {
+    // PR #5921 review: Number.longValue() on a BigInteger far outside the Long range is
+    // documented as lossy in an unspecified way (it can even flip sign), so a BigInteger bind
+    // param needs its own magnitude check instead of going through longValue() first.
+    final BigInteger huge = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN);
+    assertThat(NumberUtils.saturateToInt(huge)).isEqualTo(Integer.MAX_VALUE);
+
+    final BigInteger hugeNegative = BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.TEN);
+    assertThat(NumberUtils.saturateToInt(hugeNegative)).isEqualTo(Integer.MIN_VALUE);
+
+    assertThat(NumberUtils.saturateToInt(BigInteger.valueOf(7))).isEqualTo(7);
+  }
+
+  @Test
+  void saturateToIntWithBigDecimalBeyondLongRangeSaturates() {
+    final BigDecimal huge = BigDecimal.valueOf(Long.MAX_VALUE).multiply(BigDecimal.TEN);
+    assertThat(NumberUtils.saturateToInt(huge)).isEqualTo(Integer.MAX_VALUE);
+
+    final BigDecimal hugeNegative = BigDecimal.valueOf(Long.MIN_VALUE).multiply(BigDecimal.TEN);
+    assertThat(NumberUtils.saturateToInt(hugeNegative)).isEqualTo(Integer.MIN_VALUE);
+
+    assertThat(NumberUtils.saturateToInt(BigDecimal.valueOf(7))).isEqualTo(7);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the unchecked-numeric-narrowing family (#5900, #5905, #5906). Fixes the three sites reported in #5919, where a wider numeric was narrowed with `.intValue()` / `.floatValue()` without a range check:

- **Site A - `LIMIT`/`SKIP` above 2^31** (`Limit.java`, `Skip.java`): `getValue()` narrowed with `.intValue()`. A `LIMIT` literal/param/expression above `Integer.MAX_VALUE` wraps to a negative int, and `LimitExecutionStep` treats any `limitVal <= loaded` as "done" - so `LIMIT 2147483648` silently returned **0 rows**. The same narrowing in `Skip.getValue()` wraps to negative too, and `SkipExecutionStep`'s `while (skipped < skipValue)` never runs for a negative `skipValue` - so `SKIP 2147483648` silently returned **all rows** instead of skipping past them. Both now saturate to `Integer.MAX_VALUE`/`Integer.MIN_VALUE` at the int boundary instead of wrapping. `Integer.MIN_VALUE` (not `-1`) is used as the negative bound because `-1` is the sentinel `LimitExecutionStep` reads as "unlimited".
- **Site B - finite `double` dropped from map JSON** (`JsonSerializer.java`): `map2json()`'s finiteness guard checked `Float.isFinite(number.floatValue())`. A finite `Double` above `Float.MAX_VALUE` (~3.4e38) narrows to `Float.POSITIVE_INFINITY`, fails the check, and the property is silently dropped (with a misleading "non finite number" log). Switched to `Double.isFinite(number.doubleValue())`, matching every other finiteness check in the serializer.
- **Site C - `DOUBLE` MIN/MAX validated as `float`** (`DocumentValidator.java`): the `DOUBLE` arms of `validateMaxValue`/`validateMinValue` compared `fieldValue.floatValue()` against the parsed `double` bound, while the adjacent `FLOAT`/`LONG`/`INTEGER` arms use matching widths. A value beyond +/-`Float.MAX_VALUE` narrows to +/-`Infinity`, which is always outside any finite bound - so a value genuinely within range was falsely rejected. Switched to `fieldValue.doubleValue()`.

## Test plan

Regression tests added, all reproducing the bug against the pre-fix code and passing after the fix:

- [x] `LimitExecutionStepTest#shouldLimitAboveIntRangeReturnsAllRows` - `LIMIT 2147483648` on 5 rows now returns 5, not 0
- [x] `LimitSkipStepTest#shouldSkipAboveIntRangeSkipsEverything` - `SKIP 2147483648` on 5 rows now returns 0, not 5
- [x] `JSONSerializerTest#map2jsonKeepsFiniteDoubleBeyondFloatRange` - `map2json` keeps a finite `1e300` entry instead of dropping it
- [x] `DocumentValidationTest#maxValidationDoubleBeyondFloatRange` / `#minValidationDoubleBeyondFloatRange` - a `DOUBLE` value beyond +/-`Float.MAX_VALUE` but within the MIN/MAX bound now validates; a value genuinely outside the bound still throws

Also ran `SelectStatementExecutionTest`, `MatchStatementExecutionTest`, `UpdateStatementExecutionTest`, `UpsertStatementExecutionTest` and `OrderByGraphFunctionTest` (368 tests) to check for regressions in LIMIT/SKIP-heavy paths - all green.

Fixes #5919.