### PR TITLE
fix(#5951): attach the SQL lexer's error listener before the token stream is eagerly filled

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLAntlrParser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLAntlrParser.java
@@ -75,20 +75,23 @@ public record SQLAntlrParser(Database database) {
       final CharStream input = CharStreams.fromString(sqlText);
       final SQLLexer lexer = new SQLLexer(input);
 
+      // Remove the default error listener (prints to stderr) and install ours before any token is
+      // pulled from the lexer - tokenize() below fills the whole stream eagerly, so the listener must
+      // already be in place or a lexer-level error (e.g. a malformed string escape) is only logged,
+      // never thrown, and the query silently falls through to parsing a mangled token stream.
+      final SQLErrorListener errorListener = new SQLErrorListener(sqlText);
+      lexer.removeErrorListeners();
+      lexer.addErrorListener(errorListener);
+
       // Create token stream
       final CommonTokenStream tokens = tokenize(lexer);
 
       // Create parser
       final SQLParser parser = new SQLParser(tokens);
 
-      // Remove default error listeners (they print to stderr)
+      // Remove default error listeners (they print to stderr) and add our custom one
       parser.removeErrorListeners();
-      lexer.removeErrorListeners();
-
-      // Add our custom error listener
-      final SQLErrorListener errorListener = new SQLErrorListener(sqlText);
       parser.addErrorListener(errorListener);
-      lexer.addErrorListener(errorListener);
 
       // Parse the SQL using two-stage strategy:
       // 1. Try SLL mode first (faster, handles most cases)
@@ -140,20 +143,21 @@ public record SQLAntlrParser(Database database) {
       final CharStream input = CharStreams.fromString(sqlScript);
       final SQLLexer lexer = new SQLLexer(input);
 
+      // See the note in parse() - the lexer's error listener must be attached before tokenize() fills
+      // the token stream, or a lexer-level error is only logged, never thrown.
+      final SQLErrorListener errorListener = new SQLErrorListener(sqlScript);
+      lexer.removeErrorListeners();
+      lexer.addErrorListener(errorListener);
+
       // Create token stream
       final CommonTokenStream tokens = tokenize(lexer);
 
       // Create parser
       final SQLParser parser = new SQLParser(tokens);
 
-      // Remove default error listeners
+      // Remove default error listeners and add our custom one
       parser.removeErrorListeners();
-      lexer.removeErrorListeners();
-
-      // Add our custom error listener
-      final SQLErrorListener errorListener = new SQLErrorListener(sqlScript);
       parser.addErrorListener(errorListener);
-      lexer.addErrorListener(errorListener);
 
       // Parse the script using two-stage strategy (SLL first, then ALL(*) on failure)
       SQLParser.ParseScriptContext parseTree;
@@ -204,20 +208,21 @@ public record SQLAntlrParser(Database database) {
       final CharStream input = CharStreams.fromString(exprText);
       final SQLLexer lexer = new SQLLexer(input);
 
+      // See the note in parse() - the lexer's error listener must be attached before tokenize() fills
+      // the token stream, or a lexer-level error is only logged, never thrown.
+      final SQLErrorListener errorListener = new SQLErrorListener(exprText);
+      lexer.removeErrorListeners();
+      lexer.addErrorListener(errorListener);
+
       // Create token stream
       final CommonTokenStream tokens = tokenize(lexer);
 
       // Create parser
       final SQLParser parser = new SQLParser(tokens);
 
-      // Remove default error listeners
+      // Remove default error listeners and add our custom one
       parser.removeErrorListeners();
-      lexer.removeErrorListeners();
-
-      // Add our custom error listener
-      final SQLErrorListener errorListener = new SQLErrorListener(exprText);
       parser.addErrorListener(errorListener);
-      lexer.addErrorListener(errorListener);
 
       // Parse the expression using two-stage strategy (SLL first, then ALL(*) on failure)
       SQLParser.ParseExpressionContext parseTree;
@@ -258,20 +263,21 @@ public record SQLAntlrParser(Database database) {
       final CharStream input = CharStreams.fromString(conditionText);
       final SQLLexer lexer = new SQLLexer(input);
 
+      // See the note in parse() - the lexer's error listener must be attached before tokenize() fills
+      // the token stream, or a lexer-level error is only logged, never thrown.
+      final SQLErrorListener errorListener = new SQLErrorListener(conditionText);
+      lexer.removeErrorListeners();
+      lexer.addErrorListener(errorListener);
+
       // Create token stream
       final CommonTokenStream tokens = tokenize(lexer);
 
       // Create parser
       final SQLParser parser = new SQLParser(tokens);
 
-      // Remove default error listeners
+      // Remove default error listeners and add our custom one
       parser.removeErrorListeners();
-      lexer.removeErrorListeners();
-
-      // Add our custom error listener
-      final SQLErrorListener errorListener = new SQLErrorListener(conditionText);
       parser.addErrorListener(errorListener);
-      lexer.addErrorListener(errorListener);
 
       // Parse the condition using two-stage strategy (SLL first, then ALL(*) on failure)
       SQLParser.ParseConditionContext parseTree;

--- a/engine/src/test/java/com/arcadedb/query/sql/antlr/SQLGrammarRegressionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/antlr/SQLGrammarRegressionTest.java
@@ -493,6 +493,27 @@ class SQLGrammarRegressionTest {
         .isInstanceOf(CommandSQLParsingException.class);
   }
 
+  @Test
+  void malformedUnicodeEscapeRaisesParsingExceptionInScript() {
+    // Same lexer-error-listener-timing bug as parse(), reproduced through parseScript().
+    assertThatThrownBy(() -> parser.parseScript("SELECT 'abc \\u30 def';"))
+        .isInstanceOf(CommandSQLParsingException.class);
+  }
+
+  @Test
+  void malformedUnicodeEscapeRaisesParsingExceptionInExpression() {
+    // Same lexer-error-listener-timing bug as parse(), reproduced through parseExpression().
+    assertThatThrownBy(() -> parser.parseExpression("'abc \\u30 def'"))
+        .isInstanceOf(CommandSQLParsingException.class);
+  }
+
+  @Test
+  void malformedUnicodeEscapeRaisesParsingExceptionInCondition() {
+    // Same lexer-error-listener-timing bug as parse(), reproduced through parseCondition().
+    assertThatThrownBy(() -> parser.parseCondition("name = 'abc \\u30 def'"))
+        .isInstanceOf(CommandSQLParsingException.class);
+  }
+
   // ============================================================================
   // SYSTEM Keyword as Identifier (Regression)
   // ============================================================================

--- a/engine/src/test/java/com/arcadedb/query/sql/antlr/SQLGrammarRegressionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/antlr/SQLGrammarRegressionTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.sql.antlr;
 
+import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.parser.*;
 import org.junit.jupiter.api.Test;
 
@@ -479,6 +480,17 @@ class SQLGrammarRegressionTest {
     // Unicode escape mixed with regular text
     assertParses("SELECT 'Hello\\u0020World'");
     assertParses("SELECT 'test\\u003Dvalue'");
+  }
+
+  @Test
+  void malformedUnicodeEscapeRaisesParsingException() {
+    // Issue #5951: a backslash-u escape with fewer than 4 hex digits is a lexer-level error that must be
+    // reported as a CommandSQLParsingException, not silently dropped by the lexer's default error
+    // recovery (which would leave the malformed token stream to parse into a different, bogus statement).
+    assertThatThrownBy(() -> parser.parse("SELECT 'abc \\u30 def'"))
+        .isInstanceOf(CommandSQLParsingException.class);
+    assertThatThrownBy(() -> parser.parse("SELECT \"abc \\u30 def\""))
+        .isInstanceOf(CommandSQLParsingException.class);
   }
 
   // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #5951.

`SQLAntlrParser.tokenize()` (added by #5864 for the parenthesis-nesting-depth DoS guard from #5851) calls `tokens.fill()` to eagerly lex the entire input up front, but in all four parse entry points (`parse`, `parseScript`, `parseExpression`, `parseCondition`) the custom `SQLErrorListener` was only attached to the lexer *after* that call returned. Any lexer-level tokenization error - e.g. a malformed `\u` unicode escape, which the grammar requires to have exactly 4 hex digits (`SQLLexer.g4:467`) - was therefore only printed by ANTLR's default `ConsoleErrorListener` (to stderr) and never thrown as a `CommandSQLParsingException`. ANTLR's default lexer error recovery then silently dropped the offending token(s), and the parser went on to successfully parse a different, bogus statement out of the mangled remainder - instead of failing with a syntax error.

This is what caused `PostgresWJdbcIT.parsingErrorMgmt` to fail deterministically starting 2026-08-07: `SELECT 'abc \u30 def';` was silently reduced to `SELECT def`, which parses fine, so no `PSQLException` was ever raised.

Root cause commit: `272457557` (#5864), 2026-08-06 - one day before the reported CI failures began.

## Fix

Move the lexer's `removeErrorListeners()` / `addErrorListener(...)` calls to before `tokenize(lexer)` is invoked, in all four `SQLAntlrParser` methods. The parser's own listener setup was already correctly sequenced (it happens after the parser object is built, before `parser.parse()`/etc. run) and is unchanged.

## Test plan

- Added `SQLGrammarRegressionTest#malformedUnicodeEscapeRaisesParsingException`, asserting `parser.parse(...)` throws `CommandSQLParsingException` for both a single- and double-quoted string containing a malformed `\u` escape. Verified this test fails without the fix (reproducing the bug) and passes with it.
- `SQLGrammarRegressionTest` (50 tests, includes existing well-formed `&`-style unicode escape coverage): pass.
- `com.arcadedb.query.sql.antlr.**` + `com.arcadedb.query.sql.parser.**` (414 tests): pass.
- `com.arcadedb.query.sql.**` (2399 tests): pass.
- `postgresw` integration tests `PostgresWJdbcIT` (43 tests, including the originally-failing `parsingErrorMgmt`) and `PostgresProtocolIT` (73 tests): pass.
- `mvn compile` across `engine`, `server`, `postgresw`: clean.

🔗 https://claude.ai/code/session_0131GDFM4QGFC5URdReusH4A