### PR TITLE
fix(#5780): a manual index must report isAutomatic() = false

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -232,6 +232,20 @@ public class DatabaseChecker {
     // no record corruption pointed at their bucket.
     affectedIndexes.addAll(corruptMetadataIndexes);
 
+    // A MANUAL index is reported but never rebuilt. It is bound to no type and no bucket, so there is no record to
+    // regenerate its entries from - they are the only copy - and the drop-and-recreate below would destroy them. It
+    // cannot even be attempted: with no associated bucket the very first line of the loop resolved bucket id -1 and
+    // raised "Bucket with id '-1' was not found", aborting the whole FIX before ANY index was repaired (issue #5780).
+    // The finding still reaches the operator through corruptedIndexes/warnings, which is all this pass can honestly
+    // do about it.
+    affectedIndexes.removeIf(index -> {
+      if (index.isAutomatic())
+        return false;
+      addWarning("index '" + index.getName() + "': it is a manual index, so it is not rebuilt automatically - its "
+          + "entries are not derived from any record. Drop it and repopulate it");
+      return true;
+    });
+
     final Set<String> rebuildIndexes = affectedIndexes.stream().map(x -> x.getName()).collect(Collectors.toSet());
     result.put("rebuiltIndexes", rebuildIndexes);
 

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -238,11 +238,15 @@ public class DatabaseChecker {
     // raised "Bucket with id '-1' was not found", aborting the whole FIX before ANY index was repaired (issue #5780).
     // The finding still reaches the operator through corruptedIndexes/warnings, which is all this pass can honestly
     // do about it.
+    //
+    // Filtered here rather than inside the `if (fix)` loop below so that rebuiltIndexes, which is reported in BOTH
+    // modes, does not name an index no run would ever rebuild. The message is therefore phrased for both: it states
+    // what this check does not cover, not what a repair attempt failed to do.
     affectedIndexes.removeIf(index -> {
       if (index.isAutomatic())
         return false;
-      addWarning("index '" + index.getName() + "': it is a manual index, so it is not rebuilt automatically - its "
-          + "entries are not derived from any record. Drop it and repopulate it");
+      addWarning("index '" + index.getName() + "': it is a manual index, so it is outside the automatic rebuild - its "
+          + "entries are not derived from any record. Drop it and repopulate it to clear this finding");
       return true;
     });
 

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -245,8 +245,8 @@ public class DatabaseChecker {
     affectedIndexes.removeIf(index -> {
       if (index.isAutomatic())
         return false;
-      addWarning("index '" + index.getName() + "': it is a manual index, so it is outside the automatic rebuild - its "
-          + "entries are not derived from any record. Drop it and repopulate it to clear this finding");
+      addWarning("index '" + index.getName() + "': it is a manual index. Its entries are not derived from any record, "
+          + "so this check does not rebuild it - drop it and repopulate it to clear this finding");
       return true;
     });
 

--- a/engine/src/main/java/com/arcadedb/index/Index.java
+++ b/engine/src/main/java/com/arcadedb/index/Index.java
@@ -96,5 +96,13 @@ public interface Index {
 
   boolean supportsOrderedIterations();
 
+  /**
+   * Whether something populates this index: it is bound to a type and to the properties of it whose values become its
+   * keys, so the engine maintains it on every write and a rebuild can regenerate it from the records.
+   * <p>
+   * False only for a MANUAL index, which is bound to nothing: its entries are whatever the caller put in it and there
+   * is no record to derive them from, which is why {@code REBUILD INDEX} and {@code COMPACT INDEX} refuse a named one
+   * and skip it in their {@code *} sweep (issue #5780).
+   */
   boolean isAutomatic();
 }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -1236,7 +1236,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
   @Override
   public boolean isAutomatic() {
-    return underlyingIndex.getPropertyNames() != null;
+    // Delegated rather than re-derived from getPropertyNames(): the list is never null (IndexMetadata coerces a
+    // missing one to empty), so the local test was the same always-true answer issue #5780 removed.
+    return underlyingIndex.isAutomatic();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -467,7 +467,9 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
 
   @Override
   public boolean isAutomatic() {
-    return underlyingIndex.getPropertyNames() != null;
+    // Delegated rather than re-derived from getPropertyNames(): the list is never null (IndexMetadata coerces a
+    // missing one to empty), so the local test was the same always-true answer issue #5780 removed.
+    return underlyingIndex.isAutomatic();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -363,7 +363,7 @@ public class HashIndex implements IndexInternal {
 
   @Override
   public boolean isAutomatic() {
-    return metadata.propertyNames != null;
+    return metadata.hasIndexedProperties();
   }
 
   // ─── INDEX INTERNAL ──────────────────────────────────────

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -534,7 +534,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
 
   @Override
   public boolean isAutomatic() {
-    return metadata.propertyNames != null;
+    return metadata.hasIndexedProperties();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -722,7 +722,9 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
 
   @Override
   public boolean isAutomatic() {
-    return underlyingIndex.getPropertyNames() != null;
+    // Delegated rather than re-derived from getPropertyNames(): the list is never null (IndexMetadata coerces a
+    // missing one to empty), so the local test was the same always-true answer issue #5780 removed.
+    return underlyingIndex.isAutomatic();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/schema/IndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexMetadata.java
@@ -294,6 +294,22 @@ public class IndexMetadata {
   }
 
   /**
+   * Whether this definition carries the indications of WHAT to index - a type and the properties of it whose values
+   * populate the index - which is what {@link com.arcadedb.index.Index#isAutomatic()} answers.
+   * <p>
+   * The empty check is the whole point and cannot be dropped for a plain null check: the constructor above coerces a
+   * null property list to {@link List#of()}, so {@code propertyNames} is never null and a manual index - the one kind
+   * built with {@code new IndexMetadata(null, null, -1)} and never bound to a type - used to report itself as
+   * automatic. {@code REBUILD INDEX *} and {@code COMPACT INDEX *} both select their targets on that answer, so every
+   * manual index entered a sweep that could only fail on it (issue #5780).
+   *
+   * @return true when the index is derived from records, false when its entries are whatever the caller put in it
+   */
+  public boolean hasIndexedProperties() {
+    return propertyNames != null && !propertyNames.isEmpty();
+  }
+
+  /**
    * Returns true if the property at the given index has case-insensitive collation.
    */
   public boolean isCaseInsensitive(final int propertyIndex) {

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1958,12 +1958,29 @@ public class LocalSchema implements Schema {
           if (index.getTypeName() == null) {
             final String indexName = index.getName();
 
+            // A type-less index is USUALLY a bucket sub-index whose schema entry could not be matched by name, and
+            // those are always named "<bucketName>_<timestamp>". A MANUAL index is type-less too and is named by the
+            // caller, so it can carry no underscore at all - and lastIndexOf then returned -1, making this substring
+            // raise StringIndexOutOfBoundsException. That exception escaped into this method's own catch, reported as
+            // "Error on loading schema. The schema will be reset". The types are already parsed by this point and
+            // survive, which is what hid it: what a database merely CONTAINING such an index silently lost on every
+            // open was everything the loader had not reached yet - the bucket selection strategies, the triggers, the
+            // materialized views and continuous aggregates, the function libraries, the extensions, and the
+            // compaction file-migration map WAL recovery redirects through (issue #5780). Nothing to relink here.
             final int pos = indexName.lastIndexOf("_");
+            if (pos < 1)
+              continue;
+
             final String bucketName = indexName.substring(0, pos);
             final Bucket bucket = bucketMap.get(bucketName);
             if (bucket != null) {
               for (final Map.Entry<String, JSONObject> entry : orphanIndexes.entrySet()) {
+                // Same guard as above, for the same reason: these keys are persisted schema entries, so a hand-edited
+                // or restored schema.json is enough to put a name with no underscore here.
                 final int pos2 = entry.getKey().lastIndexOf("_");
+                if (pos2 < 1)
+                  continue;
+
                 final String bucketNameIndex = entry.getKey().substring(0, pos2);
 
                 if (bucketName.equals(bucketNameIndex)) {

--- a/engine/src/test/java/com/arcadedb/index/Issue5780ManualIndexIsAutomaticTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5780ManualIndexIsAutomaticTest.java
@@ -174,6 +174,32 @@ public class Issue5780ManualIndexIsAutomaticTest extends TestHelper {
   }
 
   /**
+   * The other side of the predicate flip: a NAMED rebuild and a NAMED compaction of an automatic index still run.
+   * <p>
+   * The sweep test above already pins that the {@code *} form keeps rebuilding the bucket sub-indexes, but both
+   * statements guard their single-index path on the same predicate, and that path takes an index the sweep never
+   * hands it - the {@code TypeIndex} wrapper, which {@code *} deliberately excludes.
+   */
+  @Test
+  void namedRebuildAndCompactStillRunOnAnAutomaticIndex() {
+    // Present in the same database, so the flip is exercised with both kinds side by side.
+    createManualIndex(MANUAL_LSM, Schema.INDEX_TYPE.LSM_TREE, false);
+
+    final Result rebuilt = database.command("sql", "rebuild index `" + typeIndexName + "`").next();
+    assertThat((List<String>) rebuilt.getProperty("indexes")).contains(typeIndexName);
+    assertThat((Object) rebuilt.getProperty("failedIndexes")).isNull();
+
+    final String bucketIndexName = ((TypeIndex) database.getSchema().getIndexByName(typeIndexName))
+        .getIndexesOnBuckets()[0].getName();
+    final Result compacted = database.command("sql", "compact index `" + bucketIndexName + "`").next();
+    assertThat((List<String>) compacted.getProperty("indexes")).contains(bucketIndexName);
+
+    // The index still resolves its records after both operations.
+    database.transaction(() -> assertThat(database.getSchema().getIndexByName(typeIndexName)
+        .get(new Object[] { "one" }).next()).isEqualTo(RID_1));
+  }
+
+  /**
    * The predicate is public API and is reported verbatim by the schema views, so an operator listing the indexes now
    * reads the truth about which ones something populates.
    */

--- a/engine/src/test/java/com/arcadedb/index/Issue5780ManualIndexIsAutomaticTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5780ManualIndexIsAutomaticTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5780: {@code isAutomatic()} answered the opposite of the truth on a manual index.
+ * <p>
+ * {@code LSMTreeIndex} and {@code HashIndex} both answered {@code metadata.propertyNames != null}, and
+ * {@code IndexMetadata} coerces a null property list to an EMPTY one - so the field is never null and the predicate
+ * was unconditionally true, including for the one index kind for which it must be false. "Automatic" here means
+ * "there are indications of what to index", which is exactly what a manual index does not have.
+ * <p>
+ * Two consequences, both asserted below. {@code REBUILD INDEX *} and {@code COMPACT INDEX *} select their targets on
+ * that predicate, so every manual index entered the sweep and failed inside the build with the vague "metadata
+ * information are missing" - a database that merely CONTAINS a manual index made the bulk repair tool report a
+ * failure for something that was never rebuildable by definition. And the accurate message both statements already
+ * carry ("it's manual and there aren't indications of what to index") sat behind {@code if (!idx.isAutomatic())},
+ * which could never be entered.
+ */
+public class Issue5780ManualIndexIsAutomaticTest extends TestHelper {
+  private static final String TYPE_NAME   = "Doc";
+  private static final String MANUAL_LSM  = "manualLsmIdx";
+  private static final String MANUAL_HASH = "manualHashIdx";
+
+  /**
+   * Offset of the first key-type byte on a hash index metadata page, mirroring the package-private
+   * {@code HashIndexBucket.META_KEY_TYPES_START} this package cannot see.
+   */
+  private static final int HASH_INDEX_META_KEY_TYPES_START = 9;
+
+  private RID    RID_1;
+  private RID    RID_2;
+  private String typeIndexName;
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE_NAME).createProperty("name", Type.STRING);
+      typeIndexName = database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "name" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create().getName();
+
+      RID_1 = database.newDocument(TYPE_NAME).set("name", "one").save().getIdentity();
+      RID_2 = database.newDocument(TYPE_NAME).set("name", "two").save().getIdentity();
+    });
+  }
+
+  /**
+   * The predicate itself. A manual index of either kind that can be built without a type answers false, and a type
+   * index - the wrapper and its bucket sub-index alike - keeps answering true.
+   */
+  @Test
+  void aManualIndexIsNotAutomaticAndATypeIndexStillIs() {
+    final Index manualLsm = createManualIndex(MANUAL_LSM, Schema.INDEX_TYPE.LSM_TREE, false);
+    final Index manualHash = createManualIndex(MANUAL_HASH, Schema.INDEX_TYPE.HASH, true);
+
+    assertThat(manualLsm.isAutomatic())
+        .as("an LSM_TREE manual index has no indications of what to index")
+        .isFalse();
+    assertThat(manualHash.isAutomatic())
+        .as("a HASH manual index has no indications of what to index")
+        .isFalse();
+
+    final Index typeIndex = database.getSchema().getIndexByName(typeIndexName);
+    assertThat(typeIndex.isAutomatic()).isTrue();
+    for (final Index bucketIndex : ((TypeIndex) typeIndex).getIndexesOnBuckets())
+      assertThat(bucketIndex.isAutomatic())
+          .as("bucket sub-index '%s' is derived from the type's records", bucketIndex.getName())
+          .isTrue();
+  }
+
+  /**
+   * {@code REBUILD INDEX *} no longer targets what it cannot rebuild: the manual indexes are absent from the rebuilt
+   * list AND - the assertion that discriminates the fix from the bug - absent from {@code failedIndexes}, which is
+   * where they used to land. The automatic index is still rebuilt, so the sweep did not simply stop doing its job.
+   */
+  @Test
+  void rebuildIndexAllSkipsManualIndexesInsteadOfFailingOnThem() {
+    final Index manualLsm = createManualIndex(MANUAL_LSM, Schema.INDEX_TYPE.LSM_TREE, false);
+    final Index manualHash = createManualIndex(MANUAL_HASH, Schema.INDEX_TYPE.HASH, true);
+
+    database.transaction(() -> {
+      manualLsm.put(new Object[] { "a" }, new RID[] { RID_1 });
+      manualHash.put(new Object[] { "b" }, new RID[] { RID_2 });
+    });
+
+    final Result row = database.command("sql", "rebuild index *").next();
+
+    final List<String> rebuilt = row.getProperty("indexes");
+    assertThat(rebuilt).doesNotContain(MANUAL_LSM, MANUAL_HASH);
+    assertThat(rebuilt)
+        .as("the sweep must still rebuild the automatic bucket sub-indexes")
+        .isNotEmpty();
+
+    assertThat((Object) row.getProperty("failedIndexes"))
+        .as("a manual index is not a broken index: it must not be reported as a rebuild failure")
+        .isNull();
+
+    // The entries are still there. build() raised before emptying the index even before the fix, so this pins that
+    // the fix did not introduce a destructive path of its own.
+    database.transaction(() -> {
+      assertThat(manualLsm.get(new Object[] { "a" }).next()).isEqualTo(RID_1);
+      assertThat(manualHash.get(new Object[] { "b" }).next()).isEqualTo(RID_2);
+    });
+  }
+
+  /**
+   * A named rebuild of a manual index reports what is actually wrong with the request, from the guard written for
+   * exactly this case, instead of the "metadata information are missing" raised two layers down inside the build.
+   */
+  @Test
+  void rebuildIndexNamedOnAManualIndexReportsThatItIsManual() {
+    createManualIndex(MANUAL_LSM, Schema.INDEX_TYPE.LSM_TREE, false);
+
+    assertThatThrownBy(() -> database.command("sql", "rebuild index `" + MANUAL_LSM + "`"))
+        .isInstanceOf(IndexException.class)
+        .hasMessageContaining(MANUAL_LSM)
+        .hasMessageContaining("it's manual and there aren't indications of what to index");
+  }
+
+  /**
+   * {@code COMPACT INDEX} selects its targets on the same predicate and carries the same guard, so the fix reaches
+   * it too: the sweep skips a manual index and a named request is refused by the message that explains why.
+   */
+  @Test
+  void compactIndexFollowsTheSamePredicate() {
+    final Index manualLsm = createManualIndex(MANUAL_LSM, Schema.INDEX_TYPE.LSM_TREE, false);
+
+    database.transaction(() -> manualLsm.put(new Object[] { "a" }, new RID[] { RID_1 }));
+
+    final Result row = database.command("sql", "compact index *").next();
+    assertThat((List<String>) row.getProperty("indexes")).doesNotContain(MANUAL_LSM);
+
+    assertThatThrownBy(() -> database.command("sql", "compact index `" + MANUAL_LSM + "`"))
+        .isInstanceOf(IndexException.class)
+        .hasMessageContaining(MANUAL_LSM)
+        .hasMessageContaining("it's manual and there aren't indications of what to index");
+
+    // The sweep left the entries alone.
+    database.transaction(() -> assertThat(manualLsm.get(new Object[] { "a" }).next()).isEqualTo(RID_1));
+  }
+
+  /**
+   * The predicate is public API and is reported verbatim by the schema views, so an operator listing the indexes now
+   * reads the truth about which ones something populates.
+   */
+  @Test
+  void theSchemaViewReportsAManualIndexAsNotAutomatic() {
+    createManualIndex(MANUAL_LSM, Schema.INDEX_TYPE.LSM_TREE, false);
+
+    boolean seenManual = false;
+    boolean seenAutomatic = false;
+    final ResultSet rs = database.query("sql", "select from schema:indexes");
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      final String name = row.getProperty("name");
+      if (MANUAL_LSM.equals(name)) {
+        assertThat((Boolean) row.getProperty("automatic")).isFalse();
+        seenManual = true;
+      } else {
+        assertThat((Boolean) row.getProperty("automatic"))
+            .as("index '%s' is bound to a type, so it stays automatic", name)
+            .isTrue();
+        seenAutomatic = true;
+      }
+    }
+
+    assertThat(seenManual).as("schema:indexes must list the manual index").isTrue();
+    assertThat(seenAutomatic).as("schema:indexes must list the type indexes too").isTrue();
+  }
+
+  /**
+   * A manual index whose name carries no underscore does not abort the schema load.
+   * <p>
+   * The orphan-relinking pass walks every TYPE-LESS index and splits its name on the last underscore to recover the
+   * bucket a renamed sub-index belongs to - those are always {@code <bucketName>_<timestamp>}. A manual index is
+   * type-less too but is named by the caller, so {@code lastIndexOf} answered -1 and the substring raised
+   * {@code StringIndexOutOfBoundsException}, which {@code readConfiguration}'s own catch reported as "Error on
+   * loading schema. The schema will be reset".
+   * <p>
+   * What that actually costs is everything the loader had not reached yet, since the pass sits in the middle of
+   * {@code readConfiguration}: the bucket selection strategies, the triggers, the materialized views and continuous
+   * aggregates, the function libraries, the extensions, and the compaction file-migration map WAL recovery redirects
+   * through. The bucket selection strategy is the cheapest of those to pin, and it is the FIRST one after the pass,
+   * so it is what this test asserts - the types themselves are parsed BEFORE the pass and survive either way, which
+   * is why asserting their presence alone would not have caught this.
+   */
+  @Test
+  void aManualIndexWithNoUnderscoreInItsNameDoesNotAbortTheSchemaLoad() {
+    database.getSchema().getType(TYPE_NAME).setBucketSelectionStrategy("thread");
+
+    createManualIndex(MANUAL_LSM, Schema.INDEX_TYPE.LSM_TREE, false);
+    createManualIndex(MANUAL_HASH, Schema.INDEX_TYPE.HASH, true);
+
+    reopenDatabase();
+
+    assertThat(database.getSchema().getType(TYPE_NAME).getBucketSelectionStrategy().getName())
+        .as("the load must reach the settings that follow the orphan-relinking pass")
+        .isEqualTo("thread");
+
+    assertThat(database.getSchema().existsType(TYPE_NAME)).isTrue();
+    assertThat(database.getSchema().existsIndex(typeIndexName)).isTrue();
+    assertThat(database.getSchema().existsIndex(MANUAL_LSM)).isTrue();
+    assertThat(database.getSchema().existsIndex(MANUAL_HASH)).isTrue();
+    assertThat(database.countType(TYPE_NAME, false)).isEqualTo(2L);
+
+    assertThat(database.getSchema().getIndexByName(MANUAL_LSM).isAutomatic()).isFalse();
+    assertThat(database.getSchema().getIndexByName(MANUAL_HASH).isAutomatic()).isFalse();
+  }
+
+  /**
+   * {@code CHECK DATABASE FIX} reports a corrupt manual index and carries on, instead of aborting the whole repair on
+   * it.
+   * <p>
+   * The rebuild loop resolves the index's associated bucket to recreate it there. A manual index has none, so
+   * {@code getBucketById(-1)} raised "Bucket with id '-1' was not found" and the exception escaped the FIX before ANY
+   * index - including the healthy type indexes of the same database - had been repaired. The index is also left
+   * alone rather than dropped and recreated: its entries are not derived from any record, so the recreation this
+   * loop performs would destroy them.
+   */
+  @Test
+  void checkDatabaseFixReportsAManualIndexInsteadOfAbortingOnIt() {
+    createManualIndex(MANUAL_HASH, Schema.INDEX_TYPE.HASH, true);
+
+    // The exact corruption HashIndexMetadataCorruptionTest injects: an invalid key-type byte on the metadata page.
+    // It has to be re-read from disk to reach the cached key types, hence the reopen.
+    corruptHashIndexKeyType(MANUAL_HASH);
+    reopenDatabase();
+
+    final Result row = database.command("sql", "check database fix").next();
+
+    assertThat((Collection<String>) row.getProperty("corruptedIndexes"))
+        .as("the finding must still reach the operator")
+        .contains(MANUAL_HASH);
+    assertThat((Collection<String>) row.getProperty("rebuiltIndexes"))
+        .as("a manual index cannot be rebuilt from records, so FIX must not claim it rebuilt one")
+        .doesNotContain(MANUAL_HASH);
+    assertThat((Collection<String>) row.getProperty("warnings"))
+        .anyMatch(w -> w.contains(MANUAL_HASH) && w.contains("manual index"));
+
+    // The index is still there: FIX did not drop it, which on a manual index is an unrecoverable delete of its entries.
+    assertThat(database.getSchema().existsIndex(MANUAL_HASH)).isTrue();
+    // ...and the rest of the schema came through the repair pass untouched.
+    assertThat(database.getSchema().existsIndex(typeIndexName)).isTrue();
+    assertThat(database.countType(TYPE_NAME, false)).isEqualTo(2L);
+
+    // Apply the repair the warning prescribes, so the class-wide post-test integrity check sees a clean database
+    // rather than the corruption this test deliberately injected.
+    database.getSchema().dropIndex(MANUAL_HASH);
+  }
+
+  /**
+   * Overwrites the first key-type byte of a hash index metadata page (page 0) with a value no key type uses, which is
+   * what {@code checkMetadataIntegrity()} reports as corruption.
+   */
+  private void corruptHashIndexKeyType(final String indexName) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = ((IndexInternal) db.getSchema().getIndexByName(indexName)).getFileIds().get(0);
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, 0), pageSize, false);
+        page.writeByte(HASH_INDEX_META_KEY_TYPES_START, (byte) -108);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private Index createManualIndex(final String name, final Schema.INDEX_TYPE indexType, final boolean unique) {
+    return database.getSchema().buildManualIndex(name, new Type[] { Type.STRING })
+        .withType(indexType).withUnique(unique).create();
+  }
+}


### PR DESCRIPTION
Closes #5780

## The defect

`LSMTreeIndex.isAutomatic()` and `HashIndex.isAutomatic()` both answered `metadata.propertyNames != null`, and `IndexMetadata`'s constructor coerces a null property list to an EMPTY one:

```java
this.propertyNames = propertyNames != null ? List.of(propertyNames) : List.of();
```

so the field is never null and the predicate was unconditionally `true` - including for a manual index, built with `new IndexMetadata(null, null, -1)` and the one kind for which it must be `false`. "Automatic" here means "there are indications of what to index", which is exactly what a manual index does not have.

The predicate now reads through a single named accessor, `IndexMetadata.hasIndexedProperties()`, so the empty check cannot be dropped back to a null check in one of the copies. `Index.isAutomatic()` is public API and had no Javadoc; it now says what it means.

## Every caller, checked

The issue asked whether any other caller relied on the always-true answer. A full grep of the repo (no module outside `engine/` calls it; Studio only renders the value it is told):

| Caller | Effect of the fix |
|---|---|
| `RebuildIndexStatement:157` (`REBUILD INDEX *` target selection) | manual indexes drop out of the sweep - **the reported bug** |
| `RebuildIndexStatement:288` (`if (!idx.isAutomatic())`) | dead branch becomes reachable, so a named rebuild reports the accurate message |
| `CompactIndexStatement:81` / `:124` | the same pair, which the issue's grep did not reach - see the note below |
| `PartitionedBucketSelectionStrategy:153` | unaffected: it tests a `TypeIndex`, whose `isAutomatic()` is an unconditional `true` |
| `FetchFromSchemaIndexesStep` / `FetchFromSchemaIndexDetailStep` / `FetchFromSchemaTypesStep` | `schema:indexes` now reports `automatic=false` for a manual index, which is the truth |

Three wrapper indexes (`LSMTreeFullTextIndex`, `LSMTreeGeoIndex`, `LSMSparseVectorIndex`) carried their own copy of the same always-true test, spelled `underlyingIndex.getPropertyNames() != null`. They now delegate to `underlyingIndex.isAutomatic()` so there is one answer rather than four. No behaviour change for them today - none of those kinds can be built without a type - but leaving the duplicate would have re-introduced the bug the moment one could.

**Note on `COMPACT INDEX`.** The guard at `CompactIndexStatement:124` was written to be reachable and now is, so `COMPACT INDEX <manualName>` reports "it's manual and there aren't indications of what to index" instead of compacting, and `COMPACT INDEX *` skips manual indexes. That is the existing code's stated intent, and manual indexes are still compacted by the background auto-compaction scheduler, which does not consult this predicate. If the preference is instead that an explicit compaction of a manual index should be allowed - compaction is a storage operation and genuinely does not need to know what to index - that is a one-line change in `compactIndex()` and I am happy to make it; I did not want to change a documented refusal on my own initiative.

## Two more defects found in the same pass

The issue asked to confirm `CHECK DATABASE` in the same pass rather than discovering it the way #5765's were found. Both of these are reproduced by tests in this PR and were verified to fail without their fix.

**1. `CHECK DATABASE FIX` aborted on a manual index.** The rebuild loop resolves the index's associated bucket to recreate it there. A manual index has none, so a manual index that the integrity pass flagged (e.g. a damaged hash metadata page) reached `getBucketById(-1)` and raised `SchemaException: Bucket with id '-1' was not found` - escaping the FIX before ANY index, including the healthy type indexes of the same database, had been repaired. Manual indexes are now filtered out of the affected set with a warning that names the only repair available, and are neither dropped nor recreated: the drop-and-recreate the loop performs would destroy entries nothing can regenerate.

**2. A manual index whose name has no underscore aborted the schema load.** The orphan-relinking pass of `LocalSchema.readConfiguration` walks every TYPE-LESS index and splits its name on the last underscore to recover the bucket a renamed sub-index belongs to - those are always `<bucketName>_<timestamp>`. A manual index is type-less too but is named by the caller, so `lastIndexOf` answered -1 and `substring(0, -1)` raised `StringIndexOutOfBoundsException`, which `readConfiguration`'s own catch logged as *"Error on loading schema. The schema will be reset"*.

The types survive (they are parsed before the pass), which is why this went unnoticed - but everything AFTER the pass is silently skipped on every open: the bucket selection strategies, the triggers, the materialized views and continuous aggregates, the function libraries, the extensions, and the compaction file-migration map WAL recovery redirects through. The pass now skips a name it cannot parse; the same guard is applied to its twin two lines below, which reads persisted schema entries and is reachable from a hand-edited or restored `schema.json`.

Neither is a regression from this change - both predate it - but both are in the blast radius the manual-index path opened up in #5765/#5775, and both are unreachable without a manual index, which is why they are here rather than in separate PRs.

## Test plan

New: `engine/src/test/java/com/arcadedb/index/Issue5780ManualIndexIsAutomaticTest.java` (7 tests). All 7 were confirmed RED against the unfixed code first, each for the reason it names.

- [ ] `aManualIndexIsNotAutomaticAndATypeIndexStillIs` - the predicate itself, on both manual kinds (`LSM_TREE`, `HASH`) and on a type index's wrapper and bucket sub-indexes
- [ ] `rebuildIndexAllSkipsManualIndexesInsteadOfFailingOnThem` - manual indexes absent from `indexes` AND from `failedIndexes` (where they used to land), the automatic indexes still rebuilt, the manual entries still readable afterwards
- [ ] `rebuildIndexNamedOnAManualIndexReportsThatItIsManual` - the accurate message instead of the one raised two layers down
- [ ] `compactIndexFollowsTheSamePredicate` - the `*` sweep and the named refusal
- [ ] `theSchemaViewReportsAManualIndexAsNotAutomatic` - `select from schema:indexes`
- [ ] `aManualIndexWithNoUnderscoreInItsNameDoesNotAbortTheSchemaLoad` - asserts the bucket selection strategy survives the reopen, i.e. the load reached PAST the orphan-relinking pass. Asserting the types alone would not have caught it
- [ ] `checkDatabaseFixReportsAManualIndexInsteadOfAbortingOnIt` - injects the exact hash metadata corruption `HashIndexMetadataCorruptionTest` uses, then asserts FIX reports and carries on, does not claim a rebuild, and does not drop the index

Regression scope run locally: the whole `com.arcadedb.index.**` and `com.arcadedb.schema.**` packages of `engine`.
