### PR TITLE
chore(ci): split the engine unit-test lane into four parallel lanes

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -146,6 +146,12 @@ jobs:
         # package phase runs surefire (test) and JaCoCo report (prepare-package) without reaching integration-test phase
         # A watchdog dumps every JVM's stacks before the job timeout fires. Without it a deadlocked
         # surefire fork produces no output at all, so there is nothing to diagnose after the fact.
+        #
+        # This lane is the complement of the three engine-only lanes below, and the split is what keeps it
+        # inside its 60-minute budget: `slow` and `benchmark` as before, `vector` for the three vector-index
+        # classes, and `**/*Suite.java` dropped from the includes so the openCypher TCK moves to its own job.
+        # The TCK is excluded by PATTERN and not by a tag on purpose - see the javadoc on OpenCypherTCKSuite
+        # for the measurement that rules a tag out.
         run: |
           (
             sleep 2700
@@ -162,7 +168,7 @@ jobs:
           ) &
           watchdog=$!
           set +e
-          ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e,!load-tests -DexcludedGroups=slow,benchmark -Dsurefire.includes=**/*Test.java,**/*Suite.java
+          ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e,!load-tests -DexcludedGroups=slow,benchmark,vector -Dsurefire.includes=**/*Test.java
           status=$?
           kill "$watchdog" 2>/dev/null || true
           exit $status
@@ -205,6 +211,10 @@ jobs:
   slow-unit-tests:
     runs-on: ubuntu-latest
     needs: build-and-package
+    # This lane is the workflow's critical path at ~44 min, and it had no cap at all, so it inherited
+    # GitHub's 6-hour default: a hung fork would have burned six hours of a runner before anyone saw it.
+    # 60 min matches unit-tests and leaves ~16 min of headroom over the current steady state.
+    timeout-minutes: 60
     permissions:
       contents: read
       checks: write
@@ -229,8 +239,11 @@ jobs:
           mkdir -p ~/.m2/repository
           tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
 
+      # `-DexcludedGroups=vector` keeps the lanes a partition rather than an overlap. Both vector classes
+      # that moved to the vector lane still carry a method-level @Tag("slow") from before the split, and
+      # without this that one method would be selected here as well and run twice per push.
       - name: Run Slow Unit Tests with Coverage
-        run: ./mvnw package -Pcoverage --batch-mode --errors --fail-never --show-version -pl engine  -Dgroups=slow
+        run: ./mvnw package -Pcoverage --batch-mode --errors --fail-never --show-version -pl engine -Dgroups=slow -DexcludedGroups=vector
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -238,12 +251,17 @@ jobs:
         run: ./.github/scripts/check-test-database-paths.sh --runtime
 
       # See the unit-tests job: the reporter is allowed to fail, the check below is the verdict.
-      - name: Unit Tests Reporter
+      #
+      # The published check is named for THIS lane. It used to be "Unit Tests Report", the same name the
+      # unit-tests job publishes, so the two jobs raced to write one check and whichever finished last won:
+      # a failure here could be overwritten by the other lane's green summary, and a reader had no way to
+      # tell which lane a given report described.
+      - name: Slow Unit Tests Reporter
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         continue-on-error: true
         if: success() || failure()
         with:
-          name: Unit Tests Report
+          name: Slow Unit Tests Report
           path: "**/surefire-reports/TEST*.xml"
           list-tests: "failed"
           list-suites: "failed"
