### PR TITLE
fix: console robustness bugs (#5931, #5929, #5928, #5927)

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -188,8 +188,12 @@ public class Console {
         final int separatorPos = keyValue.indexOf('=');
         final String key = separatorPos < 0 ? keyValue : keyValue.substring(0, separatorPos);
         final String propertyValue = separatorPos < 0 ? "" : keyValue.substring(separatorPos + 1);
-        System.setProperty(key, propertyValue);
-        setGlobalConfiguration(key, propertyValue, true);
+        if (key.isEmpty())
+          System.err.println("Ignoring malformed system property argument '" + value + "': missing key");
+        else {
+          System.setProperty(key, propertyValue);
+          setGlobalConfiguration(key, propertyValue, true);
+        }
       } else if ("-b".equalsIgnoreCase(value)) {
         batchMode = true;
       } else if ("-fae".equalsIgnoreCase(value)) {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -934,7 +934,7 @@ public class Console {
     final StringBuilder line = new StringBuilder(128);
     line.append(operation).append(" [step ").append(stepIndex).append('/').append(totalSteps).append("] ").append(stepName);
     if (percentage >= 0) {
-      final int filled = Math.max(0, Math.min(20, percentage / 5));
+      final int filled = Math.min(20, percentage / 5);
       line.append(" |").append("=".repeat(filled)).append(" ".repeat(20 - filled)).append("| ").append(percentage).append('%');
     } else
       line.append(" ...");

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -184,9 +184,12 @@ public class Console {
       final String value = args[i].trim();
       if (value.startsWith("-D")) {
         // SETTING
-        final String[] parts = value.substring(2).split("=");
-        System.setProperty(parts[0], parts[1]);
-        setGlobalConfiguration(parts[0], parts[1], true);
+        final String keyValue = value.substring(2);
+        final int separatorPos = keyValue.indexOf('=');
+        final String key = separatorPos < 0 ? keyValue : keyValue.substring(0, separatorPos);
+        final String propertyValue = separatorPos < 0 ? "" : keyValue.substring(separatorPos + 1);
+        System.setProperty(key, propertyValue);
+        setGlobalConfiguration(key, propertyValue, true);
       } else if ("-b".equalsIgnoreCase(value)) {
         batchMode = true;
       } else if ("-fae".equalsIgnoreCase(value)) {
@@ -421,9 +424,11 @@ public class Console {
       }
     } else {
       // LOCAL DATABASE
-      for (final String f : new File(databaseDirectory).list()) {
-        outputLine(3, "- " + f);
-      }
+      final String[] databaseNames = new File(databaseDirectory).list();
+      if (databaseNames != null)
+        for (final String f : databaseNames) {
+          outputLine(3, "- " + f);
+        }
     }
 
     flushOutput();
@@ -920,12 +925,12 @@ public class Console {
     return formatProgressLine(op.getOperation(), op.getStepName(), op.getStepIndex(), op.getTotalSteps(), op.getPercentage());
   }
 
-  private static String formatProgressLine(final String operation, final String stepName, final int stepIndex,
+  static String formatProgressLine(final String operation, final String stepName, final int stepIndex,
       final int totalSteps, final int percentage) {
     final StringBuilder line = new StringBuilder(128);
     line.append(operation).append(" [step ").append(stepIndex).append('/').append(totalSteps).append("] ").append(stepName);
     if (percentage >= 0) {
-      final int filled = percentage / 5;
+      final int filled = Math.max(0, Math.min(20, percentage / 5));
       line.append(" |").append("=".repeat(filled)).append(" ".repeat(20 - filled)).append("| ").append(percentage).append('%');
     } else
       line.append(" ...");
@@ -997,7 +1002,7 @@ public class Console {
       table.setMaxWidthSize(maxWidth);
 
       try (final ResultSet typeResult = databaseProxy.command("sql",
-          "select from schema:types where name = \"" + typeName + "\"")) {
+          "select from schema:types where name = :name", Map.of("name", typeName))) {
         if (!typeResult.hasNext())
           return;
 

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -244,9 +244,7 @@ class ConsoleTest {
    */
   @Test
   void progressBarClampsPercentageAboveHundred() {
-    final String[] line = new String[1];
-    assertThatCode(() -> line[0] = Console.formatProgressLine("import", "loading", 1, 2, 110)).doesNotThrowAnyException();
-    assertThat(line[0]).contains("|" + "=".repeat(20) + "| 110%");
+    assertThat(Console.formatProgressLine("import", "loading", 1, 2, 110)).contains("|" + "=".repeat(20) + "| 110%");
   }
 
   /**

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -47,6 +47,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConsoleTest {
@@ -222,6 +223,74 @@ class ConsoleTest {
     buffer.setLength(0);
     assertThat(console.parse("info type Person")).isTrue();
     assertThat(buffer.toString().contains("DOCUMENT TYPE 'Person'")).isTrue();
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/5931
+   */
+  @Test
+  void infoTypeWithQuoteInName() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("CREATE DOCUMENT TYPE `a\"b`")).isTrue();
+
+    final StringBuilder buffer = new StringBuilder();
+    console.setOutput(output -> buffer.append(output));
+    assertThat(console.parse("info type a\"b")).isTrue();
+    assertThat(buffer.toString()).contains("DOCUMENT TYPE 'a\"b'").doesNotContain("ERROR");
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/5929
+   */
+  @Test
+  void progressBarClampsPercentageAboveHundred() {
+    assertThatCode(() -> Console.formatProgressLine("import", "loading", 1, 2, 110)).doesNotThrowAnyException();
+    assertThat(Console.formatProgressLine("import", "loading", 1, 2, 110)).contains("|" + "=".repeat(20) + "| 110%");
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/5928
+   */
+  @Test
+  void systemPropertyArgumentWithoutValueDoesNotCrash() throws Exception {
+    final String key = "arcadedb.test.issue5928";
+    try {
+      assertThatCode(() -> Console.execute(new String[] { "-D" + key + "=", "-b" })).doesNotThrowAnyException();
+      assertThat(System.getProperty(key)).isEqualTo("");
+
+      System.clearProperty(key);
+
+      assertThatCode(() -> Console.execute(new String[] { "-D" + key, "-b" })).doesNotThrowAnyException();
+      assertThat(System.getProperty(key)).isEqualTo("");
+    } finally {
+      System.clearProperty(key);
+    }
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/5927
+   */
+  @Test
+  void listDatabasesOnFreshInstallDoesNotThrow() throws Exception {
+    final File freshRoot = new File("./target/fresh-install-5927");
+    FileUtils.deleteRecursively(freshRoot);
+    assertThat(freshRoot.mkdirs()).isTrue();
+
+    final String previousRootPath = GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString();
+    GlobalConfiguration.SERVER_ROOT_PATH.setValue(freshRoot.getAbsolutePath());
+    try {
+      assertThat(new File(freshRoot, "databases").exists()).isFalse();
+
+      final Console freshConsole = new Console();
+      try {
+        assertThatCode(() -> freshConsole.parse("list databases")).doesNotThrowAnyException();
+      } finally {
+        freshConsole.close();
+      }
+    } finally {
+      GlobalConfiguration.SERVER_ROOT_PATH.setValue(previousRootPath);
+      FileUtils.deleteRecursively(freshRoot);
+    }
   }
 
   @Test

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -244,8 +244,9 @@ class ConsoleTest {
    */
   @Test
   void progressBarClampsPercentageAboveHundred() {
-    assertThatCode(() -> Console.formatProgressLine("import", "loading", 1, 2, 110)).doesNotThrowAnyException();
-    assertThat(Console.formatProgressLine("import", "loading", 1, 2, 110)).contains("|" + "=".repeat(20) + "| 110%");
+    final String[] line = new String[1];
+    assertThatCode(() -> line[0] = Console.formatProgressLine("import", "loading", 1, 2, 110)).doesNotThrowAnyException();
+    assertThat(line[0]).contains("|" + "=".repeat(20) + "| 110%");
   }
 
   /**
@@ -265,6 +266,31 @@ class ConsoleTest {
     } finally {
       System.clearProperty(key);
     }
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/5928: a value containing further '=' characters must be kept whole,
+   * not truncated at the second one.
+   */
+  @Test
+  void systemPropertyArgumentWithEmbeddedEqualsKeepsFullValue() throws Exception {
+    final String key = "arcadedb.test.issue5928.multi";
+    try {
+      assertThatCode(() -> Console.execute(new String[] { "-D" + key + "=bar=baz", "-b" })).doesNotThrowAnyException();
+      assertThat(System.getProperty(key)).isEqualTo("bar=baz");
+    } finally {
+      System.clearProperty(key);
+    }
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/5928: an argument with no key at all ('-D' alone or '-D=value') must
+   * not crash the console with IllegalArgumentException from System.setProperty.
+   */
+  @Test
+  void systemPropertyArgumentWithoutKeyDoesNotCrash() throws Exception {
+    assertThatCode(() -> Console.execute(new String[] { "-D", "-b" })).doesNotThrowAnyException();
+    assertThatCode(() -> Console.execute(new String[] { "-D=value", "-b" })).doesNotThrowAnyException();
   }
 
   /**


### PR DESCRIPTION
## Summary

Four small, independent robustness/correctness fixes in the console module, all in `console/src/main/java/com/arcadedb/console/Console.java`:

- **#5931**: `info type <name>` string-concatenated the type name into a double-quoted SQL literal, breaking on names containing a `"`. Now binds the name as a query parameter.
- **#5929**: The remote-operation progress bar computed `filled = percentage / 5` without an upper clamp; a server-reported percentage above 104 made `20 - filled` negative, throwing `IllegalArgumentException` from `String.repeat`. Now clamps `filled` to `[0, 20]`.
- **#5928**: `-D<key>=<value>` startup argument parsing used `split("=")`, which throws `ArrayIndexOutOfBoundsException` on `-Dkey=` (empty value) or bare `-Dkey` (no `=`), and silently drops everything after a second `=` in `-Da=b=c`. Now splits on the first `=` only and tolerates a missing/empty value.
- **#5927**: `list databases` dereferenced `File.list()` directly, which returns `null` (not an empty array) when the databases directory doesn't exist yet - the normal state on a fresh install. Now null-guards the listing.

## Test plan

- Added one regression test per issue in `console/src/test/java/com/arcadedb/console/ConsoleTest.java`, each verified to fail with the original code (confirmed to reproduce the exact reported exception in each case: `CommandSQLParsingException`, `IllegalArgumentException: count is negative`, `ArrayIndexOutOfBoundsException`, `NullPointerException`) and pass with the fix.
- Relaxed the private `formatProgressLine` helper to package-private so its pure formatting logic can be unit-tested directly without spinning up a remote server.
- Full `console` module test suite passes: `mvn -pl console test` -> all test classes green (`ConsoleTest`: 37/37, plus `ConsoleAsyncInsertTest`, `ConsoleBatchTest`, `CompositeIndexUpdateTest`, `TerminalParserTest`).

Closes #5931, #5929, #5928, #5927.