### PR TITLE
fix(#5646): report DROP INDEX leaving a partitioned type without its partition index at commit, not on next open

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RecordEvents;
 import com.arcadedb.database.RecordEventsRegistry;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.database.bucketselectionstrategy.BucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
@@ -927,19 +928,41 @@ public class LocalDocumentType implements DocumentType {
    * Re-runs the partition diagnosis after a schema change that can have altered it, reporting everything and
    * refusing nothing (issue #5637). A no-op on a type that is not partitioned.
    * <p>
-   * Called from {@link TypeIndexBuilder}, which runs once per {@code CREATE INDEX}. The obvious hook,
-   * {@link #addIndexInternal}, runs once per BUCKET, so it would multiply every line by the bucket count and fire
-   * during schema reload as well.
+   * Called from {@link TypeIndexBuilder} once per {@code CREATE INDEX}, and from {@link LocalSchema#dropIndexInternal}
+   * once per {@code DROP INDEX} (issue #5646). The obvious hook, {@link #addIndexInternal}, runs once per BUCKET, so
+   * it would multiply every line by the bucket count and fire during schema reload as well.
    * <p>
-   * <b>{@code DROP INDEX} deliberately does not call this, which leaves one case reported only on the next open.</b>
-   * Recollating an index is a drop followed by a create, so a hook on the drop would announce "there is no unique
-   * automatic index on the partition properties" in the middle of a sequence that is about to put one back - a line
-   * that is true for the instant it is printed, misleading by the time it is read, and printed ahead of the accurate
-   * one the create emits. That leaves a drop with no create after it saying nothing until the database is reopened,
-   * where the blocker is reported and then repeats on every open. Closing that properly means deferring the
-   * diagnosis to the end of the enclosing transaction rather than moving the hook, which is tracked as issue #5646.
+   * <b>Deferred to the end of the enclosing transaction, when one is active.</b> Recollating an index is a
+   * {@code DROP INDEX} followed by a {@code CREATE INDEX}, usually in one transaction; reporting synchronously on the
+   * drop would announce "there is no unique automatic index on the partition properties" in the middle of a sequence
+   * that is about to put one back - a line that is true for the instant it is printed, misleading by the time it is
+   * read, and printed ahead of the accurate one the create emits. Deferring the diagnosis to commit, keyed per type
+   * name via {@link TransactionContext#addAfterCommitCallbackIfAbsent}, means a {@code DROP}-then-{@code CREATE} (or
+   * any other run of index-surface edits on the same type within one transaction) is diagnosed once against the
+   * state the transaction settled on, whichever statement caused it.
+   * <p>
+   * Outside a transaction - the auto-commit / single-statement path - there is no commit to defer to, so the
+   * diagnosis runs immediately, which is also what kept the pre-#5646 {@code CREATE INDEX} behaviour for that case.
    */
   void reportPartitionSuitabilityAfterSchemaChange() {
+    if (!(bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy))
+      return;
+
+    final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
+    if (database.isTransactionActive())
+      database.getTransaction().addAfterCommitCallbackIfAbsent("partition-suitability:" + name,
+          this::reportPartitionSuitabilityNow);
+    else
+      reportPartitionSuitabilityNow();
+  }
+
+  /**
+   * The actual diagnosis, run either immediately or from the deferred callback {@link #reportPartitionSuitabilityAfterSchemaChange}
+   * registers. Re-reads {@link #bucketSelectionStrategy} rather than capturing it at scheduling time, so a callback
+   * that fires later sees whatever the transaction settled the strategy on, not a snapshot from when it was queued -
+   * a type that was reverted to round-robin (or dropped) before commit is correctly not diagnosed at all.
+   */
+  private void reportPartitionSuitabilityNow() {
     if (bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
       reportPartitionSuitability(partitioned, PartitionReport.SCHEMA_CHANGE);
   }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -943,9 +943,15 @@ public class LocalDocumentType implements DocumentType {
    * <p>
    * Outside a transaction - the auto-commit / single-statement path - there is no commit to defer to, so the
    * diagnosis runs immediately, which is also what kept the pre-#5646 {@code CREATE INDEX} behaviour for that case.
+   * <p>
+   * <b>Skipped entirely for a type that is itself being dropped.</b> {@link LocalSchema#dropType} drops every one of
+   * a type's indexes (via {@link LocalSchema#dropIndexInternal}) before removing the type from the schema, so without
+   * this check a {@code DROP TYPE} on a partitioned type would report a spurious "no unique automatic index" blocker
+   * for a type that no longer exists by the time the report is read - immediately if outside a transaction, or via
+   * the deferred callback otherwise, since {@code dropType} itself runs inside one transaction.
    */
   void reportPartitionSuitabilityAfterSchemaChange() {
-    if (!(bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy))
+    if (!(bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy) || !schema.existsType(name))
       return;
 
     final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
@@ -960,10 +966,12 @@ public class LocalDocumentType implements DocumentType {
    * The actual diagnosis, run either immediately or from the deferred callback {@link #reportPartitionSuitabilityAfterSchemaChange}
    * registers. Re-reads {@link #bucketSelectionStrategy} rather than capturing it at scheduling time, so a callback
    * that fires later sees whatever the transaction settled the strategy on, not a snapshot from when it was queued -
-   * a type that was reverted to round-robin (or dropped) before commit is correctly not diagnosed at all.
+   * a type that was reverted to round-robin, or dropped between scheduling and commit, is correctly not diagnosed at
+   * all: the round-robin case falls out of the {@code instanceof} check below, the dropped case out of re-checking
+   * {@link LocalSchema#existsType} here rather than trusting the schema membership seen when this was scheduled.
    */
   private void reportPartitionSuitabilityNow() {
-    if (bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
+    if (bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned && schema.existsType(name))
       reportPartitionSuitability(partitioned, PartitionReport.SCHEMA_CHANGE);
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -964,15 +964,21 @@ public class LocalDocumentType implements DocumentType {
 
   /**
    * The actual diagnosis, run either immediately or from the deferred callback {@link #reportPartitionSuitabilityAfterSchemaChange}
-   * registers. Re-reads {@link #bucketSelectionStrategy} rather than capturing it at scheduling time, so a callback
-   * that fires later sees whatever the transaction settled the strategy on, not a snapshot from when it was queued -
-   * a type that was reverted to round-robin, or dropped between scheduling and commit, is correctly not diagnosed at
-   * all: the round-robin case falls out of the {@code instanceof} check below, the dropped case out of re-checking
-   * {@link LocalSchema#existsType} here rather than trusting the schema membership seen when this was scheduled.
+   * registers. The callback is a method reference bound to {@code this} at scheduling time, so if a
+   * {@code DROP TYPE}-then-{@code CREATE TYPE} of the same name happened before it fires, {@code this} is a stale,
+   * no-longer-registered instance - {@code schema.existsType(name)} alone would come back {@code true} off the
+   * *new* type sharing the name, while every field read through {@code this} would still be the dropped instance's.
+   * Re-resolving the live type by name and reading/reporting through it instead of {@code this} sidesteps that: a
+   * type reverted to round-robin, dropped outright, or dropped-and-recreated between scheduling and commit is
+   * correctly diagnosed against whatever is actually registered under the name now, or not diagnosed at all if
+   * nothing is (issue #5646 review follow-up on PR #5946).
    */
   private void reportPartitionSuitabilityNow() {
-    if (bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned && schema.existsType(name))
-      reportPartitionSuitability(partitioned, PartitionReport.SCHEMA_CHANGE);
+    if (!schema.existsType(name))
+      return;
+    final LocalDocumentType live = schema.getType(name);
+    if (live.bucketSelectionStrategy instanceof PartitionedBucketSelectionStrategy partitioned)
+      live.reportPartitionSuitability(partitioned, PartitionReport.SCHEMA_CHANGE);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -755,13 +755,15 @@ public class LocalSchema implements Schema {
         if (index == null)
           return null;
 
-        if (index.getTypeName() != null && existsType(index.getTypeName())) {
-          final DocumentType type = getType(index.getTypeName());
-          final BucketSelectionStrategy strategy = type.getBucketSelectionStrategy();
+        final LocalDocumentType affectedType =
+            index.getTypeName() != null && existsType(index.getTypeName()) ? getType(index.getTypeName()) : null;
+
+        if (affectedType != null) {
+          final BucketSelectionStrategy strategy = affectedType.getBucketSelectionStrategy();
           if (strategy instanceof PartitionedBucketSelectionStrategy selectionStrategy) {
             if (List.of(selectionStrategy.getProperties()).equals(index.getPropertyNames()))
               // CURRENT INDEX WAS USED FOR PARTITION, SETTING DEFAULT STRATEGY
-              type.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy());
+              affectedType.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy());
           }
         }
 
@@ -796,6 +798,25 @@ public class LocalSchema implements Schema {
           throw e;
         } catch (final Exception e) {
           throw new SchemaException("Cannot drop the index '" + indexName + "' (error=" + e + ")", e);
+        }
+
+        // Symmetric with the CREATE INDEX side (TypeIndexBuilder, issue #5637): the index just dropped is half of
+        // what decided whether the partition is any use, so losing the automatic unique index on the partition
+        // properties can turn a suitable partition into one with none left to prune with. That used to go
+        // unreported until the next open (issue #5646); reportPartitionSuitabilityAfterSchemaChange() defers to the
+        // enclosing transaction's commit when one is active, so a DROP immediately followed by a re-CREATE
+        // (recollating, or any other index-surface edit on the same type in one transaction) is diagnosed once
+        // against the settled state rather than reporting the transient gap.
+        if (affectedType != null) {
+          try {
+            affectedType.reportPartitionSuitabilityAfterSchemaChange();
+          } catch (final RuntimeException e) {
+            // By this point the index is already dropped and the schema updated, so letting a diagnostic fault
+            // escape would fail a DROP INDEX that otherwise succeeded over nothing more than a reporting bug.
+            LogManager.instance().log(this, Level.WARNING,
+                "Cannot report the partition suitability of type '%s' after dropping index '%s'. The index itself "
+                    + "was dropped successfully", e, affectedType.getName(), indexName);
+          }
         }
 
         return null;

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -123,6 +123,15 @@ public class LocalSchema implements Schema {
   private volatile    long                                   savedGeneration               = 0;
   private             boolean                                loadInRamCompleted            = false;
   private             boolean                                multipleUpdate                = false;
+  /**
+   * Non-null while {@link #dropType} is dropping its own indexes as part of removing the type entirely (issue
+   * #5646 review follow-up on PR #5946). Checked by {@link #dropIndexInternal} to skip the partition-suitability
+   * report for a type that is going away in the same operation - at every nesting depth, including the bucket
+   * sub-index drops {@link com.arcadedb.index.TypeIndex#drop()} makes back into the public {@link #dropIndex}, which
+   * a parameter on {@code dropIndexInternal} alone cannot reach. A field rather than a parameter because the
+   * suppression has to cross that public-API boundary; save/restore around the cascade, matching {@link #multipleUpdate}.
+   */
+  private             String                                 typeBeingDropped              = null;
   private final       AtomicLong                             versionSerial                 = new AtomicLong();
   private final       Map<String, FunctionLibraryDefinition> functionLibraries             = new ConcurrentHashMap<>();
   private final       Map<Integer, Integer>                  migratedFileIds               = new ConcurrentHashMap<>();
@@ -807,7 +816,7 @@ public class LocalSchema implements Schema {
         // enclosing transaction's commit when one is active, so a DROP immediately followed by a re-CREATE
         // (recollating, or any other index-surface edit on the same type in one transaction) is diagnosed once
         // against the settled state rather than reporting the transient gap.
-        if (affectedType != null) {
+        if (affectedType != null && !affectedType.getName().equals(typeBeingDropped)) {
           try {
             affectedType.reportPartitionSuitabilityAfterSchemaChange();
           } catch (final RuntimeException e) {
@@ -1424,6 +1433,11 @@ public class LocalSchema implements Schema {
       if (!multipleUpdate)
         multipleUpdate = true;
 
+      final String previousTypeBeingDropped = typeBeingDropped;
+      // Covers the whole cascade below, not just the index-drop loop: dropBucket() a few lines down can also
+      // reach dropIndexInternal() for a leftover bucket-associated index, and the suppression must hold there too.
+      typeBeingDropped = typeName;
+
       try {
         final LocalDocumentType type = (LocalDocumentType) database.getSchema().getType(typeName);
 
@@ -1438,7 +1452,11 @@ public class LocalSchema implements Schema {
             sub.addSuperType(parent, false);
         }
 
-        // DELETE ALL ASSOCIATED INDEXES
+        // DELETE ALL ASSOCIATED INDEXES. typeBeingDropped (set above) makes dropIndexInternal() skip the
+        // partition-suitability report it would otherwise trigger on this type - directly, and through the nested
+        // calls TypeIndex.drop() makes back into dropIndex() for each bucket sub-index. Reporting here would
+        // describe a type that no longer exists by the time anyone reads it (issue #5646 review follow-up on
+        // PR #5946).
         for (final Index m : new ArrayList<>(type.getAllIndexes(true)))
           dropIndexInternal(m.getName());
 
@@ -1459,6 +1477,7 @@ public class LocalSchema implements Schema {
         if (types.remove(typeName) == null)
           throw new SchemaException("Type '" + typeName + "' not found");
       } finally {
+        typeBeingDropped = previousTypeBeingDropped;
         if (setMultipleUpdate)
           multipleUpdate = false;
         saveConfiguration();

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -214,6 +214,68 @@ class PartitionedStrategyLifecycleTest extends TestHelper {
     assertThat(database.query("sql", "SELECT FROM Orphaned").stream().count()).isEqualTo(1);
   }
 
+  // ---------------------------------------------------------------------------------------------------------------
+  // 3b. Issue #5646: a DROP INDEX that leaves a partitioned type without its partition index is reported when it
+  //     happens, not only on the next open.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * The single-statement / auto-commit case: there is no enclosing transaction for the diagnosis to defer to, so it
+   * has to run immediately, exactly like the pre-#5646 {@code CREATE INDEX} side already does.
+   */
+  @Test
+  void dropIndexOnAnOrphanedPartitionIsReportedImmediatelyOutsideATransaction() {
+    createPartitionedType("Immediate");
+
+    final List<String> warnings = captureWarnings(() -> database.command("sql", "DROP INDEX `Immediate[k]`"));
+
+    assertThat(warnings)
+        .as("dropping the partition's only unique automatic index must say so right away, not wait for a restart")
+        .anyMatch(m -> m.contains("Immediate") && m.contains("unique automatic index"));
+  }
+
+  /**
+   * Inside an explicit transaction the diagnosis must wait for the commit: reporting mid-transaction would describe
+   * a state the transaction might still walk back from (recollating is exactly a DROP followed by a CREATE).
+   */
+  @Test
+  void dropIndexOnAnOrphanedPartitionInATransactionIsReportedOnCommit() {
+    createPartitionedType("Deferred");
+
+    // captureWarnings nests: the inner capture sees only what is logged while the DROP INDEX statement itself runs,
+    // the outer capture (which is still installed as the inner one's delegate) also sees everything logged
+    // afterwards, including at commit.
+    final List<String>[] midTransactionWarnings = new List[1];
+    final List<String> afterCommitWarnings = captureWarnings(() -> database.transaction(
+        () -> midTransactionWarnings[0] = captureWarnings(() -> database.command("sql", "DROP INDEX `Deferred[k]`"))));
+
+    assertThat(midTransactionWarnings[0])
+        .as("the diagnosis must not fire before the transaction that dropped the index commits")
+        .noneMatch(m -> m.contains("Deferred"));
+    assertThat(afterCommitWarnings)
+        .as("the blocker is reported once the transaction that dropped the index commits")
+        .anyMatch(m -> m.contains("Deferred") && m.contains("unique automatic index"));
+  }
+
+  /**
+   * The case the synchronous hook could not handle: DROP followed by a re-CREATE of the identical index in one
+   * transaction must settle quietly, the same way {@link #anIndexChangeThatChangesNothingStaysQuiet} already pins
+   * for the CREATE side. Driving it from the DROP side is what #5646 is about - this used to be silent only because
+   * DROP INDEX never reported anything at all, not because the settled state was correctly recognised as unchanged.
+   */
+  @Test
+  void dropThenRecreateInOneTransactionReportsOnlyTheSettledState() {
+    createPartitionedType("Recreated");
+
+    final List<String> warnings = captureWarnings(() -> database.transaction(() -> {
+      database.command("sql", "DROP INDEX `Recreated[k]`");
+      database.command("sql", "CREATE INDEX ON Recreated(k) UNIQUE");
+    }));
+
+    assertThat(warnings).as("re-creating the partition index unchanged is not worth a line, even driven from DROP")
+        .noneMatch(m -> m.contains("Recreated"));
+  }
+
   /**
    * The same fault isolation, from the other direction: a strategy whose implementation class cannot be resolved at
    * all. Nothing about it is recoverable, but it must not take the rest of the schema down - the strategy block runs

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -277,6 +277,47 @@ class PartitionedStrategyLifecycleTest extends TestHelper {
   }
 
   /**
+   * {@code DROP TYPE} drops every one of the type's indexes (via the same {@code dropIndexInternal} the two tests
+   * above exercise) before removing the type itself from the schema. Without suppressing the report for that
+   * cascade, dropping a partitioned type would trigger the exact "no unique automatic index" blocker this issue
+   * fixes for {@code DROP INDEX} - except about a type that no longer exists by the time anyone reads it. Found by
+   * review on PR #5946: reusing the type-survives assertion style of the two tests above, driven from
+   * {@code DROP TYPE} outside a transaction, which is the immediate-report path and the one the fix's first
+   * attempt (an existence check made only at commit time) still missed.
+   */
+  @Test
+  void dropTypeOfAPartitionedTypeReportsNothingAboutTheTypeItJustRemoved() {
+    createPartitionedType("Vanishing");
+
+    final List<String> warnings = captureWarnings(() -> database.command("sql", "DROP TYPE Vanishing"));
+
+    assertThat(warnings)
+        .as("the type is gone by the time this report would be read - it must not be diagnosed at all")
+        .noneMatch(m -> m.contains("Vanishing"));
+    assertThat(database.getSchema().existsType("Vanishing")).isFalse();
+  }
+
+  /**
+   * The cross-statement variant: a {@code DROP INDEX} inside a transaction schedules the after-commit callback
+   * (the deferred case above), and a {@code DROP TYPE} of the same type later in the same transaction removes the
+   * type before that callback fires. This is what the existence re-check inside the deferred diagnosis itself
+   * (rather than only at scheduling time) is for.
+   */
+  @Test
+  void dropTypeAfterDropIndexInTheSameTransactionReportsNothing() {
+    createPartitionedType("VanishingDeferred");
+
+    final List<String> warnings = captureWarnings(() -> database.transaction(() -> {
+      database.command("sql", "DROP INDEX `VanishingDeferred[k]`");
+      database.command("sql", "DROP TYPE VanishingDeferred");
+    }));
+
+    assertThat(warnings)
+        .as("the DROP INDEX callback must not fire once the same transaction went on to drop the type entirely")
+        .noneMatch(m -> m.contains("VanishingDeferred"));
+  }
+
+  /**
    * The same fault isolation, from the other direction: a strategy whose implementation class cannot be resolved at
    * all. Nothing about it is recoverable, but it must not take the rest of the schema down - the strategy block runs
    * near the end of the loader, so an exception escaping it drops everything the loader has not reached yet.

--- a/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/partitioning/PartitionedStrategyLifecycleTest.java
@@ -318,6 +318,36 @@ class PartitionedStrategyLifecycleTest extends TestHelper {
   }
 
   /**
+   * Found on review of this fix (PR #5946): {@code reportPartitionSuitabilityAfterSchemaChange()} schedules a
+   * callback bound to {@code this} - the {@code LocalDocumentType} instance live when the DROP INDEX ran.
+   * {@code CREATE TYPE} always builds a brand-new instance ({@code LocalSchema}, {@code case "d" ->}), so a
+   * DROP-then-CREATE of the same name in one transaction leaves the scheduled callback pointing at a stale,
+   * no-longer-registered object by the time it fires. A bare {@code schema.existsType(name)} re-check would have
+   * come back {@code true} anyway - off the *new* type sharing the name - and gone on to read the *old* instance's
+   * fields. Re-resolving the live type by name before reading anything is what closes that: the new type here is
+   * plain (round-robin, the default), so if the diagnosis were still reading the old, partitioned instance's
+   * fields, this would report; reading the live instance's, it must not.
+   */
+  @Test
+  void dropTypeThenRecreateWithTheSameNameInOneTransactionDiagnosesTheLiveInstance() {
+    createPartitionedType("VanishingRecreated");
+
+    final List<String> warnings = captureWarnings(() -> database.transaction(() -> {
+      database.command("sql", "DROP INDEX `VanishingRecreated[k]`");
+      database.command("sql", "DROP TYPE VanishingRecreated");
+      database.command("sql", "CREATE DOCUMENT TYPE VanishingRecreated");
+    }));
+
+    assertThat(warnings)
+        .as("the callback must diagnose the new, plain (round-robin) type actually registered under the name, "
+            + "not the dropped partitioned instance it was scheduled against")
+        .noneMatch(m -> m.contains("VanishingRecreated"));
+    assertThat(database.getSchema().getType("VanishingRecreated").getBucketSelectionStrategy().getName())
+        .as("sanity check that the recreated type really is the plain default, not still partitioned")
+        .isEqualTo("round-robin");
+  }
+
+  /**
    * The same fault isolation, from the other direction: a strategy whose implementation class cannot be resolved at
    * all. Nothing about it is recoverable, but it must not take the rest of the schema down - the strategy block runs
    * near the end of the loader, so an exception escaping it drops everything the loader has not reached yet.


### PR DESCRIPTION
## What does this PR do?

Makes `DROP INDEX` report when it leaves a partitioned type without its partition index, at the moment it happens instead of only on the next database open.

`LocalDocumentType.reportPartitionSuitabilityAfterSchemaChange()` was only invoked from `CREATE INDEX` (`TypeIndexBuilder`), never from `DROP INDEX` (`LocalSchema.dropIndexInternal`). `DROP INDEX` can't simply call the same synchronous hook `CREATE INDEX` uses, though: recollating an index is a `DROP` followed by a `CREATE`, usually inside one transaction, and reporting synchronously on the drop would announce "there is no unique automatic index on the partition properties" in the middle of a sequence that is about to put one back - true for the instant it's printed, misleading by the time it's read.

`reportPartitionSuitabilityAfterSchemaChange()` now defers the actual diagnosis to the enclosing transaction's after-commit callback (via `TransactionContext.addAfterCommitCallbackIfAbsent`, keyed per type name so repeated index-surface edits on the same type in one transaction collapse into a single report of the settled state) when a transaction is active, and still runs immediately outside one, preserving the existing `CREATE INDEX` single-statement behavior. `LocalSchema.dropIndexInternal()` now calls it symmetrically with the `CREATE INDEX` side, wrapped so a diagnostic failure can't fail a `DROP INDEX` that otherwise succeeded.

## Motivation

Closes #5646.

## Related issues

Closes #5646

## Additional Notes

Three new regression tests in `PartitionedStrategyLifecycleTest`:
- `dropIndexOnAnOrphanedPartitionIsReportedImmediatelyOutsideATransaction` - the auto-commit/single-statement case
- `dropIndexOnAnOrphanedPartitionInATransactionIsReportedOnCommit` - the deferred-to-commit case
- `dropThenRecreateInOneTransactionReportsOnlyTheSettledState` - recollating (DROP then re-CREATE of the identical index in one transaction) settles quietly, driven from the DROP side rather than the CREATE side already covered elsewhere

All three were confirmed failing before the fix and passing after. Also ran the full `com.arcadedb.partitioning` package, `PartitionedStrategyLifecycleTest`, and adjacent schema/index regression classes (`SchemaTest`, `DropTypeTest`, `DropBucketTest`, `TypeTest`, `DropIndexTest`, `MaterializedView*` suite) - 198 tests, all green.

A pre-existing, unrelated issue was noticed but intentionally left untouched, since the issue explicitly scopes itself to reporting only: `dropIndexInternal`'s reset-to-round-robin check wraps a `List<String>` in `List.of(...)`, producing a `List<List<String>>` that can never equal `index.getPropertyNames()`, so that reset never fires. An existing test (`aPartitionedTypeWhoseIndexWasDroppedStillOpens`) already asserts the current (unreset) behavior.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
