### PR TITLE
fix(#5884,#5885): validate argument count for SQL functions and methods before execution

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionDifference.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionDifference.java
@@ -39,6 +39,11 @@ public class SQLFunctionDifference extends SQLAggregatedCollectionFunction<Set<O
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
   @SuppressWarnings("unchecked")
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionFirst.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionFirst.java
@@ -35,6 +35,16 @@ public class SQLFunctionFirst extends SQLFunctionConfigurableAbstract {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     final Object value = params[0];

--- a/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionIntersect.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionIntersect.java
@@ -38,6 +38,11 @@ public class SQLFunctionIntersect extends SQLAggregatedCollectionFunction<Object
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext ctx) {
     Object value = params[0];

--- a/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionLast.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionLast.java
@@ -35,6 +35,16 @@ public class SQLFunctionLast extends SQLFunctionConfigurableAbstract {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     final Object value = params[0];

--- a/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionSymmetricDifference.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionSymmetricDifference.java
@@ -41,6 +41,11 @@ public class SQLFunctionSymmetricDifference extends SQLAggregatedCollectionFunct
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
   private static void addItemToResult(final Object o, final Set<Object> accepted, final Set<Object> rejected) {
     if (!accepted.contains(o) && !rejected.contains(o)) {
       accepted.add(o);

--- a/engine/src/main/java/com/arcadedb/function/sql/geo/SQLFunctionGeoLineString.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/geo/SQLFunctionGeoLineString.java
@@ -39,6 +39,16 @@ public class SQLFunctionGeoLineString extends SQLFunctionAbstract {
   }
 
   @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
+  @Override
   public Object execute(final Object iThis, final Identifiable iCurrentRecord, final Object iCurrentResult,
       final Object[] iParams, final CommandContext iContext) {
     if (iParams == null || iParams.length < 1 || iParams[0] == null)

--- a/engine/src/main/java/com/arcadedb/function/sql/geo/SQLFunctionGeoPolygon.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/geo/SQLFunctionGeoPolygon.java
@@ -40,6 +40,16 @@ public class SQLFunctionGeoPolygon extends SQLFunctionAbstract {
   }
 
   @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
+  @Override
   public Object execute(final Object iThis, final Identifiable iCurrentRecord, final Object iCurrentResult,
       final Object[] iParams, final CommandContext iContext) {
     if (iParams == null || iParams.length < 1 || iParams[0] == null)

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -76,6 +76,16 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 3;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 4;
+  }
+
   public LinkedList<RID> execute(final Object self, final Identifiable currentRecord, final Object currentResult,
       final Object[] params, final CommandContext ctx) {
     context = ctx;

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionDijkstra.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionDijkstra.java
@@ -48,6 +48,16 @@ public class SQLFunctionDijkstra extends SQLFunctionPathFinder {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 3;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 4;
+  }
+
   public LinkedList<RID> execute(final Object thisObj, final Identifiable currentRecord, final Object currentResult,
       final Object[] params, final CommandContext context) {
     return new SQLFunctionAstar().execute(thisObj, currentRecord, currentResult, toAStarParams(params), context);

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionMove.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionMove.java
@@ -94,6 +94,8 @@ public abstract class SQLFunctionMove extends SQLFunctionConfigurableAbstract {
   // not edge RIDs. Unlike v2v, there is no CSR acceleration possible for edge-returning functions.
   protected Object v2e(final Identifiable iRecord, final Vertex.DIRECTION iDirection,
       final String[] iLabels) {
+    if (iRecord == null)
+      return null;
     final Document rec = (Document) iRecord.getRecord();
     if (rec instanceof Vertex vertex)
       return vertex.getEdges(iDirection, iLabels);
@@ -103,6 +105,8 @@ public abstract class SQLFunctionMove extends SQLFunctionConfigurableAbstract {
 
   protected Object e2v(final Identifiable iRecord, final Vertex.DIRECTION iDirection,
       final String[] iLabels) {
+    if (iRecord == null)
+      return null;
     final Document rec = (Document) iRecord.getRecord();
     if (rec instanceof Edge edge) {
       // Tolerate a ghost edge (dangling segment pointer whose backing edge record is gone): it has no

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -66,6 +66,16 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 5;
+  }
+
   private static class ShortestPathContext {
     Vertex           sourceVertex;
     Vertex           destinationVertex;

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
@@ -49,6 +49,16 @@ public class SQLFunctionAbsoluteValue extends SQLFunctionMathAbstract {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
   public Object execute(final Object self, final Identifiable record, final Object currentResult, final Object[] params, final CommandContext context) {
     final Object inputValue = params[0];
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionCount.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionCount.java
@@ -38,7 +38,10 @@ public class SQLFunctionCount extends SQLAggregatedFunction {
   }
 
   /**
-   * {@code count(*)} carries no argument at all, which is why the minimum is 0 rather than 1.
+   * The parser represents {@code count(*)} as a single synthetic argument, not zero - {@code FunctionCall.isStar()}
+   * requires {@code params.size() == 1} to recognize the star form. The minimum is 0 rather than 1 because
+   * {@link #execute} itself also tolerates an empty {@code params} array ({@code params.length == 0}) as an
+   * alternate "count everything" shape, so both need to pass {@code checkArity()} without a real field argument.
    */
   @Override
   public int getMinArgs() {

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMedian.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMedian.java
@@ -34,6 +34,20 @@ public class SQLFunctionMedian extends SQLFunctionPercentile {
     this.quantiles.add(.5);
   }
 
+  /**
+   * Unlike {@link SQLFunctionPercentile}, the quantile is fixed at construction (0.5), so a call only ever
+   * supplies the field.
+   */
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
   @Override
   public String getSyntax() {
     return NAME + "(<field>)";

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMode.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMode.java
@@ -47,6 +47,16 @@ public class SQLFunctionMode extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPercentile.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPercentile.java
@@ -46,6 +46,11 @@ public class SQLFunctionPercentile extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionSquareRoot.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionSquareRoot.java
@@ -33,6 +33,16 @@ public class SQLFunctionSquareRoot extends SQLFunctionMathAbstract {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
   public Object execute(final Object self, final Identifiable record, final Object currentResult, final Object[] params,
       final CommandContext context) {
     final Object inputValue = params[0];

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionDecode.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionDecode.java
@@ -42,6 +42,16 @@ public class SQLFunctionDecode extends SQLFunctionAbstract {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute( final Object self, final Identifiable currentRecord, final Object currentResult,
       final Object[] params, final CommandContext context) {
 

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionEncode.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionEncode.java
@@ -46,6 +46,16 @@ public class SQLFunctionEncode extends SQLFunctionAbstract {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
 

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIfEmpty.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIfEmpty.java
@@ -69,6 +69,16 @@ public class SQLFunctionIfEmpty extends SQLFunctionAbstract {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 3;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     /*

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIfNull.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIfNull.java
@@ -66,6 +66,16 @@ public class SQLFunctionIfNull extends SQLFunctionAbstract {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 3;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     /*

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionConcat.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionConcat.java
@@ -31,6 +31,16 @@ public class SQLFunctionConcat extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (sb == null) {

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionFormat.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionFormat.java
@@ -34,6 +34,11 @@ public class SQLFunctionFormat extends SQLFunctionAbstract {
     super(NAME);
   }
 
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     final Object[] args = new Object[params.length - 1];

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionStrcmpci.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionStrcmpci.java
@@ -34,6 +34,16 @@ public class SQLFunctionStrcmpci extends SQLFunctionAbstract {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     String s1 = null;

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionCorrelate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionCorrelate.java
@@ -43,6 +43,16 @@ public class SQLFunctionCorrelate extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (params[0] == null || params[1] == null)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDelta.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDelta.java
@@ -40,6 +40,16 @@ public class SQLFunctionDelta extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (params[0] == null || params[1] == null)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionInterpolate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionInterpolate.java
@@ -45,6 +45,16 @@ public class SQLFunctionInterpolate extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 3;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (method == null && params.length > 1 && params[1] != null)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLag.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLag.java
@@ -49,6 +49,16 @@ public class SQLFunctionLag extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 4;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (!paramsRead) {

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLead.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLead.java
@@ -49,6 +49,16 @@ public class SQLFunctionLead extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 4;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (!paramsRead) {

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionMovingAvg.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionMovingAvg.java
@@ -46,6 +46,16 @@ public class SQLFunctionMovingAvg extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (windowSize < 0)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionRank.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionRank.java
@@ -42,6 +42,16 @@ public class SQLFunctionRank extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     pairs.add(new Object[] { params[0], params[1] });

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionRate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionRate.java
@@ -52,6 +52,16 @@ public class SQLFunctionRate extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 3;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (params[0] == null || params[1] == null)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTsFirst.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTsFirst.java
@@ -37,6 +37,16 @@ public class SQLFunctionTsFirst extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (params[0] == null || params[1] == null)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTsLast.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTsLast.java
@@ -37,6 +37,16 @@ public class SQLFunctionTsLast extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (params[0] == null || params[1] == null)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTsPercentile.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTsPercentile.java
@@ -48,6 +48,16 @@ public class SQLFunctionTsPercentile extends SQLAggregatedFunction {
   }
 
   @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (params[0] == null)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FunctionAggregationContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FunctionAggregationContext.java
@@ -37,6 +37,11 @@ public class FunctionAggregationContext implements AggregationContext {
     this.params = params;
     if (this.params == null)
       this.params = new ArrayList<>();
+    // Argument count does not change across the rows apply() is called for, so the check belongs here, once,
+    // rather than on every row (#5884): this is the aggregate-projection dispatch path (used for both real
+    // aggregate functions and any function projected with no FROM), a second entry point FunctionCall.execute()'s
+    // checkArity does not cover.
+    this.aggregateFunction.checkArity(new Object[this.params.size()]);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SQLMethod.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SQLMethod.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.function.FunctionArity;
 import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
 /**
@@ -48,6 +49,32 @@ public interface SQLMethod extends Comparable<SQLMethod> {
    * @return String , never null.
    */
   String getSyntax();
+
+  /**
+   * Returns the minimum number of parameters required.
+   *
+   * @return minimum parameter count (>= 0)
+   */
+  int getMinParams();
+
+  /**
+   * Returns the maximum number of parameters allowed, or {@link Integer#MAX_VALUE} when the method is variadic.
+   *
+   * @return maximum parameter count (>= getMinParams())
+   */
+  int getMaxParams();
+
+  /**
+   * Rejects a call whose argument count falls outside {@link #getMinParams()}..{@link #getMaxParams()}, mirroring
+   * {@link com.arcadedb.function.Function#checkArity} on the SQL-function side (#5884/#5885): a wrong argument count
+   * is the caller's mistake, so it is reported as a {@link com.arcadedb.exception.CommandSemanticException} (HTTP
+   * 400) rather than surfacing as whatever raw JDK exception the unguarded {@link #execute} happened to throw.
+   *
+   * @param params the arguments the call carried
+   */
+  default void checkArity(final Object[] params) {
+    FunctionArity.check("Method", getName(), getMinParams(), getMaxParams(), params);
+  }
 
   /**
    * Process a record.

--- a/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
@@ -49,6 +49,16 @@ public abstract class AbstractSQLMethod implements SQLMethod {
   }
 
   @Override
+  public int getMinParams() {
+    return minParams;
+  }
+
+  @Override
+  public int getMaxParams() {
+    return maxParams;
+  }
+
+  @Override
   public String getSyntax() {
     final StringBuilder sb = new StringBuilder("<field>.");
     sb.append(getName());

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodSort.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodSort.java
@@ -35,7 +35,7 @@ public class SQLMethodSort extends AbstractSQLMethod {
   public static final String NAME = "sort";
 
   public SQLMethodSort() {
-    super(NAME);
+    super(NAME, 0, 1);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodTransform.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodTransform.java
@@ -42,7 +42,7 @@ public class SQLMethodTransform extends AbstractSQLMethod {
   private static final Object[] EMPTY_ARGS = new Object[] {};
 
   public SQLMethodTransform() {
-    super(NAME, 0, 0);
+    super(NAME, 0, -1);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodIfEmpty.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodIfEmpty.java
@@ -35,7 +35,7 @@ public class SQLMethodIfEmpty extends AbstractSQLMethod {
   public static final String NAME = "ifempty";
 
   public SQLMethodIfEmpty() {
-    super(NAME);
+    super(NAME, 1, 1);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodIfNull.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodIfNull.java
@@ -32,7 +32,7 @@ public class SQLMethodIfNull extends AbstractSQLMethod {
   public static final String NAME = "ifnull";
 
   public SQLMethodIfNull() {
-    super(NAME);
+    super(NAME, 1, 1);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodCharAt.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodCharAt.java
@@ -43,11 +43,16 @@ public class SQLMethodCharAt extends AbstractSQLMethod {
 
   @Override
   public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
-    if (params[0] == null) {
+    if (value == null || params[0] == null) {
       return null;
     }
 
     final int index = Integer.parseInt(params[0].toString());
-    return "" + value.toString().charAt(index);
+    final String valueAsString = value.toString();
+    // Out of range (including negative) has no character to return: null rather than letting
+    // charAt() throw StringIndexOutOfBoundsException (#5885).
+    if (index < 0 || index >= valueAsString.length())
+      return null;
+    return "" + valueAsString.charAt(index);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodLeft.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodLeft.java
@@ -48,7 +48,9 @@ public class SQLMethodLeft extends AbstractSQLMethod {
 
     final String valueAsString = value.toString();
 
-    final int len = Integer.parseInt(params[0].toString());
+    // A negative length has no characters to return, same as MySQL's LEFT(): clamp rather than let
+    // substring() throw StringIndexOutOfBoundsException (#5885).
+    final int len = Math.max(0, Integer.parseInt(params[0].toString()));
     return valueAsString.substring(0, len <= valueAsString.length() ? len : valueAsString.length());
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodRight.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodRight.java
@@ -50,7 +50,9 @@ public class SQLMethodRight extends AbstractSQLMethod {
 
     final String valueAsString = value.toString();
 
-    final int offset = Integer.parseInt(params[0].toString());
+    // A negative offset has no characters to return, same as MySQL's RIGHT(): clamp rather than let
+    // substring() throw StringIndexOutOfBoundsException (#5885).
+    final int offset = Math.max(0, Integer.parseInt(params[0].toString()));
     return valueAsString.substring(offset < valueAsString.length() ? valueAsString.length() - offset : 0);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToLowerCase.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToLowerCase.java
@@ -33,7 +33,7 @@ public class SQLMethodToLowerCase extends AbstractSQLMethod {
   public static final String NAME = "tolowercase";
 
   public SQLMethodToLowerCase() {
-    super(NAME);
+    super(NAME, 0, 1);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToUpperCase.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToUpperCase.java
@@ -33,7 +33,7 @@ public class SQLMethodToUpperCase extends AbstractSQLMethod {
   public static final String NAME = "touppercase";
 
   public SQLMethodToUpperCase() {
-    super(NAME);
+    super(NAME, 0, 1);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
@@ -127,6 +127,7 @@ public class FunctionCall extends SimpleNode {
 
     final SQLFunction function = ((SQLQueryEngine) context.getDatabase().getQueryEngine("sql")).getFunction(name);
     if (function != null) {
+      function.checkArity(paramValues.toArray());
       if (record instanceof Identifiable identifiable) {
         return function.execute(targetObjects, identifiable, null, paramValues.toArray(), context);
       } else if (record instanceof Result result) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
@@ -127,13 +127,14 @@ public class FunctionCall extends SimpleNode {
 
     final SQLFunction function = ((SQLQueryEngine) context.getDatabase().getQueryEngine("sql")).getFunction(name);
     if (function != null) {
-      function.checkArity(paramValues.toArray());
+      final Object[] functionParams = paramValues.toArray();
+      function.checkArity(functionParams);
       if (record instanceof Identifiable identifiable) {
-        return function.execute(targetObjects, identifiable, null, paramValues.toArray(), context);
+        return function.execute(targetObjects, identifiable, null, functionParams, context);
       } else if (record instanceof Result result) {
-        return function.execute(targetObjects, result.getElement().orElse(null), null, paramValues.toArray(), context);
+        return function.execute(targetObjects, result.getElement().orElse(null), null, functionParams, context);
       } else if (record == null) {
-        return function.execute(targetObjects, null, null, paramValues.toArray(), context);
+        return function.execute(targetObjects, null, null, functionParams, context);
       } else {
         throw new CommandExecutionException("Invalid value for $current: " + record);
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
@@ -105,6 +105,7 @@ public class MethodCall extends SimpleNode {
     }
     if (isGraphFunction()) {
       final SQLFunction function = ((SQLQueryEngine) context.getDatabase().getQueryEngine("sql")).getFunction(name);
+      function.checkArity(paramValues.toArray());
       if (function instanceof SQLFunctionFiltered filtered) {
         final Identifiable currentRecord = resolveCurrentAsIdentifiable(context);
         return filtered.execute(targetObjects, currentRecord, null, paramValues.toArray(), iPossibleResults, context);
@@ -123,6 +124,9 @@ public class MethodCall extends SimpleNode {
 
     final SQLMethod method = ((SQLQueryEngine) context.getDatabase().getQueryEngine("sql")).getMethod(name);
     if (method != null) {
+      final Object[] methodParams = paramValues.toArray();
+      method.checkArity(methodParams);
+
       final Identifiable currentRecord;
       if (val instanceof Result result)
         currentRecord = result.getElement().orElse(null);
@@ -131,7 +135,7 @@ public class MethodCall extends SimpleNode {
       else
         currentRecord = null;
 
-      return method.execute(targetObjects, currentRecord, context, paramValues.toArray());
+      return method.execute(targetObjects, currentRecord, context, methodParams);
     }
     throw new UnsupportedOperationException("OMethod call, something missing in the implementation...?");
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
@@ -105,18 +105,22 @@ public class MethodCall extends SimpleNode {
     }
     if (isGraphFunction()) {
       final SQLFunction function = ((SQLQueryEngine) context.getDatabase().getQueryEngine("sql")).getFunction(name);
-      function.checkArity(paramValues.toArray());
+      if (function == null)
+        throw new CommandExecutionException("Function not found: " + name);
+
+      final Object[] functionParams = paramValues.toArray();
+      function.checkArity(functionParams);
       if (function instanceof SQLFunctionFiltered filtered) {
         final Identifiable currentRecord = resolveCurrentAsIdentifiable(context);
-        return filtered.execute(targetObjects, currentRecord, null, paramValues.toArray(), iPossibleResults, context);
+        return filtered.execute(targetObjects, currentRecord, null, functionParams, iPossibleResults, context);
       } else {
         final Object current = context.getVariable("current");
         if (current instanceof Identifiable identifiable) {
-          return function.execute(targetObjects, identifiable, null, paramValues.toArray(), context);
+          return function.execute(targetObjects, identifiable, null, functionParams, context);
         } else if (current instanceof Result result) {
-          return function.execute(targetObjects, result.getElement().orElse(null), null, paramValues.toArray(), context);
+          return function.execute(targetObjects, result.getElement().orElse(null), null, functionParams, context);
         } else {
-          return function.execute(targetObjects, null, null, paramValues.toArray(), context);
+          return function.execute(targetObjects, null, null, functionParams, context);
         }
       }
 

--- a/engine/src/test/java/com/arcadedb/function/sql/FunctionArgumentValidationRegressionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/FunctionArgumentValidationRegressionTest.java
@@ -120,6 +120,19 @@ class FunctionArgumentValidationRegressionTest extends TestHelper {
   }
 
   @Test
+  void graphFunctionAsMethodCallSyntaxStillWorksWithCorrectArguments() {
+    // MethodCall's isGraphFunction() branch (used for the <expr>.out()/.in()/.both()/... method-call syntax,
+    // as opposed to the out()/in()/both() function-call syntax the other tests exercise) also calls
+    // checkArity() now. Confirm a normal traversal through that branch still works.
+    database.getSchema().createVertexType("ArityMethodSyntaxVertex");
+    database.transaction(() -> database.newVertex("ArityMethodSyntaxVertex").save());
+
+    assertThatCode(() -> consume("SELECT @this.bothE() AS r FROM ArityMethodSyntaxVertex")) //
+        .as("bothE() via method-call syntax with correct (zero) arguments must not throw") //
+        .doesNotThrowAnyException();
+  }
+
+  @Test
   void everyAffectedFunctionIsAccountedFor() {
     // Every name in AFFECTED_FUNCTIONS is exercised by exactly one of the two parameterized tests above.
     for (final String name : AFFECTED_FUNCTIONS) {

--- a/engine/src/test/java/com/arcadedb/function/sql/FunctionArgumentValidationRegressionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/FunctionArgumentValidationRegressionTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.executor.SQLFunction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for #5884: calling one of the 43 listed SQL functions with too few arguments used to surface a raw JDK
+ * exception (ArrayIndexOutOfBoundsException, NullPointerException, ClassCastException, NegativeArraySizeException) instead
+ * of a validation error, because {@link com.arcadedb.query.sql.parser.FunctionCall} never called
+ * {@link com.arcadedb.function.Function#checkArity} before invoking the function - even though every one of these
+ * functions now declares {@code getMinArgs()}/{@code getMaxArgs()} correctly.
+ * <p>
+ * Driven off the declared bounds themselves (not a hand-picked argument count per function), so a function whose
+ * declaration regresses back to the unenforced default (0, MAX_VALUE) is caught here rather than only by a person
+ * re-running the reporter's original sweep.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class FunctionArgumentValidationRegressionTest extends TestHelper {
+
+  /**
+   * The 43 functions #5884 found throwing a raw JDK exception on too few arguments.
+   */
+  private static final String[] AFFECTED_FUNCTIONS = { //
+      "abs", "astar", "bothE", "bothV", "concat", "decode", "difference", "dijkstra", "encode", "first", //
+      "format", "geo.lineString", "geo.polygon", "ifempty", "ifnull", "inE", "inV", "intersect", "last", //
+      "median", "mode", "outE", "outV", "percentile", "shortestPath", "sqrt", "stddev", "stddevp", "strcmpci", //
+      "symmetricDifference", "ts.correlate", "ts.delta", "ts.first", "ts.interpolate", "ts.lag", "ts.last", //
+      "ts.lead", "ts.movingAvg", "ts.percentile", "ts.rank", "ts.rate", "variance", "variancep" };
+
+  /**
+   * Graph-traversal functions that legitimately accept zero arguments (the labels are optional varargs): the bug for
+   * these was not a missing arity check but {@link com.arcadedb.function.sql.graph.SQLFunctionMove#v2e} /
+   * {@link com.arcadedb.function.sql.graph.SQLFunctionMove#e2v} dereferencing a null receiver. Calling them with no
+   * arguments outside a graph context must return gracefully (null), not throw.
+   */
+  private static final String[] ZERO_ARG_GRAPH_FUNCTIONS = { "bothE", "bothV", "inE", "inV", "outE", "outV" };
+
+  @ParameterizedTest
+  @ValueSource(strings = { //
+      "abs", "astar", "concat", "decode", "difference", "dijkstra", "encode", "first", //
+      "format", "geo.lineString", "geo.polygon", "ifempty", "ifnull", "intersect", "last", //
+      "median", "mode", "percentile", "shortestPath", "sqrt", "stddev", "stddevp", "strcmpci", //
+      "symmetricDifference", "ts.correlate", "ts.delta", "ts.first", "ts.interpolate", "ts.lag", "ts.last", //
+      "ts.lead", "ts.movingAvg", "ts.percentile", "ts.rank", "ts.rate", "variance", "variancep" })
+  void tooFewArgumentsIsAValidationErrorNotARawException(final String functionName) {
+    final int minArgs = functionInstance(functionName).getMinArgs();
+    assertThat(minArgs).as("%s should require at least one argument", functionName).isGreaterThan(0);
+
+    final String query = "SELECT " + functionName + "(" + placeholders(minArgs - 1) + ") AS r";
+    assertThatThrownBy(() -> consume(query)) //
+        .as("%s called with %d (< %d required) arguments", functionName, minArgs - 1, minArgs) //
+        .isInstanceOf(CommandSemanticException.class) //
+        .hasMessageContaining(functionName);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "bothE", "bothV", "inE", "inV", "outE", "outV" })
+  void graphTraversalFunctionsToleratesZeroArgumentsOutsideAGraphContext(final String functionName) {
+    assertThatCode(() -> consume("SELECT " + functionName + "() AS r")) //
+        .as("%s() with no current vertex must return gracefully, not throw", functionName) //
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void everyAffectedFunctionIsAccountedFor() {
+    // Every name in AFFECTED_FUNCTIONS is exercised by exactly one of the two parameterized tests above.
+    for (final String name : AFFECTED_FUNCTIONS) {
+      final boolean isZeroArgGraphFunction = Arrays.asList(ZERO_ARG_GRAPH_FUNCTIONS).contains(name);
+      if (!isZeroArgGraphFunction)
+        assertThat(functionInstance(name).getMinArgs()).as("%s", name).isGreaterThan(0);
+    }
+  }
+
+  private static SQLFunction functionInstance(final String name) {
+    return DefaultSQLFunctionFactory.getInstance().getFunctionInstance(name);
+  }
+
+  private static String placeholders(final int count) {
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < count; i++) {
+      if (i > 0)
+        sb.append(", ");
+      sb.append("'x'");
+    }
+    return sb.toString();
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/FunctionArgumentValidationRegressionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/FunctionArgumentValidationRegressionTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.offset;
 
 /**
  * Regression test for #5884: calling one of the 43 listed SQL functions with too few arguments used to surface a raw JDK
@@ -89,6 +90,33 @@ class FunctionArgumentValidationRegressionTest extends TestHelper {
     assertThatCode(() -> consume("SELECT " + functionName + "() AS r")) //
         .as("%s() with no current vertex must return gracefully, not throw", functionName) //
         .doesNotThrowAnyException();
+  }
+
+  @Test
+  void aggregateProjectionDispatchPathStillWorksWithCorrectArguments() {
+    // FunctionAggregationContext (used for real GROUP BY aggregation, not just a no-FROM synthetic call) got its
+    // own checkArity() call alongside FunctionCall's. A call with the right argument count must still work through
+    // that path, not just through the no-FROM cases the other tests above exercise.
+    database.getSchema().createDocumentType("AggregateArityFixture");
+    database.transaction(() -> {
+      for (final int value : new int[] { 1, 2, 3, 4, 5 })
+        database.newDocument("AggregateArityFixture").set("value", value).save();
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT stddev(value) AS r FROM AggregateArityFixture")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat((Double) rs.next().getProperty("r")).isCloseTo(Math.sqrt(2.5), offset(0.0001));
+    }
+
+    try (final ResultSet rs = database.query("sql",
+        "SELECT (value % 2) AS parity, count(*) AS c FROM AggregateArityFixture GROUP BY parity")) {
+      int rows = 0;
+      while (rs.hasNext()) {
+        rs.next();
+        rows++;
+      }
+      assertThat(rows).isEqualTo(2);
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/method/MethodArgumentValidationRegressionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/MethodArgumentValidationRegressionTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.executor.SQLMethod;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for #5885: calling one of the 19 listed SQL methods with too few arguments, or with more than the
+ * declared maximum, used to either surface a raw JDK exception or be silently accepted, because
+ * {@link com.arcadedb.query.sql.parser.MethodCall} never called {@link SQLMethod#checkArity} before invoking the
+ * method - even though {@link AbstractSQLMethod} already stored the correct {@code minParams}/{@code maxParams} for
+ * every one of them (only {@code ifempty} had them wrong).
+ * <p>
+ * Driven off the declared bounds themselves (not a hand-picked argument count per method), so a method whose
+ * declaration regresses stays covered.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MethodArgumentValidationRegressionTest extends TestHelper {
+
+  /**
+   * The 19 methods #5885 found affected, called against a plain string receiver.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { //
+      "append", "asdate", "asdatetime", "charat", "convert", "field", "format", "ifempty", "include", //
+      "indexof", "lastindexof", "left", "prefix", "replace", "right", "split", "substring", "trimprefix", //
+      "trimsuffix" })
+  void tooFewArgumentsIsAValidationErrorNotARawException(final String methodName) {
+    final SQLMethod method = methodInstance(methodName);
+    final int minParams = method.getMinParams();
+    if (minParams == 0)
+      return; // nothing to under-supply
+
+    final String query = "SELECT 'abc'." + methodName + "(" + placeholders(minParams - 1) + ") AS r";
+    assertThatThrownBy(() -> consume(query)) //
+        .as("%s called with %d (< %d required) arguments", methodName, minParams - 1, minParams) //
+        .isInstanceOf(CommandSemanticException.class) //
+        .hasMessageContaining(methodName);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { //
+      "append", "asdate", "asdatetime", "charat", "convert", "field", "format", "ifempty", "include", //
+      "indexof", "lastindexof", "left", "prefix", "replace", "right", "split", "substring", "trimprefix", //
+      "trimsuffix" })
+  void tooManyArgumentsIsAValidationError(final String methodName) {
+    final SQLMethod method = methodInstance(methodName);
+    final int maxParams = method.getMaxParams();
+    if (maxParams < 0 || maxParams == Integer.MAX_VALUE)
+      return; // variadic: no upper bound to exceed
+
+    final String query = "SELECT 'abc'." + methodName + "(" + placeholders(maxParams + 1) + ") AS r";
+    assertThatThrownBy(() -> consume(query)) //
+        .as("%s called with %d (> %d allowed) arguments", methodName, maxParams + 1, maxParams) //
+        .isInstanceOf(CommandSemanticException.class) //
+        .hasMessageContaining(methodName);
+  }
+
+  @Test
+  void ifEmptyDeclaresExactlyOneRequiredParameter() {
+    // The one method in the 19 whose declared bounds (not just their enforcement) were wrong: super(NAME) defaulted
+    // to (0, 0), while execute() unconditionally reads params[0].
+    final SQLMethod ifEmpty = methodInstance("ifempty");
+    assertThat(ifEmpty.getMinParams()).isEqualTo(1);
+    assertThat(ifEmpty.getMaxParams()).isEqualTo(1);
+  }
+
+  @Test
+  void leftWithANegativeLengthReturnsEmptyRatherThanThrowing() {
+    assertThatCode(() -> assertThat(single("SELECT 'abcdef'.left(-3) AS r")).isEqualTo("")) //
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void rightWithANegativeOffsetReturnsEmptyRatherThanThrowing() {
+    assertThatCode(() -> assertThat(single("SELECT 'abcdef'.right(-3) AS r")).isEqualTo("")) //
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void charAtWithANegativeOrOutOfRangeIndexReturnsNullRatherThanThrowing() {
+    assertThatCode(() -> assertThat(single("SELECT 'abcdef'.charat(-1) AS r")).isNull()) //
+        .doesNotThrowAnyException();
+    assertThatCode(() -> assertThat(single("SELECT 'abcdef'.charat(99) AS r")).isNull()) //
+        .doesNotThrowAnyException();
+  }
+
+  private static SQLMethod methodInstance(final String name) {
+    return DefaultSQLMethodFactory.getInstance().createMethod(name);
+  }
+
+  private static String placeholders(final int count) {
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < count; i++) {
+      if (i > 0)
+        sb.append(", ");
+      sb.append("'x'");
+    }
+    return sb.toString();
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodCharAtTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodCharAtTest.java
@@ -40,6 +40,14 @@ class SQLMethodCharAtTest {
     }
 
     @Test
+    void nullReceiverWithANonNullIndexIsReturnedAsNull() {
+        // Isolates the value == null guard (#5885): before it was added, a non-null index still reached
+        // value.toString() unconditionally and threw a NullPointerException on a null receiver.
+        final Object result = method.execute(null, null, null, new Object[]{0});
+        assertThat(result).isNull();
+    }
+
+    @Test
     void chartAt() {
         final Object result = method.execute("chars", null, null, new Object[]{3});
         assertThat(result).isEqualTo("r");


### PR DESCRIPTION
## Summary

Fixes #5884 and #5885: 43 SQL functions and 19 SQL methods answered a call with too few arguments with a raw JDK exception (`ArrayIndexOutOfBoundsException`, `NullPointerException`, `ClassCastException`, `NegativeArraySizeException`) instead of a validation error.

The infrastructure for this already existed (`Function.checkArity()` / `FunctionArity`, added for #5484/#5602/#5627) but was never invoked from the SQL-parser dispatch points these two issues cover. This is a chokepoint fix rather than 62 separate hand-written guards:

- `FunctionCall.execute()` and `MethodCall.execute()` (the two SQL-parser dispatch points for `function()` / `.method()` calls) now call `checkArity()` before invoking the function/method.
- `FunctionAggregationContext` (a second, less obvious dispatch path used both for real aggregate functions and for any function projected with no `FROM` clause) gets the same check, once per statement rather than per row.
- `SQLMethod` gained the same `getMinParams()`/`getMaxParams()`/`checkArity()` contract `Function` already had; `AbstractSQLMethod` already stored the right `minParams`/`maxParams` for almost every method, they just weren't enforced.

A wrong argument count is now a `CommandSemanticException` (HTTP 400), matching how it already worked for the functions that got this right (`bellmanFord()`, `circle()`, `vector.fuse()`).

### Two sub-cases handled differently

- **Missing arguments** (both issues): fixed by declaring correct `getMinArgs()`/`getMaxArgs()` (functions) or constructor bounds (methods) and wiring the enforcement described above.
- **Not actually an arity bug**: `bothE`/`bothV`/`inE`/`inV`/`outE`/`outV` legitimately take zero required arguments (labels are optional). Their `NullPointerException` came from `SQLFunctionMove.v2e()`/`e2v()` dereferencing a null receiver unconditionally, unlike `v2v()` which already null-checks. Fixed to match `v2v()`.
- **Negative values** (#5885): `left()`, `right()`, `charat()` had the right argument *count* but no guard on the *value*. They now clamp/return-null for out-of-range input the way MySQL's `LEFT`/`RIGHT` do, instead of throwing `StringIndexOutOfBoundsException`. `substring()`, `indexof()`, `lastindexof()` turned out to already tolerate negative values safely on inspection - verified rather than "fixed" a second time.

### Fallout from turning on enforcement

Running the full test suite after wiring the checks surfaced a handful of *other* pre-existing methods whose declared `minParams`/`maxParams` didn't match what their `execute()` actually needed/tolerated - previously invisible because nothing enforced the declaration. Fixed the same way: `ifnull` (method), `sort`, `transform`, `toUpperCase`, `toLowerCase`.

## Test plan

- [x] Added `FunctionArgumentValidationRegressionTest` - sweeps all 43 listed functions, driven off each function's own declared `getMinArgs()`/`getMaxArgs()`, asserting too-few-arguments raises `CommandSemanticException` (not a raw exception), and that the six zero-arg graph functions tolerate a missing receiver gracefully.
- [x] Added `MethodArgumentValidationRegressionTest` - same sweep for all 19 listed methods (too few / too many args), plus dedicated negative-value tests for `left()`, `right()`, `charat()`.
- [x] Full `engine` module test suite: 10,963 tests / 1,314 classes, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1y2csftaVgtrNwgSNETzL