### PR TITLE
fix(#5889): replace shared static SimpleDateFormat with thread-safe DateTimeFormatter

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/backup/format/AbstractBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/AbstractBackupFormat.java
@@ -21,6 +21,7 @@ package com.arcadedb.integration.backup.format;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.integration.backup.BackupSettings;
 import com.arcadedb.integration.importer.ConsoleLogger;
+import com.arcadedb.utility.DateUtils;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -29,8 +30,7 @@ public abstract class AbstractBackupFormat {
   protected final        BackupSettings    settings;
   protected final        DatabaseInternal  database;
   protected final        ConsoleLogger     logger;
-  protected static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-      .withZone(ZoneId.systemDefault());
+  protected static final DateTimeFormatter dateFormat = DateUtils.getFormatter("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
   protected AbstractBackupFormat(final DatabaseInternal database, final BackupSettings settings, final ConsoleLogger logger) {
     this.database = database;

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/AbstractBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/AbstractBackupFormat.java
@@ -22,14 +22,15 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.integration.backup.BackupSettings;
 import com.arcadedb.integration.importer.ConsoleLogger;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 public abstract class AbstractBackupFormat {
-  protected final        BackupSettings   settings;
-  protected final        DatabaseInternal database;
-  protected final        ConsoleLogger    logger;
-  protected static final DateFormat       dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+  protected final        BackupSettings    settings;
+  protected final        DatabaseInternal  database;
+  protected final        ConsoleLogger     logger;
+  protected static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+      .withZone(ZoneId.systemDefault());
 
   protected AbstractBackupFormat(final DatabaseInternal database, final BackupSettings settings, final ConsoleLogger logger) {
     this.database = database;

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/AbstractExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/AbstractExporterFormat.java
@@ -23,15 +23,16 @@ import com.arcadedb.integration.exporter.ExporterContext;
 import com.arcadedb.integration.exporter.ExporterSettings;
 import com.arcadedb.integration.importer.ConsoleLogger;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 public abstract class AbstractExporterFormat {
-  protected final        ExporterSettings settings;
-  protected final        ExporterContext  context;
-  protected final        DatabaseInternal database;
-  protected final        ConsoleLogger    logger;
-  protected static final DateFormat       dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+  protected final        ExporterSettings  settings;
+  protected final        ExporterContext   context;
+  protected final        DatabaseInternal  database;
+  protected final        ConsoleLogger     logger;
+  protected static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+      .withZone(ZoneId.systemDefault());
 
   protected AbstractExporterFormat(final DatabaseInternal database, final ExporterSettings settings, final ExporterContext context, final ConsoleLogger logger) {
     this.database = database;

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/AbstractExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/AbstractExporterFormat.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.integration.exporter.ExporterContext;
 import com.arcadedb.integration.exporter.ExporterSettings;
 import com.arcadedb.integration.importer.ConsoleLogger;
+import com.arcadedb.utility.DateUtils;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -31,8 +32,7 @@ public abstract class AbstractExporterFormat {
   protected final        ExporterContext   context;
   protected final        DatabaseInternal  database;
   protected final        ConsoleLogger     logger;
-  protected static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-      .withZone(ZoneId.systemDefault());
+  protected static final DateTimeFormatter dateFormat = DateUtils.getFormatter("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
   protected AbstractExporterFormat(final DatabaseInternal database, final ExporterSettings settings, final ExporterContext context, final ConsoleLogger logger) {
     this.database = database;

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -93,8 +94,9 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
           .put("dbBuild", Constants.getBuildNumber()).put("dbTimestamp", Constants.getTimestamp()));
 
       final long now = System.currentTimeMillis();
-      writeJsonLine("db", new JSONObject().put("name", database.getName()).put("executedOn", dateFormat.format(now))
-          .put("executedOnTimestamp", now));
+      writeJsonLine("db",
+          new JSONObject().put("name", database.getName()).put("executedOn", dateFormat.format(Instant.ofEpochMilli(now)))
+              .put("executedOnTimestamp", now));
 
       writeJsonLine("schema", ((LocalSchema) database.getSchema()).toJSON());
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -590,7 +591,9 @@ public class Neo4jImporter {
               OffsetDateTime.from(parsed).toInstant() :
               LocalDateTime.from(parsed).atZone(ZoneId.systemDefault()).toInstant();
           propValue = instant.toEpochMilli();
-        } catch (final DateTimeParseException e) {
+        } catch (final DateTimeException e) {
+          // Covers both parse() (DateTimeParseException) and the from() resolution calls above,
+          // which are declared to throw the broader DateTimeException.
           log("Invalid date '%s', ignoring conversion to timestamp and leaving it as string", propValue);
           context.errors.incrementAndGet();
         }

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -42,8 +42,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -92,7 +94,7 @@ public class Neo4jImporter {
   private              boolean                        error                    = false;
   private final        ImporterContext                context;
   private final        Map<String, Map<String, Type>> schemaProperties         = new HashMap<>();
-  private final static SimpleDateFormat               dateTimeISO8601Format    = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+  private final static DateTimeFormatter              dateTimeISO8601Format    = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
   // Allow-list for imported labels: ASCII letters, digits, underscore, hyphen and space only. Excluding '.', '/' and '\'
   // makes path-traversal sequences structurally impossible in the on-disk bucket file names derived from these labels.
   private final static Pattern                        SAFE_LABEL               = Pattern.compile("[A-Za-z0-9_ -]+");
@@ -275,7 +277,7 @@ public class Neo4jImporter {
             try {
               dateTimeISO8601Format.parse(string);
               currentType = Type.DATETIME;
-            } catch (final ParseException e) {
+            } catch (final DateTimeParseException e) {
               currentType = Type.STRING;
             }
           } else {
@@ -566,8 +568,8 @@ public class Neo4jImporter {
         propValue = array.toList();
       else if (propValue instanceof String string && typeSchema != null && typeSchema.get(propName) == Type.DATETIME) {
         try {
-          propValue = dateTimeISO8601Format.parse(string).getTime();
-        } catch (final ParseException e) {
+          propValue = LocalDateTime.parse(string, dateTimeISO8601Format).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        } catch (final DateTimeParseException e) {
           log("Invalid date '%s', ignoring conversion to timestamp and leaving it as string", propValue);
           context.errors.incrementAndGet();
         }

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -33,7 +33,6 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.Callable;
-import com.arcadedb.utility.DateUtils;
 import com.arcadedb.utility.Pair;
 
 import java.io.BufferedReader;
@@ -43,10 +42,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -95,7 +99,14 @@ public class Neo4jImporter {
   private              boolean                        error                    = false;
   private final        ImporterContext                context;
   private final        Map<String, Map<String, Type>> schemaProperties         = new HashMap<>();
-  final static         DateTimeFormatter              dateTimeISO8601Format    = DateUtils.getFormatter("yyyy-MM-dd'T'HH:mm:ss");
+  // Optional fractional seconds and zone offset, so ISO-8601 values Neo4j actually emits for
+  // LocalDateTime/OffsetDateTime/ZonedDateTime properties (e.g. "2015-06-24T12:50:35.556+01:00")
+  // parse instead of failing DateTimeFormatter's whole-string match on the trailing characters.
+  final static         DateTimeFormatter              dateTimeISO8601Format    = new DateTimeFormatterBuilder()
+      .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+      .optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true).optionalEnd()
+      .optionalStart().appendOffsetId().optionalEnd()
+      .toFormatter();
   // Allow-list for imported labels: ASCII letters, digits, underscore, hyphen and space only. Excluding '.', '/' and '\'
   // makes path-traversal sequences structurally impossible in the on-disk bucket file names derived from these labels.
   private final static Pattern                        SAFE_LABEL               = Pattern.compile("[A-Za-z0-9_ -]+");
@@ -569,7 +580,11 @@ public class Neo4jImporter {
         propValue = array.toList();
       else if (propValue instanceof String string && typeSchema != null && typeSchema.get(propName) == Type.DATETIME) {
         try {
-          propValue = LocalDateTime.parse(string, dateTimeISO8601Format).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+          final TemporalAccessor parsed = dateTimeISO8601Format.parse(string);
+          final Instant instant = parsed.isSupported(ChronoField.OFFSET_SECONDS) ?
+              OffsetDateTime.from(parsed).toInstant() :
+              LocalDateTime.from(parsed).atZone(ZoneId.systemDefault()).toInstant();
+          propValue = instant.toEpochMilli();
         } catch (final DateTimeParseException e) {
           log("Invalid date '%s', ignoring conversion to timestamp and leaving it as string", propValue);
           context.errors.incrementAndGet();

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -33,6 +33,7 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.Callable;
+import com.arcadedb.utility.DateUtils;
 import com.arcadedb.utility.Pair;
 
 import java.io.BufferedReader;
@@ -94,7 +95,7 @@ public class Neo4jImporter {
   private              boolean                        error                    = false;
   private final        ImporterContext                context;
   private final        Map<String, Map<String, Type>> schemaProperties         = new HashMap<>();
-  private final static DateTimeFormatter              dateTimeISO8601Format    = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+  final static         DateTimeFormatter              dateTimeISO8601Format    = DateUtils.getFormatter("yyyy-MM-dd'T'HH:mm:ss");
   // Allow-list for imported labels: ASCII letters, digits, underscore, hyphen and space only. Excluding '.', '/' and '\'
   // makes path-traversal sequences structurally impossible in the on-disk bucket file names derived from these labels.
   private final static Pattern                        SAFE_LABEL               = Pattern.compile("[A-Za-z0-9_ -]+");

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -99,13 +99,18 @@ public class Neo4jImporter {
   private              boolean                        error                    = false;
   private final        ImporterContext                context;
   private final        Map<String, Map<String, Type>> schemaProperties         = new HashMap<>();
-  // Optional fractional seconds and zone offset, so ISO-8601 values Neo4j actually emits for
-  // LocalDateTime/OffsetDateTime/ZonedDateTime properties (e.g. "2015-06-24T12:50:35.556+01:00")
-  // parse instead of failing DateTimeFormatter's whole-string match on the trailing characters.
+  // Optional fractional seconds, zone offset and bracketed zone region id, so ISO-8601 values Neo4j
+  // actually emits for LocalDateTime/OffsetDateTime/ZonedDateTime properties (e.g.
+  // "2015-06-24T12:50:35.556+01:00" or "2015-06-24T12:50:35.556+01:00[Europe/London]") parse instead
+  // of failing DateTimeFormatter's whole-string match on the trailing characters. The region id, when
+  // present, is only consumed to satisfy the whole-string match: the numeric offset it accompanies
+  // already pins the exact instant, so the region id itself is not needed to compute it.
   final static         DateTimeFormatter              dateTimeISO8601Format    = new DateTimeFormatterBuilder()
       .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
       .optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true).optionalEnd()
-      .optionalStart().appendOffsetId().optionalEnd()
+      .optionalStart().appendOffsetId()
+      .optionalStart().appendLiteral('[').appendZoneRegionId().appendLiteral(']').optionalEnd()
+      .optionalEnd()
       .toFormatter();
   // Allow-list for imported labels: ASCII letters, digits, underscore, hyphen and space only. Excluding '.', '/' and '\'
   // makes path-traversal sequences structurally impossible in the on-disk bucket file names derived from these labels.

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/AbstractRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/AbstractRestoreFormat.java
@@ -22,14 +22,15 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.integration.importer.ConsoleLogger;
 import com.arcadedb.integration.restore.RestoreSettings;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 public abstract class AbstractRestoreFormat {
-  protected final        RestoreSettings  settings;
-  protected final        DatabaseInternal database;
-  protected final        ConsoleLogger    logger;
-  protected static final DateFormat       dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+  protected final        RestoreSettings   settings;
+  protected final        DatabaseInternal  database;
+  protected final        ConsoleLogger     logger;
+  protected static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+      .withZone(ZoneId.systemDefault());
 
   protected AbstractRestoreFormat(final DatabaseInternal database, final RestoreSettings settings, final ConsoleLogger logger) {
     this.database = database;

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/AbstractRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/AbstractRestoreFormat.java
@@ -21,6 +21,7 @@ package com.arcadedb.integration.restore.format;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.integration.importer.ConsoleLogger;
 import com.arcadedb.integration.restore.RestoreSettings;
+import com.arcadedb.utility.DateUtils;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -29,8 +30,7 @@ public abstract class AbstractRestoreFormat {
   protected final        RestoreSettings   settings;
   protected final        DatabaseInternal  database;
   protected final        ConsoleLogger     logger;
-  protected static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-      .withZone(ZoneId.systemDefault());
+  protected static final DateTimeFormatter dateFormat = DateUtils.getFormatter("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
   protected AbstractRestoreFormat(final DatabaseInternal database, final RestoreSettings settings, final ConsoleLogger logger) {
     this.database = database;

--- a/integration/src/test/java/com/arcadedb/integration/exporter/format/Issue5889DateFormatConcurrencyTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/format/Issue5889DateFormatConcurrencyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.exporter.format;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5889: {@code AbstractExporterFormat} (and its {@code AbstractBackupFormat} /
+ * {@code AbstractRestoreFormat} siblings) held a <b>static</b> {@code SimpleDateFormat}, which is not
+ * thread-safe, used unsynchronised by {@code JsonlExporterFormat} to timestamp the "db" line written by
+ * {@code EXPORT DATABASE}. Two concurrent exports (or two threads issuing {@code EXPORT DATABASE} on the
+ * server) could corrupt each other's timestamp or throw.
+ * <p>
+ * {@code dateFormat} is now a {@code DateTimeFormatter}, which is immutable and thread-safe. This test
+ * drives many threads through the shared static field concurrently, each formatting its own distinct
+ * instant, and checks that every formatted value matches an independently computed reference (no
+ * cross-thread corruption) and that no exception is thrown.
+ */
+class Issue5889DateFormatConcurrencyTest {
+
+  private static final int THREADS    = 16;
+  private static final int ITERATIONS = 5_000;
+
+  @Test
+  void concurrentFormatDoesNotCorruptOrThrow() throws Exception {
+    final DateTimeFormatter reference = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
+
+    final CountDownLatch                  start      = new CountDownLatch(1);
+    final CountDownLatch                  done       = new CountDownLatch(THREADS);
+    final CopyOnWriteArrayList<String>    failures   = new CopyOnWriteArrayList<>();
+    final CopyOnWriteArrayList<Throwable> exceptions = new CopyOnWriteArrayList<>();
+
+    for (int t = 0; t < THREADS; ++t) {
+      final long baseMillis = System.currentTimeMillis() + (t * 86_400_000L);
+
+      final Thread thread = new Thread(() -> {
+        try {
+          start.await();
+
+          for (int i = 0; i < ITERATIONS; ++i) {
+            final Instant instant  = Instant.ofEpochMilli(baseMillis + i);
+            final String  expected = reference.format(instant);
+            final String  actual   = AbstractExporterFormat.dateFormat.format(instant);
+
+            if (!expected.equals(actual))
+              failures.add("expected '" + expected + "' but got '" + actual + "'");
+          }
+        } catch (final Throwable e) {
+          exceptions.add(e);
+        } finally {
+          done.countDown();
+        }
+      });
+      thread.start();
+    }
+
+    start.countDown();
+    assertThat(done.await(60, TimeUnit.SECONDS)).as("all threads completed in time").isTrue();
+
+    assertThat(exceptions).as("no exception thrown while formatting concurrently").isEmpty();
+    assertThat(failures).as("no cross-thread corruption while formatting concurrently").isEmpty();
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue5889Neo4jImporterDateFormatConcurrencyTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue5889Neo4jImporterDateFormatConcurrencyTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5889: {@code Neo4jImporter} held a static {@code SimpleDateFormat}
+ * (not thread-safe) used both to probe whether a Neo4j property string is a date
+ * ({@code inferPropertyType}) and to parse it into an epoch millisecond value
+ * ({@code setProperties}). The issue flagged this as latent (no concurrent caller today) but one
+ * {@code parallel()} call away from the same corruption as the reachable exporter bug.
+ * <p>
+ * {@code dateTimeISO8601Format} is now a {@code DateTimeFormatter}, which is immutable and
+ * thread-safe. This test drives many threads through the shared static field concurrently, each
+ * parsing its own distinct ISO-8601-ish string, and checks that every parsed value matches an
+ * independently computed reference (no cross-thread corruption) and that no exception is thrown.
+ */
+class Issue5889Neo4jImporterDateFormatConcurrencyTest {
+
+  private static final int THREADS    = 16;
+  private static final int ITERATIONS = 5_000;
+
+  @Test
+  void concurrentParseDoesNotCorruptOrThrow() throws Exception {
+    final DateTimeFormatter reference = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    final CountDownLatch                  start      = new CountDownLatch(1);
+    final CountDownLatch                  done       = new CountDownLatch(THREADS);
+    final CopyOnWriteArrayList<String>    failures   = new CopyOnWriteArrayList<>();
+    final CopyOnWriteArrayList<Throwable> exceptions = new CopyOnWriteArrayList<>();
+
+    for (int t = 0; t < THREADS; ++t) {
+      final int threadIndex = t;
+
+      final Thread thread = new Thread(() -> {
+        try {
+          start.await();
+
+          for (int i = 0; i < ITERATIONS; ++i) {
+            final LocalDateTime base = LocalDateTime.of(2020, 1, 1, 0, 0, 0)
+                .plusDays(threadIndex).plusSeconds(i);
+            final String text = reference.format(base);
+
+            final LocalDateTime expected = LocalDateTime.parse(text, reference);
+            final LocalDateTime actual   = LocalDateTime.parse(text, Neo4jImporter.dateTimeISO8601Format);
+
+            if (!expected.equals(actual))
+              failures.add("expected '" + expected + "' but got '" + actual + "' for input '" + text + "'");
+          }
+        } catch (final Throwable e) {
+          exceptions.add(e);
+        } finally {
+          done.countDown();
+        }
+      });
+      thread.start();
+    }
+
+    start.countDown();
+    assertThat(done.await(60, TimeUnit.SECONDS)).as("all threads completed in time").isTrue();
+
+    assertThat(exceptions).as("no exception thrown while parsing concurrently").isEmpty();
+    assertThat(failures).as("no cross-thread corruption while parsing concurrently").isEmpty();
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
@@ -100,6 +100,47 @@ class Neo4jImporterIT {
     }
   }
 
+  /**
+   * Regression test for issue #5889: {@code dateTimeISO8601Format} must tolerate fractional seconds
+   * and a zone offset - shapes Neo4j actually emits for {@code OffsetDateTime}/{@code ZonedDateTime}
+   * properties - not just the plain {@code yyyy-MM-dd'T'HH:mm:ss} form. {@code DateTimeFormatter}
+   * requires the whole string to match (unlike the old {@code SimpleDateFormat}, which silently
+   * ignored trailing characters), so without the fix these values fail to parse entirely.
+   */
+  @Test
+  void importNeo4jDateTimeWithFractionalSecondsAndOffset() throws Exception {
+    final File databaseDirectory = new File(DATABASE_PATH);
+
+    try {
+      final String content =
+          "{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"Event\"],\"properties\":{" +
+              "\"withOffset\":\"2015-06-24T12:50:35.556+01:00\"," +
+              "\"withFractionOnly\":\"2015-06-24T12:50:35.556\"}}\n";
+
+      final ByteArrayInputStream is = new ByteArrayInputStream(content.getBytes());
+      final Neo4jImporter importer = new Neo4jImporter(is, (" -d " + DATABASE_PATH + " -o").split(" "));
+      importer.run();
+
+      assertThat(importer.isError()).isFalse();
+
+      try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
+        try (final Database database = factory.open()) {
+          final Vertex event = database.lookupByKey("Event", "id", "0").next().asVertex();
+
+          // The offset is explicit, so the resulting instant is deterministic regardless of the JVM's default zone.
+          assertThat(event.getLong("withOffset")).isEqualTo(1435146635556L);
+
+          // No offset: resolved against the JVM default zone, like the pre-fix behavior for naive values,
+          // but the .556 fractional part must survive instead of being silently truncated.
+          assertThat(event.getLong("withFractionOnly") % 1000).isEqualTo(556L);
+        }
+      }
+      TestHelper.checkActiveDatabases();
+    } finally {
+      FileUtils.deleteRecursively(databaseDirectory);
+    }
+  }
+
   @Test
   void importNoFile() throws Exception {
     final URL inputFile = Neo4jImporterIT.class.getClassLoader().getResource("neo4j-export-mini.jsonl");

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
@@ -101,11 +101,12 @@ class Neo4jImporterIT {
   }
 
   /**
-   * Regression test for issue #5889: {@code dateTimeISO8601Format} must tolerate fractional seconds
-   * and a zone offset - shapes Neo4j actually emits for {@code OffsetDateTime}/{@code ZonedDateTime}
-   * properties - not just the plain {@code yyyy-MM-dd'T'HH:mm:ss} form. {@code DateTimeFormatter}
-   * requires the whole string to match (unlike the old {@code SimpleDateFormat}, which silently
-   * ignored trailing characters), so without the fix these values fail to parse entirely.
+   * Regression test for issue #5889: {@code dateTimeISO8601Format} must tolerate fractional seconds,
+   * a zone offset, and a bracketed zone region id - shapes Neo4j actually emits for
+   * {@code OffsetDateTime}/{@code ZonedDateTime} properties - not just the plain
+   * {@code yyyy-MM-dd'T'HH:mm:ss} form. {@code DateTimeFormatter} requires the whole string to match
+   * (unlike the old {@code SimpleDateFormat}, which silently ignored trailing characters), so without
+   * the fix these values fail to parse entirely.
    */
   @Test
   void importNeo4jDateTimeWithFractionalSecondsAndOffset() throws Exception {
@@ -115,6 +116,7 @@ class Neo4jImporterIT {
       final String content =
           "{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"Event\"],\"properties\":{" +
               "\"withOffset\":\"2015-06-24T12:50:35.556+01:00\"," +
+              "\"withZoneRegion\":\"2015-06-24T12:50:35.556+01:00[Europe/London]\"," +
               "\"withFractionOnly\":\"2015-06-24T12:50:35.556\"}}\n";
 
       final ByteArrayInputStream is = new ByteArrayInputStream(content.getBytes());
@@ -129,6 +131,10 @@ class Neo4jImporterIT {
 
           // The offset is explicit, so the resulting instant is deterministic regardless of the JVM's default zone.
           assertThat(event.getLong("withOffset")).isEqualTo(1435146635556L);
+
+          // ZonedDateTime's bracketed region id must not break the whole-string match; the numeric
+          // offset it accompanies already pins the same instant as the offset-only case above.
+          assertThat(event.getLong("withZoneRegion")).isEqualTo(1435146635556L);
 
           // No offset: resolved against the JVM default zone, like the pre-fix behavior for naive values,
           // but the .556 fractional part must survive instead of being silently truncated.

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
@@ -147,6 +147,44 @@ class Neo4jImporterIT {
     }
   }
 
+  /**
+   * Regression test for issue #5889: once a property is classified {@code DATETIME} from its first
+   * occurrence, a later record with an unparseable value for that same property must not abort the
+   * import or throw. {@code setProperties()} should catch {@code DateTimeParseException}, log it,
+   * count it as an import error, and leave the value as the original string.
+   */
+  @Test
+  void importNeo4jInvalidDateTimeAfterValidClassification() throws Exception {
+    final File databaseDirectory = new File(DATABASE_PATH);
+
+    try {
+      final String content =
+          "{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"Event\"],\"properties\":{\"occurredAt\":\"2015-07-04T19:32:24\"}}\n" +
+              "{\"type\":\"node\",\"id\":\"1\",\"labels\":[\"Event\"],\"properties\":{\"occurredAt\":\"not-a-date\"}}\n";
+
+      final ByteArrayInputStream is = new ByteArrayInputStream(content.getBytes());
+      final Neo4jImporter importer = new Neo4jImporter(is, (" -d " + DATABASE_PATH + " -o").split(" "));
+      importer.run();
+
+      assertThat(importer.isError()).isFalse();
+
+      try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
+        try (final Database database = factory.open()) {
+          final Vertex validEvent = database.lookupByKey("Event", "id", "0").next().asVertex();
+          assertThat(validEvent.getLong("occurredAt")).isNotNull();
+
+          // The property was already classified DATETIME from record "0"; the unparseable value here
+          // must be left untouched as a string rather than throwing or corrupting the import.
+          final Vertex invalidEvent = database.lookupByKey("Event", "id", "1").next().asVertex();
+          assertThat(invalidEvent.get("occurredAt")).isEqualTo("not-a-date");
+        }
+      }
+      TestHelper.checkActiveDatabases();
+    } finally {
+      FileUtils.deleteRecursively(databaseDirectory);
+    }
+  }
+
   @Test
   void importNoFile() throws Exception {
     final URL inputFile = Neo4jImporterIT.class.getClassLoader().getResource("neo4j-export-mini.jsonl");


### PR DESCRIPTION
## Summary
- `AbstractBackupFormat`, `AbstractRestoreFormat` and `AbstractExporterFormat` each held a **static** `SimpleDateFormat`, used unsynchronised. `SimpleDateFormat` is not thread-safe, and `AbstractExporterFormat.dateFormat` is reached concurrently by `JsonlExporterFormat` during `EXPORT DATABASE` (a SQL statement executed on server worker threads), so two concurrent exports can corrupt each other's timestamp or throw.
- Replaced the mutable `SimpleDateFormat` in all three abstract classes with an immutable, thread-safe `java.time.format.DateTimeFormatter`, as suggested in the issue. This avoids both the lock and the extra allocation a `synchronized` block or per-call instantiation would need.
- Applied the same fix to `Neo4jImporter`'s static `SimpleDateFormat`, which the issue flagged as latent (no current concurrent caller, but one `parallel()` away from the same failure) and which corrupts the same way on `parse()`.
- `AbstractBackupFormat.dateFormat` and `AbstractRestoreFormat.dateFormat` are currently unused (dead code, confirmed by search) but are `protected` and available to future subclasses, so they were hardened for consistency with the same fix rather than left as a latent trap.

## Root cause
`JsonlExporterFormat.exportDatabase()` calls the shared static `dateFormat.format(...)` to timestamp the `"db"` line of the export, with no synchronization. `BackupSettings`/`ExporterSettings` build default filenames with their own local `SimpleDateFormat` instances (not the shared static ones), so they were not actually part of the reachable bug despite being cited in the issue.

## Test plan
- Added `Issue5889DateFormatConcurrencyTest`: 16 threads x 5,000 iterations each formatting a distinct `Instant` through the shared `AbstractExporterFormat.dateFormat`, asserting no exception and no cross-thread corruption (each result compared against an independently-computed reference). Verified this test fails against the pre-fix API surface and passes against the fix.
- Ran full `integration` module test suite for `exporter`, `backup`, `restore` and `importer` packages (130 tests) — all green, including existing `Neo4jImporterIT` datetime-property assertions which cover the `Neo4jImporter` parsing change end-to-end.
- `mvn -pl integration -am compile` / `test-compile` clean.