### PR TITLE
fix(#5863): decouple @props type hint emission from includeMetadata in map2json

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -241,7 +241,7 @@ public class JsonSerializer {
     else
       includePropertiesSet = null;
 
-    final StringBuilder propertyTypes = includeMetadata ? new StringBuilder() : null;
+    final StringBuilder propertyTypes = includeTypeHints ? new StringBuilder() : null;
 
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
       final String propertyName = entry.getKey();
@@ -259,8 +259,10 @@ public class JsonSerializer {
       else
         propertyType = null;
 
-      // Unlike serializeResult (which omits JSON-faithful types), this opt-in metadata path is exhaustive by design.
-      if (includeMetadata && propertyType != null) {
+      // Issue #5863: @props emission is gated by includeTypeHints (off by default), decoupled from
+      // includeMetadata - which keeps meaning "include @rid/@type/@cat/@in/@out" only. Unlike serializeResult
+      // (which omits JSON-faithful types), this opt-in path is exhaustive by design when enabled.
+      if (includeTypeHints && propertyType != null) {
         if (propertyTypes.length() > 0)
           propertyTypes.append(",");
         propertyTypes.append(propertyName).append(":").append(propertyType.getId());

--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -263,7 +263,7 @@ public class JsonSerializer {
       // includeMetadata - which keeps meaning "include @rid/@type/@cat/@in/@out" only. Unlike serializeResult
       // (which omits JSON-faithful types), this opt-in path is exhaustive by design when enabled.
       if (includeTypeHints && propertyType != null) {
-        if (propertyTypes.length() > 0)
+        if (!propertyTypes.isEmpty())
           propertyTypes.append(",");
         propertyTypes.append(propertyName).append(":").append(propertyType.getId());
       }

--- a/engine/src/test/java/com/arcadedb/serializer/JsonSerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/JsonSerializerTest.java
@@ -72,6 +72,26 @@ class JsonSerializerTest extends TestHelper {
     }
   }
 
+  /**
+   * Issue #5863: {@code map2json} used to gate {@code @props} emission on {@code includeMetadata}, so any
+   * {@code Document.toJSON(true)} caller - and, via {@code ChangeEvent}, every WebSocket subscriber - got the
+   * hint for free on a schemaless property with a lossy-through-JSON type. {@code MutableDocument#toJSON}
+   * always builds its own default {@link JsonSerializer}, so this pins the off-by-default behavior at the
+   * Document API level, mirroring {@link #propsHintOffByDefault()} for {@code serializeResult}.
+   */
+  @Test
+  void map2jsonPropsHintOffByDefaultForSchemalessLossyProperty() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Issue5863SchemalessType");
+      final MutableDocument doc = database.newDocument("Issue5863SchemalessType").set("dynamicLong", 42L).save();
+
+      final JSONObject json = doc.toJSON(true);
+      assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isFalse();
+      assertThat(json.getLong("dynamicLong")).isEqualTo(42L);
+      assertThat(json.getString("@type")).isEqualTo("Issue5863SchemalessType");
+    });
+  }
+
   @Test
   void serializeDocument() {
     database.transaction(() -> {

--- a/server/src/test/java/com/arcadedb/server/http/ws/ChangeEventTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/ChangeEventTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.schema.Property;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5863: {@code WebSocketEventBus} calls {@code record.toJSON(true)} once per change
+ * event and broadcasts the resulting JSON to every connected subscriber, with no per-subscriber signal to opt
+ * in to the {@code @props} type-hint. It must therefore never appear in the broadcast payload.
+ */
+class ChangeEventTest {
+  private DatabaseFactory factory;
+  private Database        database;
+
+  @BeforeEach
+  void setUp() {
+    final String path = "./target/databases/changeevent5863_" + UUID.randomUUID();
+    factory = new DatabaseFactory(path);
+    database = factory.create();
+    database.getSchema().createDocumentType("Doc");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+    if (factory != null)
+      factory.close();
+  }
+
+  @Test
+  void changeEventNeverEmitsPropsHint() {
+    database.begin();
+    // A dynamic (non-schema) LONG property is lossy through JSON, exactly the shape that leaked @props before the fix.
+    final MutableDocument doc = database.newDocument("Doc").set("dynamicLong", 99L);
+    doc.save();
+    database.commit();
+
+    final String json = new ChangeEvent(ChangeEvent.TYPE.CREATE, doc).toJSON();
+
+    assertThat(json).doesNotContain(Property.PROPERTY_TYPES_PROPERTY);
+    assertThat(json).contains("\"dynamicLong\":99");
+  }
+}


### PR DESCRIPTION
## Description

`map2json` was using the `includeMetadata` parameter to decide whether to emit the `@props` per-column JSON type-hint string. This bundled `@props` into every `toJSON(true)` call, including the `WebSocketEventBus`/`ChangeEvent` broadcast path where no consumer can opt in to receiving it (and, incidentally, the Redis and Postgres wire-protocol paths, which call `record.toJSON(true)` too).

The `WebSocketEventBus` calls `record.toJSON(true)` **once** per change event and broadcasts the resulting JSON string to **every** connected subscriber. There is no per-subscriber request to key an opt-in off of, so every subscriber got `@props` on any property whose type is lossy through JSON (`SHORT`, `FLOAT`, `LONG`, temporals, ...) and isn't declared in the schema.

## Fix

Mirrors the #5860 fix for `serializeResult`:

- `map2json` now uses the serializer-level `includeTypeHints` field (off by default) instead of the `includeMetadata` parameter to decide whether to emit `@props`.
- `includeMetadata` keeps its original meaning: "include `@rid`/`@type`/`@cat`/`@in`/`@out`" identity metadata only (unchanged, still handled by the `MutableDocument`/`ImmutableDocument`/`DetachedDocument` wrappers).
- The `@props` hint is now emitted only when the caller explicitly enables it via `JsonSerializer.setIncludeTypeHints(true)`.

## Regression proof

Reverting just the `JsonSerializer.java` change reproduces the exact leak reported in #5863 - the new `ChangeEventTest` fails with:
```
"record":{"dynamicLong":99,"@props":"dynamicLong:3","@cat":"d","@type":"Doc","@rid":"#1:0"}
```

## Tests

- `JsonSerializerTest#map2jsonPropsHintOffByDefaultForSchemalessLossyProperty` - pins the off-by-default behavior at the `Document.toJSON(true)` API level (mirrors `propsHintOffByDefault` from #5860).
- `ChangeEventTest#changeEventNeverEmitsPropsHint` (new file) - asserts a broadcast `ChangeEvent` payload never contains `@props`, exercising `ChangeEvent`/`WebSocketEventBus` directly with no HTTP server needed.
- Ran `JsonSerializerTest`, `JSONSerializerTest`, `WebSocketEventBusIT`, `Issue5024WebSocketEventBusConcurrencyTest`, and the full `redisw`/`postgresw` module test suites (all green) plus a full reactor compile.

## Note on #5952

This supersedes #5952 (same fix, opened by @waterWang, thank you for the report and initial patch). That PR's CI failures were unrelated to its one-line change: `claude-review` failed on an OIDC-token permission limitation for fork PRs, `unit-tests` hit a pre-existing stale-assertion bug in `RangeFunctionTest` that was fixed on `main` by #5954 minutes after that PR's CI ran, and `integration-tests`/`ha-integration-tests`/`coverage-report` match known chronic CI flakes unrelated to this change. This PR adds the test coverage #5952 was missing and confirms the fix against current `main`.

Closes #5863