### PR TITLE
fix(#5863): decouple @props type hint emission from includeMetadata in map2json

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -259,7 +259,9 @@ public class JsonSerializer {
       else
         propertyType = null;
 
-      // Unlike serializeResult (which omits JSON-faithful types), this opt-in metadata path is exhaustive by design.
+      // Issue #5863: @props emission is now gated by includeTypeHints (off by default),
+      // decoupled from includeMetadata. Same opt-in as serializeResult (#5860), so toJSON(true)
+      // no longer leaks @props into WebSocket ChangeEvent fan-out or embedded-API callers.
       if (includeTypeHints && propertyType != null) {
         if (propertyTypes.length() > 0)
           propertyTypes.append(",");

--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -241,7 +241,7 @@ public class JsonSerializer {
     else
       includePropertiesSet = null;
 
-    final StringBuilder propertyTypes = includeMetadata ? new StringBuilder() : null;
+    final StringBuilder propertyTypes = includeTypeHints ? new StringBuilder() : null;
 
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
       final String propertyName = entry.getKey();
@@ -260,7 +260,7 @@ public class JsonSerializer {
         propertyType = null;
 
       // Unlike serializeResult (which omits JSON-faithful types), this opt-in metadata path is exhaustive by design.
-      if (includeMetadata && propertyType != null) {
+      if (includeTypeHints && propertyType != null) {
         if (propertyTypes.length() > 0)
           propertyTypes.append(",");
         propertyTypes.append(propertyName).append(":").append(propertyType.getId());


### PR DESCRIPTION
## Description

Follow-up to #5812 / #5860. `map2json` was using the `includeMetadata` parameter to decide whether to emit the `@props` per-column JSON type-hint string. This bundled `@props` into every `toJSON(true)` call, including the `WebSocketEventBus`/`ChangeEvent` broadcast path where no consumer can opt in to receiving it.

The `WebSocketEventBus` calls `record.toJSON(true)` **once** per change event and broadcasts the resulting JSON string to **every** connected subscriber. There is no per-subscriber request to key an opt-in off of, so today every subscriber gets `@props` on any property whose type is lossy through JSON (`SHORT`, `FLOAT`, `LONG`, temporals, ...) and isn't declared in the schema.

## Fix

Decouple `@props` emission from `includeMetadata` in `map2json`, mirroring the #5860 fix for `serializeResult`:

- `map2json` now uses the serializer-level `includeTypeHints` field (off by default) instead of the `includeMetadata` parameter to decide whether to emit `@props`.
- `includeMetadata` keeps its original meaning: "include `@rid`/`@type`/`@cat`/`@in`/`@out`" identity metadata only.
- The `@props` hint is now emitted only when the caller explicitly enables it via `JsonSerializer.setIncludeTypeHints(true)`.

## Behavior

- `ChangeEvent.toJSON()` (WebSocket fan-out) no longer emits `@props` — a WS subscriber has no way to request it.
- Embedded-API callers of `document.toJSON(true)` no longer get an unexpected `@props` field mixed in.
- The driver's own document round-tripping can still opt in via `setIncludeTypeHints(true)` if needed; the server ignores unknown `@`-prefixed fields either way.

## Test plan

- `JsonSerializerTest` already covers `propsHintOffByDefault` from #5860 for `serializeResult`; the same `includeTypeHints` field now governs `map2json`, so the existing fixtures hold.
- A WebSocket `ChangeEvent` serialization no longer contains `@props` by default.

Closes #5863