### PR TITLE
fix(#5886): bound SQL MATCHES and openCypher =~ against catastrophic regex backtracking

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -327,116 +327,55 @@ only the "nothing at all was imported" guarantee differs between the two formats
 
 [#5968](https://github.com/ArcadeData/arcadedb/issues/5968)
 
-## SQL `MATCHES` and openCypher `=~` are no longer able to pin a worker thread indefinitely on a pathological regex (#5886)
+## Regex-based query and validation surfaces are no longer able to pin a worker thread indefinitely on a pathological pattern (#5886)
 
 A regex like `(.*a){20}$` against a 41-character string triggers catastrophic backtracking in
 `java.util.regex`: still running after 30+ seconds for a pattern and input small enough to be typed by
-hand. `arcadedb.command.timeout` did not help, because `Matcher.matches()` never polls an interrupt flag or
-checks a deadline while backtracking - the only thing it calls on every backtracking step is
-`CharSequence.charAt()` on the input being matched, and nothing in the surrounding query execution machinery
-gets a chance to run again until that call returns on its own. In a deployment where query access reaches
-low-privilege users or an application layer that forwards user-supplied patterns, a handful of such queries
-is enough to permanently tie up the HTTP worker pool.
+hand. `arcadedb.command.timeout` does not help, because `Matcher` never polls an interrupt flag or checks a
+deadline while backtracking - the only thing it calls on every backtracking step is `CharSequence.charAt()`
+on the input, and nothing in the surrounding query execution machinery gets a chance to run again until that
+call returns on its own. In a deployment where query access reaches low-privilege users, or an application
+layer forwards user-supplied patterns, a handful of such operations is enough to permanently tie up worker
+threads.
 
-Both regex entry points - SQL `MATCHES` (`MatchesCondition`) and openCypher `=~` (`RegexExpression`) - now
-run the match through `TimeBoundRegex`, which wraps the input `CharSequence` so `charAt()` throws once a
-deadline elapses. Because `java.util.regex` calls `charAt()` on every backtracking step, this turns the one
-call site the engine cannot otherwise intercept into the interruption point `arcadedb.command.timeout` was
-supposed to provide. The deadline itself is a new, dedicated setting, `arcadedb.command.regexTimeout`
-(default 1000ms), independent of `arcadedb.command.timeout` and active even when the latter is left at its
-default of disabled (`0`) - which it is by default, so `MATCHES`/`=~` would otherwise have had no bound at
-all regardless of configuration. `charAt()` checks the deadline every 256 calls rather than every call, to
-keep the check off the hot path for the overwhelming majority of well-behaved patterns that never come close
-to that many backtracking steps in the first place.
+A new utility, `TimeBoundRegex`, closes that gap by wrapping the matched input in a `CharSequence` that throws
+once a deadline elapses - the one interception point `java.util.regex` offers, for `matches()`, `replaceAll()`,
+and `split()` alike. The deadline comes from a new setting, `arcadedb.command.regexTimeout` (default 1000ms,
+per-database), independent of `arcadedb.command.timeout` and active even when that setting is left at its own
+default of disabled (`0`). The deadline is checked every 256 `charAt()` calls rather than every call, keeping
+the check off the hot path for the overwhelming majority of patterns that never come close to that many
+backtracking steps.
 
-A `MATCHES`/`=~` evaluation against a multi-value (list-typed) property shares one deadline across every item
-rather than giving each item its own full budget - otherwise a crafted list could still tie up the thread for
-`item count * regexTimeout`. Whichever item trips the deadline aborts the whole `WHERE` evaluation with a
-`TimeoutException`, the same as a single-value timeout: a catastrophic pattern is treated as a query failure,
-not as that one item silently failing to match, since swallowing it would let the pattern keep consuming its
-full budget on every future scan without ever surfacing.
+**Covered entry points:**
+- SQL `MATCHES` and openCypher `=~`
+- SQL `LIKE`/`ILIKE`, including the native query engine's `SelectOperator` path
+- `text.regexReplace()` and the `.normalize()` SQL method's optional pattern argument
+- Full-text search's Lucene `RegexpQuery` (`/pattern/`) and `WildcardQuery` (`*`/`?`) support
+- PromQL's `=~`/`!~` label matchers
+- Schema-level `REGEXP` property validation (`CREATE PROPERTY ... REGEXP <pattern>`) - notably reachable with
+  no query privileges at all, since it runs on every insert/update of a validated property through any write
+  path (REST, any wire protocol)
 
-A second review pass caught two more entry points the initial audit missed, both now bounded the same way:
-the `text.regexReplace(string, regex, replacement)` SQL function, whose only previous defense was a 500-char
-pattern-length cap plus a `catch (StackOverflowError)` - neither of which bounds a *time*-based catastrophic
-match, as opposed to a *stack-depth* one; and full-text search's Lucene `RegexpQuery` support (the `/pattern/`
-query syntax), arguably the worse instance of the two since a pathological pattern there is evaluated against
-every token in what is, absent a literal prefix, a full index scan. `TimeBoundRegex` gained a `replaceAll()`
-counterpart to `matches()` for the first case, and now also catches `StackOverflowError` alongside a deadline
-trip in both - a sufficiently pathological pattern can blow the (recursive) backtracking stack before the
-next 256-call checkpoint is reached, and that failure mode gets the same bound and the same `TimeoutException`
-as an explicit deadline.
+The `.split(delimiter)` SQL method got a different fix: unlike its three siblings (the `split()` function,
+`text.split()`, and Cypher's `split()`), which all treat the delimiter as a literal via `Pattern.quote(...)`,
+it passed the delimiter straight to `String.split(regex)` unescaped. Matched to its siblings' behavior, which
+removes the risk entirely rather than just bounding it.
 
-A third review pass corrected a wrong conclusion from the first: SQL `LIKE`/`ILIKE` had been audited as "safe"
-because `QueryHelper.convertForRegExp` escapes every regex metacharacter except `%` (`.*`) and `?` (`.`), so
-the generated pattern can never contain grouping, alternation, or nested quantifiers - true, but that only
-rules out *one* class of catastrophic backtracking. A sequence of several `.*` segments reproduces the same
-exponential blowup with no nesting at all (`%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%c` against a string of
-just `a`s hangs exactly like the issue's own `(.*a){20}$` reproducer), and full-text search's wildcard queries
-(`*`/`?`, the `WildcardQuery` sibling of the already-fixed `RegexpQuery` path) build the identical shape.
-`LIKE`/`ILIKE` (`QueryHelper.like`/`likeUntil`, used by `LikeOperator`, `ILikeOperator`, and the native query
-engine's `SelectOperator`) and full-text wildcard matching now run through `TimeBoundRegex` like every other
-entry point here, including the same shared-deadline treatment for a multi-value `LIKE`/`ILIKE` evaluation.
+**Deadline sharing.** A regex evaluated once per row/token/item over a scan must not get a fresh timeout
+budget per item - a table or index shaped so every row triggers catastrophic backtracking would then cost up
+to `itemCount * regexTimeout` instead of one bounded operation. `MATCHES`/`=~` share one deadline across an
+entire query execution (cached on the `CommandContext`, the same mechanism used to cache the compiled
+`Pattern`); full-text, PromQL, and `REGEXP` validation share one deadline across the whole scan they run
+against. `LIKE`/`ILIKE` are the one exception: `BinaryCompareOperator`, the interface they implement, has no
+`CommandContext` to cache a deadline on (only a `Database`), and widening that interface across every
+comparison operator was judged out of proportion here - each row still gets its own `regexTimeout` budget, so
+a `LIKE`-heavy scan where many rows are individually catastrophic is bounded per row but not for the scan as
+a whole.
 
-A fourth review pass found one more: PromQL's `=~`/`!~` label matchers (`PromQLEvaluator#matchesPostFilters`)
-compile the user-supplied pattern straight into `Pattern.matcher(...).matches()`, with only a static
-`REDOS_CHECK` pre-filter that flags *parenthesized* nested-quantifier/alternation shapes (`(a+)+`, `(a|aa)+`).
-A sequence of unparenthesized quantified segments (`a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*ac`, PromQL's
-equivalent of the `LIKE`/wildcard gap above) contains no `(` for that check to catch, and reaches the same
-unbounded `.matches()` call. Now bounded the same way, with one shared deadline across the whole row scan a
-label matcher runs against - the same N-rows-times-timeout concern as every other multi-item entry point here.
-
-**A sharper edge of the upgrade-behavior tradeoff, worth calling out on its own.** Full-text `RegexpQuery`/
-`WildcardQuery` and PromQL `=~`/`!~` each share one `regexTimeout` budget across an entire scan - every token
-in a full-text index, every row in a time-series range query - not per item, for the reasons above. That is
-correct (per-item budgets reopen the N-times-timeout bypass), but it means a large, *non-catastrophic* scan
-that legitimately takes more than the default 1000ms purely because there is a lot of data - a big full-text
-index, or a wide PromQL time range - now fails with `TimeoutException` where it previously (with
-`arcadedb.command.timeout` disabled by default) ran to completion, however slowly. If a workload does
-legitimate full-text or PromQL regex matching over a large volume of data, raise `arcadedb.command.regexTimeout`
-for that database rather than leaving it at the default.
-
-A fifth review pass found the most exposed entry point of all: the schema-level `REGEXP` property constraint
-(`CREATE PROPERTY ... REGEXP <pattern>`) validated `fieldValue.toString().matches(p.getRegexp())` on every
-insert/update of that property with no bound whatsoever - `DocumentValidator.validateField`. Unlike every
-other entry point here, this needs no query privileges at all: any write path (REST, any wire protocol) into
-a validated type is enough, and admin-defined validation patterns (classic email/URL regexes, in particular)
-are a notorious source of accidentally-catastrophic shapes. Now bounded the same way as everything else - which
-means the same default-1000ms tradeoff described above for full-text/PromQL applies here too: a legitimate,
-non-catastrophic pattern validated against a very large field value that previously took over a second (however
-undesirable that already was) now fails the write with `TimeoutException` instead. Raise
-`arcadedb.command.regexTimeout` for a database with that kind of validation workload.
-
-Also fixed: `MATCHES`/`=~` shared one deadline across a multi-value evaluation (an earlier fix in this issue)
-but still gave each *row* of a table/graph scan its own fresh budget, so a table shaped so every row triggers
-catastrophic backtracking could still cost up to `rowCount * regexTimeout` overall. Both now cache one deadline
-for the lifetime of the query on the `CommandContext` - the same per-execution object `MatchesCondition` already
-used to cache the compiled `Pattern`. `RegexExpression` needed the same context-based caching, not an AST-node
-instance field: unlike a compiled `Pattern` (content-addressed, safe to reuse indefinitely), a deadline is a
-point in time, and `CypherStatementCache` caches parsed queries - this AST node included - by query text across
-repeated executions, so an instance-field deadline would go stale after the first execution and then make every
-later run of that same cached query throw a spurious `TimeoutException` on any pattern, benign or not, until
-LRU eviction; a 6th review pass caught this exact regression before it merged. `LIKE`/`ILIKE` could not get the
-per-scan fix: `BinaryCompareOperator`, the interface `LikeOperator`/`ILikeOperator` implement, has no
-`CommandContext` to cache a query-wide deadline on (only a `Database`), and widening that interface across every
-comparison operator was judged out of proportion for this fix - a conscious, narrower-scope tradeoff, documented
-in `LikeOperator`, not an oversight.
-
-A 7th review pass found a second regression, caught the same way: `MatchesCondition`'s query-wide deadline was
-cached under the fixed key `"MATCHES_DEADLINE"` in the same flat, string-keyed `CommandContext` cache used for
-compiled patterns (keyed `"MATCHES_" + <regex text>`). A query using the literal pattern text `DEADLINE` (e.g.
-`WHERE name MATCHES 'DEADLINE'`) produced the identical key for both, so the Pattern and the deadline overwrote
-each other's cache slot and every row threw `ClassCastException` on the very first evaluation - 100%
-reproducible, not a theoretical race. The deadline key now lives entirely outside the `"MATCHES_"` namespace, so
-it cannot collide with `"MATCHES_" + <any regex text>` regardless of what that text reads.
-
-The same pass also found two more unbounded entry points reachable from plain SQL: the `.split(delimiter)`
-method syntax (`field.split(pattern)`) passed its delimiter straight to `String.split(regex)` unescaped, unlike
-its three siblings (the `split()` function, `text.split()`, and Cypher's `split()`), which all correctly treat
-the delimiter as a literal via `Pattern.quote(...)` - now fixed to match them, which removes the risk entirely
-rather than just bounding it, since a `Pattern.quote()`d literal can never form a catastrophic shape. The
-`.normalize(form, pattern)` method's optional second argument, by contrast, is *meant* to be a real regex (it
-controls what gets stripped after Unicode normalization), so that one is bounded through `TimeBoundRegex` like
-every other intentional regex entry point, not literalized.
+**Upgrade note.** Because the deadline is shared per query/scan rather than per match, and defaults to an
+enabled 1000ms, a *legitimate, non-catastrophic* operation that previously ran slowly to completion - a
+`MATCHES`/`LIKE` query over a very large table, a full-text or PromQL scan over a lot of data, or `REGEXP`
+validation against a large field value - can now fail with `TimeoutException` instead. Raise
+`arcadedb.command.regexTimeout` for any database with that kind of workload.
 
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -386,4 +386,14 @@ equivalent of the `LIKE`/wildcard gap above) contains no `(` for that check to c
 unbounded `.matches()` call. Now bounded the same way, with one shared deadline across the whole row scan a
 label matcher runs against - the same N-rows-times-timeout concern as every other multi-item entry point here.
 
+**A sharper edge of the upgrade-behavior tradeoff, worth calling out on its own.** Full-text `RegexpQuery`/
+`WildcardQuery` and PromQL `=~`/`!~` each share one `regexTimeout` budget across an entire scan - every token
+in a full-text index, every row in a time-series range query - not per item, for the reasons above. That is
+correct (per-item budgets reopen the N-times-timeout bypass), but it means a large, *non-catastrophic* scan
+that legitimately takes more than the default 1000ms purely because there is a lot of data - a big full-text
+index, or a wide PromQL time range - now fails with `TimeoutException` where it previously (with
+`arcadedb.command.timeout` disabled by default) ran to completion, however slowly. If a workload does
+legitimate full-text or PromQL regex matching over a large volume of data, raise `arcadedb.command.regexTimeout`
+for that database rather than leaving it at the default.
+
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -372,7 +372,13 @@ the rows within one step. `LIKE`/`ILIKE` are the one exception: `BinaryCompareOp
 implement, has no `CommandContext` to cache a deadline on (only a `Database`), and widening that interface
 across every comparison operator was judged out of proportion here - each row still gets its own
 `regexTimeout` budget, so a `LIKE`-heavy scan where many rows are individually catastrophic is bounded per row
-but not for the scan as a whole.
+but not for the scan as a whole. A parallel bucket scan (SQL's default for a type spread across multiple
+buckets) is a second, narrower exception: each worker thread gets its own copy of the `CommandContext`
+(deliberately, so workers don't race on a shared, non-thread-safe cache), so it computes its own deadline
+independently rather than sharing the sequential-scan path's single deadline - a type scanned in parallel
+across N buckets is bounded by `N * regexTimeout` overall, not one shared budget. Unlike the row/item counts
+this issue defends against, bucket count is a schema/DDL property, not attacker-controlled, so this is a much
+narrower gap than the one this fix closes.
 
 **Upgrade note.** Because the deadline is shared per query/scan rather than per match, and defaults to an
 enabled 1000ms, a *legitimate, non-catastrophic* operation that previously ran slowly to completion - a

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -401,16 +401,25 @@ A fifth review pass found the most exposed entry point of all: the schema-level 
 insert/update of that property with no bound whatsoever - `DocumentValidator.validateField`. Unlike every
 other entry point here, this needs no query privileges at all: any write path (REST, any wire protocol) into
 a validated type is enough, and admin-defined validation patterns (classic email/URL regexes, in particular)
-are a notorious source of accidentally-catastrophic shapes. Now bounded the same way as everything else.
+are a notorious source of accidentally-catastrophic shapes. Now bounded the same way as everything else - which
+means the same default-1000ms tradeoff described above for full-text/PromQL applies here too: a legitimate,
+non-catastrophic pattern validated against a very large field value that previously took over a second (however
+undesirable that already was) now fails the write with `TimeoutException` instead. Raise
+`arcadedb.command.regexTimeout` for a database with that kind of validation workload.
 
 Also fixed: `MATCHES`/`=~` shared one deadline across a multi-value evaluation (an earlier fix in this issue)
 but still gave each *row* of a table/graph scan its own fresh budget, so a table shaped so every row triggers
 catastrophic backtracking could still cost up to `rowCount * regexTimeout` overall. Both now cache one deadline
-for the lifetime of the query - `MatchesCondition` on the `CommandContext` (the same mechanism already used to
-cache the compiled `Pattern`), `RegexExpression` as an AST-node instance field (ditto) - closing the same gap
-already closed for full-text and PromQL scans. `LIKE`/`ILIKE` could not get the same fix: `BinaryCompareOperator`,
-the interface `LikeOperator`/`ILikeOperator` implement, has no `CommandContext` to cache a query-wide deadline
-on (only a `Database`), and widening that interface across every comparison operator was judged out of
-proportion for this fix - a conscious, narrower-scope tradeoff, documented in `LikeOperator`, not an oversight.
+for the lifetime of the query on the `CommandContext` - the same per-execution object `MatchesCondition` already
+used to cache the compiled `Pattern`. `RegexExpression` needed the same context-based caching, not an AST-node
+instance field: unlike a compiled `Pattern` (content-addressed, safe to reuse indefinitely), a deadline is a
+point in time, and `CypherStatementCache` caches parsed queries - this AST node included - by query text across
+repeated executions, so an instance-field deadline would go stale after the first execution and then make every
+later run of that same cached query throw a spurious `TimeoutException` on any pattern, benign or not, until
+LRU eviction; a 6th review pass caught this exact regression before it merged. `LIKE`/`ILIKE` could not get the
+per-scan fix: `BinaryCompareOperator`, the interface `LikeOperator`/`ILikeOperator` implement, has no
+`CommandContext` to cache a query-wide deadline on (only a `Database`), and widening that interface across every
+comparison operator was judged out of proportion for this fix - a conscious, narrower-scope tradeoff, documented
+in `LikeOperator`, not an oversight.
 
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -361,4 +361,15 @@ escapes every regex metacharacter except `%` (`.*`) and `?` (`.`), so the genera
 grouping, alternation, or nested quantifiers - the shapes catastrophic backtracking requires. It stays on
 plain `String.matches()`.
 
+A second review pass caught two more entry points the initial audit missed, both now bounded the same way:
+the `text.regexReplace(string, regex, replacement)` SQL function, whose only previous defense was a 500-char
+pattern-length cap plus a `catch (StackOverflowError)` - neither of which bounds a *time*-based catastrophic
+match, as opposed to a *stack-depth* one; and full-text search's Lucene `RegexpQuery` support (the `/pattern/`
+query syntax), arguably the worse instance of the two since a pathological pattern there is evaluated against
+every token in what is, absent a literal prefix, a full index scan. `TimeBoundRegex` gained a `replaceAll()`
+counterpart to `matches()` for the first case, and now also catches `StackOverflowError` alongside a deadline
+trip in both - a sufficiently pathological pattern can blow the (recursive) backtracking stack before the
+next 256-call checkpoint is reached, and that failure mode gets the same bound and the same `TimeoutException`
+as an explicit deadline.
+
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -356,11 +356,6 @@ rather than giving each item its own full budget - otherwise a crafted list coul
 not as that one item silently failing to match, since swallowing it would let the pattern keep consuming its
 full budget on every future scan without ever surfacing.
 
-SQL `LIKE`/`ILIKE` were audited for the same gap and found not to need it: `QueryHelper.convertForRegExp`
-escapes every regex metacharacter except `%` (`.*`) and `?` (`.`), so the generated pattern can never contain
-grouping, alternation, or nested quantifiers - the shapes catastrophic backtracking requires. It stays on
-plain `String.matches()`.
-
 A second review pass caught two more entry points the initial audit missed, both now bounded the same way:
 the `text.regexReplace(string, regex, replacement)` SQL function, whose only previous defense was a 500-char
 pattern-length cap plus a `catch (StackOverflowError)` - neither of which bounds a *time*-based catastrophic
@@ -371,5 +366,16 @@ counterpart to `matches()` for the first case, and now also catches `StackOverfl
 trip in both - a sufficiently pathological pattern can blow the (recursive) backtracking stack before the
 next 256-call checkpoint is reached, and that failure mode gets the same bound and the same `TimeoutException`
 as an explicit deadline.
+
+A third review pass corrected a wrong conclusion from the first: SQL `LIKE`/`ILIKE` had been audited as "safe"
+because `QueryHelper.convertForRegExp` escapes every regex metacharacter except `%` (`.*`) and `?` (`.`), so
+the generated pattern can never contain grouping, alternation, or nested quantifiers - true, but that only
+rules out *one* class of catastrophic backtracking. A sequence of several `.*` segments reproduces the same
+exponential blowup with no nesting at all (`%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%c` against a string of
+just `a`s hangs exactly like the issue's own `(.*a){20}$` reproducer), and full-text search's wildcard queries
+(`*`/`?`, the `WildcardQuery` sibling of the already-fixed `RegexpQuery` path) build the identical shape.
+`LIKE`/`ILIKE` (`QueryHelper.like`/`likeUntil`, used by `LikeOperator`, `ILikeOperator`, and the native query
+engine's `SelectOperator`) and full-text wildcard matching now run through `TimeBoundRegex` like every other
+entry point here, including the same shared-deadline treatment for a multi-value `LIKE`/`ILIKE` evaluation.
 
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -422,4 +422,21 @@ per-scan fix: `BinaryCompareOperator`, the interface `LikeOperator`/`ILikeOperat
 comparison operator was judged out of proportion for this fix - a conscious, narrower-scope tradeoff, documented
 in `LikeOperator`, not an oversight.
 
+A 7th review pass found a second regression, caught the same way: `MatchesCondition`'s query-wide deadline was
+cached under the fixed key `"MATCHES_DEADLINE"` in the same flat, string-keyed `CommandContext` cache used for
+compiled patterns (keyed `"MATCHES_" + <regex text>`). A query using the literal pattern text `DEADLINE` (e.g.
+`WHERE name MATCHES 'DEADLINE'`) produced the identical key for both, so the Pattern and the deadline overwrote
+each other's cache slot and every row threw `ClassCastException` on the very first evaluation - 100%
+reproducible, not a theoretical race. The deadline key now lives entirely outside the `"MATCHES_"` namespace, so
+it cannot collide with `"MATCHES_" + <any regex text>` regardless of what that text reads.
+
+The same pass also found two more unbounded entry points reachable from plain SQL: the `.split(delimiter)`
+method syntax (`field.split(pattern)`) passed its delimiter straight to `String.split(regex)` unescaped, unlike
+its three siblings (the `split()` function, `text.split()`, and Cypher's `split()`), which all correctly treat
+the delimiter as a literal via `Pattern.quote(...)` - now fixed to match them, which removes the risk entirely
+rather than just bounding it, since a `Pattern.quote()`d literal can never form a catastrophic shape. The
+`.normalize(form, pattern)` method's optional second argument, by contrast, is *meant* to be a real regex (it
+controls what gets stripped after Unicode normalization), so that one is bounded through `TimeBoundRegex` like
+every other intentional regex entry point, not literalized.
+
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -361,16 +361,18 @@ The `.split(delimiter)` SQL method got a different fix: unlike its three sibling
 it passed the delimiter straight to `String.split(regex)` unescaped. Matched to its siblings' behavior, which
 removes the risk entirely rather than just bounding it.
 
-**Deadline sharing.** A regex evaluated once per row/token/item over a scan must not get a fresh timeout
-budget per item - a table or index shaped so every row triggers catastrophic backtracking would then cost up
-to `itemCount * regexTimeout` instead of one bounded operation. `MATCHES`/`=~` share one deadline across an
-entire query execution (cached on the `CommandContext`, the same mechanism used to cache the compiled
-`Pattern`); full-text, PromQL, and `REGEXP` validation share one deadline across the whole scan they run
-against. `LIKE`/`ILIKE` are the one exception: `BinaryCompareOperator`, the interface they implement, has no
-`CommandContext` to cache a deadline on (only a `Database`), and widening that interface across every
-comparison operator was judged out of proportion here - each row still gets its own `regexTimeout` budget, so
-a `LIKE`-heavy scan where many rows are individually catastrophic is bounded per row but not for the scan as
-a whole.
+**Deadline sharing.** A regex evaluated once per row/token/item/property over a scan must not get a fresh
+timeout budget per item - a table, index, or document shaped so every item triggers catastrophic backtracking
+would then cost up to `itemCount * regexTimeout` instead of one bounded operation. `MATCHES`, `=~`,
+`text.regexReplace()`, and `.normalize()`'s pattern argument all share one deadline across an entire query
+execution (cached on the `CommandContext`, the same mechanism used to cache `MATCHES`'s compiled `Pattern`);
+full-text and schema `REGEXP` validation share one deadline across the whole scan/document they run against;
+PromQL shares one deadline across an entire query's lifetime, including every step of a range query, not just
+the rows within one step. `LIKE`/`ILIKE` are the one exception: `BinaryCompareOperator`, the interface they
+implement, has no `CommandContext` to cache a deadline on (only a `Database`), and widening that interface
+across every comparison operator was judged out of proportion here - each row still gets its own
+`regexTimeout` budget, so a `LIKE`-heavy scan where many rows are individually catastrophic is bounded per row
+but not for the scan as a whole.
 
 **Upgrade note.** Because the deadline is shared per query/scan rather than per match, and defaults to an
 enabled 1000ms, a *legitimate, non-catastrophic* operation that previously ran slowly to completion - a

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -349,6 +349,13 @@ all regardless of configuration. `charAt()` checks the deadline every 256 calls 
 keep the check off the hot path for the overwhelming majority of well-behaved patterns that never come close
 to that many backtracking steps in the first place.
 
+A `MATCHES`/`=~` evaluation against a multi-value (list-typed) property shares one deadline across every item
+rather than giving each item its own full budget - otherwise a crafted list could still tie up the thread for
+`item count * regexTimeout`. Whichever item trips the deadline aborts the whole `WHERE` evaluation with a
+`TimeoutException`, the same as a single-value timeout: a catastrophic pattern is treated as a query failure,
+not as that one item silently failing to match, since swallowing it would let the pattern keep consuming its
+full budget on every future scan without ever surfacing.
+
 SQL `LIKE`/`ILIKE` were audited for the same gap and found not to need it: `QueryHelper.convertForRegExp`
 escapes every regex metacharacter except `%` (`.*`) and `?` (`.`), so the generated pattern can never contain
 grouping, alternation, or nested quantifiers - the shapes catastrophic backtracking requires. It stays on

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -396,4 +396,21 @@ index, or a wide PromQL time range - now fails with `TimeoutException` where it 
 legitimate full-text or PromQL regex matching over a large volume of data, raise `arcadedb.command.regexTimeout`
 for that database rather than leaving it at the default.
 
+A fifth review pass found the most exposed entry point of all: the schema-level `REGEXP` property constraint
+(`CREATE PROPERTY ... REGEXP <pattern>`) validated `fieldValue.toString().matches(p.getRegexp())` on every
+insert/update of that property with no bound whatsoever - `DocumentValidator.validateField`. Unlike every
+other entry point here, this needs no query privileges at all: any write path (REST, any wire protocol) into
+a validated type is enough, and admin-defined validation patterns (classic email/URL regexes, in particular)
+are a notorious source of accidentally-catastrophic shapes. Now bounded the same way as everything else.
+
+Also fixed: `MATCHES`/`=~` shared one deadline across a multi-value evaluation (an earlier fix in this issue)
+but still gave each *row* of a table/graph scan its own fresh budget, so a table shaped so every row triggers
+catastrophic backtracking could still cost up to `rowCount * regexTimeout` overall. Both now cache one deadline
+for the lifetime of the query - `MatchesCondition` on the `CommandContext` (the same mechanism already used to
+cache the compiled `Pattern`), `RegexExpression` as an AST-node instance field (ditto) - closing the same gap
+already closed for full-text and PromQL scans. `LIKE`/`ILIKE` could not get the same fix: `BinaryCompareOperator`,
+the interface `LikeOperator`/`ILikeOperator` implement, has no `CommandContext` to cache a query-wide deadline
+on (only a `Database`), and widening that interface across every comparison operator was judged out of
+proportion for this fix - a conscious, narrower-scope tradeoff, documented in `LikeOperator`, not an oversight.
+
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -326,3 +326,32 @@ so are fully atomic. `abort` mode still fails the import and stops processing fu
 only the "nothing at all was imported" guarantee differs between the two formats.
 
 [#5968](https://github.com/ArcadeData/arcadedb/issues/5968)
+
+## SQL `MATCHES` and openCypher `=~` are no longer able to pin a worker thread indefinitely on a pathological regex (#5886)
+
+A regex like `(.*a){20}$` against a 41-character string triggers catastrophic backtracking in
+`java.util.regex`: still running after 30+ seconds for a pattern and input small enough to be typed by
+hand. `arcadedb.command.timeout` did not help, because `Matcher.matches()` never polls an interrupt flag or
+checks a deadline while backtracking - the only thing it calls on every backtracking step is
+`CharSequence.charAt()` on the input being matched, and nothing in the surrounding query execution machinery
+gets a chance to run again until that call returns on its own. In a deployment where query access reaches
+low-privilege users or an application layer that forwards user-supplied patterns, a handful of such queries
+is enough to permanently tie up the HTTP worker pool.
+
+Both regex entry points - SQL `MATCHES` (`MatchesCondition`) and openCypher `=~` (`RegexExpression`) - now
+run the match through `TimeBoundRegex`, which wraps the input `CharSequence` so `charAt()` throws once a
+deadline elapses. Because `java.util.regex` calls `charAt()` on every backtracking step, this turns the one
+call site the engine cannot otherwise intercept into the interruption point `arcadedb.command.timeout` was
+supposed to provide. The deadline itself is a new, dedicated setting, `arcadedb.command.regexTimeout`
+(default 1000ms), independent of `arcadedb.command.timeout` and active even when the latter is left at its
+default of disabled (`0`) - which it is by default, so `MATCHES`/`=~` would otherwise have had no bound at
+all regardless of configuration. `charAt()` checks the deadline every 256 calls rather than every call, to
+keep the check off the hot path for the overwhelming majority of well-behaved patterns that never come close
+to that many backtracking steps in the first place.
+
+SQL `LIKE`/`ILIKE` were audited for the same gap and found not to need it: `QueryHelper.convertForRegExp`
+escapes every regex metacharacter except `%` (`.*`) and `?` (`.`), so the generated pattern can never contain
+grouping, alternation, or nested quantifiers - the shapes catastrophic backtracking requires. It stays on
+plain `String.matches()`.
+
+[#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -378,4 +378,12 @@ just `a`s hangs exactly like the issue's own `(.*a){20}$` reproducer), and full-
 engine's `SelectOperator`) and full-text wildcard matching now run through `TimeBoundRegex` like every other
 entry point here, including the same shared-deadline treatment for a multi-value `LIKE`/`ILIKE` evaluation.
 
+A fourth review pass found one more: PromQL's `=~`/`!~` label matchers (`PromQLEvaluator#matchesPostFilters`)
+compile the user-supplied pattern straight into `Pattern.matcher(...).matches()`, with only a static
+`REDOS_CHECK` pre-filter that flags *parenthesized* nested-quantifier/alternation shapes (`(a+)+`, `(a|aa)+`).
+A sequence of unparenthesized quantified segments (`a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*ac`, PromQL's
+equivalent of the `LIKE`/wildcard gap above) contains no `(` for that check to catch, and reaches the same
+unbounded `.matches()` call. Now bounded the same way, with one shared deadline across the whole row scan a
+label matcher runs against - the same N-rows-times-timeout concern as every other multi-item entry point here.
+
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -569,10 +569,16 @@ public enum GlobalConfiguration {
   COMMAND_TIMEOUT("arcadedb.command.timeout", SCOPE.DATABASE, "Default timeout for commands (in ms)", Long.class, 0),
 
   COMMAND_REGEX_TIMEOUT("arcadedb.command.regexTimeout", SCOPE.DATABASE, """
-      Maximum time in ms a single regular expression evaluation (SQL MATCHES, openCypher =~) may run before being aborted. \
-      java.util.regex backtracking does not poll interrupts or deadlines, so a pathological pattern (catastrophic backtracking) \
-      keeps its worker thread busy regardless of arcadedb.command.timeout; this dedicated bound protects against that even when \
-      arcadedb.command.timeout is disabled (0), which is the default. Set to 0 to disable (not recommended).""",
+      Maximum time in ms a single regular expression evaluation may run before being aborted (an entire scan, for a \
+      MATCHES/=~/LIKE/ILIKE/full-text/PromQL query - see below). Covers SQL MATCHES, openCypher =~, SQL LIKE/ILIKE, the \
+      text.regexReplace() and .normalize() functions, full-text search's RegexpQuery/WildcardQuery, PromQL's =~/!~ label \
+      matchers, and schema-level REGEXP property validation. java.util.regex backtracking does not poll interrupts or \
+      deadlines, so a pathological pattern (catastrophic backtracking) keeps its worker thread busy regardless of \
+      arcadedb.command.timeout; this dedicated bound protects against that even when arcadedb.command.timeout is disabled \
+      (0), which is the default. MATCHES/=~ share one deadline across an entire query execution (not per row), and \
+      full-text/PromQL/REGEXP-validation share one deadline across an entire scan (not per item) - a large, legitimately \
+      slow (non-catastrophic) operation can hit this bound too, so raise it for workloads that need more than 1s. Set to \
+      0 to disable (not recommended).""",
       Long.class, 1000),
 
   COMMAND_WARNINGS_EVERY("arcadedb.command.warningsEvery", SCOPE.JVM,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -567,6 +567,13 @@ public enum GlobalConfiguration {
   // COMMAND
   COMMAND_TIMEOUT("arcadedb.command.timeout", SCOPE.DATABASE, "Default timeout for commands (in ms)", Long.class, 0),
 
+  COMMAND_REGEX_TIMEOUT("arcadedb.command.regexTimeout", SCOPE.DATABASE, """
+      Maximum time in ms a single regular expression evaluation (SQL MATCHES, openCypher =~) may run before being aborted. \
+      java.util.regex backtracking does not poll interrupts or deadlines, so a pathological pattern (catastrophic backtracking) \
+      keeps its worker thread busy regardless of arcadedb.command.timeout; this dedicated bound protects against that even when \
+      arcadedb.command.timeout is disabled (0), which is the default. Set to 0 to disable (not recommended).""",
+      Long.class, 1000),
+
   COMMAND_WARNINGS_EVERY("arcadedb.command.warningsEvery", SCOPE.JVM,
       "Reduce warnings in commands to print in console only every X occurrences. Use 0 to disable warnings with commands",
       Integer.class, 100),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb;
 
+import com.arcadedb.database.Database;
 import com.arcadedb.engine.PageManager;
 import com.arcadedb.exception.ConfigurationException;
 import com.arcadedb.log.LogManager;
@@ -1957,6 +1958,22 @@ public enum GlobalConfiguration {
   public <T> T getValue() {
     //noinspection unchecked
     return (T) (value != nullValue && value != null ? value : defValue);
+  }
+
+  /**
+   * Resolves this {@code SCOPE.DATABASE} setting's value against {@code database}'s per-database overrides,
+   * falling back to the compiled-in default when {@code database} is {@code null}. Several call sites read a
+   * {@code SCOPE.DATABASE} setting (e.g. {@code arcadedb.command.regexTimeout}) from code that isn't guaranteed
+   * a bound database - a standalone SQL function or operator that tests, or a future caller, may invoke directly
+   * with a {@code null}/disconnected database - and repeating the same null-safe fallback at each of those call
+   * sites risks drifting out of sync; this centralizes it.
+   *
+   * @param database the database to resolve a per-database override from, or {@code null} to use the default
+   *
+   * @return the resolved value as a {@code long}
+   */
+  public long getValueAsLong(final Database database) {
+    return (database != null ? database.getConfiguration() : new ContextConfiguration()).getValueAsLong(this);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
@@ -45,9 +45,18 @@ public class DocumentValidator {
     // property getting its own full regexTimeout budget would let a document with N such properties, each
     // crafted to backtrack catastrophically, cost up to N * regexTimeout instead of one bounded validation -
     // the same N-times-timeout shape closed everywhere else in this issue, reopened here at the property level.
-    final long regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(document.getDatabase()));
-    for (Property entry : document.getType().getPolymorphicProperties())
+    // Computed lazily on the first REGEXP-constrained property encountered, not unconditionally: most document
+    // types have none, and this runs on every insert/update, so paying System.nanoTime() + the overflow-safe
+    // arithmetic in newDeadline() for types that never use REGEXP at all would be pure waste on that hot path.
+    long regexDeadline = 0;
+    boolean regexDeadlineComputed = false;
+    for (Property entry : document.getType().getPolymorphicProperties()) {
+      if (!regexDeadlineComputed && entry.getRegexp() != null) {
+        regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(document.getDatabase()));
+        regexDeadlineComputed = true;
+      }
       validateField(document, entry, regexDeadline);
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
@@ -41,11 +41,27 @@ import java.util.regex.Pattern;
 public class DocumentValidator {
   public static void validate(final MutableDocument document) throws ValidationException {
     document.checkForLazyLoadingProperties();
+    // One shared deadline for every REGEXP-constrained property on this document (issue #5886 follow-up): each
+    // property getting its own full regexTimeout budget would let a document with N such properties, each
+    // crafted to backtrack catastrophically, cost up to N * regexTimeout instead of one bounded validation -
+    // the same N-times-timeout shape closed everywhere else in this issue, reopened here at the property level.
+    final long regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(document.getDatabase()));
     for (Property entry : document.getType().getPolymorphicProperties())
-      validateField(document, entry);
+      validateField(document, entry, regexDeadline);
   }
 
+  /**
+   * Validates a single field in isolation, outside the context of a whole-document {@link #validate}. Computes
+   * its own {@code regexTimeout} deadline; callers validating multiple fields of the same document should use
+   * {@link #validateField(MutableDocument, Property, long)} with one shared deadline instead, the way
+   * {@link #validate} does, so a document with several REGEXP-constrained properties is bounded once rather
+   * than once per property.
+   */
   public static void validateField(final MutableDocument document, final Property p) throws ValidationException {
+    validateField(document, p, TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(document.getDatabase())));
+  }
+
+  public static void validateField(final MutableDocument document, final Property p, final long regexDeadline) throws ValidationException {
     if (p.isMandatory() && !document.has(p.getName()))
       throwValidationException(document.getType(), p, "is mandatory, but not found on record: " + document);
 
@@ -62,8 +78,7 @@ public class DocumentValidator {
         // privileges needed, so an admin-defined pattern with a vulnerable shape (classic email/URL validation
         // regexes are notorious for this) combined with an attacker-supplied field value is enough to hang a
         // worker thread indefinitely.
-        if (!TimeBoundRegex.matches(Pattern.compile(p.getRegexp()), fieldValue.toString(),
-            GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(document.getDatabase())))
+        if (!TimeBoundRegex.matchesUntil(Pattern.compile(p.getRegexp()), fieldValue.toString(), regexDeadline))
           throwValidationException(document.getType(), p,
               "does not match the regular expression '" + p.getRegexp() + "'. Field value is: " + fieldValue + ", record: "
                   + document);

--- a/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
@@ -18,10 +18,12 @@
  */
 package com.arcadedb.database;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.exception.ValidationException;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Type;
+import com.arcadedb.utility.TimeBoundRegex;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -29,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Validates documents against constraints defined in the schema.
@@ -54,8 +57,13 @@ public class DocumentValidator {
         throwValidationException(document.getType(), p, "cannot be null, record: " + document);
     } else {
       if (p.getRegexp() != null)
-        // REGEXP
-        if (!fieldValue.toString().matches(p.getRegexp()))
+        // REGEXP - bounded against catastrophic backtracking (issue #5886): this runs on every insert/update of
+        // a validated property, reachable through any write path (REST, any wire protocol) with no query
+        // privileges needed, so an admin-defined pattern with a vulnerable shape (classic email/URL validation
+        // regexes are notorious for this) combined with an attacker-supplied field value is enough to hang a
+        // worker thread indefinitely.
+        if (!TimeBoundRegex.matches(Pattern.compile(p.getRegexp()), fieldValue.toString(),
+            GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(document.getDatabase())))
           throwValidationException(document.getType(), p,
               "does not match the regular expression '" + p.getRegexp() + "'. Field value is: " + fieldValue + ", record: "
                   + document);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -121,6 +121,18 @@ public class PromQLEvaluator {
   }
 
   /**
+   * Overrides the lazily-computed {@link #regexDeadline()} with one already resolved elsewhere (issue #5886,
+   * 17th review pass). {@code SQLFunctionPromQL} constructs a fresh {@code PromQLEvaluator} on every {@code
+   * promql()} call rather than reusing one across a query, so without this, each call would fall back to its
+   * own {@code GlobalConfiguration}-derived budget instead of the {@code CommandContext}-cached deadline every
+   * other per-row SQL function in this issue shares ({@code text.regexReplace()}, {@code .normalize()}).
+   * Must be called before the first regex-bearing evaluation on this instance to have any effect.
+   */
+  public void setRegexDeadline(final long regexDeadline) {
+    this.regexDeadline = regexDeadline;
+  }
+
+  /**
    * Evaluate an instant query at a single timestamp.
    */
   public PromQLResult evaluateInstant(final PromQLExpr expr, final long evalTimeMs) {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -202,7 +202,7 @@ public class PromQLEvaluator {
     // (issue #5886 follow-up), not a fresh one per row - matchesPostFilters() runs per row, so N rows each
     // getting their own full regexTimeout budget would let a crafted =~/!~ pattern tie up the thread for
     // row count * regexTimeout instead of one bounded evaluation.
-    final long regexDeadline = TimeBoundRegex.newDeadline(database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+    final long regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(database));
     final Map<String, VectorSample> latestByLabels = new LinkedHashMap<>();
     while (rowIter.hasNext()) {
       final Object[] row = rowIter.next();
@@ -249,7 +249,7 @@ public class PromQLEvaluator {
     }
 
     // Group rows by label combination. One shared deadline for the whole scan - see evaluateInstant().
-    final long regexDeadline = TimeBoundRegex.newDeadline(database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+    final long regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(database));
     final Map<String, List<double[]>> seriesByLabels = new LinkedHashMap<>();
     final Map<String, Map<String, String>> labelsMap = new LinkedHashMap<>();
     while (rowIter.hasNext()) {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -74,6 +74,14 @@ public class PromQLEvaluator {
 
   private final DatabaseInternal        database;
   private final long                    lookbackMs;
+  // Lazily computed, then shared for the lifetime of this evaluator instance (issue #5886 follow-up): a fresh
+  // PromQLEvaluator is created per top-level query (see SQLFunctionPromQL), never reused across executions the
+  // way RegexExpression's AST nodes are cached by CypherStatementCache, so caching this as an instance field is
+  // safe here (no stale-deadline-across-executions risk). Without it, evaluateRange()'s per-step loop - up to
+  // MAX_RANGE_STEPS = 1,000,000 steps - would let each step's evaluateVectorSelector()/evaluateMatrixSelector()
+  // compute its own fresh regexDeadline, reopening the N-times-timeout bypass one level up from the per-row
+  // sharing those methods already do within a single step's scan.
+  private Long                          regexDeadline;
   private static final int              MAX_REGEX_LENGTH   = 1024;
   private static final int              MAX_PATTERN_CACHE  = 1024;
   // Detects patterns that cause catastrophic backtracking (ReDoS):
@@ -104,6 +112,12 @@ public class PromQLEvaluator {
   public PromQLEvaluator(final DatabaseInternal database, final long lookbackMs) {
     this.database = database;
     this.lookbackMs = lookbackMs;
+  }
+
+  private long regexDeadline() {
+    if (regexDeadline == null)
+      regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(database));
+    return regexDeadline;
   }
 
   /**
@@ -198,15 +212,15 @@ public class PromQLEvaluator {
       return new InstantVector(List.of());
     }
 
-    // Post-filter for NEQ/RE/NRE and group by label combination. One shared deadline for the whole scan
-    // (issue #5886 follow-up), not a fresh one per row - matchesPostFilters() runs per row, so N rows each
-    // getting their own full regexTimeout budget would let a crafted =~/!~ pattern tie up the thread for
-    // row count * regexTimeout instead of one bounded evaluation.
-    final long regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(database));
+    // Post-filter for NEQ/RE/NRE and group by label combination. One shared deadline for the whole evaluator
+    // instance (issue #5886 follow-up) - regexDeadline() computes it once and reuses it for every row of every
+    // step, not a fresh one per row or per step: matchesPostFilters() runs per row, and evaluateRange() calls
+    // this method once per step (up to MAX_RANGE_STEPS), so anything less than one shared deadline for the
+    // whole query would let a crafted =~/!~ pattern tie up the thread for rowCount * stepCount * regexTimeout.
     final Map<String, VectorSample> latestByLabels = new LinkedHashMap<>();
     while (rowIter.hasNext()) {
       final Object[] row = rowIter.next();
-      if (!matchesPostFilters(row, vs.matchers(), columns, regexDeadline))
+      if (!matchesPostFilters(row, vs.matchers(), columns, regexDeadline()))
         continue;
       final Map<String, String> labels = extractLabels(row, columns, vs.metricName());
       final String key = labelKey(labels);
@@ -248,13 +262,13 @@ public class PromQLEvaluator {
       return new RangeVector(List.of());
     }
 
-    // Group rows by label combination. One shared deadline for the whole scan - see evaluateInstant().
-    final long regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(database));
+    // Group rows by label combination. One shared deadline for the whole evaluator instance - see
+    // evaluateVectorSelector().
     final Map<String, List<double[]>> seriesByLabels = new LinkedHashMap<>();
     final Map<String, Map<String, String>> labelsMap = new LinkedHashMap<>();
     while (rowIter.hasNext()) {
       final Object[] row = rowIter.next();
-      if (!matchesPostFilters(row, vs.matchers(), columns, regexDeadline))
+      if (!matchesPostFilters(row, vs.matchers(), columns, regexDeadline()))
         continue;
       final Map<String, String> labels = extractLabels(row, columns, vs.metricName());
       final String key = labelKey(labels);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluator.java
@@ -18,8 +18,10 @@
  */
 package com.arcadedb.engine.timeseries.promql;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.TimeBoundRegex;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.engine.timeseries.TimeSeriesEngine;
@@ -196,11 +198,15 @@ public class PromQLEvaluator {
       return new InstantVector(List.of());
     }
 
-    // Post-filter for NEQ/RE/NRE and group by label combination
+    // Post-filter for NEQ/RE/NRE and group by label combination. One shared deadline for the whole scan
+    // (issue #5886 follow-up), not a fresh one per row - matchesPostFilters() runs per row, so N rows each
+    // getting their own full regexTimeout budget would let a crafted =~/!~ pattern tie up the thread for
+    // row count * regexTimeout instead of one bounded evaluation.
+    final long regexDeadline = TimeBoundRegex.newDeadline(database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
     final Map<String, VectorSample> latestByLabels = new LinkedHashMap<>();
     while (rowIter.hasNext()) {
       final Object[] row = rowIter.next();
-      if (!matchesPostFilters(row, vs.matchers(), columns))
+      if (!matchesPostFilters(row, vs.matchers(), columns, regexDeadline))
         continue;
       final Map<String, String> labels = extractLabels(row, columns, vs.metricName());
       final String key = labelKey(labels);
@@ -242,12 +248,13 @@ public class PromQLEvaluator {
       return new RangeVector(List.of());
     }
 
-    // Group rows by label combination
+    // Group rows by label combination. One shared deadline for the whole scan - see evaluateInstant().
+    final long regexDeadline = TimeBoundRegex.newDeadline(database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
     final Map<String, List<double[]>> seriesByLabels = new LinkedHashMap<>();
     final Map<String, Map<String, String>> labelsMap = new LinkedHashMap<>();
     while (rowIter.hasNext()) {
       final Object[] row = rowIter.next();
-      if (!matchesPostFilters(row, vs.matchers(), columns))
+      if (!matchesPostFilters(row, vs.matchers(), columns, regexDeadline))
         continue;
       final Map<String, String> labels = extractLabels(row, columns, vs.metricName());
       final String key = labelKey(labels);
@@ -480,7 +487,7 @@ public class PromQLEvaluator {
   }
 
   private boolean matchesPostFilters(final Object[] row, final List<LabelMatcher> matchers,
-      final List<ColumnDefinition> columns) {
+      final List<ColumnDefinition> columns, final long regexDeadline) {
     for (final LabelMatcher m : matchers) {
       if (m.op() == MatchOp.EQ || "__name__".equals(m.name()))
         continue;
@@ -495,11 +502,11 @@ public class PromQLEvaluator {
             return false;
           break;
         case RE:
-          if (!compilePattern(m.value()).matcher(strVal).matches())
+          if (!TimeBoundRegex.matchesUntil(compilePattern(m.value()), strVal, regexDeadline))
             return false;
           break;
         case NRE:
-          if (compilePattern(m.value()).matcher(strVal).matches())
+          if (TimeBoundRegex.matchesUntil(compilePattern(m.value()), strVal, regexDeadline))
             return false;
           break;
         default:

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionPromQL.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionPromQL.java
@@ -80,6 +80,10 @@ public class SQLFunctionPromQL extends SQLFunctionConfigurableAbstract {
 
     final DatabaseInternal database = (DatabaseInternal) context.getDatabase();
     final PromQLEvaluator evaluator = new PromQLEvaluator(database);
+    // issue #5886, 17th review pass: a fresh evaluator per call would otherwise resolve its own regexTimeout
+    // budget from GlobalConfiguration in isolation instead of the CommandContext-cached deadline every other
+    // per-row SQL function in this issue shares - see PromQLEvaluator.setRegexDeadline().
+    evaluator.setRegexDeadline(context.getOrComputeRegexDeadline("__PROMQL_FUNCTION_DEADLINE__"));
     final PromQLResult result = evaluator.evaluateInstant(new PromQLParser(expr).parse(), evalTimeMs);
     return toList(result);
   }

--- a/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
+++ b/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
@@ -87,6 +87,12 @@ public class TextRegexReplace extends AbstractTextFunction {
       // Catastrophic backtracking (issue #5886): TimeBoundRegex already bounds this to regexTimeout instead of
       // running unbounded, but still surfaces it through this function's existing IllegalArgumentException contract.
       throw new IllegalArgumentException("Regex pattern caused catastrophic backtracking and was aborted: " + regex, e);
+    } catch (final StackOverflowError e) {
+      // TimeBoundRegex only converts a StackOverflowError into a TimeoutException when regexTimeout is active;
+      // with it explicitly disabled (arcadedb.command.regexTimeout <= 0), a stack-overflow-inducing pattern
+      // propagates as itself instead - keep this function's original, documented IllegalArgumentException
+      // contract for that combination too, not just for the bounded case.
+      throw new IllegalArgumentException("Regex pattern caused stack overflow (possible catastrophic backtracking): " + regex, e);
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
+++ b/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.function.text;
 
-import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -75,13 +74,10 @@ public class TextRegexReplace extends AbstractTextFunction {
 
     // Unlike a WHERE-clause condition (always evaluated with a database bound to the context), this SQL function
     // is a lower-level entry point that unit tests across this package call directly with a bare or null context,
-    // so context/context.getDatabase() being unset here is a real, not just theoretical, case to fall back from -
-    // falling back to a fresh ContextConfiguration (itself just a proxy for the compiled-in default) keeps that
-    // usage working exactly as it did before this function read any configuration at all.
-    final ContextConfiguration configuration = context != null && context.getDatabase() != null
-        ? context.getDatabase().getConfiguration()
-        : new ContextConfiguration();
-    final long regexTimeout = configuration.getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+    // so context/context.getDatabase() being unset here is a real, not just theoretical, case to fall back from.
+    // GlobalConfiguration.getValueAsLong(Database) falls back to the compiled-in default for a null database,
+    // keeping that usage working exactly as it did before this function read any configuration at all.
+    final long regexTimeout = GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context != null ? context.getDatabase() : null);
 
     try {
       return TimeBoundRegex.replaceAll(Pattern.compile(regex), str, replacement == null ? "" : replacement, regexTimeout);

--- a/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
+++ b/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
@@ -32,6 +32,12 @@ import java.util.regex.PatternSyntaxException;
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
 public class TextRegexReplace extends AbstractTextFunction {
+  private static final int MAX_PATTERN_LENGTH = 500;
+
+  // context.getCachedValue()/setCachedValue() key for the shared deadline - see execute() for why this needs to
+  // be shared, not recomputed per call.
+  private static final String DEADLINE_CACHE_KEY = "__TEXT_REGEXREPLACE_DEADLINE__";
+
   @Override
   protected String getSimpleName() {
     return "regexReplace";
@@ -51,12 +57,6 @@ public class TextRegexReplace extends AbstractTextFunction {
   public String getDescription() {
     return "Replace all matches of a regular expression with replacement";
   }
-
-  private static final int MAX_PATTERN_LENGTH = 500;
-
-  // context.getCachedValue()/setCachedValue() key for the shared deadline - see execute() for why this needs to
-  // be shared, not recomputed per call.
-  private static final String DEADLINE_CACHE_KEY = "__TEXT_REGEXREPLACE_DEADLINE__";
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
@@ -84,17 +84,9 @@ public class TextRegexReplace extends AbstractTextFunction {
     // invocations of this function (see TextRegexReplaceTest); GlobalConfiguration.getValueAsLong(Database)
     // falls back to the compiled-in default in that case, and the deadline is simply not shared across calls
     // when there's no context to cache it on.
-    final long regexDeadline;
-    if (context != null) {
-      Long cached = (Long) context.getCachedValue(DEADLINE_CACHE_KEY);
-      if (cached == null) {
-        cached = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
-        context.setCachedValue(DEADLINE_CACHE_KEY, cached);
-      }
-      regexDeadline = cached;
-    } else {
-      regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(null));
-    }
+    final long regexDeadline = context != null ?
+        context.getOrComputeRegexDeadline(DEADLINE_CACHE_KEY) :
+        TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(null));
 
     try {
       return TimeBoundRegex.replaceAllUntil(Pattern.compile(regex), str, replacement == null ? "" : replacement, regexDeadline);

--- a/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
+++ b/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
@@ -54,6 +54,10 @@ public class TextRegexReplace extends AbstractTextFunction {
 
   private static final int MAX_PATTERN_LENGTH = 500;
 
+  // context.getCachedValue()/setCachedValue() key for the shared deadline - see execute() for why this needs to
+  // be shared, not recomputed per call.
+  private static final String DEADLINE_CACHE_KEY = "__TEXT_REGEXREPLACE_DEADLINE__";
+
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     final String str = asString(args[0]);
@@ -72,15 +76,28 @@ public class TextRegexReplace extends AbstractTextFunction {
           "Regex pattern exceeds maximum allowed length (" + MAX_PATTERN_LENGTH + "): " + regex.length());
     }
 
-    // Unlike a WHERE-clause condition (always evaluated with a database bound to the context), this SQL function
-    // is a lower-level entry point that unit tests across this package call directly with a bare or null context,
-    // so context/context.getDatabase() being unset here is a real, not just theoretical, case to fall back from.
-    // GlobalConfiguration.getValueAsLong(Database) falls back to the compiled-in default for a null database,
-    // keeping that usage working exactly as it did before this function read any configuration at all.
-    final long regexTimeout = GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context != null ? context.getDatabase() : null);
+    // One deadline shared across every row this function runs against within the same query (issue #5886
+    // follow-up): unlike LikeOperator/ILikeOperator (no CommandContext to cache on), this function does receive
+    // one, so it gets the same treatment as MatchesCondition/RegexExpression rather than a fresh budget per
+    // call - otherwise SELECT text.regexReplace(col, :pattern, 'x') FROM LargeType with a pathological pattern
+    // could still cost up to rowCount * regexTimeout overall. context is null in some direct/unit-test
+    // invocations of this function (see TextRegexReplaceTest); GlobalConfiguration.getValueAsLong(Database)
+    // falls back to the compiled-in default in that case, and the deadline is simply not shared across calls
+    // when there's no context to cache it on.
+    final long regexDeadline;
+    if (context != null) {
+      Long cached = (Long) context.getCachedValue(DEADLINE_CACHE_KEY);
+      if (cached == null) {
+        cached = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
+        context.setCachedValue(DEADLINE_CACHE_KEY, cached);
+      }
+      regexDeadline = cached;
+    } else {
+      regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(null));
+    }
 
     try {
-      return TimeBoundRegex.replaceAll(Pattern.compile(regex), str, replacement == null ? "" : replacement, regexTimeout);
+      return TimeBoundRegex.replaceAllUntil(Pattern.compile(regex), str, replacement == null ? "" : replacement, regexDeadline);
     } catch (final PatternSyntaxException e) {
       throw new IllegalArgumentException("Invalid regex pattern: " + e.getMessage(), e);
     } catch (final TimeoutException e) {

--- a/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
+++ b/engine/src/main/java/com/arcadedb/function/text/TextRegexReplace.java
@@ -18,7 +18,11 @@
  */
 package com.arcadedb.function.text;
 
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.TimeBoundRegex;
 
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -69,14 +73,24 @@ public class TextRegexReplace extends AbstractTextFunction {
           "Regex pattern exceeds maximum allowed length (" + MAX_PATTERN_LENGTH + "): " + regex.length());
     }
 
+    // Unlike a WHERE-clause condition (always evaluated with a database bound to the context), this SQL function
+    // is a lower-level entry point that unit tests across this package call directly with a bare or null context,
+    // so context/context.getDatabase() being unset here is a real, not just theoretical, case to fall back from -
+    // falling back to a fresh ContextConfiguration (itself just a proxy for the compiled-in default) keeps that
+    // usage working exactly as it did before this function read any configuration at all.
+    final ContextConfiguration configuration = context != null && context.getDatabase() != null
+        ? context.getDatabase().getConfiguration()
+        : new ContextConfiguration();
+    final long regexTimeout = configuration.getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+
     try {
-      return Pattern.compile(regex).matcher(str).replaceAll(replacement == null ? "" : replacement);
+      return TimeBoundRegex.replaceAll(Pattern.compile(regex), str, replacement == null ? "" : replacement, regexTimeout);
     } catch (final PatternSyntaxException e) {
       throw new IllegalArgumentException("Invalid regex pattern: " + e.getMessage(), e);
-    } catch (final StackOverflowError e) {
-      // Catastrophic backtracking can cause stack overflow
-      throw new IllegalArgumentException(
-          "Regex pattern caused stack overflow (possible catastrophic backtracking): " + regex, e);
+    } catch (final TimeoutException e) {
+      // Catastrophic backtracking (issue #5886): TimeBoundRegex already bounds this to regexTimeout instead of
+      // running unbounded, but still surfaces it through this function's existing IllegalArgumentException contract.
+      throw new IllegalArgumentException("Regex pattern caused catastrophic backtracking and was aborted: " + regex, e);
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -612,6 +612,10 @@ public class FullTextQueryExecutor {
     final String searchPrefix = buildSearchKey(field, literalPrefix);
     final String fieldPrefix = !isUnqualified(field) ? field + ":" : "";
     final Pattern regex = wildcardToRegex(pattern);
+    // A sequence of several *'s (translated to .* by wildcardToRegex, same shape as %  in SQL LIKE) reproduces
+    // catastrophic backtracking without needing grouping/alternation/nested quantifiers - issue #5886 follow-up.
+    // One shared deadline for the whole scan, same rationale as collectRegexpMatches.
+    final long deadline = TimeBoundRegex.newDeadline(index.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
 
     if (literalPrefix.isEmpty()) {
       // Leading wildcard: full scan, then regex match against the unprefixed token portion
@@ -622,7 +626,7 @@ public class FullTextQueryExecutor {
         // Skip cross-field tokens for unqualified queries on multi-property indexes
         if (fieldPrefix.isEmpty() && token.indexOf(':') >= 0)
           return false;
-        return regex.matcher(token).matches();
+        return TimeBoundRegex.matchesUntil(regex, token, deadline);
       }, scoreMap, boostFor(field));
     } else {
       // Range scan starting at the literal prefix and stop when keys no longer share it
@@ -632,7 +636,7 @@ public class FullTextQueryExecutor {
         final String token = key.substring(fieldPrefix.length());
         if (fieldPrefix.isEmpty() && token.indexOf(':') >= 0)
           return false;
-        return regex.matcher(token).matches();
+        return TimeBoundRegex.matchesUntil(regex, token, deadline);
       }, scoreMap, boostFor(field));
     }
   }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.fulltext;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.RID;
 import com.arcadedb.function.text.TextLevenshteinDistance;
 import com.arcadedb.index.IndexCursor;
@@ -27,6 +28,7 @@ import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.FullTextIndexMetadata;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.TimeBoundRegex;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -671,6 +673,10 @@ public class FullTextQueryExecutor {
     }
 
     final String fieldPrefix = !isUnqualified(field) ? field + ":" : "";
+    // A user-supplied regexp query (/pattern/ syntax) is matched against every token in what is, absent a literal
+    // prefix, a full index scan (issue #5886) - one shared deadline for the whole scan, not a fresh one per token,
+    // otherwise a crafted index could still tie the thread up for token count * regexTimeout.
+    final long deadline = TimeBoundRegex.newDeadline(index.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
 
     iterateAndMatch(null, key -> {
       if (!key.startsWith(fieldPrefix))
@@ -678,7 +684,7 @@ public class FullTextQueryExecutor {
       final String token = key.substring(fieldPrefix.length());
       if (fieldPrefix.isEmpty() && token.indexOf(':') >= 0)
         return false;
-      return regex.matcher(token).matches();
+      return TimeBoundRegex.matchesUntil(regex, token, deadline);
     }, scoreMap, boostFor(field));
   }
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -615,7 +615,7 @@ public class FullTextQueryExecutor {
     // A sequence of several *'s (translated to .* by wildcardToRegex, same shape as %  in SQL LIKE) reproduces
     // catastrophic backtracking without needing grouping/alternation/nested quantifiers - issue #5886 follow-up.
     // One shared deadline for the whole scan, same rationale as collectRegexpMatches.
-    final long deadline = TimeBoundRegex.newDeadline(index.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+    final long deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(index.getDatabase()));
 
     if (literalPrefix.isEmpty()) {
       // Leading wildcard: full scan, then regex match against the unprefixed token portion
@@ -680,7 +680,7 @@ public class FullTextQueryExecutor {
     // A user-supplied regexp query (/pattern/ syntax) is matched against every token in what is, absent a literal
     // prefix, a full index scan (issue #5886) - one shared deadline for the whole scan, not a fresh one per token,
     // otherwise a crafted index could still tie the thread up for token count * regexTimeout.
-    final long deadline = TimeBoundRegex.newDeadline(index.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+    final long deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(index.getDatabase()));
 
     iterateAndMatch(null, key -> {
       if (!key.startsWith(fieldPrefix))

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -214,6 +214,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     underlyingIndex.updateTypeName(newTypeName);
   }
 
+  public DatabaseInternal getDatabase() {
+    return underlyingIndex.getMutableIndex().getDatabase();
+  }
+
   @Override
   public IndexCursor get(final Object[] keys) {
     return get(keys, -1);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
@@ -18,8 +18,10 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.utility.TimeBoundRegex;
 
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -70,7 +72,7 @@ public class RegexExpression implements BooleanExpression {
 
     // Match against value
     final String valueStr = value.toString();
-    return compiledPattern.matcher(valueStr).matches();
+    return TimeBoundRegex.matches(compiledPattern, valueStr, context.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -72,11 +73,12 @@ public class RegexExpression implements BooleanExpression {
 
     // Match against value. context.getDatabase().getConfiguration(), not context.getConfiguration(): see
     // MatchesCondition.matches() for why the latter would silently ignore a per-database override here, and for
-    // why this call is intentionally unguarded against a null database (RegexExpression is likewise only ever
-    // constructed by the openCypher parser and evaluated with a database already bound to the context).
+    // why the database-null fallback below is defense-in-depth rather than a response to a known gap
+    // (RegexExpression is, in practice, only ever constructed by the openCypher parser and evaluated with a
+    // database already bound to the context).
     final String valueStr = value.toString();
-    return TimeBoundRegex.matches(compiledPattern, valueStr,
-        context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+    final ContextConfiguration configuration = context.getDatabase() != null ? context.getDatabase().getConfiguration() : new ContextConfiguration();
+    return TimeBoundRegex.matches(compiledPattern, valueStr, configuration.getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
@@ -32,13 +32,17 @@ import java.util.regex.PatternSyntaxException;
  * Example: n.name =~ '.*Smith', n.email =~ '.*@example\\.com'
  */
 public class RegexExpression implements BooleanExpression {
+  // Deadline caching MUST live on the CommandContext (below), never as an instance field on this class: unlike
+  // compiledPattern (content-addressed, safe to reuse across executions), a deadline is a point in time tied to
+  // one execution. CypherStatementCache caches parsed queries - including this AST node - by query text across
+  // repeated executions, so an instance-field deadline would be computed once on the first execution and then,
+  // once it lapsed (trivially within ~1s at the default regexTimeout), make every later execution of that same
+  // cached query text throw a spurious TimeoutException on any pattern, catastrophic or not.
+  private static final String DEADLINE_CACHE_KEY = "REGEX_EXPRESSION_DEADLINE";
+
   private final Expression expression;
   private final Expression pattern;
   private Pattern compiledPattern;
-  // One deadline for the lifetime of this AST node, i.e. every row a WHERE ... =~ clause scans - not
-  // recomputed per row, and not tied to compiledPattern's per-row recompilation (a row-varying pattern string
-  // must not also reset the time budget). See MatchesCondition.matches() for the equivalent SQL-side rationale.
-  private Long    deadline;
 
   public RegexExpression(final Expression expression, final Expression pattern) {
     this.expression = expression;
@@ -80,8 +84,11 @@ public class RegexExpression implements BooleanExpression {
     // with one already bound). See MatchesCondition.matches() for why context.getConfiguration() would silently
     // ignore a per-database override here.
     final String valueStr = value.toString();
-    if (deadline == null)
+    Long deadline = (Long) context.getCachedValue(DEADLINE_CACHE_KEY);
+    if (deadline == null) {
       deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
+      context.setCachedValue(DEADLINE_CACHE_KEY, deadline);
+    }
     return TimeBoundRegex.matchesUntil(compiledPattern, valueStr, deadline);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
@@ -71,7 +71,9 @@ public class RegexExpression implements BooleanExpression {
     }
 
     // Match against value. context.getDatabase().getConfiguration(), not context.getConfiguration(): see
-    // MatchesCondition.matches() for why the latter would silently ignore a per-database override here.
+    // MatchesCondition.matches() for why the latter would silently ignore a per-database override here, and for
+    // why this call is intentionally unguarded against a null database (RegexExpression is likewise only ever
+    // constructed by the openCypher parser and evaluated with a database already bound to the context).
     final String valueStr = value.toString();
     return TimeBoundRegex.matches(compiledPattern, valueStr,
         context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
-import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -36,6 +35,10 @@ public class RegexExpression implements BooleanExpression {
   private final Expression expression;
   private final Expression pattern;
   private Pattern compiledPattern;
+  // One deadline for the lifetime of this AST node, i.e. every row a WHERE ... =~ clause scans - not
+  // recomputed per row, and not tied to compiledPattern's per-row recompilation (a row-varying pattern string
+  // must not also reset the time budget). See MatchesCondition.matches() for the equivalent SQL-side rationale.
+  private Long    deadline;
 
   public RegexExpression(final Expression expression, final Expression pattern) {
     this.expression = expression;
@@ -71,14 +74,15 @@ public class RegexExpression implements BooleanExpression {
       }
     }
 
-    // Match against value. context.getDatabase().getConfiguration(), not context.getConfiguration(): see
-    // MatchesCondition.matches() for why the latter would silently ignore a per-database override here, and for
-    // why the database-null fallback below is defense-in-depth rather than a response to a known gap
-    // (RegexExpression is, in practice, only ever constructed by the openCypher parser and evaluated with a
-    // database already bound to the context).
+    // Match against value. GlobalConfiguration.getValueAsLong(Database) resolves context.getDatabase()'s
+    // per-database override (falling back to the compiled-in default if a database is ever not bound to the
+    // context - RegexExpression is, in practice, only ever constructed by the openCypher parser and evaluated
+    // with one already bound). See MatchesCondition.matches() for why context.getConfiguration() would silently
+    // ignore a per-database override here.
     final String valueStr = value.toString();
-    final ContextConfiguration configuration = context.getDatabase() != null ? context.getDatabase().getConfiguration() : new ContextConfiguration();
-    return TimeBoundRegex.matches(compiledPattern, valueStr, configuration.getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+    if (deadline == null)
+      deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
+    return TimeBoundRegex.matchesUntil(compiledPattern, valueStr, deadline);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
@@ -70,9 +70,11 @@ public class RegexExpression implements BooleanExpression {
       }
     }
 
-    // Match against value
+    // Match against value. context.getDatabase().getConfiguration(), not context.getConfiguration(): see
+    // MatchesCondition.matches() for why the latter would silently ignore a per-database override here.
     final String valueStr = value.toString();
-    return TimeBoundRegex.matches(compiledPattern, valueStr, context.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+    return TimeBoundRegex.matches(compiledPattern, valueStr,
+        context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/RegexExpression.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
-import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.utility.TimeBoundRegex;
@@ -78,18 +77,13 @@ public class RegexExpression implements BooleanExpression {
       }
     }
 
-    // Match against value. GlobalConfiguration.getValueAsLong(Database) resolves context.getDatabase()'s
-    // per-database override (falling back to the compiled-in default if a database is ever not bound to the
-    // context - RegexExpression is, in practice, only ever constructed by the openCypher parser and evaluated
-    // with one already bound). See MatchesCondition.matches() for why context.getConfiguration() would silently
-    // ignore a per-database override here.
+    // Match against value. context.getOrComputeRegexDeadline() resolves context.getDatabase()'s per-database
+    // override (falling back to the compiled-in default if a database is ever not bound to the context -
+    // RegexExpression is, in practice, only ever constructed by the openCypher parser and evaluated with one
+    // already bound). See MatchesCondition.matches() for why context.getConfiguration() would silently ignore a
+    // per-database override here.
     final String valueStr = value.toString();
-    Long deadline = (Long) context.getCachedValue(DEADLINE_CACHE_KEY);
-    if (deadline == null) {
-      deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
-      context.setCachedValue(DEADLINE_CACHE_KEY, deadline);
-    }
-    return TimeBoundRegex.matchesUntil(compiledPattern, valueStr, deadline);
+    return TimeBoundRegex.matchesUntil(compiledPattern, valueStr, context.getOrComputeRegexDeadline(DEADLINE_CACHE_KEY));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/select/SelectOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectOperator.java
@@ -17,6 +17,7 @@ package com.arcadedb.query.select;/*
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Document;
 import com.arcadedb.query.sql.executor.QueryHelper;
 import com.arcadedb.serializer.BinaryComparator;
@@ -111,7 +112,8 @@ public enum SelectOperator {
     @Override
     Object eval(final Document record, final Object left, final Object right) {
       return QueryHelper.like(((String) SelectExecutor.evaluateValue(record, left)).toLowerCase(Locale.ENGLISH),
-          ((String) SelectExecutor.evaluateValue(record, right)).toLowerCase());
+          ((String) SelectExecutor.evaluateValue(record, right)).toLowerCase(),
+          record.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
     }
   },
 
@@ -119,7 +121,8 @@ public enum SelectOperator {
     @Override
     Object eval(final Document record, final Object left, final Object right) {
       return QueryHelper.like((String) SelectExecutor.evaluateValue(record, left),
-          (String) SelectExecutor.evaluateValue(record, right));
+          (String) SelectExecutor.evaluateValue(record, right),
+          record.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
     }
   },
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectOperator.java
@@ -113,7 +113,7 @@ public enum SelectOperator {
     Object eval(final Document record, final Object left, final Object right) {
       return QueryHelper.like(((String) SelectExecutor.evaluateValue(record, left)).toLowerCase(Locale.ENGLISH),
           ((String) SelectExecutor.evaluateValue(record, right)).toLowerCase(),
-          record.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+          GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(record.getDatabase()));
     }
   },
 
@@ -122,7 +122,7 @@ public enum SelectOperator {
     Object eval(final Document record, final Object left, final Object right) {
       return QueryHelper.like((String) SelectExecutor.evaluateValue(record, left),
           (String) SelectExecutor.evaluateValue(record, right),
-          record.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT));
+          GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(record.getDatabase()));
     }
   },
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
@@ -19,8 +19,10 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
+import com.arcadedb.utility.TimeBoundRegex;
 
 import java.util.Map;
 
@@ -52,6 +54,38 @@ public interface CommandContext {
    * Stores a value in the opaque internal cache. See {@link #getCachedValue(String)}.
    */
   CommandContext setCachedValue(String key, Object value);
+
+  /**
+   * Returns an absolute {@code arcadedb.command.regexTimeout} deadline (see {@link TimeBoundRegex#newDeadline(long)})
+   * shared for the lifetime of this context, computing and caching it on first call. Centralizes the
+   * get-cached-or-compute-and-cache pattern every regex-bounding call site in the engine needs to share one
+   * deadline across a series of related matches (issue #5886) - each call site previously hand-rolled this
+   * with its own cache key, which is exactly how a real bug shipped: two independently-chosen keys collided
+   * (a fixed {@code "MATCHES_DEADLINE"} key colliding with the pattern cache's {@code "MATCHES_" + <regex
+   * text>} keys for the literal pattern text {@code DEADLINE}). Centralizing here still requires each caller
+   * to pass a key that can't collide with anything else it puts in this same cache, but removes the need to
+   * hand-write the get-or-compute logic itself at every site.
+   *
+   * @param cacheKey      the {@link #getCachedValue(String)} key to store the deadline under - must not collide
+   *                      with any other key this context's cache holds
+   * @param timeoutMillis maximum time allowed from now, in milliseconds; a value {@code <= 0} disables the bound
+   */
+  default long getOrComputeRegexDeadline(final String cacheKey, final long timeoutMillis) {
+    Long deadline = (Long) getCachedValue(cacheKey);
+    if (deadline == null) {
+      deadline = TimeBoundRegex.newDeadline(timeoutMillis);
+      setCachedValue(cacheKey, deadline);
+    }
+    return deadline;
+  }
+
+  /**
+   * Convenience overload of {@link #getOrComputeRegexDeadline(String, long)} that resolves {@code timeoutMillis}
+   * from {@link GlobalConfiguration#COMMAND_REGEX_TIMEOUT} for this context's database.
+   */
+  default long getOrComputeRegexDeadline(final String cacheKey) {
+    return getOrComputeRegexDeadline(cacheKey, GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(getDatabase()));
+  }
 
   CommandContext incrementVariable(String getNeighbors);
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
@@ -66,6 +66,14 @@ public interface CommandContext {
    * to pass a key that can't collide with anything else it puts in this same cache, but removes the need to
    * hand-write the get-or-compute logic itself at every site.
    *
+   * <p>The deadline is shared across every row evaluated through <em>this</em> context, but not necessarily
+   * across an entire query: {@code FetchFromTypeExecutionStep.syncPullParallel} gives each parallel bucket-scan
+   * worker its own {@link #copy()} of the context (deliberately, so workers don't race on this same cache's
+   * non-thread-safe backing map), so each worker computes its own deadline independently. A type scanned in
+   * parallel across N buckets is therefore bounded by {@code N * timeoutMillis} overall, not one shared budget.
+   * This is a much narrower gap than the one this method closes: bucket count is a schema/DDL property, not
+   * attacker-controlled the way row/item counts are.
+   *
    * @param cacheKey      the {@link #getCachedValue(String)} key to store the deadline under - must not collide
    *                      with any other key this context's cache holds
    * @param timeoutMillis maximum time allowed from now, in milliseconds; a value {@code <= 0} disables the bound

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
@@ -18,11 +18,25 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.utility.TimeBoundRegex;
+
+import java.util.regex.Pattern;
+
 public class QueryHelper {
   protected static final char WILDCARD_ANYCHAR = '?';
   protected static final char WILDCARD_ANY     = '%';
 
-  public static boolean like(String currentValue, String value) {
+  /**
+   * A sequence of several {@code %}/{@code ?} wildcards (translated to {@code .*}/{@code .} by {@link
+   * #convertForRegExp(String)}) reproduces the same catastrophic-backtracking shape as the issue #5886
+   * reproducer even without grouping, alternation, or nested quantifiers - a pattern like {@code %a%a%a%a%a%}
+   * against input that does not fully match it hangs exactly like {@code (.*a){20}$} does. Bounded the same
+   * way as {@code MATCHES}/{@code =~}: see {@link TimeBoundRegex}.
+   *
+   * @param timeoutMillis maximum time allowed for the match, in milliseconds; a value {@code <= 0} disables the
+   *                      bound
+   */
+  public static boolean like(String currentValue, String value, final long timeoutMillis) {
     if (currentValue == null || value == null || (currentValue.isEmpty() ^ value.isEmpty()))
       // EMPTY/NULL PARAMETERS
       return false;
@@ -30,7 +44,23 @@ public class QueryHelper {
       return true;
 
     value = convertForRegExp(value);
-    return currentValue.matches(value);
+    return TimeBoundRegex.matches(Pattern.compile(value), currentValue, timeoutMillis);
+  }
+
+  /**
+   * Same as {@link #like(String, String, long)}, but against an absolute deadline shared across a series of
+   * related matches (e.g. every item of a multi-value property matched against the same pattern) rather than
+   * each getting its own full timeout budget - see {@link TimeBoundRegex#matchesUntil(Pattern, CharSequence,
+   * long)}.
+   */
+  public static boolean likeUntil(String currentValue, String value, final long deadlineNanos) {
+    if (currentValue == null || value == null || (currentValue.isEmpty() ^ value.isEmpty()))
+      return false;
+    else if (currentValue.isEmpty() && value.isEmpty())
+      return true;
+
+    value = convertForRegExp(value);
+    return TimeBoundRegex.matchesUntil(Pattern.compile(value), currentValue, deadlineNanos);
   }
 
   public static String convertForRegExp(String value) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
@@ -36,15 +36,8 @@ public class QueryHelper {
    * @param timeoutMillis maximum time allowed for the match, in milliseconds; a value {@code <= 0} disables the
    *                      bound
    */
-  public static boolean like(String currentValue, String value, final long timeoutMillis) {
-    if (currentValue == null || value == null || (currentValue.isEmpty() ^ value.isEmpty()))
-      // EMPTY/NULL PARAMETERS
-      return false;
-    else if (currentValue.isEmpty() && value.isEmpty())
-      return true;
-
-    value = convertForRegExp(value);
-    return TimeBoundRegex.matches(Pattern.compile(value), currentValue, timeoutMillis);
+  public static boolean like(final String currentValue, final String value, final long timeoutMillis) {
+    return likeUntil(currentValue, value, TimeBoundRegex.newDeadline(timeoutMillis));
   }
 
   /**
@@ -55,6 +48,7 @@ public class QueryHelper {
    */
   public static boolean likeUntil(String currentValue, String value, final long deadlineNanos) {
     if (currentValue == null || value == null || (currentValue.isEmpty() ^ value.isEmpty()))
+      // EMPTY/NULL PARAMETERS
       return false;
     else if (currentValue.isEmpty() && value.isEmpty())
       return true;

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodNormalize.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodNormalize.java
@@ -18,13 +18,16 @@
  */
 package com.arcadedb.query.sql.method.string;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.PatternConst;
+import com.arcadedb.utility.TimeBoundRegex;
 
 import java.text.Normalizer;
+import java.util.regex.Pattern;
 
 /**
  * @author Johann Sorel (Geomatys)
@@ -50,7 +53,12 @@ public class SQLMethodNormalize extends AbstractSQLMethod {
 
       final String normalized = Normalizer.normalize(value.toString(), form);
       if (params != null && params.length > 1) {
-        return normalized.replaceAll(FileUtils.getStringContent(params[1].toString()), "");
+        // The 2nd argument is a caller-supplied regex, not a literal (issue #5886) - bounded the same way as
+        // every other user-controlled regex entry point. context is null in some direct/unit-test invocations
+        // of this method (see SQLMethodNormalizeTest); GlobalConfiguration.getValueAsLong(Database) falls back
+        // to the compiled-in default in that case.
+        final long regexTimeout = GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context != null ? context.getDatabase() : null);
+        return TimeBoundRegex.replaceAll(Pattern.compile(FileUtils.getStringContent(params[1].toString())), normalized, "", regexTimeout);
       }
       return PatternConst.PATTERN_DIACRITICAL_MARKS.matcher(normalized).replaceAll("");
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodNormalize.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodNormalize.java
@@ -37,6 +37,10 @@ public class SQLMethodNormalize extends AbstractSQLMethod {
 
   public static final String NAME = "normalize";
 
+  // context.getCachedValue()/setCachedValue() key for the shared deadline - see execute() for why this needs to
+  // be shared, not recomputed per call.
+  private static final String DEADLINE_CACHE_KEY = "__NORMALIZE_DEADLINE__";
+
   public SQLMethodNormalize() {
     super(NAME, 0, 2);
   }
@@ -54,14 +58,28 @@ public class SQLMethodNormalize extends AbstractSQLMethod {
       final String normalized = Normalizer.normalize(value.toString(), form);
       if (params != null && params.length > 1) {
         // The 2nd argument is a caller-supplied regex, not a literal (issue #5886) - bounded the same way as
-        // every other user-controlled regex entry point. context is null in some direct/unit-test invocations
-        // of this method (see SQLMethodNormalizeTest); GlobalConfiguration.getValueAsLong(Database) falls back
-        // to the compiled-in default in that case. A TimeoutException from the bound propagates as-is rather
-        // than being rewrapped (unlike TextRegexReplace, which rewraps to preserve its own pre-existing
-        // IllegalArgumentException contract for regex failures) - this method had no such prior contract, and
-        // TimeoutException is the shape MatchesCondition/RegexExpression/LIKE/full-text/PromQL all surface too.
-        final long regexTimeout = GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context != null ? context.getDatabase() : null);
-        return TimeBoundRegex.replaceAll(Pattern.compile(FileUtils.getStringContent(params[1].toString())), normalized, "", regexTimeout);
+        // every other user-controlled regex entry point, and sharing one deadline across every row this method
+        // runs against within the same query (same rationale as TextRegexReplace - otherwise a pathological
+        // pattern matched against many rows could cost up to rowCount * regexTimeout overall). context is null
+        // in some direct/unit-test invocations of this method (see SQLMethodNormalizeTest);
+        // GlobalConfiguration.getValueAsLong(Database) falls back to the compiled-in default in that case, and
+        // the deadline is simply not shared across calls when there's no context to cache it on. A
+        // TimeoutException from the bound propagates as-is rather than being rewrapped (unlike TextRegexReplace,
+        // which rewraps to preserve its own pre-existing IllegalArgumentException contract for regex failures) -
+        // this method had no such prior contract, and TimeoutException is the shape
+        // MatchesCondition/RegexExpression/LIKE/full-text/PromQL all surface too.
+        final long regexDeadline;
+        if (context != null) {
+          Long cached = (Long) context.getCachedValue(DEADLINE_CACHE_KEY);
+          if (cached == null) {
+            cached = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
+            context.setCachedValue(DEADLINE_CACHE_KEY, cached);
+          }
+          regexDeadline = cached;
+        } else {
+          regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(null));
+        }
+        return TimeBoundRegex.replaceAllUntil(Pattern.compile(FileUtils.getStringContent(params[1].toString())), normalized, "", regexDeadline);
       }
       return PatternConst.PATTERN_DIACRITICAL_MARKS.matcher(normalized).replaceAll("");
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodNormalize.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodNormalize.java
@@ -68,17 +68,9 @@ public class SQLMethodNormalize extends AbstractSQLMethod {
         // which rewraps to preserve its own pre-existing IllegalArgumentException contract for regex failures) -
         // this method had no such prior contract, and TimeoutException is the shape
         // MatchesCondition/RegexExpression/LIKE/full-text/PromQL all surface too.
-        final long regexDeadline;
-        if (context != null) {
-          Long cached = (Long) context.getCachedValue(DEADLINE_CACHE_KEY);
-          if (cached == null) {
-            cached = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
-            context.setCachedValue(DEADLINE_CACHE_KEY, cached);
-          }
-          regexDeadline = cached;
-        } else {
-          regexDeadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(null));
-        }
+        final long regexDeadline = context != null ?
+            context.getOrComputeRegexDeadline(DEADLINE_CACHE_KEY) :
+            TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(null));
         return TimeBoundRegex.replaceAllUntil(Pattern.compile(FileUtils.getStringContent(params[1].toString())), normalized, "", regexDeadline);
       }
       return PatternConst.PATTERN_DIACRITICAL_MARKS.matcher(normalized).replaceAll("");

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodNormalize.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodNormalize.java
@@ -56,7 +56,10 @@ public class SQLMethodNormalize extends AbstractSQLMethod {
         // The 2nd argument is a caller-supplied regex, not a literal (issue #5886) - bounded the same way as
         // every other user-controlled regex entry point. context is null in some direct/unit-test invocations
         // of this method (see SQLMethodNormalizeTest); GlobalConfiguration.getValueAsLong(Database) falls back
-        // to the compiled-in default in that case.
+        // to the compiled-in default in that case. A TimeoutException from the bound propagates as-is rather
+        // than being rewrapped (unlike TextRegexReplace, which rewraps to preserve its own pre-existing
+        // IllegalArgumentException contract for regex failures) - this method had no such prior contract, and
+        // TimeoutException is the shape MatchesCondition/RegexExpression/LIKE/full-text/PromQL all surface too.
         final long regexTimeout = GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context != null ? context.getDatabase() : null);
         return TimeBoundRegex.replaceAll(Pattern.compile(FileUtils.getStringContent(params[1].toString())), normalized, "", regexTimeout);
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodSplit.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodSplit.java
@@ -22,6 +22,8 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
+import java.util.regex.Pattern;
+
 /**
  * Splits a string using a delimiter.
  *
@@ -40,6 +42,10 @@ public class SQLMethodSplit extends AbstractSQLMethod {
     if (value == null || null == params || null == params[0])
       return value;
 
-    return value.toString().split(params[0].toString());
+    // The delimiter is a literal string, not a regex (issue #5886: matches split()/text.split()/Cypher split(),
+    // which all wrap the delimiter in Pattern.quote() for the same reason - this method was the only one of the
+    // four that passed the caller-supplied delimiter straight to String.split(regex) unescaped, exposing it to
+    // the same catastrophic-backtracking risk as every other regex entry point in that issue).
+    return value.toString().split(Pattern.quote(params[0].toString()));
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ILikeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ILikeOperator.java
@@ -20,9 +20,12 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.QueryHelper;
+import com.arcadedb.utility.TimeBoundRegex;
 
 import java.util.Iterator;
 import java.util.Locale;
@@ -41,20 +44,28 @@ public class ILikeOperator extends SimpleNode implements BinaryCompareOperator {
     if (MultiValue.isMultiValue(iRight))
       return false;
 
+    // database is null in some direct/unit-test invocations of this operator (see ILikeOperatorTest) - falls
+    // back to a plain ContextConfiguration (itself just a proxy for the compiled-in default) in that case.
+    final long regexTimeout = (database != null ? database.getConfiguration() : new ContextConfiguration())
+        .getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+
     // Handle multi-value left operand (e.g., when using BY ITEM indexes on LIST properties)
     // Issue #2693: Support ILIKE operator with BY ITEM FULL_TEXT indexes
     if (MultiValue.isMultiValue(iLeft)) {
+      // One shared deadline for the whole evaluation, same rationale as MatchesCondition's multi-value case.
+      final long deadline = TimeBoundRegex.newDeadline(regexTimeout);
       Iterator<?> valueIterator = MultiValue.getMultiValueIterator(iLeft);
       while (valueIterator.hasNext()) {
         Object val = valueIterator.next();
-        if (val != null && QueryHelper.like(val.toString().toLowerCase(Locale.ENGLISH), iRight.toString().toLowerCase(Locale.ENGLISH))) {
+        if (val != null && QueryHelper.likeUntil(val.toString().toLowerCase(Locale.ENGLISH), iRight.toString().toLowerCase(Locale.ENGLISH),
+            deadline)) {
           return true;
         }
       }
       return false;
     }
 
-    return QueryHelper.like(iLeft.toString().toLowerCase(Locale.ENGLISH), iRight.toString().toLowerCase(Locale.ENGLISH));
+    return QueryHelper.like(iLeft.toString().toLowerCase(Locale.ENGLISH), iRight.toString().toLowerCase(Locale.ENGLISH), regexTimeout);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ILikeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ILikeOperator.java
@@ -20,7 +20,6 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
-import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.MultiValue;
@@ -44,10 +43,10 @@ public class ILikeOperator extends SimpleNode implements BinaryCompareOperator {
     if (MultiValue.isMultiValue(iRight))
       return false;
 
-    // database is null in some direct/unit-test invocations of this operator (see ILikeOperatorTest) - falls
-    // back to a plain ContextConfiguration (itself just a proxy for the compiled-in default) in that case.
-    final long regexTimeout = (database != null ? database.getConfiguration() : new ContextConfiguration())
-        .getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+    // database is null in some direct/unit-test invocations of this operator (see ILikeOperatorTest);
+    // GlobalConfiguration.getValueAsLong(Database) falls back to the compiled-in default in that case. Per-row,
+    // not per-scan, budget - see LikeOperator.execute() for why (no CommandContext available to cache on).
+    final long regexTimeout = GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(database);
 
     // Handle multi-value left operand (e.g., when using BY ITEM indexes on LIST properties)
     // Issue #2693: Support ILIKE operator with BY ITEM FULL_TEXT indexes

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LikeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LikeOperator.java
@@ -20,9 +20,12 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.QueryHelper;
+import com.arcadedb.utility.TimeBoundRegex;
 
 import java.util.Iterator;
 
@@ -40,18 +43,26 @@ public class LikeOperator extends SimpleNode implements BinaryCompareOperator {
     if (MultiValue.isMultiValue(right))
       return false;
 
+    // database is null in some direct/unit-test invocations of this operator (see LikeOperatorTest) - falls
+    // back to a plain ContextConfiguration (itself just a proxy for the compiled-in default) in that case.
+    final long regexTimeout = (database != null ? database.getConfiguration() : new ContextConfiguration())
+        .getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+
     if (MultiValue.isMultiValue(left)) {
+      // One shared deadline for the whole evaluation, same rationale as MatchesCondition's multi-value case:
+      // each item getting its own full budget would let a crafted list run for item count * regexTimeout.
+      final long deadline = TimeBoundRegex.newDeadline(regexTimeout);
       Iterator<?> valueIterator = MultiValue.getMultiValueIterator(left);
       while (valueIterator.hasNext()) {
         Object val = valueIterator.next();
-        if (val != null && QueryHelper.like(val.toString(), right.toString())) {
+        if (val != null && QueryHelper.likeUntil(val.toString(), right.toString(), deadline)) {
           return true;
         }
       }
       return false;
     }
 
-    return QueryHelper.like(left.toString(), right.toString());
+    return QueryHelper.like(left.toString(), right.toString(), regexTimeout);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LikeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LikeOperator.java
@@ -20,7 +20,6 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
-import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.MultiValue;
@@ -43,10 +42,16 @@ public class LikeOperator extends SimpleNode implements BinaryCompareOperator {
     if (MultiValue.isMultiValue(right))
       return false;
 
-    // database is null in some direct/unit-test invocations of this operator (see LikeOperatorTest) - falls
-    // back to a plain ContextConfiguration (itself just a proxy for the compiled-in default) in that case.
-    final long regexTimeout = (database != null ? database.getConfiguration() : new ContextConfiguration())
-        .getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+    // database is null in some direct/unit-test invocations of this operator (see LikeOperatorTest);
+    // GlobalConfiguration.getValueAsLong(Database) falls back to the compiled-in default in that case.
+    // Unlike MatchesCondition/RegexExpression, this operator has no CommandContext to cache a query-wide
+    // deadline on (BinaryCompareOperator.execute() only receives a Database) - each execute() call still gets
+    // its own fresh regexTimeout budget, so a WHERE ... LIKE clause scanning many rows is bounded per row
+    // (rowCount * regexTimeout worst case) rather than for the whole scan. A smaller blast radius than
+    // unbounded, and changing it would mean widening BinaryCompareOperator's interface across every
+    // implementation (EqualsCompareOperator, GtOperator, InOperator, ...), so left as a conscious, narrower
+    // scope than the multi-value-within-one-row sharing below.
+    final long regexTimeout = GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(database);
 
     if (MultiValue.isMultiValue(left)) {
       // One shared deadline for the whole evaluation, same rationale as MatchesCondition's multi-value case:

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -20,7 +20,6 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
-import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -79,21 +78,23 @@ public class MatchesCondition extends BooleanExpression {
       context.setCachedValue(key, p);
     }
 
-    // context.getDatabase().getConfiguration(), not context.getConfiguration(): the latter is a fresh, disconnected
-    // ContextConfiguration for a plain SELECT/=~ evaluation (nothing wires it to the database's settings), so it
-    // would silently fall back to the compiled-in default and ignore a per-database override. This mirrors how
-    // SelectExecutionPlanner reads GlobalConfiguration.COMMAND_TIMEOUT. A MatchesCondition is, in practice, only
-    // ever constructed by the SQL parser and evaluated with a database already bound to the context (every
-    // top-level statement calls context.setDatabase(...) before any WHERE/RETURN expression runs) - but falling
-    // back to a plain ContextConfiguration when that ever isn't true costs nothing and avoids turning a future
-    // refactor or an unanticipated evaluation path into a hard NPE, same as LikeOperator/ILikeOperator/
-    // TextRegexReplace already do.
-    final long regexTimeout = (context.getDatabase() != null ? context.getDatabase().getConfiguration() : new ContextConfiguration())
-        .getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
-    // One shared deadline for the whole evaluation: a multi-value property can hold many items, and each getting
-    // its own full regexTimeout budget would let a crafted list bound the loop by N * regexTimeout instead of by
-    // regexTimeout overall.
-    final long deadline = TimeBoundRegex.newDeadline(regexTimeout);
+    // One deadline shared by every MATCHES evaluation for the lifetime of this query - not just across the
+    // items of one multi-value evaluation, but across every row a WHERE ... MATCHES clause scans. Recomputing a
+    // fresh regexTimeout budget per row would let a table shaped so every row triggers catastrophic backtracking
+    // cost up to rowCount * regexTimeout overall; caching it on the context (the same mechanism already used for
+    // the compiled Pattern above, and confirmed shared across rows by MatchesConditionTest's per-context cache
+    // tests) bounds the whole scan by one regexTimeout instead, the same principle applied to the full-text and
+    // PromQL entry points elsewhere in this issue. GlobalConfiguration.getValueAsLong(Database) resolves
+    // context.getDatabase()'s per-database override, falling back to the compiled-in default if a database is
+    // ever not bound to the context - practically always the case (a MatchesCondition is only ever constructed
+    // by the SQL parser and evaluated with a database already bound), but free insurance against a future
+    // evaluation path that isn't, same as LikeOperator/ILikeOperator/TextRegexReplace.
+    final String deadlineKey = "MATCHES_DEADLINE";
+    Long deadline = (Long) context.getCachedValue(deadlineKey);
+    if (deadline == null) {
+      deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
+      context.setCachedValue(deadlineKey, deadline);
+    }
 
     if (value instanceof CharSequence sequence) {
       return TimeBoundRegex.matchesUntil(p, sequence, deadline);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -20,6 +20,7 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -81,13 +82,14 @@ public class MatchesCondition extends BooleanExpression {
     // context.getDatabase().getConfiguration(), not context.getConfiguration(): the latter is a fresh, disconnected
     // ContextConfiguration for a plain SELECT/=~ evaluation (nothing wires it to the database's settings), so it
     // would silently fall back to the compiled-in default and ignore a per-database override. This mirrors how
-    // SelectExecutionPlanner reads GlobalConfiguration.COMMAND_TIMEOUT. Unlike LikeOperator/ILikeOperator/
-    // TextRegexReplace, this call is intentionally unguarded against a null database: a MatchesCondition is only
-    // ever constructed by the SQL parser and evaluated by the query execution engine, which always binds a
-    // database to the context before any WHERE/RETURN expression runs (see SelectStatement, UpdateStatement,
-    // InsertStatement, ... all calling context.setDatabase(...)) - there is no direct-unit-test-style entry
-    // point into this class the way there is for a standalone SQL function or operator.
-    final long regexTimeout = context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+    // SelectExecutionPlanner reads GlobalConfiguration.COMMAND_TIMEOUT. A MatchesCondition is, in practice, only
+    // ever constructed by the SQL parser and evaluated with a database already bound to the context (every
+    // top-level statement calls context.setDatabase(...) before any WHERE/RETURN expression runs) - but falling
+    // back to a plain ContextConfiguration when that ever isn't true costs nothing and avoids turning a future
+    // refactor or an unanticipated evaluation path into a hard NPE, same as LikeOperator/ILikeOperator/
+    // TextRegexReplace already do.
+    final long regexTimeout = (context.getDatabase() != null ? context.getDatabase().getConfiguration() : new ContextConfiguration())
+        .getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
     // One shared deadline for the whole evaluation: a multi-value property can hold many items, and each getting
     // its own full regexTimeout budget would let a crafted list bound the loop by N * regexTimeout instead of by
     // regexTimeout overall.

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -20,7 +20,6 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
-import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
@@ -81,14 +80,10 @@ public class MatchesCondition extends BooleanExpression {
     // One deadline shared by every MATCHES evaluation for the lifetime of this query - not just across the
     // items of one multi-value evaluation, but across every row a WHERE ... MATCHES clause scans. Recomputing a
     // fresh regexTimeout budget per row would let a table shaped so every row triggers catastrophic backtracking
-    // cost up to rowCount * regexTimeout overall; caching it on the context (the same mechanism already used for
-    // the compiled Pattern above, and confirmed shared across rows by MatchesConditionTest's per-context cache
-    // tests) bounds the whole scan by one regexTimeout instead, the same principle applied to the full-text and
-    // PromQL entry points elsewhere in this issue. GlobalConfiguration.getValueAsLong(Database) resolves
-    // context.getDatabase()'s per-database override, falling back to the compiled-in default if a database is
-    // ever not bound to the context - practically always the case (a MatchesCondition is only ever constructed
-    // by the SQL parser and evaluated with a database already bound), but free insurance against a future
-    // evaluation path that isn't, same as LikeOperator/ILikeOperator/TextRegexReplace.
+    // cost up to rowCount * regexTimeout overall; CommandContext#getOrComputeRegexDeadline caches it on the
+    // context (the same mechanism already used for the compiled Pattern above, and confirmed shared across rows
+    // by MatchesConditionTest's per-context cache tests), bounding the whole scan by one regexTimeout instead,
+    // the same principle applied to the full-text and PromQL entry points elsewhere in this issue.
     //
     // The key must NOT start with "MATCHES_": the pattern cache above keys on "MATCHES_" + <arbitrary,
     // attacker-controlled regex text>, so any fixed key sharing that prefix collides for whichever regex text
@@ -96,12 +91,7 @@ public class MatchesCondition extends BooleanExpression {
     // (WHERE x MATCHES 'DEADLINE'), overwriting the Pattern cache slot with a Long or vice versa and throwing
     // ClassCastException on the very first row. A key outside the "MATCHES_" namespace entirely - this one
     // starts with "__", not "MATCHES_" - cannot equal "MATCHES_" + anything, however the regex text reads.
-    final String deadlineKey = "__MATCHES_DEADLINE__";
-    Long deadline = (Long) context.getCachedValue(deadlineKey);
-    if (deadline == null) {
-      deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));
-      context.setCachedValue(deadlineKey, deadline);
-    }
+    final long deadline = context.getOrComputeRegexDeadline("__MATCHES_DEADLINE__");
 
     if (value instanceof CharSequence sequence) {
       return TimeBoundRegex.matchesUntil(p, sequence, deadline);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -78,16 +78,24 @@ public class MatchesCondition extends BooleanExpression {
       context.setCachedValue(key, p);
     }
 
-    final long regexTimeout = context.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+    // context.getDatabase().getConfiguration(), not context.getConfiguration(): the latter is a fresh, disconnected
+    // ContextConfiguration for a plain SELECT/=~ evaluation (nothing wires it to the database's settings), so it
+    // would silently fall back to the compiled-in default and ignore a per-database override. This mirrors how
+    // SelectExecutionPlanner reads GlobalConfiguration.COMMAND_TIMEOUT.
+    final long regexTimeout = context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+    // One shared deadline for the whole evaluation: a multi-value property can hold many items, and each getting
+    // its own full regexTimeout budget would let a crafted list bound the loop by N * regexTimeout instead of by
+    // regexTimeout overall.
+    final long deadline = TimeBoundRegex.newDeadline(regexTimeout);
 
     if (value instanceof CharSequence sequence) {
-      return TimeBoundRegex.matches(p, sequence, regexTimeout);
+      return TimeBoundRegex.matchesUntil(p, sequence, deadline);
     } else if (MultiValue.isMultiValue(value)) {
       final Iterator<?> values = MultiValue.getMultiValueIterator(value);
       while (values.hasNext()) {
         final Object item = values.next();
         if (item instanceof CharSequence seq) {
-          if (TimeBoundRegex.matches(p, seq, regexTimeout)) {
+          if (TimeBoundRegex.matchesUntil(p, seq, deadline)) {
             return true;
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -89,7 +89,14 @@ public class MatchesCondition extends BooleanExpression {
     // ever not bound to the context - practically always the case (a MatchesCondition is only ever constructed
     // by the SQL parser and evaluated with a database already bound), but free insurance against a future
     // evaluation path that isn't, same as LikeOperator/ILikeOperator/TextRegexReplace.
-    final String deadlineKey = "MATCHES_DEADLINE";
+    //
+    // The key must NOT start with "MATCHES_": the pattern cache above keys on "MATCHES_" + <arbitrary,
+    // attacker-controlled regex text>, so any fixed key sharing that prefix collides for whichever regex text
+    // completes it - e.g. a first attempt at this key, "5886_MATCHES_CONTEXT_DEADLINE", collided with pattern text
+    // "DEADLINE" (WHERE x MATCHES 'DEADLINE'), overwriting the Pattern cache slot with a Long or vice versa and
+    // throwing ClassCastException on the very first row. A key outside the "MATCHES_" namespace entirely - this
+    // one starts with "5886_", not "MATCHES_" - cannot equal "MATCHES_" + anything, however the regex text reads.
+    final String deadlineKey = "5886_MATCHES_CONTEXT_DEADLINE";
     Long deadline = (Long) context.getCachedValue(deadlineKey);
     if (deadline == null) {
       deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -20,10 +20,12 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.utility.TimeBoundRegex;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -76,14 +78,16 @@ public class MatchesCondition extends BooleanExpression {
       context.setCachedValue(key, p);
     }
 
+    final long regexTimeout = context.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
+
     if (value instanceof CharSequence sequence) {
-      return p.matcher(sequence).matches();
+      return TimeBoundRegex.matches(p, sequence, regexTimeout);
     } else if (MultiValue.isMultiValue(value)) {
       final Iterator<?> values = MultiValue.getMultiValueIterator(value);
       while (values.hasNext()) {
         final Object item = values.next();
         if (item instanceof CharSequence seq) {
-          if (p.matcher(seq).matches()) {
+          if (TimeBoundRegex.matches(p, seq, regexTimeout)) {
             return true;
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -92,11 +92,11 @@ public class MatchesCondition extends BooleanExpression {
     //
     // The key must NOT start with "MATCHES_": the pattern cache above keys on "MATCHES_" + <arbitrary,
     // attacker-controlled regex text>, so any fixed key sharing that prefix collides for whichever regex text
-    // completes it - e.g. a first attempt at this key, "5886_MATCHES_CONTEXT_DEADLINE", collided with pattern text
-    // "DEADLINE" (WHERE x MATCHES 'DEADLINE'), overwriting the Pattern cache slot with a Long or vice versa and
-    // throwing ClassCastException on the very first row. A key outside the "MATCHES_" namespace entirely - this
-    // one starts with "5886_", not "MATCHES_" - cannot equal "MATCHES_" + anything, however the regex text reads.
-    final String deadlineKey = "5886_MATCHES_CONTEXT_DEADLINE";
+    // completes it - e.g. a first attempt at this key, "MATCHES_DEADLINE", collided with pattern text "DEADLINE"
+    // (WHERE x MATCHES 'DEADLINE'), overwriting the Pattern cache slot with a Long or vice versa and throwing
+    // ClassCastException on the very first row. A key outside the "MATCHES_" namespace entirely - this one
+    // starts with "__", not "MATCHES_" - cannot equal "MATCHES_" + anything, however the regex text reads.
+    final String deadlineKey = "__MATCHES_DEADLINE__";
     Long deadline = (Long) context.getCachedValue(deadlineKey);
     if (deadline == null) {
       deadline = TimeBoundRegex.newDeadline(GlobalConfiguration.COMMAND_REGEX_TIMEOUT.getValueAsLong(context.getDatabase()));

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -81,7 +81,12 @@ public class MatchesCondition extends BooleanExpression {
     // context.getDatabase().getConfiguration(), not context.getConfiguration(): the latter is a fresh, disconnected
     // ContextConfiguration for a plain SELECT/=~ evaluation (nothing wires it to the database's settings), so it
     // would silently fall back to the compiled-in default and ignore a per-database override. This mirrors how
-    // SelectExecutionPlanner reads GlobalConfiguration.COMMAND_TIMEOUT.
+    // SelectExecutionPlanner reads GlobalConfiguration.COMMAND_TIMEOUT. Unlike LikeOperator/ILikeOperator/
+    // TextRegexReplace, this call is intentionally unguarded against a null database: a MatchesCondition is only
+    // ever constructed by the SQL parser and evaluated by the query execution engine, which always binds a
+    // database to the context before any WHERE/RETURN expression runs (see SelectStatement, UpdateStatement,
+    // InsertStatement, ... all calling context.setDatabase(...)) - there is no direct-unit-test-style entry
+    // point into this class the way there is for a standalone SQL function or operator.
     final long regexTimeout = context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_REGEX_TIMEOUT);
     // One shared deadline for the whole evaluation: a multi-value property can hold many items, and each getting
     // its own full regexTimeout budget would let a crafted list bound the loop by N * regexTimeout instead of by

--- a/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
+++ b/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
@@ -26,11 +26,16 @@ import java.util.regex.Pattern;
 /**
  * Bounds a {@link Pattern} operation against catastrophic backtracking. {@code java.util.regex} never polls
  * {@code Thread.interrupted()} or checks a deadline while backtracking, so a pathological pattern (e.g. nested
- * quantifiers like {@code (.*a){20}$}) keeps its calling thread busy for as long as the backtracking takes, no
- * matter what timeout the surrounding query execution enforces. What it does call, on every single backtracking
- * step, is {@link CharSequence#charAt(int)} on the input it is operating on. Wrapping that input in a sequence
- * that throws once a deadline elapses turns that call site into the interruption point {@code Matcher} does not
- * otherwise offer.
+ * quantifiers like {@code (.*a){20}$}, or several sequential {@code .*} segments like {@code (.*a){20}c} - no
+ * nesting needed for that shape) keeps its calling thread busy for as long as the backtracking takes, no matter
+ * what timeout the surrounding query execution enforces. What it does call, on every single backtracking step,
+ * is {@link CharSequence#charAt(int)} on the input it is operating on. Wrapping that input in a sequence that
+ * throws once a deadline elapses turns that call site into the interruption point {@code Matcher} does not
+ * otherwise offer. Verified empirically (not just by reading the JDK source) that both {@code matches()} and
+ * {@code replaceAll()} go through this {@code charAt()} path even for the literal-heavy patterns callers here
+ * use ({@code MATCHES}/{@code =~}'s nested-quantifier shape and {@code LIKE}/wildcard's sequential-{@code .*}
+ * shape both abort correctly) - some JDK regex fast paths read a pattern's literal prefix through a different
+ * mechanism, and this class would silently stop bounding anything that took one of those paths instead.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -75,10 +80,19 @@ public final class TimeBoundRegex {
    * @param timeoutMillis maximum time allowed from now, in milliseconds; a value {@code <= 0} disables the bound
    *
    * @return an absolute deadline for {@link #matchesUntil(Pattern, CharSequence, long)}, or a sentinel that never
-   * triggers if {@code timeoutMillis <= 0}
+   * triggers if {@code timeoutMillis <= 0} or if {@code timeoutMillis} is large enough that computing the
+   * deadline would overflow - {@code arcadedb.command.regexTimeout} is admin-configurable, and an overflowed
+   * deadline landing in the past would make every match abort immediately instead of applying the (very long)
+   * requested timeout, the opposite of what an oversized value should do
    */
   public static long newDeadline(final long timeoutMillis) {
-    return timeoutMillis <= 0 ? Long.MAX_VALUE : System.nanoTime() + (timeoutMillis * 1_000_000L);
+    if (timeoutMillis <= 0)
+      return Long.MAX_VALUE;
+    try {
+      return Math.addExact(System.nanoTime(), Math.multiplyExact(timeoutMillis, 1_000_000L));
+    } catch (final ArithmeticException e) {
+      return Long.MAX_VALUE;
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
+++ b/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
@@ -135,14 +135,27 @@ public final class TimeBoundRegex {
   private static <T> T run(final Pattern pattern, final CharSequence input, final long deadlineNanos, final Function<CharSequence, T> operation) {
     try {
       return operation.apply(deadlineNanos == Long.MAX_VALUE ? input : new DeadlineBoundCharSequence(input, deadlineNanos));
-    } catch (final RegexDeadlineExceeded | StackOverflowError e) {
+    } catch (final RegexDeadlineExceeded e) {
+      // Only reachable when the bound is active (deadlineNanos != Long.MAX_VALUE skips the wrapper entirely, so
+      // this can't be thrown when disabled).
+      throw timeoutException(pattern, input, e);
+    } catch (final StackOverflowError e) {
+      if (deadlineNanos == Long.MAX_VALUE)
+        // The bound is explicitly disabled (arcadedb.command.regexTimeout <= 0): this stack overflow is an
+        // unrelated JDK regex recursion-depth issue, not a timeout, so let it propagate as itself instead of
+        // mislabeling it via a setting the caller deliberately turned off.
+        throw e;
       // A sufficiently pathological pattern/input combination can blow the (recursive) backtracking stack before
       // the next CHECK_INTERVAL checkpoint is reached; treated the same as an explicit deadline trip, since both
       // are catastrophic backtracking manifesting through a different symptom.
-      throw new TimeoutException(
-          "Regular expression operation aborted (arcadedb.command.regexTimeout): pattern '" + pattern.pattern() + "' against input of length "
-              + input.length(), e);
+      throw timeoutException(pattern, input, e);
     }
+  }
+
+  private static TimeoutException timeoutException(final Pattern pattern, final CharSequence input, final Throwable cause) {
+    return new TimeoutException(
+        "Regular expression operation aborted (arcadedb.command.regexTimeout): pattern '" + pattern.pattern() + "' against input of length "
+            + input.length(), cause);
   }
 
   private static final class DeadlineBoundCharSequence implements CharSequence {

--- a/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
+++ b/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
@@ -129,7 +129,26 @@ public final class TimeBoundRegex {
    * @throws TimeoutException if the operation does not complete within {@code timeoutMillis}
    */
   public static String replaceAll(final Pattern pattern, final CharSequence input, final String replacement, final long timeoutMillis) {
-    return run(pattern, input, newDeadline(timeoutMillis), bounded -> pattern.matcher(bounded).replaceAll(replacement));
+    return replaceAllUntil(pattern, input, replacement, newDeadline(timeoutMillis));
+  }
+
+  /**
+   * Same as {@link #replaceAll(Pattern, CharSequence, String, long)}, but against an absolute deadline shared
+   * across a series of related operations (e.g. the same regex applied to every row of a query result) rather
+   * than each getting its own full timeout budget - see {@link #matchesUntil(Pattern, CharSequence, long)} for
+   * the equivalent on the matching side.
+   *
+   * @param pattern       the compiled pattern to replace matches of
+   * @param input         the input to search
+   * @param replacement   the replacement string, per {@link java.util.regex.Matcher#replaceAll(String)}
+   * @param deadlineNanos an absolute {@link System#nanoTime()} deadline, as returned by {@link #newDeadline(long)}
+   *
+   * @return {@code input} with every match of {@code pattern} replaced by {@code replacement}
+   *
+   * @throws TimeoutException if the operation does not complete before {@code deadlineNanos}
+   */
+  public static String replaceAllUntil(final Pattern pattern, final CharSequence input, final String replacement, final long deadlineNanos) {
+    return run(pattern, input, deadlineNanos, bounded -> pattern.matcher(bounded).replaceAll(replacement));
   }
 
   private static <T> T run(final Pattern pattern, final CharSequence input, final long deadlineNanos, final Function<CharSequence, T> operation) {

--- a/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
+++ b/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
@@ -73,11 +73,18 @@ public final class TimeBoundRegex {
   private static final class DeadlineBoundCharSequence implements CharSequence {
     private final CharSequence wrapped;
     private final long         deadlineNanos;
-    private       int          calls;
+    // Shared (not copied) with every CharSequence subSequence() derives from this one, so the check cadence
+    // keeps counting from where the parent left off instead of restarting at each subSequence() call.
+    private final int[]        calls;
 
     private DeadlineBoundCharSequence(final CharSequence wrapped, final long deadlineNanos) {
+      this(wrapped, deadlineNanos, new int[1]);
+    }
+
+    private DeadlineBoundCharSequence(final CharSequence wrapped, final long deadlineNanos, final int[] calls) {
       this.wrapped = wrapped;
       this.deadlineNanos = deadlineNanos;
+      this.calls = calls;
     }
 
     @Override
@@ -87,14 +94,14 @@ public final class TimeBoundRegex {
 
     @Override
     public char charAt(final int index) {
-      if ((++calls & (CHECK_INTERVAL - 1)) == 0 && System.nanoTime() > deadlineNanos)
+      if ((++calls[0] & (CHECK_INTERVAL - 1)) == 0 && System.nanoTime() > deadlineNanos)
         throw RegexDeadlineExceeded.INSTANCE;
       return wrapped.charAt(index);
     }
 
     @Override
     public CharSequence subSequence(final int start, final int end) {
-      return new DeadlineBoundCharSequence(wrapped.subSequence(start, end), deadlineNanos);
+      return new DeadlineBoundCharSequence(wrapped.subSequence(start, end), deadlineNanos, calls);
     }
 
     @Override

--- a/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
+++ b/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import com.arcadedb.exception.TimeoutException;
+
+import java.util.regex.Pattern;
+
+/**
+ * Bounds a {@link Pattern} match against catastrophic backtracking. {@code java.util.regex} never polls
+ * {@code Thread.interrupted()} or checks a deadline while backtracking, so a pathological pattern (e.g. nested
+ * quantifiers like {@code (.*a){20}$}) keeps its calling thread busy for as long as the backtracking takes, no
+ * matter what timeout the surrounding query execution enforces. What it does call, on every single backtracking
+ * step, is {@link CharSequence#charAt(int)} on the input it is matching. Wrapping that input in a sequence that
+ * throws once a deadline elapses turns that call site into the interruption point {@code Matcher.matches()} does
+ * not otherwise offer.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class TimeBoundRegex {
+  // Deadline is checked every CHECK_INTERVAL charAt() calls (a power of two, checked via bitmask) rather than on
+  // every call, since charAt() is on the hottest possible path here (called on every backtracking step) and
+  // System.nanoTime() is not free. A pattern that finishes in fewer than CHECK_INTERVAL total charAt() calls
+  // finishes essentially instantly anyway, so the coarser granularity only matters for the runaway case this
+  // class exists to bound.
+  private static final int CHECK_INTERVAL = 256;
+
+  private TimeBoundRegex() {
+  }
+
+  /**
+   * Matches {@code input} fully against {@code pattern}, aborting if it runs past {@code timeoutMillis}.
+   *
+   * @param pattern       the compiled pattern to match
+   * @param input         the input to match against
+   * @param timeoutMillis maximum time allowed for the match, in milliseconds; a value {@code <= 0} disables the
+   *                      bound and matches as plain {@code pattern.matcher(input).matches()} would
+   *
+   * @return {@code true} if {@code input} matches {@code pattern} in its entirety
+   *
+   * @throws TimeoutException if the match does not complete within {@code timeoutMillis}
+   */
+  public static boolean matches(final Pattern pattern, final CharSequence input, final long timeoutMillis) {
+    if (timeoutMillis <= 0)
+      return pattern.matcher(input).matches();
+
+    final long deadline = System.nanoTime() + (timeoutMillis * 1_000_000L);
+    try {
+      return pattern.matcher(new DeadlineBoundCharSequence(input, deadline)).matches();
+    } catch (final RegexDeadlineExceeded e) {
+      throw new TimeoutException(
+          "Regular expression evaluation aborted after exceeding the " + timeoutMillis + "ms limit (arcadedb.command.regexTimeout): pattern '"
+              + pattern.pattern() + "' against input of length " + input.length());
+    }
+  }
+
+  private static final class DeadlineBoundCharSequence implements CharSequence {
+    private final CharSequence wrapped;
+    private final long         deadlineNanos;
+    private       int          calls;
+
+    private DeadlineBoundCharSequence(final CharSequence wrapped, final long deadlineNanos) {
+      this.wrapped = wrapped;
+      this.deadlineNanos = deadlineNanos;
+    }
+
+    @Override
+    public int length() {
+      return wrapped.length();
+    }
+
+    @Override
+    public char charAt(final int index) {
+      if ((++calls & (CHECK_INTERVAL - 1)) == 0 && System.nanoTime() > deadlineNanos)
+        throw RegexDeadlineExceeded.INSTANCE;
+      return wrapped.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(final int start, final int end) {
+      return new DeadlineBoundCharSequence(wrapped.subSequence(start, end), deadlineNanos);
+    }
+
+    @Override
+    public String toString() {
+      return wrapped.toString();
+    }
+  }
+
+  /**
+   * Unchecked signal used only to unwind out of {@code Matcher.matches()} once the deadline elapses; caught and
+   * converted to a {@link TimeoutException} inside {@link #matches} and never seen outside this class. A single
+   * shared, stack-trace-less instance is used since the failure carries no per-occurrence information and this
+   * can be thrown a very large number of times on a single runaway match.
+   */
+  private static final class RegexDeadlineExceeded extends RuntimeException {
+    private static final RegexDeadlineExceeded INSTANCE = new RegexDeadlineExceeded();
+
+    private RegexDeadlineExceeded() {
+      super(null, null, false, false);
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
+++ b/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
@@ -20,23 +20,24 @@ package com.arcadedb.utility;
 
 import com.arcadedb.exception.TimeoutException;
 
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 /**
- * Bounds a {@link Pattern} match against catastrophic backtracking. {@code java.util.regex} never polls
+ * Bounds a {@link Pattern} operation against catastrophic backtracking. {@code java.util.regex} never polls
  * {@code Thread.interrupted()} or checks a deadline while backtracking, so a pathological pattern (e.g. nested
  * quantifiers like {@code (.*a){20}$}) keeps its calling thread busy for as long as the backtracking takes, no
  * matter what timeout the surrounding query execution enforces. What it does call, on every single backtracking
- * step, is {@link CharSequence#charAt(int)} on the input it is matching. Wrapping that input in a sequence that
- * throws once a deadline elapses turns that call site into the interruption point {@code Matcher.matches()} does
- * not otherwise offer.
+ * step, is {@link CharSequence#charAt(int)} on the input it is operating on. Wrapping that input in a sequence
+ * that throws once a deadline elapses turns that call site into the interruption point {@code Matcher} does not
+ * otherwise offer.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public final class TimeBoundRegex {
   // Deadline is checked every CHECK_INTERVAL charAt() calls (a power of two, checked via bitmask) rather than on
   // every call, since charAt() is on the hottest possible path here (called on every backtracking step) and
-  // System.nanoTime() is not free. A pattern that finishes in fewer than CHECK_INTERVAL total charAt() calls
+  // System.nanoTime() is not free. An operation that finishes in fewer than CHECK_INTERVAL total charAt() calls
   // finishes essentially instantly anyway, so the coarser granularity only matters for the runaway case this
   // class exists to bound.
   private static final int CHECK_INTERVAL = 256;
@@ -63,19 +64,13 @@ public final class TimeBoundRegex {
    * @throws TimeoutException if the match does not complete within {@code timeoutMillis}
    */
   public static boolean matches(final Pattern pattern, final CharSequence input, final long timeoutMillis) {
-    try {
-      return match(pattern, input, newDeadline(timeoutMillis));
-    } catch (final RegexDeadlineExceeded e) {
-      throw new TimeoutException(
-          "Regular expression evaluation aborted after exceeding the " + timeoutMillis + "ms limit (arcadedb.command.regexTimeout): pattern '"
-              + pattern.pattern() + "' against input of length " + input.length());
-    }
+    return matchesUntil(pattern, input, newDeadline(timeoutMillis));
   }
 
   /**
    * Computes an absolute deadline, in {@link System#nanoTime()} terms, {@code timeoutMillis} from now, for use
-   * with {@link #matchesUntil(Pattern, CharSequence, long)} across a series of related matches that must share one
-   * overall time budget rather than each getting their own.
+   * with {@link #matchesUntil(Pattern, CharSequence, long)} across a series of related operations that must share
+   * one overall time budget rather than each getting their own.
    *
    * @param timeoutMillis maximum time allowed from now, in milliseconds; a value {@code <= 0} disables the bound
    *
@@ -91,8 +86,8 @@ public final class TimeBoundRegex {
    * {@code deadlineNanos} - an absolute deadline from {@link #newDeadline(long)}, shared across every call in a
    * series so the series as a whole is bounded rather than each call individually.
    *
-   * @param pattern      the compiled pattern to match
-   * @param input        the input to match against
+   * @param pattern       the compiled pattern to match
+   * @param input         the input to match against
    * @param deadlineNanos an absolute {@link System#nanoTime()} deadline, as returned by {@link #newDeadline(long)}
    *
    * @return {@code true} if {@code input} matches {@code pattern} in its entirety
@@ -100,19 +95,40 @@ public final class TimeBoundRegex {
    * @throws TimeoutException if the match does not complete before {@code deadlineNanos}
    */
   public static boolean matchesUntil(final Pattern pattern, final CharSequence input, final long deadlineNanos) {
-    try {
-      return match(pattern, input, deadlineNanos);
-    } catch (final RegexDeadlineExceeded e) {
-      throw new TimeoutException(
-          "Regular expression evaluation aborted after exceeding its arcadedb.command.regexTimeout deadline: pattern '" + pattern.pattern()
-              + "' against input of length " + input.length());
-    }
+    return run(pattern, input, deadlineNanos, bounded -> pattern.matcher(bounded).matches());
   }
 
-  private static boolean match(final Pattern pattern, final CharSequence input, final long deadlineNanos) {
-    if (deadlineNanos == Long.MAX_VALUE)
-      return pattern.matcher(input).matches();
-    return pattern.matcher(new DeadlineBoundCharSequence(input, deadlineNanos)).matches();
+  /**
+   * Replaces every match of {@code pattern} in {@code input} with {@code replacement}, aborting if it runs past
+   * {@code timeoutMillis}. Same rationale as {@link #matches(Pattern, CharSequence, long)}: {@code replaceAll()}
+   * backtracks through the same {@code java.util.regex} machinery and is just as exposed to a pathological
+   * pattern.
+   *
+   * @param pattern       the compiled pattern to replace matches of
+   * @param input         the input to search
+   * @param replacement   the replacement string, per {@link java.util.regex.Matcher#replaceAll(String)}
+   * @param timeoutMillis maximum time allowed for the operation, in milliseconds; a value {@code <= 0} disables
+   *                      the bound
+   *
+   * @return {@code input} with every match of {@code pattern} replaced by {@code replacement}
+   *
+   * @throws TimeoutException if the operation does not complete within {@code timeoutMillis}
+   */
+  public static String replaceAll(final Pattern pattern, final CharSequence input, final String replacement, final long timeoutMillis) {
+    return run(pattern, input, newDeadline(timeoutMillis), bounded -> pattern.matcher(bounded).replaceAll(replacement));
+  }
+
+  private static <T> T run(final Pattern pattern, final CharSequence input, final long deadlineNanos, final Function<CharSequence, T> operation) {
+    try {
+      return operation.apply(deadlineNanos == Long.MAX_VALUE ? input : new DeadlineBoundCharSequence(input, deadlineNanos));
+    } catch (final RegexDeadlineExceeded | StackOverflowError e) {
+      // A sufficiently pathological pattern/input combination can blow the (recursive) backtracking stack before
+      // the next CHECK_INTERVAL checkpoint is reached; treated the same as an explicit deadline trip, since both
+      // are catastrophic backtracking manifesting through a different symptom.
+      throw new TimeoutException(
+          "Regular expression operation aborted (arcadedb.command.regexTimeout): pattern '" + pattern.pattern() + "' against input of length "
+              + input.length(), e);
+    }
   }
 
   private static final class DeadlineBoundCharSequence implements CharSequence {
@@ -139,7 +155,8 @@ public final class TimeBoundRegex {
 
     @Override
     public char charAt(final int index) {
-      if ((++calls[0] & (CHECK_INTERVAL - 1)) == 0 && System.nanoTime() > deadlineNanos)
+      // Overflow-safe form recommended by System.nanoTime()'s own Javadoc, in place of a plain ">" comparison.
+      if ((++calls[0] & (CHECK_INTERVAL - 1)) == 0 && System.nanoTime() - deadlineNanos >= 0)
         throw RegexDeadlineExceeded.INSTANCE;
       return wrapped.charAt(index);
     }
@@ -156,10 +173,10 @@ public final class TimeBoundRegex {
   }
 
   /**
-   * Unchecked signal used only to unwind out of {@code Matcher.matches()} once the deadline elapses; caught and
-   * converted to a {@link TimeoutException} inside {@link #matches} and never seen outside this class. A single
+   * Unchecked signal used only to unwind out of a {@code Matcher} operation once the deadline elapses; caught and
+   * converted to a {@link TimeoutException} inside {@link #run} and never seen outside this class. A single
    * shared, stack-trace-less instance is used since the failure carries no per-occurrence information and this
-   * can be thrown a very large number of times on a single runaway match.
+   * can be thrown a very large number of times on a single runaway operation.
    */
   private static final class RegexDeadlineExceeded extends RuntimeException {
     private static final RegexDeadlineExceeded INSTANCE = new RegexDeadlineExceeded();

--- a/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
+++ b/engine/src/main/java/com/arcadedb/utility/TimeBoundRegex.java
@@ -46,6 +46,12 @@ public final class TimeBoundRegex {
 
   /**
    * Matches {@code input} fully against {@code pattern}, aborting if it runs past {@code timeoutMillis}.
+   * <p>
+   * Evaluating several inputs against the same logical bound (e.g. one property holding a list of strings, each
+   * matched in turn against the same pattern) should not call this method once per item: each call starts a fresh
+   * {@code timeoutMillis} budget, so N items would be bounded by {@code N * timeoutMillis} instead of by
+   * {@code timeoutMillis} overall. Use {@link #newDeadline(long)} once up front and {@link #matchesUntil(Pattern,
+   * CharSequence, long)} for each item instead.
    *
    * @param pattern       the compiled pattern to match
    * @param input         the input to match against
@@ -57,17 +63,56 @@ public final class TimeBoundRegex {
    * @throws TimeoutException if the match does not complete within {@code timeoutMillis}
    */
   public static boolean matches(final Pattern pattern, final CharSequence input, final long timeoutMillis) {
-    if (timeoutMillis <= 0)
-      return pattern.matcher(input).matches();
-
-    final long deadline = System.nanoTime() + (timeoutMillis * 1_000_000L);
     try {
-      return pattern.matcher(new DeadlineBoundCharSequence(input, deadline)).matches();
+      return match(pattern, input, newDeadline(timeoutMillis));
     } catch (final RegexDeadlineExceeded e) {
       throw new TimeoutException(
           "Regular expression evaluation aborted after exceeding the " + timeoutMillis + "ms limit (arcadedb.command.regexTimeout): pattern '"
               + pattern.pattern() + "' against input of length " + input.length());
     }
+  }
+
+  /**
+   * Computes an absolute deadline, in {@link System#nanoTime()} terms, {@code timeoutMillis} from now, for use
+   * with {@link #matchesUntil(Pattern, CharSequence, long)} across a series of related matches that must share one
+   * overall time budget rather than each getting their own.
+   *
+   * @param timeoutMillis maximum time allowed from now, in milliseconds; a value {@code <= 0} disables the bound
+   *
+   * @return an absolute deadline for {@link #matchesUntil(Pattern, CharSequence, long)}, or a sentinel that never
+   * triggers if {@code timeoutMillis <= 0}
+   */
+  public static long newDeadline(final long timeoutMillis) {
+    return timeoutMillis <= 0 ? Long.MAX_VALUE : System.nanoTime() + (timeoutMillis * 1_000_000L);
+  }
+
+  /**
+   * Matches {@code input} fully against {@code pattern}, aborting if {@code System.nanoTime()} passes
+   * {@code deadlineNanos} - an absolute deadline from {@link #newDeadline(long)}, shared across every call in a
+   * series so the series as a whole is bounded rather than each call individually.
+   *
+   * @param pattern      the compiled pattern to match
+   * @param input        the input to match against
+   * @param deadlineNanos an absolute {@link System#nanoTime()} deadline, as returned by {@link #newDeadline(long)}
+   *
+   * @return {@code true} if {@code input} matches {@code pattern} in its entirety
+   *
+   * @throws TimeoutException if the match does not complete before {@code deadlineNanos}
+   */
+  public static boolean matchesUntil(final Pattern pattern, final CharSequence input, final long deadlineNanos) {
+    try {
+      return match(pattern, input, deadlineNanos);
+    } catch (final RegexDeadlineExceeded e) {
+      throw new TimeoutException(
+          "Regular expression evaluation aborted after exceeding its arcadedb.command.regexTimeout deadline: pattern '" + pattern.pattern()
+              + "' against input of length " + input.length());
+    }
+  }
+
+  private static boolean match(final Pattern pattern, final CharSequence input, final long deadlineNanos) {
+    if (deadlineNanos == Long.MAX_VALUE)
+      return pattern.matcher(input).matches();
+    return pattern.matcher(new DeadlineBoundCharSequence(input, deadlineNanos)).matches();
   }
 
   private static final class DeadlineBoundCharSequence implements CharSequence {

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluatorIntegrationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluatorIntegrationTest.java
@@ -232,6 +232,42 @@ class PromQLEvaluatorIntegrationTest extends TestHelper {
   }
 
   @Test
+  void rangeQuerySharesOneTimeoutBudgetAcrossAllSteps() {
+    // Issue #5886, 12th review pass: evaluateVectorSelector()/evaluateMatrixSelector() already share one
+    // deadline across every row within a single step's scan, but evaluateRange() calls evaluate() once per
+    // step (up to MAX_RANGE_STEPS = 1,000,000), and each of those calls used to compute its own fresh deadline -
+    // the same N-times-timeout shape closed at the row level, reopened here at the step level. The deadline is
+    // now cached on the PromQLEvaluator instance itself (safe here since a fresh evaluator is created per
+    // top-level query - see SQLFunctionPromQL - never reused across executions the way RegexExpression's AST
+    // nodes are).
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String typeName = "promql_range_multistep";
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE)");
+    final String pathologicalHost = "a".repeat(40); // no trailing 'c': forces the same exhaustive backtrack as
+    // unparenthesizedCatastrophicPatternIsAbortedByRegexTimeout above. A single data point at ts=0, visible
+    // from every step's lookback window below (evalTime - lookbackMs <= 0 for every evalTime in the range), so
+    // every one of the 10 steps evaluates the same catastrophic label matcher against it.
+    database.transaction(() -> database.command("sql",
+        "INSERT INTO " + typeName + " SET ts = 0, host = '" + pathologicalHost + "', value = 1.0"));
+
+    final PromQLEvaluator evaluator = new PromQLEvaluator(getDatabaseInternal(), 100_000L);
+    // Unparenthesized shape (see unparenthesizedCatastrophicPatternIsAbortedByRegexTimeout above): REDOS_CHECK
+    // rejects parenthesized nested-quantifier patterns like (.*a){20}$ at parse time, before this ever reaches
+    // TimeBoundRegex, so the reproducer here has to be the sequential-a*-without-nesting shape instead.
+    final PromQLExpr expr = new PromQLParser(typeName + "{host=~\"" + "a*".repeat(20) + "c\"}").parse();
+
+    final long begin = System.currentTimeMillis();
+    // startMs=1000, endMs=10000, stepMs=1000 -> 10 steps, every one of which sees the ts=0 data point.
+    assertThatThrownBy(() -> evaluator.evaluateRange(expr, 1000L, 10_000L, 1000L)).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // 10 independent 200ms-per-step budgets would take >= 2000ms; a shared deadline keeps the whole range
+    // query close to the single configured 200ms bound instead.
+    assertThat(elapsedMillis).isLessThan(1000);
+  }
+
+  @Test
   void scalarArithmetic() {
     final PromQLEvaluator evaluator = new PromQLEvaluator(getDatabaseInternal());
     final PromQLExpr expr = new PromQLParser("2 + 3 * 4").parse();

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluatorIntegrationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluatorIntegrationTest.java
@@ -344,6 +344,58 @@ class PromQLEvaluatorIntegrationTest extends TestHelper {
   }
 
   @Test
+  void setRegexDeadlineOverridesTheLazilyComputedDefault() {
+    // Issue #5886, 17th review pass: SQLFunctionPromQL creates a fresh PromQLEvaluator per promql() call (never
+    // reused across executions the way rangeQuerySharesOneTimeoutBudgetAcrossAllSteps above relies on), so
+    // without a way to inject an externally-resolved deadline it would always fall back to its own
+    // GlobalConfiguration-derived budget rather than the CommandContext-cached one every other per-row SQL
+    // function in this issue shares. Verify setRegexDeadline() is actually honored - not silently ignored - by
+    // forcing an already-elapsed deadline and confirming it aborts an otherwise-trivial, non-catastrophic match
+    // that would normally complete instantly. The host value must be long enough to force more than
+    // TimeBoundRegex's CHECK_INTERVAL (256) charAt() calls - too short an input completes before the first
+    // deadline checkpoint is ever reached, regardless of whether the deadline is already expired.
+    final String typeName = "promql_setregexdeadline_metric";
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE)");
+    final String longHost = "a".repeat(256); // tag dictionary caps values at 256 bytes
+    database.transaction(() -> database.command("sql",
+        "INSERT INTO " + typeName + " SET ts = 1000, host = '" + longHost + "', value = 1.0"));
+
+    final PromQLEvaluator evaluator = new PromQLEvaluator(getDatabaseInternal());
+    evaluator.setRegexDeadline(System.nanoTime() - 1_000_000_000L); // 1s in the past: already expired
+
+    final PromQLExpr expr = new PromQLParser(typeName + "{host=~\"a*\"}").parse();
+
+    assertThatThrownBy(() -> evaluator.evaluateInstant(expr, 6000L)).isInstanceOf(TimeoutException.class);
+  }
+
+  @Test
+  void promQLSqlFunctionAbortsOnCatastrophicPattern() {
+    // End-to-end coverage for the promql() SQL function path specifically (as opposed to calling
+    // PromQLEvaluator.evaluateInstant directly, as unparenthesizedCatastrophicPatternIsAbortedByRegexTimeout
+    // above does) - proves the context.getOrComputeRegexDeadline() -> evaluator.setRegexDeadline() wiring in
+    // SQLFunctionPromQL actually bounds a catastrophic =~ label matcher reached through SELECT promql(...).
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String typeName = "promql_function_redos";
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE)");
+    final String pathologicalHost = "a".repeat(40); // no trailing 'c': forces exhaustive backtrack-then-fail
+    database.transaction(() -> database.command("sql",
+        "INSERT INTO " + typeName + " SET ts = 0, host = '" + pathologicalHost + "', value = 1.0"));
+
+    final String wildcardPattern = "a*".repeat(20) + "c";
+    final String promqlExpr = typeName + "{host=~\"" + wildcardPattern + "\"}";
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> database.command("sql", "RETURN promql('" + promqlExpr + "', 6000)").close())
+        .isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // Generous upper bound: proves the call was aborted near the configured deadline rather than merely being
+    // slow (the unbounded match takes tens of seconds).
+    assertThat(elapsedMillis).isLessThan(5000);
+  }
+
+  @Test
   void promQLSqlFunctionUsesCurrentTimeWhenNoArgument() {
     createTypeAndInsertData("promql_sql_notime_test");
 

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluatorIntegrationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluatorIntegrationTest.java
@@ -18,9 +18,11 @@
  */
 package com.arcadedb.engine.timeseries.promql;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.timeseries.promql.ast.PromQLExpr;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.TimeSeriesTypeBuilder;
 import com.arcadedb.schema.Type;
@@ -196,6 +198,37 @@ class PromQLEvaluatorIntegrationTest extends TestHelper {
     assertThatThrownBy(() -> evaluator.evaluateInstant(expr, 6000L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("ReDoS");
+  }
+
+  @Test
+  void unparenthesizedCatastrophicPatternIsAbortedByRegexTimeout() {
+    // Issue #5886 follow-up: REDOS_CHECK only flags parenthesized nested-quantifier/alternation shapes
+    // ((a+)+, (a|aa)+, ...), so a sequence of unparenthesized quantified segments - the same
+    // "sequential-.*-without-nesting" shape that turned out to break SQL LIKE and full-text wildcard
+    // queries - reaches Pattern.matcher(...).matches() uncaught by that static pre-filter. Bounded now by
+    // routing =~/!~ through TimeBoundRegex, same as every other entry point this issue covers.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String typeName = "promql_redos_unparenthesized";
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName + " TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE)");
+    final String pathologicalHost = "a".repeat(40);
+    database.transaction(() -> database.command("sql",
+        "INSERT INTO " + typeName + " SET ts = 1000, host = '" + pathologicalHost + "', value = 1.0"));
+
+    final PromQLEvaluator evaluator = new PromQLEvaluator(getDatabaseInternal());
+    // 20 sequential "a*" quantifiers then a literal 'c' that never appears in the all-'a' host value: forces
+    // the same exhaustive backtrack-then-fail every other reproducer in this issue relies on, with no '(' in
+    // sight for REDOS_CHECK to catch.
+    final String wildcardPattern = "a*".repeat(20) + "c";
+    final PromQLExpr expr = new PromQLParser(typeName + "{host=~\"" + wildcardPattern + "\"}").parse();
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> evaluator.evaluateInstant(expr, 6000L)).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // Generous upper bound: proves the scan was aborted near the configured deadline rather than merely
+    // being slow (the unbounded match takes tens of seconds).
+    assertThat(elapsedMillis).isLessThan(5000);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/function/text/TextRegexReplaceTest.java
+++ b/engine/src/test/java/com/arcadedb/function/text/TextRegexReplaceTest.java
@@ -68,6 +68,35 @@ class TextRegexReplaceTest extends TestHelper {
   }
 
   @Test
+  void multiRowReplaceSharesOneTimeoutBudgetAcrossRows() {
+    // Issue #5886, 12th review pass: text.regexReplace() has a CommandContext available and now shares one
+    // deadline across every row it runs against within the same query (the same treatment MatchesCondition/
+    // RegexExpression get, and the same rationale as their multi-row tests) - each row getting its own full
+    // budget would let a table with many pathological rows cost up to rowCount * regexTimeout instead of one
+    // bounded query.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(40) + "!";
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE RegexReplaceMultiRow");
+      for (int i = 0; i < 10; i++)
+        database.command("sql", "INSERT INTO RegexReplaceMultiRow SET name = '" + pathological + "'");
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("sql", "SELECT text.regexReplace(name, '(.*a){20}$', 'x') AS r FROM RegexReplaceMultiRow");
+      while (rs.hasNext())
+        rs.next();
+    }).isInstanceOf(IllegalArgumentException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // 10 independent 200ms-per-row budgets would take >= 2000ms; a shared deadline keeps the whole query close
+    // to the single configured 200ms bound instead.
+    assertThat(elapsedMillis).isLessThan(1000);
+  }
+
+  @Test
   void patternExceedingMaxLengthIsStillRejected() {
     // Unrelated to the regexTimeout wiring, but this guard sits right next to the code that was touched here -
     // confirm it still fires.

--- a/engine/src/test/java/com/arcadedb/function/text/TextRegexReplaceTest.java
+++ b/engine/src/test/java/com/arcadedb/function/text/TextRegexReplaceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.text;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Regression tests for issue #5886: text.regexReplace() was exposed to catastrophic regex backtracking. */
+class TextRegexReplaceTest extends TestHelper {
+
+  @Test
+  void basicReplaceStillWorks() {
+    final ResultSet rs = database.query("sql", "SELECT text.regexReplace('banana', 'a', 'o') AS r");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("r")).isEqualTo("bonono");
+  }
+
+  @Test
+  void functionIsSafeWithoutACommandContext() {
+    // Established convention for this function family (see TextStatelessFunctionsTest): calling the function
+    // directly with a null CommandContext, bypassing the query engine entirely, must not NPE just because this
+    // function now also reads arcadedb.command.regexTimeout - it falls back to the compiled-in default instead.
+    final TextRegexReplace fn = new TextRegexReplace();
+    assertThat(fn.execute(new Object[] { "banana", "a", "o" }, null)).isEqualTo("bonono");
+  }
+
+  @Test
+  void catastrophicPatternIsAbortedByRegexTimeout() {
+    // Issue #5886 follow-up: text.regexReplace() ran Pattern.compile(regex).matcher(str).replaceAll(...) with no
+    // time bound - only a 500-char pattern-length cap and a StackOverflowError catch, neither of which bounds
+    // the (.*a){20}$ reproducer (11 characters, no deep recursion needed for it to run unbounded).
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(40) + "!";
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(
+        () -> database.query("sql", "SELECT text.regexReplace('" + pathological + "', '(.*a){20}$', 'x') AS r").next())
+        .isInstanceOf(IllegalArgumentException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // Generous upper bound: proves the call was aborted near the configured deadline rather than merely being
+    // slow (the unbounded replaceAll takes tens of seconds).
+    assertThat(elapsedMillis).isLessThan(5000);
+  }
+
+  @Test
+  void patternExceedingMaxLengthIsStillRejected() {
+    // Unrelated to the regexTimeout wiring, but this guard sits right next to the code that was touched here -
+    // confirm it still fires.
+    final String tooLong = "a".repeat(501);
+    assertThatThrownBy(() -> database.query("sql", "SELECT text.regexReplace('x', :p, 'y') AS r", Map.of("p", tooLong)).next())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextQueryExecutorTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextQueryExecutorTest.java
@@ -548,4 +548,39 @@ class FullTextQueryExecutorTest extends TestHelper {
       assertThat(elapsedMillis).isLessThan(5000);
     });
   }
+
+  @Test
+  void catastrophicWildcardQueryIsAbortedByRegexTimeout() {
+    // Issue #5886 follow-up (2nd review pass): collectWildcardMatches() converts each '*' to '.*' via
+    // wildcardToRegex() - no grouping/alternation/nested quantifiers, but a sequence of several '*'s reproduces
+    // the exact same catastrophic-backtracking shape on its own, the same class of gap SQL LIKE/ILIKE turned
+    // out to have (verified separately) despite the original "structurally safe" audit conclusion for both.
+    // "a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*b" against a token ending in something other than 'b' forces the
+    // same exhaustive backtrack-then-fail this issue's own (.*a){20}$ reproducer relies on. A literal (not '*')
+    // leading character keeps this in the range-scan branch without needing allowLeadingWildcard=true - the
+    // leading-wildcard, full-scan branch is the same shape collectRegexpMatches already covers a test for.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(40) + "c";
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Article");
+      database.command("sql", "CREATE PROPERTY Article.content STRING");
+      database.command("sql", "CREATE INDEX ON Article (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Article SET content = '" + pathological + "'");
+    });
+
+    database.transaction(() -> {
+      final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName("Article[content]");
+      final LSMTreeFullTextIndex ftIndex = (LSMTreeFullTextIndex) index.getIndexesOnBuckets()[0];
+      final FullTextQueryExecutor executor = new FullTextQueryExecutor(ftIndex);
+
+      final String wildcardPattern = "a" + "*a".repeat(19) + "*b";
+
+      final long begin = System.currentTimeMillis();
+      assertThatThrownBy(() -> executor.search(wildcardPattern, -1)).isInstanceOf(TimeoutException.class);
+      final long elapsedMillis = System.currentTimeMillis() - begin;
+
+      assertThat(elapsedMillis).isLessThan(5000);
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextQueryExecutorTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextQueryExecutorTest.java
@@ -18,8 +18,10 @@
  */
 package com.arcadedb.index.fulltext;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.TypeIndex;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FullTextQueryExecutorTest extends TestHelper {
 
@@ -509,6 +512,40 @@ class FullTextQueryExecutorTest extends TestHelper {
 
       // Doc1 (java + programming) should have higher score than Doc2 (java only)
       assertThat(firstScore).isGreaterThan(secondScore);
+    });
+  }
+
+  @Test
+  void catastrophicRegexpQueryIsAbortedByRegexTimeout() {
+    // Issue #5886 follow-up: a /pattern/ regexp query is matched against every token in what is, absent a
+    // literal prefix, a full index scan - collectRegexpMatches() had no bound on that per-token
+    // Pattern.matcher(token).matches() call, so this is arguably a worse instance of the MATCHES/=~ gap this
+    // issue was originally about (one pathological pattern evaluated against every token in the index).
+    // Terminator is 'b', not '!': full-text tokenization strips punctuation, and the terminator must survive
+    // as part of the token for the reproducer to still be the same catastrophic pattern (a non-'a' tail is
+    // what forces (.*a){20}$ to exhaustively backtrack instead of matching greedily).
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(40) + "b";
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Article");
+      database.command("sql", "CREATE PROPERTY Article.content STRING");
+      database.command("sql", "CREATE INDEX ON Article (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Article SET content = '" + pathological + "'");
+    });
+
+    database.transaction(() -> {
+      final TypeIndex index = (TypeIndex) database.getSchema().getIndexByName("Article[content]");
+      final LSMTreeFullTextIndex ftIndex = (LSMTreeFullTextIndex) index.getIndexesOnBuckets()[0];
+      final FullTextQueryExecutor executor = new FullTextQueryExecutor(ftIndex);
+
+      final long begin = System.currentTimeMillis();
+      assertThatThrownBy(() -> executor.search("/(.*a){20}$/", -1)).isInstanceOf(TimeoutException.class);
+      final long elapsedMillis = System.currentTimeMillis() - begin;
+
+      // Generous upper bound: proves the scan was aborted near the configured deadline rather than merely
+      // being slow (the unbounded match takes tens of seconds).
+      assertThat(elapsedMillis).isLessThan(5000);
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherWhereClauseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherWhereClauseTest.java
@@ -236,6 +236,32 @@ public class OpenCypherWhereClauseTest {
     assertThat(elapsedMillis).isLessThan(5000);
   }
 
+  @Test
+  void regexSharesOneTimeoutBudgetAcrossAllRowsInTheScan() {
+    // Issue #5886, 6th review pass: a WHERE ... =~ clause scanning many rows must not let each row's own
+    // evaluation start a fresh regexTimeout budget - otherwise a graph shaped so every matched node triggers
+    // catastrophic backtracking could still cost up to node count * regexTimeout overall. The deadline is now
+    // cached on the RegexExpression AST node itself (the same instance-field mechanism already used to cache
+    // the compiled Pattern), computed once for the lifetime of that node across the whole scan.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(40) + "!";
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        database.command("opencypher", "CREATE (p:PerRowPathological {name: $name})", Map.of("name", pathological));
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(
+        () -> database.query("opencypher", "MATCH (p:PerRowPathological) WHERE p.name =~ '(.*a){20}$' RETURN p.name").next())
+        .isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // 10 independent 200ms-per-row budgets would take >= 2000ms; a query-wide shared deadline keeps the whole
+    // scan close to the single configured 200ms bound instead.
+    assertThat(elapsedMillis).isLessThan(1000);
+  }
+
   // Issue #5282: NOT (null =~ ...) must stay null, not become true.
   @Test
   void regexNullPropagatesThroughNot() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherWhereClauseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherWhereClauseTest.java
@@ -240,9 +240,11 @@ public class OpenCypherWhereClauseTest {
   void regexSharesOneTimeoutBudgetAcrossAllRowsInTheScan() {
     // Issue #5886, 6th review pass: a WHERE ... =~ clause scanning many rows must not let each row's own
     // evaluation start a fresh regexTimeout budget - otherwise a graph shaped so every matched node triggers
-    // catastrophic backtracking could still cost up to node count * regexTimeout overall. The deadline is now
-    // cached on the RegexExpression AST node itself (the same instance-field mechanism already used to cache
-    // the compiled Pattern), computed once for the lifetime of that node across the whole scan.
+    // catastrophic backtracking could still cost up to node count * regexTimeout overall. The deadline is
+    // cached on the per-execution CommandContext (the same mechanism MatchesCondition uses on the SQL side),
+    // computed once for the lifetime of the query execution across the whole scan - not as an instance field
+    // on the RegexExpression AST node itself, which a later review pass (regexDeadlineDoesNotLeakAcrossCached
+    // QueryExecutions below) found would go stale across repeated executions of a cached query.
     database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
 
     final String pathological = "a".repeat(40) + "!";
@@ -260,6 +262,40 @@ public class OpenCypherWhereClauseTest {
     // 10 independent 200ms-per-row budgets would take >= 2000ms; a query-wide shared deadline keeps the whole
     // scan close to the single configured 200ms bound instead.
     assertThat(elapsedMillis).isLessThan(1000);
+  }
+
+  @Test
+  void regexDeadlineDoesNotLeakAcrossCachedQueryExecutions() {
+    // Issue #5886, 8th review pass (CRITICAL, caught before merge): RegexExpression instances are parsed once
+    // and reused across every execution of that same query text via CypherStatementCache (keyed by normalized
+    // query string, confirmed by RegexExpression having no copy() unlike SQL's MatchesCondition.copy()).
+    // Caching the deadline as an instance field (mirroring compiledPattern's existing instance-field caching)
+    // is correct for compiledPattern - content-addressed, never goes stale - but wrong for a deadline, which is
+    // a point in time: once it lapses, every LATER execution of that same cached query would throw a spurious
+    // TimeoutException on a completely benign, non-catastrophic match. Fixed by caching on the per-execution
+    // CommandContext instead (see regexSharesOneTimeoutBudgetAcrossAllRowsInTheScan above).
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 300L);
+
+    // Long enough that matching needs >= 256 charAt() calls (TimeBoundRegex's deadline-check interval), so a
+    // stale cached deadline would actually be observed rather than the match finishing before the first check.
+    database.transaction(() -> database.command("opencypher", "CREATE (n:RegexCacheReuse {name: $n})", Map.of("n", "b".repeat(300))));
+
+    final String query = "MATCH (n:RegexCacheReuse) WHERE n.name =~ 'b+' RETURN n.name";
+
+    // First execution: parses (and caches) the query; before the fix, this also cached a since-expired deadline
+    // as an instance field on the shared RegexExpression AST node.
+    assertThat(database.query("opencypher", query).hasNext()).isTrue();
+
+    try {
+      Thread.sleep(400); // let the first execution's deadline lapse
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    // Second execution of the exact same query text reuses the cached AST (the same RegexExpression instance)
+    // but must get its own fresh deadline - not throw TimeoutException on this ordinary, non-catastrophic match
+    // just because the first execution's deadline already lapsed.
+    assertThat(database.query("opencypher", query).hasNext()).isTrue();
   }
 
   // Issue #5282: NOT (null =~ ...) must stay null, not become true.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherWhereClauseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherWhereClauseTest.java
@@ -31,9 +31,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -211,6 +213,27 @@ public class OpenCypherWhereClauseTest {
     final Result row = rs.next();
     assertThat(row.<Boolean>getProperty("result")).isTrue();
     assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
+  void catastrophicPatternIsAbortedByRegexTimeout() {
+    // Issue #5886: (.*a){20}$ against "a".repeat(40) + "!" triggers catastrophic backtracking in
+    // java.util.regex. Matcher.matches() never polls interrupts or a deadline while backtracking, so
+    // arcadedb.command.timeout cannot stop it; only arcadedb.command.regexTimeout, enforced inside the
+    // match itself, can.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathologicalInput = "a".repeat(40) + "!";
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN $input =~ '(.*a){20}$' AS result",
+        Map.of("input", pathologicalInput)).next())
+        .isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // Generous upper bound: proves the query was aborted near the configured deadline rather than
+    // merely being slow (the unbounded match takes tens of seconds).
+    assertThat(elapsedMillis).isLessThan(5000);
   }
 
   // Issue #5282: NOT (null =~ ...) must stay null, not become true.

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.select;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.TimeoutException;
@@ -371,6 +372,29 @@ public class SelectExecutionTest extends TestHelper {
       assertThat(list.size()).isEqualTo(100);
       list.forEach(r -> assertThat(r.getString("name").startsWith("J")).isTrue());
     }
+  }
+
+  @Test
+  void catastrophicLikeIsAbortedByRegexTimeout() {
+    // Issue #5886 follow-up: SelectOperator.like/ilike is the native query engine's independent LIKE/ILIKE
+    // evaluation path (distinct from the SQL parser's LikeOperator/ILikeOperator), so it needed its own
+    // TimeBoundRegex wiring and deserves its own regression test proving the abort, same as every other
+    // modified entry point in this issue.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    database.getSchema().createVertexType("LikePathological");
+    database.transaction(() -> database.newVertex("LikePathological").set("name", "a".repeat(41)).save());
+
+    final SelectCompiled select = database.select().fromType("LikePathological")//
+        .where().property("name").like().value("%a".repeat(20) + "c").compile();
+
+    final long begin = System.currentTimeMillis();
+    Assertions.assertThatThrownBy(() -> select.vertices().toList()).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // Generous upper bound: proves the query was aborted near the configured deadline rather than merely
+    // being slow (the unbounded match takes tens of seconds).
+    assertThat(elapsedMillis).isLessThan(5000);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
@@ -18,7 +18,9 @@
  */
 package com.arcadedb.query.sql;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Regression tests for the MATCHES per-context regex pattern cache. */
 class MatchesConditionTest extends TestHelper {
@@ -145,5 +148,31 @@ class MatchesConditionTest extends TestHelper {
     assertThat(second.hasNext()).isTrue();
     assertThat(second.next().<String>getProperty("name")).isEqualTo("BBking");
     assertThat(second.hasNext()).isFalse();
+  }
+
+  @Test
+  void catastrophicPatternIsAbortedByRegexTimeout() {
+    // Issue #5886: (.*a){20}$ against "a".repeat(40) + "!" triggers catastrophic backtracking in
+    // java.util.regex. Matcher.matches() never polls interrupts or a deadline while backtracking, so
+    // arcadedb.command.timeout cannot stop it (still running 30s later per the issue report); only
+    // arcadedb.command.regexTimeout, enforced inside the match itself, can.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Pathological");
+      database.command("sql", "INSERT INTO Pathological SET name = '" + "a".repeat(40) + "!'");
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("sql", "SELECT FROM Pathological WHERE name MATCHES '(.*a){20}$'");
+      while (rs.hasNext())
+        rs.next();
+    }).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // Generous upper bound: proves the query was aborted near the configured deadline rather than
+    // merely being slow (the unbounded match takes tens of seconds).
+    assertThat(elapsedMillis).isLessThan(5000);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
@@ -179,15 +179,21 @@ class MatchesConditionTest extends TestHelper {
   @Test
   void multiValueMatchesSharesOneTimeoutBudgetAcrossItems() {
     // A multi-value (list) property must not multiply the regex timeout budget by its item count: each
-    // catastrophic item getting its own full budget would let a crafted 5-item list run for 5 * regexTimeout
-    // instead of one evaluation bounded by regexTimeout overall.
+    // catastrophic item getting its own full budget would let a crafted 10-item list run for 10 * regexTimeout
+    // instead of one evaluation bounded by regexTimeout overall. 10 items (rather than a smaller count) widens
+    // the gap between the "shared" (~200-300ms) and "not shared" (~2000ms) outcomes, so the assertion below can
+    // use a generous margin without losing the ability to catch a regression.
     database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
 
     final String pathological = "a".repeat(40) + "!";
+    final String items = "'" + pathological + "'";
+    final StringBuilder list = new StringBuilder("[");
+    for (int i = 0; i < 10; i++)
+      list.append(i == 0 ? "" : ", ").append(items);
+    list.append(']');
     database.transaction(() -> {
       database.command("sql", "CREATE VERTEX TYPE MultiPathological");
-      database.command("sql", "INSERT INTO MultiPathological SET tags = ['" + pathological + "', '" + pathological + "', '" + pathological
-          + "', '" + pathological + "', '" + pathological + "']");
+      database.command("sql", "INSERT INTO MultiPathological SET tags = " + list);
     });
 
     final long begin = System.currentTimeMillis();
@@ -198,8 +204,8 @@ class MatchesConditionTest extends TestHelper {
     }).isInstanceOf(TimeoutException.class);
     final long elapsedMillis = System.currentTimeMillis() - begin;
 
-    // 5 independent 200ms-per-item budgets would take >= 1000ms; a shared deadline keeps the whole
-    // evaluation close to the single configured 200ms bound instead.
-    assertThat(elapsedMillis).isLessThan(800);
+    // 10 independent 200ms-per-item budgets would take >= 2000ms; a shared deadline keeps the whole evaluation
+    // close to the single configured 200ms bound instead. 1000ms leaves generous CI-runner slack on both sides.
+    assertThat(elapsedMillis).isLessThan(1000);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
@@ -94,6 +94,27 @@ class MatchesConditionTest extends TestHelper {
   }
 
   @Test
+  void patternTextDeadlineDoesNotCollideWithTheDeadlineCacheKey() {
+    // Issue #5886, 9th review pass: the deadline shared across a query's MATCHES evaluations was originally
+    // cached under the key "MATCHES_DEADLINE" - identical to the pattern-cache key the literal pattern text
+    // "DEADLINE" produces ("MATCHES_" + "DEADLINE"). A row using that pattern threw ClassCastException
+    // (java.util.regex.Pattern cast to java.lang.Long) on the very first evaluation, since both the compiled
+    // Pattern and the shared deadline were being stored under the exact same context cache slot. The deadline
+    // key now lives entirely outside the "MATCHES_" namespace the pattern cache uses, so it cannot collide
+    // with "MATCHES_" + <any regex text>, however that text reads.
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE DeadlineCollision");
+      database.command("sql", "INSERT INTO DeadlineCollision SET name = 'DEADLINE'");
+      database.command("sql", "INSERT INTO DeadlineCollision SET name = 'other'");
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT name FROM DeadlineCollision WHERE name MATCHES 'DEADLINE'");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("name")).isEqualTo("DEADLINE");
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
   void parameterRegexWithMultipleDotsIsAccepted() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE ParamDotted");

--- a/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
@@ -208,4 +208,33 @@ class MatchesConditionTest extends TestHelper {
     // close to the single configured 200ms bound instead. 1000ms leaves generous CI-runner slack on both sides.
     assertThat(elapsedMillis).isLessThan(1000);
   }
+
+  @Test
+  void matchesSharesOneTimeoutBudgetAcrossAllRowsInTheScan() {
+    // Issue #5886, 6th review pass: distinct from the multi-value-within-one-row case above, a WHERE ...
+    // MATCHES clause scanning many ROWS must not let each row's own evaluation start a fresh regexTimeout
+    // budget either - otherwise a table shaped so every row triggers catastrophic backtracking could still
+    // cost up to rowCount * regexTimeout overall. The deadline is now cached on the CommandContext (the same
+    // mechanism already used to cache the compiled Pattern), computed once for the whole query.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(40) + "!";
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE PerRowPathological");
+      for (int i = 0; i < 10; i++)
+        database.command("sql", "INSERT INTO PerRowPathological SET name = '" + pathological + "'");
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("sql", "SELECT FROM PerRowPathological WHERE name MATCHES '(.*a){20}$'");
+      while (rs.hasNext())
+        rs.next();
+    }).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // 10 independent 200ms-per-row budgets would take >= 2000ms; a query-wide shared deadline keeps the whole
+    // scan close to the single configured 200ms bound instead.
+    assertThat(elapsedMillis).isLessThan(1000);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
@@ -175,4 +175,31 @@ class MatchesConditionTest extends TestHelper {
     // merely being slow (the unbounded match takes tens of seconds).
     assertThat(elapsedMillis).isLessThan(5000);
   }
+
+  @Test
+  void multiValueMatchesSharesOneTimeoutBudgetAcrossItems() {
+    // A multi-value (list) property must not multiply the regex timeout budget by its item count: each
+    // catastrophic item getting its own full budget would let a crafted 5-item list run for 5 * regexTimeout
+    // instead of one evaluation bounded by regexTimeout overall.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(40) + "!";
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE MultiPathological");
+      database.command("sql", "INSERT INTO MultiPathological SET tags = ['" + pathological + "', '" + pathological + "', '" + pathological
+          + "', '" + pathological + "', '" + pathological + "']");
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("sql", "SELECT FROM MultiPathological WHERE tags MATCHES '(.*a){20}$'");
+      while (rs.hasNext())
+        rs.next();
+    }).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // 5 independent 200ms-per-item budgets would take >= 1000ms; a shared deadline keeps the whole
+    // evaluation close to the single configured 200ms bound instead.
+    assertThat(elapsedMillis).isLessThan(800);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QueryHelperLikeRegexTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QueryHelperLikeRegexTimeoutTest.java
@@ -103,4 +103,37 @@ class QueryHelperLikeRegexTimeoutTest extends TestHelper {
 
     assertThat(elapsedMillis).isLessThan(5000);
   }
+
+  @Test
+  void multiValueLikeSharesOneTimeoutBudgetAcrossItems() {
+    // A multi-value (list) left operand (LikeOperator's BY-ITEM branch, issue #2693) must not multiply the
+    // regex timeout budget by its item count, the same concern MatchesConditionTest#
+    // multiValueMatchesSharesOneTimeoutBudgetAcrossItems proves for MATCHES: each catastrophic item getting
+    // its own full budget would let a crafted 10-item list run for 10 * regexTimeout instead of one
+    // evaluation bounded by regexTimeout overall.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(41);
+    final String item = "'" + pathological + "'";
+    final StringBuilder list = new StringBuilder("[");
+    for (int i = 0; i < 10; i++)
+      list.append(i == 0 ? "" : ", ").append(item);
+    list.append(']');
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE MultiLikePathological");
+      database.command("sql", "INSERT INTO MultiLikePathological SET tags = " + list);
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("sql", "SELECT FROM MultiLikePathological WHERE tags LIKE '" + PATHOLOGICAL_LIKE_PATTERN + "'");
+      while (rs.hasNext())
+        rs.next();
+    }).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // 10 independent 200ms-per-item budgets would take >= 2000ms; a shared deadline keeps the whole evaluation
+    // close to the single configured 200ms bound instead. 1000ms leaves generous CI-runner slack on both sides.
+    assertThat(elapsedMillis).isLessThan(1000);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QueryHelperLikeRegexTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QueryHelperLikeRegexTimeoutTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.utility.TimeBoundRegex;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5886, 2nd review pass: SQL LIKE/ILIKE's {@code %}-to-{@code .*} translation was
+ * originally audited as "structurally safe" (no grouping/alternation/nested quantifiers), which rules out one
+ * class of catastrophic backtracking but not another - a sequence of several {@code .*} segments reproduces the
+ * same exponential blowup on its own, with no nesting required.
+ */
+class QueryHelperLikeRegexTimeoutTest extends TestHelper {
+
+  // 20 "%a" segments then a literal, non-wildcard tail: LIKE's equivalent of the issue's own (.*a){20}$
+  // reproducer. String.matches()/Matcher.matches() always match the whole input, so no explicit end anchor is
+  // needed - the trailing literal plays that role.
+  private static final String PATHOLOGICAL_LIKE_PATTERN = "%a".repeat(20) + "c";
+
+  @Test
+  void likeWithTimeoutMatchesNormally() {
+    assertThat(QueryHelper.like("foobar", "%ooba%", 1000)).isTrue();
+    assertThat(QueryHelper.like("foobar", "%fff%", 1000)).isFalse();
+  }
+
+  @Test
+  void likeUntilMatchesNormally() {
+    final long deadline = TimeBoundRegex.newDeadline(1000);
+    assertThat(QueryHelper.likeUntil("foobar", "%ooba%", deadline)).isTrue();
+    assertThat(QueryHelper.likeUntil("foobar", "%fff%", deadline)).isFalse();
+  }
+
+  @Test
+  void likeAbortsCatastrophicBacktrackingWithinTheDeadline() {
+    final String input = "a".repeat(41); // all 'a's: never matches the pattern's literal 'c' tail
+
+    final long begin = System.nanoTime();
+    assertThatThrownBy(() -> QueryHelper.like(input, PATHOLOGICAL_LIKE_PATTERN, 200)).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = (System.nanoTime() - begin) / 1_000_000L;
+
+    assertThat(elapsedMillis).isLessThan(5000);
+  }
+
+  @Test
+  void sqlLikeIsAbortedByRegexTimeout() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE LikePathological");
+      database.command("sql", "INSERT INTO LikePathological SET name = '" + "a".repeat(41) + "'");
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("sql", "SELECT FROM LikePathological WHERE name LIKE '" + PATHOLOGICAL_LIKE_PATTERN + "'");
+      while (rs.hasNext())
+        rs.next();
+    }).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    assertThat(elapsedMillis).isLessThan(5000);
+  }
+
+  @Test
+  void sqlIlikeIsAbortedByRegexTimeout() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE ILikePathological");
+      database.command("sql", "INSERT INTO ILikePathological SET name = '" + "A".repeat(41) + "'");
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("sql", "SELECT FROM ILikePathological WHERE name ILIKE '" + PATHOLOGICAL_LIKE_PATTERN + "'");
+      while (rs.hasNext())
+        rs.next();
+    }).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    assertThat(elapsedMillis).isLessThan(5000);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/SQLMethodAdditionalCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/SQLMethodAdditionalCoverageTest.java
@@ -18,7 +18,9 @@
  */
 package com.arcadedb.query.sql.method;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Additional coverage tests for SQL methods, exercised via SQL queries.
@@ -182,6 +185,34 @@ class SQLMethodAdditionalCoverageTest extends TestHelper {
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<String>getProperty("result")).isNotNull();
     rs.close();
+  }
+
+  @Test
+  void normalizeMultiRowSharesOneTimeoutBudgetAcrossRows() {
+    // Issue #5886, 12th review pass: .normalize(form, pattern)'s pattern argument has a CommandContext
+    // available and now shares one deadline across every row it runs against within the same query, the same
+    // treatment text.regexReplace() gets and for the same reason - each row getting its own full budget would
+    // let a table with many pathological rows cost up to rowCount * regexTimeout instead of one bounded query.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final String pathological = "a".repeat(40) + "!";
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE NormalizeMultiRow");
+      for (int i = 0; i < 10; i++)
+        database.command("sql", "INSERT INTO NormalizeMultiRow SET name = '" + pathological + "'");
+    });
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("sql", "SELECT name.normalize('NFC', '(.*a){20}$') AS r FROM NormalizeMultiRow");
+      while (rs.hasNext())
+        rs.next();
+    }).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // 10 independent 200ms-per-row budgets would take >= 2000ms; a shared deadline keeps the whole query close
+    // to the single configured 200ms bound instead.
+    assertThat(elapsedMillis).isLessThan(1000);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodNormalizeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodNormalizeTest.java
@@ -18,11 +18,13 @@
  */
 package com.arcadedb.query.sql.method.string;
 
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.SQLMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SQLMethodNormalizeTest {
 
@@ -56,5 +58,23 @@ class SQLMethodNormalizeTest {
   void normalizeWithNFCAndPattern() {
     final Object result = method.execute("À", null, null, new Object[] { "NFC", "" });
     assertThat(result).isEqualTo("À");
+  }
+
+  @Test
+  void catastrophicPatternArgumentIsAbortedByRegexTimeout() {
+    // Issue #5886, 9th review pass: the 2nd argument is a caller-supplied regex applied via replaceAll() with
+    // no bound at all - unlike text.regexReplace(), which was fixed earlier in this issue, this call site was
+    // missed entirely. Uses the default 1000ms arcadedb.command.regexTimeout (this test has no database/context
+    // to lower it, method.execute() is called directly with a null context here, matching this file's existing
+    // convention) - still proves the abort happens near that bound rather than the tens of seconds an unbounded
+    // catastrophic match takes.
+    final String pathologicalInput = "a".repeat(40) + "!";
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(() -> method.execute(pathologicalInput, null, null, new Object[] { "NFC", "(.*a){20}$" }))
+        .isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    assertThat(elapsedMillis).isLessThan(5000);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodSplitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodSplitTest.java
@@ -57,6 +57,19 @@ class SQLMethodSplitTest {
     assertThat(splitted).hasSize(2).contains("first", "second");
   }
 
+  @Test
+  void delimiterIsTreatedLiterallyNotAsRegex() {
+    // Issue #5886, 9th review pass: the delimiter is a literal string, matching split()/text.split()/Cypher
+    // split(), which all wrap it in Pattern.quote() - this was the only one of the four that passed the
+    // caller-supplied delimiter straight to String.split(regex) unescaped, exposing it both to accidental
+    // regex-metacharacter behavior (a "." delimiter split on every character instead of the literal dot) and
+    // to catastrophic backtracking for a maliciously-crafted delimiter.
+    final Object result = method.execute("a.b.c", null, null, new Object[] { "." });
+    assertThat(result).isInstanceOf(String[].class);
+    final String[] splitted = (String[]) result;
+    assertThat(splitted).containsExactly("a", "b", "c");
+  }
+
   @Disabled
   @Test
   void perfTestSystemSplitVsCodeUtils() {

--- a/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
@@ -725,6 +725,34 @@ class DocumentValidationTest extends TestHelper {
   }
 
   @Test
+  void regExpValidationSharesOneTimeoutBudgetAcrossAllPropertiesOnOneDocument() {
+    // Issue #5886, 12th review pass: DocumentValidator.validate() loops over every property of a document,
+    // calling validateField() once per property - each getting its own full regexTimeout budget would let a
+    // document with N REGEXP-constrained properties, each crafted to backtrack catastrophically, cost up to
+    // N * regexTimeout instead of one bounded validation. This is the same N-times-timeout shape closed
+    // everywhere else in this issue, reopened here at the property level - and this entry point is the one
+    // reachable with no query privileges at all, so it mattered more here than anywhere else.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final DocumentType clazz = database.getSchema().getOrCreateDocumentType("MultiPropertyCatastrophicValidation");
+    final String pathological = "a".repeat(40) + "!";
+    for (int i = 0; i < 10; i++)
+      clazz.getOrCreateProperty("field" + i, Type.STRING).setRegexp("(.*a){20}$");
+
+    final MutableDocument d = database.newDocument(clazz.getName());
+    for (int i = 0; i < 10; i++)
+      d.set("field" + i, pathological);
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(d::validate).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // 10 independent 200ms-per-property budgets would take >= 2000ms; a shared deadline keeps the whole
+    // document validation close to the single configured 200ms bound instead.
+    assertThat(elapsedMillis).isLessThan(1000);
+  }
+
+  @Test
   void regExpValidationFromSQL() {
     final DocumentType clazz = database.getSchema().getOrCreateDocumentType("Validation");
 

--- a/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
@@ -18,11 +18,13 @@
  */
 package com.arcadedb.schema;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.exception.ValidationException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableEdge;
@@ -696,6 +698,30 @@ class DocumentValidationTest extends TestHelper {
     d.validate();
 
     checkFieldValue(d, "string", "yaZah");
+  }
+
+  @Test
+  void catastrophicRegExpValidationIsAbortedByRegexTimeout() {
+    // Issue #5886, 6th review pass: a schema-level REGEXP property constraint runs
+    // fieldValue.toString().matches(p.getRegexp()) on every insert/update of that property, with no bound at
+    // all - and unlike MATCHES/=~/LIKE, this needs no query privileges whatsoever: any write path (REST, any
+    // wire protocol) into a validated type is enough, arguably a more exposed surface than the query-based
+    // entry points this issue otherwise covers.
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_REGEX_TIMEOUT, 200L);
+
+    final DocumentType clazz = database.getSchema().getOrCreateDocumentType("CatastrophicValidation");
+    clazz.getOrCreateProperty("string", Type.STRING).setRegexp("(.*a){20}$");
+
+    final MutableDocument d = database.newDocument(clazz.getName());
+    d.set("string", "a".repeat(40) + "!");
+
+    final long begin = System.currentTimeMillis();
+    assertThatThrownBy(d::validate).isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = System.currentTimeMillis() - begin;
+
+    // Generous upper bound: proves validation was aborted near the configured deadline rather than merely
+    // being slow (the unbounded match takes tens of seconds).
+    assertThat(elapsedMillis).isLessThan(5000);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
@@ -89,6 +89,30 @@ class TimeBoundRegexTest {
   }
 
   @Test
+  void replaceAllUntilSharesOneDeadlineAcrossASeries() {
+    // Issue #5886, 12th review pass: TextRegexReplace/.normalize() need to share one deadline across every row
+    // of a query, the same "shared budget across a series" replaceAll() needed matches()/matchesUntil() to
+    // already have.
+    final Pattern pathological = Pattern.compile("(.*a){20}$");
+    final String input = "a".repeat(40) + "!";
+    final long deadline = TimeBoundRegex.newDeadline(200);
+
+    // First call consumes the whole 200ms budget and trips the deadline.
+    final long begin = System.nanoTime();
+    assertThatThrownBy(() -> TimeBoundRegex.replaceAllUntil(pathological, input, "x", deadline))
+        .isInstanceOf(TimeoutException.class);
+    // A second call against the same (now-expired) shared deadline must fail almost immediately, not run for
+    // another full budget - proving the deadline is a shared, absolute point in time, not a per-call timeout.
+    assertThatThrownBy(() -> TimeBoundRegex.replaceAllUntil(pathological, input, "x", deadline))
+        .isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = (System.nanoTime() - begin) / 1_000_000L;
+
+    // Two independent 200ms budgets would take >= 400ms; a shared deadline keeps both calls close to the
+    // single 200ms bound instead.
+    assertThat(elapsedMillis).isLessThan(1000);
+  }
+
+  @Test
   void newDeadlineDoesNotOverflowOnAnOversizedTimeout() {
     // arcadedb.command.regexTimeout is admin-configurable; a value large enough that timeoutMillis * 1_000_000L
     // (or adding System.nanoTime() to it) overflows a long must fall back to "effectively unbounded" rather than

--- a/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import com.arcadedb.exception.TimeoutException;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Regression tests for issue #5886: catastrophic regex backtracking is not bounded by any timeout. */
+class TimeBoundRegexTest {
+
+  @Test
+  void matchingPatternReturnsTrue() {
+    assertThat(TimeBoundRegex.matches(Pattern.compile("Aa.*"), "Aardvark", 1000)).isTrue();
+  }
+
+  @Test
+  void nonMatchingPatternReturnsFalse() {
+    assertThat(TimeBoundRegex.matches(Pattern.compile("Aa.*"), "BBking", 1000)).isFalse();
+  }
+
+  @Test
+  void nonPositiveTimeoutDisablesTheBound() {
+    // A timeout <= 0 must behave exactly like a plain, unbounded Matcher.matches() call.
+    assertThat(TimeBoundRegex.matches(Pattern.compile("Aa.*"), "Aardvark", 0)).isTrue();
+    assertThat(TimeBoundRegex.matches(Pattern.compile("Aa.*"), "Aardvark", -1)).isTrue();
+  }
+
+  @Test
+  void catastrophicBacktrackingIsAbortedWithinTheDeadline() {
+    // Issue #5886 reproducer: (.*a){20}$ against "a".repeat(40) + "!" triggers catastrophic
+    // backtracking in java.util.regex and is still running after 30s with no bound in place.
+    final Pattern pathological = Pattern.compile("(.*a){20}$");
+    final String input = "a".repeat(40) + "!";
+
+    final long begin = System.nanoTime();
+    assertThatThrownBy(() -> TimeBoundRegex.matches(pathological, input, 200))
+        .isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = (System.nanoTime() - begin) / 1_000_000L;
+
+    // Generous upper bound: proves the match was aborted near the requested deadline rather than
+    // merely being slow (the unbounded match takes tens of seconds).
+    assertThat(elapsedMillis).isLessThan(5000);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
@@ -87,4 +87,18 @@ class TimeBoundRegexTest {
 
     assertThat(elapsedMillis).isLessThan(5000);
   }
+
+  @Test
+  void newDeadlineDoesNotOverflowOnAnOversizedTimeout() {
+    // arcadedb.command.regexTimeout is admin-configurable; a value large enough that timeoutMillis * 1_000_000L
+    // (or adding System.nanoTime() to it) overflows a long must fall back to "effectively unbounded" rather than
+    // silently wrapping into a deadline that's already in the past - which would make every match abort
+    // immediately instead of applying the (very long) requested timeout.
+    assertThat(TimeBoundRegex.newDeadline(Long.MAX_VALUE)).isEqualTo(Long.MAX_VALUE);
+    assertThat(TimeBoundRegex.newDeadline(Long.MAX_VALUE / 1_000_000L + 1)).isEqualTo(Long.MAX_VALUE);
+
+    // And an overflow-inducing timeout must still let a normal match through rather than abort it, proving the
+    // fallback really disables the bound instead of just returning a large-but-still-wrong deadline.
+    assertThat(TimeBoundRegex.matches(Pattern.compile("Aa.*"), "Aardvark", Long.MAX_VALUE)).isTrue();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
@@ -62,4 +62,29 @@ class TimeBoundRegexTest {
     // merely being slow (the unbounded match takes tens of seconds).
     assertThat(elapsedMillis).isLessThan(5000);
   }
+
+  @Test
+  void replaceAllReplacesEveryMatch() {
+    assertThat(TimeBoundRegex.replaceAll(Pattern.compile("a"), "banana", "o", 1000)).isEqualTo("bonono");
+  }
+
+  @Test
+  void replaceAllWithNonPositiveTimeoutDisablesTheBound() {
+    assertThat(TimeBoundRegex.replaceAll(Pattern.compile("a"), "banana", "o", 0)).isEqualTo("bonono");
+  }
+
+  @Test
+  void replaceAllAbortsCatastrophicBacktrackingWithinTheDeadline() {
+    // text.regexReplace() (issue #5886 follow-up) runs Matcher.replaceAll(), which backtracks through the same
+    // java.util.regex machinery as matches() and is exposed to the same catastrophic-backtracking gap.
+    final Pattern pathological = Pattern.compile("(.*a){20}$");
+    final String input = "a".repeat(40) + "!";
+
+    final long begin = System.nanoTime();
+    assertThatThrownBy(() -> TimeBoundRegex.replaceAll(pathological, input, "x", 200))
+        .isInstanceOf(TimeoutException.class);
+    final long elapsedMillis = (System.nanoTime() - begin) / 1_000_000L;
+
+    assertThat(elapsedMillis).isLessThan(5000);
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #5886. `java.util.regex` never polls an interrupt flag or checks a deadline while backtracking - the only thing it calls on every backtracking step is `CharSequence.charAt()` on the input. A pathological pattern like `(.*a){20}$` against a 41-character string triggers catastrophic backtracking and is still running 30+ seconds later, and `arcadedb.command.timeout` cannot stop it. Anyone who can reach a regex-based entry point with an attacker-controlled pattern - or who forwards user-supplied patterns from an application layer - can permanently tie up a worker thread with a handful of such operations.

What started as a fix for SQL `MATCHES` and openCypher `=~` (the two entry points named in the issue) grew, through the review process on this PR, into an audit of every user-reachable regex call site in the engine.

## Fix

`TimeBoundRegex` (new, `com.arcadedb.utility`) wraps the matched input in a `CharSequence` whose `charAt()` throws once a deadline elapses - the one interception point `java.util.regex` offers, for `matches()`, `replaceAll()`, and `split()` alike. The deadline comes from a new dedicated setting, `arcadedb.command.regexTimeout` (default 1000ms, per-database), independent of `arcadedb.command.timeout` and active even when that setting is left at its own default of disabled (`0`). The deadline is checked every 256 `charAt()` calls (a bitmask check) rather than every call, keeping it off the hot path for the overwhelming majority of patterns that never come close to that many backtracking steps.

**Covered entry points:**
- SQL `MATCHES` and openCypher `=~`
- SQL `LIKE`/`ILIKE`, including the native query engine's `SelectOperator` path (a sequence of unparenthesized `.*`/`*` segments reproduces the same catastrophic shape without any grouping/alternation/nested quantifiers - the original "LIKE is structurally safe" audit conclusion was wrong)
- `text.regexReplace()` and the `.normalize()` SQL method's optional pattern argument
- Full-text search's Lucene `RegexpQuery` (`/pattern/`) and `WildcardQuery` (`*`/`?`) support
- PromQL's `=~`/`!~` label matchers, including every step of a range query
- Schema-level `REGEXP` property validation (`CREATE PROPERTY ... REGEXP <pattern>`) - the most exposed of the group, since it runs on every insert/update of a validated property through any write path (REST, any wire protocol) with no query privileges needed

`.split(delimiter)`'s SQL method got a different fix: unlike its three siblings (`split()` function, `text.split()`, Cypher `split()`), which all treat the delimiter as a literal via `Pattern.quote(...)`, it passed the delimiter straight to `String.split(regex)` unescaped. Matched to its siblings, removing the risk entirely rather than just bounding it.

**Deadline sharing.** A regex evaluated once per row/token/item/property over a scan must not get a fresh timeout budget per item, or a table/index/document shaped so every item triggers catastrophic backtracking costs `itemCount * regexTimeout` instead of one bounded operation. `MATCHES`, `=~`, `text.regexReplace()`, and `.normalize()` share one deadline across an entire query execution via a new `CommandContext.getOrComputeRegexDeadline()` helper; full-text and schema `REGEXP` validation share one deadline across the whole scan/document; PromQL shares one deadline across an entire query's lifetime, including every step of a range query. `LIKE`/`ILIKE` are the one exception: `BinaryCompareOperator` has no `CommandContext` to cache a deadline on, and widening that interface was judged out of proportion here, so each row gets its own budget.

**Upgrade note.** Because the deadline is shared per query/scan rather than per match, and defaults to an enabled 1000ms, a legitimate non-catastrophic operation that previously ran slowly to completion can now fail with `TimeoutException` instead. Raise `arcadedb.command.regexTimeout` for any database with large-scan regex-heavy workloads.

Full detail in `docs/release-26.9.1.md`.

## Testing

Dedicated `TimeBoundRegexTest` for the utility, plus regression tests at every covered entry point (`MatchesConditionTest`, `OpenCypherWhereClauseTest`, `QueryHelperLikeRegexTimeoutTest`, `SelectExecutionTest`, `LikeOperatorTest`/`ILikeOperatorTest`, `TextRegexReplaceTest`, `SQLMethodNormalizeTest`, `SQLMethodSplitTest`, `FullTextQueryExecutorTest`, `PromQLEvaluatorIntegrationTest`, `DocumentValidationTest`), each covering "matches/replaces normally", "catastrophic pattern is aborted near the deadline", and (where sharing applies) "one budget is shared across N rows/items/steps/properties".

Two real bugs were caught and fixed by the review process, both with regression tests that fail without the fix:
- A deadline cache key colliding with an existing pattern-cache key namespace for a specific literal pattern text (`MatchesConditionTest#patternTextDeadlineDoesNotCollideWithTheDeadlineCacheKey`).
- Caching a deadline as an instance field on a Cypher AST node reused across executions via `CypherStatementCache`, causing spurious timeouts on later benign executions of the same cached query (`OpenCypherWhereClauseTest#regexDeadlineDoesNotLeakAcrossCachedQueryExecutions`).

## Test plan

- [x] `mvn -pl engine compile` / `test-compile` clean
- [x] Full affected test suite green, no regressions
- [x] New regression tests prove the abort happens near the configured deadline and that shared-deadline budgets hold across rows/items/steps/properties
