### PR TITLE
fix: Redis RESP parser correctness and idle-connection hardening

### DIFF
--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -857,6 +857,10 @@ public class RedisNetworkExecutor extends Thread {
         // RESP2 null bulk string ($-1): the header IS the complete, self-terminated token - unlike a
         // present bulk string, there is no trailing CRLF to skip (issue #5911). Mirrors the null/empty
         // array short-circuit below; skipping it here avoided consuming the next token's leading byte.
+        // Deliberately treats every negative size as null, not just -1: RESP2 only defines -1, but nothing
+        // else about "negative" is meaningful either, and rejecting e.g. $-2 would need its own protocol-
+        // error branch for no behavioral benefit over just treating it the same as the one negative value
+        // that is defined.
         return null;
       if (size > maxBulkLength)
         throw new RedisProtocolLimitException(

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -219,6 +219,21 @@ public class RedisNetworkExecutor extends Thread {
 
       final String cmdString = ((String) cmd).toUpperCase(Locale.ENGLISH);
 
+      // A RESP2 null bulk string ($-1) is only meaningful as an "absent" value; no real command handler
+      // below is written to expect one as an argument (issue #5911 made it reachable here at all, since the
+      // $ branch used to desync instead of returning null). Reject it uniformly, with a clean protocol
+      // error, rather than letting whichever handler happens to touch it first crash with a raw
+      // NullPointerException it wasn't written to expect - e.g. defaultBucket is a ConcurrentHashMap, whose
+      // put/get reject a null key or value outright, so "SET key $-1" or "GET $-1" would otherwise NPE deep
+      // inside setVariable/getVariable instead of getting a clear, single reply.
+      for (int i = 1; i < list.size(); i++) {
+        if (list.get(i) == null) {
+          value.append("-ERR Protocol error: unexpected null bulk string argument");
+          appendCrLf();
+          return;
+        }
+      }
+
       // Redis maps commands directly to engine operations rather than going through
       // Database.query/command, so the engine-boundary span never fires for it. Open one here so
       // Redis is traced like the other protocols (protocol=redis comes from ProtocolContext, set in

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -656,7 +656,7 @@ public class RedisNetworkExecutor extends Thread {
       password = (String) list.get(2);
     } else if (list.size() == 2) {
       // Single-argument AUTH targets Redis' "default" user, which ArcadeDB does not model.
-      this.authenticatedUser = null;
+      markUnauthenticated();
       throw new RedisException("WRONGPASS ArcadeDB requires the 'AUTH <username> <password>' form");
     } else
       throw new RedisException("ERR wrong number of arguments for 'auth' command");
@@ -665,7 +665,7 @@ public class RedisNetworkExecutor extends Thread {
       markAuthenticated(server.getSecurity().authenticate(userName, password, null));
       value.append("+OK");
     } catch (final ServerSecurityException e) {
-      this.authenticatedUser = null;
+      markUnauthenticated();
       throw new RedisException("WRONGPASS invalid username-password pair or user is disabled");
     }
   }
@@ -681,6 +681,24 @@ public class RedisNetworkExecutor extends Thread {
       channel.socket.setSoTimeout(0);
     } catch (final SocketException e) {
       LogManager.instance().log(this, Level.FINE, "Redis wrapper: unable to lift the idle read timeout after authentication", e);
+    }
+  }
+
+  /**
+   * Marks the connection unauthenticated and (re-)arms the bounded pre-authentication idle read timeout
+   * (issue #5912 follow-up, review on #5965): a connection that authenticated once has its timeout lifted
+   * to infinite by {@link #markAuthenticated}. If it then fails a subsequent AUTH/HELLO re-authentication
+   * attempt on the same connection, {@code authenticatedUser} goes back to null - and without this, the
+   * infinite timeout would stay in place, breaking the invariant that "unauthenticated" always implies the
+   * bounded handshake timeout applies.
+   */
+  private void markUnauthenticated() {
+    this.authenticatedUser = null;
+    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    try {
+      channel.socket.setSoTimeout(Math.max(handshakeTimeout, 0));
+    } catch (final SocketException e) {
+      LogManager.instance().log(this, Level.FINE, "Redis wrapper: unable to restore the idle read timeout after failed authentication", e);
     }
   }
 
@@ -714,7 +732,7 @@ public class RedisNetworkExecutor extends Thread {
       try {
         markAuthenticated(server.getSecurity().authenticate(userName, password, null));
       } catch (final ServerSecurityException e) {
-        this.authenticatedUser = null;
+        markUnauthenticated();
         throw new RedisException("WRONGPASS invalid username-password pair or user is disabled");
       }
     }

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -226,6 +226,11 @@ public class RedisNetworkExecutor extends Thread {
       // NullPointerException it wasn't written to expect - e.g. defaultBucket is a ConcurrentHashMap, whose
       // put/get reject a null key or value outright, so "SET key $-1" or "GET $-1" would otherwise NPE deep
       // inside setVariable/getVariable instead of getting a clear, single reply.
+      // Deliberately checks only top-level (depth-1) arguments: a $-1 nested inside a multibulk argument
+      // (e.g. "SET key *1\r\n$-1\r\n") still reaches a handler as a null inside a List and would surface as a
+      // raw ClassCastException from the generic catch-all instead of this message. No handler actually
+      // consumes a nested array argument today, so that's an obscure, already-non-crashing edge case rather
+      // than a gap worth a recursive check for.
       for (int i = 1; i < list.size(); i++) {
         if (list.get(i) == null) {
           value.append("-ERR Protocol error: unexpected null bulk string argument");
@@ -990,6 +995,11 @@ public class RedisNetworkExecutor extends Thread {
       // UTF-8 character (e.g. accented Latin, CJK, emoji) is 1 String char but more than 1 byte once
       // replyToClient() encodes the whole reply, so v.toString().length() under-declares the length for any
       // non-ASCII value and desyncs the client exactly like a truncated bulk string would.
+      // TODO(perf): this encodes `text` to bytes here just to measure its length, then replyToClient()
+      // encodes the whole accumulated `value` StringBuilder (including this same text) to bytes again right
+      // after - a double UTF-8 encode per non-numeric reply, noticeable for a value near maxBulkLength.
+      // Avoiding it cleanly needs `value`'s reply-building to move off a single shared StringBuilder of
+      // chars onto something byte-oriented, which is a larger change than this correctness fix warrants.
       final String text = v.toString();
       value.append("$");
       value.append(text.getBytes(DatabaseFactory.getDefaultCharset()).length);

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -96,9 +96,12 @@ public class RedisNetworkExecutor extends Thread {
     // Bound the pre-authentication window (issue #5912): without a read timeout, a client that opens a
     // connection and never completes AUTH/HELLO - or trickles bytes arbitrarily slowly - can hold this
     // connection thread open indefinitely. Lifted back to infinite once authentication succeeds (see
-    // markAuthenticated), mirroring how BoltNetworkExecutor bounds its own pre-handshake window: an
-    // authenticated RESP client is expected to keep a long-lived, often idle connection open between
-    // commands, so the timeout must not keep applying past that point.
+    // markAuthenticated), reusing the same setSoTimeout(NETWORK_SOCKET_TIMEOUT)-then-setSoTimeout(0) idiom
+    // BoltNetworkExecutor.negotiateTransport() uses to bound its own TLS-detection window (review on #5965:
+    // Bolt only bounds that window, not its own subsequent HELLO/LOGON auth phase, so this goes further -
+    // it bounds the entire pre-auth phase here, through AUTH/HELLO itself). An authenticated RESP client is
+    // expected to keep a long-lived, often idle connection open between commands, so the timeout must not
+    // keep applying past that point.
     final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
     if (handshakeTimeout > 0)
       channel.socket.setSoTimeout(handshakeTimeout);
@@ -685,6 +688,9 @@ public class RedisNetworkExecutor extends Thread {
     try {
       channel.socket.setSoTimeout(0);
     } catch (final SocketException e) {
+      // setSoTimeout() only throws on an already-broken/closed socket (review on #5965): there is nothing
+      // left to hold open in that case, so logging and moving on - rather than failing the whole
+      // authentication - is safe. The connection dies on its next read/write either way.
       LogManager.instance().log(this, Level.FINE, "Redis wrapper: unable to lift the idle read timeout after authentication", e);
     }
   }
@@ -703,6 +709,9 @@ public class RedisNetworkExecutor extends Thread {
     try {
       channel.socket.setSoTimeout(Math.max(handshakeTimeout, 0));
     } catch (final SocketException e) {
+      // As in markAuthenticated(): setSoTimeout() only throws on an already-broken/closed socket, so there
+      // is no live connection left for the un-restored timeout to matter on - the "unauthenticated implies
+      // bounded timeout" invariant this method exists for has nothing left to protect in that case.
       LogManager.instance().log(this, Level.FINE, "Redis wrapper: unable to restore the idle read timeout after failed authentication", e);
     }
   }

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -93,6 +93,16 @@ public class RedisNetworkExecutor extends Thread {
     this.maxMultiBulkLength = sanitizedLimit(GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH, 1);
     this.maxBulkLength = sanitizedLimit(GlobalConfiguration.REDIS_MAX_BULK_LENGTH, 1);
 
+    // Bound the pre-authentication window (issue #5912): without a read timeout, a client that opens a
+    // connection and never completes AUTH/HELLO - or trickles bytes arbitrarily slowly - can hold this
+    // connection thread open indefinitely. Lifted back to infinite once authentication succeeds (see
+    // markAuthenticated), mirroring how BoltNetworkExecutor bounds its own pre-handshake window: an
+    // authenticated RESP client is expected to keep a long-lived, often idle connection open between
+    // commands, so the timeout must not keep applying past that point.
+    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    if (handshakeTimeout > 0)
+      channel.socket.setSoTimeout(handshakeTimeout);
+
     // Initialize default database from configuration if set. The database access is authorized lazily,
     // once the connection has authenticated (see getAuthorizedDatabase), so here we only record the name.
     final String defaultDbName = GlobalConfiguration.REDIS_DEFAULT_DATABASE.getValueAsString();
@@ -143,7 +153,11 @@ public class RedisNetworkExecutor extends Thread {
           LogManager.instance().log(this, Level.FINE, "Redis wrapper: Error on reading request", e);
           close();
         } catch (final SocketTimeoutException e) {
-          // IGNORE IT
+          // No data received within the pre-authentication window (issue #5912): close instead of holding
+          // the connection thread open indefinitely. Authenticated connections never reach here - their
+          // read timeout is lifted to infinite in markAuthenticated().
+          LogManager.instance().log(this, Level.FINE, "Redis wrapper: closing idle unauthenticated connection %s", channel.socket.getRemoteSocketAddress());
+          close();
         } catch (final RedisProtocolLimitException e) {
           // The message violates a configured protocol limit (issue #5895): the stream position can no
           // longer be trusted, so report the error and close rather than trying to resync and continue.
@@ -196,8 +210,10 @@ public class RedisNetworkExecutor extends Thread {
 
       final Object cmd = list.getFirst();
       if (!(cmd instanceof String)) {
+        // cmd can be null here (issue #5911: a RESP2 null bulk string, $-1, is now a legal array element),
+        // so guard the diagnostic itself rather than calling getClass() on a possibly-null reference.
         LogManager.instance().log(this, Level.SEVERE, "Redis wrapper: Invalid command[0] %s (type=%s)", command,
-            cmd.getClass());
+            cmd == null ? "null" : cmd.getClass());
         return;
       }
 
@@ -631,11 +647,25 @@ public class RedisNetworkExecutor extends Thread {
       throw new RedisException("ERR wrong number of arguments for 'auth' command");
 
     try {
-      this.authenticatedUser = server.getSecurity().authenticate(userName, password, null);
+      markAuthenticated(server.getSecurity().authenticate(userName, password, null));
       value.append("+OK");
     } catch (final ServerSecurityException e) {
       this.authenticatedUser = null;
       throw new RedisException("WRONGPASS invalid username-password pair or user is disabled");
+    }
+  }
+
+  /**
+   * Marks the connection authenticated and lifts the pre-authentication idle read timeout (issue #5912):
+   * unlike the bounded handshake window enforced before authentication, an authenticated RESP client is
+   * expected to keep a long-lived, often idle connection open between commands.
+   */
+  private void markAuthenticated(final ServerSecurityUser user) {
+    this.authenticatedUser = user;
+    try {
+      channel.socket.setSoTimeout(0);
+    } catch (final SocketException e) {
+      LogManager.instance().log(this, Level.FINE, "Redis wrapper: unable to lift the idle read timeout after authentication", e);
     }
   }
 
@@ -667,7 +697,7 @@ public class RedisNetworkExecutor extends Thread {
       final String userName = (String) list.get(idx + 1);
       final String password = (String) list.get(idx + 2);
       try {
-        this.authenticatedUser = server.getSecurity().authenticate(userName, password, null);
+        markAuthenticated(server.getSecurity().authenticate(userName, password, null));
       } catch (final ServerSecurityException e) {
         this.authenticatedUser = null;
         throw new RedisException("WRONGPASS invalid username-password pair or user is disabled");
@@ -821,8 +851,13 @@ public class RedisNetworkExecutor extends Thread {
       // INTEGER
       return parseLength(parseValueUntilLF(), "integer");
     else if (b == '$') {
-      // BATCH STRING
+      // BULK STRING
       final int size = parseLength(parseValueUntilLF(), "bulk length");
+      if (size < 0)
+        // RESP2 null bulk string ($-1): the header IS the complete, self-terminated token - unlike a
+        // present bulk string, there is no trailing CRLF to skip (issue #5911). Mirrors the null/empty
+        // array short-circuit below; skipping it here avoided consuming the next token's leading byte.
+        return null;
       if (size > maxBulkLength)
         throw new RedisProtocolLimitException(
             "Protocol error: invalid bulk length " + size + " (maximum allowed is " + maxBulkLength + ")");
@@ -914,10 +949,15 @@ public class RedisNetworkExecutor extends Thread {
       value.append(":");
       value.append(v);
     } else {
+      // The RESP bulk-length header is a byte count, not a char count (issue #5907 fallout): a multi-byte
+      // UTF-8 character (e.g. accented Latin, CJK, emoji) is 1 String char but more than 1 byte once
+      // replyToClient() encodes the whole reply, so v.toString().length() under-declares the length for any
+      // non-ASCII value and desyncs the client exactly like a truncated bulk string would.
+      final String text = v.toString();
       value.append("$");
-      value.append(v.toString().length());
+      value.append(text.getBytes(DatabaseFactory.getDefaultCharset()).length);
       appendCrLf();
-      value.append(v);
+      value.append(text);
     }
   }
 
@@ -925,15 +965,22 @@ public class RedisNetworkExecutor extends Thread {
     value.append("\r\n");
   }
 
+  /**
+   * Reads {@code size} raw bytes and decodes them once with the same charset {@link #replyToClient} encodes
+   * with, instead of the previous per-byte {@code (char) b} widening (issue #5907): that widening
+   * sign-extended any byte {@code >= 0x80} into the wrong UTF-16 code unit rather than decoding it, mangling
+   * every non-ASCII bulk string. Reading into a right-sized {@code byte[]} first - rather than building a
+   * {@link StringBuilder} one UTF-16 char at a time and copying it via {@code toString()} - also keeps the
+   * transient cost close to the wire size instead of roughly double it. {@code size} is assumed
+   * non-negative: the RESP2 null bulk string ({@code $-1}) is handled by the caller before this is reached.
+   */
   private String parseChars(final int size) throws IOException {
-    value.setLength(0);
+    final byte[] bytes = new byte[size];
+    int read = 0;
+    for (; read < size && !shutdown; ++read)
+      bytes[read] = readNext();
 
-    for (int i = 0; i < size && !shutdown; ++i) {
-      final byte b = readNext();
-      value.append((char) b);
-    }
-
-    return value.toString();
+    return new String(bytes, 0, read, DatabaseFactory.getDefaultCharset());
   }
 
   private byte readNext() throws IOException {

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for three follow-ups filed during the security review of #5895/#5902:
+ * <ul>
+ *   <li>#5907 - {@code RedisNetworkExecutor.parseChars()} widened each byte to a UTF-16 char instead of
+ *   decoding it, mangling any non-ASCII bulk string.</li>
+ *   <li>#5911 - the {@code $} (bulk string) branch of {@code parseNext()} unconditionally skipped a
+ *   trailing CRLF even for a RESP2 null bulk string ({@code $-1\r\n}), which has none, desyncing the
+ *   parser from the next token on the wire.</li>
+ *   <li>#5912 - the Redis listener never configured a socket read timeout, so an unauthenticated client
+ *   that opens a connection and never sends anything held the connection thread open indefinitely.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class RedisRespCorrectnessTest extends BaseGraphServerTest {
+
+  private static final int    DEF_PORT = GlobalConfiguration.REDIS_PORT.getValueAsInteger();
+  private static final String USER     = "root";
+  private static final String PASSWORD = DEFAULT_PASSWORD_FOR_TESTS;
+
+  @Test
+  void bulkStringWithMultibyteUtf8RoundTripsExactly() {
+    // Accented Latin, CJK and a 4-byte emoji code point: every one of these has at least one byte >= 0x80,
+    // which the old `(char) b` per-byte widening corrupted instead of decoding.
+    final String valueText = "héllo wörld 日本語 😀";
+
+    final Jedis jedis = new Jedis("localhost", DEF_PORT);
+    jedis.auth(USER, PASSWORD);
+    jedis.set("utf8Key", valueText);
+    assertThat(jedis.get("utf8Key")).isEqualTo(valueText);
+  }
+
+  @Test
+  void bulkStringRawWireBytesDecodeAsUtf8NotPerByteWidening() throws IOException {
+    // Same regression as above, but talking raw RESP so the assertion is against the exact bytes the
+    // server sends back rather than however the client library happens to decode them.
+    final byte[] payloadValue = "café".getBytes(StandardCharsets.UTF_8); // 5 bytes: c,a,f,e-acute(2 bytes)
+
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      readReply(socket); // +OK
+
+      sendRaw(socket, "*3\r\n$3\r\nSET\r\n$6\r\nrawKey\r\n$" + payloadValue.length + "\r\n");
+      socket.getOutputStream().write(payloadValue);
+      socket.getOutputStream().write("\r\n".getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+      readReply(socket); // +OK
+
+      sendCommand(socket, "GET", "rawKey");
+      final String reply = readReply(socket);
+
+      // A well-formed bulk-string reply: "$<len>\r\n<payload>" (readReply() strips the trailing CRLF) with
+      // <len> matching the UTF-8 byte length of the original value, not the char-widened (and re-encoded)
+      // mismatch the bug produced.
+      assertThat(reply).isEqualTo("$" + payloadValue.length + "\r\n" + new String(payloadValue, StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  void nullBulkStringArgumentDoesNotDesyncParser() throws IOException {
+    // A RESP2 null bulk string ($-1) as a command argument, immediately followed - on the very same
+    // connection - by a normal AUTH/PING pair. Before the fix, the unconditional skipLF() after $-1
+    // swallowed the leading byte of the next command, corrupting everything parsed afterward.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      final StringBuilder payload = new StringBuilder();
+      payload.append("*1\r\n$-1\r\n"); // a 1-element array containing a null bulk string
+      payload.append("*3\r\n$4\r\nAUTH\r\n$4\r\nroot\r\n$").append(PASSWORD.length()).append("\r\n").append(PASSWORD).append("\r\n");
+      payload.append("*1\r\n$4\r\nPING\r\n");
+
+      socket.getOutputStream().write(payload.toString().getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      // The null-bulk command itself has no valid command name, so it produces no reply at all; the very
+      // next bytes on the wire must be AUTH's clean "+OK", followed by PING's clean "+PONG" - proving the
+      // parser stayed in sync instead of drifting into the following command's bytes.
+      assertThat(readReply(socket)).isEqualTo("+OK");
+      assertThat(readReply(socket)).isEqualTo("+PONG");
+    }
+  }
+
+  @Test
+  void idleUnauthenticatedConnectionIsClosedInsteadOfHeldOpenIndefinitely() throws IOException {
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(500);
+    try {
+      try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+        // Safety bound for the test itself only, well above the lowered server-side timeout: if this
+        // fires instead of a clean EOF, the server is still holding the idle connection open.
+        socket.setSoTimeout(10_000);
+        assertThat(socket.getInputStream().read()).isEqualTo(-1);
+      }
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+  }
+
+  @Test
+  void authenticatedConnectionIsNotClosedWhileIdle() throws Exception {
+    // The idle timeout only bounds the pre-authentication window: once authenticated, a RESP connection is
+    // expected to sit idle between commands (that is normal client usage, not a hostile pattern).
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(500);
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      Thread.sleep(1_500); // well over the lowered pre-auth timeout
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+  }
+
+  private static void sendCommand(final Socket socket, final String... args) throws IOException {
+    sendRaw(socket, encodeCommand(args));
+  }
+
+  private static void sendRaw(final Socket socket, final String raw) throws IOException {
+    socket.getOutputStream().write(raw.getBytes(StandardCharsets.US_ASCII));
+    socket.getOutputStream().flush();
+  }
+
+  private static String encodeCommand(final String... args) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("*").append(args.length).append("\r\n");
+    for (final String arg : args)
+      sb.append("$").append(arg.length()).append("\r\n").append(arg).append("\r\n");
+    return sb.toString();
+  }
+
+  /**
+   * Reads exactly one RESP reply frame (simple string, error, integer or bulk string) from the socket.
+   * Returns the frame without its trailing CRLF, e.g. {@code "+OK"} or {@code "$4\r\ntest"}.
+   */
+  private static String readReply(final Socket socket) throws IOException {
+    final String firstLine = readLine(socket);
+    if (firstLine.startsWith("$")) {
+      final int size = Integer.parseInt(firstLine.substring(1));
+      if (size < 0)
+        return firstLine;
+      final byte[] body = new byte[size];
+      int read = 0;
+      while (read < size) {
+        final int n = socket.getInputStream().read(body, read, size - read);
+        if (n == -1)
+          throw new IOException("Unexpected EOF while reading bulk string body");
+        read += n;
+      }
+      readLine(socket); // trailing CRLF
+      return firstLine + "\r\n" + new String(body, StandardCharsets.UTF_8);
+    }
+    return firstLine;
+  }
+
+  private static String readLine(final Socket socket) throws IOException {
+    final StringBuilder sb = new StringBuilder();
+    int prev = -1;
+    while (true) {
+      final int b = socket.getInputStream().read();
+      if (b == -1)
+        throw new IOException("Unexpected EOF while reading a line");
+      if (prev == '\r' && b == '\n') {
+        sb.setLength(sb.length() - 1);
+        break;
+      }
+      sb.append((char) b);
+      prev = b;
+    }
+    return sb.toString();
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Redis Protocol:com.arcadedb.redis.RedisProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+}

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -57,10 +57,11 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
     // which the old `(char) b` per-byte widening corrupted instead of decoding.
     final String valueText = "héllo wörld 日本語 😀";
 
-    final Jedis jedis = new Jedis("localhost", DEF_PORT);
-    jedis.auth(USER, PASSWORD);
-    jedis.set("utf8Key", valueText);
-    assertThat(jedis.get("utf8Key")).isEqualTo(valueText);
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      jedis.auth(USER, PASSWORD);
+      jedis.set("utf8Key", valueText);
+      assertThat(jedis.get("utf8Key")).isEqualTo(valueText);
+    }
   }
 
   @Test

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -116,6 +116,28 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
   }
 
   @Test
+  void nonMinusOneNegativeBulkLengthIsAlsoTreatedAsNull() throws IOException {
+    // RESP2 only defines -1 as the null bulk string, but parseNext() deliberately treats every negative
+    // size the same way (see the comment on that branch) rather than adding a separate protocol-error case
+    // for e.g. $-5. Locks in that this is a real, tested decision and not just an artifact of `size < 0`
+    // happening to also be true for -1: same parser-resync proof as the $-1 case above, with $-5 instead.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      final StringBuilder payload = new StringBuilder();
+      payload.append("*1\r\n$-5\r\n");
+      payload.append("*3\r\n$4\r\nAUTH\r\n$4\r\nroot\r\n$").append(PASSWORD.length()).append("\r\n").append(PASSWORD).append("\r\n");
+      payload.append("*1\r\n$4\r\nPING\r\n");
+
+      socket.getOutputStream().write(payload.toString().getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      assertThat(readReply(socket)).isEqualTo("+OK");
+      assertThat(readReply(socket)).isEqualTo("+PONG");
+    }
+  }
+
+  @Test
   void nullBulkStringAsCommandArgumentIsRejectedCleanly() throws IOException {
     // $-1 is reachable as any array element now (issue #5911's fix), not just the command name - including
     // as a SET argument, which used to reach ConcurrentHashMap.put() with a null value and NPE deep inside

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.redis;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.Jedis;
 
@@ -115,6 +116,31 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
   }
 
   @Test
+  void nullBulkStringAsCommandArgumentIsRejectedCleanly() throws IOException {
+    // $-1 is reachable as any array element now (issue #5911's fix), not just the command name - including
+    // as a SET argument, which used to reach ConcurrentHashMap.put() with a null value and NPE deep inside
+    // setVariable() instead of getting one clear reply. Must get a clean protocol error instead, and the
+    // connection must stay usable afterward.
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      assertThat(readReply(socket)).isEqualTo("+OK");
+
+      sendRaw(socket, "*3\r\n$3\r\nSET\r\n$6\r\nsomeky\r\n$-1\r\n");
+      final String reply = readReply(socket);
+      assertThat(reply).startsWith("-ERR");
+      assertThat(reply).containsIgnoringCase("null bulk string");
+
+      // The connection must still be usable - the malformed command must not have desynced the parser or
+      // left the connection in a broken state.
+      sendCommand(socket, "PING");
+      assertThat(readReply(socket)).isEqualTo("+PONG");
+    }
+  }
+
+  @Test
+  @Tag("slow")
   void idleUnauthenticatedConnectionIsClosedInsteadOfHeldOpenIndefinitely() throws IOException {
     GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(500);
     try {
@@ -136,6 +162,7 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
   }
 
   @Test
+  @Tag("slow")
   void authenticatedConnectionIsNotClosedWhileIdle() throws Exception {
     // The idle timeout only bounds the pre-authentication window: once authenticated, a RESP connection is
     // expected to sit idle between commands (that is normal client usage, not a hostile pattern).

--- a/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java
@@ -141,6 +141,39 @@ public class RedisRespCorrectnessTest extends BaseGraphServerTest {
 
   @Test
   @Tag("slow")
+  void failedReauthenticationRearmsThePreAuthTimeout() throws IOException {
+    // A connection that already authenticated once has its idle timeout lifted to infinite. If it then
+    // fails a *subsequent* AUTH on the same connection, it goes back to logically unauthenticated and must
+    // not be left with an infinite read timeout - otherwise it could be held open forever despite never
+    // (currently) holding valid credentials, exactly the resource-exhaustion shape #5912 fixes pre-auth.
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(500);
+    try (final Socket socket = new Socket("localhost", DEF_PORT)) {
+      socket.setSoTimeout(10_000);
+
+      sendCommand(socket, "AUTH", USER, PASSWORD);
+      assertThat(readReply(socket)).isEqualTo("+OK");
+
+      sendCommand(socket, "AUTH", USER, "wrong-password");
+      final String reply = readReply(socket);
+      assertThat(reply).startsWith("-");
+      assertThat(reply).containsIgnoringCase("WRONGPASS");
+
+      // Now idle: must be closed like a never-authenticated connection, not held open by the timeout that
+      // got lifted on the earlier successful AUTH.
+      assertThat(socket.getInputStream().read()).isEqualTo(-1);
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally.
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      assertThat(jedis.auth(USER, PASSWORD)).isEqualTo("OK");
+      assertThat(jedis.ping()).isEqualTo("PONG");
+    }
+  }
+
+  @Test
+  @Tag("slow")
   void idleUnauthenticatedConnectionIsClosedInsteadOfHeldOpenIndefinitely() throws IOException {
     GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(500);
     try {


### PR DESCRIPTION
## Summary

Three follow-ups filed during the security review of #5895/#5902, all in `RedisNetworkExecutor` (the RESP wire-protocol parser).

Closes #5907
Closes #5911
Closes #5912

### #5907 - non-ASCII/binary bulk strings were mangled

`parseChars()` widened each byte to a UTF-16 char via `(char) b` instead of decoding it. Java's implicit byte→int conversion sign-extends any byte `>= 0x80`, so non-ASCII UTF-8 (or arbitrary binary) input didn't just lose fidelity, it landed on the wrong code unit entirely. Now reads into a right-sized `byte[]` and decodes once with the same charset `replyToClient()` already encodes replies with.

**Went further than the issue's suggested fix**: full byte-passthrough plumbing (never decoding to `String` at all) would touch most of this ~1000-line file, since every command handler already treats arguments as `String`/JSON (`SET`/`HSET` parse JSON bodies, keys are matched by string comparison, etc.) - true binary opacity isn't something this wrapper's command set can use today. Decoding correctly with the wrapper's existing charset gets the real-world bug (mangled accented/CJK/emoji text) without a much larger, riskier rewrite for a benefit (round-tripping arbitrary non-UTF-8 byte sequences) nothing in this codebase currently exercises.

Fixing this surfaced a mirror-image bug in `respondValue()`: the RESP bulk-length header used `String.length()` (UTF-16 char count) instead of the UTF-8 byte count. That was silently correct before only because the old broken `parseChars` happened to produce exactly 1 char per input byte; once decoding is correct, a multi-byte character is 1 char but >1 byte, so the old header under-declared the reply length and would desync the *client* the same way #5911 desyncs the *server*. Fixed alongside since it's the direct fallout of the real fix.

### #5911 - `$-1` (RESP2 null bulk string) desynced the parser

The `$` branch always called `skipLF()` after `parseChars()`, but `$-1\r\n` is a complete, self-terminated token with no trailing CRLF. `skipLF()` then silently consumed the next token's leading byte. Now mirrors the array branch's existing null/empty short-circuit and returns `null` immediately for a negative size.

This makes a `null` command name reachable for the first time, which exposed an unguarded `cmd.getClass()` NPE in `executeCommand()` sitting outside any catch block (would have killed the connection thread with an uncaught exception instead of the usual clean `-ERR` reply). Guarded it.

`$-1` is also reachable as *any* argument now, not just the command name (e.g. `SET key $-1`), which could reach a `ConcurrentHashMap` with a null key/value and NPE deep inside a handler instead of getting one clear reply. Rejected uniformly before dispatch with a clean `-ERR Protocol error: unexpected null bulk string argument`, rather than special-casing every handler.

### #5912 - no idle/read timeout, so a slow client holds a connection thread forever

The listener never configured a socket timeout, so `readNext()`'s blocking read could wait indefinitely - a slow-connection-exhaustion vector distinct from the unbounded-*declared-size* DoS #5902 already fixed. Now sets `NETWORK_SOCKET_TIMEOUT` as a pre-authentication read timeout (mirroring `BoltNetworkExecutor`'s own handshake-timeout pattern) and lifts it back to infinite once authentication succeeds, since an authenticated RESP connection is expected to sit idle between commands - that's normal client usage, not a hostile pattern, and Redis itself doesn't time out idle authenticated connections by default.

**Known limitation, called out explicitly so it isn't rediscovered later**: `Socket.setSoTimeout` bounds each individual blocking `read()` call, not total handshake time. A client that trickles one byte every `NETWORK_SOCKET_TIMEOUT - ε` resets the deadline on every partial read and can still hold a pre-auth connection thread open indefinitely - this fix stops a fully-silent connection, not a slow trickle. That's the same tradeoff `BoltNetworkExecutor` already accepts for its own handshake window, so it's consistent with established practice in this codebase rather than a new gap, but it is a partial mitigation, not a complete one.

Also fixes a state-machine gap this pattern opened up: a connection that authenticates once has its timeout lifted to infinite by `markAuthenticated()`. If it then fails a *subsequent* re-AUTH/HELLO on the same connection, `authenticatedUser` goes back to `null` but the timeout wasn't being re-armed, leaving an unauthenticated connection with an infinite read timeout. Introduced `markUnauthenticated()`, used everywhere `authenticatedUser` is reset, to keep "unauthenticated implies bounded timeout" true in every case.

## Test plan

`RedisRespCorrectnessTest` (7 tests, new), all passing:
- [x] Multi-byte UTF-8 (accented Latin, CJK, emoji) SET/GET round-trips exactly through Jedis
- [x] Same, over raw RESP, asserting the exact wire bytes/length header
- [x] A `$-1` argument followed by AUTH/PING on the *same* connection proves the parser stays in sync
- [x] A `$-1` SET argument gets a clean protocol error instead of a raw NPE, and the connection stays usable
- [x] An idle unauthenticated connection is closed instead of held open
- [x] An idle *authenticated* connection is NOT closed (no regression on normal usage)
- [x] A failed re-AUTH on an already-authenticated connection re-arms the pre-auth timeout

Also ran the full existing `redisw` suite (unit + integration, 65 tests total, including TLS and query-metrics paths that share the touched auth/connection code): all green, no regressions.

## Files changed
- `redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java`
- `redisw/src/test/java/com/arcadedb/redis/RedisRespCorrectnessTest.java` (new)
