### PR TITLE
fix(#5890): RaftHAPlugin.stopService() shuts down SnapshotHttpHandler and PostVerifyDatabaseHandler executors

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
@@ -58,8 +58,9 @@ public class PostVerifyDatabaseHandler extends AbstractServerHttpHandler {
   private final RaftHAPlugin    plugin;
   /**
    * Dedicated pool for fanning peer verify calls out in parallel. Cached (threads idle out after
-   * 60 s by default) so a rarely-invoked endpoint does not keep N idle threads around, daemon so
-   * the JVM can shut down without an explicit close on this handler.
+   * 60 s by default) so a rarely-invoked endpoint does not keep N idle threads around; daemon so a
+   * process exit is never blocked on it. {@link #close()} shuts it down explicitly on a plugin
+   * stop/restart within one JVM, where daemon-ness alone would not prevent a leak (issue #5890).
    */
   private final ExecutorService peerQueryExecutor;
 
@@ -72,6 +73,16 @@ public class PostVerifyDatabaseHandler extends AbstractServerHttpHandler {
       t.setDaemon(true);
       return t;
     });
+  }
+
+  /**
+   * Shuts down the peer-query pool. Called by {@link RaftHAPlugin#stopService()} so that a server
+   * stop/restart cycle within one JVM does not leak the pool (issue #5890): a fresh
+   * {@code PostVerifyDatabaseHandler} (and pool) is otherwise created on every restart while the
+   * previous one, and any in-flight peer queries on it, are left running.
+   */
+  public void close() {
+    peerQueryExecutor.shutdownNow();
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
@@ -87,7 +87,7 @@ public class PostVerifyDatabaseHandler extends AbstractServerHttpHandler {
    * so an in-flight peer query can still linger up to {@code PEER_READ_TIMEOUT_MS} after this returns.
    * Harmless (daemon threads, no new work accepted), just not immediate.
    */
-  public void close() {
+  void close() {
     peerQueryExecutor.shutdownNow();
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
@@ -80,6 +80,11 @@ public class PostVerifyDatabaseHandler extends AbstractServerHttpHandler {
    * stop/restart cycle within one JVM does not leak the pool (issue #5890): a fresh
    * {@code PostVerifyDatabaseHandler} (and pool) is otherwise created on every restart while the
    * previous one, and any in-flight peer queries on it, are left running.
+   * <p>
+   * Not instantaneous: {@code shutdownNow()} interrupts pool threads, but a thread blocked in
+   * {@link java.net.HttpURLConnection}'s blocking socket read is not woken by {@code Thread.interrupt()},
+   * so an in-flight peer query can still linger up to {@code PEER_READ_TIMEOUT_MS} after this returns.
+   * Harmless (daemon threads, no new work accepted), just not immediate.
    */
   public void close() {
     peerQueryExecutor.shutdownNow();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
@@ -171,9 +172,7 @@ public class PostVerifyDatabaseHandler extends AbstractServerHttpHandler {
     for (final RaftPeer peer : raftHAServer.getRaftGroup().getPeers()) {
       if (peer.getId().equals(raftHAServer.getLocalPeerId()))
         continue;
-      futures.add(CompletableFuture.supplyAsync(
-          () -> queryPeer(raftHAServer, peer, databaseName, localChecksums, user, useSsl),
-          peerQueryExecutor));
+      futures.add(submitPeerQuery(raftHAServer, peer, databaseName, localChecksums, user, useSsl));
     }
 
     final JSONArray peerResults = new JSONArray();
@@ -199,6 +198,29 @@ public class PostVerifyDatabaseHandler extends AbstractServerHttpHandler {
     result.put("overallStatus", allConsistent ? "ALL_CONSISTENT" : "INCONSISTENCY_DETECTED");
     response.put("result", result);
     return new ExecutionResponse(200, response.toString());
+  }
+
+  /**
+   * Submits a peer query to {@link #peerQueryExecutor}. {@code stopService()}/a repeated {@code registerAPI()}
+   * call can shut the pool down concurrently with an in-flight request (issue #5890 follow-up: closing the
+   * pool introduced this narrow race, which could not happen while it leaked); {@code ExecutorService.execute()}
+   * then throws {@link RejectedExecutionException} synchronously, before {@code queryPeer} ever runs. Catching
+   * it here and degrading to a completed ERROR future keeps that one peer's failure inside the normal
+   * per-peer error reporting instead of aborting the whole request with an uncaught exception. Package-private
+   * for unit testing.
+   */
+  CompletableFuture<JSONObject> submitPeerQuery(final RaftHAServer raftHAServer, final RaftPeer peer, final String databaseName,
+      final JSONObject localChecksums, final ServerSecurityUser user, final boolean useSsl) {
+    try {
+      return CompletableFuture.supplyAsync(
+          () -> queryPeer(raftHAServer, peer, databaseName, localChecksums, user, useSsl), peerQueryExecutor);
+    } catch (final RejectedExecutionException e) {
+      final JSONObject err = new JSONObject();
+      err.put("peerId", peer.getId().toString());
+      err.put("status", "ERROR");
+      err.put("error", "peer query rejected: server is stopping");
+      return CompletableFuture.completedFuture(err);
+    }
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -64,8 +64,11 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   // instance (and thus fresh handler instances) is created by PluginManager on every server
   // start, so stopService() must close the ones THIS instance created rather than relying on any
   // static/shared state (issue #5890). Unlike raftHAServer above, plain (non-volatile) fields:
-  // registerAPI()/stopService() only ever run on the server's own sequential start/stop thread,
-  // never concurrently with each other or with one another's reads of these two fields.
+  // registerAPI() (called from the thread that invoked ArcadeDBServer.start()) and stopService()
+  // (which can run on that same thread OR on the JVM shutdown-hook thread via stopFromShutdownHook())
+  // are never concurrent with each other, but the reason is ArcadeDBServer.lifecycleLock - a
+  // ReentrantLock wrapping startInternal()/stopInternal() - giving a happens-before edge across
+  // threads, not thread confinement. Safe only as long as that lock still wraps both paths.
   private SnapshotHttpHandler       snapshotHttpHandler;
   private PostVerifyDatabaseHandler postVerifyDatabaseHandler;
 
@@ -143,9 +146,12 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     if (server != null)
       server.setDatabaseWrapper(null);
 
-    // Close the handlers' background executors. registerAPI() runs on THIS instance before
-    // stopService() ever can (see its call sites), so both fields are already populated whenever
-    // this plugin was actually wired into the HTTP server (issue #5890).
+    // Close the handlers' background executors. The null-guards below are not just for the case
+    // where registerAPI() never ran (e.g. a discovered-but-never-wired plugin): this same
+    // stopService() is invoked TWICE on every HA-enabled shutdown - once via PluginManager.stopPlugins()
+    // (RaftHAPlugin is itself a discovered ServerPlugin) and once via ArcadeDBServer.stopInternal()'s
+    // direct haServer.stopService() call, since startService() above did server.setHA(this), making
+    // ArcadeDBServer.haServer the very same instance. The second call must be a no-op (issue #5890).
     if (snapshotHttpHandler != null) {
       snapshotHttpHandler.close();
       snapshotHttpHandler = null;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -60,6 +60,13 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   // database per plugin lifetime instead of on every (re)wrap.
   private final Set<String> warnedSingleBucketDatabases = ConcurrentHashMap.newKeySet();
 
+  // Handlers registered by registerAPI() that own a background executor. A fresh RaftHAPlugin
+  // instance (and thus fresh handler instances) is created by PluginManager on every server
+  // start, so stopService() must close the ones THIS instance created rather than relying on any
+  // static/shared state (issue #5890).
+  private SnapshotHttpHandler       snapshotHttpHandler;
+  private PostVerifyDatabaseHandler postVerifyDatabaseHandler;
+
   @Override
   public void configure(final ArcadeDBServer arcadeDBServer, final ContextConfiguration configuration) {
     this.server = arcadeDBServer;
@@ -133,6 +140,18 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     // startService() will set a fresh wrapper and call rewrapDatabases().
     if (server != null)
       server.setDatabaseWrapper(null);
+
+    // Close the handlers' background executors. registerAPI() runs on THIS instance before
+    // stopService() ever can (see its call sites), so both fields are already populated whenever
+    // this plugin was actually wired into the HTTP server (issue #5890).
+    if (snapshotHttpHandler != null) {
+      snapshotHttpHandler.close();
+      snapshotHttpHandler = null;
+    }
+    if (postVerifyDatabaseHandler != null) {
+      postVerifyDatabaseHandler.close();
+      postVerifyDatabaseHandler = null;
+    }
   }
 
   public RaftHAServer getRaftHAServer() {
@@ -190,14 +209,16 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     // so isRaftEnabled() cannot be checked here.
     routes.addExactPath("/api/v1/cluster", new GetClusterHandler(httpServer, this));
     LogManager.instance().log(this, Level.INFO, "Raft cluster status endpoint registered at /api/v1/cluster");
-    routes.addPrefixPath("/api/v1/ha/snapshot/", new SnapshotHttpHandler(httpServer));
+    snapshotHttpHandler = new SnapshotHttpHandler(httpServer);
+    routes.addPrefixPath("/api/v1/ha/snapshot/", snapshotHttpHandler);
     LogManager.instance().log(this, Level.INFO, "Raft snapshot endpoint registered at /api/v1/ha/snapshot/{database}");
     routes.addExactPath("/api/v1/cluster/peer", new PostAddPeerHandler(httpServer, this));
     routes.addPrefixPath("/api/v1/cluster/peer/", new DeletePeerHandler(httpServer, this));
     routes.addExactPath("/api/v1/cluster/leader", new PostTransferLeaderHandler(httpServer, this));
     routes.addExactPath("/api/v1/cluster/stepdown", new PostStepDownHandler(httpServer, this));
     routes.addExactPath("/api/v1/cluster/leave", new PostLeaveHandler(httpServer, this));
-    routes.addPrefixPath("/api/v1/cluster/verify/", new PostVerifyDatabaseHandler(httpServer, this));
+    postVerifyDatabaseHandler = new PostVerifyDatabaseHandler(httpServer, this);
+    routes.addPrefixPath("/api/v1/cluster/verify/", postVerifyDatabaseHandler);
     routes.addPrefixPath("/api/v1/cluster/resync/", new PostResyncDatabaseHandler(httpServer, this));
     // Issue #4147: pre-bootstrap state RPC, used by the bootstrap leader at first cluster
     // formation to collect each peer's (fingerprint, lastTxId) per database.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -209,6 +209,12 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     // so isRaftEnabled() cannot be checked here.
     routes.addExactPath("/api/v1/cluster", new GetClusterHandler(httpServer, this));
     LogManager.instance().log(this, Level.INFO, "Raft cluster status endpoint registered at /api/v1/cluster");
+    // Close a previous handler before replacing it: registerAPI() is expected to run once per plugin
+    // instance (a fresh RaftHAPlugin is created on every server start), but closing defensively here
+    // means a repeated call can never re-leak the executor regardless of that caller-side invariant
+    // (issue #5890).
+    if (snapshotHttpHandler != null)
+      snapshotHttpHandler.close();
     snapshotHttpHandler = new SnapshotHttpHandler(httpServer);
     routes.addPrefixPath("/api/v1/ha/snapshot/", snapshotHttpHandler);
     LogManager.instance().log(this, Level.INFO, "Raft snapshot endpoint registered at /api/v1/ha/snapshot/{database}");
@@ -217,6 +223,9 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     routes.addExactPath("/api/v1/cluster/leader", new PostTransferLeaderHandler(httpServer, this));
     routes.addExactPath("/api/v1/cluster/stepdown", new PostStepDownHandler(httpServer, this));
     routes.addExactPath("/api/v1/cluster/leave", new PostLeaveHandler(httpServer, this));
+    // Same defensive close as snapshotHttpHandler above (issue #5890).
+    if (postVerifyDatabaseHandler != null)
+      postVerifyDatabaseHandler.close();
     postVerifyDatabaseHandler = new PostVerifyDatabaseHandler(httpServer, this);
     routes.addPrefixPath("/api/v1/cluster/verify/", postVerifyDatabaseHandler);
     routes.addPrefixPath("/api/v1/cluster/resync/", new PostResyncDatabaseHandler(httpServer, this));

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -63,7 +63,9 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   // Handlers registered by registerAPI() that own a background executor. A fresh RaftHAPlugin
   // instance (and thus fresh handler instances) is created by PluginManager on every server
   // start, so stopService() must close the ones THIS instance created rather than relying on any
-  // static/shared state (issue #5890).
+  // static/shared state (issue #5890). Unlike raftHAServer above, plain (non-volatile) fields:
+  // registerAPI()/stopService() only ever run on the server's own sequential start/stop thread,
+  // never concurrently with each other or with one another's reads of these two fields.
   private SnapshotHttpHandler       snapshotHttpHandler;
   private PostVerifyDatabaseHandler postVerifyDatabaseHandler;
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -110,6 +110,16 @@ public class SnapshotHttpHandler implements HttpHandler {
     this.httpServer = httpServer;
   }
 
+  /**
+   * Shuts down the stall watchdog scheduler. Called by {@link RaftHAPlugin#stopService()} so that
+   * a server stop/restart cycle within one JVM does not leak the watchdog thread (issue #5890): a
+   * fresh {@code SnapshotHttpHandler} (and watchdog) is otherwise created on every restart while the
+   * previous one is left running.
+   */
+  public void close() {
+    watchdogExecutor.shutdownNow();
+  }
+
   @Override
   public void handleRequest(final HttpServerExchange exchange) throws Exception {
     if (exchange.isInIoThread()) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -117,7 +117,7 @@ public class SnapshotHttpHandler implements HttpHandler {
    * fresh {@code SnapshotHttpHandler} (and watchdog) is otherwise created on every restart while the
    * previous one is left running.
    */
-  public void close() {
+  void close() {
     watchdogExecutor.shutdownNow();
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
@@ -324,8 +325,8 @@ public class SnapshotHttpHandler implements HttpHandler {
     // Poll a few times within the timeout window so a stall is detected (and the semaphore slot freed)
     // promptly once progress halts, without spinning. Floored at 1s for very small configured timeouts.
     final long pollIntervalMs = Math.max(1_000L, writeTimeoutMs / 4);
-    final ScheduledFuture<?> watchdog = scheduleStallWatchdog(watchdogExecutor, completed, lastProgressMs,
-        writeTimeoutMs, pollIntervalMs, databaseName, () -> {
+    final ScheduledFuture<?> watchdog = scheduleWatchdogOrSkip(completed, lastProgressMs, writeTimeoutMs, pollIntervalMs,
+        databaseName, () -> {
           try {
             exchange.getConnection().close();
           } catch (final Exception ignored) {
@@ -397,7 +398,8 @@ public class SnapshotHttpHandler implements HttpHandler {
       }
     } finally {
       completed.set(true);
-      watchdog.cancel(false);
+      if (watchdog != null)
+        watchdog.cancel(false);
     }
   }
 
@@ -503,6 +505,30 @@ public class SnapshotHttpHandler implements HttpHandler {
         onStall.run();
       }
     }, pollIntervalMs, pollIntervalMs, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Calls {@link #scheduleStallWatchdog}, degrading to an unmonitored transfer (returns {@code null})
+   * instead of propagating {@link RejectedExecutionException} when {@code watchdogExecutor} has already
+   * been shut down. {@code ArcadeDBServer.stopInternal()} stops plugins - which shuts down this handler's
+   * executor via {@code close()} - before it stops the HTTP server, so a request already in flight, or one
+   * accepted in that window, can reach this call after the executor is shut down; the raw
+   * {@code scheduleWithFixedDelay} call throws synchronously in that case, before this method's caller's
+   * try block is even entered (issue #5890 follow-up; same fix shape as
+   * {@code PostVerifyDatabaseHandler#submitPeerQuery}). {@code close()} only fires during shutdown, so
+   * losing the stall watchdog for the rest of this one transfer is an acceptable tradeoff. Package-private
+   * for unit testing.
+   */
+  ScheduledFuture<?> scheduleWatchdogOrSkip(final AtomicBoolean completed, final AtomicLong lastProgressMs,
+      final long writeTimeoutMs, final long pollIntervalMs, final String databaseName, final Runnable onStall) {
+    try {
+      return scheduleStallWatchdog(watchdogExecutor, completed, lastProgressMs, writeTimeoutMs, pollIntervalMs,
+          databaseName, onStall);
+    } catch (final RejectedExecutionException e) {
+      LogManager.instance().log(this, Level.FINE,
+          "Snapshot watchdog rejected for '%s': the handler is shutting down, transfer proceeds unmonitored", databaseName);
+      return null;
+    }
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandlerRejectedExecutionTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandlerRejectedExecutionTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.serializer.json.JSONObject;
 import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
@@ -44,7 +45,7 @@ class PostVerifyDatabaseHandlerRejectedExecutionTest {
     final PostVerifyDatabaseHandler handler = new PostVerifyDatabaseHandler(null, new RaftHAPlugin());
     handler.close(); // shuts down peerQueryExecutor, simulating a concurrent stopService()
 
-    final RaftPeer peer = RaftPeer.newBuilder().setId("peer1").build();
+    final RaftPeer peer = RaftPeer.newBuilder().setId(RaftPeerId.valueOf("peer1")).build();
     // raftHAServer/localChecksums/user are never dereferenced: the pool rejects the submission before
     // queryPeer's lambda body ever runs, so null is safe here.
     final CompletableFuture<JSONObject> future =

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandlerRejectedExecutionTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandlerRejectedExecutionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import org.apache.ratis.protocol.RaftPeer;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5890 (code review follow-up): closing {@code PostVerifyDatabaseHandler}'s
+ * {@code peerQueryExecutor} in {@code RaftHAPlugin.stopService()} means a request already fanning out to
+ * peers can now race a concurrent shutdown. {@code CompletableFuture.supplyAsync(...)} submitting to an
+ * already-shut-down pool throws {@link java.util.concurrent.RejectedExecutionException} synchronously -
+ * a failure mode that could not previously occur, since the pool was never shut down at all.
+ * {@link PostVerifyDatabaseHandler#submitPeerQuery} must degrade that into a normal per-peer ERROR result
+ * instead of letting the exception abort the whole request.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostVerifyDatabaseHandlerRejectedExecutionTest {
+
+  @Test
+  void submitPeerQueryDegradesGracefullyWhenThePoolIsAlreadyShutDown() {
+    final PostVerifyDatabaseHandler handler = new PostVerifyDatabaseHandler(null, new RaftHAPlugin());
+    handler.close(); // shuts down peerQueryExecutor, simulating a concurrent stopService()
+
+    final RaftPeer peer = RaftPeer.newBuilder().setId("peer1").build();
+    // raftHAServer/localChecksums/user are never dereferenced: the pool rejects the submission before
+    // queryPeer's lambda body ever runs, so null is safe here.
+    final CompletableFuture<JSONObject> future =
+        handler.submitPeerQuery(null, peer, "mydb", null, null, false);
+
+    final JSONObject result = future.join();
+    assertThat(result.getString("status", null)).isEqualTo("ERROR");
+    assertThat(result.getString("peerId", null)).isEqualTo("peer1");
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAPluginExecutorLeakTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAPluginExecutorLeakTest.java
@@ -82,6 +82,26 @@ class RaftHAPluginExecutorLeakTest {
   }
 
   @Test
+  void stopServiceIsIdempotentWhenCalledTwiceBackToBack() throws Exception {
+    // The real-world trigger for the null-guards: ArcadeDBServer.stopInternal() invokes stopService() on
+    // this SAME instance twice on every HA shutdown - once via PluginManager.stopPlugins() (RaftHAPlugin
+    // is itself a discovered ServerPlugin) and once directly via haServer.stopService(), since
+    // startService() aliases ArcadeDBServer.haServer to this instance via server.setHA(this) (issue #5890).
+    final RaftHAPlugin plugin = new RaftHAPlugin();
+    plugin.registerAPI(null, new PathHandler());
+    final SnapshotHttpHandler snapshotHandler = getField(plugin, "snapshotHttpHandler", SnapshotHttpHandler.class);
+    final ScheduledExecutorService watchdogExecutor = getField(snapshotHandler, "watchdogExecutor", ScheduledExecutorService.class);
+    final PostVerifyDatabaseHandler verifyHandler = getField(plugin, "postVerifyDatabaseHandler", PostVerifyDatabaseHandler.class);
+    final ExecutorService peerQueryExecutor = getField(verifyHandler, "peerQueryExecutor", ExecutorService.class);
+
+    plugin.stopService();
+    plugin.stopService(); // must be a no-op, not throw
+
+    assertThat(watchdogExecutor.isShutdown()).isTrue();
+    assertThat(peerQueryExecutor.isShutdown()).isTrue();
+  }
+
+  @Test
   void registerAPIClosesAPreviouslyRegisteredSnapshotHandlerBeforeReplacingIt() throws Exception {
     // Defensive close in registerAPI() itself: even without an intervening stopService(), a second
     // registerAPI() call must not leak the first handler's executor (issue #5890).

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAPluginExecutorLeakTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAPluginExecutorLeakTest.java
@@ -81,6 +81,38 @@ class RaftHAPluginExecutorLeakTest {
     plugin.stopService();
   }
 
+  @Test
+  void registerAPIClosesAPreviouslyRegisteredSnapshotHandlerBeforeReplacingIt() throws Exception {
+    // Defensive close in registerAPI() itself: even without an intervening stopService(), a second
+    // registerAPI() call must not leak the first handler's executor (issue #5890).
+    final RaftHAPlugin plugin = new RaftHAPlugin();
+    plugin.registerAPI(null, new PathHandler());
+    final SnapshotHttpHandler firstHandler = getField(plugin, "snapshotHttpHandler", SnapshotHttpHandler.class);
+    final ScheduledExecutorService firstWatchdogExecutor = getField(firstHandler, "watchdogExecutor", ScheduledExecutorService.class);
+
+    plugin.registerAPI(null, new PathHandler());
+
+    assertThat(firstWatchdogExecutor.isShutdown())
+        .as("A second registerAPI() call must close the previous SnapshotHttpHandler's watchdog executor")
+        .isTrue();
+    assertThat(getField(plugin, "snapshotHttpHandler", SnapshotHttpHandler.class)).isNotSameAs(firstHandler);
+  }
+
+  @Test
+  void registerAPIClosesAPreviouslyRegisteredVerifyHandlerBeforeReplacingIt() throws Exception {
+    final RaftHAPlugin plugin = new RaftHAPlugin();
+    plugin.registerAPI(null, new PathHandler());
+    final PostVerifyDatabaseHandler firstHandler = getField(plugin, "postVerifyDatabaseHandler", PostVerifyDatabaseHandler.class);
+    final ExecutorService firstPeerQueryExecutor = getField(firstHandler, "peerQueryExecutor", ExecutorService.class);
+
+    plugin.registerAPI(null, new PathHandler());
+
+    assertThat(firstPeerQueryExecutor.isShutdown())
+        .as("A second registerAPI() call must close the previous PostVerifyDatabaseHandler's peer-query pool")
+        .isTrue();
+    assertThat(getField(plugin, "postVerifyDatabaseHandler", PostVerifyDatabaseHandler.class)).isNotSameAs(firstHandler);
+  }
+
   @SuppressWarnings("unchecked")
   private static <T> T getField(final Object target, final String fieldName, final Class<T> type) throws Exception {
     final Field field = target.getClass().getDeclaredField(fieldName);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAPluginExecutorLeakTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAPluginExecutorLeakTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import io.undertow.server.handlers.PathHandler;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5890: {@code RaftHAPlugin.stopService()} left the {@link SnapshotHttpHandler}
+ * watchdog scheduler and the {@link PostVerifyDatabaseHandler} peer-query pool running after the plugin
+ * stopped. {@code registerAPI()} runs once per {@code HttpServer.setupRoutes()} call, and a fresh
+ * {@code RaftHAPlugin} (and thus fresh handlers) is created by {@code PluginManager} on every server start,
+ * so an in-JVM stop/start cycle (test suites, embedded deployments) leaked one watchdog thread and one
+ * cached thread pool per restart.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class RaftHAPluginExecutorLeakTest {
+
+  @Test
+  void stopServiceShutsDownSnapshotHandlerWatchdogExecutor() throws Exception {
+    final RaftHAPlugin plugin = new RaftHAPlugin();
+    plugin.registerAPI(null, new PathHandler());
+
+    final SnapshotHttpHandler snapshotHandler = getField(plugin, "snapshotHttpHandler", SnapshotHttpHandler.class);
+    final ScheduledExecutorService watchdogExecutor = getField(snapshotHandler, "watchdogExecutor", ScheduledExecutorService.class);
+    assertThat(watchdogExecutor.isShutdown()).isFalse();
+
+    plugin.stopService();
+
+    assertThat(watchdogExecutor.isShutdown())
+        .as("SnapshotHttpHandler's watchdog scheduler must be shut down when the plugin stops, or every "
+            + "in-JVM server restart leaks a watchdog thread (issue #5890)")
+        .isTrue();
+  }
+
+  @Test
+  void stopServiceShutsDownVerifyHandlerPeerQueryExecutor() throws Exception {
+    final RaftHAPlugin plugin = new RaftHAPlugin();
+    plugin.registerAPI(null, new PathHandler());
+
+    final PostVerifyDatabaseHandler verifyHandler = getField(plugin, "postVerifyDatabaseHandler", PostVerifyDatabaseHandler.class);
+    final ExecutorService peerQueryExecutor = getField(verifyHandler, "peerQueryExecutor", ExecutorService.class);
+    assertThat(peerQueryExecutor.isShutdown()).isFalse();
+
+    plugin.stopService();
+
+    assertThat(peerQueryExecutor.isShutdown())
+        .as("PostVerifyDatabaseHandler's peer-query pool must be shut down when the plugin stops, or every "
+            + "in-JVM server restart leaks a cached thread pool (issue #5890)")
+        .isTrue();
+  }
+
+  @Test
+  void stopServiceIsNullSafeWhenHandlersWereNeverRegistered() {
+    // registerAPI() is only reached once the plugin is actually wired into the HTTP server; stopService()
+    // must not NPE if it is invoked without that having happened.
+    final RaftHAPlugin plugin = new RaftHAPlugin();
+    plugin.stopService();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T getField(final Object target, final String fieldName, final Class<T> type) throws Exception {
+    final Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return (T) field.get(target);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerRejectedExecutionTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerRejectedExecutionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5890 (code review follow-up): {@code ArcadeDBServer.stopInternal()} stops
+ * plugins - closing {@code SnapshotHttpHandler}'s {@code watchdogExecutor} via {@code close()} - before it
+ * stops the HTTP server, so a snapshot request already in flight, or one accepted in that window, can reach
+ * the watchdog scheduling call after the executor is shut down. {@code ScheduledExecutorService.scheduleWithFixedDelay}
+ * throws {@link java.util.concurrent.RejectedExecutionException} synchronously in that case - a failure mode
+ * that could not previously occur, since the executor was never shut down while the handler was alive.
+ * {@link SnapshotHttpHandler#scheduleWatchdogOrSkip} must degrade to an unmonitored transfer instead of
+ * letting the exception escape {@code handleRequest()} uncaught.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SnapshotHttpHandlerRejectedExecutionTest {
+
+  @Test
+  void scheduleWatchdogOrSkipReturnsNullWhenThePoolIsAlreadyShutDown() {
+    final SnapshotHttpHandler handler = new SnapshotHttpHandler(null);
+    handler.close(); // shuts down watchdogExecutor, simulating a concurrent stopService()
+
+    final ScheduledFuture<?> watchdog = handler.scheduleWatchdogOrSkip(
+        new AtomicBoolean(false), new AtomicLong(System.currentTimeMillis()), 30_000L, 5_000L, "mydb", () -> { });
+
+    assertThat(watchdog == null).isTrue();
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #5890.

`RaftHAPlugin.registerAPI()` constructs a fresh `SnapshotHttpHandler` (owns a `watchdogExecutor` `ScheduledExecutorService`) and a fresh `PostVerifyDatabaseHandler` (owns a `peerQueryExecutor` cached thread pool) every time it runs, but both instances were discarded straight into `PathHandler.addPrefixPath(...)` without RaftHAPlugin keeping a reference. `stopService()` therefore had no way to reach them.

`PluginManager` creates a brand-new `RaftHAPlugin` instance (via `ServiceLoader`) on every `ArcadeDBServer.start()`, and `registerAPI()` runs again on that fresh instance before `stopService()` on the previous instance ever gets called. So every in-JVM server stop/start cycle - test suites, embedded deployments - leaked one watchdog thread (`SnapshotHttpHandler`) and one cached thread pool (`PostVerifyDatabaseHandler`), on top of the previous instances' in-flight work outliving the stopped server.

## Fix
- `RaftHAPlugin` now keeps the handler instances it creates in `registerAPI()` in two fields.
- Both `SnapshotHttpHandler` and `PostVerifyDatabaseHandler` gained a `close()` method that shuts down their executor.
- `RaftHAPlugin.stopService()` calls `close()` on both (null-guarded, since `registerAPI()` may never have run) and clears the fields.

Same defect class as #5850 (`HAReplicationMetrics`'s scheduler) and the `PrometheusMetricsPlugin` finding noted in that issue's comments - each is a "startService/registerAPI creates it, stopService doesn't clean it up" leak site, but a different owner/fix location, so this PR only addresses #5890 (`RaftHAPlugin`'s two handlers).

## Test plan
- Added `RaftHAPluginExecutorLeakTest`: calls `registerAPI()` then `stopService()` on a `RaftHAPlugin` instance and asserts (via reflection on the package-private/private fields, matching the existing style of `SnapshotHttpHandlerSuspendLockTest`/`SnapshotHttpHandlerDisconnectTest`) that both executors report `isShutdown() == true` afterward. Also covers the `stopService()` null-safety when `registerAPI()` was never reached.
- Verified the new test fails against the pre-fix code (stashed the fix, reran - both assertions failed with `NoSuchFieldException` since the fields didn't exist yet) and passes with the fix restored.
- `mvn -pl ha-raft -am compile` and `test-compile` succeed.
- Ran the new test plus the existing `RaftHAPluginTest`, `SnapshotHttpHandlerSuspendLockTest`, `SnapshotHttpHandlerDisconnectTest`, `PostVerifyDatabaseHandlerTest` - all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)