### PR TITLE
fix(#5945): compareAgainstNumericString no longer throws on out-of-range or special-value numeric strings

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -314,16 +314,32 @@ public class BinaryComparator {
 
   /**
    * Widens to whichever precision the string's own format needs - {@code double} for a fractional/exponent
-   * literal, {@code long} otherwise - so an integral string is compared without the precision loss a double
-   * round-trip would introduce for large longs, and a fractional string doesn't hard-fail a {@code long} parse.
+   * literal or one of the {@code Double} special values, {@code long} otherwise - so an integral string is
+   * compared without the precision loss a double round-trip would introduce for large longs, and a fractional
+   * string doesn't hard-fail a {@code long} parse. {@code value1} is always integral here: this helper is only
+   * reached from {@link #compareNarrowIntegral} and {@link #compareWideningLong}, both of which declare
+   * {@code value1} as {@code INT}/{@code SHORT}/{@code BYTE}/{@code LONG}.
    * <p>
-   * A numeric string outside both {@code long} and {@code double} range (e.g. 20+ integral digits) still throws
-   * an uncaught {@code NumberFormatException} rather than degrading gracefully; tracked as #5945.
+   * An integral string outside {@code long}'s range (e.g. 20+ digits, issue #5945) falls back to
+   * {@link BigDecimal}, which compares it exactly rather than losing precision through a {@code double}
+   * round-trip.
    */
   private static int compareAgainstNumericString(final Number value1, final String string) {
+    switch (string) {
+    case "NaN":
+    case "Infinity":
+    case "-Infinity":
+      return Double.compare(value1.doubleValue(), Double.parseDouble(string));
+    }
+
     if (string.indexOf('.') >= 0 || string.indexOf('e') >= 0 || string.indexOf('E') >= 0)
       return Double.compare(value1.doubleValue(), Double.parseDouble(string));
-    return Long.compare(value1.longValue(), Long.parseLong(string));
+
+    try {
+      return Long.compare(value1.longValue(), Long.parseLong(string));
+    } catch (final NumberFormatException e) {
+      return BigDecimal.valueOf(value1.longValue()).compareTo(new BigDecimal(string));
+    }
   }
 
   public int compareBytes(final byte[] buffer1, final Binary buffer2) {

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -329,6 +329,8 @@ public class BinaryComparator {
   private static int compareAgainstNumericString(final Number value1, final String string) {
     switch (string) {
     case "NaN":
+    case "+NaN":
+    case "-NaN":
     case "Infinity":
     case "+Infinity":
     case "-Infinity":

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -322,12 +322,15 @@ public class BinaryComparator {
    * <p>
    * An integral string outside {@code long}'s range (e.g. 20+ digits, issue #5945) falls back to
    * {@link BigDecimal}, which compares it exactly rather than losing precision through a {@code double}
-   * round-trip.
+   * round-trip. The same catch also covers a string that isn't numeric at all (e.g. {@code "abc"}): the
+   * {@code BigDecimal} constructor throws its own {@code NumberFormatException} for that case, so behaviour is
+   * unchanged there, this method has never guaranteed a result for a non-numeric string.
    */
   private static int compareAgainstNumericString(final Number value1, final String string) {
     switch (string) {
     case "NaN":
     case "Infinity":
+    case "+Infinity":
     case "-Infinity":
       return Double.compare(value1.doubleValue(), Double.parseDouble(string));
     }

--- a/engine/src/test/java/com/arcadedb/serializer/Issue5945NumericStringOverflowTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue5945NumericStringOverflowTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.serializer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #5945. {@link BinaryComparator}'s {@code compareAgainstNumericString} helper (added by
@@ -92,9 +93,29 @@ class Issue5945NumericStringOverflowTest {
   @Test
   void infinityStringComparesAsDoubleInfinityRatherThanThrowing() {
     assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "Infinity", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "+Infinity", BinaryTypes.TYPE_STRING)).isLessThan(0);
     assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "-Infinity", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
     assertThat(comparator.compare(5L, BinaryTypes.TYPE_LONG, "Infinity", BinaryTypes.TYPE_STRING)).isLessThan(0);
     assertThat(comparator.compare(5L, BinaryTypes.TYPE_LONG, "-Infinity", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+  }
+
+  @Test
+  void minLongMinusOneNumericStringComparesCorrectly() {
+    // Long.MIN_VALUE (9223372036854775808, 19 digits after the sign) minus one, expressed as its own
+    // out-of-range string: covers the low-end boundary, complementing the MAX_VALUE + 1 check above.
+    final long minLong = Long.MIN_VALUE;
+    final String minLongMinusOne = "-9223372036854775809";
+
+    assertThat(comparator.compare(minLong, BinaryTypes.TYPE_LONG, minLongMinusOne, BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    assertThat(comparator.compare(minLongMinusOne, BinaryTypes.TYPE_STRING, minLong, BinaryTypes.TYPE_LONG)).isLessThan(0);
+  }
+
+  @Test
+  void nonNumericStringStillThrowsRatherThanSilentlyComparing() {
+    // Regression guard: the overflow catch must not swallow a genuinely non-numeric string; BigDecimal's own
+    // NumberFormatException should still propagate, same as before this fix.
+    assertThatThrownBy(() -> comparator.compare(5, BinaryTypes.TYPE_INT, "abc", BinaryTypes.TYPE_STRING))
+        .isInstanceOf(NumberFormatException.class);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/serializer/Issue5945NumericStringOverflowTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue5945NumericStringOverflowTest.java
@@ -88,6 +88,14 @@ class Issue5945NumericStringOverflowTest {
     // being routed to Double.parseDouble, which correctly parses it as Double.NaN.
     assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "NaN", BinaryTypes.TYPE_STRING))
         .isEqualTo(Double.compare(5, Double.NaN));
+
+    // Double.parseDouble's grammar also accepts an explicit sign on NaN (Signopt NaN), even though it has no
+    // effect on the parsed value: both must be routed the same way as the unsigned form, not fall through to
+    // Long.parseLong.
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "+NaN", BinaryTypes.TYPE_STRING))
+        .isEqualTo(Double.compare(5, Double.NaN));
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "-NaN", BinaryTypes.TYPE_STRING))
+        .isEqualTo(Double.compare(5, Double.NaN));
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/serializer/Issue5945NumericStringOverflowTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue5945NumericStringOverflowTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.serializer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5945. {@link BinaryComparator}'s {@code compareAgainstNumericString} helper (added by
+ * PR #5922 fixing #5900) widens a numeric {@code String} to {@code long} or {@code double} based on its shape, but
+ * an integral string outside {@code long}'s range (e.g. 20+ digits) threw a raw, uncaught
+ * {@code NumberFormatException} instead of comparing correctly. It also mis-routed {@code "NaN"} /
+ * {@code "Infinity"} / {@code "-Infinity"} into the {@code Long.parseLong} branch, since none of those strings
+ * contain {@code '.'}, {@code 'e'} or {@code 'E'}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5945NumericStringOverflowTest {
+  private final BinaryComparator comparator = new BinaryComparator();
+
+  @Test
+  void intVersusOutOfLongRangeNumericStringDoesNotThrow() {
+    // 20-digit integral string, far beyond Long.MAX_VALUE (19 digits): must compare, not throw.
+    final String huge = "99999999999999999999";
+
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, huge, BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(huge, BinaryTypes.TYPE_STRING, 5, BinaryTypes.TYPE_INT)).isGreaterThan(0);
+  }
+
+  @Test
+  void longVersusOutOfLongRangeNumericStringIsAntisymmetricAndExact() {
+    final String huge = "99999999999999999999";
+    final long five = 5L;
+
+    final int forward = comparator.compare(five, BinaryTypes.TYPE_LONG, huge, BinaryTypes.TYPE_STRING);
+    final int backward = comparator.compare(huge, BinaryTypes.TYPE_STRING, five, BinaryTypes.TYPE_LONG);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    assertThat(forward).isLessThan(0);
+    assertThat(backward).isGreaterThan(0);
+  }
+
+  @Test
+  void negativeOutOfLongRangeNumericStringComparesCorrectly() {
+    // 20-digit negative integral string, beyond Long.MIN_VALUE's range.
+    final String hugeNegative = "-99999999999999999999";
+
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, hugeNegative, BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    assertThat(comparator.compare(hugeNegative, BinaryTypes.TYPE_STRING, 5, BinaryTypes.TYPE_INT)).isLessThan(0);
+  }
+
+  @Test
+  void outOfLongRangeNumericStringComparisonIsExactNotDoubleApproximated() {
+    // Long.MAX_VALUE (19 digits, 9223372036854775807) versus a 20-digit value one order of magnitude larger.
+    // A double round-trip of the huge string would lose precision but must still land unambiguously above
+    // Long.MAX_VALUE, so this alone would not catch a double fallback; the real exactness check is that a
+    // string differing from Long.MAX_VALUE by a small amount round-trips through BigDecimal, not through a
+    // double that cannot represent 19-digit integers exactly.
+    final long maxLong = Long.MAX_VALUE;
+    // One more than Long.MAX_VALUE, expressed as its own out-of-range string.
+    final String maxLongPlusOne = "9223372036854775808";
+
+    assertThat(comparator.compare(maxLong, BinaryTypes.TYPE_LONG, maxLongPlusOne, BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(maxLongPlusOne, BinaryTypes.TYPE_STRING, maxLong, BinaryTypes.TYPE_LONG)).isGreaterThan(0);
+  }
+
+  @Test
+  void nanStringComparesAsDoubleNaNRatherThanThrowing() {
+    // "NaN" contains none of '.', 'e', 'E', so it fell into the Long.parseLong branch and threw instead of
+    // being routed to Double.parseDouble, which correctly parses it as Double.NaN.
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "NaN", BinaryTypes.TYPE_STRING))
+        .isEqualTo(Double.compare(5, Double.NaN));
+  }
+
+  @Test
+  void infinityStringComparesAsDoubleInfinityRatherThanThrowing() {
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "Infinity", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(5, BinaryTypes.TYPE_INT, "-Infinity", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+    assertThat(comparator.compare(5L, BinaryTypes.TYPE_LONG, "Infinity", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(5L, BinaryTypes.TYPE_LONG, "-Infinity", BinaryTypes.TYPE_STRING)).isGreaterThan(0);
+  }
+
+  @Test
+  void ordinaryInRangeNumericStringsAreUnaffected() {
+    assertThat(comparator.compare(10, BinaryTypes.TYPE_INT, "15", BinaryTypes.TYPE_STRING)).isLessThan(0);
+    assertThat(comparator.compare(10, BinaryTypes.TYPE_INT, "10", BinaryTypes.TYPE_STRING)).isZero();
+    assertThat(comparator.compare(5L, BinaryTypes.TYPE_LONG, "5.5", BinaryTypes.TYPE_STRING)).isLessThan(0);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5945. `BinaryComparator`'s numeric-vs-string comparison helper (`compareAgainstNumericString`, added by PR #5922 fixing #5900) widened a numeric string to `long` or `double` based on its shape, but two syntactically-numeric shapes still threw a raw, uncaught `NumberFormatException`:

1. An integral string outside `long`'s range (e.g. `"99999999999999999999"`, 20 digits, beyond `Long.MAX_VALUE`) - it contains no `.`/`e`/`E`, so it took the `Long.parseLong` branch and threw.
2. `"NaN"`, `"Infinity"`, `"-Infinity"` - none of those strings contain `.`/`e`/`E` either, so they also took the `Long.parseLong` branch instead of `Double.parseDouble`, which parses them correctly as-is (flagged as a follow-up in the issue thread).

## Fix

- The three `Double` special-value strings are now dispatched straight to `Double.parseDouble`/`Double.compare`.
- `Long.parseLong` is now wrapped in a `try/catch`; on overflow it falls back to `BigDecimal`, which represents the out-of-range integral string exactly - `value1` is always an integral `Number` at this call site (`compareNarrowIntegral`/`compareWideningLong` only route `INT`/`SHORT`/`BYTE`/`LONG` here), so `BigDecimal.valueOf(value1.longValue())` is exact and the comparison is not a lossy `double` round-trip.

As noted in the issue, this path is not currently reachable from SQL (`BinaryComparator.compare(Object,byte,Object,byte)` is only invoked from the LSM index hot path with matching types after `convertKeys()` normalization), but the class is general-purpose public API and the contract violation is real, consistent with why PR #5922 fixed the sibling narrowing bugs in this same class.

## Testing

- `engine/src/test/java/com/arcadedb/serializer/Issue5945NumericStringOverflowTest.java` - new regression test: 20-digit positive/negative integral strings no longer throw and compare exactly (including antisymmetry and a Long.MAX_VALUE+1 boundary check), `"NaN"`/`"Infinity"`/`"-Infinity"` compare as the corresponding `Double` special value instead of throwing, ordinary in-range numeric strings are unaffected.
- Reproduced the exact `NumberFormatException` from the issue before the fix (all 6 new-behavior test methods failed with the reported stack trace), confirmed all 7 pass after.
- `BinaryComparatorNarrowingTest` (#5900) and `Issue5900ComparisonTypeMismatchTest` (SQL-level) both still pass - 32 tests, no regressions.
- Full `com.arcadedb.serializer.**` package: 150 tests, no regressions.
- Full `com.arcadedb.index.**` package (exercises `BinaryComparator` via the LSM index hot path): 1208 tests, no regressions.