### PR TITLE
fix(#5905,#5906): reject out-of-range integral narrowing instead of silently wrapping

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -516,7 +516,7 @@ public enum Type {
         else if (value instanceof String string)
           return Byte.parseByte(string);
         else
-          return ((Number) value).byteValue();
+          return narrowToIntegral((Number) value, Byte.MIN_VALUE, Byte.MAX_VALUE, "BYTE", property).byteValue();
 
       } else if (targetClass.equals(Short.TYPE) || targetClass.equals(Short.class)) {
         if (value instanceof Short)
@@ -524,7 +524,7 @@ public enum Type {
         else if (value instanceof String string)
           return string.isEmpty() ? 0 : Short.parseShort(string);
         else
-          return ((Number) value).shortValue();
+          return narrowToIntegral((Number) value, Short.MIN_VALUE, Short.MAX_VALUE, "SHORT", property).shortValue();
 
       } else if (targetClass.equals(Integer.TYPE) || targetClass.equals(Integer.class)) {
         if (value instanceof Integer)
@@ -532,7 +532,7 @@ public enum Type {
         else if (value instanceof String string)
           return string.isEmpty() ? 0 : Integer.parseInt(string);
         else
-          return ((Number) value).intValue();
+          return narrowToIntegral((Number) value, Integer.MIN_VALUE, Integer.MAX_VALUE, "INTEGER", property).intValue();
 
       } else if (targetClass.equals(Long.TYPE) || targetClass.equals(Long.class)) {
         if (value instanceof Long)
@@ -784,6 +784,37 @@ public enum Type {
     return value;
   }
 
+  /**
+   * Range-checks {@code value} before narrowing it to a smaller integral type ({@code BYTE}, {@code SHORT} or
+   * {@code INTEGER}). Narrowing with a plain {@code .intValue()}/{@code .shortValue()}/{@code .byteValue()} wraps
+   * two's-complement on overflow instead of rejecting - {@code 3000000000L} silently became {@code -1294967296} -
+   * which corrupts the stored value without any error (issue #5905).
+   * <p>
+   * The comparison is done in {@code long}, so a {@link Double}/{@link Float} outside the long range (including
+   * {@code Infinity}) is caught via the saturating conversion {@link Number#longValue()} already performs. A
+   * {@link BigDecimal}/{@link BigInteger} can exceed even the long range, where {@code longValue()} truncates bits
+   * instead of saturating, so those two types are range-checked directly against {@code long} bounds first.
+   */
+  private static Number narrowToIntegral(final Number value, final long min, final long max, final String targetType,
+      final Property property) {
+    final long longValue;
+    if (value instanceof BigDecimal bigDecimal)
+      longValue = bigDecimal.compareTo(BigDecimal.valueOf(Long.MAX_VALUE)) > 0 ? Long.MAX_VALUE
+          : bigDecimal.compareTo(BigDecimal.valueOf(Long.MIN_VALUE)) < 0 ? Long.MIN_VALUE : bigDecimal.longValue();
+    else if (value instanceof BigInteger bigInteger)
+      longValue = bigInteger.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0 ? Long.MAX_VALUE
+          : bigInteger.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0 ? Long.MIN_VALUE : bigInteger.longValue();
+    else
+      longValue = value.longValue();
+
+    if (longValue < min || longValue > max)
+      throw new IllegalArgumentException(
+          "Value '" + value + "' is out of range for type " + targetType + " (" + min + " to " + max + ")" //
+              + (property != null ? " for property '" + property.getName() + "'" : ""));
+
+    return longValue;
+  }
+
   public static Number increment(final Number a, final Number b) {
     if (a == null || b == null)
       throw new IllegalArgumentException("Cannot increment a null value");
@@ -792,21 +823,23 @@ public enum Type {
     case Integer i -> {
       switch (b) {
       case Integer integer -> {
-        final int sum = a.intValue() + b.intValue();
-        if (sum < 0 && a.intValue() > 0 && b.intValue() > 0)
+        try {
+          return Math.addExact(a.intValue(), b.intValue());
+        } catch (final ArithmeticException e) {
           // SPECIAL CASE: UPGRADE TO LONG
-          return (long) (a.intValue() + b.intValue());
-        return sum;
+          return (long) a.intValue() + (long) b.intValue();
+        }
       }
       case Long l -> {
         return a.intValue() + b.longValue();
       }
       case Short aShort -> {
-        final int sum = a.intValue() + b.shortValue();
-        if (sum < 0 && a.intValue() > 0 && b.shortValue() > 0)
+        try {
+          return Math.addExact(a.intValue(), b.shortValue());
+        } catch (final ArithmeticException e) {
           // SPECIAL CASE: UPGRADE TO LONG
-          return (long) (a.intValue() + b.shortValue());
-        return sum;
+          return (long) a.intValue() + (long) b.shortValue();
+        }
       }
       case Float v -> {
         return a.intValue() + b.floatValue();
@@ -848,21 +881,19 @@ public enum Type {
     case Short i -> {
       switch (b) {
       case Integer integer -> {
-        final int sum = a.shortValue() + b.intValue();
-        if (sum < 0 && a.shortValue() > 0 && b.intValue() > 0)
+        try {
+          return Math.addExact(a.shortValue(), b.intValue());
+        } catch (final ArithmeticException e) {
           // SPECIAL CASE: UPGRADE TO LONG
-          return Long.valueOf(a.shortValue() + b.intValue());
-        return sum;
+          return (long) a.shortValue() + (long) b.intValue();
+        }
       }
       case Long l -> {
         return Long.valueOf(a.shortValue() + b.longValue());
       }
       case Short aShort -> {
-        final int sum = a.shortValue() + b.shortValue();
-        if (sum < 0 && a.shortValue() > 0 && b.shortValue() > 0)
-          // SPECIAL CASE: UPGRADE TO INTEGER
-          return a.intValue() + b.intValue();
-        return sum;
+        // A SHORT + SHORT SUM CAN NEVER OVERFLOW int (MAGNITUDE <= 2 * 32768), SO int ARITHMETIC IS ALWAYS EXACT HERE
+        return a.shortValue() + b.shortValue();
       }
       case Float v -> {
         return a.shortValue() + b.floatValue();
@@ -965,21 +996,23 @@ public enum Type {
     case Integer i -> {
       switch (b) {
       case Integer integer -> {
-        final int sum = a.intValue() - b.intValue();
-        if (sum < 0 && a.intValue() > 0 && b.intValue() > 0)
+        try {
+          return Math.subtractExact(a.intValue(), b.intValue());
+        } catch (final ArithmeticException e) {
           // SPECIAL CASE: UPGRADE TO LONG
-          return (long) (a.intValue() - b.intValue());
-        return sum;
+          return (long) a.intValue() - (long) b.intValue();
+        }
       }
       case Long l -> {
         return a.intValue() - b.longValue();
       }
       case Short aShort -> {
-        final int sum = a.intValue() - b.shortValue();
-        if (sum < 0 && a.intValue() > 0 && b.shortValue() > 0)
+        try {
+          return Math.subtractExact(a.intValue(), b.shortValue());
+        } catch (final ArithmeticException e) {
           // SPECIAL CASE: UPGRADE TO LONG
-          return (long) (a.intValue() - b.shortValue());
-        return sum;
+          return (long) a.intValue() - (long) b.shortValue();
+        }
       }
       case Float v -> {
         return a.intValue() - b.floatValue();
@@ -1021,21 +1054,19 @@ public enum Type {
     case Short i -> {
       switch (b) {
       case Integer integer -> {
-        final int sum = a.shortValue() - b.intValue();
-        if (sum < 0 && a.shortValue() > 0 && b.intValue() > 0)
+        try {
+          return Math.subtractExact(a.shortValue(), b.intValue());
+        } catch (final ArithmeticException e) {
           // SPECIAL CASE: UPGRADE TO LONG
-          return (long) (a.shortValue() - b.intValue());
-        return sum;
+          return (long) a.shortValue() - (long) b.intValue();
+        }
       }
       case Long l -> {
         return a.shortValue() - b.longValue();
       }
       case Short aShort -> {
-        final int sum = a.shortValue() - b.shortValue();
-        if (sum < 0 && a.shortValue() > 0 && b.shortValue() > 0)
-          // SPECIAL CASE: UPGRADE TO INTEGER
-          return a.intValue() - b.intValue();
-        return sum;
+        // A SHORT - SHORT DIFFERENCE CAN NEVER OVERFLOW int (MAGNITUDE <= 2 * 32768), SO int ARITHMETIC IS ALWAYS EXACT HERE
+        return a.shortValue() - b.shortValue();
       }
       case Float v -> {
         return a.shortValue() - b.floatValue();

--- a/engine/src/test/java/com/arcadedb/function/sql/math/Issue5906SumAverageIntegerOverflowTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/math/Issue5906SumAverageIntegerOverflowTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.math;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5906: {@code SUM()}/{@code AVG()} over an INTEGER column silently overflowed once the running total
+ * exceeded {@code Integer.MAX_VALUE}, because {@code Type.increment()}'s "upgrade to long" guard recomputed the
+ * same overflowing {@code int} addition before widening it instead of widening the operands first.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5906SumAverageIntegerOverflowTest {
+
+  @Test
+  void sumOverIntegerColumnDoesNotOverflow() throws Exception {
+    TestHelper.executeInNewDatabase("issue-5906-sum", db -> {
+      db.command("sql", "CREATE VERTEX TYPE V");
+      db.command("sql", "CREATE PROPERTY V.n INTEGER");
+      // TRUE SUM = 10,000,000,000 - FITS IN A LONG, NOT AN INTEGER
+      for (int i = 0; i < 5; i++)
+        db.command("sql", "INSERT INTO V SET n = 2000000000");
+
+      try (final ResultSet rs = db.query("sql", "SELECT sum(n) AS s, avg(n) AS a, count(n) AS c FROM V")) {
+        final var row = rs.next();
+        assertThat(((Number) row.getProperty("s")).longValue()).isEqualTo(10_000_000_000L);
+        assertThat(((Number) row.getProperty("a")).doubleValue()).isEqualTo(2.0E9);
+        assertThat(((Number) row.getProperty("c")).longValue()).isEqualTo(5L);
+      }
+    });
+  }
+
+  @Test
+  void sumOverIntegerColumnHandlesNegativeOverflow() throws Exception {
+    TestHelper.executeInNewDatabase("issue-5906-sum-negative", db -> {
+      db.command("sql", "CREATE VERTEX TYPE V");
+      db.command("sql", "CREATE PROPERTY V.n INTEGER");
+      for (int i = 0; i < 3; i++)
+        db.command("sql", "INSERT INTO V SET n = -2000000000");
+
+      try (final ResultSet rs = db.query("sql", "SELECT sum(n) AS s FROM V")) {
+        assertThat(((Number) rs.next().getProperty("s")).longValue()).isEqualTo(-6_000_000_000L);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue5967IndexRebuildBoundaryIntegerValueTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5967IndexRebuildBoundaryIntegerValueTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Code review follow-up on PR #5967 (fix for #5905/#5906): {@code Type.convert()} now range-checks before narrowing
+ * to BYTE/SHORT/INTEGER instead of silently wrapping, and {@code LSMTreeIndexAbstract.convertKeysToDeclaredTypes()}/
+ * {@code LSMTreeIndex.convertKeys()}/{@code HashIndex.convertKeys()} call {@code Type.convert()} directly with no
+ * catch guard - unlike {@code QueryOperatorEquals}/{@code FetchFromIndexStep}, which already defend against the new
+ * exception. The reviewer asked to confirm that an index rebuild, which re-reads already-stored property values,
+ * can never hand one of these paths an out-of-range raw value.
+ * <p>
+ * It can't: an INTEGER/SHORT/BYTE property's on-disk representation is a fixed-width primitive, so a value that
+ * reached storage is by construction already in range for its declared type - there is no way to persist an
+ * out-of-range value in the first place (that is exactly the bug #5905 fixed). This test locks that invariant in
+ * for both index engines by round-tripping the boundary values through {@code REBUILD INDEX}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5967IndexRebuildBoundaryIntegerValueTest extends TestHelper {
+
+  @Test
+  void lsmTreeIndexRebuildSurvivesBoundaryIntegerValues() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V");
+      database.command("sql", "CREATE PROPERTY V.n INTEGER");
+      database.command("sql", "CREATE INDEX ON V (n) NOTUNIQUE");
+      database.command("sql", "INSERT INTO V SET n = " + Integer.MAX_VALUE);
+      database.command("sql", "INSERT INTO V SET n = " + Integer.MIN_VALUE);
+      database.command("sql", "INSERT INTO V SET n = 0");
+    });
+
+    database.transaction(() -> database.command("sql", "REBUILD INDEX `V[n]`"));
+
+    database.transaction(() -> {
+      try (final var rs = database.query("sql", "SELECT FROM V WHERE n = " + Integer.MAX_VALUE)) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(((Number) rs.next().getProperty("n")).intValue()).isEqualTo(Integer.MAX_VALUE);
+      }
+      try (final var rs = database.query("sql", "SELECT FROM V WHERE n = " + Integer.MIN_VALUE)) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(((Number) rs.next().getProperty("n")).intValue()).isEqualTo(Integer.MIN_VALUE);
+      }
+    });
+  }
+
+  @Test
+  void hashIndexRebuildSurvivesBoundaryIntegerValues() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V");
+      database.command("sql", "CREATE PROPERTY V.n INTEGER");
+      database.command("sql", "CREATE INDEX ON V (n) UNIQUE_HASH");
+      database.command("sql", "INSERT INTO V SET n = " + Integer.MAX_VALUE);
+      database.command("sql", "INSERT INTO V SET n = " + Integer.MIN_VALUE);
+    });
+
+    database.transaction(() -> database.command("sql", "REBUILD INDEX `V[n]`"));
+
+    database.transaction(() -> {
+      try (final var rs = database.query("sql", "SELECT FROM V WHERE n = " + Integer.MAX_VALUE)) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(((Number) rs.next().getProperty("n")).intValue()).isEqualTo(Integer.MAX_VALUE);
+      }
+      try (final var rs = database.query("sql", "SELECT FROM V WHERE n = " + Integer.MIN_VALUE)) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(((Number) rs.next().getProperty("n")).intValue()).isEqualTo(Integer.MIN_VALUE);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue5905IntegerTruncationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue5905IntegerTruncationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #5905: storing a numeric value that does not fit an INTEGER/SHORT/BYTE property used to silently truncate
+ * it by two's-complement overflow ({@code 3000000000 -> -1294967296}), with no error and no warning. The write must
+ * be rejected instead, both through SQL {@code INSERT}/{@code UPDATE} and through the typed record API.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5905IntegerTruncationTest {
+
+  @Test
+  void insertOutOfRangeIntegerIsRejectedNotTruncated() throws Exception {
+    TestHelper.executeInNewDatabase("issue-5905-insert", db -> {
+      db.command("sql", "CREATE VERTEX TYPE V");
+      db.command("sql", "CREATE PROPERTY V.n INTEGER");
+
+      assertThatThrownBy(() -> db.command("sql", "INSERT INTO V SET n = 3000000000, id = 'big'"))
+          .isInstanceOf(IllegalArgumentException.class);
+
+      // THE ROW MUST NOT HAVE BEEN WRITTEN WITH A CORRUPTED VALUE
+      try (final var rs = db.query("sql", "SELECT FROM V WHERE id = 'big'")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void typedApiSetOutOfRangeIntegerIsRejectedNotTruncated() throws Exception {
+    TestHelper.executeInNewDatabase("issue-5905-typed-api", db -> {
+      db.command("sql", "CREATE VERTEX TYPE V");
+      db.command("sql", "CREATE PROPERTY V.n INTEGER");
+
+      final MutableVertex v = db.newVertex("V");
+      assertThatThrownBy(() -> v.set("n", 3_000_000_000L))
+          .isInstanceOf(IllegalArgumentException.class);
+    });
+  }
+
+  @Test
+  void updateOutOfRangeShortIsRejected() throws Exception {
+    TestHelper.executeInNewDatabase("issue-5905-short", db -> {
+      db.command("sql", "CREATE VERTEX TYPE V");
+      db.command("sql", "CREATE PROPERTY V.n SHORT");
+      db.command("sql", "INSERT INTO V SET id = 'a'");
+
+      assertThatThrownBy(() -> db.command("sql", "UPDATE V SET n = 40000 WHERE id = 'a'"))
+          .isInstanceOf(IllegalArgumentException.class);
+
+      try (final var rs = db.query("sql", "SELECT n FROM V WHERE id = 'a'")) {
+        assertThat(rs.next().<Object>getProperty("n")).isNull();
+      }
+    });
+  }
+
+  @Test
+  void updateOutOfRangeByteIsRejected() throws Exception {
+    TestHelper.executeInNewDatabase("issue-5905-byte", db -> {
+      db.command("sql", "CREATE VERTEX TYPE V");
+      db.command("sql", "CREATE PROPERTY V.n BYTE");
+      db.command("sql", "INSERT INTO V SET id = 'a'");
+
+      assertThatThrownBy(() -> db.command("sql", "UPDATE V SET n = 200 WHERE id = 'a'"))
+          .isInstanceOf(IllegalArgumentException.class);
+    });
+  }
+
+  @Test
+  void inRangeIntegerStillWorks() throws Exception {
+    TestHelper.executeInNewDatabase("issue-5905-inrange", db -> {
+      db.command("sql", "CREATE VERTEX TYPE V");
+      db.command("sql", "CREATE PROPERTY V.n INTEGER");
+      db.command("sql", "INSERT INTO V SET n = 2000000000, id = 'ok'");
+
+      try (final var rs = db.query("sql", "SELECT n FROM V WHERE id = 'ok'")) {
+        assertThat(((Number) rs.next().getProperty("n")).intValue()).isEqualTo(2_000_000_000);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -472,6 +472,13 @@ class TypeTest extends TestHelper {
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> Type.convert(database, 3_000_000_000L, Byte.class))
         .isInstanceOf(IllegalArgumentException.class);
+    // THE BigDecimal/BigInteger BRANCHES OF narrowToIntegral() ARE SHARED CODE, EXERCISED ELSEWHERE ONLY FOR
+    // INTEGER TARGETS (convertToIntegerOutOfRangeRejected) - COVER BYTE TOO SO A BOUNDARY-CONSTANT TYPO THERE
+    // WOULD BE CAUGHT REGARDLESS OF TARGET TYPE
+    assertThatThrownBy(() -> Type.convert(database, new BigDecimal("200"), Byte.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new BigInteger("200"), Byte.class))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -496,6 +503,10 @@ class TypeTest extends TestHelper {
     assertThatThrownBy(() -> Type.convert(database, Short.MIN_VALUE - 1, Short.class))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> Type.convert(database, 3_000_000_000L, Short.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new BigDecimal("40000"), Short.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new BigInteger("40000"), Short.class))
         .isInstanceOf(IllegalArgumentException.class);
   }
 

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.utility.MultiIterator;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.*;
 import java.util.*;
 
@@ -533,6 +534,12 @@ class TypeTest extends TestHelper {
     // A BIGDECIMAL WHOSE MAGNITUDE EXCEEDS EVEN A LONG MUST ALSO BE REJECTED
     assertThatThrownBy(() -> Type.convert(database, new BigDecimal("9999999999999999999999999999"), Integer.class))
         .isInstanceOf(IllegalArgumentException.class);
+    // A BIGINTEGER WHOSE MAGNITUDE EXCEEDS EVEN A LONG MUST ALSO BE REJECTED (longValue() TRUNCATES BITS INSTEAD OF
+    // SATURATING, SO THIS EXERCISES THE DEDICATED BigInteger BRANCH IN narrowToIntegral())
+    assertThatThrownBy(() -> Type.convert(database, new BigInteger("9999999999999999999999999999"), Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    // AN IN-RANGE BIGINTEGER MUST STILL CONVERT
+    assertThat(Type.convert(database, BigInteger.valueOf(42), Integer.class)).isEqualTo(42);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -454,6 +454,23 @@ class TypeTest extends TestHelper {
     assertThat(Type.convert(database, "42", Byte.class)).isEqualTo((byte) 42);
     assertThat(Type.convert(database, 42, Byte.class)).isEqualTo((byte) 42);
     assertThat(Type.convert(database, 42L, Byte.TYPE)).isEqualTo((byte) 42);
+    // BOUNDARY VALUES MUST STILL CONVERT
+    assertThat(Type.convert(database, (long) Byte.MAX_VALUE, Byte.class)).isEqualTo(Byte.MAX_VALUE);
+    assertThat(Type.convert(database, (long) Byte.MIN_VALUE, Byte.class)).isEqualTo(Byte.MIN_VALUE);
+  }
+
+  /**
+   * Issue #5905: narrowing an out-of-range value to a BYTE property must reject it rather than silently wrap
+   * (two's-complement truncation), which would corrupt the stored value with no error.
+   */
+  @Test
+  void convertToByteOutOfRangeRejected() {
+    assertThatThrownBy(() -> Type.convert(database, Byte.MAX_VALUE + 1, Byte.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Byte.MIN_VALUE - 1, Byte.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, 3_000_000_000L, Byte.class))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -463,6 +480,22 @@ class TypeTest extends TestHelper {
     assertThat(Type.convert(database, "", Short.class)).isEqualTo((short) 0);
     assertThat(Type.convert(database, 42, Short.class)).isEqualTo((short) 42);
     assertThat(Type.convert(database, 42L, Short.TYPE)).isEqualTo((short) 42);
+    // BOUNDARY VALUES MUST STILL CONVERT
+    assertThat(Type.convert(database, (long) Short.MAX_VALUE, Short.class)).isEqualTo(Short.MAX_VALUE);
+    assertThat(Type.convert(database, (long) Short.MIN_VALUE, Short.class)).isEqualTo(Short.MIN_VALUE);
+  }
+
+  /**
+   * Issue #5905: same as {@link #convertToByteOutOfRangeRejected()} for SHORT.
+   */
+  @Test
+  void convertToShortOutOfRangeRejected() {
+    assertThatThrownBy(() -> Type.convert(database, Short.MAX_VALUE + 1, Short.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Short.MIN_VALUE - 1, Short.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, 3_000_000_000L, Short.class))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -472,6 +505,34 @@ class TypeTest extends TestHelper {
     assertThat(Type.convert(database, "", Integer.class)).isEqualTo(0);
     assertThat(Type.convert(database, 42L, Integer.class)).isEqualTo(42);
     assertThat(Type.convert(database, 42L, Integer.TYPE)).isEqualTo(42);
+    // BOUNDARY VALUES MUST STILL CONVERT
+    assertThat(Type.convert(database, (long) Integer.MAX_VALUE, Integer.class)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(Type.convert(database, (long) Integer.MIN_VALUE, Integer.class)).isEqualTo(Integer.MIN_VALUE);
+    assertThat(Type.convert(database, new BigDecimal(Integer.MAX_VALUE), Integer.class)).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  /**
+   * Issue #5905: {@code Type.convert()} narrowed an out-of-range value to INTEGER with {@code .intValue()}, which
+   * wraps on overflow instead of rejecting (e.g. {@code 3000000000L -> -1294967296}). A typed column must reject
+   * the value rather than silently corrupt it.
+   */
+  @Test
+  void convertToIntegerOutOfRangeRejected() {
+    assertThatThrownBy(() -> Type.convert(database, 3_000_000_000L, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("3000000000");
+    assertThatThrownBy(() -> Type.convert(database, 2_147_483_648L, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Long.MAX_VALUE, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Long.MIN_VALUE, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    // A WIDE FLOATING-POINT VALUE MUST ALSO BE REJECTED, NOT SILENTLY WRAPPED
+    assertThatThrownBy(() -> Type.convert(database, 1e20d, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    // A BIGDECIMAL WHOSE MAGNITUDE EXCEEDS EVEN A LONG MUST ALSO BE REJECTED
+    assertThatThrownBy(() -> Type.convert(database, new BigDecimal("9999999999999999999999999999"), Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -783,9 +844,67 @@ class TypeTest extends TestHelper {
 
   @Test
   void incrementIntegerOverflow() {
-    // Integer + Integer overflow -> upgrade to Long
+    // Integer + Integer positive overflow -> upgrade to Long, WITH THE CORRECT VALUE (issue #5906: the guard used
+    // to recompute the same overflowing int addition before widening it, e.g. (long)(2000000000+2000000000)
+    // produced -294967296L instead of 4000000000L)
     final Number result = Type.increment(Integer.MAX_VALUE, 1);
     assertThat(result).isInstanceOf(Long.class);
+    assertThat(result.longValue()).isEqualTo((long) Integer.MAX_VALUE + 1L);
+
+    final Number bigSum = Type.increment(2_000_000_000, 2_000_000_000);
+    assertThat(bigSum).isInstanceOf(Long.class);
+    assertThat(bigSum.longValue()).isEqualTo(4_000_000_000L);
+  }
+
+  @Test
+  void incrementIntegerNegativeOverflow() {
+    // Issue #5906: the overflow guard only checked "sum < 0 && a > 0 && b > 0", so two large negative operands
+    // (whose sum wraps positive) slipped through unchecked.
+    final Number result = Type.increment(-2_000_000_000, -2_000_000_000);
+    assertThat(result).isInstanceOf(Long.class);
+    assertThat(result.longValue()).isEqualTo(-4_000_000_000L);
+
+    final Number minValueResult = Type.increment(Integer.MIN_VALUE, -1);
+    assertThat(minValueResult).isInstanceOf(Long.class);
+    assertThat(minValueResult.longValue()).isEqualTo((long) Integer.MIN_VALUE - 1L);
+  }
+
+  @Test
+  void decrementIntegerOverflow() {
+    // Integer - Integer negative overflow -> upgrade to Long, with the correct value
+    final Number result = Type.decrement(Integer.MIN_VALUE, 1);
+    assertThat(result).isInstanceOf(Long.class);
+    assertThat(result.longValue()).isEqualTo((long) Integer.MIN_VALUE - 1L);
+
+    final Number bigDiff = Type.decrement(-2_000_000_000, 2_000_000_000);
+    assertThat(bigDiff).isInstanceOf(Long.class);
+    assertThat(bigDiff.longValue()).isEqualTo(-4_000_000_000L);
+  }
+
+  @Test
+  void decrementIntegerPositiveOverflow() {
+    // a - (-b) is an addition in disguise: Integer.MAX_VALUE - (-1) overflows positively.
+    final Number result = Type.decrement(Integer.MAX_VALUE, -1);
+    assertThat(result).isInstanceOf(Long.class);
+    assertThat(result.longValue()).isEqualTo((long) Integer.MAX_VALUE + 1L);
+  }
+
+  /**
+   * Issue #5906: the Integer-Short and Short-Integer branches of {@code decrement} have the same "recompute before
+   * widening" bug shape as {@code increment}.
+   */
+  @Test
+  void decrementIntegerMinusShortOverflow() {
+    final Number result = Type.decrement(Integer.MIN_VALUE, (short) 1);
+    assertThat(result).isInstanceOf(Long.class);
+    assertThat(result.longValue()).isEqualTo((long) Integer.MIN_VALUE - 1L);
+  }
+
+  @Test
+  void decrementShortMinusIntegerOverflow() {
+    final Number result = Type.decrement((short) -30_000, Integer.MAX_VALUE);
+    assertThat(result).isInstanceOf(Long.class);
+    assertThat(result.longValue()).isEqualTo(-30_000L - Integer.MAX_VALUE);
   }
 
   @Test
@@ -813,6 +932,27 @@ class TypeTest extends TestHelper {
     // Short + Short overflow -> upgrade to Integer
     final Number result = Type.increment((short) Short.MAX_VALUE, (short) 1);
     assertThat(result.intValue()).isEqualTo(Short.MAX_VALUE + 1);
+  }
+
+  /**
+   * Issue #5906: the Integer+Short branch has the identical "recompute the overflowing sum before widening" shape
+   * as the Integer+Integer branch.
+   */
+  @Test
+  void incrementIntegerPlusShortOverflow() {
+    final Number result = Type.increment(Integer.MAX_VALUE, (short) 1);
+    assertThat(result).isInstanceOf(Long.class);
+    assertThat(result.longValue()).isEqualTo((long) Integer.MAX_VALUE + 1L);
+  }
+
+  /**
+   * Issue #5906: same bug shape in the Short+Integer branch.
+   */
+  @Test
+  void incrementShortPlusIntegerOverflow() {
+    final Number result = Type.increment((short) 30_000, Integer.MAX_VALUE);
+    assertThat(result).isInstanceOf(Long.class);
+    assertThat(result.longValue()).isEqualTo(30_000L + Integer.MAX_VALUE);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -546,8 +546,10 @@ class TypeTest extends TestHelper {
     assertThatThrownBy(() -> Type.convert(database, new BigDecimal("9999999999999999999999999999"), Integer.class))
         .isInstanceOf(IllegalArgumentException.class);
     // A BIGINTEGER WHOSE MAGNITUDE EXCEEDS EVEN A LONG MUST ALSO BE REJECTED (longValue() TRUNCATES BITS INSTEAD OF
-    // SATURATING, SO THIS EXERCISES THE DEDICATED BigInteger BRANCH IN narrowToIntegral())
+    // SATURATING, SO THIS EXERCISES THE DEDICATED BigInteger BRANCH IN narrowToIntegral()), IN BOTH DIRECTIONS
     assertThatThrownBy(() -> Type.convert(database, new BigInteger("9999999999999999999999999999"), Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new BigInteger("-9999999999999999999999999999"), Integer.class))
         .isInstanceOf(IllegalArgumentException.class);
     // AN IN-RANGE BIGINTEGER MUST STILL CONVERT
     assertThat(Type.convert(database, BigInteger.valueOf(42), Integer.class)).isEqualTo(42);


### PR DESCRIPTION
## Summary

Fixes #5905 and #5906, both in `Type.java`'s integral narrowing/arithmetic.

- **#5905**: `Type.convert()` narrowed a wider `Number` to `BYTE`/`SHORT`/`INTEGER` with a plain `.byteValue()`/`.shortValue()`/`.intValue()`, which wraps two's-complement on overflow instead of rejecting (`3000000000L -> -1294967296`, no error, no warning). It now range-checks before narrowing and throws `IllegalArgumentException` naming the value, the target type and the property when known. `IllegalArgumentException` is the existing error convention used throughout `Type.java` for this method, and already classifies as `VALIDATION` for every wire protocol via `ErrorCategory`, so no new exception type or wire-layer wiring is needed.
- **#5906**: `Type.increment()`/`decrement()` had a broken "upgrade to long on overflow" guard: the `Integer+Integer`, `Integer+Short` and `Short+Integer` branches recomputed the *same* overflowing `int` addition/subtraction before widening it to `long` (`(long)(2000000000+2000000000)` is `-294967296L`, not `4000000000L`), and the guard only checked for positive overflow, leaving negative overflow undetected entirely. Both methods now use `Math.addExact`/`Math.subtractExact` and widen to `long` on the resulting `ArithmeticException`, matching the exact-arithmetic pattern already used in `MathExpression.exactIntegerArithmetic`. `SUM()`/`AVG()` accumulate through `Type.increment()`, so this also fixes their silent overflow over an `INTEGER` column.

The `Short+Short` branches in both methods never actually needed the guard (two `short` values can never sum/differ outside `int` range), so those are simplified to plain `int` arithmetic.

Also fixed the existing `incrementIntegerOverflow`/`incrementShortOverflow` unit tests, which only asserted the result's *class* (`Long`) and not its *value*, so they kept passing even with the overflow bug in place.

## Verification

- Added range-check and boundary-value unit tests to `TypeTest` for `convert()`, plus overflow/negative-overflow unit tests for `increment()`/`decrement()` across the `Integer`/`Short` branch combinations.
- Added `Issue5905IntegerTruncationTest`: SQL `INSERT`/`UPDATE` and typed-API (`MutableVertex.set`) reproductions confirming the out-of-range write is rejected and never lands in storage, plus an in-range control case.
- Added `Issue5906SumAverageIntegerOverflowTest`: SQL-level `SUM()`/`AVG()` over an `INTEGER` column exceeding `Integer.MAX_VALUE`, both positive and negative.
- Confirmed all 17 new/changed assertions fail against the pre-fix code (temporarily reverted `Type.java`) and pass after the fix.
- Ran `TypeTest` (118 tests), the new regression classes, `SQLFunctionSumAverageMultiArgTest`, `BinaryComparatorNarrowingTest`, `MathExpressionTest`, `DocumentValidationTest`, `UpdateStatementExecutionTest`, `CreatePropertyStatementExecutionTest`, the full `com.arcadedb.schema` package (382 tests) and the full `com.arcadedb.index` package (1098 tests) - all green, confirming the numeric-comparison and index-lookup paths that also call `Type.convert()`/`increment()` are unaffected.

## Test plan

- [x] `TypeTest` (118 tests) green
- [x] `Issue5905IntegerTruncationTest` (new) green
- [x] `Issue5906SumAverageIntegerOverflowTest` (new) green
- [x] `com.arcadedb.schema.**` (382 tests) green
- [x] `com.arcadedb.index.**` (1098 tests) green
- [x] Confirmed new tests fail against pre-fix code

## Behavioral note: bulk importers

`CSVImporterFormat`/`JSONImporterFormat` have no per-row error handling - they only catch `IOException` around the whole import loop. This was already true before this PR for malformed data (e.g. a non-numeric string into an `INTEGER` column already threw `NumberFormatException` and aborted the job). This PR extends the same "fail fast" behavior to one more case: a numeric value out of range for its declared type (mainly affects JSON import, since CSV values arrive as strings and already went through the pre-existing `Integer.parseInt`/`Short.parseShort`/`Byte.parseByte` path). Filed as a separate follow-up: #5968, since adding per-row skip-and-log resilience to the importers is its own design decision (opt-in flag, whole-row-vs-property skip, logging/reporting) independent of this fix.


Same "fail fast instead of silently wrap" note applies to the direct Java `Index` API (`LSMTreeIndex`/`HashIndex` `get()`/`range()`/etc.): a caller handing an out-of-range key literal straight to the low-level index API (bypassing SQL/schema `convert()`) now gets `IllegalArgumentException` where it previously silently produced a wrong/empty result. `FetchFromIndexStep` (the SQL-driven path) is already defended and unaffected.
