### PR TITLE
fix(engine) #2378: SELECT * stops filtering properties the schema marks hidden

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
@@ -20,7 +20,6 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
-import com.arcadedb.database.Document;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -117,17 +116,16 @@ public class Projection extends SimpleNode {
       if (item.isAll()) {
         result.setElement(record.toElement());
 
+        // `hidden` is a schema annotation only, and has been since #2378 removed database-level support for it:
+        // ALTER PROPERTY still records the flag and SHOW/schema introspection still report it, but no read path
+        // filters on it. This loop used to, which made `SELECT *` disagree with a bare `SELECT` on the same row -
+        // and the disagreement was invisible for a year because ResultInternal.getPropertyNames() unioned the
+        // element's names back over the top of it, until #5613 removed that union and left the filter exposed.
+        // Do not reinstate it here: hiding a property from a projection but not from the record that backs it is
+        // not a security boundary, it only makes the two spellings of "give me everything" return different rows.
         for (final String alias : record.getPropertyNames()) {
-          if (excludes.contains(alias)) {
+          if (excludes.contains(alias))
             continue;
-          } else if (record.getElement().isPresent()) {
-            final Document doc = record.getElement().get();
-            if (excludes.contains(alias) ||
-                (doc.getType().existsProperty(alias) &&
-                    doc.getType().getProperty(alias).isHidden())) {
-              continue;
-            }
-          }
           Object value = item.convert(record.getProperty(alias));
           if (item.nestedProjection != null) {
             value = item.nestedProjection.apply(item.expression, value, context);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CreatePropertyStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CreatePropertyStatementExecutionTest.java
@@ -29,6 +29,7 @@ import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -220,8 +221,8 @@ class CreatePropertyStatementExecutionTest extends TestHelper {
 
   @Test
   void createHiddenProperty() {
-    // due to https://github.com/ArcadeData/arcadedb/issues/2378 hidden properties are supported in thhe schema, but not in the
-    // database
+    // Issue #2378: `hidden` is kept as a schema annotation but has no effect on any read path. The two assertions
+    // below - `SELECT *` and a bare `SELECT` - are the whole contract, and they must agree.
     database.command("sql", "create vertex type testHiddenProperty").close();
     database.command("sql", "CREATE property testHiddenProperty.name STRING (hidden)").close();
 
@@ -246,5 +247,57 @@ class CreatePropertyStatementExecutionTest extends TestHelper {
     assertThat(doc.getPropertyNames()).contains("name").contains("no_secret");
     assertThat(doc.isVertex()).isTrue();
 
+  }
+
+  /**
+   * Issue #2378, exposed by #5613. `SELECT *` runs through {@code Projection}, which used to skip any alias whose
+   * schema property was marked {@code hidden}; a bare {@code SELECT} returns the record's own names and never did.
+   * The disagreement went unseen for a year because {@code ResultInternal.getPropertyNames()} merged the element's
+   * names over the projection's, putting the filtered name back - until #5613 stopped merging them to fix a Cypher
+   * projection emitting null columns, and left the filter showing.
+   * <p>
+   * This pins the two spellings of "give me everything" to the same answer. It fails on the filter: `SELECT *`
+   * comes back without {@code secret}, while the bare form still has it.
+   */
+  @Test
+  void hiddenPropertyIsReturnedByEverySpellingOfSelectAll() {
+    database.command("sql", "CREATE vertex type HiddenAgreement").close();
+    database.command("sql", "CREATE property HiddenAgreement.secret STRING (hidden)").close();
+    database.command("sql", "CREATE property HiddenAgreement.plain STRING").close();
+    database.transaction(
+        () -> database.command("sql", "INSERT INTO HiddenAgreement SET secret = 's', plain = 'p'").close());
+
+    assertThat(database.getSchema().getType("HiddenAgreement").getProperty("secret").isHidden())
+        .as("the schema still records the annotation - #2378 removed its effect, not the flag").isTrue();
+
+    final List<String> star;
+    try (final ResultSet rs = database.query("sql", "SELECT * FROM HiddenAgreement")) {
+      star = new ArrayList<>(rs.next().getPropertyNames());
+    }
+    final List<String> bare;
+    try (final ResultSet rs = database.query("sql", "SELECT FROM HiddenAgreement")) {
+      bare = new ArrayList<>(rs.next().getPropertyNames());
+    }
+
+    assertThat(star).as("SELECT * must not drop a property just because the schema calls it hidden, got %s", star)
+        .contains("secret", "plain");
+    assertThat(bare).as("and the bare form has always returned it, got %s", bare).contains("secret", "plain");
+    assertThat(star).as("so the two must agree on the record's own properties")
+        .containsAll(bare);
+  }
+
+  /** Removing the hidden filter must not disturb the exclusion syntax that shares the same loop. */
+  @Test
+  void selectStarStillHonoursExplicitExclusions() {
+    database.command("sql", "CREATE vertex type HiddenExclude").close();
+    database.command("sql", "CREATE property HiddenExclude.secret STRING (hidden)").close();
+    database.transaction(
+        () -> database.command("sql", "INSERT INTO HiddenExclude SET secret = 's', plain = 'p'").close());
+
+    try (final ResultSet rs = database.query("sql", "SELECT *, !secret FROM HiddenExclude")) {
+      final List<String> names = new ArrayList<>(rs.next().getPropertyNames());
+      assertThat(names).as("an explicit exclusion is the supported way to drop a column, got %s", names)
+          .doesNotContain("secret").contains("plain");
+    }
   }
 }


### PR DESCRIPTION
Finishes #2378.

### What was left behind

#2378 removed database-level support for hidden properties in 2025, but left the filter in `Projection`: for `SELECT *` it skipped any alias whose schema property was marked `hidden`, while a bare `SELECT` returned the record's own names and never filtered. The two spellings of "give me everything" have disagreed ever since.

It stayed invisible because `Projection` also sets the element on the row, and `ResultInternal.getPropertyNames()` used to union the element's names over the content's - putting the filtered name straight back. #5613 stopped merging them (to keep a Cypher `RETURN n` from emitting every type property as a null column) and left the year-old filter exposed.

That is what has had `CreatePropertyStatementExecutionTest.createHiddenProperty`, and with it the whole `unit-tests` job, red on `main`.

Measured on `ea4f6af30` before this change:

```
SELECT * FROM Plain -> [name, extra, @rid, @type]
SELECT * FROM Hid   -> [extra, @rid, @type]        <- hidden `name` dropped
SELECT   FROM Hid   -> [name, extra]               <- hidden `name` returned
```

### The change

The filter goes. `hidden` stays a schema annotation exactly as #2378 intended - `ALTER PROPERTY` still records it, `AbstractProperty` still exposes it, schema introspection still reports it. Only the read path stops honouring it. Hiding a property from a projection but not from the record behind it was never a security boundary; it only made two queries that should agree return different rows.

The inner `else if` goes with it: once the hidden clause was removed its only other condition was an `excludes` check the line above already performs, leaving it dead.

### Tests

- `createHiddenProperty` passes as written for the first time since #5613.
- `hiddenPropertyIsReturnedByEverySpellingOfSelectAll` pins `SELECT *` and bare `SELECT` to the same answer, and asserts the schema flag survives.
- `selectStarStillHonoursExplicitExclusions` guards the loop simplification - `SELECT *, !secret` still excludes.
- Mutation-checked by restoring the filter: both go red, the new one reporting `got [plain, @rid, @type]`.

Full `com.arcadedb.query.**` sweep: **10598 tests**, one failure - `Issue4305Test.pointRaisesCleanErrorOnNonNumericString`, which fails identically on a clean `ea4f6af30` checkout and comes from #5909 landing after this branch's base. Unrelated to this diff, but note it will keep `unit-tests` red after this merges.