### PR TITLE
fix(#5891): reject malformed host strings in HostUtil.parseHostAddress()

### DIFF
--- a/network/src/main/java/com/arcadedb/network/HostUtil.java
+++ b/network/src/main/java/com/arcadedb/network/HostUtil.java
@@ -40,25 +40,59 @@ public class HostUtil {
         throw new IllegalArgumentException("Invalid host " + host);
 
       final String addr = host.substring(1, closeBracket);
+      if (addr.isEmpty())
+        throw new IllegalArgumentException("Invalid host " + host);
+
       if (closeBracket == host.length() - 1)
         return new String[] { addr, defaultPort };
       if (host.charAt(closeBracket + 1) == ':')
-        return new String[] { addr, host.substring(closeBracket + 2) };
+        return new String[] { addr, validatePort(host, host.substring(closeBracket + 2)) };
 
       throw new IllegalArgumentException("Invalid host " + host);
     }
 
-    // Legacy unbracketed format: colon-count heuristic for fully-expanded IPv6
-    final String[] parts = host.split(":");
-    if (parts.length == 1 || parts.length == 8)
-      // ( IPV4 OR IPV6 ) NO PORT
+    // A bracket outside the RFC 3986 bracketed-IPv6 form above is always malformed.
+    if (host.indexOf('[') >= 0 || host.indexOf(']') >= 0)
+      throw new IllegalArgumentException("Invalid host " + host);
+
+    // Legacy unbracketed format: colon-count heuristic for fully-expanded IPv6.
+    // Split with limit -1 so a trailing colon (e.g. "host:") surfaces as a trailing
+    // empty part instead of being silently dropped.
+    final String[] parts = host.split(":", -1);
+    if (parts.length == 1)
+      // IPV4 OR HOST NAME, NO PORT
       return new String[] { host, defaultPort };
-    else if (parts.length == 2 || parts.length == 9) {
-      // ( IPV4 OR IPV6 ) + PORT
-      final int pos = host.lastIndexOf(":");
-      return new String[] { host.substring(0, pos), host.substring(pos + 1) };
+    else if (parts.length == 2) {
+      // ( IPV4 OR HOST NAME ) + PORT
+      if (parts[0].isEmpty())
+        throw new IllegalArgumentException("Invalid host " + host);
+      return new String[] { parts[0], validatePort(host, parts[1]) };
+    } else if (parts.length == 8 && !host.endsWith(":"))
+      // IPV6 NO PORT
+      return new String[] { host, defaultPort };
+    else if (parts.length == 9 && !host.endsWith(":")) {
+      // IPV6 + PORT
+      final int pos = host.lastIndexOf(':');
+      return new String[] { host.substring(0, pos), validatePort(host, host.substring(pos + 1)) };
     }
 
     throw new IllegalArgumentException("Invalid host " + host);
+  }
+
+  private static String validatePort(final String host, final String port) {
+    if (port.isEmpty())
+      throw new IllegalArgumentException("Invalid host " + host);
+
+    final int value;
+    try {
+      value = Integer.parseInt(port);
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid host " + host);
+    }
+
+    if (value < 1 || value > 65535)
+      throw new IllegalArgumentException("Invalid host " + host);
+
+    return port;
   }
 }

