### PR TITLE
fix(#5625): clamp NANOS-precision datetime conversion instead of silently overflowing

### DIFF
--- a/docs/5625-gremlin-datetime-precision.md
+++ b/docs/5625-gremlin-datetime-precision.md
@@ -1,0 +1,91 @@
+# Issue #5625: Gremlin DATETIME comparison broken for far-future dates
+
+https://github.com/ArcadeData/arcadedb/issues/5625
+
+## Reported symptom
+
+A user filtering edges by a `_validFrom`/`_validTo` DATETIME overlap check via
+Gremlin's `where(startKey, P).by().by()` construct got wrong results whenever
+one side was a far-future "no expiration" sentinel (`2499-12-31 23:59:59.999`).
+Their own isolation probe found `_validFrom <= _validTo` false on ~1/3 of
+sampled edges, always with the sentinel on one side. Projecting the property
+to a `String` first (`by(__.values('_validFrom').asString())`) worked around
+it.
+
+## Root cause
+
+TinkerPop 3.8.x's `Compare.lt/lte/gt/gte` biPredicates route through
+`org.apache.tinkerpop.gremlin.util.GremlinValueComparator` - a class ArcadeDB
+supplies under the exact same fully-qualified name as TinkerPop's own,
+replacing it on the classpath (`gremlin/src/main/java/org/apache/tinkerpop/gremlin/util/GremlinValueComparator.java`).
+Its date comparator always normalises both operands to `ChronoUnit.NANOS`
+precision via `DateUtils.dateTimeToTimestamp(value, ChronoUnit.NANOS)`,
+regardless of the property's actual stored precision.
+
+That NANOS conversion multiplies epoch-seconds by one billion. For any date
+beyond roughly the year 2262 the multiplication already saturates to
+`Long.MAX_VALUE` (via `TimeUnit.NANOSECONDS.convert`, which is documented as
+saturating). Until this fix, every date/time branch in
+`DateUtils.dateTimeToTimestamp` except `OffsetDateTime` then added the
+sub-second nanosecond fraction on top of that already-saturated value with no
+overflow guard - overflowing a SECOND time and silently wrapping around to a
+large NEGATIVE number. That inverted chronological order: the far-future
+sentinel compared as LESS than an ordinary near-present date wherever the
+NANOS-precision timestamp drove the comparison.
+
+`LocalDate`'s NANOS/MICROS branches had an even more aggressive variant of the
+same bug: a raw `epochMillis * 1_000_000_000L` multiplication that overflows
+for almost any real-world date, not just far-future ones.
+
+Interestingly, `OffsetDateTime`'s branch already carried an overflow guard
+(presumably added for an earlier, unfiled issue), but the fix was never
+applied to the sibling `LocalDateTime`, `ZonedDateTime`, `Instant`, and
+`LocalDate` branches - a "dual-path" gap where one type was fixed and its
+siblings were not.
+
+## Fix
+
+`engine/src/main/java/com/arcadedb/utility/DateUtils.java`:
+- Extracted the existing `OffsetDateTime` overflow guard into a shared
+  `addNanosClampingOverflow(long, int)` helper and applied it to
+  `LocalDateTime`, `ZonedDateTime`, and `Instant`'s NANOS branches (in
+  addition to refactoring `OffsetDateTime` to use it too).
+- Replaced `LocalDate`'s raw `* 1_000_000L` / `* 1_000_000_000L`
+  multiplications with `TimeUnit.convert()`, which saturates instead of
+  silently wrapping.
+
+This is the single, shared root of the comparison for every consumer of
+`DateUtils.dateTimeToTimestamp` - `GremlinValueComparator` (Gremlin
+`P.lt/lte/gt/gte` and `order()`), `BinaryComparator` (SQL/index comparisons
+of `DATETIME_NANOS` values), and `MathExpression` - so fixing it here fixes
+the bug for all of them at once, not just the reported Gremlin path.
+
+## Tests
+
+- `engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java`: added 5
+  tests asserting `dateTimeToTimestamp(farFutureDate, ChronoUnit.NANOS)`
+  clamps to `Long.MAX_VALUE` and stays greater than a near-present date's
+  NANOS timestamp, for `LocalDateTime`, `ZonedDateTime`, `Instant`,
+  `OffsetDateTime`, and `LocalDate`. 4 of the 5 fail without the fix (the
+  `OffsetDateTime` one already passed, since its guard pre-existed).
+- `gremlin/src/test/java/com/arcadedb/gremlin/GremlinDateTimeFarFutureComparisonTest.java`:
+  a full end-to-end reproduction using a real `ArcadeGraph`, an edge type
+  with `_validFrom`/`_validTo` DATETIME properties, and the exact
+  `where(startKey, P).by().by()` shape from the issue (plus a `project()`
+  variant and an `order()` regression). All 4 tests fail against the
+  pre-fix code with the exact wrong counts (1 instead of 2) reported in the
+  issue, and pass with the fix.
+
+Verified both suites fail on a `git stash` of the fix and pass with it
+restored, per the "prove a test can fail" testing discipline.
+
+## Commands run
+
+```
+mvn -pl engine,gremlin -am install -DskipTests
+mvn -pl engine test -Dtest=DateUtilsTest
+mvn -pl gremlin install -DskipTests   # produces the shaded/tests artifacts gremlin-it consumes
+mvn -pl gremlin-it test -Dtest=GremlinDateTimeFarFutureComparisonTest
+mvn -pl engine test -Dtest='DateUtils*,BinaryComparator*,Type*'   # no regressions
+mvn -pl gremlin-it test   # full gremlin-it suite, no regressions
+```

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -178,8 +178,8 @@ public class DateUtils {
             TimeUnit.MICROSECONDS.convert(localDateTime.toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS) + (localDateTime.getNano()
                 / 1000);
       else if (precisionToUse.equals(ChronoUnit.NANOS))
-        timestamp =
-            TimeUnit.NANOSECONDS.convert(localDateTime.toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS) + localDateTime.getNano();
+        timestamp = addNanosClampingOverflow(TimeUnit.NANOSECONDS.convert(localDateTime.toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS),
+            localDateTime.getNano());
       else
         // NOT SUPPORTED
         timestamp = 0;
@@ -189,9 +189,11 @@ public class DateUtils {
       else if (precisionToUse.equals(ChronoUnit.MILLIS))
         timestamp = localDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
       else if (precisionToUse.equals(ChronoUnit.MICROS))
-        timestamp = localDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli() * 1_000_000L;
+        // TimeUnit.convert() SATURATES to Long.MAX_VALUE/MIN_VALUE on overflow instead of silently wrapping,
+        // unlike a raw `* 1_000_000L` multiplication (issue #5625).
+        timestamp = TimeUnit.MICROSECONDS.convert(localDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(), TimeUnit.MILLISECONDS);
       else if (precisionToUse.equals(ChronoUnit.NANOS))
-        timestamp = localDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli() * 1_000_000_000L;
+        timestamp = TimeUnit.NANOSECONDS.convert(localDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(), TimeUnit.MILLISECONDS);
       else
         // NOT SUPPORTED
         timestamp = 0;
@@ -204,7 +206,8 @@ public class DateUtils {
         timestamp =
             TimeUnit.MICROSECONDS.convert(zonedDateTime.toEpochSecond(), TimeUnit.SECONDS) + (zonedDateTime.getNano() / 1000);
       else if (precisionToUse.equals(ChronoUnit.NANOS))
-        timestamp = TimeUnit.NANOSECONDS.convert(zonedDateTime.toEpochSecond(), TimeUnit.SECONDS) + zonedDateTime.getNano();
+        timestamp = addNanosClampingOverflow(TimeUnit.NANOSECONDS.convert(zonedDateTime.toEpochSecond(), TimeUnit.SECONDS),
+            zonedDateTime.getNano());
       else
         // NOT SUPPORTED
         timestamp = 0;
@@ -216,10 +219,10 @@ public class DateUtils {
       else if (precisionToUse.equals(ChronoUnit.MICROS))
         timestamp =
             TimeUnit.MICROSECONDS.convert(offsetDateTime.toEpochSecond(), TimeUnit.SECONDS) + (offsetDateTime.getNano() / 1000);
-      else if (precisionToUse.equals(ChronoUnit.NANOS)) {
-        long s2n = TimeUnit.NANOSECONDS.convert(offsetDateTime.toEpochSecond(), TimeUnit.SECONDS);
-        timestamp = s2n >= 0 && Long.MAX_VALUE - s2n < offsetDateTime.getNano() ? Long.MAX_VALUE : s2n + offsetDateTime.getNano();
-      } else
+      else if (precisionToUse.equals(ChronoUnit.NANOS))
+        timestamp = addNanosClampingOverflow(TimeUnit.NANOSECONDS.convert(offsetDateTime.toEpochSecond(), TimeUnit.SECONDS),
+            offsetDateTime.getNano());
+      else
         // NOT SUPPORTED
         timestamp = 0;
     } else if (value instanceof Instant instant) {
@@ -230,7 +233,7 @@ public class DateUtils {
       else if (precisionToUse.equals(ChronoUnit.MICROS))
         timestamp = TimeUnit.MICROSECONDS.convert(instant.getEpochSecond(), TimeUnit.SECONDS) + (instant.getNano() / 1000);
       else if (precisionToUse.equals(ChronoUnit.NANOS))
-        timestamp = TimeUnit.NANOSECONDS.convert(instant.getEpochSecond(), TimeUnit.SECONDS) + instant.getNano();
+        timestamp = addNanosClampingOverflow(TimeUnit.NANOSECONDS.convert(instant.getEpochSecond(), TimeUnit.SECONDS), instant.getNano());
       else
         // NOT SUPPORTED
         timestamp = 0;
@@ -246,6 +249,30 @@ public class DateUtils {
       return null;
 
     return timestamp;
+  }
+
+  /**
+   * Adds a non-negative sub-second nanosecond fraction (0..999,999,999, as returned by {@code getNano()}) to an
+   * already-computed NANOS-precision epoch value without silently wrapping past {@link Long#MAX_VALUE}.
+   * <p>
+   * {@code epochSecondsAsNanos} is normally {@code TimeUnit.NANOSECONDS.convert(epochSeconds, SECONDS)}, which
+   * itself saturates to {@link Long#MAX_VALUE} for any date far enough in the future that its NANOS-precision
+   * epoch timestamp does not fit a signed 64-bit long (roughly beyond the year 2262). Without this guard, adding
+   * the nanosecond fraction on top of that already-saturated value overflows a second time and wraps around to a
+   * large NEGATIVE number, silently inverting chronological order for such dates - e.g. the far-future sentinel
+   * date pattern (`9999-12-31`, `2499-12-31 23:59:59.999`, ...) commonly used to mean "no expiration" then
+   * compares as LESS than an ordinary near-present date. This broke every {@code P.lt/lte/gt/gte} Gremlin
+   * predicate and {@code order()} step touching such a value, because {@code Compare}'s biPredicates route
+   * through {@code org.apache.tinkerpop.gremlin.util.GremlinValueComparator}, which always normalises date/time
+   * operands to {@link ChronoUnit#NANOS} regardless of their actual precision (issue #5625).
+   * <p>
+   * There is no matching underflow risk: the nanosecond fraction is always non-negative, so adding it to an
+   * already Long.MIN_VALUE-saturated {@code epochSecondsAsNanos} (from a very ancient date) only moves the
+   * result toward zero.
+   */
+  private static long addNanosClampingOverflow(final long epochSecondsAsNanos, final int nanoFraction) {
+    return epochSecondsAsNanos >= 0 && Long.MAX_VALUE - epochSecondsAsNanos < nanoFraction ?
+        Long.MAX_VALUE : epochSecondsAsNanos + nanoFraction;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
@@ -20,8 +20,12 @@ package com.arcadedb.utility;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,5 +73,89 @@ class DateUtilsTest {
     final Long withZ = DateUtils.dateTimeToTimestamp("2026-05-08T18:37:54Z", ChronoUnit.MILLIS);
     final Long withoutZone = DateUtils.dateTimeToTimestamp("2026-05-08T18:37:54", ChronoUnit.MILLIS);
     assertThat(withZ).isEqualTo(withoutZone);
+  }
+
+  /**
+   * Regression for issue #5625: converting a far-future date - e.g. a "9999-12-31"/"2499-12-31" sentinel
+   * commonly used to mean "no expiration" - to {@link ChronoUnit#NANOS} precision used to overflow a
+   * {@code long} twice: once inside {@code TimeUnit.NANOSECONDS.convert(epochSeconds, SECONDS)} (which itself
+   * saturates to {@link Long#MAX_VALUE}), and again when the sub-second nanosecond fraction was added on top of
+   * that already-saturated value with no overflow guard, wrapping around to a large NEGATIVE number. That
+   * silently inverted chronological order: the far-future sentinel compared as LESS than an ordinary
+   * near-present date wherever the NANOS-precision timestamp was used for comparison (Gremlin's
+   * {@code Compare.lt/lte/gt/gte} route through {@code GremlinValueComparator}, which always normalises
+   * date/time operands to NANOS regardless of their actual precision).
+   * <p>
+   * The fix clamps the NANOS-precision conversion to {@link Long#MAX_VALUE} instead of wrapping, so ordering is
+   * preserved for every representable {@link LocalDateTime}, no matter how far in the future.
+   */
+  @Test
+  void nanosPrecisionOfFarFutureLocalDateTimeDoesNotOverflowAndPreservesOrdering() {
+    final LocalDateTime nearPresent = LocalDateTime.of(2020, 1, 1, 0, 0, 0, 0);
+    final LocalDateTime farFutureSentinel = LocalDateTime.of(2499, 12, 31, 23, 59, 59, 999_000_000);
+
+    final long nearPresentNanos = DateUtils.dateTimeToTimestamp(nearPresent, ChronoUnit.NANOS);
+    final long farFutureNanos = DateUtils.dateTimeToTimestamp(farFutureSentinel, ChronoUnit.NANOS);
+
+    assertThat(nearPresentNanos).isPositive();
+    assertThat(farFutureNanos)
+        .as("the far-future sentinel must clamp to Long.MAX_VALUE instead of wrapping to a negative number")
+        .isEqualTo(Long.MAX_VALUE);
+    assertThat(farFutureNanos)
+        .as("chronological order must be preserved: a far-future date must compare AFTER a near-present one")
+        .isGreaterThan(nearPresentNanos);
+  }
+
+  @Test
+  void nanosPrecisionOfFarFutureZonedDateTimeDoesNotOverflowAndPreservesOrdering() {
+    final ZonedDateTime nearPresent = ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    final ZonedDateTime farFutureSentinel = ZonedDateTime.of(2499, 12, 31, 23, 59, 59, 999_000_000, ZoneOffset.UTC);
+
+    final long nearPresentNanos = DateUtils.dateTimeToTimestamp(nearPresent, ChronoUnit.NANOS);
+    final long farFutureNanos = DateUtils.dateTimeToTimestamp(farFutureSentinel, ChronoUnit.NANOS);
+
+    assertThat(farFutureNanos).isEqualTo(Long.MAX_VALUE);
+    assertThat(farFutureNanos).isGreaterThan(nearPresentNanos);
+  }
+
+  @Test
+  void nanosPrecisionOfFarFutureInstantDoesNotOverflowAndPreservesOrdering() {
+    final Instant nearPresent = LocalDateTime.of(2020, 1, 1, 0, 0, 0, 0).toInstant(ZoneOffset.UTC);
+    final Instant farFutureSentinel = LocalDateTime.of(2499, 12, 31, 23, 59, 59, 999_000_000).toInstant(ZoneOffset.UTC);
+
+    final long nearPresentNanos = DateUtils.dateTimeToTimestamp(nearPresent, ChronoUnit.NANOS);
+    final long farFutureNanos = DateUtils.dateTimeToTimestamp(farFutureSentinel, ChronoUnit.NANOS);
+
+    assertThat(farFutureNanos).isEqualTo(Long.MAX_VALUE);
+    assertThat(farFutureNanos).isGreaterThan(nearPresentNanos);
+  }
+
+  @Test
+  void nanosPrecisionOfFarFutureOffsetDateTimeDoesNotOverflowAndPreservesOrdering() {
+    final OffsetDateTime nearPresent = OffsetDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    final OffsetDateTime farFutureSentinel = OffsetDateTime.of(2499, 12, 31, 23, 59, 59, 999_000_000, ZoneOffset.UTC);
+
+    final long nearPresentNanos = DateUtils.dateTimeToTimestamp(nearPresent, ChronoUnit.NANOS);
+    final long farFutureNanos = DateUtils.dateTimeToTimestamp(farFutureSentinel, ChronoUnit.NANOS);
+
+    assertThat(farFutureNanos).isEqualTo(Long.MAX_VALUE);
+    assertThat(farFutureNanos).isGreaterThan(nearPresentNanos);
+  }
+
+  /**
+   * {@link LocalDate} took a different, multiplication-based overflow path (`millis * 1_000_000_000L`) that
+   * wrapped even earlier than the addition-based date/time types above - any date whose epoch millis exceeded
+   * roughly 9.2 million (year ~1970 + 107 days) would already overflow at MICROS or NANOS precision.
+   */
+  @Test
+  void nanosPrecisionOfFarFutureLocalDateDoesNotOverflowAndPreservesOrdering() {
+    final LocalDate nearPresent = LocalDate.of(2020, 1, 1);
+    final LocalDate farFutureSentinel = LocalDate.of(2499, 12, 31);
+
+    final long nearPresentNanos = DateUtils.dateTimeToTimestamp(nearPresent, ChronoUnit.NANOS);
+    final long farFutureNanos = DateUtils.dateTimeToTimestamp(farFutureSentinel, ChronoUnit.NANOS);
+
+    assertThat(farFutureNanos).isEqualTo(Long.MAX_VALUE);
+    assertThat(farFutureNanos).isGreaterThan(nearPresentNanos);
   }
 }

--- a/gremlin/src/test/java/com/arcadedb/gremlin/GremlinDateTimeFarFutureComparisonTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/GremlinDateTimeFarFutureComparisonTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin;
+
+import com.arcadedb.database.BasicDatabase;
+import com.arcadedb.graph.MutableEdge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.EdgeType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for <a href="https://github.com/ArcadeData/arcadedb/issues/5625">issue #5625</a>: comparing DATETIME
+ * edge properties inside a Gremlin {@code where(startKey, P).by(...).by(...)} predicate (as used to implement a
+ * validity-range overlap check) returned the wrong result whenever one of the two operands was a far-future date -
+ * a common "no expiration" sentinel such as {@code 2499-12-31 23:59:59.999} or {@code 9999-12-31}.
+ * <p>
+ * Root cause: TinkerPop 3.8.x's {@code Compare.lt/lte/gt/gte} biPredicates route through
+ * {@code org.apache.tinkerpop.gremlin.util.GremlinValueComparator} - a class ArcadeDB supplies under the same
+ * fully-qualified name as TinkerPop's own, replacing it on the classpath. Its date comparator always normalises
+ * both operands to {@link java.time.temporal.ChronoUnit#NANOS} precision via
+ * {@link com.arcadedb.utility.DateUtils#dateTimeToTimestamp(Object, java.time.temporal.ChronoUnit)}, regardless of
+ * the property's actual precision. That conversion multiplies epoch-seconds by one billion; for any date beyond
+ * roughly the year 2262 the multiplication already saturates to {@code Long.MAX_VALUE}, and until this fix, adding
+ * the sub-second nanosecond fraction on top of that saturated value silently overflowed a SECOND time and wrapped
+ * around to a large NEGATIVE number - inverting chronological order so the far-future sentinel compared as LESS
+ * than an ordinary near-present date.
+ */
+class GremlinDateTimeFarFutureComparisonTest {
+  private static final String DB_PATH = "./target/testGremlinDateTimeFarFutureComparison";
+
+  private ArcadeGraph graph;
+
+  @BeforeEach
+  void setUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    graph = ArcadeGraph.open(DB_PATH);
+
+    final BasicDatabase db = graph.getDatabase();
+    db.getSchema().createVertexType("Party");
+    final EdgeType ownsLegal = db.getSchema().createEdgeType("OWNS_LEGAL");
+    ownsLegal.createProperty("_validFrom", Type.DATETIME);
+    ownsLegal.createProperty("_validTo", Type.DATETIME);
+
+    db.transaction(() -> {
+      final MutableVertex a = db.newVertex("Party").save();
+      final MutableVertex b = db.newVertex("Party").save();
+
+      // An ordinary near-present start date paired with the classic "no expiration" far-future sentinel -
+      // exactly the shape reported in issue #5625.
+      final MutableEdge openEnded = a.newEdge("OWNS_LEGAL", b);
+      openEnded.set("_validFrom", LocalDateTime.of(2020, 1, 1, 0, 0, 0, 0));
+      openEnded.set("_validTo", LocalDateTime.of(2499, 12, 31, 23, 59, 59, 999_000_000));
+      openEnded.save();
+
+      // A second, unrelated edge whose validity window is entirely ordinary (no far-future value), used as a
+      // control to confirm normal comparisons are unaffected by the fix.
+      final MutableEdge bounded = a.newEdge("OWNS_LEGAL", b);
+      bounded.set("_validFrom", LocalDateTime.of(2021, 6, 1, 0, 0, 0, 0));
+      bounded.set("_validTo", LocalDateTime.of(2022, 6, 1, 0, 0, 0, 0));
+      bounded.save();
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (graph != null)
+      graph.drop();
+  }
+
+  /**
+   * Reproduces the reporter's own isolation probe: on the SAME edge, {@code _validFrom <= _validTo} must always
+   * hold when {@code _validFrom} is an ordinary date and {@code _validTo} is the far-future sentinel.
+   */
+  @Test
+  void validFromLessThanOrEqualValidToHoldsForFarFutureSentinel() {
+    final ResultSet result = graph.gremlin(
+        "g.E().hasLabel('OWNS_LEGAL').as('currentEdge').where('currentEdge', lte('currentEdge')).by('_validFrom').by('_validTo').count()")
+        .execute();
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat((Long) row.getProperty("result"))
+        .as("both edges must satisfy _validFrom <= _validTo, including the one with the far-future sentinel")
+        .isEqualTo(2L);
+  }
+
+  /**
+   * The symmetric half of the reporter's overlap check: {@code _validTo >= _validFrom} on the same edge.
+   */
+  @Test
+  void validToGreaterThanOrEqualValidFromHoldsForFarFutureSentinel() {
+    final ResultSet result = graph.gremlin(
+        "g.E().hasLabel('OWNS_LEGAL').as('currentEdge').where('currentEdge', gte('currentEdge')).by('_validTo').by('_validFrom').count()")
+        .execute();
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat((Long) row.getProperty("result")).isEqualTo(2L);
+  }
+
+  /**
+   * A {@code where(key, P).by().by()} comparison over a projected map - the general shape underlying validity
+   * range overlap checks - must also order the far-future sentinel correctly.
+   */
+  @Test
+  void projectedDateTimeComparisonOrdersFarFutureSentinelCorrectly() {
+    final ResultSet result = graph.gremlin(
+        "g.E().hasLabel('OWNS_LEGAL').project('vf','vt').by('_validFrom').by('_validTo').where('vf', lte('vt')).count()")
+        .execute();
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat((Long) row.getProperty("result")).isEqualTo(2L);
+  }
+
+  /**
+   * {@code order()} routes through the same {@code GremlinValueComparator} used by {@code P.lt/lte/gt/gte}, so a
+   * far-future sentinel must still sort after every ordinary date instead of appearing first as a wrapped
+   * negative timestamp would.
+   */
+  @Test
+  void orderByDateTimeSortsFarFutureSentinelLast() {
+    final ResultSet result = graph.gremlin(
+        "g.E().hasLabel('OWNS_LEGAL').order().by('_validTo', desc).limit(1).project('vt').by('_validTo')").execute();
+    assertThat(result.hasNext()).isTrue();
+    final Object latest = result.next().getProperty("vt");
+    assertThat(latest).isEqualTo(LocalDateTime.of(2499, 12, 31, 23, 59, 59, 999_000_000));
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a long overflow in `DateUtils.dateTimeToTimestamp()` that silently inverted chronological ordering for far-future dates whenever a comparison forced NANOS precision.

Closes #5625

## Motivation

The reporter's Gremlin `where(startKey, P).by('_validFrom').by('_validTo')` validity-range overlap check returned wrong results whenever one side was a far-future "no expiration" sentinel date (e.g. `2499-12-31 23:59:59.999`). Their own isolation probe found `_validFrom <= _validTo` false on ~1/3 of sampled edges, always with the sentinel on one side. Projecting the property to a `String` first worked around it, which was the strongest clue that the raw (non-string) comparison path was the culprit.

### Root cause

TinkerPop 3.8.x's `Compare.lt/lte/gt/gte` biPredicates route through `org.apache.tinkerpop.gremlin.util.GremlinValueComparator` - a class ArcadeDB supplies under the exact same fully-qualified name as TinkerPop's own, replacing it on the classpath. Its date comparator always normalises both operands to `ChronoUnit.NANOS` via `DateUtils.dateTimeToTimestamp(value, ChronoUnit.NANOS)`, regardless of the property's actual stored precision.

That NANOS conversion multiplies epoch-seconds by one billion. For any date beyond roughly the year 2262, `TimeUnit.NANOSECONDS.convert()` already saturates the multiplication to `Long.MAX_VALUE` (documented, safe). Until this fix, every date/time branch except `OffsetDateTime` then added the sub-second nanosecond fraction on top of that already-saturated value with **no overflow guard**, overflowing a second time and silently wrapping around to a large **negative** number. That inverted chronological order: the far-future sentinel compared as *less than* an ordinary near-present date.

`OffsetDateTime`'s branch already carried a saturating guard (from an earlier, unfiled issue), but the same fix was never applied to the sibling `LocalDateTime`, `ZonedDateTime`, `Instant`, and `LocalDate` branches - a "one type fixed, siblings left broken" gap. `LocalDate` additionally used a raw multiplication (`epochMillis * 1_000_000_000L`) that overflows for almost any real date, not just far-future ones.

## Related issues

Closes #5625

## Additional Notes

This is the single shared root used by `GremlinValueComparator` (Gremlin `P.lt/lte/gt/gte` and `order()`), `BinaryComparator` (SQL/index comparisons of `DATETIME_NANOS` values), and `MathExpression`, so the fix covers all three call sites uniformly rather than only the reported Gremlin path.

Full tracking doc with more detail: `docs/5625-gremlin-datetime-precision.md`.

## Test plan

- [x] `engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java` - 5 new tests asserting the NANOS-precision conversion of a far-future date clamps to `Long.MAX_VALUE` and stays ordered after a near-present date, for `LocalDateTime`, `ZonedDateTime`, `Instant`, `OffsetDateTime`, and `LocalDate`. Verified 4 of the 5 fail on the pre-fix code (the `OffsetDateTime` one already passed).
- [x] `gremlin/src/test/java/com/arcadedb/gremlin/GremlinDateTimeFarFutureComparisonTest.java` - end-to-end reproduction using a real `ArcadeGraph`, an edge type with `_validFrom`/`_validTo` DATETIME properties, and the exact `where(startKey, P).by().by()` shape from the issue (plus a `project()` variant and an `order()` regression). Verified all 4 fail on the pre-fix code with the exact wrong counts (1 instead of 2) matching the issue, and pass with the fix.
- [x] `mvn -pl engine test -Dtest='DateUtils*,BinaryComparator*,Type*'` - no regressions
- [x] `mvn -pl gremlin-it test` (full suite, 166 tests) - no regressions
- [x] `mvn -pl engine,gremlin,gremlin-it -am install` - full reactor build for these modules compiles clean

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios