### PR TITLE
fix(#5956): numeric-string date/datetime comparison infers precision from digit count

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -166,8 +166,8 @@ public class BinaryComparator {
     case BinaryTypes.TYPE_DATETIME_MICROS:
     case BinaryTypes.TYPE_DATETIME_NANOS: {
       final ChronoUnit higherPrecision = DateUtils.getHigherPrecision(value1, value2);
-      final long v1 = DateUtils.dateTimeToTimestamp(value1, higherPrecision);
-      final long v2 = DateUtils.dateTimeToTimestamp(value2, higherPrecision);
+      final long v1 = DateUtils.dateTimeToTimestampInferringStringPrecision(value1, higherPrecision);
+      final long v2 = DateUtils.dateTimeToTimestampInferringStringPrecision(value2, higherPrecision);
       return Long.compare(v1, v2);
     }
 
@@ -441,7 +441,8 @@ public class BinaryComparator {
     else if (a instanceof ChronoLocalDateTime<?> aDate && b instanceof ChronoLocalDateTime<?> bDate)
       return aDate.compareTo(bDate);
     else if (DateUtils.isDate(a) || DateUtils.isDate(b))
-      return DateUtils.dateTimeToTimestamp(a, ChronoUnit.NANOS).compareTo(DateUtils.dateTimeToTimestamp(b, ChronoUnit.NANOS));
+      return DateUtils.dateTimeToTimestampInferringStringPrecision(a, ChronoUnit.NANOS)
+          .compareTo(DateUtils.dateTimeToTimestampInferringStringPrecision(b, ChronoUnit.NANOS));
     return ((Comparable<Object>) a).compareTo(b);
   }
 

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -87,8 +87,8 @@ public class BinaryComparator {
         // the other side's own comparator and negate, rather than falling through to a lexicographic compareTo()
         // that silently ignores type2 and breaks antisymmetry the same way the narrowing branches did before this
         // fix (e.g. compare("2", STRING, 10, INT) and its reverse both answered "greater"). The DATE/DATETIME
-        // branch below already parses a String operand via DateUtils.dateTimeToTimestamp(), so this reuses that
-        // parsing rather than duplicating it (issue #5947).
+        // branch below already parses a String operand via DateUtils.dateTimeToTimestampInferringStringPrecision(),
+        // so this reuses that parsing rather than duplicating it (issue #5947).
         return -compare(value2, type2, value1, type1);
 
       default:

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -240,15 +240,40 @@ public class DateUtils {
     } else if (value instanceof Number number)
       timestamp = number.longValue();
     else if (value instanceof String string) {
-      if (FileUtils.isLong(string))
-        timestamp = Long.parseLong(value.toString());
-      else
+      if (FileUtils.isLong(string)) {
+        final long rawValue = Long.parseLong(string);
+        timestamp = convertTimestamp(rawValue, inferEpochPrecision(rawValue), precisionToUse);
+      } else
         return dateTimeToTimestamp(database, parseIsoDateTime(database, string), precisionToUse);
     } else
       // UNSUPPORTED
       return null;
 
     return timestamp;
+  }
+
+  /**
+   * Infers the epoch precision a bare numeric string most likely represents, from its digit count: for a
+   * present-day moment, an epoch value grows by roughly 3 digits per finer precision step (~10 digits for
+   * seconds, ~13 for millis, ~16 for micros, ~19 for nanos). Without this, a numeric string handed to
+   * {@link #dateTimeToTimestamp(Database, Object, ChronoUnit)} was assumed to already be at whatever
+   * {@code precisionToUse} the caller asked for, so e.g. a nanos-epoch string compared against a
+   * {@link Date}/{@link Calendar} operand (which forces {@code MILLIS}) was misinterpreted by 6 orders of
+   * magnitude instead of being converted (issue #5956).
+   * <p>
+   * This cannot distinguish a genuinely small value (e.g. a millis timestamp within the first ~3 months of 1970)
+   * from the coarser unit it also matches digit-for-digit; {@code SECONDS} wins that tie, since a near-zero
+   * epoch value is far more common as a duration/offset than as an actual date that close to the epoch.
+   */
+  private static ChronoUnit inferEpochPrecision(final long epochValue) {
+    final int digits = Long.toString(Math.abs(epochValue)).length();
+    if (digits <= 10)
+      return ChronoUnit.SECONDS;
+    else if (digits <= 13)
+      return ChronoUnit.MILLIS;
+    else if (digits <= 16)
+      return ChronoUnit.MICROS;
+    return ChronoUnit.NANOS;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -285,6 +285,11 @@ public class DateUtils {
    * boundary - e.g. a millis timestamp within the first ~3 months of 1970, or a micros/nanos timestamp within the
    * first ~10 seconds of 1970 - the coarser unit wins every such tie, since a near-zero epoch value is far more
    * common as a duration/offset than as an actual date that close to the epoch.
+   * <p>
+   * A value near the top of the MICROS bucket (16 digits) widened up to NANOS by {@link #convertTimestamp} can
+   * exceed {@link Long#MAX_VALUE} - unlike {@link #addNanosClampingOverflow}, {@code convertTimestamp}'s widening
+   * multiplication has no saturation guard, so it wraps silently. Pre-existing behavior in {@code convertTimestamp},
+   * not introduced by this inference; noted here since a bare numeric string now reaches that path more directly.
    */
   private static ChronoUnit inferEpochPrecision(final long epochValue) {
     final int digits = digitCount(epochValue);

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -285,11 +285,6 @@ public class DateUtils {
    * boundary - e.g. a millis timestamp within the first ~3 months of 1970, or a micros/nanos timestamp within the
    * first ~10 seconds of 1970 - the coarser unit wins every such tie, since a near-zero epoch value is far more
    * common as a duration/offset than as an actual date that close to the epoch.
-   * <p>
-   * A value near the top of the MICROS bucket (16 digits) widened up to NANOS by {@link #convertTimestamp} can
-   * exceed {@link Long#MAX_VALUE} - unlike {@link #addNanosClampingOverflow}, {@code convertTimestamp}'s widening
-   * multiplication has no saturation guard, so it wraps silently. Pre-existing behavior in {@code convertTimestamp},
-   * not introduced by this inference; noted here since a bare numeric string now reaches that path more directly.
    */
   private static ChronoUnit inferEpochPrecision(final long epochValue) {
     final int digits = digitCount(epochValue);
@@ -413,43 +408,30 @@ public class DateUtils {
       return ChronoUnit.NANOS;
   }
 
+  /**
+   * Widening conversions (e.g. SECONDS to NANOS) delegate to {@link TimeUnit#convert}, which saturates to
+   * {@link Long#MAX_VALUE}/{@link Long#MIN_VALUE} on overflow instead of silently wrapping the way a raw
+   * multiplication would - the same reasoning already applied to {@code LocalDate}'s conversion a few lines up
+   * in {@link #dateTimeToTimestamp(Database, Object, ChronoUnit)} (issue #5625). This matters more directly since
+   * {@link #dateTimeToTimestampInferringStringPrecision} started routing bare numeric strings through a widening
+   * conversion here (issue #5956 review follow-up): a MICROS-bucketed 16-digit string above roughly
+   * {@code Long.MAX_VALUE / 1000} widened to NANOS by {@code BinaryComparator.compareTo} used to wrap to a large
+   * negative number and silently invert the comparison.
+   */
   public static long convertTimestamp(final long timestamp, final ChronoUnit from, final ChronoUnit to) {
     if (from == to)
       return timestamp;
+    return toTimeUnit(to).convert(timestamp, toTimeUnit(from));
+  }
 
-    if (from == ChronoUnit.SECONDS) {
-      if (to == ChronoUnit.MILLIS)
-        return timestamp * 1_000;
-      else if (to == ChronoUnit.MICROS)
-        return timestamp * 1_000_000;
-      else if (to == ChronoUnit.NANOS)
-        return timestamp * 1_000_000_000;
-
-    } else if (from == ChronoUnit.MILLIS) {
-      if (to == ChronoUnit.SECONDS)
-        return timestamp / 1_000;
-      else if (to == ChronoUnit.MICROS)
-        return timestamp * 1_000;
-      else if (to == ChronoUnit.NANOS)
-        return timestamp * 1_000_000;
-
-    } else if (from == ChronoUnit.MICROS) {
-      if (to == ChronoUnit.SECONDS)
-        return timestamp / 1_000_000;
-      else if (to == ChronoUnit.MILLIS)
-        return timestamp / 1_000;
-      else if (to == ChronoUnit.NANOS)
-        return timestamp * 1_000;
-
-    } else if (from == ChronoUnit.NANOS) {
-      if (to == ChronoUnit.SECONDS)
-        return timestamp / 1_000_000_000;
-      else if (to == ChronoUnit.MILLIS)
-        return timestamp / 1_000_000;
-      else if (to == ChronoUnit.MICROS)
-        return timestamp / 1_000;
-    }
-    throw new IllegalArgumentException("Not supported conversion from '" + from + "' to '" + to + "'");
+  private static TimeUnit toTimeUnit(final ChronoUnit unit) {
+    return switch (unit) {
+      case SECONDS -> TimeUnit.SECONDS;
+      case MILLIS -> TimeUnit.MILLISECONDS;
+      case MICROS -> TimeUnit.MICROSECONDS;
+      case NANOS -> TimeUnit.NANOSECONDS;
+      default -> throw new IllegalArgumentException("Not supported conversion unit '" + unit + "'");
+    };
   }
 
   public static byte getBestBinaryTypeForPrecision(final ChronoUnit precision) {

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -261,12 +261,13 @@ public class DateUtils {
    * {@link Date}/{@link Calendar} operand (which forces {@code MILLIS}) was misinterpreted by 6 orders of
    * magnitude instead of being converted (issue #5956).
    * <p>
-   * This cannot distinguish a genuinely small value (e.g. a millis timestamp within the first ~3 months of 1970)
-   * from the coarser unit it also matches digit-for-digit; {@code SECONDS} wins that tie, since a near-zero
-   * epoch value is far more common as a duration/offset than as an actual date that close to the epoch.
+   * This cannot distinguish a genuinely small value from the coarser unit it also matches digit-for-digit at each
+   * boundary - e.g. a millis timestamp within the first ~3 months of 1970, or a micros/nanos timestamp within the
+   * first ~10 seconds of 1970 - the coarser unit wins every such tie, since a near-zero epoch value is far more
+   * common as a duration/offset than as an actual date that close to the epoch.
    */
   private static ChronoUnit inferEpochPrecision(final long epochValue) {
-    final int digits = Long.toString(Math.abs(epochValue)).length();
+    final int digits = digitCount(epochValue);
     if (digits <= 10)
       return ChronoUnit.SECONDS;
     else if (digits <= 13)
@@ -274,6 +275,22 @@ public class DateUtils {
     else if (digits <= 16)
       return ChronoUnit.MICROS;
     return ChronoUnit.NANOS;
+  }
+
+  /**
+   * Counts the decimal digits of a non-negative value without the {@code String} allocation a
+   * {@code Long.toString(value).length()} round trip would cost - {@link #inferEpochPrecision(long)} runs on the
+   * {@code BinaryComparator} hot path for every date/numeric-string comparison. {@code value} is always
+   * non-negative here: its only caller receives it from {@code Long.parseLong()} on a string that already passed
+   * {@code FileUtils.isLong()}, which accepts only the digits {@code 0-9} (no sign).
+   */
+  private static int digitCount(long value) {
+    int digits = 1;
+    while (value >= 10) {
+      value /= 10;
+      digits++;
+    }
+    return digits;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -240,10 +240,9 @@ public class DateUtils {
     } else if (value instanceof Number number)
       timestamp = number.longValue();
     else if (value instanceof String string) {
-      if (FileUtils.isLong(string)) {
-        final long rawValue = Long.parseLong(string);
-        timestamp = convertTimestamp(rawValue, inferEpochPrecision(rawValue), precisionToUse);
-      } else
+      if (FileUtils.isLong(string))
+        timestamp = Long.parseLong(string);
+      else
         return dateTimeToTimestamp(database, parseIsoDateTime(database, string), precisionToUse);
     } else
       // UNSUPPORTED
@@ -253,13 +252,34 @@ public class DateUtils {
   }
 
   /**
+   * Like {@link #dateTimeToTimestamp(Object, ChronoUnit)}, except a bare numeric {@link String} has its own epoch
+   * precision inferred from its digit count and converted to {@code precisionToUse}, instead of its raw digits
+   * being assumed to already be at {@code precisionToUse}.
+   * <p>
+   * This distinction matters because {@code dateTimeToTimestamp}'s numeric-string handling is shared by two
+   * semantically different callers: {@link com.arcadedb.serializer.BinaryComparator}'s {@code TYPE_DATE}/
+   * {@code TYPE_DATETIME*} branch, where the string represents an independent absolute moment being compared
+   * against another date/time value - use this method there - and {@code MathExpression}'s date {@code +}/{@code -}
+   * arithmetic, where a numeric operand represents a raw duration/offset count to add at the date's own precision
+   * (e.g. {@code date + '10'} meaning "10 units of the date's precision"), for which digit count carries no
+   * meaning and {@code dateTimeToTimestamp} must keep its original raw-digits behavior.
+   * <p>
+   * Without this, a numeric string holding a <em>different</em> precision than whatever the comparison settled on
+   * (e.g. a nanos-epoch string compared against a {@link Date}/{@link Calendar} operand, which forces
+   * {@code MILLIS}) was misinterpreted by orders of magnitude instead of being converted (issue #5956).
+   */
+  public static Long dateTimeToTimestampInferringStringPrecision(final Object value, final ChronoUnit precisionToUse) {
+    if (value instanceof String string && FileUtils.isLong(string)) {
+      final long rawValue = Long.parseLong(string);
+      return convertTimestamp(rawValue, inferEpochPrecision(rawValue), precisionToUse);
+    }
+    return dateTimeToTimestamp(value, precisionToUse);
+  }
+
+  /**
    * Infers the epoch precision a bare numeric string most likely represents, from its digit count: for a
    * present-day moment, an epoch value grows by roughly 3 digits per finer precision step (~10 digits for
-   * seconds, ~13 for millis, ~16 for micros, ~19 for nanos). Without this, a numeric string handed to
-   * {@link #dateTimeToTimestamp(Database, Object, ChronoUnit)} was assumed to already be at whatever
-   * {@code precisionToUse} the caller asked for, so e.g. a nanos-epoch string compared against a
-   * {@link Date}/{@link Calendar} operand (which forces {@code MILLIS}) was misinterpreted by 6 orders of
-   * magnitude instead of being converted (issue #5956).
+   * seconds, ~13 for millis, ~16 for micros, ~19 for nanos).
    * <p>
    * This cannot distinguish a genuinely small value from the coarser unit it also matches digit-for-digit at each
    * boundary - e.g. a millis timestamp within the first ~3 months of 1970, or a micros/nanos timestamp within the

--- a/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -266,6 +267,28 @@ class BinaryComparatorNarrowingTest {
     final int backward = comparator.compare(earlierDate, BinaryTypes.TYPE_DATE, laterIsoDateTime, BinaryTypes.TYPE_STRING);
 
     assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    assertThat(forward).isGreaterThan(0);
+    assertThat(backward).isLessThan(0);
+  }
+
+  /**
+   * Regression for issue #5956: {@code DateUtils.dateTimeToTimestamp()}'s numeric-string branch used to hand the
+   * string's raw digits straight through as if they were already at whatever precision the comparison settled on
+   * (here {@code MILLIS}, forced by {@code java.util.Date}), instead of converting from the precision those digits
+   * actually represent. {@code millisDate} (2033) is chronologically AFTER {@code nanosString}'s true moment
+   * (2001), but misreading the 19 nanos digits directly as millis inflates it to a moment ~31 million years in the
+   * future - larger than {@code millisDate} - which used to flip the comparison's sign.
+   */
+  @Test
+  void numericStringVersusDateInfersPrecisionFromDigitCountAndIsAntisymmetric() {
+    final Date millisDate = new Date(2_000_000_000_000L); // 2033-05-18T03:33:20.000Z
+    final String nanosString = "1000000000000000000"; // 19 digits: 2001-09-09T01:46:40Z expressed in epoch nanos
+
+    final int forward = comparator.compare(millisDate, BinaryTypes.TYPE_DATETIME, nanosString, BinaryTypes.TYPE_STRING);
+    final int backward = comparator.compare(nanosString, BinaryTypes.TYPE_STRING, millisDate, BinaryTypes.TYPE_DATETIME);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    // 2033 is chronologically after 2001, regardless of how the nanos digits were misread before the fix.
     assertThat(forward).isGreaterThan(0);
     assertThat(backward).isLessThan(0);
   }

--- a/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinaryComparatorNarrowingTest.java
@@ -292,4 +292,26 @@ class BinaryComparatorNarrowingTest {
     assertThat(forward).isGreaterThan(0);
     assertThat(backward).isLessThan(0);
   }
+
+  /**
+   * Same defect as {@link #numericStringVersusDateInfersPrecisionFromDigitCountAndIsAntisymmetric()}, but for
+   * {@link BinaryComparator#compareTo(Object, Object)} - the entry point the SQL {@code <}/{@code >}/{@code <=}/
+   * {@code >=} operators ({@code LtOperator}, {@code GtOperator}, ...) and {@code ORDER BY} actually use, and which
+   * always compares at {@code NANOS} precision. A 10-digit epoch-SECONDS string used to be read as raw NANOS
+   * digits (1.7 seconds after epoch - January 1970), always earlier than {@code millisDate} (2000) regardless of
+   * the string's true (2023) moment, which is actually LATER than {@code millisDate}.
+   */
+  @Test
+  void compareToInfersNumericStringPrecisionAndIsAntisymmetric() {
+    final Date millisDate = new Date(946_684_800_000L); // 2000-01-01T00:00:00.000Z
+    final String secondsString = "1700000000"; // 10 digits: 2023-11-14T22:13:20Z expressed in epoch seconds
+
+    final int forward = BinaryComparator.compareTo(millisDate, secondsString);
+    final int backward = BinaryComparator.compareTo(secondsString, millisDate);
+
+    assertThat(Integer.signum(forward)).isEqualTo(-Integer.signum(backward));
+    // 2000 is chronologically before 2023, regardless of how the seconds digits were misread before the fix.
+    assertThat(forward).isLessThan(0);
+    assertThat(backward).isGreaterThan(0);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
@@ -158,4 +158,37 @@ class DateUtilsTest {
     assertThat(farFutureNanos).isEqualTo(Long.MAX_VALUE);
     assertThat(farFutureNanos).isGreaterThan(nearPresentNanos);
   }
+
+  /**
+   * Regression for issue #5956: the numeric-string branch of {@link DateUtils#dateTimeToTimestamp(Object, ChronoUnit)}
+   * used to hand a bare numeric string's digits straight to the caller's requested {@code precisionToUse} via
+   * {@code Long.parseLong()}, with no regard for which precision those digits actually represent - a nanos-epoch
+   * string asked for at {@code MILLIS} came back 6 orders of magnitude wrong instead of being converted. The fix
+   * infers the string's own precision from its digit count (present-day epoch values grow by ~3 digits per finer
+   * step: ~10 for seconds, ~13 for millis, ~16 for micros, ~19 for nanos) and routes it through the same
+   * {@code convertTimestamp} helper every other branch in this method already uses.
+   */
+  @Test
+  void numericStringInfersOwnPrecisionFromDigitCountInsteadOfAssumingPrecisionToUse() {
+    // 10 digits: looks like epoch-SECONDS (2023-11-14T22:13:20Z).
+    final String epochSecondsString = "1700000000";
+    assertThat(DateUtils.dateTimeToTimestamp(epochSecondsString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
+    assertThat(DateUtils.dateTimeToTimestamp(epochSecondsString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_000L);
+
+    // 13 digits: looks like epoch-MILLIS: unaffected by the fix, matches pre-existing behavior.
+    final String epochMillisString = "1700000000123";
+    assertThat(DateUtils.dateTimeToTimestamp(epochMillisString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
+    assertThat(DateUtils.dateTimeToTimestamp(epochMillisString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
+
+    // 16 digits: looks like epoch-MICROS.
+    final String epochMicrosString = "1700000000123456";
+    assertThat(DateUtils.dateTimeToTimestamp(epochMicrosString, ChronoUnit.MICROS)).isEqualTo(1_700_000_000_123_456L);
+    assertThat(DateUtils.dateTimeToTimestamp(epochMicrosString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
+
+    // 19 digits: looks like epoch-NANOS - the exact case raised in #5956.
+    final String epochNanosString = "1700000000123456789";
+    assertThat(DateUtils.dateTimeToTimestamp(epochNanosString, ChronoUnit.NANOS)).isEqualTo(1_700_000_000_123_456_789L);
+    assertThat(DateUtils.dateTimeToTimestamp(epochNanosString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
+    assertThat(DateUtils.dateTimeToTimestamp(epochNanosString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
@@ -160,35 +160,86 @@ class DateUtilsTest {
   }
 
   /**
-   * Regression for issue #5956: the numeric-string branch of {@link DateUtils#dateTimeToTimestamp(Object, ChronoUnit)}
-   * used to hand a bare numeric string's digits straight to the caller's requested {@code precisionToUse} via
-   * {@code Long.parseLong()}, with no regard for which precision those digits actually represent - a nanos-epoch
-   * string asked for at {@code MILLIS} came back 6 orders of magnitude wrong instead of being converted. The fix
-   * infers the string's own precision from its digit count (present-day epoch values grow by ~3 digits per finer
-   * step: ~10 for seconds, ~13 for millis, ~16 for micros, ~19 for nanos) and routes it through the same
-   * {@code convertTimestamp} helper every other branch in this method already uses.
+   * Regression for issue #5956: {@link DateUtils#dateTimeToTimestampInferringStringPrecision(Object, ChronoUnit)}
+   * infers a bare numeric string's own precision from its digit count (present-day epoch values grow by ~3 digits
+   * per finer step: ~10 for seconds, ~13 for millis, ~16 for micros, ~19 for nanos) and converts it to
+   * {@code precisionToUse}, instead of assuming the raw digits already are at {@code precisionToUse} - a
+   * nanos-epoch string asked for at {@code MILLIS} used to come back 6 orders of magnitude wrong.
    */
   @Test
   void numericStringInfersOwnPrecisionFromDigitCountInsteadOfAssumingPrecisionToUse() {
     // 10 digits: looks like epoch-SECONDS (2023-11-14T22:13:20Z).
     final String epochSecondsString = "1700000000";
-    assertThat(DateUtils.dateTimeToTimestamp(epochSecondsString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
-    assertThat(DateUtils.dateTimeToTimestamp(epochSecondsString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_000L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochSecondsString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochSecondsString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_000L);
 
-    // 13 digits: looks like epoch-MILLIS: unaffected by the fix, matches pre-existing behavior.
+    // 13 digits: looks like epoch-MILLIS.
     final String epochMillisString = "1700000000123";
-    assertThat(DateUtils.dateTimeToTimestamp(epochMillisString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
-    assertThat(DateUtils.dateTimeToTimestamp(epochMillisString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochMillisString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochMillisString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
 
     // 16 digits: looks like epoch-MICROS.
     final String epochMicrosString = "1700000000123456";
-    assertThat(DateUtils.dateTimeToTimestamp(epochMicrosString, ChronoUnit.MICROS)).isEqualTo(1_700_000_000_123_456L);
-    assertThat(DateUtils.dateTimeToTimestamp(epochMicrosString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochMicrosString, ChronoUnit.MICROS)).isEqualTo(1_700_000_000_123_456L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochMicrosString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
 
     // 19 digits: looks like epoch-NANOS - the exact case raised in #5956.
     final String epochNanosString = "1700000000123456789";
-    assertThat(DateUtils.dateTimeToTimestamp(epochNanosString, ChronoUnit.NANOS)).isEqualTo(1_700_000_000_123_456_789L);
-    assertThat(DateUtils.dateTimeToTimestamp(epochNanosString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
-    assertThat(DateUtils.dateTimeToTimestamp(epochNanosString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochNanosString, ChronoUnit.NANOS)).isEqualTo(1_700_000_000_123_456_789L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochNanosString, ChronoUnit.MILLIS)).isEqualTo(1_700_000_000_123L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(epochNanosString, ChronoUnit.SECONDS)).isEqualTo(1_700_000_000L);
+  }
+
+  /**
+   * Off-boundary digit counts (11/12, 14/15, 17/18) must resolve to the same unit as their bucket's edges - this
+   * locks in the exact thresholds documented on {@code DateUtils#inferEpochPrecision}, per code review follow-up
+   * on PR #5960.
+   */
+  @Test
+  void numericStringPrecisionInferenceCoversOffBoundaryDigitCounts() {
+    // 11 and 12 digits: still MILLIS (bucket is 11-13 digits).
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision("17000000000", ChronoUnit.MILLIS)).isEqualTo(17_000_000_000L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision("170000000000", ChronoUnit.MILLIS)).isEqualTo(170_000_000_000L);
+
+    // 14 and 15 digits: still MICROS (bucket is 14-16 digits).
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision("17000000001234", ChronoUnit.MICROS)).isEqualTo(17_000_000_001_234L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision("170000000012345", ChronoUnit.MICROS)).isEqualTo(170_000_000_012_345L);
+
+    // 17 and 18 digits: still NANOS (bucket is 17+ digits).
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision("17000000001234567", ChronoUnit.NANOS)).isEqualTo(17_000_000_001_234_567L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision("170000000012345678", ChronoUnit.NANOS)).isEqualTo(170_000_000_012_345_678L);
+  }
+
+  /**
+   * A small value matches the digit count of more than one precision bucket at once (e.g. {@code "5"} is a valid
+   * 1-digit SECONDS value, but also a valid 1-digit MILLIS/MICROS/NANOS value within the first fraction of a
+   * second after the epoch) - the coarser unit (SECONDS) must win every such tie, per the documented tie-break
+   * rule on {@code DateUtils#inferEpochPrecision}.
+   */
+  @Test
+  void numericStringPrecisionInferenceTieBreaksTowardCoarserUnit() {
+    final String nearZero = "5";
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(nearZero, ChronoUnit.SECONDS)).isEqualTo(5L);
+    // Interpreted as 5 SECONDS, converted (not left as raw "5") to every finer target precision.
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(nearZero, ChronoUnit.MILLIS)).isEqualTo(5_000L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(nearZero, ChronoUnit.MICROS)).isEqualTo(5_000_000L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(nearZero, ChronoUnit.NANOS)).isEqualTo(5_000_000_000L);
+  }
+
+  /**
+   * Guard against over-fixing: the original {@link DateUtils#dateTimeToTimestamp(Object, ChronoUnit)} must keep its
+   * pre-#5956 raw-digits behavior for numeric strings. It is shared by {@code MathExpression}'s date {@code +}/
+   * {@code -} arithmetic, where a numeric string operand represents a raw duration/offset count to add at the
+   * date's own precision (e.g. {@code date + '10'} meaning "10 units of the date's precision") - digit-count
+   * inference would silently turn a small offset into a wildly different one there. Only
+   * {@code dateTimeToTimestampInferringStringPrecision} (used by comparison-context callers, where the numeric
+   * string represents an independent absolute moment) applies the inference.
+   */
+  @Test
+  void plainDateTimeToTimestampKeepsRawDigitsBehaviorForMathExpressionCompatibility() {
+    // "10" is a 2-digit string that would infer as SECONDS: the plain method must NOT convert it, unlike the
+    // inferring one.
+    assertThat(DateUtils.dateTimeToTimestamp("10", ChronoUnit.MILLIS)).isEqualTo(10L);
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision("10", ChronoUnit.MILLIS)).isEqualTo(10_000L);
   }
 }

--- a/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DateUtilsTest.java
@@ -242,4 +242,22 @@ class DateUtilsTest {
     assertThat(DateUtils.dateTimeToTimestamp("10", ChronoUnit.MILLIS)).isEqualTo(10L);
     assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision("10", ChronoUnit.MILLIS)).isEqualTo(10_000L);
   }
+
+  /**
+   * Regression for a code-review follow-up on PR #5960: a 16-digit numeric string infers as {@code MICROS}, and
+   * {@link DateUtils#convertTimestamp} widening it to {@code NANOS} used to be a raw {@code * 1_000} with no
+   * overflow guard - a value above {@code Long.MAX_VALUE / 1000} silently wrapped to a large negative number
+   * instead of saturating, which would have inverted a {@code BinaryComparator.compareTo()}-based comparison
+   * (that entry point always widens to {@code NANOS}). {@code convertTimestamp} now delegates to
+   * {@link java.util.concurrent.TimeUnit#convert}, which saturates to {@link Long#MAX_VALUE} on overflow instead.
+   */
+  @Test
+  void numericStringPrecisionInferenceSaturatesInsteadOfOverflowingOnWideningToNanos() {
+    // 16 digits: infers as MICROS. Value chosen above Long.MAX_VALUE / 1_000 (~9_223_372_036_854_775) so the
+    // MICROS -> NANOS widening multiplication would overflow a signed 64-bit long.
+    final String microsAboveNanosRange = "9999999999999999";
+    assertThat(DateUtils.dateTimeToTimestampInferringStringPrecision(microsAboveNanosRange, ChronoUnit.NANOS))
+        .as("must saturate to Long.MAX_VALUE instead of silently wrapping to a negative number")
+        .isEqualTo(Long.MAX_VALUE);
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #5956: `DateUtils.dateTimeToTimestamp()`'s numeric-string branch treated any bare numeric string as already being at whatever `precisionToUse` the caller requested, via a plain `Long.parseLong()`, with no regard for what precision the string's digits actually represent.

`BinaryComparator.compare()`'s `TYPE_DATE`/`TYPE_DATETIME*` branch computes a shared precision purely from the *other* operand's runtime type (e.g. `Date`/`Calendar` force `MILLIS`). A numeric string holding a *different* precision than that (e.g. a nanos-epoch string compared against a plain `java.util.Date`) was misinterpreted by orders of magnitude, since its raw digits were used as-is at the wrong unit.

## Fix

Infer the numeric string's own epoch precision from its digit count - for a present-day moment, an epoch value grows by ~3 digits per finer precision step (~10 digits for seconds, ~13 for millis, ~16 for micros, ~19 for nanos) - then convert via the existing `DateUtils.convertTimestamp(raw, inferredPrecision, precisionToUse)` helper, the same pattern every other branch of `dateTimeToTimestamp()` already follows (parse in the value's own native precision, then convert to what the caller asked for). No new parsing logic or public API surface; the fix only wires the numeric-string branch into the existing conversion helper.

This cannot distinguish a genuinely tiny value (e.g. a millis timestamp within the first ~3 months of 1970) from the coarser unit it also matches digit-for-digit - `SECONDS` wins that tie, since a near-zero epoch value is far more common as a duration/offset than an actual date that close to the epoch. This is a documented, accepted limitation inherent to any magnitude-based unit inference.

## Testing

- `DateUtilsTest.numericStringInfersOwnPrecisionFromDigitCountInsteadOfAssumingPrecisionToUse` - direct coverage of the digit-count inference at all four precisions (10/13/16/19 digits), verifying conversion to a *different* target precision.
- `BinaryComparatorNarrowingTest.numericStringVersusDateInfersPrecisionFromDigitCountAndIsAntisymmetric` - reproduces the exact antisymmetry failure from the issue: a nanos-epoch string vs. a MILLIS `java.util.Date`, where misreading the nanos digits as millis used to flip the comparison's sign entirely.
- Both new tests fail against the pre-fix code (confirmed) and pass after the fix.
- Full `com.arcadedb.serializer.**`, `com.arcadedb.utility.**`, `com.arcadedb.schema.**` test packages pass with no regressions; verified no pre-existing test asserts on the old (buggy) numeric-string semantics.

## Context

Spawned by review on PR #5955 (fixing #5947, itself a follow-up to #5900/#5922) - see the `BinaryComparator` antisymmetry chain in the linked issues.
