### PR TITLE
fix(#5947): BinaryComparator STRING-vs-DATE/DATETIME delegates instead of falling to lexicographic compareTo

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -78,10 +78,17 @@ public class BinaryComparator {
       case BinaryTypes.TYPE_DOUBLE:
       case BinaryTypes.TYPE_DECIMAL:
       case BinaryTypes.TYPE_BOOLEAN:
-        // A String value1 against a numeric/boolean value2 must agree with the reverse call - delegate to the
-        // numeric side's own widening comparator and negate, rather than falling through to a lexicographic
-        // compareTo() that silently ignores type2 and breaks antisymmetry the same way the narrowing branches
-        // did before this fix (e.g. compare("2", STRING, 10, INT) and its reverse both answered "greater").
+      case BinaryTypes.TYPE_DATE:
+      case BinaryTypes.TYPE_DATETIME:
+      case BinaryTypes.TYPE_DATETIME_SECOND:
+      case BinaryTypes.TYPE_DATETIME_MICROS:
+      case BinaryTypes.TYPE_DATETIME_NANOS:
+        // A String value1 against a numeric/boolean/date value2 must agree with the reverse call - delegate to
+        // the other side's own comparator and negate, rather than falling through to a lexicographic compareTo()
+        // that silently ignores type2 and breaks antisymmetry the same way the narrowing branches did before this
+        // fix (e.g. compare("2", STRING, 10, INT) and its reverse both answered "greater"). The DATE/DATETIME
+        // branch below already parses a String operand via DateUtils.dateTimeToTimestamp(), so this reuses that
+        // parsing rather than duplicating it (issue #5947).
         return -compare(value2, type2, value1, type1);
 
       default:

--- a/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
@@ -18,7 +18,12 @@
  */
 package com.arcadedb.serializer;
 
+import com.arcadedb.utility.DateUtils;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -218,5 +223,50 @@ class BinaryComparatorNarrowingTest {
     assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
     assertThat(forward).isLessThan(0);
     assertThat(backward).isGreaterThan(0);
+  }
+
+  /**
+   * {@code TYPE_STRING} as {@code type1} against a {@code TYPE_DATETIME}/{@code TYPE_DATE}/{@code type2} fell
+   * through the same unconditional lexicographic {@code compareTo()} the numeric/boolean branches had before the
+   * previous fix - issue #5947, filed as a follow-up to #5900/#5922 since it needed date parsing rather than a
+   * mechanical widen-and-negate. An epoch-millis string makes the mismatch deterministic: every ISO date string
+   * for a real-world year starts with {@code '1'} (years 1000-1999) or {@code '2'} (years 2000+), and every
+   * epoch-millis string for a real-world moment also starts with {@code '1'} (millis since 1970 stay 13 digits
+   * until the year 2286) - so a millis string compared against a post-2000 ISO date string always loses
+   * lexicographically, regardless of which moment is actually later.
+   */
+  @Test
+  void stringVersusDateTimeIsAntisymmetric() {
+    final LocalDateTime earlierDate = LocalDateTime.of(2001, 1, 1, 0, 0, 0);
+    // Chronologically AFTER earlierDate, despite its epoch-millis string starting with '1' - a lexicographically
+    // smaller digit than the date's ISO string ("2001-01-01T00:00").
+    final String laterAsEpochMillis =
+        String.valueOf(DateUtils.dateTimeToTimestamp(LocalDateTime.of(2023, 11, 14, 0, 0, 0), ChronoUnit.MILLIS));
+
+    final int forward = comparator.compare(laterAsEpochMillis, BinaryTypes.TYPE_STRING, earlierDate, BinaryTypes.TYPE_DATETIME);
+    final int backward = comparator.compare(earlierDate, BinaryTypes.TYPE_DATETIME, laterAsEpochMillis, BinaryTypes.TYPE_STRING);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    // The 2023 moment is strictly later than the 2001 date.
+    assertThat(forward).isGreaterThan(0);
+    assertThat(backward).isLessThan(0);
+  }
+
+  /**
+   * Same defect as {@link #stringVersusDateTimeIsAntisymmetric()} but for {@code TYPE_DATE}, and using a
+   * parseable ISO datetime string (rather than an epoch-millis string) to exercise the date-parsing path end to
+   * end - the shape a user's {@code WHERE dateColumn < '2001-06-01T00:00:00'} query would actually hit.
+   */
+  @Test
+  void stringVersusDateIsAntisymmetric() {
+    final LocalDate earlierDate = LocalDate.of(2001, 1, 1);
+    final String laterIsoDateTime = "2001-06-01T00:00:00";
+
+    final int forward = comparator.compare(laterIsoDateTime, BinaryTypes.TYPE_STRING, earlierDate, BinaryTypes.TYPE_DATE);
+    final int backward = comparator.compare(earlierDate, BinaryTypes.TYPE_DATE, laterIsoDateTime, BinaryTypes.TYPE_STRING);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    assertThat(forward).isGreaterThan(0);
+    assertThat(backward).isLessThan(0);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #5947. `BinaryComparator.compare()`'s `TYPE_STRING` branch delegated to the numeric/boolean side's own comparator (and negated) when `type2` was numeric or boolean - fixed by #5922/#5900 - but still fell through to an unconditional lexicographic `((String) value1).compareTo(value2.toString())` when `type2` was `TYPE_DATE`, `TYPE_DATETIME`, `TYPE_DATETIME_SECOND`, `TYPE_DATETIME_MICROS`, or `TYPE_DATETIME_NANOS`. That breaks antisymmetry the same way the pre-#5922 numeric branches did: `compare("2023-11-14...", STRING, date(2001), DATETIME)` and its reverse could both answer the same sign.

## Fix

The `DATE`/`DATETIME*` branch (`type1` side) already parses a `String` operand correctly via `DateUtils.dateTimeToTimestamp()` (it accepts a `String`, trying ISO-8601 formats or a raw epoch value for a numeric string). So rather than duplicating date-parsing logic in the `TYPE_STRING` branch (the issue's suggested approach), this reuses the existing `-compare(value2, type2, value1, type1)` delegate-and-negate pattern already used for numeric/boolean `type2` - it was one line short of covering dates too.

## Testing

- `engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java`:
  - `stringVersusDateTimeIsAntisymmetric` - a String holding an epoch-millis value that is chronologically *after* a `LocalDateTime`, but whose ISO string sorts lexicographically *before* it. Confirmed this fails on `main` (`expected: 1, but was: -1`) before the fix.
  - `stringVersusDateIsAntisymmetric` - same shape for `TYPE_DATE`, using a parseable ISO datetime string (the shape a `WHERE dateColumn < '...'` query would hit).
- Full local runs, all green, no new failures:
  - `com.arcadedb.serializer.**` + `com.arcadedb.index.lsm.**` - 277 tests
  - `com.arcadedb.query.sql.**` - 2653 tests
  - `DateQueryConsistencyTest`, `OffsetDateTimeStorageTest`, `OpenCypherDateFunctionsTest`, `DateUtilsTest`, `Issue5900ComparisonTypeMismatchTest`

## Scope note

This is `BinaryComparator.compare(Object,byte,Object,byte)`, which per #5922's root-cause note is currently only invoked from the LSM index hot path with matching types after key normalization - SQL `<`/`>`/`=` etc. go through `Type.convert`/`BinaryComparator.compareTo(Object,Object)` instead, which already handles dates via `DateUtils.isDate`. So this closes a latent public-API contract gap in the typed comparator (consistent with how #5922 treated the equivalent numeric/boolean case), not a currently reachable SQL crash.