### PR TITLE
fix(#5781): cover and correct the TypeIndexBuilder half of the guarded-create METADATA comparison

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -254,6 +254,11 @@ public class CreateIndexStatement extends DDLStatement {
 
     final AtomicLong total = new AtomicLong();
 
+    // What create() answered with: the index this statement built, or - for a guarded request whose NAME did not
+    // exist but whose properties are already indexed - the existing index the builder decided satisfies it. The two
+    // are told apart by the name, see {@link #isNewlyCreated}.
+    final TypeIndex resultingIndex;
+
     // Use unified buildTypeIndex() API for all index types
     TypeIndexBuilder builder = database.getSchema().buildTypeIndex(typeName.getStringValue(), fields);
     builder = builder.withType(indexType);  // This may return LSMVectorIndexBuilder for LSM_VECTOR
@@ -324,9 +329,12 @@ public class CreateIndexStatement extends DDLStatement {
       }
 
       final TypeIndex typeIndex = vectorBuilder.create();
+      resultingIndex = typeIndex;
 
-      // Build the HNSW graph immediately unless explicitly disabled
-      if (buildGraphNow)
+      // Build the HNSW graph immediately unless explicitly disabled - and only for an index this statement actually
+      // created. When create() answered a guarded request with the index already on those properties (issue #5781),
+      // rebuilding its graph is work nobody asked for on an index the statement was told to leave alone.
+      if (buildGraphNow && isNewlyCreated(typeIndex, name.getValue()))
         for (final Index idx : typeIndex.getIndexesOnBuckets())
           if (idx instanceof LSMVectorIndex)
             ((LSMVectorIndex) idx).buildVectorGraphNow();
@@ -345,7 +353,7 @@ public class CreateIndexStatement extends DDLStatement {
         // statement, so an unknown key or an out-of-range BM25 parameter is a client mistake and must answer 400.
         throw new CommandSQLParsingException("Invalid METADATA for FULL_TEXT index: " + e.getMessage(), e);
       }
-      ftBuilder.create();
+      resultingIndex = ftBuilder.create();
 
     } else if (indexType == Schema.INDEX_TYPE.LSM_SPARSE_VECTOR) {
       final TypeLSMSparseVectorIndexBuilder sparseBuilder = builder.withType(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR)
@@ -360,7 +368,7 @@ public class CreateIndexStatement extends DDLStatement {
           throw new CommandSQLParsingException("Invalid METADATA for LSM_SPARSE_VECTOR index: " + e.getMessage(), e);
         }
       }
-      sparseBuilder.create();
+      resultingIndex = sparseBuilder.create();
 
     } else if (indexType == Schema.INDEX_TYPE.GEOSPATIAL) {
       // Builder is already a TypeGeoIndexBuilder after withType(GEOSPATIAL)
@@ -379,7 +387,7 @@ public class CreateIndexStatement extends DDLStatement {
           throw new CommandSQLParsingException(e.getMessage(), e);
         }
       }