--- a/network/src/main/java/com/arcadedb/network/HostUtil.java
+++ b/network/src/main/java/com/arcadedb/network/HostUtil.java
@@ -40,7 +40,7 @@ public class HostUtil {
         throw new IllegalArgumentException("Invalid host " + host);
 
       final String addr = host.substring(1, closeBracket);
-      if (addr.isEmpty())
+      if (addr.isEmpty() || addr.indexOf('[') >= 0 || addr.indexOf(']') >= 0)
         throw new IllegalArgumentException("Invalid host " + host);
 
       if (closeBracket == host.length() - 1)
@@ -79,6 +79,10 @@ public class HostUtil {
     throw new IllegalArgumentException("Invalid host " + host);
   }
 
+  /**
+   * Validates that {@code port} is a non-empty integer in the range 1-65535. The full original
+   * {@code host} string is only used to name the offending value in the exception message.
+   */
   private static String validatePort(final String host, final String port) {
     if (port.isEmpty())
       throw new IllegalArgumentException("Invalid host " + host);

--- a/network/src/test/java/com/arcadedb/network/HostUtilEdgeCasesTest.java
+++ b/network/src/test/java/com/arcadedb/network/HostUtilEdgeCasesTest.java
@@ -203,4 +203,25 @@ class HostUtilEdgeCasesTest {
     assertThat(HostUtil.parseHostAddress("host:1", HostUtil.CLIENT_DEFAULT_PORT)[1]).isEqualTo("1");
     assertThat(HostUtil.parseHostAddress("host:65535", HostUtil.CLIENT_DEFAULT_PORT)[1]).isEqualTo("65535");
   }
+
+  @Test
+  void bracketedIPv6NonNumericPortIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("[::1]:abc", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void bracketedIPv6NegativePortIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("[::1]:-1", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void embeddedBracketInAddressIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("[a[b]:80", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
 }

--- a/network/src/test/java/com/arcadedb/network/HostUtilEdgeCasesTest.java
+++ b/network/src/test/java/com/arcadedb/network/HostUtilEdgeCasesTest.java
@@ -111,4 +111,96 @@ class HostUtilEdgeCasesTest {
     assertThat(parts[0]).isEqualTo("2001:db8:85a3:0:0:8a2e:370:7334");
     assertThat(parts[1]).isEqualTo(HostUtil.CLIENT_DEFAULT_PORT);
   }
+
+  // -- Malformed inputs that used to be silently accepted (issue #5891) --
+
+  @Test
+  void trailingColonIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("host:", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void doubleTrailingColonIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("host::", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void emptyHostBeforeColonIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress(":2480", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void bracketedIPv6EmptyPortIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("[::1]:", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void bracketedIPv6DoubleColonPortIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("[::1]::2480", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void emptyBracketedAddressIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("[]", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void strayClosingBracketIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("]", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void nonNumericPortIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("host:abc", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void negativePortIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("host:-1", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void outOfRangePortIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("host:99999999999999", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void portZeroIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("host:0", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void portAboveRangeIsRejected() {
+    assertThatThrownBy(() -> HostUtil.parseHostAddress("host:65536", HostUtil.CLIENT_DEFAULT_PORT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host");
+  }
+
+  @Test
+  void validEdgePortsAreAccepted() {
+    assertThat(HostUtil.parseHostAddress("host:1", HostUtil.CLIENT_DEFAULT_PORT)[1]).isEqualTo("1");
+    assertThat(HostUtil.parseHostAddress("host:65535", HostUtil.CLIENT_DEFAULT_PORT)[1]).isEqualTo("65535");
+  }
 }


### PR DESCRIPTION
## Summary
- `HostUtil.parseHostAddress()` accepted several malformed host strings and returned a nonsensical split instead of rejecting them at the parse point, where the diagnostic can still name the offending config value.
- Fixes #5891.

## Root cause
- The unbracketed branch keyed off `host.split(":")`, and `String.split` drops trailing empty strings, so `"host:"` produced `["host"]` (length 1) and the method returned the whole string, colon included, as the host name.
- The bracketed branch checked that the character after `]` was `:` but never that anything valid followed it, so `"[::1]:"` produced an empty port and `"[::1]::2480"` produced a port of `":2480"`.
- Neither branch validated the port was numeric or in range, and a stray `]` outside the bracketed form (e.g. `"]"`) fell through to the unbracketed branch and was accepted as a host name.

## Fix
- Bracketed branch: reject an empty address (`"[]"`), and route the port through a new `validatePort` check.
- Unbracketed branch: reject a host with a `[` or `]` (only valid in the bracketed form above); split with `limit = -1` so a trailing colon surfaces as an empty trailing part instead of being silently dropped; reject an empty host before the port; route the port through `validatePort`.
- New `validatePort` helper: reject empty, non-numeric, or out-of-range (not in 1-65535) ports.
- All rejections keep the existing `Invalid host <value>` message shape, so the diagnostic still names the offending value.

All existing call sites (`RemoteHttpComponent`'s HA leader/replica address parsing, `ArcadeGraph`'s Gremlin remote host list) already immediately do `Integer.parseInt()` on the parsed port, so pre-validating it here turns a `NumberFormatException` several frames away (with no reference to the original config value) into a clear `IllegalArgumentException` naming the input while it's still in scope.

## Test plan
- [x] Added regression tests in `HostUtilEdgeCasesTest` for every malformed input reported in the issue (`host:`, `host::`, `:2480`, `[::1]:`, `[::1]::2480`, `[]`, `]`, `host:abc`, `host:-1`, `host:99999999999999`, `host:0`, `host:65536`) plus valid boundary ports (`1`, `65535`).
- [x] Confirmed the new tests fail against the unmodified code (TDD red step) and pass after the fix.
- [x] `mvn -pl network test` (full network module suite) green.
- [x] `mvn -DskipTests install` (full reactor compile) green, confirming no downstream breakage in `gremlin`, `ha-raft`, `server`.