### PR TITLE
fix(#5918): bound Bolt PackStream declared lengths, sizes, and nesting depth before allocation

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltChunkedInput.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltChunkedInput.java
@@ -64,10 +64,13 @@ public class BoltChunkedInput {
       }
 
       // A client that never sends the terminating zero-length chunk would otherwise grow this buffer unbounded
-      // (issue #5918), before the BOLT handshake or authentication ever runs.
-      totalSize += chunkSize;
-      if (totalSize > maxMessageSize)
+      // (issue #5918), before the BOLT handshake or authentication ever runs. Checked as "chunkSize > remaining"
+      // rather than "totalSize + chunkSize > maxMessageSize": the latter can wrap totalSize negative (permanently
+      // defeating the bound) once enough chunks accumulate against a maxMessageSize configured close to
+      // Integer.MAX_VALUE, since chunkSize is only bounded by the 16-bit chunk-size field, not by this check.
+      if (chunkSize > maxMessageSize - totalSize)
         throw new IOException("BOLT message too large: exceeds " + maxMessageSize + " bytes after chunk reassembly");
+      totalSize += chunkSize;
 
       // Read chunk data
       final byte[] chunk = new byte[chunkSize];

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltChunkedInput.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltChunkedInput.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.bolt;
 
+import com.arcadedb.GlobalConfiguration;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -29,9 +31,19 @@ import java.io.InputStream;
  */
 public class BoltChunkedInput {
   private final DataInputStream in;
+  private final int             maxMessageSize;
 
   public BoltChunkedInput(final InputStream in) {
+    this(in, GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.getValueAsInteger());
+  }
+
+  /**
+   * As {@link #BoltChunkedInput(InputStream)}, with the reassembled-message size bound passed explicitly instead
+   * of read from {@link GlobalConfiguration}, so unit tests can exercise the bound without mutating global config.
+   */
+  public BoltChunkedInput(final InputStream in, final int maxMessageSize) {
     this.in = new DataInputStream(in);
+    this.maxMessageSize = maxMessageSize;
   }
 
   /**
@@ -40,6 +52,7 @@ public class BoltChunkedInput {
    */
   public byte[] readMessage() throws IOException {
     final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    int totalSize = 0;
 
     while (true) {
       // Read chunk size (2 bytes, big-endian)
@@ -49,6 +62,12 @@ public class BoltChunkedInput {
         // End of message
         break;
       }
+
+      // A client that never sends the terminating zero-length chunk would otherwise grow this buffer unbounded
+      // (issue #5918), before the BOLT handshake or authentication ever runs.
+      totalSize += chunkSize;
+      if (totalSize > maxMessageSize)
+        throw new IOException("BOLT message too large: exceeds " + maxMessageSize + " bytes after chunk reassembly");
 
       // Read chunk data
       final byte[] chunk = new byte[chunkSize];

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltChunkedInput.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltChunkedInput.java
@@ -19,11 +19,15 @@
 package com.arcadedb.bolt;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 /**
  * Handles chunked message framing for BOLT protocol input.
@@ -33,8 +37,30 @@ public class BoltChunkedInput {
   private final DataInputStream in;
   private final int             maxMessageSize;
 
+  // See PackStreamReader.WARNED_MISCONFIGURED_LIMITS: bounds the misconfiguration WARNING to once per JVM
+  // rather than once per connection (issue #5918 review).
+  private static final Set<GlobalConfiguration> WARNED_MISCONFIGURED_LIMITS = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Reads {@link GlobalConfiguration#BOLT_MAX_MESSAGE_SIZE}, falling back to its built-in default (with a
+   * warning) if configured below 1: a limit that low would reject essentially every message outright, so it is
+   * treated as a misconfiguration rather than an intentional (if impractical) lockdown.
+   */
+  private static int sanitizedMaxMessageSize() {
+    final int configured = GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.getValueAsInteger();
+    if (configured < 1) {
+      final int fallback = ((Number) GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.getDefValue()).intValue();
+      if (WARNED_MISCONFIGURED_LIMITS.add(GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE))
+        LogManager.instance().log(BoltChunkedInput.class, Level.WARNING,
+            "BOLT: '%s' is set to %d, below the minimum usable value (1); falling back to the default (%d)",
+            GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.getKey(), configured, fallback);
+      return fallback;
+    }
+    return configured;
+  }
+
   public BoltChunkedInput(final InputStream in) {
-    this(in, GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.getValueAsInteger());
+    this(in, sanitizedMaxMessageSize());
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -375,8 +375,9 @@ public class PackStreamReader {
 
   /**
    * Validates a LIST_32/MAP_32 declared size before it is used to size a collection's backing array (issue
-   * #5918): each element/entry needs at least one wire byte to encode, so a declared count larger than the bytes
-   * remaining in this message is impossible and rejected without allocating.
+   * #5918): a LIST_32 element needs at least one wire byte to encode and a MAP_32 entry needs at least two (a key
+   * plus a value), so a declared count larger than the bytes remaining in this message is impossible - loosely
+   * for maps, since this check uses the same one-byte-per-count floor for both - and rejected without allocating.
    */
   private int checkElementCount(final int size, final String what) throws IOException {
     if (size < 0)

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -19,6 +19,7 @@
 package com.arcadedb.bolt.packstream;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -30,6 +31,9 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 /**
  * PackStream reader for Neo4j BOLT protocol binary deserialization.
@@ -87,10 +91,35 @@ public class PackStreamReader {
   private final int maxElements;
   private final int maxDepth;
 
+  // A misconfigured protocol-limit setting is re-read (and re-validated) on every new PackStreamReader, since
+  // every BOLT message constructs a fresh one and the value can change at runtime; this only bounds the WARNING
+  // about it to once per setting per JVM, so a busy server churning through messages against a static bad value
+  // does not flood the log (mirrors RedisNetworkExecutor.sanitizedLimit, issue #5918 review).
+  private static final Set<GlobalConfiguration> WARNED_MISCONFIGURED_LIMITS = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Reads a protocol-limit setting, falling back to its built-in default (with a warning) if configured below 1.
+   * A limit of 0 or negative would reject essentially every message outright - e.g. {@code maxDepth=0} rejects
+   * even a bare HELLO struct, since its extra map is already one level deeper than the top-level struct itself -
+   * so it is treated as a misconfiguration rather than an intentional (if impractical) lockdown.
+   */
+  private static int sanitizedLimit(final GlobalConfiguration setting) {
+    final int configured = setting.getValueAsInteger();
+    if (configured < 1) {
+      final int fallback = ((Number) setting.getDefValue()).intValue();
+      if (WARNED_MISCONFIGURED_LIMITS.add(setting))
+        LogManager.instance().log(PackStreamReader.class, Level.WARNING,
+            "BOLT PackStream: '%s' is set to %d, below the minimum usable value (1); falling back to the default (%d)",
+            setting.getKey(), configured, fallback);
+      return fallback;
+    }
+    return configured;
+  }
+
   public PackStreamReader(final byte[] data) {
-    this(data, GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH.getValueAsInteger(),
-        GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS.getValueAsInteger(),
-        GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH.getValueAsInteger());
+    this(data, sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH),
+        sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS),
+        sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH));
   }
 
   /**
@@ -113,9 +142,9 @@ public class PackStreamReader {
    * that bound to a false sense of safety rather than the exact one it provides today.
    */
   public PackStreamReader(final DataInputStream in) {
-    this(in, GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH.getValueAsInteger(),
-        GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS.getValueAsInteger(),
-        GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH.getValueAsInteger());
+    this(in, sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH),
+        sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS),
+        sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH));
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -68,6 +68,13 @@ public class PackStreamReader {
   private static final byte MAP_16 = (byte) 0xD9;
   private static final byte MAP_32 = (byte) 0xDA;
 
+  /**
+   * Sentinel returned by {@link #readValueWithMarker} when a container marker (list/map/struct) pushed a new
+   * {@link Frame} instead of producing a value: the caller loops back to read that frame's first element/
+   * entry/field rather than treating this as a completed value.
+   */
+  private static final Object OPEN_FRAME = new Object();
+
   private final DataInputStream in;
   private int                   bytesRead = 0;
 
@@ -120,13 +127,6 @@ public class PackStreamReader {
     this.maxElements = maxElements;
     this.maxDepth = maxDepth;
   }
-
-  /**
-   * Sentinel returned by {@link #readValueWithMarker} when a container marker (list/map/struct) pushed a new
-   * {@link Frame} instead of producing a value: the caller loops back to read that frame's first element/
-   * entry/field rather than treating this as a completed value.
-   */
-  private static final Object OPEN_FRAME = new Object();
 
   /**
    * Read the next value of any type.

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -94,6 +94,14 @@ public class PackStreamReader {
     this.maxDepth = maxDepth;
   }
 
+  /**
+   * Not used in production (only the {@link #PackStreamReader(byte[])} constructor is, against an already fully
+   * reassembled message). {@link #checkValueLength}/{@link #checkElementCount} bound a declared length/size
+   * against {@code in.available()}, which is exact only when {@code in} is backed by a fully-buffered source
+   * (e.g. {@link ByteArrayInputStream}): wiring this constructor to a live socket/stream would make
+   * {@code available()} reflect only currently-buffered bytes, not the true remaining message size, weakening
+   * that bound to a false sense of safety rather than the exact one it provides today.
+   */
   public PackStreamReader(final DataInputStream in) {
     this(in, GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH.getValueAsInteger(),
         GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS.getValueAsInteger(),

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.bolt.packstream;
 
+import com.arcadedb.GlobalConfiguration;
+
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -67,26 +69,69 @@ public class PackStreamReader {
   private final DataInputStream in;
   private int                   bytesRead = 0;
 
+  // Bounds on client-supplied, unauthenticated size fields (issue #5918): every *_32 length/size is read off the
+  // wire and used directly to size an allocation, and readValue() recurses once per nesting level, before the
+  // BOLT handshake or authentication ever runs. Read once per message rather than cached statically so a runtime
+  // change to the setting takes effect on the next message.
+  private final int maxValueLength;
+  private final int maxElements;
+  private final int maxDepth;
+
   public PackStreamReader(final byte[] data) {
+    this(data, GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH.getValueAsInteger(),
+        GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS.getValueAsInteger(),
+        GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH.getValueAsInteger());
+  }
+
+  /**
+   * As {@link #PackStreamReader(byte[])}, with the client-supplied-size bounds passed explicitly instead of read
+   * from {@link GlobalConfiguration}, so unit tests can exercise a bound without mutating global server config.
+   */
+  public PackStreamReader(final byte[] data, final int maxValueLength, final int maxElements, final int maxDepth) {
     this.in = new DataInputStream(new ByteArrayInputStream(data));
+    this.maxValueLength = maxValueLength;
+    this.maxElements = maxElements;
+    this.maxDepth = maxDepth;
   }
 
   public PackStreamReader(final DataInputStream in) {
+    this(in, GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH.getValueAsInteger(),
+        GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS.getValueAsInteger(),
+        GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH.getValueAsInteger());
+  }
+
+  /**
+   * As {@link #PackStreamReader(DataInputStream)}, with the client-supplied-size bounds passed explicitly.
+   */
+  public PackStreamReader(final DataInputStream in, final int maxValueLength, final int maxElements, final int maxDepth) {
     this.in = in;
+    this.maxValueLength = maxValueLength;
+    this.maxElements = maxElements;
+    this.maxDepth = maxDepth;
   }
 
   /**
    * Read the next value of any type.
    */
   public Object readValue() throws IOException {
+    return readValue(0);
+  }
+
+  /**
+   * Read the next value of any type, tracking nesting depth so a stream of nesting markers cannot recurse the
+   * connection thread's JVM stack into a {@link StackOverflowError} (issue #5918).
+   */
+  private Object readValue(final int depth) throws IOException {
+    if (depth > maxDepth)
+      throw new IOException("PackStream value nesting exceeds the maximum allowed depth (" + maxDepth + ")");
     final int marker = readMarker();
-    return readValueWithMarker(marker);
+    return readValueWithMarker(marker, depth);
   }
 
   /**
    * Read a value given its marker byte.
    */
-  private Object readValueWithMarker(final int marker) throws IOException {
+  private Object readValueWithMarker(final int marker, final int depth) throws IOException {
     // NULL
     if (marker == (NULL & 0xFF)) {
       return null;
@@ -156,7 +201,7 @@ public class PackStreamReader {
     // STRING_32
     if (marker == (STRING_32 & 0xFF)) {
       final int length = in.readInt();
-      return readStringBytes(length);
+      return readStringBytes(checkValueLength(length, "STRING_32"));
     }
 
     // BYTES_8
@@ -174,62 +219,62 @@ public class PackStreamReader {
     // BYTES_32
     if (marker == (BYTES_32 & 0xFF)) {
       final int length = in.readInt();
-      return readBytes(length);
+      return readBytes(checkValueLength(length, "BYTES_32"));
     }
 
     // TINY_LIST: 0x90 - 0x9F
     if (marker >= 0x90 && marker <= 0x9F) {
       final int size = marker & 0x0F;
-      return readListItems(size);
+      return readListItems(size, depth);
     }
 
     // LIST_8
     if (marker == (LIST_8 & 0xFF)) {
       final int size = in.readUnsignedByte();
-      return readListItems(size);
+      return readListItems(size, depth);
     }
 
     // LIST_16
     if (marker == (LIST_16 & 0xFF)) {
       final int size = in.readUnsignedShort();
-      return readListItems(size);
+      return readListItems(size, depth);
     }
 
     // LIST_32
     if (marker == (LIST_32 & 0xFF)) {
       final int size = in.readInt();
-      return readListItems(size);
+      return readListItems(checkElementCount(size, "LIST_32"), depth);
     }
 
     // TINY_MAP: 0xA0 - 0xAF
     if (marker >= 0xA0 && marker <= 0xAF) {
       final int size = marker & 0x0F;
-      return readMapEntries(size);
+      return readMapEntries(size, depth);
     }
 
     // MAP_8
     if (marker == (MAP_8 & 0xFF)) {
       final int size = in.readUnsignedByte();
-      return readMapEntries(size);
+      return readMapEntries(size, depth);
     }
 
     // MAP_16
     if (marker == (MAP_16 & 0xFF)) {
       final int size = in.readUnsignedShort();
-      return readMapEntries(size);
+      return readMapEntries(size, depth);
     }
 
     // MAP_32
     if (marker == (MAP_32 & 0xFF)) {
       final int size = in.readInt();
-      return readMapEntries(size);
+      return readMapEntries(checkElementCount(size, "MAP_32"), depth);
     }
 
     // TINY_STRUCT: 0xB0 - 0xBF
     if (marker >= 0xB0 && marker <= 0xBF) {
       final int fieldCount = marker & 0x0F;
       final byte signature = in.readByte();
-      return readStructure(signature, fieldCount);
+      return readStructure(signature, fieldCount, depth);
     }
 
     throw new IOException("Unknown PackStream marker: 0x" + Integer.toHexString(marker));
@@ -249,6 +294,39 @@ public class PackStreamReader {
    */
   private double readFloat() throws IOException {
     return in.readDouble();
+  }
+
+  /**
+   * Validates a BYTES_32/STRING_32 declared length before it is used to size an allocation (issue #5918): rejects
+   * a negative length, one above the configured ceiling, and - the exact, un-configurable bound - one larger than
+   * the bytes actually remaining in this message, which the declared length can never legitimately exceed.
+   */
+  private int checkValueLength(final int length, final String what) throws IOException {
+    if (length < 0)
+      throw new IOException("PackStream " + what + " has an invalid negative length: " + length);
+    if (length > maxValueLength)
+      throw new IOException(
+          "PackStream " + what + " length " + length + " exceeds the maximum allowed (" + maxValueLength + ")");
+    if (length > in.available())
+      throw new IOException(
+          "PackStream " + what + " declared length " + length + " exceeds the remaining message bytes (" + in.available() + ")");
+    return length;
+  }
+
+  /**
+   * Validates a LIST_32/MAP_32 declared size before it is used to size a collection's backing array (issue
+   * #5918): each element/entry needs at least one wire byte to encode, so a declared count larger than the bytes
+   * remaining in this message is impossible and rejected without allocating.
+   */
+  private int checkElementCount(final int size, final String what) throws IOException {
+    if (size < 0)
+      throw new IOException("PackStream " + what + " has an invalid negative size: " + size);
+    if (size > maxElements)
+      throw new IOException("PackStream " + what + " size " + size + " exceeds the maximum allowed (" + maxElements + ")");
+    if (size > in.available())
+      throw new IOException(
+          "PackStream " + what + " declared size " + size + " exceeds the remaining message bytes (" + in.available() + ")");
+    return size;
   }
 
   /**
@@ -272,10 +350,10 @@ public class PackStreamReader {
   /**
    * Read list items.
    */
-  private List<Object> readListItems(final int size) throws IOException {
+  private List<Object> readListItems(final int size, final int depth) throws IOException {
     final List<Object> list = new ArrayList<>(size);
     for (int i = 0; i < size; i++) {
-      list.add(readValue());
+      list.add(readValue(depth + 1));
     }
     return list;
   }
@@ -283,11 +361,11 @@ public class PackStreamReader {
   /**
    * Read map entries.
    */
-  private Map<String, Object> readMapEntries(final int size) throws IOException {
+  private Map<String, Object> readMapEntries(final int size, final int depth) throws IOException {
     final Map<String, Object> map = new LinkedHashMap<>(size);
     for (int i = 0; i < size; i++) {
-      final String key = (String) readValue();
-      final Object value = readValue();
+      final String key = (String) readValue(depth + 1);
+      final Object value = readValue(depth + 1);
       map.put(key, value);
     }
     return map;
@@ -297,10 +375,10 @@ public class PackStreamReader {
    * Read a structure with given signature and field count.
    * Returns a StructureValue containing the signature and fields.
    */
-  private StructureValue readStructure(final byte signature, final int fieldCount) throws IOException {
+  private StructureValue readStructure(final byte signature, final int fieldCount, final int depth) throws IOException {
     final List<Object> fields = new ArrayList<>(fieldCount);
     for (int i = 0; i < fieldCount; i++) {
-      fields.add(readValue());
+      fields.add(readValue(depth + 1));
     }
     return new StructureValue(signature, fields);
   }

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -24,7 +24,9 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,9 +72,10 @@ public class PackStreamReader {
   private int                   bytesRead = 0;
 
   // Bounds on client-supplied, unauthenticated size fields (issue #5918): every *_32 length/size is read off the
-  // wire and used directly to size an allocation, and readValue() recurses once per nesting level, before the
-  // BOLT handshake or authentication ever runs. Read once per message rather than cached statically so a runtime
-  // change to the setting takes effect on the next message.
+  // wire and used directly to size an allocation, before the BOLT handshake or authentication ever runs.
+  // maxDepth bounds nesting complexity/memory (readValue() decodes containers iteratively via an explicit Frame
+  // stack, not JVM recursion, so it is not a stack-overflow guard). Read once per message rather than cached
+  // statically so a runtime change to the setting takes effect on the next message.
   private final int maxValueLength;
   private final int maxElements;
   private final int maxDepth;
@@ -119,27 +122,59 @@ public class PackStreamReader {
   }
 
   /**
+   * Sentinel returned by {@link #readValueWithMarker} when a container marker (list/map/struct) pushed a new
+   * {@link Frame} instead of producing a value: the caller loops back to read that frame's first element/
+   * entry/field rather than treating this as a completed value.
+   */
+  private static final Object OPEN_FRAME = new Object();
+
+  /**
    * Read the next value of any type.
+   * <p>
+   * Implemented iteratively with an explicit heap-allocated {@link Frame} stack rather than JVM recursion.
+   * PackStream nests lists/maps/structures arbitrarily deep, and a naive recursive-descent decoder recurses once
+   * per nesting level - CI observed a real {@link StackOverflowError} at a nesting depth (1000) that a local run
+   * with a larger default thread stack did not: native JVM stack budget per recursion level is platform/JIT
+   * dependent, not something this class can rely on as a safety bound (issue #5918). A heap-allocated frame has
+   * no such risk, so {@link #maxDepth} below now bounds nesting complexity/memory rather than guarding against a
+   * stack overflow, and stays safe at any configured value on any platform.
    */
   public Object readValue() throws IOException {
-    return readValue(0);
+    final Deque<Frame> stack = new ArrayDeque<>();
+
+    while (true) {
+      if (stack.size() > maxDepth)
+        throw new IOException("PackStream value nesting exceeds the maximum allowed depth (" + maxDepth + ")");
+
+      final int marker = readMarker();
+      Object value = readValueWithMarker(marker, stack);
+      if (value == OPEN_FRAME)
+        continue; // a new container frame was pushed; read its first element/entry/field next
+
+      // Attach the completed value to the frame on top of the stack, popping and re-attaching any frame that
+      // becomes complete as a result, until either the stack is empty (this value is the final result) or a
+      // frame still needs more input (go back around to read it off the wire).
+      while (true) {
+        final Frame top = stack.peek();
+        if (top == null)
+          return value;
+
+        final Object result = top.attach(value);
+        if (result == Frame.NEEDS_MORE)
+          break;
+
+        stack.pop();
+        value = result;
+      }
+    }
   }
 
   /**
-   * Read the next value of any type, tracking nesting depth so a stream of nesting markers cannot recurse the
-   * connection thread's JVM stack into a {@link StackOverflowError} (issue #5918).
+   * Read a value given its marker byte. For a container marker (list/map/struct) with at least one
+   * element/entry/field, pushes a new {@link Frame} onto {@code stack} and returns {@link #OPEN_FRAME} instead
+   * of a value; an empty container is returned directly, matching a zero-element loop never recursing.
    */
-  private Object readValue(final int depth) throws IOException {
-    if (depth > maxDepth)
-      throw new IOException("PackStream value nesting exceeds the maximum allowed depth (" + maxDepth + ")");
-    final int marker = readMarker();
-    return readValueWithMarker(marker, depth);
-  }
-
-  /**
-   * Read a value given its marker byte.
-   */
-  private Object readValueWithMarker(final int marker, final int depth) throws IOException {
+  private Object readValueWithMarker(final int marker, final Deque<Frame> stack) throws IOException {
     // NULL
     if (marker == (NULL & 0xFF)) {
       return null;
@@ -233,59 +268,76 @@ public class PackStreamReader {
     // TINY_LIST: 0x90 - 0x9F
     if (marker >= 0x90 && marker <= 0x9F) {
       final int size = marker & 0x0F;
-      return readListItems(size, depth);
+      return openList(size, stack);
     }
 
     // LIST_8
     if (marker == (LIST_8 & 0xFF)) {
       final int size = in.readUnsignedByte();
-      return readListItems(size, depth);
+      return openList(size, stack);
     }
 
     // LIST_16
     if (marker == (LIST_16 & 0xFF)) {
       final int size = in.readUnsignedShort();
-      return readListItems(size, depth);
+      return openList(size, stack);
     }
 
     // LIST_32
     if (marker == (LIST_32 & 0xFF)) {
       final int size = in.readInt();
-      return readListItems(checkElementCount(size, "LIST_32"), depth);
+      return openList(checkElementCount(size, "LIST_32"), stack);
     }
 
     // TINY_MAP: 0xA0 - 0xAF
     if (marker >= 0xA0 && marker <= 0xAF) {
       final int size = marker & 0x0F;
-      return readMapEntries(size, depth);
+      return openMap(size, stack);
     }
 
     // MAP_8
     if (marker == (MAP_8 & 0xFF)) {
       final int size = in.readUnsignedByte();
-      return readMapEntries(size, depth);
+      return openMap(size, stack);
     }
 
     // MAP_16
     if (marker == (MAP_16 & 0xFF)) {
       final int size = in.readUnsignedShort();
-      return readMapEntries(size, depth);
+      return openMap(size, stack);
     }
 
     // MAP_32
     if (marker == (MAP_32 & 0xFF)) {
       final int size = in.readInt();
-      return readMapEntries(checkElementCount(size, "MAP_32"), depth);
+      return openMap(checkElementCount(size, "MAP_32"), stack);
     }
 
     // TINY_STRUCT: 0xB0 - 0xBF
     if (marker >= 0xB0 && marker <= 0xBF) {
       final int fieldCount = marker & 0x0F;
       final byte signature = in.readByte();
-      return readStructure(signature, fieldCount, depth);
+      if (fieldCount == 0)
+        return new StructureValue(signature, new ArrayList<>(0));
+      stack.push(new StructFrame(signature, fieldCount));
+      return OPEN_FRAME;
     }
 
     throw new IOException("Unknown PackStream marker: 0x" + Integer.toHexString(marker));
+  }
+
+  private static Object openList(final int size, final Deque<Frame> stack) {
+    if (size == 0)
+      return new ArrayList<>(0);
+    stack.push(new ListFrame(size));
+    return OPEN_FRAME;
+  }
+
+  private static Object openMap(final int size, final Deque<Frame> stack) {
+    if (size == 0)
+      return new LinkedHashMap<>(0);
+    stack.push(new MapFrame(size));
+    return OPEN_FRAME;
   }
 
   /**
@@ -356,39 +408,72 @@ public class PackStreamReader {
   }
 
   /**
-   * Read list items.
+   * A container (list/map/struct) whose element/entry/field count is not yet fully read. Pushed onto the work
+   * stack in {@link #readValue()} in place of a recursive call; {@link #attach} feeds it one completed child
+   * value at a time until it reports completion by returning something other than {@link #NEEDS_MORE}.
    */
-  private List<Object> readListItems(final int size, final int depth) throws IOException {
-    final List<Object> list = new ArrayList<>(size);
-    for (int i = 0; i < size; i++) {
-      list.add(readValue(depth + 1));
-    }
-    return list;
+  private abstract static class Frame {
+    static final Object NEEDS_MORE = new Object();
+
+    abstract Object attach(Object value);
   }
 
-  /**
-   * Read map entries.
-   */
-  private Map<String, Object> readMapEntries(final int size, final int depth) throws IOException {
-    final Map<String, Object> map = new LinkedHashMap<>(size);
-    for (int i = 0; i < size; i++) {
-      final String key = (String) readValue(depth + 1);
-      final Object value = readValue(depth + 1);
-      map.put(key, value);
+  private static final class ListFrame extends Frame {
+    private final List<Object> list;
+    private int                remaining;
+
+    ListFrame(final int size) {
+      this.list = new ArrayList<>(size);
+      this.remaining = size;
     }
-    return map;
+
+    @Override
+    Object attach(final Object value) {
+      list.add(value);
+      return --remaining == 0 ? list : NEEDS_MORE;
+    }
   }
 
-  /**
-   * Read a structure with given signature and field count.
-   * Returns a StructureValue containing the signature and fields.
-   */
-  private StructureValue readStructure(final byte signature, final int fieldCount, final int depth) throws IOException {
-    final List<Object> fields = new ArrayList<>(fieldCount);
-    for (int i = 0; i < fieldCount; i++) {
-      fields.add(readValue(depth + 1));
+  private static final class MapFrame extends Frame {
+    private final Map<String, Object> map;
+    private       int                 remainingEntries;
+    private       boolean             expectingKey = true;
+    private       String              pendingKey;
+
+    MapFrame(final int size) {
+      this.map = new LinkedHashMap<>(size);
+      this.remainingEntries = size;
     }
-    return new StructureValue(signature, fields);
+
+    @Override
+    Object attach(final Object value) {
+      if (expectingKey) {
+        pendingKey = (String) value;
+        expectingKey = false;
+        return NEEDS_MORE;
+      }
+      map.put(pendingKey, value);
+      expectingKey = true;
+      return --remainingEntries == 0 ? map : NEEDS_MORE;
+    }
+  }
+
+  private static final class StructFrame extends Frame {
+    private final byte         signature;
+    private final List<Object> fields;
+    private       int          remaining;
+
+    StructFrame(final byte signature, final int fieldCount) {
+      this.signature = signature;
+      this.fields = new ArrayList<>(fieldCount);
+      this.remaining = fieldCount;
+    }
+
+    @Override
+    Object attach(final Object value) {
+      fields.add(value);
+      return --remaining == 0 ? new StructureValue(signature, fields) : NEEDS_MORE;
+    }
   }
 
   /**

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltChunkedIOTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltChunkedIOTest.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for BOLT chunked I/O classes.
@@ -239,6 +241,40 @@ class BoltChunkedIOTest {
     final BoltChunkedInput chunkedInput = new BoltChunkedInput(new ByteArrayInputStream(input));
 
     assertThat(chunkedInput.available()).isEqualTo(3);
+  }
+
+  /**
+   * Regression for issue #5918: a client that never sends the terminating zero-length chunk previously grew the
+   * reassembly buffer without limit, before the BOLT handshake or authentication ever ran. Two 10-byte chunks
+   * against a 15-byte bound must be rejected once the running total crosses the bound, without ever seeing (or
+   * needing) a terminator.
+   */
+  @Test
+  void readMessageExceedingMaxSizeRejectedBeforeUnboundedGrowth() {
+    final byte[] input = {
+        0x00, 0x0A, // first chunk size = 10
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0x00, 0x0A, // second chunk size = 10 (running total 20 > bound 15)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0x00, 0x00  // terminator (never reached)
+    };
+    final BoltChunkedInput chunkedInput = new BoltChunkedInput(new ByteArrayInputStream(input), 15);
+
+    assertThatThrownBy(chunkedInput::readMessage)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("too large");
+  }
+
+  @Test
+  void readMessageWithinMaxSizeStillParses() throws Exception {
+    final byte[] input = {
+        0x00, 0x0A, // chunk size = 10
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        0x00, 0x00  // terminator
+    };
+    final BoltChunkedInput chunkedInput = new BoltChunkedInput(new ByteArrayInputStream(input), 10);
+
+    assertThat(chunkedInput.readMessage()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   }
 
   // ============ Round-trip tests ============

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltChunkedIOTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltChunkedIOTest.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.bolt;
 
+import com.arcadedb.GlobalConfiguration;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -275,6 +277,29 @@ class BoltChunkedIOTest {
     final BoltChunkedInput chunkedInput = new BoltChunkedInput(new ByteArrayInputStream(input), 10);
 
     assertThat(chunkedInput.readMessage()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  }
+
+  /**
+   * A {@code maxMessageSize} of 0 (or negative) would reject essentially every real BOLT message outright. The
+   * config-reading constructor must fall back to the built-in default rather than enforcing the misconfigured
+   * value literally.
+   */
+  @Test
+  void maxMessageSizeBelowUsableFloorFallsBackToDefault() throws Exception {
+    final int original = GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.getValueAsInteger();
+    GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.setValue(0);
+    try {
+      final byte[] input = {
+          0x00, 0x0A, // chunk size = 10; would be rejected outright by a literal maxMessageSize=0
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+          0x00, 0x00  // terminator
+      };
+      final BoltChunkedInput chunkedInput = new BoltChunkedInput(new ByteArrayInputStream(input));
+
+      assertThat(chunkedInput.readMessage()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    } finally {
+      GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.setValue(original);
+    }
   }
 
   // ============ Round-trip tests ============

--- a/bolt/src/test/java/com/arcadedb/bolt/PackStreamBoundsTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/PackStreamBoundsTest.java
@@ -178,6 +178,43 @@ class PackStreamBoundsTest {
         .hasMessageContaining("remaining message bytes");
   }
 
+  /**
+   * As {@link #declaredListSizeExceedingActualRemainingBytesRejected}, for MAP_32 - checkElementCount is shared
+   * code between LIST_32/MAP_32, but each marker's decoding branch is a separate call site worth covering.
+   */
+  @Test
+  void declaredMapSizeExceedingActualRemainingBytesRejected() {
+    final byte[] data = { (byte) 0xDA, 0x00, 0x00, 0x03, (byte) 0xE8 }; // MAP_32, size = 1000
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("remaining message bytes");
+  }
+
+  /**
+   * As {@link #negativeBytes32LengthRejectedWithClearProtocolError}, for a negative LIST_32/MAP_32 declared size.
+   */
+  @Test
+  void negativeListSizeRejectedWithClearProtocolError() {
+    final byte[] data = { (byte) 0xD6, (byte) 0x80, 0x00, 0x00, 0x00 }; // LIST_32, size = Integer.MIN_VALUE
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("negative size");
+  }
+
+  @Test
+  void negativeMapSizeRejectedWithClearProtocolError() {
+    final byte[] data = { (byte) 0xDA, (byte) 0x80, 0x00, 0x00, 0x00 }; // MAP_32, size = Integer.MIN_VALUE
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("negative size");
+  }
+
   // ============ Regression: legitimate, in-bounds values still parse correctly ============
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/PackStreamBoundsTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/PackStreamBoundsTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.bolt;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 
@@ -267,5 +268,60 @@ class PackStreamBoundsTest {
         .isExactlyInstanceOf(IOException.class)
         .hasMessageContaining("STRING_32")
         .hasMessageContaining("maximum allowed");
+  }
+
+  // ============ Misconfigured-limit fallback (GlobalConfiguration below the usable floor) ============
+
+  /**
+   * A {@code maxDepth} of 0 (or negative) would reject essentially every real BOLT message outright, since even
+   * a bare HELLO's extra map is one level deeper than the top-level struct itself. The config-reading
+   * constructor must fall back to the built-in default rather than enforcing the misconfigured value literally.
+   */
+  @Test
+  void depthBelowUsableFloorFallsBackToDefaultInsteadOfRejectingEveryMessage() throws IOException {
+    final int original = GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH.getValueAsInteger();
+    GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH.setValue(0);
+    try {
+      final PackStreamWriter writer = new PackStreamWriter();
+      writer.writeList(List.of(1L, 2L, 3L)); // one level of nesting: would be rejected outright by a literal maxDepth=0
+
+      final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+      assertThat(reader.readValue()).isEqualTo(List.of(1L, 2L, 3L));
+    } finally {
+      GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH.setValue(original);
+    }
+  }
+
+  @Test
+  void maxValueLengthBelowUsableFloorFallsBackToDefault() throws IOException {
+    final int original = GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH.getValueAsInteger();
+    GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH.setValue(0);
+    try {
+      final PackStreamWriter writer = new PackStreamWriter();
+      writer.writeString("a".repeat(70_000)); // forces STRING_32; would be rejected outright by a literal maxValueLength=0
+
+      final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+      assertThat(reader.readValue()).isEqualTo("a".repeat(70_000));
+    } finally {
+      GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH.setValue(original);
+    }
+  }
+
+  @Test
+  void maxElementsBelowUsableFloorFallsBackToDefault() throws IOException {
+    final int original = GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS.getValueAsInteger();
+    GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS.setValue(0);
+    try {
+      final PackStreamWriter writer = new PackStreamWriter();
+      final List<Object> list = new ArrayList<>();
+      for (int i = 0; i < 70_000; i++)
+        list.add((long) i); // forces LIST_32; would be rejected outright by a literal maxElements=0
+      writer.writeList(list);
+
+      final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+      assertThat(reader.readValue()).isEqualTo(list);
+    } finally {
+      GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS.setValue(original);
+    }
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/PackStreamBoundsTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/PackStreamBoundsTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5918: the PackStream decoder read a client-supplied, unauthenticated 32-bit
+ * length/size off the wire and used it directly to size an allocation (BYTES_32/STRING_32/LIST_32/MAP_32),
+ * and recursed once per nesting level with no depth cap - both reachable on the very first message, before the
+ * BOLT handshake or authentication. A handful of bytes could trigger a multi-gigabyte allocation
+ * ({@link OutOfMemoryError}) or a {@link StackOverflowError}, both {@code Error}s that escape a
+ * {@code catch (Exception)} net. Every case below must fail with a plain {@link IOException} - never let an
+ * {@link Error} propagate - and must do so without the runaway allocation/recursion actually happening.
+ */
+class PackStreamBoundsTest {
+
+  /**
+   * Issue's minimal trigger: 5 bytes - {@code CE 7F FF FF FF} (BYTES_32, declared length 2147483647). Previously
+   * allocated a ~2GB byte array before any bound was checked.
+   */
+  @Test
+  void bytes32DeclaredLengthAboveConfiguredMaxRejectedBeforeAllocation() {
+    final byte[] data = { (byte) 0xCE, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("BYTES_32");
+  }
+
+  @Test
+  void string32DeclaredLengthAboveConfiguredMaxRejectedBeforeAllocation() {
+    final byte[] data = { (byte) 0xD2, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("STRING_32");
+  }
+
+  @Test
+  void list32DeclaredSizeAboveConfiguredMaxRejectedBeforeAllocation() {
+    final byte[] data = { (byte) 0xD6, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("LIST_32");
+  }
+
+  @Test
+  void map32DeclaredSizeAboveConfiguredMaxRejectedBeforeAllocation() {
+    final byte[] data = { (byte) 0xDA, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("MAP_32");
+  }
+
+  /**
+   * A negative 32-bit length (e.g. {@code CE 80 00 00 00}) previously fell through to
+   * {@code new byte[length]}, yielding a raw {@link NegativeArraySizeException} instead of a clear protocol error.
+   */
+  @Test
+  void negativeBytes32LengthRejectedWithClearProtocolError() {
+    final byte[] data = { (byte) 0xCE, (byte) 0x80, 0x00, 0x00, 0x00 };
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("negative length");
+  }
+
+  /**
+   * A declared length that is comfortably under the configured ceiling is still impossible once it exceeds the
+   * bytes actually remaining in this message - the exact, un-configurable bound. Message: BYTES_32 declaring
+   * length 1000, with zero bytes following (5-byte message total).
+   */
+  @Test
+  void declaredLengthExceedingActualRemainingBytesRejectedRegardlessOfConfiguredMax() {
+    final byte[] data = { (byte) 0xCE, 0x00, 0x00, 0x03, (byte) 0xE8 }; // BYTES_32, length = 1000
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("remaining message bytes");
+  }
+
+  /**
+   * Issue's minimal recursion trigger: N bytes of {@code 0x91} (TINY_LIST, size 1) then {@code 0xC0} (NULL).
+   * Previously overflowed the connection thread's JVM stack; must now fail cleanly at the configured depth
+   * instead.
+   */
+  @Test
+  void deeplyNestedTinyListRejectedWithoutStackOverflow() {
+    final int nestingLevels = 200_000;
+    final byte[] data = new byte[nestingLevels + 1];
+    for (int i = 0; i < nestingLevels; i++)
+      data[i] = (byte) 0x91; // TINY_LIST, size 1
+    data[nestingLevels] = (byte) 0xC0; // NULL
+
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("nesting exceeds the maximum allowed depth");
+  }
+
+  /**
+   * Depth bound is exact: exactly {@code maxDepth} nested TINY_LISTs (depth 0..maxDepth) still parses, one level
+   * deeper does not. Uses the explicit-bounds constructor to keep the fixture small and the assertion precise.
+   */
+  @Test
+  void depthBoundIsExactAtConfiguredLimit() throws IOException {
+    final int maxDepth = 5;
+
+    final byte[] withinBound = nestedTinyLists(maxDepth);
+    assertThat(new PackStreamReader(withinBound, 1024, 1024, maxDepth).readValue()).isNotNull();
+
+    final byte[] oneLevelTooDeep = nestedTinyLists(maxDepth + 1);
+    assertThatThrownBy(() -> new PackStreamReader(oneLevelTooDeep, 1024, 1024, maxDepth).readValue())
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("nesting exceeds the maximum allowed depth");
+  }
+
+  private static byte[] nestedTinyLists(final int levels) {
+    final byte[] data = new byte[levels + 1];
+    for (int i = 0; i < levels; i++)
+      data[i] = (byte) 0x91; // TINY_LIST, size 1
+    data[levels] = (byte) 0xC0; // NULL
+    return data;
+  }
+
+  /**
+   * A single value declaring an element/entry count under the configured element-count ceiling but above the
+   * bytes actually remaining is rejected the same way as the raw-length case.
+   */
+  @Test
+  void declaredListSizeExceedingActualRemainingBytesRejected() {
+    final byte[] data = { (byte) 0xD6, 0x00, 0x00, 0x03, (byte) 0xE8 }; // LIST_32, size = 1000
+    final PackStreamReader reader = new PackStreamReader(data);
+
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("remaining message bytes");
+  }
+
+  // ============ Regression: legitimate, in-bounds values still parse correctly ============
+
+  @Test
+  void withinBoundsStringStillRoundTrips() throws IOException {
+    final PackStreamWriter writer = new PackStreamWriter();
+    final String value = "hello, ArcadeDB BOLT!";
+    writer.writeString(value);
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    assertThat(reader.readValue()).isEqualTo(value);
+  }
+
+  @Test
+  void withinBoundsBytesStillRoundTrip() throws IOException {
+    final PackStreamWriter writer = new PackStreamWriter();
+    final byte[] value = new byte[10_000];
+    for (int i = 0; i < value.length; i++)
+      value[i] = (byte) i;
+    writer.writeBytes(value);
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    assertThat((byte[]) reader.readValue()).isEqualTo(value);
+  }
+
+  @Test
+  void withinBoundsNestedListAndMapStillRoundTrip() throws IOException {
+    final PackStreamWriter writer = new PackStreamWriter();
+
+    final List<Object> inner = new ArrayList<>();
+    inner.add(1L);
+    inner.add(2L);
+    inner.add(3L);
+
+    final Map<String, Object> map = new LinkedHashMap<>();
+    map.put("numbers", inner);
+    map.put("name", "arcade");
+
+    writer.writeMap(map);
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) reader.readValue();
+
+    assertThat(result.get("name")).isEqualTo("arcade");
+    assertThat(result.get("numbers")).isEqualTo(inner);
+  }
+
+  @Test
+  void withinBoundsLargeListOfManyElementsStillParses() throws IOException {
+    final PackStreamWriter writer = new PackStreamWriter();
+    final List<Object> list = new ArrayList<>();
+    for (int i = 0; i < 5000; i++)
+      list.add((long) i);
+    writer.writeList(list);
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    assertThat(reader.readValue()).isEqualTo(list);
+  }
+
+  // ============ Explicit-bounds constructor: element-count and value-length ceilings ============
+
+  @Test
+  void explicitMaxElementsBoundRejectsOversizedDeclaredListSize() throws IOException {
+    final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    final DataOutputStream out = new DataOutputStream(buffer);
+    out.writeByte(0xD6); // LIST_32
+    out.writeInt(2000);  // declared size, above the 100-element bound below, under available bytes
+    for (int i = 0; i < 2000; i++)
+      out.writeByte(0x01); // 2000 filler TINY_INT bytes, so the size passes the available() check
+
+    final PackStreamReader reader = new PackStreamReader(buffer.toByteArray(), 1024, 100, 1000);
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("LIST_32")
+        .hasMessageContaining("maximum allowed");
+  }
+
+  @Test
+  void explicitMaxValueLengthBoundRejectsOversizedDeclaredStringLength() throws IOException {
+    final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    final DataOutputStream out = new DataOutputStream(buffer);
+    out.writeByte(0xD2); // STRING_32
+    out.writeInt(2000);  // declared length, above the 100-byte bound below, under available bytes
+    out.write(new byte[2000]);
+
+    final PackStreamReader reader = new PackStreamReader(buffer.toByteArray(), 100, 1024, 1000);
+    assertThatThrownBy(reader::readValue)
+        .isExactlyInstanceOf(IOException.class)
+        .hasMessageContaining("STRING_32")
+        .hasMessageContaining("maximum allowed");
+  }
+}

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1642,6 +1642,12 @@ public enum GlobalConfiguration {
           + "since the length is read off the wire before authentication. Default is 16MB",
       Integer.class, 16 * 1024 * 1024),
 
+  // The three *_SIZE/*_LENGTH settings below are defense in depth at different layers of the same BOLT ingest
+  // path, not redundant: BOLT_MAX_MESSAGE_SIZE bounds the whole reassembled message before it is even handed to
+  // the PackStream decoder, while BOLT_PACKSTREAM_MAX_VALUE_LENGTH bounds one BYTES_32/STRING_32 value within an
+  // already-accepted message. They share the same 16MB default because a single field legitimately consuming
+  // the entire message budget is a real (if unusual) case, not because the two checks are meant to be identical.
+
   BOLT_MAX_MESSAGE_SIZE("arcadedb.bolt.maxMessageSize", SCOPE.SERVER, """
       Maximum total size in bytes accepted for a single BOLT protocol message after chunk reassembly. BOLT frames \
       a message as a sequence of chunks terminated by a zero-length chunk; without a bound on the reassembled \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1642,6 +1642,32 @@ public enum GlobalConfiguration {
           + "since the length is read off the wire before authentication. Default is 16MB",
       Integer.class, 16 * 1024 * 1024),
 
+  BOLT_MAX_MESSAGE_SIZE("arcadedb.bolt.maxMessageSize", SCOPE.SERVER, """
+      Maximum total size in bytes accepted for a single BOLT protocol message after chunk reassembly. BOLT frames \
+      a message as a sequence of chunks terminated by a zero-length chunk; without a bound on the reassembled \
+      total, a client that never sends the terminator grows the reassembly buffer unbounded, before the BOLT \
+      handshake or authentication. Default is 16MB""",
+      Integer.class, 16 * 1024 * 1024),
+
+  BOLT_PACKSTREAM_MAX_VALUE_LENGTH("arcadedb.bolt.packstream.maxValueLength", SCOPE.SERVER, """
+      Maximum length in bytes accepted for a single PackStream BYTES_32/STRING_32 value on the BOLT wire protocol. \
+      A declared length above this bound, or larger than the bytes actually remaining in the message, is rejected \
+      before allocation, since the length is read off the wire before authentication. Default is 16MB""",
+      Integer.class, 16 * 1024 * 1024),
+
+  BOLT_PACKSTREAM_MAX_ELEMENTS("arcadedb.bolt.packstream.maxElements", SCOPE.SERVER, """
+      Maximum element/entry count accepted for a single PackStream LIST_32/MAP_32 declared size on the BOLT wire \
+      protocol. Guards against a client-declared count (e.g. a handful of bytes claiming billions of items) \
+      sizing the backing collection before any element is actually read. Default is 1048576""",
+      Integer.class, 1_048_576),
+
+  BOLT_PACKSTREAM_MAX_DEPTH("arcadedb.bolt.packstream.maxDepth", SCOPE.SERVER, """
+      Maximum nesting depth accepted when decoding a PackStream value (list/map/structure) on the BOLT wire \
+      protocol. The decoder recurses once per nesting level, so an unbounded value lets an unauthenticated \
+      client overflow the connection thread's JVM stack with a stream of nesting markers. Default is 1000, \
+      generous for any real BOLT message.""",
+      Integer.class, 1000),
+
   // REDIS
   REDIS_PORT("arcadedb.redis.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for Redis plugin. Default is 6379", Integer.class, 6379),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1663,9 +1663,10 @@ public enum GlobalConfiguration {
 
   BOLT_PACKSTREAM_MAX_DEPTH("arcadedb.bolt.packstream.maxDepth", SCOPE.SERVER, """
       Maximum nesting depth accepted when decoding a PackStream value (list/map/structure) on the BOLT wire \
-      protocol. The decoder recurses once per nesting level, so an unbounded value lets an unauthenticated \
-      client overflow the connection thread's JVM stack with a stream of nesting markers. Default is 1000, \
-      generous for any real BOLT message.""",
+      protocol. The decoder builds nested containers on an explicit heap-allocated stack rather than JVM \
+      recursion, so this bounds nesting complexity/memory rather than guarding against a stack overflow; \
+      without it, an unauthenticated client could grow that stack unboundedly with a stream of nesting markers. \
+      Default is 1000, generous for any real BOLT message.""",
       Integer.class, 1000),
 
   // REDIS


### PR DESCRIPTION
## Summary

Fixes #5918.

`PackStreamReader` (the BOLT PackStream value decoder, run on every message on both raw-TCP and WebSocket transports, before authentication) read a client-supplied 32-bit length/size off the wire and used it directly to size an allocation:

- `BYTES_32`/`STRING_32` sized a `byte[]` directly from the declared length.
- `LIST_32`/`MAP_32` sized an `ArrayList`/`LinkedHashMap` directly from the declared size.
- `readValue()` recursed once per nesting level with no depth cap.

A 5-byte message (`CE 7F FF FF FF`) could trigger a multi-gigabyte allocation (`OutOfMemoryError`), and a stream of nesting markers could overflow the connection thread's stack (`StackOverflowError`). Both are `Error`s, not `Exception`s, so they escaped `BoltNetworkExecutor`'s `catch (Exception)` net - the OOM exhausts the shared heap for the whole server, the SOF is a repeatable per-connection DoS. Both are reachable pre-authentication.

## Fix

- `PackStreamReader` now validates a `BYTES_32`/`STRING_32` length or `LIST_32`/`MAP_32` size **before** allocating:
  - rejects a negative value with a clear protocol error (previously a raw `NegativeArraySizeException`),
  - rejects a value above a configured ceiling (`arcadedb.bolt.packstream.maxValueLength`, default 16MB; `arcadedb.bolt.packstream.maxElements`, default 1048576),
  - rejects a value larger than the bytes actually remaining in the message - the exact, un-configurable bound, since a legitimate declared length/size can never exceed what's actually present in an already-fully-buffered message. This is tighter than a fixed ceiling and needs no tuning: the 5-byte trigger from the issue is rejected regardless of what the configured max is set to.
- Nesting depth is tracked through `readValue`/`readListItems`/`readMapEntries`/`readStructure` and capped at `arcadedb.bolt.packstream.maxDepth` (default 1000) - generous for any real message, far short of a stack overflow.
- `BoltChunkedInput.readMessage()` had the related, lower-severity gap called out in the issue: no cap on the number of chunks / total reassembled size, so a client that never sends the terminating zero-length chunk grows the dechunking buffer unbounded. Now bounded by `arcadedb.bolt.maxMessageSize` (default 16MB), checked as each chunk arrives.

All new limits are read from `GlobalConfiguration` per message/connection (so a runtime config change takes effect immediately) via the existing constructors; explicit-bounds constructor overloads were added to `PackStreamReader` and `BoltChunkedInput` so tests can exercise a bound deterministically without mutating global config.

Same class of defect, same fix shape, as #5894 (Bolt WebSocket frame length / Postgres bind-parameter length), merged in #5920.

## Test plan

- New `PackStreamBoundsTest`: reproduces the issue's exact minimal triggers (5-byte `BYTES_32` OOM trigger, 200,000-deep `TINY_LIST` nesting SOF trigger) and asserts a plain `IOException` is thrown instead - not the runaway allocation/recursion happening. Also covers `STRING_32`/`LIST_32`/`MAP_32`, the negative-length case, the available-bytes bound independent of the configured ceiling, an exact depth-boundary test, and regression coverage that legitimate in-bounds strings/bytes/lists/maps/nested structures still round-trip correctly.
- New tests in `BoltChunkedIOTest` for the chunk-reassembly size bound (rejected over bound, still parses within bound).
- `mvn -pl bolt test` - full bolt module unit test suite (301 tests) passes.
