### PR TITLE
fix(#5900): comparison operators no longer narrow/parse-crash on type mismatch

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -384,18 +384,24 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       if (convertedTo.length == 0)
         convertedTo = null;
 
-      if (Arrays.equals(convertedFrom, convertedTo) && fromKeyIncluded && toKeyIncluded
-          && convertedFrom != null && index.getPropertyNames().size() == convertedFrom.length)
-        cursor = index.get(convertedFrom);
-      else if (index.supportsOrderedIterations()) {
-        if (orderAsc)
-          cursor = index.range(true, convertedFrom, fromKeyIncluded, convertedTo, toKeyIncluded);
-        else
-          cursor = index.range(false, convertedTo, toKeyIncluded, convertedFrom, fromKeyIncluded);
-      } else if (additionalRangeCondition == null && allEqualities((AndBlock) condition)) {
-        cursor = index.iterator(isOrderAsc(), convertedFrom, true);
-      } else {
-        throw new UnsupportedOperationException("Cannot evaluate " + this.condition + " on index " + index);
+      try {
+        if (Arrays.equals(convertedFrom, convertedTo) && fromKeyIncluded && toKeyIncluded
+            && convertedFrom != null && index.getPropertyNames().size() == convertedFrom.length)
+          cursor = index.get(convertedFrom);
+        else if (index.supportsOrderedIterations()) {
+          if (orderAsc)
+            cursor = index.range(true, convertedFrom, fromKeyIncluded, convertedTo, toKeyIncluded);
+          else
+            cursor = index.range(false, convertedTo, toKeyIncluded, convertedFrom, fromKeyIncluded);
+        } else if (additionalRangeCondition == null && allEqualities((AndBlock) condition)) {
+          cursor = index.iterator(isOrderAsc(), convertedFrom, true);
+        } else {
+          throw new UnsupportedOperationException("Cannot evaluate " + this.condition + " on index " + index);
+        }
+      } catch (final IllegalArgumentException e) {
+        // This combination's bound has no defined ordering against the index's declared key type: it matches no
+        // indexed row, consistent with the row-scan operators (#5900). Skip it rather than aborting the whole scan.
+        continue;
       }
       nextCursors.add(cursor);
 
@@ -521,10 +527,15 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     final Object secondValue = second.execute((Result) null, context);
     final Object thirdValue = third.execute((Result) null, context);
-    if (isOrderAsc())
-      cursor = index.range(true, new Object[] { secondValue }, true, new Object[] { thirdValue }, true);
-    else
-      cursor = index.range(false, new Object[] { thirdValue }, true, new Object[] { secondValue }, true);
+    try {
+      if (isOrderAsc())
+        cursor = index.range(true, new Object[] { secondValue }, true, new Object[] { thirdValue }, true);
+      else
+        cursor = index.range(false, new Object[] { thirdValue }, true, new Object[] { secondValue }, true);
+    } catch (final IllegalArgumentException e) {
+      // A bound with no defined ordering against the index's declared key type: no indexed row can match (#5900).
+      cursor = null;
+    }
 
     if (cursor != null)
       fetchNextEntry();
@@ -584,18 +595,25 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     else
       values = (Object[]) value;
 
-    if (operator instanceof EqualsCompareOperator) {
-      return index.get(values);
-    } else if (operator instanceof GeOperator) {
-      return index.iterator(true, values, true);
-    } else if (operator instanceof GtOperator) {
-      return index.iterator(true, values, false);
-    } else if (operator instanceof LeOperator) {
-      return index.iterator(false, values, true);
-    } else if (operator instanceof LtOperator) {
-      return index.iterator(false, values, false);
-    } else {
-      throw new CommandExecutionException("search for index for " + condition + " is not supported yet");
+    try {
+      if (operator instanceof EqualsCompareOperator) {
+        return index.get(values);
+      } else if (operator instanceof GeOperator) {
+        return index.iterator(true, values, true);
+      } else if (operator instanceof GtOperator) {
+        return index.iterator(true, values, false);
+      } else if (operator instanceof LeOperator) {
+        return index.iterator(false, values, true);
+      } else if (operator instanceof LtOperator) {
+        return index.iterator(false, values, false);
+      } else {
+        throw new CommandExecutionException("search for index for " + condition + " is not supported yet");
+      }
+    } catch (final IllegalArgumentException e) {
+      // The bound has no defined ordering against the index's declared key type (e.g. a non-numeric String bound
+      // on a numeric column): no indexed row can match, consistent with the row-scan operators (#5900). Type.convert()
+      // always surfaces a failed conversion as an IllegalArgumentException (NumberFormatException is a subtype).
+      return null;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -24,6 +24,7 @@ import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.RangeIndex;
 import com.arcadedb.query.sql.parser.AndBlock;
 import com.arcadedb.query.sql.parser.BetweenCondition;
@@ -40,6 +41,8 @@ import com.arcadedb.query.sql.parser.LeOperator;
 import com.arcadedb.query.sql.parser.LtOperator;
 import com.arcadedb.query.sql.parser.PCollection;
 import com.arcadedb.query.sql.parser.ValueExpression;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.BinaryTypes;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.Pair;
 
@@ -389,24 +392,23 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       if (convertedTo.length == 0)
         convertedTo = null;
 
-      try {
-        if (Arrays.equals(convertedFrom, convertedTo) && fromKeyIncluded && toKeyIncluded
-            && convertedFrom != null && index.getPropertyNames().size() == convertedFrom.length)
-          cursor = index.get(convertedFrom);
-        else if (index.supportsOrderedIterations()) {
-          if (orderAsc)
-            cursor = index.range(true, convertedFrom, fromKeyIncluded, convertedTo, toKeyIncluded);
-          else
-            cursor = index.range(false, convertedTo, toKeyIncluded, convertedFrom, fromKeyIncluded);
-        } else if (additionalRangeCondition == null && allEqualities((AndBlock) condition)) {
-          cursor = index.iterator(isOrderAsc(), convertedFrom, true);
-        } else {
-          throw new UnsupportedOperationException("Cannot evaluate " + this.condition + " on index " + index);
-        }
-      } catch (final IllegalArgumentException e) {
+      if (!valuesConvertToIndexKeyTypes(convertedFrom) || !valuesConvertToIndexKeyTypes(convertedTo))
         // This combination's bound has no defined ordering against the index's declared key type: it matches no
         // indexed row, consistent with the row-scan operators (#5900). Skip it rather than aborting the whole scan.
         continue;
+
+      if (Arrays.equals(convertedFrom, convertedTo) && fromKeyIncluded && toKeyIncluded
+          && convertedFrom != null && index.getPropertyNames().size() == convertedFrom.length)
+        cursor = index.get(convertedFrom);
+      else if (index.supportsOrderedIterations()) {
+        if (orderAsc)
+          cursor = index.range(true, convertedFrom, fromKeyIncluded, convertedTo, toKeyIncluded);
+        else
+          cursor = index.range(false, convertedTo, toKeyIncluded, convertedFrom, fromKeyIncluded);
+      } else if (additionalRangeCondition == null && allEqualities((AndBlock) condition)) {
+        cursor = index.iterator(isOrderAsc(), convertedFrom, true);
+      } else {
+        throw new UnsupportedOperationException("Cannot evaluate " + this.condition + " on index " + index);
       }
       nextCursors.add(cursor);
 
@@ -532,15 +534,14 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     final Object secondValue = second.execute((Result) null, context);
     final Object thirdValue = third.execute((Result) null, context);
-    try {
-      if (isOrderAsc())
-        cursor = index.range(true, new Object[] { secondValue }, true, new Object[] { thirdValue }, true);
-      else
-        cursor = index.range(false, new Object[] { thirdValue }, true, new Object[] { secondValue }, true);
-    } catch (final IllegalArgumentException e) {
-      // A bound with no defined ordering against the index's declared key type: no indexed row can match (#5900).
+
+    if (!valuesConvertToIndexKeyTypes(new Object[] { secondValue }) || !valuesConvertToIndexKeyTypes(new Object[] { thirdValue }))
+      // A bound has no defined ordering against the index's declared key type: no indexed row can match (#5900).
       cursor = null;
-    }
+    else if (isOrderAsc())
+      cursor = index.range(true, new Object[] { secondValue }, true, new Object[] { thirdValue }, true);
+    else
+      cursor = index.range(false, new Object[] { thirdValue }, true, new Object[] { secondValue }, true);
 
     if (cursor != null)
       fetchNextEntry();
@@ -600,26 +601,50 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     else
       values = (Object[]) value;
 
-    try {
-      if (operator instanceof EqualsCompareOperator) {
-        return index.get(values);
-      } else if (operator instanceof GeOperator) {
-        return index.iterator(true, values, true);
-      } else if (operator instanceof GtOperator) {
-        return index.iterator(true, values, false);
-      } else if (operator instanceof LeOperator) {
-        return index.iterator(false, values, true);
-      } else if (operator instanceof LtOperator) {
-        return index.iterator(false, values, false);
-      } else {
-        throw new CommandExecutionException("search for index for " + condition + " is not supported yet");
-      }
-    } catch (final IllegalArgumentException e) {
-      // The bound has no defined ordering against the index's declared key type (e.g. a non-numeric String bound
-      // on a numeric column): no indexed row can match, consistent with the row-scan operators (#5900). Type.convert()
-      // always surfaces a failed conversion as an IllegalArgumentException (NumberFormatException is a subtype).
+    if (!valuesConvertToIndexKeyTypes(values))
+      // A bound has no defined ordering against the index's declared key type (e.g. a non-numeric String bound on
+      // a numeric column): no indexed row can match, consistent with the row-scan operators (#5900).
       return null;
+
+    if (operator instanceof EqualsCompareOperator) {
+      return index.get(values);
+    } else if (operator instanceof GeOperator) {
+      return index.iterator(true, values, true);
+    } else if (operator instanceof GtOperator) {
+      return index.iterator(true, values, false);
+    } else if (operator instanceof LeOperator) {
+      return index.iterator(false, values, true);
+    } else if (operator instanceof LtOperator) {
+      return index.iterator(false, values, false);
+    } else {
+      throw new CommandExecutionException("search for index for " + condition + " is not supported yet");
     }
+  }
+
+  /**
+   * Best-effort check that every non-null value converts to the index's declared key type, mirroring exactly what
+   * the index's own key conversion does internally ({@code Type.convert} against
+   * {@code BinaryTypes.getClassFromType(...)}, e.g. {@code LSMTreeIndexAbstract.convertKeys()}). Run BEFORE calling
+   * into the index so a genuine type mismatch is what gets treated as "no match" here - catching whatever
+   * {@code IllegalArgumentException} the index call happens to throw would also silently swallow unrelated causes
+   * (a NULL-strategy violation, a non-range-capable composite sub-index) as the same "no rows" outcome.
+   */
+  private boolean valuesConvertToIndexKeyTypes(final Object[] values) {
+    if (values == null || !(index instanceof IndexInternal internalIndex))
+      return true;
+
+    final byte[] keyTypes = internalIndex.getBinaryKeyTypes();
+    final Database database = context.getDatabase();
+    for (int i = 0; i < values.length && i < keyTypes.length; i++) {
+      if (values[i] == null)
+        continue;
+      try {
+        Type.convert(database, values[i], BinaryTypes.getClassFromType(keyTypes[i]));
+      } catch (final IllegalArgumentException e) {
+        return false;
+      }
+    }
+    return true;
   }
 
   protected boolean isOrderAsc() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -288,6 +288,11 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       customIterator = new MultiIterator<>();
       for (final Object item : MultiValue.getMultiValueIterable(rightValue)) {
         final IndexCursor localCursor = createCursor(equals, unwrapSubQueryResult(item), context);
+        if (localCursor == null)
+          // This IN-list item has no defined ordering against the index's declared key type (e.g. a non-numeric
+          // String item against a numeric column): it matches no indexed row, consistent with the other operators
+          // (#5900). Skip it rather than adding a cursor-less sub-iterator that NPEs on the first hasNext()/close().
+          continue;
         customCursors.add(localCursor);
 
         customIterator.addIterator(new Iterator<Map.Entry>() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -635,6 +635,8 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     final byte[] keyTypes = internalIndex.getBinaryKeyTypes();
     final Database database = context.getDatabase();
+    // Bounded by the shorter array rather than requiring equal lengths, matching convertKeys()'s own assumption
+    // that a partial-key lookup supplies no more values than the index has key types for.
     for (int i = 0; i < values.length && i < keyTypes.length; i++) {
       if (values[i] == null)
         continue;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -635,8 +635,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     final byte[] keyTypes = internalIndex.getBinaryKeyTypes();
     final Database database = context.getDatabase();
-    // Bounded by the shorter array rather than requiring equal lengths, matching convertKeys()'s own assumption
-    // that a partial-key lookup supplies no more values than the index has key types for.
+    // Bounded by the shorter array rather than requiring equal lengths: convertKeys() itself assumes
+    // values.length <= keyTypes.length (it indexes keyTypes[i] unguarded for every key), so a partial-key
+    // lookup is expected to supply no more values than the index has key types for.
     for (int i = 0; i < values.length && i < keyTypes.length; i++) {
       if (values[i] == null)
         continue;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
@@ -56,7 +56,7 @@ public class BetweenCondition extends BooleanExpression {
     // failure (e.g. NumberFormatException) escape (#5900).
     try {
       secondValue = Type.convert(context.getDatabase(), secondValue, firstValue.getClass());
-    } catch (final Exception ignore) {
+    } catch (final IllegalArgumentException ignore) {
       return false;
     }
 
@@ -67,7 +67,7 @@ public class BetweenCondition extends BooleanExpression {
 
     try {
       thirdValue = Type.convert(context.getDatabase(), thirdValue, firstValue.getClass());
-    } catch (final Exception ignore) {
+    } catch (final IllegalArgumentException ignore) {
       return false;
     }
 
@@ -91,7 +91,7 @@ public class BetweenCondition extends BooleanExpression {
 
     try {
       secondValue = Type.convert(context.getDatabase(), secondValue, firstValue.getClass());
-    } catch (final Exception ignore) {
+    } catch (final IllegalArgumentException ignore) {
       return false;
     }
 
@@ -101,7 +101,7 @@ public class BetweenCondition extends BooleanExpression {
     }
     try {
       thirdValue = Type.convert(context.getDatabase(), thirdValue, firstValue.getClass());
-    } catch (final Exception ignore) {
+    } catch (final IllegalArgumentException ignore) {
       return false;
     }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
@@ -54,9 +54,8 @@ public class BetweenCondition extends BooleanExpression {
     // A bound with no defined ordering against firstValue (e.g. a non-numeric String bound on a numeric column)
     // makes the comparison undefined, not an error: report "not between" rather than let the raw conversion
     // failure (e.g. NumberFormatException) escape (#5900).
-    try {
-      secondValue = Type.convert(context.getDatabase(), secondValue, firstValue.getClass());
-    } catch (final IllegalArgumentException ignore) {
+    secondValue = Type.convertOrNull(context.getDatabase(), secondValue, firstValue.getClass());
+    if (secondValue == null) {
       return false;
     }
 
@@ -65,9 +64,8 @@ public class BetweenCondition extends BooleanExpression {
       return false;
     }
 
-    try {
-      thirdValue = Type.convert(context.getDatabase(), thirdValue, firstValue.getClass());
-    } catch (final IllegalArgumentException ignore) {
+    thirdValue = Type.convertOrNull(context.getDatabase(), thirdValue, firstValue.getClass());
+    if (thirdValue == null) {
       return false;
     }
 
@@ -89,9 +87,8 @@ public class BetweenCondition extends BooleanExpression {
       return false;
     }
 
-    try {
-      secondValue = Type.convert(context.getDatabase(), secondValue, firstValue.getClass());
-    } catch (final IllegalArgumentException ignore) {
+    secondValue = Type.convertOrNull(context.getDatabase(), secondValue, firstValue.getClass());
+    if (secondValue == null) {
       return false;
     }
 
@@ -99,9 +96,8 @@ public class BetweenCondition extends BooleanExpression {
     if (thirdValue == null) {
       return false;
     }
-    try {
-      thirdValue = Type.convert(context.getDatabase(), thirdValue, firstValue.getClass());
-    } catch (final IllegalArgumentException ignore) {
+    thirdValue = Type.convertOrNull(context.getDatabase(), thirdValue, firstValue.getClass());
+    if (thirdValue == null) {
       return false;
     }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
@@ -51,14 +51,25 @@ public class BetweenCondition extends BooleanExpression {
       return false;
     }
 
-    secondValue = Type.convert(context.getDatabase(), secondValue, firstValue.getClass());
+    // A bound with no defined ordering against firstValue (e.g. a non-numeric String bound on a numeric column)
+    // makes the comparison undefined, not an error: report "not between" rather than let the raw conversion
+    // failure (e.g. NumberFormatException) escape (#5900).
+    try {
+      secondValue = Type.convert(context.getDatabase(), secondValue, firstValue.getClass());
+    } catch (final Exception ignore) {
+      return false;
+    }
 
     Object thirdValue = third.execute(currentRecord, context);
     if (thirdValue == null) {
       return false;
     }
 
-    thirdValue = Type.convert(context.getDatabase(), thirdValue, firstValue.getClass());
+    try {
+      thirdValue = Type.convert(context.getDatabase(), thirdValue, firstValue.getClass());
+    } catch (final Exception ignore) {
+      return false;
+    }
 
     final int leftResult = ((Comparable<Object>) firstValue).compareTo(secondValue);
     final int rightResult = ((Comparable<Object>) firstValue).compareTo(thirdValue);
@@ -78,13 +89,21 @@ public class BetweenCondition extends BooleanExpression {
       return false;
     }
 
-    secondValue = Type.convert(context.getDatabase(), secondValue, firstValue.getClass());
+    try {
+      secondValue = Type.convert(context.getDatabase(), secondValue, firstValue.getClass());
+    } catch (final Exception ignore) {
+      return false;
+    }
 
     Object thirdValue = third.execute(currentRecord, context);
     if (thirdValue == null) {
       return false;
     }
-    thirdValue = Type.convert(context.getDatabase(), thirdValue, firstValue.getClass());
+    try {
+      thirdValue = Type.convert(context.getDatabase(), thirdValue, firstValue.getClass());
+    } catch (final Exception ignore) {
+      return false;
+    }
 
     final int leftResult = ((Comparable<Object>) firstValue).compareTo(secondValue);
     final int rightResult = ((Comparable<Object>) firstValue).compareTo(thirdValue);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
@@ -43,8 +43,15 @@ public class GeOperator extends SimpleNode implements BinaryCompareOperator {
         final Number[] couple = Type.castComparableNumber(number, number1);
         left = couple[0];
         right = couple[1];
-      } else
-        right = Type.convert(database, right, left.getClass());
+      } else {
+        // Comparing across incompatible types has no defined ordering: report "not greater-or-equal" rather than
+        // let the raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
+        try {
+          right = Type.convert(database, right, left.getClass());
+        } catch (final Exception ignore) {
+          return false;
+        }
+      }
     }
 
     if (right == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
@@ -43,15 +43,10 @@ public class GeOperator extends SimpleNode implements BinaryCompareOperator {
         final Number[] couple = Type.castComparableNumber(number, number1);
         left = couple[0];
         right = couple[1];
-      } else {
+      } else
         // Comparing across incompatible types has no defined ordering: report "not greater-or-equal" rather than
         // let the raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
-        try {
-          right = Type.convert(database, right, left.getClass());
-        } catch (final IllegalArgumentException ignore) {
-          return false;
-        }
-      }
+        right = Type.convertOrNull(database, right, left.getClass());
     }
 
     if (right == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
@@ -48,7 +48,7 @@ public class GeOperator extends SimpleNode implements BinaryCompareOperator {
         // let the raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
         try {
           right = Type.convert(database, right, left.getClass());
-        } catch (final Exception ignore) {
+        } catch (final IllegalArgumentException ignore) {
           return false;
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
@@ -45,7 +45,7 @@ public class GtOperator extends SimpleNode implements BinaryCompareOperator {
         // raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
         try {
           right = Type.convert(database, right, left.getClass());
-        } catch (final Exception ignore) {
+        } catch (final IllegalArgumentException ignore) {
           return false;
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
@@ -40,15 +40,10 @@ public class GtOperator extends SimpleNode implements BinaryCompareOperator {
         final Number[] couple = Type.castComparableNumber(number, number1);
         left = couple[0];
         right = couple[1];
-      } else {
+      } else
         // Comparing across incompatible types has no defined ordering: report "not greater" rather than let the
         // raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
-        try {
-          right = Type.convert(database, right, left.getClass());
-        } catch (final IllegalArgumentException ignore) {
-          return false;
-        }
-      }
+        right = Type.convertOrNull(database, right, left.getClass());
     }
 
     if (right == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
@@ -40,8 +40,15 @@ public class GtOperator extends SimpleNode implements BinaryCompareOperator {
         final Number[] couple = Type.castComparableNumber(number, number1);
         left = couple[0];
         right = couple[1];
-      } else
-        right = Type.convert(database, right, left.getClass());
+      } else {
+        // Comparing across incompatible types has no defined ordering: report "not greater" rather than let the
+        // raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
+        try {
+          right = Type.convert(database, right, left.getClass());
+        } catch (final Exception ignore) {
+          return false;
+        }
+      }
     }
 
     if (right == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
@@ -47,7 +47,7 @@ public class LeOperator extends SimpleNode implements BinaryCompareOperator {
         // let the raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
         try {
           right = Type.convert(database, right, left.getClass());
-        } catch (final Exception ignore) {
+        } catch (final IllegalArgumentException ignore) {
           return false;
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
@@ -42,15 +42,10 @@ public class LeOperator extends SimpleNode implements BinaryCompareOperator {
         final Number[] couple = Type.castComparableNumber(number, number1);
         left = couple[0];
         right = couple[1];
-      } else {
+      } else
         // Comparing across incompatible types has no defined ordering: report "not less-or-equal" rather than
         // let the raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
-        try {
-          right = Type.convert(database, right, left.getClass());
-        } catch (final IllegalArgumentException ignore) {
-          return false;
-        }
-      }
+        right = Type.convertOrNull(database, right, left.getClass());
     }
 
     if (right == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
@@ -43,7 +43,13 @@ public class LeOperator extends SimpleNode implements BinaryCompareOperator {
         left = couple[0];
         right = couple[1];
       } else {
-        right = Type.convert(database, right, left.getClass());
+        // Comparing across incompatible types has no defined ordering: report "not less-or-equal" rather than
+        // let the raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
+        try {
+          right = Type.convert(database, right, left.getClass());
+        } catch (final Exception ignore) {
+          return false;
+        }
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
@@ -44,7 +44,7 @@ public class LtOperator extends SimpleNode implements BinaryCompareOperator {
         // raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
         try {
           right = Type.convert(database, right, left.getClass());
-        } catch (final Exception ignore) {
+        } catch (final IllegalArgumentException ignore) {
           return false;
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
@@ -39,15 +39,10 @@ public class LtOperator extends SimpleNode implements BinaryCompareOperator {
         final Number[] couple = Type.castComparableNumber(number, number1);
         left = couple[0];
         right = couple[1];
-      } else {
+      } else
         // Comparing across incompatible types has no defined ordering: report "not less" rather than let the
         // raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
-        try {
-          right = Type.convert(database, right, left.getClass());
-        } catch (final IllegalArgumentException ignore) {
-          return false;
-        }
-      }
+        right = Type.convertOrNull(database, right, left.getClass());
     }
 
     if (right == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
@@ -40,7 +40,13 @@ public class LtOperator extends SimpleNode implements BinaryCompareOperator {
         left = couple[0];
         right = couple[1];
       } else {
-        right = Type.convert(database, right, left.getClass());
+        // Comparing across incompatible types has no defined ordering: report "not less" rather than let the
+        // raw parse/conversion failure (e.g. NumberFormatException on a non-numeric String) escape (#5900).
+        try {
+          right = Type.convert(database, right, left.getClass());
+        } catch (final Exception ignore) {
+          return false;
+        }
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -305,6 +305,21 @@ public enum Type {
   }
 
   /**
+   * Same as {@link #convert(Database, Object, Class)}, but a failed conversion returns {@code null} instead of
+   * throwing: {@code convert()} only ever lets {@link IllegalArgumentException} escape (every other exception is
+   * already caught internally and treated as {@code null}), so this unifies both failure shapes into one contract
+   * for callers - typically a comparison across incompatible types - that need "no defined ordering" rather than a
+   * raw parse exception (#5900).
+   */
+  public static Object convertOrNull(final Database database, final Object value, final Class<?> targetClass) {
+    try {
+      return convert(database, value, targetClass);
+    } catch (final IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  /**
    * When a property is declared as a collection ({@code LIST}/{@code MAP}) with a scalar {@code ofType} (e.g. {@code LIST OF LONG}),
    * returns a copy of the collection with every plain scalar entry converted to the declared {@code ofType}. Returns {@code null}
    * when no coercion applies, so the caller falls through to the normal conversion path. Nested documents, collections and links are

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -299,6 +299,9 @@ public class BinaryComparator {
    * Widens to whichever precision the string's own format needs - {@code double} for a fractional/exponent
    * literal, {@code long} otherwise - so an integral string is compared without the precision loss a double
    * round-trip would introduce for large longs, and a fractional string doesn't hard-fail a {@code long} parse.
+   * <p>
+   * A numeric string outside both {@code long} and {@code double} range (e.g. 20+ integral digits) still throws
+   * an uncaught {@code NumberFormatException} rather than degrading gracefully; tracked as #5945.
    */
   private static int compareAgainstNumericString(final Number value1, final String string) {
     if (string.indexOf('.') >= 0 || string.indexOf('e') >= 0 || string.indexOf('E') >= 0)

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -164,34 +164,30 @@ public class BinaryComparator {
 
     case BinaryTypes.TYPE_BOOLEAN: {
       final int v1 = (Boolean) value1 ? 1 : 0;
-      final int v2;
 
       switch (type2) {
       case BinaryTypes.TYPE_INT:
       case BinaryTypes.TYPE_SHORT:
+      case BinaryTypes.TYPE_BYTE:
       case BinaryTypes.TYPE_LONG:
       case BinaryTypes.TYPE_DATETIME:
       case BinaryTypes.TYPE_DATE:
-      case BinaryTypes.TYPE_BYTE:
       case BinaryTypes.TYPE_DECIMAL:
       case BinaryTypes.TYPE_FLOAT:
       case BinaryTypes.TYPE_DOUBLE:
-        v2 = ((Number) value2).byteValue();
-        break;
+        // Reuse the same widening comparator INT/SHORT/BYTE use as type1: narrowing a wide/floating operand to a
+        // `byte` here would be the identical truncation bug this class just eliminated for those three (#5900).
+        return compareNarrowIntegral(v1, type2, value2);
 
       case BinaryTypes.TYPE_BOOLEAN:
-        v2 = (Boolean) value2 ? 1 : 0;
-        break;
+        return Integer.compare(v1, (Boolean) value2 ? 1 : 0);
 
       case BinaryTypes.TYPE_STRING:
-        v2 = Boolean.parseBoolean((String) value2) ? 1 : 0;
-        break;
+        return Integer.compare(v1, Boolean.parseBoolean((String) value2) ? 1 : 0);
 
       default:
         return -1;
       }
-
-      return Integer.compare(v1, v2);
     }
     case BinaryTypes.TYPE_DATE:
     case BinaryTypes.TYPE_DATETIME:

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -45,37 +45,14 @@ public class BinaryComparator {
       return 1;
 
     switch (type1) {
-    case BinaryTypes.TYPE_INT: {
-      final int v1 = ((Number) value1).intValue();
-      final int v2;
-
-      switch (type2) {
-      case BinaryTypes.TYPE_INT:
-      case BinaryTypes.TYPE_SHORT:
-      case BinaryTypes.TYPE_LONG:
-      case BinaryTypes.TYPE_DATETIME:
-      case BinaryTypes.TYPE_DATE:
-      case BinaryTypes.TYPE_BYTE:
-      case BinaryTypes.TYPE_DECIMAL:
-      case BinaryTypes.TYPE_FLOAT:
-      case BinaryTypes.TYPE_DOUBLE:
-        v2 = ((Number) value2).intValue();
-        break;
-
-      case BinaryTypes.TYPE_BOOLEAN:
-        v2 = (Boolean) value2 ? 1 : 0;
-        break;
-
-      case BinaryTypes.TYPE_STRING:
-        v2 = Integer.parseInt((String) value2);
-        break;
-
-      default:
-        return -1;
-      }
-
-      return Integer.compare(v1, v2);
-    }
+    case BinaryTypes.TYPE_INT:
+    case BinaryTypes.TYPE_SHORT:
+    case BinaryTypes.TYPE_BYTE:
+      // Always widen the other operand to its own natural width instead of narrowing it to type1's width:
+      // narrowing a wider or floating operand (e.g. a `long` outside `int` range via intValue(), or a fractional
+      // `double` via intValue()) can silently truncate it onto the wrong side of value1, which breaks the
+      // antisymmetry every comparator must honour (issue #5900).
+      return compareNarrowIntegral((Number) value1, type2, value2);
 
     case BinaryTypes.TYPE_LONG: {
       final long v1 = ((Number) value1).longValue();
@@ -107,38 +84,6 @@ public class BinaryComparator {
       }
 
       return Long.compare(v1, v2);
-    }
-
-    case BinaryTypes.TYPE_SHORT: {
-      final short v1 = ((Number) value1).shortValue();
-      final short v2;
-
-      switch (type2) {
-      case BinaryTypes.TYPE_INT:
-      case BinaryTypes.TYPE_SHORT:
-      case BinaryTypes.TYPE_LONG:
-      case BinaryTypes.TYPE_DATETIME:
-      case BinaryTypes.TYPE_DATE:
-      case BinaryTypes.TYPE_BYTE:
-      case BinaryTypes.TYPE_DECIMAL:
-      case BinaryTypes.TYPE_FLOAT:
-      case BinaryTypes.TYPE_DOUBLE:
-        v2 = ((Number) value2).shortValue();
-        break;
-
-      case BinaryTypes.TYPE_BOOLEAN:
-        v2 = (short) ((Boolean) value2 ? 1 : 0);
-        break;
-
-      case BinaryTypes.TYPE_STRING:
-        v2 = Short.parseShort((String) value2);
-        break;
-
-      default:
-        return -1;
-      }
-
-      return Short.compare(v1, v2);
     }
 
     case BinaryTypes.TYPE_STRING: {
@@ -215,38 +160,6 @@ public class BinaryComparator {
       }
 
       return Float.compare(v1, v2);
-    }
-
-    case BinaryTypes.TYPE_BYTE: {
-      final byte v1 = ((Number) value1).byteValue();
-      final byte v2;
-
-      switch (type2) {
-      case BinaryTypes.TYPE_INT:
-      case BinaryTypes.TYPE_SHORT:
-      case BinaryTypes.TYPE_LONG:
-      case BinaryTypes.TYPE_DATETIME:
-      case BinaryTypes.TYPE_DATE:
-      case BinaryTypes.TYPE_BYTE:
-      case BinaryTypes.TYPE_DECIMAL:
-      case BinaryTypes.TYPE_FLOAT:
-      case BinaryTypes.TYPE_DOUBLE:
-        v2 = ((Number) value2).byteValue();
-        break;
-
-      case BinaryTypes.TYPE_BOOLEAN:
-        v2 = (byte) ((Boolean) value2 ? 1 : 0);
-        break;
-
-      case BinaryTypes.TYPE_STRING:
-        v2 = Byte.parseByte((String) value2);
-        break;
-
-      default:
-        return -1;
-      }
-
-      return Byte.compare(v1, v2);
     }
 
     case BinaryTypes.TYPE_BOOLEAN: {
@@ -370,6 +283,46 @@ public class BinaryComparator {
     }
 
     throw new IllegalArgumentException("Comparison between type " + type1 + " and " + type2 + " not supported");
+  }
+
+  /**
+   * Shared comparison for a {@code value1} declared as {@code INT}, {@code SHORT} or {@code BYTE} - all of which
+   * fit losslessly in a Java {@code int} - against any {@code type2}. The other operand is promoted to whichever
+   * width it actually needs (int/long/double) rather than narrowed to {@code value1}'s declared width, so no
+   * operand is ever truncated.
+   */
+  private static int compareNarrowIntegral(final Number value1, final byte type2, final Object value2) {
+    switch (type2) {
+    case BinaryTypes.TYPE_INT:
+    case BinaryTypes.TYPE_SHORT:
+    case BinaryTypes.TYPE_BYTE:
+      return Integer.compare(value1.intValue(), ((Number) value2).intValue());
+
+    case BinaryTypes.TYPE_BOOLEAN:
+      return Integer.compare(value1.intValue(), (Boolean) value2 ? 1 : 0);
+
+    case BinaryTypes.TYPE_LONG:
+    case BinaryTypes.TYPE_DATETIME:
+    case BinaryTypes.TYPE_DATE:
+      return Long.compare(value1.longValue(), ((Number) value2).longValue());
+
+    case BinaryTypes.TYPE_DECIMAL:
+    case BinaryTypes.TYPE_FLOAT:
+    case BinaryTypes.TYPE_DOUBLE:
+      return Double.compare(value1.doubleValue(), ((Number) value2).doubleValue());
+
+    case BinaryTypes.TYPE_STRING: {
+      final String string = (String) value2;
+      // Widen to the precision the string's own format needs, so an integral string is compared without the
+      // precision loss a double round-trip would introduce for large longs.
+      if (string.indexOf('.') >= 0 || string.indexOf('e') >= 0 || string.indexOf('E') >= 0)
+        return Double.compare(value1.doubleValue(), Double.parseDouble(string));
+      return Long.compare(value1.longValue(), Long.parseLong(string));
+    }
+
+    default:
+      return -1;
+    }
   }
 
   public int compareBytes(final byte[] buffer1, final Binary buffer2) {

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -54,37 +54,11 @@ public class BinaryComparator {
       // antisymmetry every comparator must honour (issue #5900).
       return compareNarrowIntegral((Number) value1, type2, value2);
 
-    case BinaryTypes.TYPE_LONG: {
-      final long v1 = ((Number) value1).longValue();
-      final long v2;
-
-      switch (type2) {
-      case BinaryTypes.TYPE_INT:
-      case BinaryTypes.TYPE_SHORT:
-      case BinaryTypes.TYPE_LONG:
-      case BinaryTypes.TYPE_DATETIME:
-      case BinaryTypes.TYPE_DATE:
-      case BinaryTypes.TYPE_BYTE:
-      case BinaryTypes.TYPE_DECIMAL:
-      case BinaryTypes.TYPE_FLOAT:
-      case BinaryTypes.TYPE_DOUBLE:
-        v2 = ((Number) value2).longValue();
-        break;
-
-      case BinaryTypes.TYPE_BOOLEAN:
-        v2 = (Boolean) value2 ? 1 : 0;
-        break;
-
-      case BinaryTypes.TYPE_STRING:
-        v2 = Long.parseLong((String) value2);
-        break;
-
-      default:
-        return -1;
-      }
-
-      return Long.compare(v1, v2);
-    }
+    case BinaryTypes.TYPE_LONG:
+      // Same rationale as the INT/SHORT/BYTE case above: a fractional DECIMAL/FLOAT/DOUBLE narrowed via
+      // longValue() drops its fraction and can land on the wrong side of value1, the same antisymmetry bug
+      // with LONG as type1 instead (#5900 review follow-up).
+      return compareWideningLong((Number) value1, type2, value2);
 
     case BinaryTypes.TYPE_STRING: {
       if (value1 instanceof byte[] bytes1) {
@@ -98,7 +72,12 @@ public class BinaryComparator {
       return ((String) value1).compareTo(value2.toString());
     }
 
-    case BinaryTypes.TYPE_DOUBLE: {
+    case BinaryTypes.TYPE_DOUBLE:
+    case BinaryTypes.TYPE_FLOAT: {
+      // FLOAT always widens losslessly into double (the reverse direction is what loses precision), so both
+      // share this branch instead of FLOAT narrowing the other operand down to float's 24-bit mantissa - the
+      // same narrow-instead-of-widen bug as INT/SHORT/BYTE/LONG, just for the floating types (#5900 review
+      // follow-up).
       final double v1 = ((Number) value1).doubleValue();
       final double v2;
 
@@ -128,38 +107,6 @@ public class BinaryComparator {
       }
 
       return Double.compare(v1, v2);
-    }
-
-    case BinaryTypes.TYPE_FLOAT: {
-      final float v1 = ((Number) value1).floatValue();
-      final float v2;
-
-      switch (type2) {
-      case BinaryTypes.TYPE_INT:
-      case BinaryTypes.TYPE_SHORT:
-      case BinaryTypes.TYPE_LONG:
-      case BinaryTypes.TYPE_DATETIME:
-      case BinaryTypes.TYPE_DATE:
-      case BinaryTypes.TYPE_BYTE:
-      case BinaryTypes.TYPE_DECIMAL:
-      case BinaryTypes.TYPE_FLOAT:
-      case BinaryTypes.TYPE_DOUBLE:
-        v2 = ((Number) value2).floatValue();
-        break;
-
-      case BinaryTypes.TYPE_BOOLEAN:
-        v2 = (float) ((Boolean) value2 ? 1 : 0);
-        break;
-
-      case BinaryTypes.TYPE_STRING:
-        v2 = Float.parseFloat((String) value2);
-        break;
-
-      default:
-        return -1;
-      }
-
-      return Float.compare(v1, v2);
     }
 
     case BinaryTypes.TYPE_BOOLEAN: {
@@ -307,18 +254,56 @@ public class BinaryComparator {
     case BinaryTypes.TYPE_DOUBLE:
       return Double.compare(value1.doubleValue(), ((Number) value2).doubleValue());
 
-    case BinaryTypes.TYPE_STRING: {
-      final String string = (String) value2;
-      // Widen to the precision the string's own format needs, so an integral string is compared without the
-      // precision loss a double round-trip would introduce for large longs.
-      if (string.indexOf('.') >= 0 || string.indexOf('e') >= 0 || string.indexOf('E') >= 0)
-        return Double.compare(value1.doubleValue(), Double.parseDouble(string));
-      return Long.compare(value1.longValue(), Long.parseLong(string));
-    }
+    case BinaryTypes.TYPE_STRING:
+      return compareAgainstNumericString(value1, (String) value2);
 
     default:
       return -1;
     }
+  }
+
+  /**
+   * Shared comparison for a {@code value1} declared as {@code LONG} (or a timestamp type using the same
+   * {@code long} representation) against any {@code type2}. {@code INT}/{@code SHORT}/{@code BYTE} widen
+   * losslessly into {@code long} so they join the same-width bucket here, unlike in
+   * {@link #compareNarrowIntegral}; a {@code DECIMAL}/{@code FLOAT}/{@code DOUBLE} operand is promoted to
+   * {@code double} rather than narrowed via {@code longValue()}, which would silently drop its fraction.
+   */
+  private static int compareWideningLong(final Number value1, final byte type2, final Object value2) {
+    switch (type2) {
+    case BinaryTypes.TYPE_INT:
+    case BinaryTypes.TYPE_SHORT:
+    case BinaryTypes.TYPE_BYTE:
+    case BinaryTypes.TYPE_LONG:
+    case BinaryTypes.TYPE_DATETIME:
+    case BinaryTypes.TYPE_DATE:
+      return Long.compare(value1.longValue(), ((Number) value2).longValue());
+
+    case BinaryTypes.TYPE_BOOLEAN:
+      return Long.compare(value1.longValue(), (Boolean) value2 ? 1L : 0L);
+
+    case BinaryTypes.TYPE_DECIMAL:
+    case BinaryTypes.TYPE_FLOAT:
+    case BinaryTypes.TYPE_DOUBLE:
+      return Double.compare(value1.doubleValue(), ((Number) value2).doubleValue());
+
+    case BinaryTypes.TYPE_STRING:
+      return compareAgainstNumericString(value1, (String) value2);
+
+    default:
+      return -1;
+    }
+  }
+
+  /**
+   * Widens to whichever precision the string's own format needs - {@code double} for a fractional/exponent
+   * literal, {@code long} otherwise - so an integral string is compared without the precision loss a double
+   * round-trip would introduce for large longs, and a fractional string doesn't hard-fail a {@code long} parse.
+   */
+  private static int compareAgainstNumericString(final Number value1, final String string) {
+    if (string.indexOf('.') >= 0 || string.indexOf('e') >= 0 || string.indexOf('E') >= 0)
+      return Double.compare(value1.doubleValue(), Double.parseDouble(string));
+    return Long.compare(value1.longValue(), Long.parseLong(string));
   }
 
   public int compareBytes(final byte[] buffer1, final Binary buffer2) {

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -69,7 +69,24 @@ public class BinaryComparator {
               ((String) value2).getBytes(DatabaseFactory.getDefaultCharset()));
       }
 
-      return ((String) value1).compareTo(value2.toString());
+      switch (type2) {
+      case BinaryTypes.TYPE_INT:
+      case BinaryTypes.TYPE_SHORT:
+      case BinaryTypes.TYPE_BYTE:
+      case BinaryTypes.TYPE_LONG:
+      case BinaryTypes.TYPE_FLOAT:
+      case BinaryTypes.TYPE_DOUBLE:
+      case BinaryTypes.TYPE_DECIMAL:
+      case BinaryTypes.TYPE_BOOLEAN:
+        // A String value1 against a numeric/boolean value2 must agree with the reverse call - delegate to the
+        // numeric side's own widening comparator and negate, rather than falling through to a lexicographic
+        // compareTo() that silently ignores type2 and breaks antisymmetry the same way the narrowing branches
+        // did before this fix (e.g. compare("2", STRING, 10, INT) and its reverse both answered "greater").
+        return -compare(value2, type2, value1, type1);
+
+      default:
+        return ((String) value1).compareTo(value2.toString());
+      }
     }
 
     case BinaryTypes.TYPE_DOUBLE:

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5900ComparisonTypeMismatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5900ComparisonTypeMismatchTest.java
@@ -148,4 +148,95 @@ class Issue5900ComparisonTypeMismatchTest {
       }
     });
   }
+
+  /**
+   * Code review follow-up on PR #5922: an indexed column bypasses the row-scan operators entirely and pushes the
+   * bound straight into {@code FetchFromIndexStep}, which reached the index's own unguarded
+   * {@code convertKeys()}/{@code Type.convert()} - the identical crash through a very common trigger (any indexed
+   * comparison column), untouched by the row-scan fix above.
+   */
+  @Test
+  void lessThanNonNumericStringOnIndexedIntegerColumnDoesNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900LtIndexed", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n < 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n > 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n <= 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n >= 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void equalsNonNumericStringOnIndexedIntegerColumnDoesNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900EqIndexed", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n = 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void betweenWithNonNumericBoundOnIndexedIntegerColumnDoesNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900BetweenIndexed", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n between 1 and 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n between 'abc' and 100")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * Guard against over-fixing on the indexed path: valid, correctly-typed comparisons must still use the index
+   * and return the correct rows. Uses a typed {@code 15} rather than the numeric string {@code '15'} used by the
+   * non-indexed equivalent above: a numeric-string bound against an indexed column hits a separate, pre-existing
+   * bug where {@code LSMTreeIndexCursor}'s constructor compares the raw (unconverted) bound against an
+   * already-typed stored key and throws {@code ClassCastException} - reproduces identically on unmodified
+   * {@code main}, independent of this fix, and out of scope here (filed separately).
+   */
+  @Test
+  void validComparisonsOnIndexedIntegerColumnStillWork() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900ValidIndexed", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n < 15")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n = 10")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n between 5 and 15")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5900ComparisonTypeMismatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5900ComparisonTypeMismatchTest.java
@@ -190,6 +190,32 @@ class Issue5900ComparisonTypeMismatchTest {
     });
   }
 
+  /**
+   * Code review follow-up on PR #5922: {@code createCursor()} returning {@code null} for a failed conversion is
+   * only safe if every caller checks for it. The multi-value branch of {@code processInCondition()} stored the
+   * per-item cursor unconditionally and wrapped it in a sub-iterator that called {@code hasNext()}/{@code close()}
+   * on it without a null check, so a mixed-type IN list against an indexed column traded the original
+   * {@code NumberFormatException} for a {@code NullPointerException} instead of actually fixing the crash.
+   */
+  @Test
+  void inListWithNonNumericItemOnIndexedIntegerColumnDoesNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900InIndexed", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n in [10, 'abc']")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n in ['abc', 'def']")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
   @Test
   void betweenWithNonNumericBoundOnIndexedIntegerColumnDoesNotThrow() throws Exception {
     TestHelper.executeInNewDatabase("testIssue5900BetweenIndexed", db -> {

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5900ComparisonTypeMismatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5900ComparisonTypeMismatchTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for issue #5900. A range comparison ({@code <}, {@code >}, {@code <=}, {@code >=}, {@code BETWEEN})
+ * between a numeric column and a non-numeric String literal (e.g. {@code WHERE n < 'abc'} on an {@code INTEGER}
+ * column) escaped as a raw {@link NumberFormatException} from {@link Type#convert}, crashing the query instead of
+ * completing. Equality already handled this gracefully ({@link QueryOperatorEquals} catches the conversion failure
+ * and answers "not equal"); the range operators and BETWEEN did not have the same guard. A comparison across
+ * incompatible types has no defined ordering, so - consistent with equality and with the Cypher engine's
+ * established behaviour for the analogous case (#5225) - it must answer "no match" rather than throw.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5900ComparisonTypeMismatchTest {
+
+  @Test
+  void lessThanNonNumericStringOnIntegerColumnDoesNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900LtInt", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.newDocument("V").set("n", 10).save();
+
+      assertThatCode(() -> {
+        try (final ResultSet rs = db.query("sql", "select n from V where n < 'abc'")) {
+          assertThat(rs.hasNext()).isFalse();
+        }
+      }).doesNotThrowAnyException();
+    });
+  }
+
+  @Test
+  void greaterThanNonNumericStringOnIntegerColumnDoesNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900GtInt", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.newDocument("V").set("n", 10).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n > 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void lessOrEqualAndGreaterOrEqualNonNumericStringDoNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900LeGeInt", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.newDocument("V").set("n", 10).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n <= 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n >= 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void betweenWithNonNumericBoundDoesNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900Between", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.newDocument("V").set("n", 10).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n between 1 and 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select n from V where n between 'abc' and 100")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void shortAndByteTypedPropertiesAlsoDoNotThrow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900ShortByte", db -> {
+      final var type = db.getSchema().createDocumentType("V");
+      type.createProperty("s", Type.SHORT);
+      type.createProperty("b", Type.BYTE);
+      db.newDocument("V").set("s", (short) 10).set("b", (byte) 5).save();
+
+      try (final ResultSet rs = db.query("sql", "select s from V where s < 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select b from V where b > 'abc'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * Guard against over-fixing: a numeric-valued String must still parse and compare correctly.
+   */
+  @Test
+  void validNumericStringComparisonsStillWork() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900ValidStringCompare", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n < '15'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * Guard against over-fixing: an INT column compared against a LONG literal outside int range must still widen
+   * correctly and return the right rows (this already worked before the fix, per the issue's own report).
+   */
+  @Test
+  void intColumnComparedAgainstOutOfRangeLongLiteralStillCorrect() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5900IntVsLong", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.newDocument("V").set("n", 10).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n < 2147483648")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.serializer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5900. When the first operand's declared type is {@code INT}, {@code SHORT} or
+ * {@code BYTE}, {@link BinaryComparator#compare(Object, byte, Object, byte)} narrowed the <em>other</em> operand
+ * down to that same width instead of widening, which breaks the antisymmetry every {@code Comparator} must honour
+ * ({@code sgn(compare(a,b)) == -sgn(compare(b,a))}): a {@code Long} outside {@code int} range truncated via
+ * {@code intValue()} could land anywhere, including on the wrong side of a small {@code int}. The {@code SHORT}
+ * and {@code BYTE} branches had the same defect, and more aggressively, since they also narrowed a same-or-wider
+ * {@code INT} operand down to their own width.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BinaryComparatorNarrowingTest {
+  private final BinaryComparator comparator = new BinaryComparator();
+
+  @Test
+  void intVersusOutOfRangeLongIsAntisymmetric() {
+    final int smallInt = -5;
+    final long bigLong = 2147483648L; // Integer.MAX_VALUE + 1, truncates to Integer.MIN_VALUE via intValue()
+
+    final int forward = comparator.compare(smallInt, BinaryTypes.TYPE_INT, bigLong, BinaryTypes.TYPE_LONG);
+    final int backward = comparator.compare(bigLong, BinaryTypes.TYPE_LONG, smallInt, BinaryTypes.TYPE_INT);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    // -5 is unambiguously less than 2147483648
+    assertThat(forward).isLessThan(0);
+    assertThat(backward).isGreaterThan(0);
+  }
+
+  @Test
+  void shortVersusOutOfRangeIntIsAntisymmetricAndNotTruncated() {
+    final short smallShort = 1;
+    final int bigInt = 100_000; // outside short range, would truncate to a small/negative short
+
+    final int forward = comparator.compare(smallShort, BinaryTypes.TYPE_SHORT, bigInt, BinaryTypes.TYPE_INT);
+    final int backward = comparator.compare(bigInt, BinaryTypes.TYPE_INT, smallShort, BinaryTypes.TYPE_SHORT);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    assertThat(forward).isLessThan(0);
+    assertThat(backward).isGreaterThan(0);
+  }
+
+  @Test
+  void byteVersusOutOfRangeIntIsAntisymmetricAndNotTruncated() {
+    final byte smallByte = 1;
+    final int bigInt = 1_000; // outside byte range
+
+    final int forward = comparator.compare(smallByte, BinaryTypes.TYPE_BYTE, bigInt, BinaryTypes.TYPE_INT);
+    final int backward = comparator.compare(bigInt, BinaryTypes.TYPE_INT, smallByte, BinaryTypes.TYPE_BYTE);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    assertThat(forward).isLessThan(0);
+    assertThat(backward).isGreaterThan(0);
+  }
+
+  @Test
+  void intVersusDoubleDoesNotTruncateTheDouble() {
+    final int smallInt = 0;
+    final double fractional = 0.5;
+
+    // 0 < 0.5, but the old code truncated 0.5 to 0 via intValue(), making them appear equal
+    assertThat(comparator.compare(smallInt, BinaryTypes.TYPE_INT, fractional, BinaryTypes.TYPE_DOUBLE)).isLessThan(0);
+    assertThat(comparator.compare(fractional, BinaryTypes.TYPE_DOUBLE, smallInt, BinaryTypes.TYPE_INT)).isGreaterThan(0);
+  }
+
+  @Test
+  void sameWidthAndBooleanComparisonsAreUnaffected() {
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, 5, BinaryTypes.TYPE_INT)).isZero();
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, 10, BinaryTypes.TYPE_INT)).isLessThan(0);
+    assertThat(comparator.compare((short) 5, BinaryTypes.TYPE_SHORT, (short) 5, BinaryTypes.TYPE_SHORT)).isZero();
+    assertThat(comparator.compare((byte) 5, BinaryTypes.TYPE_BYTE, (byte) 5, BinaryTypes.TYPE_BYTE)).isZero();
+    assertThat(comparator.compare(1, BinaryTypes.TYPE_INT, true, BinaryTypes.TYPE_BOOLEAN)).isZero();
+    assertThat(comparator.compare(0, BinaryTypes.TYPE_INT, true, BinaryTypes.TYPE_BOOLEAN)).isLessThan(0);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
@@ -95,4 +95,41 @@ class BinaryComparatorNarrowingTest {
     assertThat(comparator.compare(1, BinaryTypes.TYPE_INT, true, BinaryTypes.TYPE_BOOLEAN)).isZero();
     assertThat(comparator.compare(0, BinaryTypes.TYPE_INT, true, BinaryTypes.TYPE_BOOLEAN)).isLessThan(0);
   }
+
+  /**
+   * The String branch of {@code compareNarrowIntegral} widens to {@code long} or {@code double} depending on
+   * whether the string looks fractional, rather than always narrowing to {@code value1}'s own width.
+   */
+  @Test
+  void intVersusNumericStringWidensRatherThanNarrows() {
+    // Outside int range: the old Integer.parseInt() would have thrown; must parse and compare as a long instead.
+    assertThat(comparator.compare(0, BinaryTypes.TYPE_INT, "5000000000", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(0, BinaryTypes.TYPE_INT, "-5000000000", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+
+    // Fractional string: must parse and compare as a double, not truncate to an integral comparison.
+    assertThat(comparator.compare(0, BinaryTypes.TYPE_INT, "0.5", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(1, BinaryTypes.TYPE_INT, "0.5", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+
+    // Ordinary in-range integral string: unaffected by the widening change.
+    assertThat(comparator.compare(10, BinaryTypes.TYPE_INT, "15", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(10, BinaryTypes.TYPE_INT, "10", BinaryTypes.TYPE_STRING)).isZero();
+  }
+
+  /**
+   * The {@code TYPE_BOOLEAN} branch had the identical narrow-to-byte defect as the pre-fix INT/SHORT/BYTE
+   * branches, just unnoticed because it is even less likely to be exercised. Fixed by routing through the same
+   * {@code compareNarrowIntegral} helper.
+   */
+  @Test
+  void booleanVersusOutOfByteRangeNumberIsAntisymmetricAndNotTruncated() {
+    final boolean trueValue = true; // widens to 1
+    final int bigInt = 1000; // outside byte range; would truncate to a small/negative byte
+
+    final int forward = comparator.compare(trueValue, BinaryTypes.TYPE_BOOLEAN, bigInt, BinaryTypes.TYPE_INT);
+    final int backward = comparator.compare(bigInt, BinaryTypes.TYPE_INT, trueValue, BinaryTypes.TYPE_BOOLEAN);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    assertThat(forward).isLessThan(0);
+    assertThat(backward).isGreaterThan(0);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
@@ -132,4 +132,47 @@ class BinaryComparatorNarrowingTest {
     assertThat(forward).isLessThan(0);
     assertThat(backward).isGreaterThan(0);
   }
+
+  /**
+   * {@code TYPE_LONG} had the identical narrow-instead-of-widen defect as the pre-fix INT/SHORT/BYTE branches:
+   * a fractional {@code Double} narrowed via {@code longValue()} silently drops its fraction, which can make an
+   * unequal pair compare equal, or land on the wrong side (review follow-up on PR #5922).
+   */
+  @Test
+  void longVersusFractionalDoubleIsAntisymmetricAndNotTruncated() {
+    final long five = 5L;
+    final double fiveAndAHalf = 5.5;
+
+    // Before the fix: both directions truncated 5.5 to 5L and answered "equal".
+    assertThat(comparator.compare(five, BinaryTypes.TYPE_LONG, fiveAndAHalf, BinaryTypes.TYPE_DOUBLE)).isLessThan(0);
+    assertThat(comparator.compare(fiveAndAHalf, BinaryTypes.TYPE_DOUBLE, five, BinaryTypes.TYPE_LONG)).isGreaterThan(0);
+  }
+
+  /**
+   * {@code LONG} vs a fractional numeric {@code String} must widen to {@code double} rather than hard-fail
+   * {@code Long.parseLong} on the decimal point.
+   */
+  @Test
+  void longVersusFractionalStringWidensRatherThanThrows() {
+    assertThat(comparator.compare(5L, BinaryTypes.TYPE_LONG, "5.5", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(6L, BinaryTypes.TYPE_LONG, "5.5", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    // Out-of-int-range integral string must still compare as a long, not double-round-trip.
+    assertThat(comparator.compare(5_000_000_001L, BinaryTypes.TYPE_LONG, "5000000000", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+  }
+
+  /**
+   * {@code TYPE_FLOAT} narrowed a wider/more precise operand (a {@code Long} outside float's 24-bit mantissa, or
+   * a {@code Double}) down to {@code float} instead of widening itself to {@code double} - the same bug shape,
+   * lower severity (review follow-up on PR #5922). Fixed by merging FLOAT into DOUBLE's branch.
+   */
+  @Test
+  void floatVersusPreciseDoubleAndLongIsNotTruncated() {
+    // A double that differs from its nearest float only in the low mantissa bits: narrowing to float would
+    // collapse the two values to the same float and answer "equal".
+    final float asFloat = 16_777_217f; // rounds to 16777216f as a float (2^24 + 1 is not exactly representable)
+    final double precise = 16_777_217.0; // exactly representable as a double
+
+    assertThat(comparator.compare(asFloat, BinaryTypes.TYPE_FLOAT, precise, BinaryTypes.TYPE_DOUBLE)).isLessThan(0);
+    assertThat(comparator.compare(precise, BinaryTypes.TYPE_DOUBLE, asFloat, BinaryTypes.TYPE_FLOAT)).isGreaterThan(0);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
@@ -175,4 +175,48 @@ class BinaryComparatorNarrowingTest {
     assertThat(comparator.compare(asFloat, BinaryTypes.TYPE_FLOAT, precise, BinaryTypes.TYPE_DOUBLE)).isLessThan(0);
     assertThat(comparator.compare(precise, BinaryTypes.TYPE_DOUBLE, asFloat, BinaryTypes.TYPE_FLOAT)).isGreaterThan(0);
   }
+
+  /**
+   * {@code TYPE_STRING} as {@code type1} did an unconditional lexicographic {@code compareTo()} regardless of
+   * {@code type2}, ignoring the numeric comparator every other branch in this class now uses - the same
+   * antisymmetry bug this class was fixed for, just with the String on the other side (review follow-up on
+   * PR #5922). {@code "2".compareTo("10")} is positive (lexicographic), while the numeric {@code 10 vs 2} is also
+   * positive, so both directions of the same comparison used to agree "greater".
+   */
+  @Test
+  void stringVersusNumericIsAntisymmetric() {
+    final int forward = comparator.compare("2", BinaryTypes.TYPE_STRING, 10, BinaryTypes.TYPE_INT);
+    final int backward = comparator.compare(10, BinaryTypes.TYPE_INT, "2", BinaryTypes.TYPE_STRING);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    // 2 is numerically less than 10, even though "2" > "10" lexicographically.
+    assertThat(forward).isLessThan(0);
+    assertThat(backward).isGreaterThan(0);
+  }
+
+  /**
+   * Guard against over-fixing: a String compared against another String must still use lexicographic ordering,
+   * not fall into the new numeric-delegation branch.
+   */
+  @Test
+  void stringVersusStringStillLexicographic() {
+    assertThat(comparator.compare("2", BinaryTypes.TYPE_STRING, "10", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    assertThat(comparator.compare("abc", BinaryTypes.TYPE_STRING, "abd", BinaryTypes.TYPE_STRING)).isLessThan(0);
+  }
+
+  /**
+   * Guard against over-fixing: a numeric-valued String compared against a number must still resolve correctly in
+   * both directions, and a non-numeric String against a number/boolean routes through the numeric side's
+   * unguarded parse (consistent with every other branch in this class - #5900's SQL-level fix is what guards the
+   * query engine against that, not this low-level comparator).
+   */
+  @Test
+  void stringVersusBooleanIsAntisymmetric() {
+    final int forward = comparator.compare("false", BinaryTypes.TYPE_STRING, true, BinaryTypes.TYPE_BOOLEAN);
+    final int backward = comparator.compare(true, BinaryTypes.TYPE_BOOLEAN, "false", BinaryTypes.TYPE_STRING);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    assertThat(forward).isLessThan(0);
+    assertThat(backward).isGreaterThan(0);
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #5900. Two related defects:

1. **`BinaryComparator.compare()` narrowed the wider operand.** When the first operand's declared type was `INT`, `SHORT` or `BYTE`, the *other* operand was narrowed to that same width instead of widened (e.g. a `Long` outside `int` range truncated via `intValue()`, a fractional `Double` truncated via `intValue()`). This breaks the antisymmetry every comparator must satisfy: `compare(-5, INT, 2147483648L, LONG)` and its reverse both returned "greater". The `SHORT`/`BYTE` branches were copy-pasted from the same pattern and were even more aggressive, narrowing a same-or-wider `INT` operand down to their own width too. Fixed by widening to whichever precision the other operand actually needs, and consolidated the three duplicated branches into one helper (`compareNarrowIntegral`) so the same bug can't be reintroduced in only one of them again.

2. **`<`, `>`, `<=`, `>=`, and `BETWEEN` crashed on a type-mismatched comparison.** `SELECT n FROM V WHERE n < 'abc'` on an `INTEGER` column threw a raw `NumberFormatException` from `Type.convert()`, with no local guard. `=` already treated a failed conversion as "not equal" (see `QueryOperatorEquals`); the range operators and `BETWEEN` now follow the same established convention and answer "no match" for a comparison that has no defined ordering, instead of letting the exception escape the query.

## Root cause note

The demonstrated SQL crash's actual throw site is `Type.convert()` (via `LtOperator`/`GtOperator`/`LeOperator`/`GeOperator`/`BetweenCondition`), not `BinaryComparator.compare()` itself - `BinaryComparator.compare(Object,byte,Object,byte)` is currently only invoked from the LSM index hot path (`LSMTreeIndexAbstract`), always with matching types after key normalization, so its narrowing branches were live but unreachable via SQL today. Both defects are fixed since the comparator's own contract violation is real and the class is general-purpose public API.

## Testing

- `engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java` - direct unit tests proving antisymmetry across INT/LONG, SHORT/INT, BYTE/INT and INT/DOUBLE pairs, plus a same-width/boolean regression guard.
- `engine/src/test/java/com/arcadedb/query/sql/parser/Issue5900ComparisonTypeMismatchTest.java` - end-to-end SQL regression: `<`, `>`, `<=`, `>=`, `BETWEEN` against a non-numeric String bound on `INTEGER`/`SHORT`/`BYTE` columns no longer throw; valid numeric-string comparisons and existing int-vs-out-of-range-long comparisons still return correct results.
- Full `engine` module regression run: OpenCypher suite (11979 tests) and index/executor suite (10593 tests) both pass with zero new failures (one pre-existing, unrelated failure in `CreatePropertyStatementExecutionTest.createHiddenProperty` reproduces identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)