### PR TITLE
fix(#5942)(#5943): retarget stale exception-type assertions after CommandSemanticException retyping

### DIFF
--- a/engine/src/test/java/com/arcadedb/function/coll/RangeFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/coll/RangeFunctionTest.java
@@ -19,7 +19,6 @@
 package com.arcadedb.function.coll;
 
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.utility.LongRangeList;
 import org.junit.jupiter.api.Test;
@@ -191,7 +190,7 @@ class RangeFunctionTest {
   @Test
   void stepZeroIsStillRejected() {
     assertThatThrownBy(() -> fn.execute(new Object[]{ 0L, 10L, 0L }, null))
-        .isInstanceOf(CommandExecutionException.class)
+        .isInstanceOf(CommandSemanticException.class)
         .hasMessageContaining("step cannot be zero");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4305Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4305Test.java
@@ -19,7 +19,7 @@
 package com.arcadedb.query.opencypher;
 
 import com.arcadedb.TestHelper;
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * {@code point({latitude: c.lat, longitude: c.lon})}, the function fails with a raw
  * {@link ClassCastException} from {@code java.lang.String cannot be cast to java.lang.Number}.
  * The fix coerces numeric strings to {@link Number} and otherwise raises a clean
- * {@link CommandExecutionException} naming the offending key.
+ * {@link CommandSemanticException} naming the offending key.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -123,7 +123,7 @@ class Issue4305Test extends TestHelper {
         rs.stream().toList();
       }
     })
-        .isInstanceOf(CommandExecutionException.class)
+        .isInstanceOf(CommandSemanticException.class)
         .hasMessageContaining("point()")
         .hasMessageMatching("(?s).*(latitude|longitude).*")
         .hasMessageMatching("(?s).*(abc|def).*");


### PR DESCRIPTION
## Summary

Fixes #5942 and #5943 (duplicates of the same root cause) - `main`'s `unit-tests` job was deterministically red.

PR #5909 (fix for #5794) retyped the errors thrown by `RangeFunction.execute()` (zero step) and `CypherPointFunction.coerceCoordinate()` (non-numeric coordinate) from `CommandExecutionException` to `CommandSemanticException`, deliberately, so the HTTP layer's 400 arm (which keys on `CommandParsingException`, the parent of `CommandSemanticException`) picks them up.

That PR added its own new test (`CypherFunctionArgumentValidationIssue5794Test`) correctly asserting the new type, but two pre-existing tests exercising the same call sites were not touched by that diff and kept asserting the old type:

- `RangeFunctionTest.stepZeroIsStillRejected`
- `Issue4305Test.pointRaisesCleanErrorOnNonNumericString`

Both failed on every CI run since 456f67005 landed, masking any real regression in the `unit-tests` job.

## Fix

Retarget both assertions to `CommandSemanticException`, matching the class's own hierarchy (`CommandSemanticException extends CommandParsingException`) and what `CypherFunctionArgumentValidationIssue5794Test` already asserts for the same functions. Removed the now-unused `CommandExecutionException` import from both files and updated the one Javadoc reference in `Issue4305Test` that named the old type.

No production code changed - the thrown-exception behavior introduced by #5909 was correct; only the two stale assertions were wrong.

## Out of scope

Issue #5942 also flagged `PostgresWJdbcIT.parsingErrorMgmt` as "possibly the same root cause, not verified." I checked it: it asserts a `PSQLException` on a malformed `\u30` unicode escape in a SQL literal, unrelated to the `range()`/`point()` retyping. It's being tracked separately.

## Test plan

- [x] `mvn -o -pl engine test -Dtest='RangeFunctionTest,Issue4305Test'` - 19/19 pass (previously 2 failures)
- [x] `mvn -o -pl engine test -Dtest='CypherFunctionArgumentValidationIssue5794Test'` - 6/6 pass, confirms no regression on the sibling test added by #5909
- [x] `mvn -o -pl engine -am test-compile` - compiles clean