### PR TITLE
fix(server) #5618: a batch load accounts for the payload line by line

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -191,3 +191,41 @@ without bound if the client actually sent the declared bytes. It is now capped b
 `arcadedb.redis.maxBulkLength` (default 512MB, matching Redis' own `proto-max-bulk-len`). Malformed, non-numeric
 lengths (e.g. `$abc\r\n`) also used to throw an uncaught `NumberFormatException` that killed the connection
 thread outright; they now get the same clean error-reply-and-close treatment as an oversized length.
+
+## Bulk load: a batch now accounts for the payload line by line, and says what it does not know (#5618)
+
+A 17-million-vertex load stopped on `Unknown temporary ID 'co/32945720' at line 17234792`, for a vertex sitting in
+the payload thousands of lines above that edge - and the vertex was not in the database either. Nothing in the
+response and nothing in the log could tell whether the server had lost records or the payload had never carried
+them: the endpoint reported counts of what it *created*, with nothing to compare them against. Establishing that
+two million vertices were missing took a `grep -c` over the user's own file, and even that did not say which side
+had dropped them.
+
+**Every answer now carries `linesRead` and `linesSkipped`** - blank lines, plus CSV headers and `---` separators -
+on the 200, on the 400 that rejects a record, and on the 408 that reports a truncated upload. `linesRead -
+linesSkipped` is the number of records the parser produced, so a client can check it against `verticesCreated +
+edgesCreated` and against the line count of the file it sent, without waiting for a support round-trip.
+
+**The server checks the same equality before answering 200.** A line that was read and turned into nothing is a
+defect on our side, so the load is now reported as failed (HTTP 500, with the partial-commit counters, and a
+warning naming the numbers) instead of returning a success carrying a count that silently misses records.
+
+**`verticesWithoutId`** is reported when a payload creates vertices that declare no `@id` under the default
+`refMode=id`. Those vertices are loaded and durable, but nothing in the payload can ever reference them - until
+now the only symptom was an unresolvable reference much further down.
+
+**The unresolved-reference message reports what the load knows** instead of asserting a single cause. "Vertices
+must appear before edges that reference them" was the whole explanation, and on this report it was the wrong one;
+it now states how many ids the payload actually declared, how many of its vertices declared none, and that each
+request resolves only the ids of its *own* payload - the trap a client hits when it splits one file across several
+requests and expects `@id`s from an earlier one to still resolve.
+
+Finally, **a batch that lands on a follower is relayed to the leader with the length the client announced**, over
+a body that refuses to be handed over twice. The relay previously declared no length, which sent it chunked - and
+a chunked body announces nothing, which switches off the leader's own truncation check
+(`PostBatchHandler.bodyEndedEarly` gives up as soon as there is no announced length). A relayed upload that ended
+early therefore came back as a 200 with a partial count: the exact outcome [#5470](https://github.com/ArcadeData/arcadedb/issues/5470)
+exists to prevent, on the one path it never covered. The hop is also pinned to HTTP/1.1, since an `h2c` upgrade's
+failure mode is re-sending a request whose body cannot be rewound.
+
+[#5618](https://github.com/ArcadeData/arcadedb/issues/5618)

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftBatchEndpointIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftBatchEndpointIT.java
@@ -210,6 +210,53 @@ class RaftBatchEndpointIT extends BaseRaftHATest {
     }
   }
 
+  /**
+   * Issue #5618: a batch that lands on a FOLLOWER is relayed to the leader over a second HTTP request, and the
+   * relay used to declare no length for the body it was passing on. A chunked body announces nothing, which turns
+   * off the leader's own truncation check ({@code PostBatchHandler.bodyEndedEarly} gives up as soon as there is no
+   * announced length), so a relayed upload that ended early came back as a 200 with a partial count - the one
+   * outcome issue #5470 exists to prevent, on the one path it never covered.
+   * <p>
+   * What that costs is only visible from the outside as a load that is quietly short, so this pins the property
+   * that matters: a payload sent through a follower arrives at the leader whole, and the leader accounts for every
+   * line of it. The mechanics of the relayed request - the declared length, the pinned HTTP/1.1, the body that
+   * refuses to be sent twice - are pinned by {@code PostBatchHandlerForwardRequestTest}.
+   */
+  @Test
+  void aBatchRelayedByAFollowerArrivesWhole() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = (leaderIndex + 1) % getServerCount();
+
+    createSchema(leaderIndex);
+    waitForReplicationIsCompleted(followerIndex);
+
+    final int vertices = 500;
+    final int edges = 250;
+    final StringBuilder body = new StringBuilder();
+    for (int i = 0; i < vertices; i++)
+      body.append("{\"@type\":\"vertex\",\"@class\":\"").append(VERTEX_TYPE).append("\",\"@id\":\"relay")
+          .append(i).append("\",\"node_id\":\"relay").append(i).append("\"}\n");
+    for (int i = 0; i < edges; i++)
+      body.append("{\"@type\":\"edge\",\"@class\":\"").append(EDGE_TYPE).append("\",\"@from\":\"relay")
+          .append(i).append("\",\"@to\":\"relay").append(vertices - 1 - i).append("\"}\n");
+
+    final HttpResult result = postBatch(followerIndex, body.toString(), "vertexBatchSize=100");
+    assertThat(result.statusCode()).as("relayed batch must succeed\nbody=%s", result.body()).isEqualTo(200);
+
+    final JSONObject json = new JSONObject(result.body());
+    assertThat(json.getLong("verticesCreated")).isEqualTo(vertices);
+    assertThat(json.getLong("edgesCreated")).isEqualTo(edges);
+    assertThat(json.getLong("linesRead")).isEqualTo(vertices + edges);
+    assertThat(json.getLong("linesSkipped")).isZero();
+
+    assertClusterConsistency();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
+          .as("Server %d must hold every relayed vertex", i)
+          .isEqualTo(vertices);
+  }
+
   private void createSchema(final int serverIndex) throws Exception {
     httpCommand(serverIndex, "CREATE VERTEX TYPE " + VERTEX_TYPE + " IF NOT EXISTS");
     httpCommand(serverIndex, "CREATE PROPERTY " + VERTEX_TYPE + ".node_id IF NOT EXISTS STRING");

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -52,6 +52,8 @@ import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 
 /**
@@ -80,6 +82,15 @@ import java.util.logging.Level;
  * Response: {@code verticesCreated}, {@code edgesCreated}, {@code elapsedMs}, {@code bytesRead} and, when temporary
  * ids were used, {@code idMapping} - replaced by {@code idMappingOmitted} / {@code idMappingSize} past
  * {@link #MAX_ID_MAPPING_IN_RESPONSE} entries, unless {@code idMapping=true} demands it.
+ * <p>
+ * Line accounting: every answer, successful or not, also carries {@code linesRead} and {@code linesSkipped} (blank
+ * lines, plus CSV headers and {@code ---} separators), so {@code linesRead - linesSkipped} is the number of records
+ * the parser produced and can be checked against {@code verticesCreated + edgesCreated} - and against the line count
+ * of the file the client sent. The server checks it too: a load that read a line and turned it into nothing is
+ * answered as failed rather than successful, because "the vertices are in my file and not in the database" must not
+ * be something a user has to establish with grep after the fact (issue #5618). {@code verticesWithoutId} appears when
+ * the payload created vertices that declared no {@code @id} under {@code refMode=id}: they are loaded and durable,
+ * but no edge can ever reference them.
  * <p>
  * Giving up early: a load that fails on the payload is answered as soon as the verdict is reached, without reading
  * the rest of the upload. That is not an optimisation - closing Undertow's request stream reads the body to the end
@@ -272,10 +283,14 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     long verticesCreated = 0;
     long edgesCreated = 0;
 
-    try (final BatchRecordStream stream = isCsv
+    // Held outside the try-with-resources so the line accounting survives into the catch blocks: a load that
+    // failed has to report how much of the payload it had read just as precisely as one that succeeded, which is
+    // the whole point of counting the lines (issue #5618).
+    final BatchRecordStream stream = isCsv
         ? new CsvBatchRecordStream(inputStream)
         : new JsonlBatchRecordStream(inputStream);
-         final GraphBatch batch = builder.build()) {
+
+    try (stream; final GraphBatch batch = builder.build()) {
 
       // Phase 1: Vertices — accumulate by type for batch creation
       String currentTypeName = null;
@@ -375,14 +390,15 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       // distinction is the difference between naming the offending line and reporting the load as truncated with
       // "the last record read is not part of the payload", which was untrue and unfixable: the line WAS in the file.
       if (e instanceof MalformedBatchRecordException && bodyEndedEarly(exchange, inputStream))
-        return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated,
+        return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs,
             "only " + inputStream.getBytesRead() + " of the " + exchange.getRequestContentLength()
                 + " announced bytes were received, the last record read (" + message + ") is not part of the payload",
             null);
 
       LogManager.instance().log(this, Level.WARNING,
-          "Batch load on database '%s' failed after %d vertices and %d edges: %s",
-          null, databaseName, verticesCreated, edgesCreated, message);
+          "Batch load on database '%s' failed on line %d after %d vertices and %d edges (%d lines read, %d skipped): %s",
+          null, databaseName, stream.getLineNumber(), verticesCreated, edgesCreated, stream.getLinesRead(),
+          stream.getLinesSkipped(), message);
 
       // Bespoke body (not the shared sendErrorResponse envelope) because the partial-commit counts must
       // be machine-parsable by the client. The message is emitted in `error` even in production on
@@ -399,6 +415,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       error.put("verticesCreated", verticesCreated);
       error.put("edgesCreated", edgesCreated);
       error.put("partialCommit", verticesCreated > 0 || edgesCreated > 0);
+      addLineAccounting(error, stream, vertexRefs);
       return new ExecutionResponse(400, error.toString());
     } catch (final IOException e) {
       // The request body could not be read to the end: the client went away, a proxy cut the upload, or the
@@ -406,7 +423,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       // reading (issue #5470). Never let this look like a completed load: reaching the end of the loop with a
       // truncated body would answer 200 with a partial count and the client would happily move on.
       final String message = e.getMessage() != null ? e.getMessage() : e.toString();
-      return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, message, e.getClass().getName());
+      return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs, message,
+          e.getClass().getName());
     }
 
     // The stream ended without an error, but the client announced more than what arrived: a connection dropped
@@ -414,9 +432,18 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // reporting 200 with a truncated count is the worst possible outcome - the client moves on believing the load
     // completed.
     if (bodyEndedEarly(exchange, inputStream))
-      return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated,
+      return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs,
           "only " + inputStream.getBytesRead() + " of the " + exchange.getRequestContentLength()
               + " announced bytes were received", null);
+
+    // Every line the parser consumed has to have become a record or be one it declared skipped. Nothing in this
+    // handler is allowed to read a line and quietly do nothing with it, so a mismatch is a server-side defect,
+    // not a client one - and answering 200 with a count that silently misses records is exactly the failure
+    // issue #5618 was opened about. The check costs two field reads per load and turns "vertices disappeared" from
+    // something the user has to prove with grep into something the server states with numbers.
+    final long accounted = verticesCreated + edgesCreated + stream.getLinesSkipped();
+    if (accounted != stream.getLinesRead())
+      return recordsDropped(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs);
 
     // A chunked upload announces no length, so the only thing that can prove it arrived whole is the client saying
     // how much it was going to send. Without it a body that ends early - because the producer feeding the stream
@@ -424,7 +451,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // a partial count, which is how a load can silently import a fraction of a file (issue #5470).
     final long records = verticesCreated + edgesCreated;
     if (expectedRecords >= 0 && records != expectedRecords)
-      return recordCountMismatch(exchange, databaseName, verticesCreated, edgesCreated, expectedRecords, records);
+      return recordCountMismatch(exchange, databaseName, verticesCreated, edgesCreated, expectedRecords, records,
+          stream, vertexRefs);
 
     final long elapsed = System.currentTimeMillis() - startTime;
 
@@ -435,6 +463,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // How much of the upload the server actually consumed: on a chunked body there is nothing to compare it with
     // server-side, so this is what lets a client verify that its whole file arrived (issue #5470).
     result.put("bytesRead", inputStream.getBytesRead());
+    addLineAccounting(result, stream, vertexRefs);
 
     // Include temp ID mapping if any temp IDs were used, unless the load was too big for the mapping to be worth
     // (or even possible to) send back - see MAX_ID_MAPPING_IN_RESPONSE and the 'idMapping' parameter.
@@ -535,7 +564,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    *                       ended before the announced length
    */
   private ExecutionResponse truncatedBody(final HttpServerExchange exchange, final String databaseName,
-      final long verticesCreated, final long edgesCreated, final String message, final String exceptionClass) {
+      final long verticesCreated, final long edgesCreated, final BatchRecordStream stream,
+      final VertexRefResolver vertexRefs, final String message, final String exceptionClass) {
 
     LogManager.instance().log(this, Level.WARNING,
         "Batch load on database '%s' was interrupted after %d vertices and %d edges because the request body "
@@ -550,7 +580,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // already gone, but when it does it carries the counts needed to resume instead of restarting.
     return partialPayloadResponse(exchange, 408,
         "Request body was truncated after " + verticesCreated + " vertices and " + edgesCreated + " edges: " + message,
-        exceptionClass, verticesCreated, edgesCreated);
+        exceptionClass, verticesCreated, edgesCreated, stream, vertexRefs);
   }
 
   /**
@@ -560,19 +590,50 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    * make things worse, hence a 400 (issue #5470).
    */
   private ExecutionResponse recordCountMismatch(final HttpServerExchange exchange, final String databaseName,
-      final long verticesCreated, final long edgesCreated, final long expectedRecords, final long records) {
+      final long verticesCreated, final long edgesCreated, final long expectedRecords, final long records,
+      final BatchRecordStream stream, final VertexRefResolver vertexRefs) {
 
     final boolean truncated = records < expectedRecords;
 
     LogManager.instance().log(this, Level.WARNING,
-        "Batch load on database '%s' declared %d records but %s: %d loaded (%d vertices and %d edges). The payload "
-            + "was not what the client announced, so it is reported as incomplete instead of successful",
+        "Batch load on database '%s' declared %d records but %s: %d loaded (%d vertices and %d edges) out of %d lines "
+            + "read. The payload was not what the client announced, so it is reported as incomplete instead of "
+            + "successful",
         null, databaseName, expectedRecords, truncated ? "fewer arrived" : "more arrived", records, verticesCreated,
-        edgesCreated);
+        edgesCreated, stream.getLinesRead());
 
     return partialPayloadResponse(exchange, truncated ? 408 : 400,
         "Expected " + expectedRecords + " records but " + records + " were received (" + verticesCreated
-            + " vertices and " + edgesCreated + " edges)", null, verticesCreated, edgesCreated);
+            + " vertices and " + edgesCreated + " edges)", null, verticesCreated, edgesCreated, stream, vertexRefs);
+  }
+
+  /**
+   * Answers a load that read more lines than it turned into records. Nothing in this handler may consume a line and
+   * do nothing with it, so this is a defect on OUR side: the whole point of counting the lines is that the failure
+   * issue #5618 reports - vertices present in the file and absent from the database, with a successful-looking
+   * response - stops being something the user has to discover by grepping their own payload.
+   * <p>
+   * 500 rather than 400: the payload is not what is wrong. The counters travel with it so the client can still
+   * reconcile whatever was committed before giving up.
+   */
+  private ExecutionResponse recordsDropped(final HttpServerExchange exchange, final String databaseName,
+      final long verticesCreated, final long edgesCreated, final BatchRecordStream stream,
+      final VertexRefResolver vertexRefs) {
+
+    final long missing = stream.getLinesRead() - stream.getLinesSkipped() - verticesCreated - edgesCreated;
+
+    LogManager.instance().log(this, Level.SEVERE,
+        "Batch load on database '%s' read %d lines (%d skipped) but only created %d vertices and %d edges: %d records "
+            + "were dropped without an error. This is a server-side defect, please report it with the payload shape",
+        null, databaseName, stream.getLinesRead(), stream.getLinesSkipped(), verticesCreated, edgesCreated, missing);
+
+    return partialPayloadResponse(exchange, 500,
+        "The load read " + stream.getLinesRead() + " lines (" + stream.getLinesSkipped() + " skipped) but created "
+            + verticesCreated + " vertices and " + edgesCreated + " edges, so " + missing
+            + " records were dropped without an error. The load is reported as failed rather than successful; the "
+            + "records already committed are counted above, so do not simply re-POST the payload - that would "
+            + "duplicate them",
+        null, verticesCreated, edgesCreated, stream, vertexRefs);
   }
 
   /**
@@ -580,7 +641,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    * machine-parsable, because the load is not atomic and the client needs them to reconcile.
    */
   private ExecutionResponse partialPayloadResponse(final HttpServerExchange exchange, final int status,
-      final String message, final String exceptionClass, final long verticesCreated, final long edgesCreated) {
+      final String message, final String exceptionClass, final long verticesCreated, final long edgesCreated,
+      final BatchRecordStream stream, final VertexRefResolver vertexRefs) {
 
     final JSONObject error = new JSONObject();
     error.put("error", message);
@@ -592,7 +654,28 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     error.put("verticesCreated", verticesCreated);
     error.put("edgesCreated", edgesCreated);
     error.put("partialCommit", verticesCreated > 0 || edgesCreated > 0);
+    addLineAccounting(error, stream, vertexRefs);
     return new ExecutionResponse(status, error.toString());
+  }
+
+  /**
+   * Adds what the load did with the payload, line by line, to every answer it can give - success, partial commit and
+   * truncation alike. {@code linesRead} minus {@code linesSkipped} is the number of records the parser handed over,
+   * so a client can check it against {@code verticesCreated + edgesCreated} without trusting the server to have
+   * checked it (the server does, see {@link #recordsDropped}), and can compare it with the line count of its own
+   * file - which is what issue #5618 had to be diagnosed with, by hand, after the fact.
+   * <p>
+   * {@code verticesWithoutId} is reported only when it is not zero: those vertices are loaded and durable, but no
+   * edge of the payload can ever point at them, and today the only symptom is an "unknown temporary ID" much later.
+   */
+  private void addLineAccounting(final JSONObject json, final BatchRecordStream stream,
+      final VertexRefResolver vertexRefs) {
+    json.put("linesRead", stream.getLinesRead());
+    json.put("linesSkipped", stream.getLinesSkipped());
+
+    final int withoutId = vertexRefs.unreferenceableVertices();
+    if (withoutId > 0)
+      json.put("verticesWithoutId", withoutId);
   }
 
   /**
@@ -967,16 +1050,11 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     if (queryString != null && !queryString.isEmpty())
       url += "?" + queryString;
 
-    final InputStream body = exchange.getInputStream();
-    final HttpRequest.Builder builder = HttpRequest.newBuilder()
-        .uri(URI.create(url))
-        .header("Content-Type", contentType)
-        .header("X-ArcadeDB-Cluster-Token", clusterToken)
-        .header("X-ArcadeDB-Forwarded-User", user.getName())
-        .POST(HttpRequest.BodyPublishers.ofInputStream(() -> body));
+    final HttpRequest request = buildForwardRequest(url, contentType, clusterToken, user.getName(),
+        exchange.getRequestContentLength(), exchange.getInputStream());
 
     try {
-      final HttpResponse<String> response = HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+      final HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
 
       // ExecutionResponse carries only status + body, so the leader's X-ArcadeDB-Commit-Index bookmark
       // (issue #5862) has to be copied onto this exchange explicitly, or a READ_YOUR_WRITES client that
@@ -995,5 +1073,53 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(503,
           "{ \"error\" : \"Error forwarding batch to leader: " + e.getMessage().replace("\"", "'") + "\"}");
     }
+  }
+
+  /**
+   * Builds the request that relays a batch payload from a follower to the leader. Three things about it are not
+   * defaults, and each of them is a way a forwarded load could otherwise lose part of its payload in silence
+   * (issue #5618):
+   * <ul>
+   *   <li><b>the content length travels with the body.</b> {@code BodyPublishers.ofInputStream} declares an unknown
+   *   length, so the forwarded request goes out chunked - and a chunked body announces nothing, which switches OFF
+   *   the leader's own truncation check ({@link #bodyEndedEarly} returns false as soon as there is no announced
+   *   length). A relayed upload that ended early was then answered 200 with a partial count, which is precisely
+   *   the safety net issue #5470 added and the forwarding path never had. With the length declared, the JDK client
+   *   also fails the request outright if it cannot feed the leader exactly that many bytes;</li>
+   *   <li><b>HTTP/1.1 is pinned.</b> The default client negotiates HTTP/2, and on a plaintext connection that means
+   *   an {@code h2c} upgrade whose failure mode is re-sending the request - with a body that cannot be rewound;</li>
+   *   <li><b>the body is one-shot and says so.</b> {@code ofInputStream} takes a SUPPLIER because the JDK may
+   *   subscribe more than once and expects a fresh stream each time. There is only one request body here, so a
+   *   second subscription would have handed back a stream already positioned in the middle of the payload and the
+   *   leader would have loaded a file missing its beginning, with nothing anywhere saying so. It now fails loudly
+   *   instead, and the caller answers 503.</li>
+   * </ul>
+   *
+   * @param contentLength the client's announced body length, or a negative value when it uploaded chunked
+   */
+  static HttpRequest buildForwardRequest(final String url, final String contentType, final String clusterToken,
+      final String userName, final long contentLength, final InputStream body) {
+
+    final AtomicBoolean bodyTaken = new AtomicBoolean(false);
+    final Supplier<InputStream> oneShotBody = () -> {
+      if (!bodyTaken.compareAndSet(false, true))
+        throw new IllegalStateException(
+            "The batch payload being forwarded to the leader was requested twice, but a request body can only be "
+                + "read once: sending it again would relay a payload missing everything already consumed");
+      return body;
+    };
+
+    HttpRequest.BodyPublisher publisher = HttpRequest.BodyPublishers.ofInputStream(oneShotBody);
+    if (contentLength >= 0)
+      publisher = HttpRequest.BodyPublishers.fromPublisher(publisher, contentLength);
+
+    return HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .version(HttpClient.Version.HTTP_1_1)
+        .header("Content-Type", contentType)
+        .header("X-ArcadeDB-Cluster-Token", clusterToken)
+        .header("X-ArcadeDB-Forwarded-User", userName)
+        .POST(publisher)
+        .build();
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/BatchRecordStream.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/BatchRecordStream.java
@@ -42,6 +42,19 @@ public interface BatchRecordStream extends AutoCloseable {
    */
   int getLineNumber();
 
+  /**
+   * Physical lines consumed from the input so far, including the ones that carried no record. Together with
+   * {@link #getLinesSkipped()} it lets the caller prove that every line it read became a record: a load that
+   * quietly loses one is otherwise indistinguishable from a payload that never had it (issue #5618).
+   */
+  long getLinesRead();
+
+  /**
+   * Lines consumed that carried no record: blank lines, and for CSV the header and {@code ---} separator rows.
+   * A well-formed load satisfies {@code getLinesRead() == vertices + edges + getLinesSkipped()}.
+   */
+  long getLinesSkipped();
+
   @Override
   void close() throws IOException;
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/CsvBatchRecordStream.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/CsvBatchRecordStream.java
@@ -54,6 +54,7 @@ public class CsvBatchRecordStream implements BatchRecordStream {
   private       int            fromCol   = -1;
   private       int            toCol     = -1;
   private       int            lineNumber;
+  private       long           linesSkipped;
   private       boolean        ready;
   private       boolean        headerParsed;
 
@@ -74,18 +75,22 @@ public class CsvBatchRecordStream implements BatchRecordStream {
 
       lineNumber++;
 
-      if (line.isBlank())
+      if (line.isBlank()) {
+        linesSkipped++;
         continue;
+      }
 
       // Check for section separator
       if (line.startsWith("---")) {
         headerParsed = false;
+        linesSkipped++;
         continue;
       }
 
       // Parse header if needed
       if (!headerParsed) {
         parseHeader(line);
+        linesSkipped++;
         continue;
       }
 
@@ -104,6 +109,16 @@ public class CsvBatchRecordStream implements BatchRecordStream {
   @Override
   public int getLineNumber() {
     return lineNumber;
+  }
+
+  @Override
+  public long getLinesRead() {
+    return lineNumber;
+  }
+
+  @Override
+  public long getLinesSkipped() {
+    return linesSkipped;
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/JsonlBatchRecordStream.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/JsonlBatchRecordStream.java
@@ -50,6 +50,7 @@ public class JsonlBatchRecordStream implements BatchRecordStream {
   private final BufferedReader reader;
   private final BatchRecord    record;
   private       int            lineNumber;
+  private       long           linesSkipped;
   private       boolean        ready;
 
   public JsonlBatchRecordStream(final InputStream input) {
@@ -70,8 +71,10 @@ public class JsonlBatchRecordStream implements BatchRecordStream {
       lineNumber++;
 
       // Skip blank lines
-      if (line.isBlank())
+      if (line.isBlank()) {
+        linesSkipped++;
         continue;
+      }
 
       parseLine(line);
       ready = true;
@@ -88,6 +91,16 @@ public class JsonlBatchRecordStream implements BatchRecordStream {
   @Override
   public int getLineNumber() {
     return lineNumber;
+  }
+
+  @Override
+  public long getLinesRead() {
+    return lineNumber;
+  }
+
+  @Override
+  public long getLinesSkipped() {
+    return linesSkipped;
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/OrdinalVertexRefResolver.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/OrdinalVertexRefResolver.java
@@ -117,6 +117,15 @@ public class OrdinalVertexRefResolver implements VertexRefResolver {
     return size == 0;
   }
 
+  /**
+   * Always none: the position in the payload IS the key, so every vertex this resolver stores can be referenced
+   * whether or not it declared an {@code @id}.
+   */
+  @Override
+  public int unreferenceableVertices() {
+    return 0;
+  }
+
   @Override
   public long retainedBytes() {
     return (long) bucketIds.length * Integer.BYTES + (long) positions.length * Long.BYTES;

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/TempIdVertexRefResolver.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/TempIdVertexRefResolver.java
@@ -34,6 +34,7 @@ import com.arcadedb.utility.StringRidHashMap;
 public class TempIdVertexRefResolver implements VertexRefResolver {
 
   private final StringRidHashMap map;
+  private       int              verticesWithoutId;
 
   public TempIdVertexRefResolver(final int expectedVertices) {
     // The map doubles from its initial capacity, so a hint only saves the copies, never bounds anything.
@@ -46,18 +47,42 @@ public class TempIdVertexRefResolver implements VertexRefResolver {
       map.put(tempId, rid);
   }
 
+  /**
+   * The message reports what the load actually knows instead of asserting one cause. "Vertices must appear before
+   * edges that reference them" used to be the whole explanation, and on the 17M-vertex load of issue #5618 it sent
+   * the user looking for a vertex that was in the file, thousands of lines above the edge - the ordering was never
+   * the problem. The two numbers below separate the cases that message conflated: how many ids this payload
+   * actually declared, and how many of its vertices declared none and therefore cannot be referenced at all.
+   */
   @Override
   public RID get(final String ref, final int lineNumber) {
     final RID rid = map.get(ref);
-    if (rid == null)
-      throw new IllegalArgumentException("Unknown temporary ID '" + ref + "' at line " + lineNumber
-          + ". Vertices must appear before edges that reference them");
+    if (rid == null) {
+      final StringBuilder message = new StringBuilder("Unknown temporary ID '").append(ref).append("' at line ")
+          .append(lineNumber).append(": no vertex earlier in this payload declared it as its @id (")
+          .append(map.size()).append(" ids mapped so far");
+      if (verticesWithoutId > 0)
+        message.append(", and ").append(verticesWithoutId)
+            .append(" vertices carried no @id at all, so nothing can reference them");
+      message.append("). Vertices must appear before the edges that reference them, and each request resolves only "
+          + "the ids of its OWN payload: a vertex loaded by an earlier request has to be referenced by RID "
+          + "(#bucket:position)");
+      throw new IllegalArgumentException(message.toString());
+    }
     return rid;
   }
 
   @Override
   public void checkVertexId(final String tempId, final int ordinal, final int lineNumber) {
-    // Any id is acceptable here, including none: a vertex nothing points at does not need one.
+    // Any id is acceptable here, including none: a vertex nothing points at does not need one. It is counted
+    // though, because a payload that meant to reference it has no other way to find out (issue #5618).
+    if (tempId == null)
+      verticesWithoutId++;
+  }
+
+  @Override
+  public int unreferenceableVertices() {
+    return verticesWithoutId;
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/VertexRefResolver.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/VertexRefResolver.java
@@ -68,6 +68,14 @@ public interface VertexRefResolver {
   boolean isEmpty();
 
   /**
+   * Vertices this payload created that no edge can ever reference, because they declared nothing this resolver
+   * can key them by. Creating them is legal - a vertex nothing points at needs no id - but it is also the one way
+   * a payload can hold a vertex that is loaded and yet unreachable, so the count is reported rather than left for
+   * the user to deduce from a reference that does not resolve (issue #5618).
+   */
+  int unreferenceableVertices();
+
+  /**
    * Bytes this resolver holds, for the heap warning of a long load.
    */
   long retainedBytes();

--- a/server/src/test/java/com/arcadedb/server/Issue5618BatchLineAccountingIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5618BatchLineAccountingIT.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5618: a 17-million-vertex load stopped on {@code Unknown temporary ID 'co/32945720' at line 17234792}, for a
+ * vertex that was sitting in the payload thousands of lines above the edge - and the vertex was not in the database
+ * either. Nothing in the response, and nothing in the log, could tell whether the server had lost records or the
+ * payload had never carried them: the counts it reported were of records it CREATED, with nothing to compare them
+ * against. The user had to count the lines of their own file with grep to find out that two million vertices were
+ * missing, and that still did not say which side had dropped them.
+ * <p>
+ * So the loader now accounts for the payload line by line. Every answer carries {@code linesRead} and
+ * {@code linesSkipped}, which makes {@code linesRead - linesSkipped == verticesCreated + edgesCreated} something a
+ * client can check against its own file - and something the server checks itself before answering 200, so a record
+ * read and turned into nothing is reported as a failure instead of hiding inside a successful load.
+ * <p>
+ * The other half is the diagnosis. "Vertices must appear before edges that reference them" was the whole explanation
+ * an unresolvable reference got, and it was the wrong one here; the message now reports what the load actually knows,
+ * including how many vertices declared no {@code @id} at all and therefore cannot be referenced by anything.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5618BatchLineAccountingIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  /**
+   * The equality the user had to establish by hand: what the file holds, what the server read, what it created.
+   */
+  @Test
+  void everyLineOfASuccessfulLoadIsAccountedFor() throws Exception {
+    createSchema();
+
+    final String body = """
+        {"@type":"vertex","@class":"Ent1","@id":"co/1","fid":"co/1"}
+
+        {"@type":"vertex","@class":"Ent1","@id":"co/2","fid":"co/2"}
+        {"@type":"vertex","@class":"Ent2","@id":"co/3","fid":"co/3"}
+
+        {"@type":"edge","@class":"REL","@from":"co/1","@to":"co/3"}
+        """;
+
+    final JSONObject result = postBatch(body, "");
+
+    assertThat(result.getLong("verticesCreated")).isEqualTo(3);
+    assertThat(result.getLong("edgesCreated")).isEqualTo(1);
+    assertThat(result.getLong("linesRead")).isEqualTo(6);
+    assertThat(result.getLong("linesSkipped")).isEqualTo(2);
+    assertThat(result.getLong("linesRead") - result.getLong("linesSkipped"))
+        .as("every line read is either a record or a declared skip")
+        .isEqualTo(result.getLong("verticesCreated") + result.getLong("edgesCreated"));
+    assertThat(result.has("verticesWithoutId")).as("every vertex declared an @id").isFalse();
+  }
+
+  /**
+   * A load that fails mid-stream needs the accounting more than a successful one does: it is the only way to place
+   * the failure inside the file. The reported line was the entire diagnosis available on #5618.
+   */
+  @Test
+  void aFailedLoadStillReportsHowMuchOfThePayloadItRead() throws Exception {
+    createSchema();
+
+    final String body = """
+        {"@type":"vertex","@class":"Ent1","@id":"a1","fid":"a1"}
+        {"@type":"vertex","@class":"Ent1","@id":"a2","fid":"a2"}
+        {"@type":"edge","@class":"REL","@from":"a1","@to":"a2"}
+        {"@type":"edge","@class":"REL","@from":"a1","@to":"never-declared"}
+        {"@type":"edge","@class":"REL","@from":"a2","@to":"a1"}
+        """;
+
+    final JSONObject error = postBatchExpecting(400, body, "");
+
+    assertThat(error.getString("error")).contains("Unknown temporary ID 'never-declared' at line 4");
+    assertThat(error.getLong("verticesCreated")).isEqualTo(2);
+    assertThat(error.getLong("edgesCreated")).isEqualTo(1);
+    assertThat(error.getLong("linesRead")).as("the failing line was read too").isEqualTo(4);
+    assertThat(error.getLong("linesSkipped")).isZero();
+  }
+
+  /**
+   * The message that sent the reporter looking in the wrong place. It asserted ordering as the cause; the payload
+   * ordering was fine. It now reports what is established - how many ids this payload declared - and names the two
+   * causes it cannot tell apart, one of which (a reference to a vertex loaded by an EARLIER request) is invisible
+   * from inside a single request and is exactly what a client splitting a large file hits.
+   */
+  @Test
+  void anUnresolvedReferenceReportsWhatTheLoadKnowsInsteadOfAssumingBadOrdering() throws Exception {
+    createSchema();
+
+    final String body = """
+        {"@type":"vertex","@class":"Ent1","@id":"b1","fid":"b1"}
+        {"@type":"vertex","@class":"Ent1","@id":"b2","fid":"b2"}
+        {"@type":"edge","@class":"REL","@from":"b1","@to":"b9"}
+        """;
+
+    final JSONObject error = postBatchExpecting(400, body, "");
+    final String message = error.getString("error");
+
+    assertThat(message).contains("2 ids mapped so far");
+    assertThat(message).contains("each request resolves only the ids of its OWN payload");
+    assertThat(message).contains("#bucket:position");
+  }
+
+  /**
+   * A vertex with no {@code @id} is legal - nothing has to point at it - but it is also the one way a payload can
+   * hold a vertex that is loaded and unreachable. It used to be completely silent, so an edge that meant to
+   * reference one reported the same misleading "vertices must appear before edges". Both the count and the message
+   * now say so.
+   */
+  @Test
+  void verticesThatDeclareNoIdAreReportedInsteadOfDisappearing() throws Exception {
+    createSchema();
+
+    final String vertexOnly = """
+        {"@type":"vertex","@class":"Ent1","@id":"c1","fid":"c1"}
+        {"@type":"vertex","@class":"Ent1","fid":"c2"}
+        {"@type":"vertex","@class":"Ent1","fid":"c3"}
+        """;
+
+    final JSONObject loaded = postBatch(vertexOnly, "");
+    assertThat(loaded.getLong("verticesCreated")).isEqualTo(3);
+    assertThat(loaded.getInt("verticesWithoutId"))
+        .as("two vertices are durable but no edge can ever reference them")
+        .isEqualTo(2);
+
+    final String withEdge = """
+        {"@type":"vertex","@class":"Ent1","@id":"d1","fid":"d1"}
+        {"@type":"vertex","@class":"Ent1","fid":"d2"}
+        {"@type":"edge","@class":"REL","@from":"d1","@to":"d2"}
+        """;
+
+    final JSONObject error = postBatchExpecting(400, withEdge, "");
+    assertThat(error.getString("error")).contains("1 vertices carried no @id at all");
+    assertThat(error.getInt("verticesWithoutId")).isEqualTo(1);
+  }
+
+  /**
+   * CSV reads more lines than it produces records - a header per section plus the {@code ---} separator - so the
+   * accounting has to name them, or a good load would look like it dropped four records.
+   */
+  @Test
+  void csvHeadersAndSeparatorsAreCountedAsSkippedNotAsLostRecords() throws Exception {
+    createSchema();
+
+    final String body = """
+        @type,@class,@id,fid
+        vertex,Ent1,e1,e1
+        vertex,Ent1,e2,e2
+        ---
+        @type,@class,@from,@to
+        edge,REL,e1,e2
+        """;
+
+    final JSONObject result = postBatch(body, "", "text/csv");
+
+    assertThat(result.getLong("verticesCreated")).isEqualTo(2);
+    assertThat(result.getLong("edgesCreated")).isEqualTo(1);
+    assertThat(result.getLong("linesRead")).isEqualTo(6);
+    assertThat(result.getLong("linesSkipped")).isEqualTo(3);
+    assertThat(result.getLong("linesRead") - result.getLong("linesSkipped"))
+        .isEqualTo(result.getLong("verticesCreated") + result.getLong("edgesCreated"));
+  }
+
+  /**
+   * The shape of the reported payload, scaled down to something a build can run: many vertices, several types
+   * interleaved so the loader keeps flushing partial batches on the type change, and an edge for every single
+   * vertex. Every temporary id has to resolve and every vertex has to be on disk - the claim the issue makes is
+   * that one of them was not.
+   */
+  @Test
+  @Tag("slow")
+  void aLargeMultiTypeLoadLosesNoVertex() throws Exception {
+    createSchema();
+
+    final int total = 200_000;
+    final StringBuilder body = new StringBuilder(total * 100);
+    for (int i = 0; i < total; i++) {
+      final String id = "co/" + (30_000_000 + i);
+      body.append("{\"@type\":\"vertex\",\"@class\":\"Ent").append(1 + (i / 997) % 3).append("\",\"@id\":\"")
+          .append(id).append("\",\"fid\":\"").append(id).append("\"}\n");
+    }
+    for (int i = 0; i < total; i++)
+      body.append("{\"@type\":\"edge\",\"@class\":\"REL\",\"@from\":\"co/").append(30_000_000 + i)
+          .append("\",\"@to\":\"co/").append(30_000_000 + (total - 1 - i)).append("\"}\n");
+
+    final JSONObject result = postBatch(body.toString(), "vertexBatchSize=1000&idMapping=false");
+
+    assertThat(result.getLong("verticesCreated")).isEqualTo(total);
+    assertThat(result.getLong("edgesCreated")).isEqualTo(total);
+    assertThat(result.getLong("linesRead")).isEqualTo(2L * total);
+    assertThat(result.getLong("linesSkipped")).isZero();
+
+    final Database db = getServerDatabase(0, getDatabaseName());
+    assertThat(db.countType("Ent1", false) + db.countType("Ent2", false) + db.countType("Ent3", false))
+        .isEqualTo(total);
+  }
+
+  private void createSchema() {
+    final Database db = getServerDatabase(0, getDatabaseName());
+    if (db.getSchema().existsType("Ent1"))
+      return;
+
+    db.getSchema().createVertexType("Ent1");
+    db.getSchema().createVertexType("Ent2");
+    db.getSchema().createVertexType("Ent3");
+    db.getSchema().createEdgeType("REL");
+  }
+
+  private JSONObject postBatch(final String body, final String queryParams) throws Exception {
+    return postBatch(body, queryParams, "application/x-ndjson");
+  }
+
+  private JSONObject postBatch(final String body, final String queryParams, final String contentType)
+      throws Exception {
+    return post(200, body, queryParams, contentType);
+  }
+
+  private JSONObject postBatchExpecting(final int status, final String body, final String queryParams)
+      throws Exception {
+    return post(status, body, queryParams, "application/x-ndjson");
+  }
+
+  private JSONObject post(final int expectedStatus, final String body, final String queryParams,
+      final String contentType) throws Exception {
+    String url = "http://127.0.0.1:2480/api/v1/batch/" + getDatabaseName();
+    if (queryParams != null && !queryParams.isEmpty())
+      url += "?" + queryParams;
+
+    final HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+    conn.setRequestMethod("POST");
+    conn.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    conn.setRequestProperty("Content-Type", contentType);
+    conn.setDoOutput(true);
+
+    final byte[] data = body.getBytes(StandardCharsets.UTF_8);
+    conn.setRequestProperty("Content-Length", Integer.toString(data.length));
+    try (final DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+      out.write(data);
+    }
+    conn.connect();
+
+    try {
+      final int status = conn.getResponseCode();
+      final InputStream in = status < 400 ? conn.getInputStream() : conn.getErrorStream();
+      final String response = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      assertThat(status).as("response: %s", response).isEqualTo(expectedStatus);
+      return new JSONObject(response);
+    } finally {
+      conn.disconnect();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostBatchHandlerForwardRequestTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostBatchHandlerForwardRequestTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A batch load that lands on a follower is relayed to the leader, and that hop must not be able to deliver less than
+ * the client sent without anyone noticing (issue #5618).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostBatchHandlerForwardRequestTest {
+
+  private static final String PAYLOAD = "{\"@type\":\"vertex\",\"@class\":\"V1\",\"@id\":\"a\"}\n";
+
+  /**
+   * The relayed request has to announce the same length the client did. Without it the JDK client sends the body
+   * chunked, and a chunked body announces nothing - which disables the leader's own truncation check, so a relayed
+   * upload that ended early came back as a successful load with a partial count.
+   */
+  @Test
+  void aRelayedPayloadDeclaresTheLengthTheClientAnnounced() {
+    final byte[] body = PAYLOAD.getBytes(StandardCharsets.UTF_8);
+
+    final HttpRequest request = PostBatchHandler.buildForwardRequest("http://leader:2480/api/v1/batch/db",
+        "application/x-ndjson", "token", "root", body.length, new ByteArrayInputStream(body));
+
+    assertThat(request.bodyPublisher()).isPresent();
+    assertThat(request.bodyPublisher().get().contentLength()).isEqualTo(body.length);
+  }
+
+  /**
+   * A client that uploaded chunked announced nothing to relay, and inventing a length would truncate the payload at
+   * that many bytes. The hop stays chunked, exactly as the client's own was.
+   */
+  @Test
+  void aChunkedUploadIsRelayedWithoutALength() {
+    final HttpRequest request = PostBatchHandler.buildForwardRequest("http://leader:2480/api/v1/batch/db",
+        "application/x-ndjson", "token", "root", -1,
+        new ByteArrayInputStream(PAYLOAD.getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(request.bodyPublisher().get().contentLength()).isEqualTo(-1);
+  }
+
+  /**
+   * HTTP/2 on a plaintext connection means an h2c upgrade, whose failure mode is re-sending a request whose body
+   * cannot be rewound. The hop is pinned to HTTP/1.1 so the question never arises.
+   */
+  @Test
+  void theRelayIsPinnedToHttp11() {
+    final HttpRequest request = PostBatchHandler.buildForwardRequest("http://leader:2480/api/v1/batch/db",
+        "application/x-ndjson", "token", "root", PAYLOAD.length(),
+        new ByteArrayInputStream(PAYLOAD.getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(request.version()).contains(HttpClient.Version.HTTP_1_1);
+  }
+
+  /**
+   * The heart of it. {@code BodyPublishers.ofInputStream} takes a supplier because the JDK may subscribe more than
+   * once and expects a FRESH stream every time; there is only one request body here, so handing the same one back a
+   * second time would relay a payload starting in the middle of the file - a load missing its beginning, reported as
+   * a success, with an "unknown temporary ID" for a vertex that is right there in the payload. It refuses instead.
+   */
+  @Test
+  void theBodyCanOnlyBeHandedOverOnce() {
+    final InputStream body = new ByteArrayInputStream(PAYLOAD.getBytes(StandardCharsets.UTF_8));
+    final HttpRequest request = PostBatchHandler.buildForwardRequest("http://leader:2480/api/v1/batch/db",
+        "application/x-ndjson", "token", "root", PAYLOAD.length(), body);
+
+    // First subscription gets the body, as the single real send does.
+    final HttpRequest.BodyPublisher publisher = request.bodyPublisher().get();
+    publisher.subscribe(new DiscardingSubscriber());
+
+    assertThatThrownBy(() -> publisher.subscribe(new DiscardingSubscriber()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("can only be read once");
+  }
+
+  /**
+   * The headers the leader authenticates the hop with must be on the relayed request, or the load is rejected before
+   * a single line of it is parsed.
+   */
+  @Test
+  void theRelayCarriesTheClusterTokenAndTheForwardedUser() {
+    final HttpRequest request = PostBatchHandler.buildForwardRequest("http://leader:2480/api/v1/batch/db",
+        "text/csv", "the-token", "importer", -1,
+        new ByteArrayInputStream(PAYLOAD.getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(request.headers().firstValue("X-ArcadeDB-Cluster-Token")).contains("the-token");
+    assertThat(request.headers().firstValue("X-ArcadeDB-Forwarded-User")).contains("importer");
+    assertThat(request.headers().firstValue("Content-Type")).contains("text/csv");
+  }
+
+  /**
+   * A subscriber that cancels at once: enough to make the publisher hand out its single stream without reading it.
+   */
+  private static class DiscardingSubscriber implements java.util.concurrent.Flow.Subscriber<java.nio.ByteBuffer> {
+    @Override
+    public void onSubscribe(final java.util.concurrent.Flow.Subscription subscription) {
+      subscription.cancel();
+    }
+
+    @Override
+    public void onNext(final java.nio.ByteBuffer item) {
+    }
+
+    @Override
+    public void onError(final Throwable throwable) {
+    }
+
+    @Override
+    public void onComplete() {
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostBatchHandlerForwardRequestTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostBatchHandlerForwardRequestTest.java
@@ -24,7 +24,9 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Flow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -120,14 +122,14 @@ class PostBatchHandlerForwardRequestTest {
   /**
    * A subscriber that cancels at once: enough to make the publisher hand out its single stream without reading it.
    */
-  private static class DiscardingSubscriber implements java.util.concurrent.Flow.Subscriber<java.nio.ByteBuffer> {
+  private static class DiscardingSubscriber implements Flow.Subscriber<ByteBuffer> {
     @Override
-    public void onSubscribe(final java.util.concurrent.Flow.Subscription subscription) {
+    public void onSubscribe(final Flow.Subscription subscription) {
       subscription.cancel();
     }
 
     @Override
-    public void onNext(final java.nio.ByteBuffer item) {
+    public void onNext(final ByteBuffer item) {
     }
 
     @Override

--- a/server/src/test/java/com/arcadedb/server/http/handler/batch/BatchRecordStreamAccountingTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/batch/BatchRecordStreamAccountingTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler.batch;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every line a batch stream consumes either becomes a record or is one it declares skipped. That equality is what
+ * lets the endpoint - and the client - prove that a load did not quietly lose records, which is the question
+ * issue #5618 had no way to answer.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BatchRecordStreamAccountingTest {
+
+  @Test
+  void jsonlCountsEveryLineItReads() throws IOException {
+    final String payload = """
+        {"@type":"vertex","@class":"V1","@id":"a"}
+
+        {"@type":"vertex","@class":"V1","@id":"b"}
+        \s
+        {"@type":"edge","@class":"E1","@from":"a","@to":"b"}
+        """;
+
+    final int records = drain(new JsonlBatchRecordStream(stream(payload)), 3);
+    final JsonlBatchRecordStream counted = new JsonlBatchRecordStream(stream(payload));
+    drain(counted, records);
+
+    assertThat(counted.getLinesRead()).isEqualTo(5);
+    assertThat(counted.getLinesSkipped()).isEqualTo(2);
+    assertThat(counted.getLinesRead() - counted.getLinesSkipped()).isEqualTo(records);
+  }
+
+  /**
+   * CSV skips more than blank lines: the header of each section and the {@code ---} separator carry no record
+   * either, and counting them as records would make a perfectly good load look like it had dropped some.
+   */
+  @Test
+  void csvCountsHeadersAndSeparatorsAsSkipped() throws IOException {
+    final String payload = """
+        @type,@class,@id,id
+        vertex,V1,c1,200
+        vertex,V1,c2,201
+
+        ---
+        @type,@class,@from,@to
+        edge,E1,c1,c2
+        """;
+
+    final CsvBatchRecordStream stream = new CsvBatchRecordStream(stream(payload));
+    final int records = drain(stream, 3);
+
+    assertThat(records).isEqualTo(3);
+    assertThat(stream.getLinesRead()).isEqualTo(7);
+    // header, blank, ---, header
+    assertThat(stream.getLinesSkipped()).isEqualTo(4);
+    assertThat(stream.getLinesRead() - stream.getLinesSkipped()).isEqualTo(records);
+  }
+
+  @Test
+  void anEmptyPayloadReadsAndSkipsNothing() throws IOException {
+    final JsonlBatchRecordStream stream = new JsonlBatchRecordStream(stream(""));
+
+    assertThat(stream.hasNext()).isFalse();
+    assertThat(stream.getLinesRead()).isZero();
+    assertThat(stream.getLinesSkipped()).isZero();
+  }
+
+  private static int drain(final BatchRecordStream stream, final int expected) throws IOException {
+    int records = 0;
+    while (stream.hasNext()) {
+      stream.next();
+      records++;
+    }
+    assertThat(records).isEqualTo(expected);
+    return records;
+  }
+
+  private static ByteArrayInputStream stream(final String payload) {
+    return new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
Fixes #5618

## What was reported

A 17-million-vertex load stopped on:

```
Batch load on database 'graph-260801' failed after 17223811 vertices and 10980 edges:
Unknown temporary ID 'co/32945720' at line 17234792. Vertices must appear before edges that reference them
```

`co/32945720` is declared, as a vertex, at line 12781577 of the same file - thousands of lines *above* the edge that could not resolve it. It was not in the database either. Counting `{"@type":"vertex"` in the file gave 19,484,584, more than two million above what the load created.

## What I could and could not establish

I could not reproduce a dropped vertex. The temp-id map (`StringRidHashMap`) is exact at 20M keys, an engine-level 1M-vertex `GraphBatch` run loses nothing, and a 300K-vertex HTTP load across three interleaved types resolves every id. The counts in the report are also self-consistent - `17223811 + 10980 + 1 == 17234792` - which says every line up to the failure became a record.

So the actionable defect is the one the reporter named at the end of the issue: **the endpoint reports what it created and gives you nothing to check it against.** Whether the payload lost 2M lines upstream, the relay lost them, or the loader did, the answer looks the same from the outside, and the diagnosis costs a `grep -c` over a multi-gigabyte file and still comes out inconclusive.

The issue suggests counting lines read and records created. This does that, and three things more that make the count worth having.

## The change

**Line accounting on every answer.** `linesRead` and `linesSkipped` (blank lines, plus CSV headers and `---` separators) ride the 200, the 400 that rejects a record, and the 408 that reports a truncated upload. `linesRead - linesSkipped` is the number of records the parser produced, so a client checks it against `verticesCreated + edgesCreated` *and* against the line count of the file it sent, without a support round-trip.

**The server checks the same equality before answering 200.** A line read and turned into nothing is a defect on our side, not the client's, so the load is now reported as failed (500, with the partial-commit counters and a `SEVERE` log line naming the numbers) instead of a success carrying a count that silently misses records. Counting is only half of it - a number nobody compares is a number nobody reads.

**`verticesWithoutId`.** Under the default `refMode=id` a vertex with no `@id` is accepted silently; it is loaded and durable and *nothing in the payload can ever reference it*. That is the one shape in which a payload legitimately holds a vertex that is present and unreachable, and until now its only symptom was an unresolvable reference much further down - exactly the confusion this issue reports. It is now counted and reported.

**An honest message for an unresolved reference.** "Vertices must appear before edges that reference them" was the entire explanation, and here it was the wrong one. It now states what the load knows: how many ids the payload declared, how many of its vertices declared none, and that each request resolves only the ids of its *own* payload - the trap a client hits when it splits one file across several requests and expects `@id`s from an earlier one to still resolve.

**The follower-to-leader relay stops being a silent hole.** `forwardBatchToLeader` built its body with `BodyPublishers.ofInputStream`, which declares an unknown length, so the relayed request went out **chunked** - and a chunked body announces nothing, which switches off the leader's own truncation check (`bodyEndedEarly` gives up as soon as there is no announced length). A relayed upload that ended early therefore came back as a 200 with a partial count: precisely the outcome #5470 exists to prevent, on the one path it never covered. Three fixes:

- the client's `Content-Length` travels with the body, so the leader can check it *and* the JDK client fails the request outright if it cannot feed exactly that many bytes;
- the hop is pinned to HTTP/1.1, since h2c's failure mode is re-sending a request whose body cannot be rewound;
- `ofInputStream` takes a *supplier* because the JDK may subscribe more than once and expects a fresh stream each time. There is one request body here, so a second subscription used to hand back a stream already positioned mid-payload - the leader would load a file missing its beginning and say nothing. It now fails loudly.

## Tests

- `PostBatchHandlerForwardRequestTest` (5) - the relayed request declares the client's length, stays chunked when the client was, is pinned to HTTP/1.1, refuses to give its body up twice, and carries the cluster token. All five fail against the previous code.
- `BatchRecordStreamAccountingTest` (3) - JSONL and CSV account for every line they read; CSV headers and `---` are skips, not lost records.
- `Issue5618BatchLineAccountingIT` (6) - the accounting on success, on a failed load, and on CSV; the new unresolved-reference message; `verticesWithoutId`; and a 200K-vertex, three-type, edge-per-vertex load that loses nothing.
- `RaftBatchEndpointIT.aBatchRelayedByAFollowerArrivesWhole` - a payload posted to a follower reaches the leader whole and is accounted for line by line.

Full run: 93 batch tests in `server`, 4 in `ha-raft`, all green. `Issue5470BatchErrorDeliveryIT`, `Issue5470BatchStreamStallIT`, `PostBatchHandlerIT` and `RemoteGraphBatchIT` unchanged and passing.

## Follow-up worth having

If the reporter still has the payload, `linesRead` from a re-run would settle in one request which side dropped the two million lines. I would also suggest they pass `expectedRecords` - it already exists and would have failed this load loudly at the end rather than leaving the count to be discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131GDFM4QGFC5URdReusH4A