@@ -258,6 +276,160 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: slow-unit-coverage-reports
+          path: |
+            **/jacoco*.xml
+          retention-days: 1
+
+  # The three classes tagged `vector`. PQSearchDebugTest is a steady ~410 s on its own (10,000 x 128
+  # PQ-quantized vectors, twice). The other two are the reason this lane exists at all: they are BIMODAL,
+  # measured on the same commit at 19 s / 10 s in a green run and at 626 s / 607 s in a run that then hit
+  # the unit-test job's 60-minute timeout. LSMVectorIndex.REBUILD_SEMAPHORE holds one permit for the whole
+  # JVM, so every vector index in a Surefire fork queues behind every other one - including a rebuild left
+  # over from an already-finished class - and the settle waits have to be sized for that worst case.
+  #
+  # So this split is buying predictability more than raw minutes: it moves ~7 minutes of fixed cost plus a
+  # ~20-minute tail risk off the lane that gates every push. It does not fix the convoy, which is still
+  # there inside this job. Making the permit count configurable, or scoping it per database, would.
+  vector-unit-tests:
+    runs-on: ubuntu-latest
+    needs: build-and-package
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: "temurin"
+          java-version: 21
+          cache: "maven"
+
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: arcadedb-maven-artifacts
+          path: /tmp
+
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
+
+      - name: Run Vector Unit Tests with Coverage
+        run: ./mvnw package -Pcoverage --batch-mode --errors --fail-never --show-version -pl engine -Dgroups=vector
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check no test leaked a databases/ directory
+        run: ./.github/scripts/check-test-database-paths.sh --runtime
+
+      # See the unit-tests job: the reporter is allowed to fail, the check below is the verdict.
+      - name: Vector Unit Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        continue-on-error: true
+        if: success() || failure()
+        with:
+          name: Vector Unit Tests Report
+          path: "**/surefire-reports/TEST*.xml"
+          list-tests: "failed"
+          list-suites: "failed"
+          reporter: java-junit
+
+      - name: Check test results
+        if: success() || failure()
+        run: ./.github/scripts/check-test-results.py surefire-reports
+
+      - name: Upload vector unit test coverage reports
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vector-unit-coverage-reports
+          path: |
+            **/jacoco*.xml
+          retention-days: 1
+
+  # The openCypher TCK: ~3900 conformance scenarios that Surefire reports as a single class, so inside the
+  # unit-test lane they were a single line in a 15,000-test pass count. On their own they give a conformance
+  # figure that can be read and tracked, and TCKReportPlugin's per-feature breakdown lands in this job's log.
+  #
+  # Selected by `-Dsurefire.includes` rather than by a tag, and the unit-test lane drops `**/*Suite.java` for
+  # the same reason: Surefire's groups/excludedGroups become JUnit tag filters that the suite engine pushes
+  # down into Cucumber discovery, where they are matched against feature-file tags instead of against the
+  # suite class. Measured both ways - `-Dgroups=opencypher` discovers nothing and fails the build,
+  # `-DexcludedGroups=opencypher` excludes nothing and runs all 3897. OpenCypherTCKSuite's javadoc has the detail.
+  opencypher-tck-tests:
+    runs-on: ubuntu-latest
+    needs: build-and-package
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: "temurin"
+          java-version: 21
+          cache: "maven"
+
+      - name: Download ArcadeDB Maven artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: arcadedb-maven-artifacts
+          path: /tmp
+
+      - name: Install ArcadeDB Maven artifacts
+        run: |
+          mkdir -p ~/.m2/repository
+          tar -xzf /tmp/arcadedb-m2.tgz -C ~/.m2/repository
+
+      # No groups filter at all: any tag filter here would reach the scenarios, not the suite. `**/*Suite.java`
+      # currently resolves to OpenCypherTCKSuite alone under `engine`; a second engine suite would join this
+      # lane, which is a deliberate default so a new suite runs somewhere rather than nowhere.
+      - name: Run openCypher TCK with Coverage
+        run: ./mvnw package -Pcoverage --batch-mode --errors --fail-never --show-version -pl engine -Dsurefire.includes=**/*Suite.java
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check no test leaked a databases/ directory
+        run: ./.github/scripts/check-test-database-paths.sh --runtime
+
+      # See the unit-tests job: the reporter is allowed to fail, the check below is the verdict.
+      - name: openCypher TCK Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        continue-on-error: true
+        if: success() || failure()
+        with:
+          name: openCypher TCK Report
+          path: "**/surefire-reports/TEST*.xml"
+          list-tests: "failed"
+          list-suites: "failed"
+          reporter: java-junit
+
+      # Also the guard against the suite silently selecting nothing: a discovery that finds no scenario
+      # surfaces as a NoTestsDiscovered error in the report, and this script fails the job on it.
+      - name: Check test results
+        if: success() || failure()
+        run: ./.github/scripts/check-test-results.py surefire-reports
+
+      - name: Upload openCypher TCK HTML report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: opencypher-tck-html-report
+          path: engine/target/tck-report.html
+          retention-days: 7
+
+      - name: Upload openCypher TCK coverage reports
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: opencypher-tck-coverage-reports
           path: |
             **/jacoco*.xml
           retention-days: 1
