### PR TITLE
fix(#5973): bound K8s auto-join probe's Raft client retry policy

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -327,6 +327,12 @@ jobs:
   ha-integration-tests:
     runs-on: ubuntu-latest
     needs: build-and-package
+    # Safety net for issue #5973: a stuck Raft reconfiguration made a probe's RaftClient retry
+    # unboundedly (no sleep) inside a single blocking call, livelocking the job for the full GitHub
+    # Actions 6-hour default cap. The retry itself is now bounded (see KubernetesAutoJoin), but this
+    # keeps any future hang from silently eating a runner for hours: normal runs finish in well under
+    # 60 minutes.
+    timeout-minutes: 90
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -327,11 +327,8 @@ jobs:
   ha-integration-tests:
     runs-on: ubuntu-latest
     needs: build-and-package
-    # Safety net for issue #5973: a stuck Raft reconfiguration made a probe's RaftClient retry
-    # unboundedly (no sleep) inside a single blocking call, livelocking the job for the full GitHub
-    # Actions 6-hour default cap. The retry itself is now bounded (see KubernetesAutoJoin), but this
-    # keeps any future hang from silently eating a runner for hours: normal runs finish in well under
-    # 60 minutes.
+    # Defense-in-depth safety net for issue #5973 (livelocked this job for 6h): normal runs finish
+    # in well under 60 minutes.
     timeout-minutes: 90
     permissions:
       contents: read

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/KubernetesAutoJoin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/KubernetesAutoJoin.java
@@ -27,6 +27,8 @@ import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.SetConfigurationRequest;
+import org.apache.ratis.retry.RetryPolicies;
+import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.TimeDuration;
 
@@ -73,6 +75,18 @@ public class KubernetesAutoJoin {
   // against the peers' allowlist DNS refresh on pod recreation, stranding the node forever.
   static final long RETRY_BACKOFF_INITIAL_MS = 2_000L;
   static final long RETRY_BACKOFF_MAX_MS     = 60_000L;
+  // Bounded retry policy for the probe's temp RaftClient (issue #5973): RaftClient.Builder defaults to
+  // RetryPolicies.retryForeverNoSleep() when none is set. A setConfiguration ADD racing an in-flight
+  // reconfiguration on the peer fails fast with ReconfigurationInProgressException (a synchronous
+  // rejection, not an RPC that can time out), so an unbounded no-sleep policy spins inside this single
+  // blocking admin().setConfiguration() call as fast as the JVM can throw/catch/log, indefinitely - the
+  // RPC timeouts set in buildProbeProperties() never get a chance to apply. Observed in CI hammering a
+  // permanently-stuck reconfiguration for 5.5 hours straight (a 41GB log of the identical exception)
+  // until the job's 6-hour wall-clock cap force-killed it. Bounding it here makes a stuck reconfiguration
+  // surface as a probe failure within a couple of seconds; tryAutoJoinWithRetry's own exponential
+  // backoff (up to RETRY_BACKOFF_MAX_MS) already covers retrying the probe over the longer term.
+  static final RetryPolicy PROBE_RETRY_POLICY =
+      RetryPolicies.retryUpToMaximumCountWithFixedSleep(5, TimeDuration.valueOf(500, TimeUnit.MILLISECONDS));
 
   /** Result of a single auto-join probe round. */
   public enum Outcome {
@@ -181,6 +195,7 @@ public class KubernetesAutoJoin {
         try (final RaftClient tempClient = RaftClient.newBuilder()
             .setRaftGroup(targetGroup)
             .setProperties(tempProps)
+            .setRetryPolicy(PROBE_RETRY_POLICY)
             .build()) {
 
           final var groupInfo = tempClient.getGroupManagementApi(peer.getId()).info(raftGroup.getGroupId());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinRetryTest.java
@@ -145,14 +145,9 @@ class KubernetesAutoJoinRetryTest {
 
   @Test
   void probeRetryPolicyIsBoundedNotUnboundedDefault() {
-    // Regression for issue #5973: RaftClient.Builder falls back to RetryPolicies.retryForeverNoSleep()
-    // when no policy is set explicitly. A setConfiguration ADD racing an in-flight reconfiguration on
-    // the peer fails fast with ReconfigurationInProgressException - a synchronous rejection, not an RPC
-    // that can time out - so an unbounded no-sleep policy spins inside a single blocking
-    // admin().setConfiguration() call as fast as the JVM can throw/catch/log, forever. This is exactly
-    // what happened in CI: the probe hammered a permanently-stuck reconfiguration for 5.5 hours straight
-    // (a 41GB log of the identical exception) until GitHub Actions' 6-hour job cap force-killed it. The
-    // probe client must always set a bounded policy so a stuck reconfiguration fails fast instead.
+    // Regression for issue #5973 (see KubernetesAutoJoin.PROBE_RETRY_POLICY for the full root-cause
+    // writeup): the probe client must always set a bounded retry policy, not fall back to Ratis's
+    // unbounded retryForeverNoSleep() default.
     assertThat(KubernetesAutoJoin.PROBE_RETRY_POLICY).isInstanceOf(RetryPolicies.RetryLimited.class);
     assertThat(((RetryPolicies.RetryLimited) KubernetesAutoJoin.PROBE_RETRY_POLICY).getMaxAttempts()).isEqualTo(5);
     // RetryLimited/RetryForeverWithSleep expose no sleep-time getter, only toString(); pin it here too

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinRetryTest.java
@@ -152,7 +152,8 @@ class KubernetesAutoJoinRetryTest {
     assertThat(((RetryPolicies.RetryLimited) KubernetesAutoJoin.PROBE_RETRY_POLICY).getMaxAttempts()).isEqualTo(5);
     // RetryLimited/RetryForeverWithSleep expose no sleep-time getter, only toString(); pin it here too
     // so a future edit can't silently widen 500ms to something much larger while maxAttempts still
-    // reads 5 and this test still passes (code-review feedback on the PR that introduced this test).
+    // reads 5 and this test still passes. If this breaks after a ratis.version bump, check whether
+    // Ratis changed its toString() format before assuming an actual regression.
     assertThat(KubernetesAutoJoin.PROBE_RETRY_POLICY.toString()).contains("sleepTime=500ms");
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinRetryTest.java
@@ -155,5 +155,9 @@ class KubernetesAutoJoinRetryTest {
     // probe client must always set a bounded policy so a stuck reconfiguration fails fast instead.
     assertThat(KubernetesAutoJoin.PROBE_RETRY_POLICY).isInstanceOf(RetryPolicies.RetryLimited.class);
     assertThat(((RetryPolicies.RetryLimited) KubernetesAutoJoin.PROBE_RETRY_POLICY).getMaxAttempts()).isEqualTo(5);
+    // RetryLimited/RetryForeverWithSleep expose no sleep-time getter, only toString(); pin it here too
+    // so a future edit can't silently widen 500ms to something much larger while maxAttempts still
+    // reads 5 and this test still passes (code-review feedback on the PR that introduced this test).
+    assertThat(KubernetesAutoJoin.PROBE_RETRY_POLICY.toString()).contains("sleepTime=500ms");
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/KubernetesAutoJoinRetryTest.java
@@ -22,6 +22,7 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.retry.RetryPolicies;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
@@ -140,5 +141,19 @@ class KubernetesAutoJoinRetryTest {
     assertThat(result).isEqualTo(KubernetesAutoJoin.Outcome.INTERRUPTED);
     // The interrupt flag must be restored for the owning thread's shutdown handling.
     assertThat(Thread.interrupted()).isTrue(); // also clears it so it does not leak into other tests
+  }
+
+  @Test
+  void probeRetryPolicyIsBoundedNotUnboundedDefault() {
+    // Regression for issue #5973: RaftClient.Builder falls back to RetryPolicies.retryForeverNoSleep()
+    // when no policy is set explicitly. A setConfiguration ADD racing an in-flight reconfiguration on
+    // the peer fails fast with ReconfigurationInProgressException - a synchronous rejection, not an RPC
+    // that can time out - so an unbounded no-sleep policy spins inside a single blocking
+    // admin().setConfiguration() call as fast as the JVM can throw/catch/log, forever. This is exactly
+    // what happened in CI: the probe hammered a permanently-stuck reconfiguration for 5.5 hours straight
+    // (a 41GB log of the identical exception) until GitHub Actions' 6-hour job cap force-killed it. The
+    // probe client must always set a bounded policy so a stuck reconfiguration fails fast instead.
+    assertThat(KubernetesAutoJoin.PROBE_RETRY_POLICY).isInstanceOf(RetryPolicies.RetryLimited.class);
+    assertThat(((RetryPolicies.RetryLimited) KubernetesAutoJoin.PROBE_RETRY_POLICY).getMaxAttempts()).isEqualTo(5);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #5973: the `ha-integration-tests` CI job livelocked for the full GitHub Actions 6-hour job cap, producing a 41.2GB log of an identical repeating exception, before being force-cancelled.

## Root cause

`KubernetesAutoJoin.tryAutoJoin()` builds a short-lived probe `RaftClient` to contact a peer and (if needed) atomically add this node back to the Raft group via `setConfiguration(Mode.ADD)`. That client's builder never called `.setRetryPolicy(...)`, so it fell back to Ratis's `RaftClient.Builder` default: `RetryPolicies.retryForeverNoSleep()`.

`RaftHAServer.buildRaftClient()` already documents exactly why that default is dangerous for admin calls:

> The default Ratis retry policy is retryForeverNoSleep, which causes blocking admin calls (like setConfiguration) to hang indefinitely when the leader is not yet ready or the reconfiguration is in progress.

...and sets a bounded policy for its own client. The probe client in `KubernetesAutoJoin` was the one place that never got the same treatment.

In the failing CI run (`Issue5275MembershipSelfHealIT`), the Raft group's configuration at `index: 5` was permanently stuck "in progress." Every retry of `setConfiguration ADD servers:[localhost_2434]` immediately re-hit `ReconfigurationInProgressException` - a **synchronous rejection**, not an RPC that can time out - so the unbounded no-sleep policy spun inside the single blocking `admin().setConfiguration()` call as fast as the JVM could throw/catch/log it. That's why the RPC timeouts already configured in `buildProbeProperties()` never kicked in: there was no RPC in flight to time out, just an in-process retry loop inside the Ratis client.

## Fix

Bound the probe client's retry policy (`retryUpToMaximumCountWithFixedSleep(5, 500ms)`, ~2.5s worst case) so a stuck reconfiguration surfaces as a probe failure within seconds instead of blocking forever. `tryAutoJoinWithRetry`'s own exponential backoff (2s → 60s cap) already covers retrying the whole probe over the longer term, so this doesn't weaken retry behavior for the transient cases it's meant to handle (leader not yet ready, etc.) - it only stops an in-progress-forever reconfiguration from spinning unboundedly inside one call.

Also added a `timeout-minutes: 90` safety net on the `ha-integration-tests` CI job (normal runs finish in well under 60 minutes) so any future hang fails fast and visibly instead of silently eating a runner for hours.

## Alternative considered

The issue's own root-cause comment initially floated a generic job-level `timeout-minutes` as *the* fix. That alone would only convert a 6-hour silent hang into a 90-minute one - it doesn't stop the underlying spin, doesn't help outside CI (a real K8s deployment hitting this would burn CPU on the pod indefinitely), and gives up no diagnostic signal about *why* it hung. Bounding the retry policy fixes the actual defect; the timeout is kept as a cheap defense-in-depth safety net, not the primary fix.

## Testing

- `KubernetesAutoJoinRetryTest`: added `probeRetryPolicyIsBoundedNotUnboundedDefault`, asserting the probe client's policy is a `RetryLimited` with the expected bounded attempt count (regression guard against silently reverting to the unbounded default). All 7 tests in the class pass.
- `Issue5275MembershipSelfHealIT` (the integration test that exercises this exact probe path end-to-end against a real 3-node Raft cluster): ran 6 times total (class-level and method-level) with the fix applied - all green, consistent ~15-31s runtime, no behavior change to the happy path.
- Full `ha-raft` module unit test suite: 773 tests, 0 failures.
- `mvn -pl ha-raft -am compile` clean.
- `.github/workflows/mvn-test.yml` YAML syntax validated (`yaml.safe_load`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)