### PR TITLE
fix(#5645): re-derive each subtype's own bucket index in TypeIndex.getIndexesByKeys

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.IndexCursorCollection;
 import com.arcadedb.database.RID;
+import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.index.fulltext.FullTextSearch;
@@ -642,8 +643,10 @@ public class TypeIndex implements RangeIndex, IndexInternal {
     // which falls through to the full fan-out below.
     final List<String> propNames = getPropertyNames();
 
-    final int bucketIndex = type.getBucketIndexByKeys(propNames, keys,
-        DatabaseContext.INSTANCE.getContext(type.getSchema().getEmbedded().getDatabase().getDatabasePath()).asyncMode);
+    final boolean async =
+        DatabaseContext.INSTANCE.getContext(type.getSchema().getEmbedded().getDatabase().getDatabasePath()).asyncMode;
+
+    final int bucketIndex = type.getBucketIndexByKeys(propNames, keys, async);
 
     if (bucketIndex > -1) {
       // USE THE SHARDED INDEX
@@ -656,10 +659,21 @@ public class TypeIndex implements RangeIndex, IndexInternal {
         polymorphicIndexesOnKeys = new ArrayList<>(polymorphicIndexesOnKeys);
 
         for (DocumentType s : subTypes) {
-          final List<IndexInternal> subIndexes = s.getPolymorphicBucketIndexByBucketId(
-              s.getBuckets(false).get(bucketIndex).getFileId(), propNames);
-          polymorphicIndexesOnKeys.addAll(subIndexes);
-
+          // `bucketIndex` is only meaningful modulo the bucket count it was computed against (the
+          // parent's). A subtype is free to declare a different bucket count, so reusing it here can
+          // index past the end of the subtype's own bucket list (issue #5645). Each subtype has to
+          // re-derive its own placement through its own strategy and its own modulus instead.
+          final int subBucketIndex = s.getBucketIndexByKeys(propNames, keys, async);
+          if (subBucketIndex > -1) {
+            final List<IndexInternal> subIndexes = s.getPolymorphicBucketIndexByBucketId(
+                s.getBuckets(false).get(subBucketIndex).getFileId(), propNames);
+            polymorphicIndexesOnKeys.addAll(subIndexes);
+          } else {
+            // This subtype cannot prune (not partitioned, or its strategy declines): fall back to
+            // its own full bucket list rather than skip it or guess with the parent's bucket index.
+            for (final Bucket subBucket : s.getBuckets(false))
+              polymorphicIndexesOnKeys.addAll(s.getPolymorphicBucketIndexByBucketId(subBucket.getFileId(), propNames));
+          }
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -658,7 +658,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
         // MODIFIABLE COPY
         polymorphicIndexesOnKeys = new ArrayList<>(polymorphicIndexesOnKeys);
 
-        for (DocumentType s : subTypes) {
+        for (final DocumentType s : subTypes) {
           // `bucketIndex` is only meaningful modulo the bucket count it was computed against (the
           // parent's). A subtype is free to declare a different bucket count, so reusing it here can
           // index past the end of the subtype's own bucket list (issue #5645). Each subtype has to

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import static com.arcadedb.log.WarningCapture.captureSevere;
 import static com.arcadedb.log.WarningCapture.captureWarnings;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * Issue #5637, the two loose ends of the partitioned-strategy series (#5589, #5595, #5603).
@@ -290,6 +291,56 @@ class PartitionedStrategyLifecycleTest extends TestHelper {
 
     database.transaction(() -> database.newDocument("Derived").set("k", "acme").save());
     assertThat(database.query("sql", "SELECT FROM Derived WHERE k = 'acme'").stream().count()).isEqualTo(1);
+  }
+
+  /**
+   * Issue #5645. {@code bucketIndex} is only meaningful modulo the bucket count it was derived against - the
+   * parent's. A subtype declares its OWN bucket count, and when that count is SMALLER than the parent's,
+   * {@code TypeIndex.getIndexesByKeys} used to apply the parent-derived index straight into the subtype's own
+   * (shorter) bucket list and throw {@code IndexOutOfBoundsException} on the very first indexed insert - exactly
+   * the reproduction from the issue: a partitioned {@code Base BUCKETS 3} and a {@code Derived} that inherits the
+   * strategy but gets the schema's default single bucket.
+   */
+  @Test
+  void aSubtypeWithFewerBucketsThanItsParentDoesNotCrashOnIndexedInsert() {
+    createPartitionedType("Base");
+    // NO "BUCKETS" CLAUSE: DERIVED GETS THE DEFAULT (1), STRICTLY FEWER THAN THE PARENT'S 3
+    database.transaction(() -> database.command("sql", "CREATE DOCUMENT TYPE Derived EXTENDS Base"));
+
+    assertThat(database.getSchema().getType("Derived").getBuckets(false)).hasSize(1);
+
+    assertThatNoException().isThrownBy(
+        () -> database.transaction(() -> database.newDocument("Derived").set("k", "acme").save()));
+
+    assertThat(database.query("sql", "SELECT FROM Derived WHERE k = 'acme'").stream().count())
+        .as("the record must be both insertable and findable through the index despite the bucket-count mismatch")
+        .isEqualTo(1);
+  }
+
+  /**
+   * Issue #5645, the other direction. When the subtype's bucket count is LARGER than the parent's, the same reused
+   * {@code bucketIndex} never goes out of range - it silently prunes to a bucket the record was never placed in
+   * instead, which is the #5589 failure mode again: no exception, the record just never comes back through the
+   * index. The keys below are chosen so {@code hash(k) % 3 != hash(k) % 5}, which is exactly the condition under
+   * which the parent's 3-bucket-derived index and the subtype's own 5-bucket placement disagree.
+   */
+  @Test
+  void aSubtypeWithMoreBucketsThanItsParentIsNotSilentlyMissed() {
+    createPartitionedType("Base");
+    database.transaction(() -> database.command("sql", "CREATE DOCUMENT TYPE Wider EXTENDS Base BUCKETS 5"));
+
+    assertThat(database.getSchema().getType("Wider").getBuckets(false)).hasSize(5);
+
+    final List<String> keys = List.of("alpha", "bravo", "delta", "echo");
+    database.transaction(() -> {
+      for (final String k : keys)
+        database.newDocument("Wider").set("k", k).save();
+    });
+
+    for (final String k : keys)
+      assertThat(database.query("sql", "SELECT FROM Wider WHERE k = ?", k).stream().count())
+          .as("key '%s' must be found through the index, not silently pruned to a bucket it was never placed in", k)
+          .isEqualTo(1);
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

Fixes `TypeIndex.getIndexesByKeys` so a partitioned type's subtype with a different bucket count
no longer crashes (fewer buckets) or silently misses records (more buckets) on the first indexed
insert or index lookup.

## Motivation

Closes #5645

`TypeIndex.getIndexesByKeys` prunes an index lookup/lock to one bucket by asking the **type's own**
strategy for a bucket index, then reuses that same index verbatim against every subtype's own
bucket list:

```java
final int bucketIndex = type.getBucketIndexByKeys(propNames, keys, async);
...
for (DocumentType s : subTypes) {
  final List<IndexInternal> subIndexes = s.getPolymorphicBucketIndexByBucketId(
      s.getBuckets(false).get(bucketIndex).getFileId(), propNames);   // <-- reused verbatim
  ...
}
```

`bucketIndex` is only meaningful **modulo the bucket count it was computed against** - the
parent's (`PartitionedBucketSelectionStrategy.getBucketIdByKeys` returns `(hash & 0x7fffffff) %
total`, where `total` is set to `type.getBuckets(false).size()` in `setType`, called separately
per type). A subtype is free to declare its own bucket count, so reusing the parent's
`bucketIndex` against `s.getBuckets(false)` uses the wrong modulus:

- **Subtype has FEWER buckets than the parent**: `s.getBuckets(false).get(bucketIndex)` throws
  `IndexOutOfBoundsException` on the first indexed insert - the uniqueness check on insert calls
  into this same method to find which bucket-level sub-indexes must be locked
  (`DocumentIndexer.addToIndex -> LSMTreeIndex.put -> TransactionContext.addIndexOperation ->
  TransactionIndexContext.addIndexKeyLock -> TypeIndex.getIndexesByKeys`).
- **Subtype has MORE buckets than the parent**: no exception, but the reused index falls inside
  range and silently points at a bucket the record was never physically placed in - the same
  "wrong bucket, record silently missed" failure mode as #5589, just triggered by a bucket-count
  mismatch across a type boundary instead of an unrelated index.

Physical record *placement* was never affected - `getBucketIdByRecord` is called on the record's
own type, whose strategy instance already carries that type's own `total`. Only the read/lock-side
bucket **selection** reused the wrong modulus.

`PartitionedStrategyLifecycleTest.aSubtypeInheritsAPartitionedStrategyAndItStillPrunes` sidesteps
this today by giving the subtype the identical bucket count, with a comment pointing at this
issue - which is how the bug shipped silently through the rest of the partitioned-strategy series
(#5589, #5595, #5603, #5637).

### Fix

Each subtype now re-derives its own bucket index through its own strategy and its own modulus,
instead of reusing the parent's:

- A subtype whose own strategy CAN verify the key (same partition properties, compatible key
  type, own bucket count) prunes to its own correct bucket, regardless of whether its bucket count
  matches the parent's.
- A subtype whose own strategy declines (`-1` - not partitioned, a strategy like `round-robin`/
  `thread` that never supports key lookups, or any of the existing decline reasons from #5589/
  #5595/#5603) falls back to fanning out across **its own** full bucket list, mirroring the
  top-level "search all underlying indexes" fallback but scoped to that one subtype so it doesn't
  duplicate entries already added for the base type or sibling subtypes.

This matches the fix direction the issue calls out as correct: re-deriving placement per subtype
rather than refusing the bucket-count mismatch at schema time, which would be a real restriction
on existing databases and would do nothing for ones already in that shape.

**Out of scope** (called out explicitly in the issue as follow-up, not touched here): the same
"reuse a bucket index across a type boundary" question in `SelectExecutionPlanner` and the Cypher
`PartitionPruning` rule, which each turn a bucket index into a bucket name for polymorphic
queries. This PR is scoped to `TypeIndex.getIndexesByKeys`, the method and crash the issue reports.

## Related issues

Closes #5645

## Additional Notes

Two regression tests added to `PartitionedStrategyLifecycleTest`, next to the existing
`aSubtypeInheritsAPartitionedStrategyAndItStillPrunes` (same-bucket-count happy path) whose doc
comment already references this issue:

- `aSubtypeWithFewerBucketsThanItsParentDoesNotCrashOnIndexedInsert` - reproduces the issue's exact
  repro (`Base BUCKETS 3`, `Derived EXTENDS Base` with the schema's default single bucket) and
  asserts the insert does not throw and the record is findable through the index afterward. Fails
  with `IndexOutOfBoundsException` on the pre-fix code.
- `aSubtypeWithMoreBucketsThanItsParentIsNotSilentlyMissed` - `Base BUCKETS 3`, `Wider EXTENDS Base
  BUCKETS 5`, inserting keys deliberately chosen so `hash(k) % 3 != hash(k) % 5` (`alpha`, `bravo`,
  `delta`, `echo` - Java `String.hashCode()` is a documented, stable algorithm, so these are
  deterministic across JVM versions). Asserts each key is found through the index. Fails with a
  `count()` of `0` for at least one key on the pre-fix code, with no exception to signal it.

## Test plan

- [x] `mvn -pl engine -am compile -DskipTests` - clean compile.
- [x] `mvn -pl engine test -Dtest=PartitionedStrategyLifecycleTest` - 13/13 pass, including the two
      new regression tests and all pre-existing lifecycle tests (persistence, suitability checks,
      inheritance, `DROP TYPE` re-attachment).
- [x] `mvn -pl engine test -Dtest='com.arcadedb.partitioning.**'` - full partitioning package,
      50/50 pass (`PartitionedBoxedKeyLookupTest`, `PartitionedSecondaryIndexLookupTest`,
      `PartitionedStrategyLifecycleTest`, `PartitionedStrategySuitabilityTest`).

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