-      geoBuilder.create();
+      resultingIndex = geoBuilder.create();
 
     } else {
       // Every index type whose settings live in METADATA is handled above. Reaching here with a METADATA clause means
@@ -387,20 +395,40 @@ public class CreateIndexStatement extends DDLStatement {
       if (metadata != null && !metadata.toMap((Result) null, context).isEmpty())
         throw new CommandSQLParsingException(
             "METADATA is not supported by index type '" + typeAsString + "'");
-      builder.create();
+      resultingIndex = builder.create();
     }
     typeName = prevName;
+
+    // A guarded statement that named an index NOT yet in the schema gets past the existsIndex shortcut above and
+    // reaches the builder, which answers it with the index already on those properties whenever that one provides
+    // what was asked for (issue #5781). Nothing was created under the requested name, so reporting created=true
+    // under that name told the caller its name is now on an index - leaving a later DROP INDEX <name> to fail on a
+    // name that never existed. Report the index that actually satisfied the request, under its own name.
+    final boolean created = isNewlyCreated(resultingIndex, name.getValue());
 
     final InternalResultSet rs = new InternalResultSet();
     final ResultInternal result = new ResultInternal(context.getDatabase());
     result.setProperty("operation", "create index");
-    result.setProperty("name", name.getValue());
+    result.setProperty("name", created ? name.getValue() : resultingIndex.getName());
     result.setProperty("type", indexType);
-    result.setProperty("created", true);
+    result.setProperty("created", created);
     result.setProperty("totalIndexed", total.get());
 
     rs.add(result);
     return rs;
+  }
+
+  /**
+   * Whether {@code create()} built a new index, as opposed to answering a guarded request with the index already on
+   * those properties. The builder returns that existing index under ITS own name, and an index this statement created
+   * always carries the name the statement asked for - the manual one when written, otherwise the auto-derived
+   * {@code typeName[properties]} form both this method and {@code LocalDocumentType.addIndexInternal} derive.
+   * <p>
+   * A {@code null} answer counts as created: no builder returns one today, and treating an unexpected null as a no-op
+   * would turn a successful statement into a reported one.
+   */
+  private static boolean isNewlyCreated(final TypeIndex index, final String requestedName) {
+    return index == null || index.getName().equals(requestedName);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/Issue5765IndexSettingsIfNotExistsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5765IndexSettingsIfNotExistsTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.index;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.LSMVectorIndexMetadata;
 import com.arcadedb.schema.Schema;
@@ -169,6 +170,85 @@ public class Issue5765IndexSettingsIfNotExistsTest extends TestHelper {
         .hasMessageContaining("LSM_TREE")
         .hasMessageContaining("FULL_TEXT")
         .hasMessageNotContaining("analyzer=");
+  }
+
+  /**
+   * The same comparison asked through the OTHER entry point (issue #5781). Every case above writes the statement in
+   * the auto-derived-name form, so {@code CreateIndexStatement} answers from its {@code existsIndex(name)} shortcut and
+   * never reaches {@link com.arcadedb.schema.TypeIndexBuilder#create()}. Naming the index explicitly is what gets past
+   * that shortcut: {@code myVectorIdx} does not exist, so the statement builds a builder, and the builder is the one
+   * that finds the existing index BY PROPERTIES and compares the settings the clause named.
+   */
+  @Test
+  void namedGuardedVectorDimensionsMismatchIsReportedByTheBuilder() {
+    createVectorIndex(384, "COSINE");
+
+    assertThatThrownBy(() -> database.command("sql",
+        "CREATE INDEX myVectorIdx IF NOT EXISTS ON Doc (embedding) LSM_VECTOR METADATA {\"dimensions\": 768}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("dimensions=384")
+        .hasMessageContaining("768");
+
+    assertThat(dimensionsOf("Doc[embedding]")).isEqualTo(384);
+    assertThat(database.getSchema().existsIndex("myVectorIdx")).isFalse();
+  }
+
+  /**
+   * Not a vector-only rule: the builder half is shared by every index type that keeps settings of its own, so a named
+   * guarded full-text create over an existing auto-named index is compared on its analyzer the same way.
+   */
+  @Test
+  void namedGuardedFullTextAnalyzerMismatchIsReportedByTheBuilder() {
+    database.command("sql", "CREATE INDEX ON Doc (title) FULL_TEXT METADATA "
+        + "{\"analyzer\": \"org.apache.lucene.analysis.core.KeywordAnalyzer\"}");
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE INDEX myTitleIdx IF NOT EXISTS ON Doc (title) FULL_TEXT "
+        + "METADATA {\"analyzer\": \"org.apache.lucene.analysis.standard.StandardAnalyzer\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("analyzer=org.apache.lucene.analysis.core.KeywordAnalyzer");
+
+    assertThat(database.getSchema().existsIndex("Doc[title]")).isTrue();
+    assertThat(database.getSchema().existsIndex("myTitleIdx")).isFalse();
+  }
+
+  /**
+   * The other direction of the builder half: settings that match make the guarded statement the no-op it asks to be.
+   * The answer names the index that actually satisfied the request - not the name the statement asked for, which
+   * nothing was created under - and reports {@code created: false} so a caller cannot read success as "my name is
+   * now on an index".
+   */
+  @Test
+  void namedGuardedMatchingSettingsStayANoOp() {
+    createVectorIndex(384, "COSINE");
+
+    final ResultSet rs = database.command("sql", "CREATE INDEX myVectorIdx IF NOT EXISTS ON Doc (embedding) LSM_VECTOR "
+        + "METADATA {\"dimensions\": 384, \"similarity\": \"COSINE\"}");
+    final Result result = rs.next();
+    assertThat(result.<Boolean>getProperty("created")).isFalse();
+    assertThat(result.<String>getProperty("name")).isEqualTo("Doc[embedding]");
+    assertThat(result.<Long>getProperty("totalIndexed")).isEqualTo(0L);
+
+    assertThat(dimensionsOf("Doc[embedding]")).isEqualTo(384);
+    assertThat(database.getSchema().existsIndex("myVectorIdx")).isFalse();
+  }
+
+  /**
+   * Same no-op, on the non-vector builder: a named guarded full-text create whose analyzer matches leaves the existing
+   * index alone and reports it under its own name.
+   */
+  @Test
+  void namedGuardedMatchingFullTextSettingsStayANoOp() {
+    database.command("sql", "CREATE INDEX ON Doc (title) FULL_TEXT METADATA "
+        + "{\"analyzer\": \"org.apache.lucene.analysis.core.KeywordAnalyzer\"}");
+
+    final ResultSet rs = database.command("sql", "CREATE INDEX myTitleIdx IF NOT EXISTS ON Doc (title) FULL_TEXT "
+        + "METADATA {\"analyzer\": \"org.apache.lucene.analysis.core.KeywordAnalyzer\"}");
+    final Result result = rs.next();
+    assertThat(result.<Boolean>getProperty("created")).isFalse();
+    assertThat(result.<String>getProperty("name")).isEqualTo("Doc[title]");
+
+    assertThat(database.getSchema().existsIndex("Doc[title]")).isTrue();
+    assertThat(database.getSchema().existsIndex("myTitleIdx")).isFalse();
   }
 
   private void createVectorIndex(final int dimensions, final String similarity) {


### PR DESCRIPTION
Closes #5781

## The gap

`CREATE INDEX IF NOT EXISTS ... METADATA {...}` compares the settings the clause *named* against the existing index, and that question is asked from two places, both routed through the shared `IndexBuilder.findUnsatisfiedSettings`:

1. the `existsIndex(name)` shortcut in `CreateIndexStatement.executeDDL`, which answers before any builder exists;
2. `TypeIndexBuilder.create()`, for a request that gets past the shortcut.

Every case in `Issue5765IndexSettingsIfNotExistsTest` was written in the auto-derived-name form (`CREATE INDEX IF NOT EXISTS ON Doc (embedding) ...`), so `name` resolved to `Doc[embedding]`, `existsIndex` was true, and the statement returned from the shortcut. The builder half had no assertion on it.

The way past the shortcut is a **manually named** guarded create over an auto-named existing index: `myVectorIdx` does not exist, so the statement builds a builder, and the builder finds the existing index *by properties* and compares the named settings.

## What this adds

Four cases in `Issue5765IndexSettingsIfNotExistsTest`, all in the named form, asserting both directions on both a vector index (`dimensions`) and a full-text one (`analyzer`), so the coverage is not vector-specific:

- `namedGuardedVectorDimensionsMismatchIsReportedByTheBuilder`
- `namedGuardedFullTextAnalyzerMismatchIsReportedByTheBuilder`
- `namedGuardedMatchingSettingsStayANoOp`
- `namedGuardedMatchingFullTextSettingsStayANoOp`

**Mutation check** (requested in the issue): removing the `findUnsatisfiedSettings` call from `TypeIndexBuilder.create()` fails **exactly** the two new mismatch tests (`namedGuardedVectorDimensionsMismatchIsReportedByTheBuilder`, `namedGuardedFullTextAnalyzerMismatchIsReportedByTheBuilder`) and leaves the original eight passing. The builder path is reachable and that call is not dead code, as the issue predicted.

## The defect the matching direction found

The issue expected "it is the assertion that is missing, not the behaviour". That holds for the *mismatch* direction, which passed unchanged. The *matching* direction did not.

When `TypeIndexBuilder.create()` answers a guarded request with the index already on those properties, it returns that existing index. `CreateIndexStatement` then fell through to its unconditional tail and reported:

```
name: myVectorIdx, created: true, totalIndexed: 0
```

Nothing was created, and nothing named `myVectorIdx` exists. A caller reading `created: true` as "my name is now on an index" gets a later `DROP INDEX myVectorIdx` failing on a name that never existed. Same shape as #5675 one level down: a guarded statement reporting success for something it did not do.

The vector branch additionally ran `buildVectorGraphNow()` over the returned index, rebuilding the HNSW graph of an index the statement was told to leave alone.

Both are now keyed off whether `create()` answered with a new index. `isNewlyCreated` compares the returned index's name against the requested one: an index this statement created always carries the name asked for (the manual one when written, otherwise the auto-derived `typeName[properties]` form that `LocalDocumentType.addIndexInternal` derives), while the existing index the builder hands back carries its own. The no-op now reports `created: false` under the name of the index that actually satisfied the request.

Each branch of the create chain now captures its `create()` return value, which is what makes the single decision at the tail possible; the `else` fallthrough and the sparse/geo/full-text branches previously discarded it.

Note this also corrects the inherited-index case reached through the auto-derived name: `CREATE INDEX IF NOT EXISTS ON Child (embedding)` where only `Parent` carries the index used to report `created: true` under `Child[embedding]`, and now reports `created: false` under `Parent[embedding]`.

## Test plan

- [x] `mvn -pl engine test -Dtest=Issue5765IndexSettingsIfNotExistsTest` - 12 pass (8 pre-existing + 4 new)
- [x] Mutation check: `findUnsatisfiedSettings` removed from `TypeIndexBuilder.create()` fails exactly the 2 new mismatch tests, the original 8 stay green; call restored afterwards
- [x] Targeted regression run, 264 tests, all green: `Issue5675IndexIfNotExistsConflictTest`, `PolymorphicIndexConflictTest`, `IndexSyntaxTest`, `LSMTreeIndexTest` (incl. `Issue4139ManualIndexName`), `MapIndexByKeyValueTest`, `CreateIndexStatementTestParserTest`, `IndexMetadataUserSettingComparisonTest`, `Issue5723CopyTypeIndexConfigurationTest`, `Issue5713HashIndexPageSizeTest`, `Issue5639IndexMetadataKeysTest`, `Issue5607VectorIndexMetadataTest`, `RebuildIndexPreservesNameTest`, `LSMVectorIndexInheritanceTest`, `VectorIndexBuildGraphOnCreateTest`, `OpenCypherIndexTest`, `OpenCypherConstraintTest`, `LSMVectorIndexTest`, `LSMTreeGeoIndexSchemaTest`, `FullTextAnalyzerConfigTest`, `LSMSparseVectorIndexTest`, `SchemaTest`, `DDLTest`
- [x] Server module, the HTTP consumers of the `created` field: `Issue5675CreateIndexIfNotExistsHttpTest`, `ExecutionResponseTest` - 12 pass