@@ -790,7 +962,7 @@ jobs:
   # in the setup job now enforces the rule for every workflow.
   coverage-report:
     runs-on: ubuntu-latest
-    needs: [ unit-tests, integration-tests, slow-unit-tests, ha-integration-tests ]
+    needs: [ unit-tests, integration-tests, slow-unit-tests, vector-unit-tests, opencypher-tck-tests, ha-integration-tests ]
     # Coverage is still worth publishing when a suite reported failing tests: the suites run with
     # --fail-never, so JaCoCo writes its report and the job records the failure afterwards.
     #
@@ -799,14 +971,21 @@ jobs:
     # missing artifact would only add a second red check to an already-red build. Skipping keeps
     # the collector's failure meaning what it says: a suite that should have uploaded, and did not.
     #
-    # This reads any one skipped suite as "none of them ran", which holds because all four hang off
+    # This reads any one skipped suite as "none of them ran", which holds because all six hang off
     # build-and-package and so skip together. Give one of them a path filter or a condition of its
-    # own and that stops being true: the other three would still have coverage worth publishing,
+    # own and that stops being true: the other five would still have coverage worth publishing,
     # and this condition would drop it. Revisit here if a suite ever gains its own gate.
+    #
+    # vector-unit-tests and opencypher-tck-tests carry engine coverage that used to arrive inside
+    # unit-tests. They are listed here, in the downloads, and in the collector call for that reason:
+    # a lane that contributes no report makes the merge under-report every class it exercised, and
+    # that becomes the base the next pull request is measured against.
     if: >-
       ${{ !cancelled()
       && needs.unit-tests.result != 'skipped'
       && needs.slow-unit-tests.result != 'skipped'
+      && needs.vector-unit-tests.result != 'skipped'
+      && needs.opencypher-tck-tests.result != 'skipped'
       && needs.integration-tests.result != 'skipped'
       && needs.ha-integration-tests.result != 'skipped' }}
     steps:
@@ -827,6 +1006,20 @@ jobs:
         with:
           name: slow-unit-coverage-reports
           path: slow-unit-coverage
+
+      - name: Download vector unit test coverage reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: vector-unit-coverage-reports
+          path: vector-unit-coverage
+
+      - name: Download openCypher TCK coverage reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: opencypher-tck-coverage-reports
+          path: opencypher-tck-coverage
 
 
       - name: Download integration test coverage reports
@@ -852,6 +1045,8 @@ jobs:
           ./.github/scripts/collect-coverage-reports.sh \
             unit-tests=unit-coverage \
             slow-unit-tests=slow-unit-coverage \
+            vector-unit-tests=vector-unit-coverage \
+            opencypher-tck-tests=opencypher-tck-coverage \
             integration-tests=integration-coverage \
             ha-integration-tests=ha-integration-coverage
 

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -417,8 +417,38 @@ jobs:
         if: success() || failure()
         run: ./.github/scripts/check-test-results.py surefire-reports
 
-      - name: Upload openCypher TCK HTML report
+      # TCKReportPlugin writes both forms of the compliance report on every run. Putting the markdown one
+      # in the step summary is the whole reason this lane is separate: conformance becomes a number on the
+      # job page instead of a line buried in a 15,000-test pass count.
+      - name: Publish openCypher TCK compliance report
         if: success() || failure()
+        run: |
+          if [[ -f engine/target/tck-compliance-report.md ]]; then
+            cat engine/target/tck-compliance-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            # Not cosmetic: no report means the plugin never reached TestRunFinished, so the run died
+            # part-way and any scenario counts reported elsewhere describe a partial run.
+            echo "::error::TCK compliance report missing - the suite did not finish"
+            echo '## openCypher TCK compliance' >> "$GITHUB_STEP_SUMMARY"
+            echo 'Report missing: the suite did not reach the end of the run.' >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Upload openCypher TCK compliance report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: opencypher-tck-compliance-report
+          path: |
+            engine/target/tck-compliance-report.md
+            engine/target/tck-compliance-report.txt
+          retention-days: 30
+
+      # Cucumber's HTML report embeds every scenario and runs to ~28 MB, so it is kept only when something
+      # failed and someone needs the per-scenario detail. On a green run the compliance report above and the
+      # surefire XML already say everything, and 28 MB per push is not worth retaining to say it again.
+      - name: Upload openCypher TCK HTML report
+        if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: opencypher-tck-html-report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,11 @@ General design principles:
 - Annotate performance/benchmark tests so they're skipped from regular CI builds:
   - Use `@Tag("benchmark")` for pure microbenchmarks (e.g., JMH-style or comparison runs)
   - Use `@Tag("slow")` for functional regression tests that take noticeably long (large batches, multi-second elapsed time, big payloads)
