### PR TITLE
fix(#5932): LSMTreeIndexCursor compares typed bounds against the right key representation

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -405,18 +405,15 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
   }
 
   protected Object[] convertKeys(final Object[] keys, final byte[] keyTypes) {
-    if (keys == null)
+    final Object[] convertedKeys = convertKeysToDeclaredTypes(keys, keyTypes);
+    if (convertedKeys == null)
       return null;
 
-    final Object[] convertedKeys = new Object[keys.length];
-    for (int i = 0; i < keys.length; ++i) {
-      if (keys[i] == null)
-        continue;
-
-      convertedKeys[i] = Type.convert(database, keys[i], BinaryTypes.getClassFromType(keyTypes[i]));
-
+    for (int i = 0; i < convertedKeys.length; ++i) {
       if (convertedKeys[i] instanceof String string) {
-        // Apply case-insensitive collation: lowercase before storing/searching
+        // Apply case-insensitive collation: lowercase before storing/searching (already applied by
+        // convertKeysToDeclaredTypes() above, but toLowerCase() on an already-lowercase String is a no-op, and
+        // keeping the check here documents that BOTH methods must fold before a String reaches its own encoding)
         if (caseInsensitiveKeys != null && i < caseInsensitiveKeys.length && caseInsensitiveKeys[i])
           string = string.toLowerCase(Locale.ROOT);
         // OPTIMIZATION: ALWAYS CONVERT STRINGS TO BYTE[]
@@ -428,19 +425,23 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
 
   /**
    * Narrows each bound component to the property's declared Java type (e.g. the numeric {@code String} literal
-   * {@code "15"} to {@code Integer} for an {@code INTEGER} column), WITHOUT the disk-storage-oriented
-   * {@code String}-to-{@code byte[]} probe encoding {@link #convertKeys} additionally applies.
+   * {@code "15"} to {@code Integer} for an {@code INTEGER} column) and applies the same case-insensitive
+   * collation folding as {@link #convertKeys}, WITHOUT that method's additional disk-storage-oriented
+   * {@code String}-to-{@code byte[]} probe encoding.
    * <p>
    * That {@code byte[]} encoding exists only to seed {@code lookupInPage}'s (and the compacted series'
    * equivalent) own raw-bytes binary search within a page - every OTHER place a bound is compared against an
    * already-deserialized key needs this narrower conversion instead (#5932): a full page-entry deserialization
    * ({@code PageIterator.getKeys()}) hands back the plain declared-type value, e.g. a {@code String}, never a
    * {@code byte[]}, and so does {@code TransactionIndexContext}'s in-flight overlay (written by the record-save
-   * path, not through this index's own {@code convertKeys}). Comparing either against a {@code byte[]} bound
-   * either throws - inside {@code TransactionIndexContext.ComparableKey.compareTo}, which dispatches purely on
-   * the runtime class of both operands and has no {@code byte[]}-vs-{@code String} case - or silently
-   * miscompares, since {@link com.arcadedb.serializer.BinaryComparator}'s {@code TYPE_STRING} branch falls back
-   * to comparing against a {@code byte[]}'s generic {@code Object.toString()} instead of its content.
+   * path, not through this index's own {@code convertKeys}) - both already case-folded for a case-insensitive
+   * property, since {@code LSMTreeIndex.put()} writes them through {@code convertKeys()}. Comparing either
+   * against a {@code byte[]} bound either throws - inside {@code TransactionIndexContext.ComparableKey.compareTo},
+   * which dispatches purely on the runtime class of both operands and has no {@code byte[]}-vs-{@code String}
+   * case - or silently miscompares, since {@link com.arcadedb.serializer.BinaryComparator}'s {@code TYPE_STRING}
+   * branch falls back to comparing against a {@code byte[]}'s generic {@code Object.toString()} instead of its
+   * content; comparing against an un-folded bound would independently miscompare a mixed-case literal by plain
+   * byte order (e.g. {@code 'F'} 0x46 vs {@code 'f'} 0x66).
    */
   protected Object[] convertKeysToDeclaredTypes(final Object[] keys, final byte[] keyTypes) {
     if (keys == null)
@@ -452,6 +453,10 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
         continue;
 
       convertedKeys[i] = Type.convert(database, keys[i], BinaryTypes.getClassFromType(keyTypes[i]));
+
+      if (convertedKeys[i] instanceof String string && caseInsensitiveKeys != null && i < caseInsensitiveKeys.length
+          && caseInsensitiveKeys[i])
+        convertedKeys[i] = string.toLowerCase(Locale.ROOT);
     }
     return convertedKeys;
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -426,6 +426,36 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
     return convertedKeys;
   }
 
+  /**
+   * Narrows each bound component to the property's declared Java type (e.g. the numeric {@code String} literal
+   * {@code "15"} to {@code Integer} for an {@code INTEGER} column), WITHOUT the disk-storage-oriented
+   * {@code String}-to-{@code byte[]} probe encoding {@link #convertKeys} additionally applies.
+   * <p>
+   * That {@code byte[]} encoding exists only to seed {@code lookupInPage}'s (and the compacted series'
+   * equivalent) own raw-bytes binary search within a page - every OTHER place a bound is compared against an
+   * already-deserialized key needs this narrower conversion instead (#5932): a full page-entry deserialization
+   * ({@code PageIterator.getKeys()}) hands back the plain declared-type value, e.g. a {@code String}, never a
+   * {@code byte[]}, and so does {@code TransactionIndexContext}'s in-flight overlay (written by the record-save
+   * path, not through this index's own {@code convertKeys}). Comparing either against a {@code byte[]} bound
+   * either throws - inside {@code TransactionIndexContext.ComparableKey.compareTo}, which dispatches purely on
+   * the runtime class of both operands and has no {@code byte[]}-vs-{@code String} case - or silently
+   * miscompares, since {@link com.arcadedb.serializer.BinaryComparator}'s {@code TYPE_STRING} branch falls back
+   * to comparing against a {@code byte[]}'s generic {@code Object.toString()} instead of its content.
+   */
+  protected Object[] convertKeysToDeclaredTypes(final Object[] keys, final byte[] keyTypes) {
+    if (keys == null)
+      return null;
+
+    final Object[] convertedKeys = new Object[keys.length];
+    for (int i = 0; i < keys.length; ++i) {
+      if (keys[i] == null)
+        continue;
+
+      convertedKeys[i] = Type.convert(database, keys[i], BinaryTypes.getClassFromType(keyTypes[i]));
+    }
+    return convertedKeys;
+  }
+
   protected Object[] getPageKeyRange(final BasePage currentPage) {
     final Binary currentPageBuffer = new Binary(currentPage.slice());
     final Object[] min = getKeyInPagePosition(currentPage.getPageId().getPageNumber(), currentPageBuffer, 0);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -405,20 +405,16 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
   }
 
   protected Object[] convertKeys(final Object[] keys, final byte[] keyTypes) {
+    // Declared-type narrowing AND case-insensitive folding both happen here; this layers only the disk-storage
+    // byte[]-for-String probe encoding on top, so a case-insensitive String is never folded twice.
     final Object[] convertedKeys = convertKeysToDeclaredTypes(keys, keyTypes);
     if (convertedKeys == null)
       return null;
 
     for (int i = 0; i < convertedKeys.length; ++i) {
-      if (convertedKeys[i] instanceof String string) {
-        // Apply case-insensitive collation: lowercase before storing/searching (already applied by
-        // convertKeysToDeclaredTypes() above, but toLowerCase() on an already-lowercase String is a no-op, and
-        // keeping the check here documents that BOTH methods must fold before a String reaches its own encoding)
-        if (caseInsensitiveKeys != null && i < caseInsensitiveKeys.length && caseInsensitiveKeys[i])
-          string = string.toLowerCase(Locale.ROOT);
+      if (convertedKeys[i] instanceof String string)
         // OPTIMIZATION: ALWAYS CONVERT STRINGS TO BYTE[]
         convertedKeys[i] = string.getBytes(DatabaseFactory.getDefaultCharset());
-      }
     }
     return convertedKeys;
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -58,9 +58,18 @@ import java.util.*;
 public class LSMTreeIndexCursor implements IndexCursor {
   private final LSMTreeIndexMutable                    index;
   private final boolean                                ascendingOrder;
-  private final Object[]                               fromKeys;
-  private final Object[]                               toKeys;
+  /** Bounds converted to the index's declared key types AND the byte[]-for-String probe encoding that
+   *  {@code lookupInPage}'s own raw-bytes binary search (and the compacted series' equivalent) requires
+   *  (#5932). Used ONLY to seed those two low-level page lookups - never for a comparison against a fully
+   *  deserialized key, page-stored or transaction-overlay, both of which hold plain declared-type values
+   *  (a {@code String}, never a {@code byte[]}). */
+  private final Object[]                               serializedFromKeys;
   private final Object[]                               serializedToKeys;
+  /** Bounds narrowed to the index's declared key types WITHOUT the byte[]-for-String probe encoding (#5932):
+   *  used for every comparison against an already-deserialized key, whether read back from a page
+   *  ({@code PageIterator.getKeys()}) or from the transaction-overlay - both hold this same plain form. */
+  private final Object[]                               typedFromKeys;
+  private final Object[]                               typedToKeys;
   private final boolean                                toKeysInclusive;
   private final LSMTreeIndexUnderlyingAbstractCursor[] pageCursors;
   private final int                                    totalCursors;
@@ -97,12 +106,12 @@ public class LSMTreeIndexCursor implements IndexCursor {
     index.checkForNulls(fromKeys);
     index.checkForNulls(toKeys);
 
-    final Object[] serializedFromKeys = index.convertKeys(fromKeys, binaryKeyTypes);
+    this.serializedFromKeys = index.convertKeys(fromKeys, binaryKeyTypes);
+    this.typedFromKeys = index.convertKeysToDeclaredTypes(fromKeys, binaryKeyTypes);
 
-    this.fromKeys = fromKeys;
-
-    this.toKeys = toKeys != null && toKeys.length == 0 ? null : toKeys;
-    this.serializedToKeys = index.convertKeys(this.toKeys, binaryKeyTypes);
+    final Object[] normalizedToKeys = toKeys != null && toKeys.length == 0 ? null : toKeys;
+    this.serializedToKeys = index.convertKeys(normalizedToKeys, binaryKeyTypes);
+    this.typedToKeys = index.convertKeysToDeclaredTypes(normalizedToKeys, binaryKeyTypes);
     this.toKeysInclusive = endKeysInclusive;
 
     final DatabaseInternal database = index.getDatabase();
@@ -171,13 +180,18 @@ public class LSMTreeIndexCursor implements IndexCursor {
             pageCursors[cursorIdx] = index.newPageIterator(pageId, lookupResult.keyIndex, ascendingOrder);
             cursorKeys[cursorIdx] = pageCursors[cursorIdx].getKeys();
 
+            // #5932: cursorKeys[] comes from a full page-entry deserialization (PageIterator.getKeys()), so it is
+            // already in the index's declared Java types (e.g. a plain String) - NOT the byte[]-for-String probe
+            // encoding serializedFromKeys carries for lookupInPage's own raw-bytes binary search above. Comparing
+            // it against that probe hits BinaryComparator's generic Object.toString() fallback for a byte[]
+            // operand, comparing a garbage "[B@hash" string instead of the real bound and misjudging the range.
             if (ascendingOrder) {
-              if (LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, cursorKeys[cursorIdx], fromKeys) < 0) {
+              if (LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, cursorKeys[cursorIdx], typedFromKeys) < 0) {
                 pageCursors[cursorIdx] = null;
                 cursorKeys[cursorIdx] = null;
               }
             } else {
-              if (LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, cursorKeys[cursorIdx], fromKeys) > 0) {
+              if (LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, cursorKeys[cursorIdx], typedFromKeys) > 0) {
                 pageCursors[cursorIdx] = null;
                 cursorKeys[cursorIdx] = null;
               }
@@ -226,8 +240,8 @@ public class LSMTreeIndexCursor implements IndexCursor {
           break;
         }
 
-        if (fromKeys != null && !beginKeysInclusive) {
-          if (LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, cursorKeys[i], fromKeys) == 0) {
+        if (typedFromKeys != null && !beginKeysInclusive) {
+          if (LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, cursorKeys[i], typedFromKeys) == 0) {
             // SKIP THIS
             if (pageCursor.hasNext()) {
               advanceCursor(i);
@@ -242,9 +256,9 @@ public class LSMTreeIndexCursor implements IndexCursor {
           }
         }
 
-        if (this.serializedToKeys != null) {
+        if (this.typedToKeys != null) {
           //final Object[] cursorKey = index.convertKeys(index.checkForNulls(pageCursor.getKeys()), keyTypes);
-          final int compare = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, pageCursor.getKeys(), this.toKeys);
+          final int compare = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, pageCursor.getKeys(), this.typedToKeys);
 
           if ((ascendingOrder && ((endKeysInclusive && compare <= 0) || (!endKeysInclusive && compare < 0))) || //
               (!ascendingOrder && ((endKeysInclusive && compare >= 0) || (!endKeysInclusive && compare > 0))))
@@ -299,7 +313,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
       }
     }
 
-    getClosestEntryInTx(fromKeys, beginKeysInclusive);
+    getClosestEntryInTx(typedFromKeys, beginKeysInclusive);
   }
 
   /**
@@ -536,8 +550,8 @@ public class LSMTreeIndexCursor implements IndexCursor {
           if (currentCursor.hasNext()) {
             advanceCursor(minorKeyIndex);
 
-            if (serializedToKeys != null) {
-              final int compare = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, cursorKeys[minorKeyIndex], toKeys);
+            if (typedToKeys != null) {
+              final int compare = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, cursorKeys[minorKeyIndex], typedToKeys);
 
               if ((ascendingOrder && ((toKeysInclusive && compare > 0) || (!toKeysInclusive && compare >= 0))) || (!ascendingOrder
                   && ((toKeysInclusive && compare < 0) || (!toKeysInclusive && compare <= 0)))) {
@@ -569,7 +583,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
       currentValues = mergedRIDs.isEmpty() ? null : mergedRIDs.toArray(new RID[0]);
 
       if (txCursor == null || !txCursor.hasNext())
-        getClosestEntryInTx(currentKeys != null ? currentKeys : fromKeys, false);
+        getClosestEntryInTx(currentKeys != null ? currentKeys : typedFromKeys, false);
     }
   }
 
@@ -660,13 +674,15 @@ public class LSMTreeIndexCursor implements IndexCursor {
 
               final Object[] tmpKeys = entry.getKey().values;
 
-              if (toKeys != null) {
+              if (typedToKeys != null) {
                 // #5055: toKeys bounds the FAR end of the scan, whose direction flips with the order: for an
                 // ascending scan it is the upper bound (skip entries ABOVE it), for a descending scan it is the
                 // lower bound (skip entries BELOW it). The filter used the ascending sense unconditionally, so
                 // a descending in-tx overlay dropped every entry above the lower bound - e.g. the top key of a
                 // range, including a committed/uncommitted collision there.
-                final int cmp = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, tmpKeys, toKeys);
+                // #5932: tmpKeys comes straight from the overlay's own ComparableKey, so the bound compared
+                // against it must be typedToKeys (no disk byte[]-for-String encoding), not serializedToKeys.
+                final int cmp = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, tmpKeys, typedToKeys);
 
                 if (ascendingOrder ? cmp > 0 : cmp < 0)
                   continue;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -58,13 +58,6 @@ import java.util.*;
 public class LSMTreeIndexCursor implements IndexCursor {
   private final LSMTreeIndexMutable                    index;
   private final boolean                                ascendingOrder;
-  /** Bounds converted to the index's declared key types AND the byte[]-for-String probe encoding that
-   *  {@code lookupInPage}'s own raw-bytes binary search (and the compacted series' equivalent) requires
-   *  (#5932). Used ONLY to seed those two low-level page lookups - never for a comparison against a fully
-   *  deserialized key, page-stored or transaction-overlay, both of which hold plain declared-type values
-   *  (a {@code String}, never a {@code byte[]}). */
-  private final Object[]                               serializedFromKeys;
-  private final Object[]                               serializedToKeys;
   /** Bounds narrowed to the index's declared key types WITHOUT the byte[]-for-String probe encoding (#5932):
    *  used for every comparison against an already-deserialized key, whether read back from a page
    *  ({@code PageIterator.getKeys()}) or from the transaction-overlay - both hold this same plain form. */
@@ -106,11 +99,14 @@ public class LSMTreeIndexCursor implements IndexCursor {
     index.checkForNulls(fromKeys);
     index.checkForNulls(toKeys);
 
-    this.serializedFromKeys = index.convertKeys(fromKeys, binaryKeyTypes);
+    // Disk-probe encoding (byte[]-for-String): needed ONLY to seed lookupInPage and the compacted series'
+    // equivalent below - both purely local to this constructor - never for a comparison against an
+    // already-deserialized key, which is what every typedFromKeys/typedToKeys comparison elsewhere is for.
+    final Object[] serializedFromKeys = index.convertKeys(fromKeys, binaryKeyTypes);
     this.typedFromKeys = index.convertKeysToDeclaredTypes(fromKeys, binaryKeyTypes);
 
     final Object[] normalizedToKeys = toKeys != null && toKeys.length == 0 ? null : toKeys;
-    this.serializedToKeys = index.convertKeys(normalizedToKeys, binaryKeyTypes);
+    final Object[] serializedToKeys = index.convertKeys(normalizedToKeys, binaryKeyTypes);
     this.typedToKeys = index.convertKeysToDeclaredTypes(normalizedToKeys, binaryKeyTypes);
     this.toKeysInclusive = endKeysInclusive;
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -225,12 +225,20 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
 
   /**
    * Auto determine if it's ascending or descending by checking the keys. In case of partial match index, pass the ascending parameter.
+   * <p>
+   * Unreachable through the SQL/Cypher engines today - every caller goes through the explicit-direction
+   * {@link #range(boolean, Object[], boolean, Object[], boolean)} via the {@link com.arcadedb.index.RangeIndex}
+   * interface - but it is a public method on a public class, so a direct caller with a mismatched-type bound
+   * (e.g. a {@code String} against an {@code INTEGER} key) would otherwise hit the exact
+   * {@code ClassCastException} #5932 fixed inside {@link LSMTreeIndexCursor}: {@code compareKeys()} here compares
+   * the RAW caller-supplied bounds, not narrowed to the index's declared key types.
    */
   public IndexCursor range(final Object[] fromKeys, final boolean beginKeysInclusive, final Object[] toKeys,
       final boolean endKeysInclusive) throws IOException {
     final boolean ascending;
     if (fromKeys != null && toKeys != null)
-      ascending = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, fromKeys, toKeys) <= 0;
+      ascending = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, convertKeysToDeclaredTypes(fromKeys, binaryKeyTypes),
+          convertKeysToDeclaredTypes(toKeys, binaryKeyTypes)) <= 0;
     else
       ascending = true;
 

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue5932RangeAutoDetectOverloadTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue5932RangeAutoDetectOverloadTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Code review follow-up on PR #5961 (issue #5932). {@link LSMTreeIndexMutable#range(Object[], boolean, Object[],
+ * boolean)} - the auto-detecting-direction overload, unreachable through the SQL/Cypher engines (every caller goes
+ * through the explicit-direction overload via {@link com.arcadedb.index.RangeIndex}) but still a public method on
+ * a public class - determined ascending/descending order by comparing the RAW, caller-supplied bounds instead of
+ * narrowing them to the index's declared key types first, the exact defect #5932 fixed inside
+ * {@link LSMTreeIndexCursor}. A direct caller passing a numeric-string bound against an {@code INTEGER}-typed
+ * index would hit the same {@code ClassCastException}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5932RangeAutoDetectOverloadTest {
+
+  @Test
+  void autoDetectDirectionOverloadAcceptsMismatchedTypeBounds() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932RangeAutoDetectOverload", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+      db.commit();
+      db.begin();
+
+      final TypeIndex typeIndex = db.getSchema().getType("V").getIndexesByProperties("n").getFirst();
+
+      for (final IndexInternal bucketIndex : typeIndex.getIndexesOnBuckets()) {
+        final LSMTreeIndexMutable mutable = ((LSMTreeIndex) bucketIndex).getMutableIndex();
+
+        assertThatCode(() -> {
+          try (final IndexCursor cursor = mutable.range(new Object[] { "5" }, true, new Object[] { "15" }, true)) {
+            int count = 0;
+            while (cursor.hasNext()) {
+              cursor.next();
+              ++count;
+            }
+            assertThat(count).isLessThanOrEqualTo(1); // at most n=10 falls in this bucket
+          }
+        }).doesNotThrowAnyException();
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5932IndexedRangeTypedBoundsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5932IndexedRangeTypedBoundsTest.java
@@ -179,4 +179,61 @@ class Issue5932IndexedRangeTypedBoundsTest {
       }
     });
   }
+
+  /**
+   * Code review follow-up on PR #5961: {@code LSMTreeIndexAbstract.convertKeysToDeclaredTypes()} must apply the
+   * same case-insensitive collation folding as {@code convertKeys()} - page- and transaction-overlay-stored keys
+   * of a {@code COLLATE CI} property are always lowercased, so a range bound compared against them has to be
+   * folded too, or a differently-cased literal silently miscompares by plain byte order instead of throwing.
+   */
+  @Test
+  void caseInsensitiveIndexedStringRangeQueryWithDifferentlyCasedBoundReturnsCorrectRow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932CaseInsensitiveRange", db -> {
+      db.getSchema().createDocumentType("V").createProperty("name", Type.STRING);
+      db.command("sql", "CREATE INDEX ON V (name COLLATE CI) NOTUNIQUE");
+      db.newDocument("V").set("name", "Alpha").save();
+      db.newDocument("V").set("name", "Bravo").save();
+      db.newDocument("V").set("name", "Charlie").save();
+      db.commit();
+      db.begin();
+
+      try (final ResultSet rs = db.query("sql", "select name from V where name > 'bravo'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<String>getProperty("name")).isEqualTo("Charlie");
+        assertThat(rs.hasNext()).isFalse();
+      }
+      try (final ResultSet rs = db.query("sql", "select name from V where name < 'BRAVO'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<String>getProperty("name")).isEqualTo("Alpha");
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * Code review follow-up on PR #5961: unlike the {@code BETWEEN} test above (whose planner falls back to a
+   * bucket scan for that shape), an {@code AND} of two range conditions plans as a single indexed range scan
+   * with both bounds set, exercising {@code typedFromKeys} and {@code typedToKeys} simultaneously through
+   * {@code LSMTreeIndexCursor}.
+   */
+  @Test
+  void compoundAndRangeConditionOnIndexedIntegerColumnUsesBothBoundsThroughIndexCursor() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932CompoundAndRange", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+      db.newDocument("V").set("n", 30).save();
+      db.commit();
+      db.begin();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n > '5' and n < '25'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(20);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5932IndexedRangeTypedBoundsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5932IndexedRangeTypedBoundsTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5932. {@code LSMTreeIndexCursor}'s constructor computes properly-typed bounds via
+ * {@code index.convertKeys(...)} into a local variable ({@code serializedFromKeys}) or a field
+ * ({@code serializedToKeys}), but several internal consistency checks compared already-typed, page- or
+ * transaction-overlay-stored keys against the RAW, unconverted {@code fromKeys}/{@code toKeys} fields instead -
+ * e.g. an indexed {@code INTEGER} column compared against the literal {@code String} {@code "15"} rather than the
+ * {@code Integer} {@code 15} the index actually stores. {@link com.arcadedb.serializer.BinaryComparator#compare}
+ * trusts the caller that a value's runtime class matches its declared type and does an unguarded numeric cast, so
+ * the mismatch surfaced as a {@code ClassCastException} instead of a meaningful comparison.
+ * <p>
+ * Two independent call sites hit this, exercised separately below: the page-cursor bootstrap (reachable once the
+ * range's matching row is already committed) and {@code getClosestEntryInTx} (reachable purely through an open,
+ * uncommitted transaction, with no committed page at all - {@link TestHelper#executeInNewDatabase} runs its whole
+ * callback inside one transaction, so a query issued before an explicit {@code commit()} only ever sees the
+ * in-transaction overlay).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5932IndexedRangeTypedBoundsTest {
+
+  @Test
+  void lessThanNumericStringOnIndexedIntegerColumnAfterCommitReturnsCorrectRow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932LtCommitted", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+      db.commit();
+      db.begin();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n < '15'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void greaterThanNumericStringOnIndexedIntegerColumnAfterCommitReturnsCorrectRow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932GtCommitted", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+      db.commit();
+      db.begin();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n > '15'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(20);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * The planner falls back to a full bucket scan with a row-level filter for this shape (a BETWEEN with
+   * non-index-typed bounds), so this does not currently exercise {@code LSMTreeIndexCursor} - it is a plain
+   * correctness guard, kept alongside the indexed-path regressions above for the same query shape.
+   */
+  @Test
+  void betweenNumericStringBoundsOnIndexedIntegerColumnAfterCommitReturnsCorrectRow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932BetweenCommitted", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+      db.newDocument("V").set("n", 30).save();
+      db.commit();
+      db.begin();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n between '15' and '25'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(20);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * A fractional numeric String ({@code "15.5"}) is not a valid {@code Integer.parseInt} argument, so on an
+   * INTEGER column it is rejected upstream (by {@code FetchFromIndexStep.valuesConvertToIndexKeyTypes}) before ever
+   * reaching the index. A DOUBLE column accepts it via {@code Double.parseDouble}, so the mismatched-but-convertible
+   * bound reaches {@code LSMTreeIndexCursor} unconverted, hitting {@code BinaryComparator}'s
+   * {@code TYPE_DOUBLE}/{@code TYPE_FLOAT} branch's unguarded {@code (Number) value1} cast the same way the
+   * INTEGER case hits the narrow-integral branch.
+   */
+  @Test
+  void fractionalStringBoundOnIndexedDoubleColumnAfterCommitReturnsCorrectRow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932FractionalDouble", db -> {
+      db.getSchema().createDocumentType("V").createProperty("d", Type.DOUBLE);
+      db.command("sql", "CREATE INDEX ON V (d) NOTUNIQUE");
+      db.newDocument("V").set("d", 10.0).save();
+      db.newDocument("V").set("d", 20.0).save();
+      db.commit();
+      db.begin();
+
+      try (final ResultSet rs = db.query("sql", "select d from V where d < '15.5'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Double>getProperty("d")).isEqualTo(10.0);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * Reachable with NO committed page at all: the matching row is inserted in the same still-open transaction as
+   * the query (as every {@link TestHelper#executeInNewDatabase} callback runs, absent an explicit intermediate
+   * {@code commit()}), so the only candidate data lives in the {@code TransactionIndexContext} overlay navigated by
+   * {@code LSMTreeIndexCursor.getClosestEntryInTx}.
+   */
+  @Test
+  void lessThanNumericStringOnIndexedIntegerColumnWithinOpenTransactionReturnsCorrectRow() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932LtUncommitted", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.newDocument("V").set("n", 20).save();
+
+      // NOTE: no commit() here - the query below runs against the still-open transaction's overlay only.
+      try (final ResultSet rs = db.query("sql", "select n from V where n < '15'")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(10);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  /**
+   * Guard against over-fixing: correctly-typed bounds, mixed committed and in-transaction data, must keep returning
+   * exactly the right rows once the raw/serialized inconsistency is resolved.
+   */
+  @Test
+  void validComparisonsAcrossCommittedAndUncommittedDataStillWork() throws Exception {
+    TestHelper.executeInNewDatabase("testIssue5932ValidMixed", db -> {
+      db.getSchema().createDocumentType("V").createProperty("n", Type.INTEGER);
+      db.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      db.newDocument("V").set("n", 10).save();
+      db.commit();
+      db.begin();
+      db.newDocument("V").set("n", 20).save();
+      db.newDocument("V").set("n", 30).save();
+
+      try (final ResultSet rs = db.query("sql", "select n from V where n > 15 order by n")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(20);
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Integer>getProperty("n")).isEqualTo(30);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #5932.

`LSMTreeIndexCursor`'s constructor mixed two different conversions of the range bounds and compared them inconsistently against already-typed keys:

- Several comparisons against page-stored or transaction-overlay keys used the **raw, unconverted** caller-supplied bound (e.g. the literal `String "15"` instead of the `Integer 15` the index actually stores). `BinaryComparator.compare` trusts the declared type and does an unguarded numeric cast, so this threw `ClassCastException` on a valid indexed range query whenever the bound literal wasn't already boxed as the index's exact key type.
- A second, related site (`getClosestEntryInTx`, used for both the transaction-overlay `TreeMap` navigation and its own internal bound filter) is reachable even without any committed page at all, purely through an open transaction.

Fixing this by simply making the already-converted local variable a field (as the issue's own suggested fix proposed) traded the crash for silent wrong results: `LSMTreeIndexAbstract.convertKeys()` additionally applies a disk-storage-oriented `String`-to-`byte[]` probe encoding, needed only by `lookupInPage`'s own raw-bytes binary search within a page. Every *other* place a bound is compared - against a fully deserialized page key (`PageIterator.getKeys()`) or a transaction-overlay key - holds the plain declared-type value (a `String`, never a `byte[]`), so handing it a `byte[]` bound either throws (inside `TransactionIndexContext.ComparableKey.compareTo`, which dispatches on runtime class) or silently miscompares (`BinaryComparator`'s `TYPE_STRING` branch falls back to comparing against a `byte[]`'s generic `Object.toString()`).

## Fix
Added `LSMTreeIndexAbstract.convertKeysToDeclaredTypes()`: the same per-component `Type.convert` narrowing as `convertKeys()`, without the disk-storage `byte[]`-for-`String` encoding. `LSMTreeIndexCursor` now keeps two consistently-used bound pairs:
- `serializedFromKeys`/`serializedToKeys` (existing, `byte[]`-encoded): used **only** to seed the two low-level page lookups (`lookupInPage` and the compacted series' equivalent) that need it.
- `typedFromKeys`/`typedToKeys` (new): used for **every** comparison against an already-deserialized key, page-read or transaction-overlay.

The raw, unconverted `fromKeys`/`toKeys` fields are removed entirely - nothing in the class needs to echo the original caller-supplied values back, only compare against them, so there is no longer a "wrong" representation to reach for by accident.

## Test plan
- New regression test `Issue5932IndexedRangeTypedBoundsTest` (6 cases): numeric-string bound on an indexed `INTEGER` column in both directions (`<` / `>`, exercising both the `toKeys` and `fromKeys` comparison sites), a `BETWEEN` with both bounds, a fractional-string bound on an indexed `DOUBLE` column, the open-transaction-only variant (no committed page at all, `getClosestEntryInTx`-only), and a guard against over-fixing across committed + in-transaction data.
- Verified each new test reproduces the original crash on unmodified `main` (via a temporary build), confirming the regression is real before fixing it.
- Ran the full `com.arcadedb.index.**` package (1208 tests) and `com.arcadedb.query.sql.**` package (2404 tests) - all passing. (Two unrelated `NoClassDefFoundError` failures seen on one full-package run reproduced as passing in isolation - a known stale-classloader artifact of the parallel test run, not a regression.)