+  - Use `@Tag("vector")` for an LSM vector-index test that spends most of its time waiting on a background rebuild. `LSMVectorIndex.REBUILD_SEMAPHORE` holds one permit for the whole JVM, so these tests convoy against each other and the waits have to be sized for the worst case; the tag routes the class to the `vector-unit-tests` lane where the convoy costs nobody else anything
   - Apply at the class level when every method in the class is slow; at the method level when only some methods are slow
+  - The tags are a partition, not a set of overlapping labels: CI selects each lane with `-Dgroups`/`-DexcludedGroups` such that every test runs in exactly one lane. Tagging a class `vector` and one of its methods `slow` is fine, but do not expect that method in the slow lane
   - Required imports: `import org.junit.jupiter.api.Tag;`
+  - A JUnit tag on a Cucumber `@Suite` does not work: Surefire's `groups`/`excludedGroups` reach the scenarios inside the suite rather than the suite class. Route a suite to a lane with `-Dsurefire.includes` instead, as `.github/workflows/mvn-test.yml` does for the openCypher TCK
 - don't add Claude as author of any source code
 
 ## Build and Development Commands

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -43,7 +43,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * LSM vector index rebuild semantics: threshold-triggered, inactivity-triggered, async retrigger, metadata preservation, and concurrent rebuild serialization.
+ * <p>
+ * Tagged {@code vector} so the whole class runs in the {@code vector-unit-tests} CI lane. What earns the tag is not the average cost but the spread:
+ * measured on one commit, this class took 19 s in a green unit-test run and 626 s in a run that then hit the job's 60-minute timeout. Almost none of
+ * either figure is compute. {@link com.arcadedb.index.vector.LSMVectorIndex}'s {@code REBUILD_SEMAPHORE} has one permit for the entire JVM, so every
+ * vector class sharing a Surefire fork queues behind every other one - including a rebuild left over from an already-finished class - and the waits
+ * below then have to be sized for that worst case. A lane of its own keeps the convoy off the other ~1300 engine test classes. It does not fix the
+ * convoy, which is still here; making the permit count configurable, or scoping it per database, would.
  */
+@Tag("vector")
 class LSMVectorIndexRebuildTest extends TestHelper {
 
   private static final int EMBEDDING_DIM = 32;

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
@@ -56,7 +56,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * LSM vector index recovery, reopen, restore, and tombstone parsing regression tests.
+ * <p>
+ * Tagged {@code vector} so the whole class runs in the {@code vector-unit-tests} CI lane. Same spread as its sibling: 10 s in a green unit-test run and
+ * 607 s in the run that timed out, on the same commit. See {@link LSMVectorIndexRebuildTest} for why the vector classes are slow as a group rather than
+ * individually, and why the tag treats that as a property of the group.
  */
+@Tag("vector")
 class LSMVectorIndexRecoveryTest extends TestHelper {
 
   private static final int EMBEDDING_DIM = 32;

--- a/engine/src/test/java/com/arcadedb/index/vector/PQSearchDebugTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/PQSearchDebugTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.Pair;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -38,9 +39,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The root cause was FusedPQ approximate scoring producing incorrect results when PQ codes
  * were persisted through ArcadeDB's page-based storage, causing beam search to not expand
  * beyond the entry node.
+ * <p>
+ * Tagged {@code vector} so it runs in the {@code vector-unit-tests} CI lane. Unlike its siblings in that lane this one is steady rather than bimodal,
+ * at 408-431 s across runs, because each of the two tests genuinely builds a 10,000 x 128 PQ-quantized index. The dataset is far larger than the defect
+ * needs - the bug is about PQ codes surviving a reopen, not about scale - so shrinking {@link #NUM_VECTORS} is the obvious follow-up, and is
+ * deliberately not bundled with this lane split.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
+@Tag("vector")
 class PQSearchDebugTest {
   private static final String DB_PATH = "target/test-databases/PQSearchDebugTest";
   private static final int NUM_VECTORS = 10_000;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/tck/OpenCypherTCKSuite.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/tck/OpenCypherTCKSuite.java
@@ -26,6 +26,26 @@ import org.junit.platform.suite.api.Suite;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 
+/**
+ * Runs the openCypher TCK feature files against the engine's Cypher implementation.
+ * <p>
+ * This suite runs in a CI lane of its own (the {@code opencypher-tck-tests} job in {@code .github/workflows/mvn-test.yml}), not in the general
+ * unit-test lane. It is one Surefire "class" holding ~3900 scenarios, and conformance is a number worth reading on its own rather than averaged into a
+ * 15,000-test pass count.
+ * <p>
+ * <b>The lane is selected by file pattern, not by a JUnit tag, and that is not a style preference.</b> Surefire's {@code groups} /
+ * {@code excludedGroups} become JUnit tag filters that the suite engine propagates <i>into</i> the nested Cucumber discovery, where they are matched
+ * against the scenarios' own feature-file tags rather than against this class. Measured against the real suite:
+ * <ul>
+ *   <li>with {@code @Tag("opencypher")} here and {@code -Dgroups=opencypher}, no scenario carries that tag, so discovery yields
+ *       {@code NoTestsDiscovered} and the build fails;</li>
+ *   <li>with the same tag and {@code -DexcludedGroups=opencypher}, the filter again matches no scenario, so all 3897 run anyway.</li>
+ * </ul>
+ * A tag on a Cucumber {@code @Suite} is therefore inert in one direction and actively fatal in the other. The jobs select by
+ * {@code -Dsurefire.includes}: the TCK lane asks for {@code **}{@code /*Suite.java}, and the unit-test lane asks only for {@code **}{@code /*Test.java},
+ * which no longer matches this file. Adding a second {@code *Suite.java} under {@code engine} puts it in the TCK lane too - move it, or narrow that
+ * job's include, rather than reaching for a tag.
+ */
 @Suite
 @IncludeEngines("cucumber")
 @SelectClasspathResource("opencypher/tck/features")

--- a/engine/src/test/java/com/arcadedb/query/opencypher/tck/TCKReportPlugin.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/tck/TCKReportPlugin.java
@@ -28,12 +28,28 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Cucumber plugin that generates a summary compliance report for the OpenCypher TCK.
+ * <p>
+ * Writes two files next to each other under {@code target/}, both consumed by the {@code opencypher-tck-tests} CI job:
+ * <ul>
+ *   <li>{@code tck-compliance-report.txt} - the fixed-width form, also echoed to stdout so it is readable in a raw build log;</li>
+ *   <li>{@code tck-compliance-report.md} - the same numbers as markdown, appended to {@code $GITHUB_STEP_SUMMARY} so conformance renders on the job
+ *       page without anyone downloading an artifact.</li>
+ * </ul>
+ * The markdown form leads with the categories that are not at 100%, because that is the question a compliance report exists to answer, and keeps the
+ * full list behind a {@code <details>} block so the summary stays short. Category order inside each table is stable (worst rate first for the gaps,
+ * alphabetical for the full list) so two runs can be diffed against each other.
+ * <p>
+ * Percentages are reported to one decimal here and as integers in the text form. Integer truncation is misleading at this scale: 3812 of 3897 is 97.8%,
+ * which the text form has always rendered as "97%".
  */
 public class TCKReportPlugin implements ConcurrentEventListener {
 
@@ -108,11 +124,57 @@ public class TCKReportPlugin implements ConcurrentEventListener {
 
     System.out.println(sb);
 
-    // Write report to file
-    try (final PrintWriter writer = new PrintWriter(new FileWriter("target/tck-compliance-report.txt"))) {
-      writer.print(sb);
+    write("target/tck-compliance-report.txt", sb.toString());
+    write("target/tck-compliance-report.md", buildMarkdownReport(total, pass, fail, skip));
+  }
+
+  private String buildMarkdownReport(final int total, final int pass, final int fail, final int skip) {
+    final StringBuilder md = new StringBuilder();
+
+    md.append("## openCypher TCK compliance\n\n");
+    md.append(String.format(Locale.ROOT, "**%,d of %,d scenarios passed (%s)** - %,d failed, %,d skipped%n%n", pass, total, percentage(pass, total),
+        fail, skip));
+
+    final List<Map.Entry<String, int[]>> gaps = categoryStats.entrySet().stream().filter(e -> e.getValue()[1] < e.getValue()[0])
+        .sorted(Comparator.<Map.Entry<String, int[]>>comparingDouble(e -> ratio(e.getValue()[1], e.getValue()[0]))
+            .thenComparing(Map.Entry::getKey)).toList();
+
+    if (gaps.isEmpty())
+      md.append("Every category is at 100%.\n\n");
+    else {
+      md.append(String.format(Locale.ROOT, "### Not yet at 100%% (%d of %d categories)%n%n", gaps.size(), categoryStats.size()));
+      appendTable(md, gaps);
+      md.append("\n");
+    }
+
+    md.append("<details>\n<summary>All ").append(categoryStats.size()).append(" categories</summary>\n\n");
+    appendTable(md, categoryStats.entrySet().stream().sorted(Map.Entry.comparingByKey()).toList());
+    md.append("\n</details>\n");
+
+    return md.toString();
+  }
+
+  private void appendTable(final StringBuilder md, final List<Map.Entry<String, int[]>> rows) {
+    md.append("| Category | Passed | Total | Rate |\n|---|---:|---:|---:|\n");
+    for (final Map.Entry<String, int[]> entry : rows) {
+      final int[] s = entry.getValue();
+      md.append(String.format(Locale.ROOT, "| `%s` | %,d | %,d | %s |%n", entry.getKey(), s[1], s[0], percentage(s[1], s[0])));
+    }
+  }
+
+  private static String percentage(final int part, final int whole) {
+    return String.format(Locale.ROOT, "%.1f%%", ratio(part, whole) * 100.0);
+  }
+
+  private static double ratio(final int part, final int whole) {
+    return whole > 0 ? (double) part / whole : 0.0;
+  }
+
+  private static void write(final String path, final String content) {
+    try (final PrintWriter writer = new PrintWriter(new FileWriter(path))) {
+      writer.print(content);
     } catch (final IOException e) {
-      System.err.println("Failed to write TCK report: " + e.getMessage());
+      System.err.println("Failed to write TCK report '" + path + "': " + e.getMessage());
     }
   }
 


### PR DESCRIPTION
## Problem

`unit-tests` hit its 60-minute timeout on **5 of the last 8 `main` runs**. A cancelled job never reaches `check-test-results.py`, so the gate produced **no verdict at all**, and the run died around module 8 of 25 with 17 modules' unit tests never executed.

The engine module is effectively the whole job: **1844 s of the job's 2697 s** of surefire time in the last green run (1353 of 1736 classes, 15284 of 19023 tests). Everything else together is about 4 minutes.

## What actually costs the time

Profiling one run gives a confident and wrong answer. The same commit, two runs:

| class | green run `31294419795` | run `31296074260`, timed out |
|---|---:|---:|
| `LSMVectorIndexRebuildTest` | 19.4 s | 626.0 s |
| `LSMVectorIndexRecoveryTest` | 10.4 s | 606.7 s |
| `PQSearchDebugTest` | 408.6 s | 431.3 s |
| `OpenCypherTCKSuite` | 144.2 s | 205.2 s |

Only `PQSearchDebugTest` is an unconditional hog, and it is honest work: 10,000 x 128 PQ-quantized vectors, twice.

The other two are the lane's **variance**, not its volume. `LSMVectorIndex.REBUILD_SEMAPHORE` holds **one permit for the whole JVM**, so every vector index in a Surefire fork queues behind every other one, including a rebuild left over from an already-finished class, and the settle waits have to be sized for that worst case (`REBUILD_SETTLE_TIMEOUT` was raised 120 s to 300 s in #5960 for exactly this). That variance is what converts a 46-minute job into a 60-minute timeout.

So this PR buys **predictability more than raw minutes**. It moves ~570 s of fixed cost plus a ~20-minute tail risk off the lane that gates every push. It does not fix the convoy, which is still there inside the new lane.

## Changes

- `@Tag("vector")` on the three classes, each with a javadoc note carrying the measurement
- **`unit-tests`**: `-DexcludedGroups=slow,benchmark,vector`, and `**/*Suite.java` dropped from `-Dsurefire.includes`
- **New `vector-unit-tests`** (`-Dgroups=vector`, 45 min cap)
- **New `opencypher-tck-tests`** (`-Dsurefire.includes=**/*Suite.java`, 30 min cap), which also uploads `tck-report.html` so conformance is readable on its own instead of being averaged into a 15,000-test pass count
- **`slow-unit-tests`**: `-DexcludedGroups=vector` so the lanes stay a partition, plus two pre-existing fixes below
- `CLAUDE.md` documents the `vector` tag, the one-test-one-lane rule, and the suite caveat

### Why the TCK is routed by pattern and not by a tag

A JUnit tag on a Cucumber `@Suite` does not work. Surefire's `groups`/`excludedGroups` become tag filters that the suite engine propagates **into** the nested Cucumber discovery, where they are matched against feature-file tags rather than the suite class. Measured both ways against the real suite:

- `-Dgroups=opencypher` -> `NoTestsDiscovered ... did not discover any tests`, **BUILD FAILURE**
- `-DexcludedGroups=opencypher` -> `Tests run: 3897`, ran in full as if the tag were absent

So the tag was removed and the lane is selected by `-Dsurefire.includes` instead. `OpenCypherTCKSuite` is the only `*Suite.java` that lane has ever run (gremlin's two `*Suite.java` files never execute, since `gremlin/pom.xml` skips both surefire and failsafe), confirmed by grepping a green CI log, so dropping `**/*Suite.java` from `unit-tests` orphans nothing.

### Two pre-existing problems in `slow-unit-tests`

- **No `timeout-minutes`**, so it inherited GitHub's 6-hour default. A hung fork would have burned six hours of a runner. Now 60, matching `unit-tests`, with ~16 min of headroom over its ~44 min steady state
- It published its reporter check as **`Unit Tests Report`, the same name `unit-tests` uses**, so the two jobs raced to write one check: a failure here could be overwritten by the other lane's green summary. Renamed to `Slow Unit Tests Report`. All reporter check names in the workflow are now unique

## Coverage is preserved

Both new lanes run with `-Pcoverage` and upload JaCoCo XML, and are wired into `coverage-report`'s `needs`, its not-skipped guard, its downloads and the `collect-coverage-reports.sh` call. Smoke-tested with all six lanes: 6 reports collected; with the TCK lane contributing nothing it exits 1 and refuses the partial merge, rather than silently under-reporting every class that lane covers.

## Verification

Against a **same-machine pre-split control** in the same worktree:

| lane | tests | skipped |
|---|---:|---:|
| control (pre-split selection) | **15288** | **108** |
| `unit-tests` | 11355 | 23 |
| `vector-unit-tests` | 38 | 0 |
| `opencypher-tck-tests` | 3897 | 85 |
| **total after split** | **15290** | **108** |

Skips reconcile exactly. The +2 is the two method-level `@Tag("slow")` methods inside the vector classes: the old unit lane excluded them and the vector lane now runs them, so two tests that previously ran in neither engine lane now do.

Also verified:

- partition guard: `-Dtest=LSMVectorIndexRebuildTest -Dgroups=slow` selects 1 test; adding `-DexcludedGroups=vector` selects 0. Without it that method would run in two lanes
- the post-split unit lane reached `com.arcadedb.index.vector` and produced reports for 94 other vector classes while containing none of the 4 moved ones
- each new lane writes `jacoco.xml`, and the TCK lane also writes `tck-report.html`

## Follow-ups, deliberately not in this PR

- `PQSearchDebugTest.NUM_VECTORS` is 10,000 for a defect about PQ codes surviving a reopen, which has nothing to do with scale. Shrinking it is a straightforward further ~7 minutes
- The single-permit `REBUILD_SEMAPHORE` is the actual root cause of the variance. Making the permit count configurable, or scoping it per database, would fix it rather than contain it
- `forkCount` is still 1, so all four lanes run single-threaded on a 4-vCPU runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
