### PR TITLE
fix(#5779): moveEdge must clean the old edge record's index entries, external values and bucket count

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -852,6 +852,13 @@ public class GraphEngine {
     // readable. moveEdge writes FRESH external records for the replacement, so without this the old ones are
     // orphaned. Same transaction as the removal itself. Runs BEFORE the index cleanup because it reads the
     // record's own buffer and restores its position, while the pre-image built below consumes that same buffer.
+    //
+    // Deliberately NOT pre-gated on hasExternalProperties() the way LocalDatabase.cascadeDeleteExternalValues is:
+    // that flag reflects the CURRENT schema and flips to false the instant setExternal(false) commits, so it would
+    // skip cleanup during the EXTERNAL -> inline migration window and leak the blobs of every record not yet
+    // re-serialised. findExistingExternalRids gates itself on hasExternalBuckets(), which stays true for the whole
+    // window and is the correct test - and it is already a couple of field reads for a type that never used the
+    // feature, so there is nothing to save by guarding it again here.
     final Map<String, RID> externalRids = database.getSerializer().findExistingExternalRids(database, edge);
     for (final RID externalRID : externalRids.values()) {
       final Bucket externalBucket = database.getSchema().getBucketByIdIfExists(externalRID.getBucketId());
@@ -882,8 +889,10 @@ public class GraphEngine {
    *   index has left behind;</li>
    *   <li>otherwise an immutable record over that frozen buffer, which is exactly the committed state the index
    *   entries were written from;</li>
-   *   <li>otherwise the live instance, which is the only image there is for a record created inside this
-   *   transaction (no committed buffer to read).</li>
+   *   <li>otherwise the live instance, for a record with no committed buffer to read at all - one created inside
+   *   this transaction, and equally one saved with {@code discardRecordAfter} (the bulk-import path through
+   *   {@code LocalBucket.createRecord}), which drops the buffer although the record is persisted. There is no
+   *   better image available in either case, and it is the same one the ordinary delete path uses.</li>
    * </ol>
    */
   private Document indexedImageOf(final MutableEdge edge) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -19,6 +19,7 @@
 package com.arcadedb.graph;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Binary;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
@@ -27,6 +28,7 @@ import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.database.RecordInternal;
 import com.arcadedb.database.TransactionContext;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.engine.Bucket;
@@ -833,30 +835,70 @@ public class GraphEngine {
    * it, so there is no index entry, no external value and no counted record, and folding a {@code -1} here would
    * drift the cached bucket count behind {@code count(*)} - persisted in {@code statistics.json}, so it would
    * survive a reopen.
+   * <p>
+   * Unlike {@code deleteRecordNoLock} this does NOT tolerate a corrupted record buffer, and does not need to: that
+   * tolerance exists so a record whose body cannot be parsed can still be DELETED, while {@link #moveEdge} has
+   * already had to parse the whole record into {@code propertiesAsMap()} - the source of the replacement's
+   * properties - before it gets here. A buffer that cannot be read fails the move at that point, which is the right
+   * answer: there is nothing to copy the edge's content from. The one buffer read left here,
+   * {@code findExistingExternalRids}, absorbs its own parse failures and counts them for CHECK DATABASE.
    */
   private void cleanUpBeforePhysicalDelete(final MutableEdge edge) {
     final RID edgeRID = edge.getIdentity();
     if (edgeRID == null || edge instanceof LightEdge || edgeRID.getPosition() < 0)
       return;
 
-    database.getIndexer().deleteDocument(edge);
-
     // Cascade-delete EXTERNAL property values living in the paired external bucket, while the buffer is still
     // readable. moveEdge writes FRESH external records for the replacement, so without this the old ones are
-    // orphaned. Same transaction as the removal itself.
+    // orphaned. Same transaction as the removal itself. Runs BEFORE the index cleanup because it reads the
+    // record's own buffer and restores its position, while the pre-image built below consumes that same buffer.
     final Map<String, RID> externalRids = database.getSerializer().findExistingExternalRids(database, edge);
     for (final RID externalRID : externalRids.values()) {
-      final LocalBucket externalBucket = database.getSchema().getEmbedded().getBucketById(externalRID.getBucketId(), false);
+      final Bucket externalBucket = database.getSchema().getBucketByIdIfExists(externalRID.getBucketId());
       if (externalBucket != null) {
         externalBucket.deleteRecord(externalRID);
         database.getTransaction().updateBucketRecordDelta(externalBucket.getFileId(), -1);
       }
     }
 
+    database.getIndexer().deleteDocument(indexedImageOf(edge));
+
     // The replacement folds its own +1 when it is created, so without this the move inflates the cached record
     // count of the type by one for every edge ever moved.
     database.getTransaction()
         .updateBucketRecordDelta(database.getSchema().getBucketById(edgeRID.getBucketId()).getFileId(), -1);
+  }
+
+  /**
+   * The image of {@code edge} that the INDEX was built from, which is NOT the instance the caller holds:
+   * {@code DocumentIndexer.deleteDocument} builds the keys it removes out of the LIVE property values of whatever
+   * record it is handed, and {@link #moveEdge} is entered from {@code MutableEdge.set("@in"/"@out")} - so a caller
+   * that changed an indexed property in the same session ({@code edge.set("code", "new"); edge.set("@in", v)})
+   * would have it remove a key the index never held, leaving the real entry dangling. Same resolution order
+   * {@code LocalDatabase.updateRecord} uses for the same reason (#4935):
+   * <ol>
+   *   <li>the transaction's last indexed snapshot, when an earlier {@code save()} in this transaction already
+   *   moved the index forward - the record's buffer stays frozen until commit, so it would describe a state the
+   *   index has left behind;</li>
+   *   <li>otherwise an immutable record over that frozen buffer, which is exactly the committed state the index
+   *   entries were written from;</li>
+   *   <li>otherwise the live instance, which is the only image there is for a record created inside this
+   *   transaction (no committed buffer to read).</li>
+   * </ol>
+   */
+  private Document indexedImageOf(final MutableEdge edge) {
+    final RID edgeRID = edge.getIdentity();
+    final Document snapshot = database.getTransaction().getLastIndexedSnapshot(edgeRID);
+    if (snapshot != null)
+      return snapshot;
+
+    final Binary committedBuffer = ((RecordInternal) edge).getBuffer();
+    if (committedBuffer == null)
+      return edge;
+
+    committedBuffer.rewind();
+    return (Document) database.getRecordFactory()
+        .newImmutableRecord(database, edge.getType(), edgeRID, committedBuffer, null);
   }
 
   public void deleteVertex(final VertexInternal vertex) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -836,12 +836,19 @@ public class GraphEngine {
    * drift the cached bucket count behind {@code count(*)} - persisted in {@code statistics.json}, so it would
    * survive a reopen.
    * <p>
-   * Unlike {@code deleteRecordNoLock} this does NOT tolerate a corrupted record buffer, and does not need to: that
-   * tolerance exists so a record whose body cannot be parsed can still be DELETED, while {@link #moveEdge} has
-   * already had to parse the whole record into {@code propertiesAsMap()} - the source of the replacement's
-   * properties - before it gets here. A buffer that cannot be read fails the move at that point, which is the right
-   * answer: there is nothing to copy the edge's content from. The one buffer read left here,
-   * {@code findExistingExternalRids}, absorbs its own parse failures and counts them for CHECK DATABASE.
+   * Unlike {@code deleteRecordNoLock} this takes no catch around the cleanup, and needs none: by the time it runs,
+   * {@link #moveEdge} has already read the whole record through {@code propertiesAsMap()} - the source of the
+   * replacement's properties - so a buffer broken badly enough to throw has already failed the move there, which
+   * is the right answer for a move (there is nothing to copy the edge's content from) even though it is the wrong
+   * one for a delete. The remaining buffer read here, {@code findExistingExternalRids}, absorbs its own parse
+   * failures and counts them for CHECK DATABASE.
+   * <p>
+   * That leaves one BOUNDARY, measured and pinned by
+   * {@code Issue5779MoveEdgeIndexCleanupTest.movingAnEdgeWithAnUnreadablePropertyIsBestEffortLikeTheDeletePath}:
+   * corruption the reader TOLERATES - a bad length prefix on an inline value (#4420) surfaces as the property
+   * being absent, not as an exception. Nothing here can then learn the key the index holds, so that entry outlives
+   * the record. It is not a leak this method can close, and not one it introduces: {@code deleteRecordNoLock}
+   * degrades identically on the same record, and CHECK DATABASE does not detect a dangling LSM entry either.
    */
   private void cleanUpBeforePhysicalDelete(final MutableEdge edge) {
     final RID edgeRID = edge.getIdentity();
@@ -889,10 +896,14 @@ public class GraphEngine {
    *   index has left behind;</li>
    *   <li>otherwise an immutable record over that frozen buffer, which is exactly the committed state the index
    *   entries were written from;</li>
-   *   <li>otherwise the live instance, for a record with no committed buffer to read at all - one created inside
-   *   this transaction, and equally one saved with {@code discardRecordAfter} (the bulk-import path through
-   *   {@code LocalBucket.createRecord}), which drops the buffer although the record is persisted. There is no
-   *   better image available in either case, and it is the same one the ordinary delete path uses.</li>
+   *   <li>otherwise the live instance, DEFENSIVE and not currently reachable from here. It would cover a record
+   *   with no committed buffer at all - one saved with {@code discardRecordAfter} (the bulk-import path through
+   *   {@code LocalBucket.createRecord}) drops the buffer although the record is persisted. Not the obvious
+   *   candidate, an edge created earlier in this same transaction: {@code newEdge()} saves it, and the save
+   *   serializes, so it reaches {@link #moveEdge} with a buffer like any other (verified by making this branch
+   *   throw and watching the whole test class still pass). Kept because the alternative on a null buffer is what
+   *   {@code LocalDatabase.getOriginalDocument} does - raise {@code IllegalStateException} - and failing a move
+   *   over a missing pre-image is worse than cleaning up from the only image there is.</li>
    * </ol>
    */
   private Document indexedImageOf(final MutableEdge edge) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -704,17 +704,13 @@ public class GraphEngine {
         // does; verified by deleting an edge carrying an indexed property and watching the index drop from 1
         // entry to 0.)
         //
-        // "Normally" is load-bearing: moveEdge calls the public deleteEdge(Edge) DIRECTLY, and there the
-        // precondition does NOT hold - the old edge record's index entries are never cleaned. Measured rather
-        // than assumed before writing this down, and it is benign TODAY for a reason that is an allocation
-        // coincidence rather than a guarantee: moveEdge re-creates the edge with the same properties, and the
-        // bucket hands the just-freed slot straight back, so the stale entry ends up on the new record with the
-        // same key (checked on a multi-bucket edge type - 41 records, 41 index entries, identical RID). Anything
-        // that breaks that coincidence - a different bucket, a concurrent allocation taking the slot - leaves an
-        // index entry naming a record that is gone. A new caller of the public deleteEdge(Edge) must therefore
-        // either arrive through deleteRecordNoLock or clean up after itself. Tracked as #5779, which carries the
-        // measurement above and the ways the coincidence breaks - the comment is where you are, the issue is
-        // where the fix gets scheduled.
+        // "Normally" is load-bearing, and it is a PRECONDITION on the caller rather than a description: a caller
+        // of the public deleteEdge(Edge) must either arrive through deleteRecordNoLock or do that cleanup itself.
+        // moveEdge is the one that does not arrive that way, and it discharges the obligation explicitly in
+        // cleanUpBeforePhysicalDelete (#5779). It used to skip it and stay correct only by an allocation
+        // coincidence - the bucket handed the just-freed slot straight back, so the stale entry landed on the new
+        // record with the same key - which a second bucket, a concurrent allocation taking the slot, or a UNIQUE
+        // index all break. A NEW caller inherits the same obligation.
         final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(edge.getIdentity().getBucketId());
         bucket.deleteRecord(edge.getIdentity());
       } catch (final RecordNotFoundException e) {
@@ -780,6 +776,24 @@ public class GraphEngine {
     }
   }
 
+  /**
+   * Re-points {@code edge} at {@code newVertexRID} on the given side by removing the edge record and creating a
+   * replacement, then re-identifies the caller's instance onto it.
+   * <p>
+   * #5779: this is the ONE caller that reaches {@link #deleteEdge(Edge)} without coming through
+   * {@code LocalDatabase.deleteRecordNoLock}, and that method performs the PHYSICAL removal only - see the note
+   * there. Everything {@code deleteRecordNoLock} would have done before dispatching the edge is therefore this
+   * method's obligation, and {@link #cleanUpBeforePhysicalDelete} is where it is discharged. Skipping it used to
+   * look harmless because the bucket normally hands the just-freed slot straight back to the replacement, so the
+   * stale index entry ended up on a new record carrying the same key - correct by allocation coincidence, not by
+   * an invariant. Round-robin bucket selection breaks the coincidence as soon as the type has more than one
+   * bucket: the replacement lands elsewhere and the old entry names a RID that is gone, or worse a slot an
+   * unrelated edge is handed later. On a UNIQUE index the leak is not even silent - the old key stays taken and
+   * the replacement is rejected as a duplicate, which made a move impossible on such a type.
+   * <p>
+   * Delete/create events are deliberately NOT fired: a move is not a delete, and a listener that vetoed the
+   * delete would leave this method creating a second edge on top of one that was never removed.
+   */
   public void moveEdge(final MutableEdge edge, final Vertex.DIRECTION direction, final RID newVertexRID) {
     if (direction != Vertex.DIRECTION.IN && direction != Vertex.DIRECTION.OUT)
       throw new IllegalArgumentException("Unsupported direction for moveEdge: " + direction);
@@ -789,6 +803,7 @@ public class GraphEngine {
     final RID newOut = direction == Vertex.DIRECTION.OUT ? newVertexRID : edge.getOut();
     final RID newIn = direction == Vertex.DIRECTION.IN ? newVertexRID : edge.getIn();
 
+    cleanUpBeforePhysicalDelete(edge);
     deleteEdge(edge);
 
     final EdgeType edgeType = (EdgeType) database.getSchema().getType(typeName);
@@ -805,6 +820,43 @@ public class GraphEngine {
       connectIncomingEdge(toVertex, newOut, newEdge.getIdentity());
 
     edge.updateIdentity(newEdge.getIdentity(), newOut, newIn);
+  }
+
+  /**
+   * The bookkeeping {@code LocalDatabase.deleteRecordNoLock} performs on a record BEFORE handing it to the
+   * physical-only {@link #deleteEdge(Edge)}: its index entries, the EXTERNAL property values it owns, and the
+   * bucket record counter (#5779). It mirrors that method rather than calling it, because routing the move through
+   * the database would also fire the delete events - and a listener that vetoes them would abort the removal while
+   * {@link #moveEdge} went on to create the replacement anyway.
+   * <p>
+   * A LIGHTWEIGHT edge has no record to clean up after: {@link #deleteEdge(Edge)} skips the physical removal for
+   * it, so there is no index entry, no external value and no counted record, and folding a {@code -1} here would
+   * drift the cached bucket count behind {@code count(*)} - persisted in {@code statistics.json}, so it would
+   * survive a reopen.
+   */
+  private void cleanUpBeforePhysicalDelete(final MutableEdge edge) {
+    final RID edgeRID = edge.getIdentity();
+    if (edgeRID == null || edge instanceof LightEdge || edgeRID.getPosition() < 0)
+      return;
+
+    database.getIndexer().deleteDocument(edge);
+
+    // Cascade-delete EXTERNAL property values living in the paired external bucket, while the buffer is still
+    // readable. moveEdge writes FRESH external records for the replacement, so without this the old ones are
+    // orphaned. Same transaction as the removal itself.
+    final Map<String, RID> externalRids = database.getSerializer().findExistingExternalRids(database, edge);
+    for (final RID externalRID : externalRids.values()) {
+      final LocalBucket externalBucket = database.getSchema().getEmbedded().getBucketById(externalRID.getBucketId(), false);
+      if (externalBucket != null) {
+        externalBucket.deleteRecord(externalRID);
+        database.getTransaction().updateBucketRecordDelta(externalBucket.getFileId(), -1);
+      }
+    }
+
+    // The replacement folds its own +1 when it is created, so without this the move inflates the cached record
+    // count of the type by one for every edge ever moved.
+    database.getTransaction()
+        .updateBucketRecordDelta(database.getSchema().getBucketById(edgeRID.getBucketId()).getFileId(), -1);
   }
 
   public void deleteVertex(final VertexInternal vertex) {

--- a/engine/src/test/java/com/arcadedb/graph/Issue5779MoveEdgeIndexCleanupTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5779MoveEdgeIndexCleanupTest.java
@@ -19,7 +19,12 @@
 package com.arcadedb.graph;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.query.sql.executor.Result;
@@ -30,6 +35,7 @@ import com.arcadedb.schema.VertexType;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,7 +62,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class Issue5779MoveEdgeIndexCleanupTest extends TestHelper {
 
-  private static final int BUCKETS = 4;
+  private static final int    BUCKETS         = 4;
+  /** Long enough to be found verbatim in the page, and distinctive enough not to collide with anything else. */
+  private static final String CORRUPT_MARKER  = "CORRUPT5779MARKERVALUE";
 
   /**
    * The leak itself, on a NOTUNIQUE index: after the move the index must hold exactly one entry for the edge's key,
@@ -240,6 +248,86 @@ class Issue5779MoveEdgeIndexCleanupTest extends TestHelper {
   }
 
   /**
+   * A move of an edge CREATED in the same transaction, with its indexed property changed in between - the sequence
+   * that looks like it should reach {@code indexedImageOf}'s buffer-less fallback and does not: {@code newEdge()}
+   * saves the edge, the save serializes, so it arrives with a committed buffer like any other record and the
+   * ordinary pre-image path handles it. Worth pinning precisely because the intuition points the other way.
+   */
+  @Test
+  void movingAnEdgeCreatedInTheSameTransactionUsesItsCommittedPreImage() {
+    createSchema(false);
+
+    final RID[] moved = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex near = database.newVertex("Node").set("name", "near").save();
+      final MutableVertex far0 = database.newVertex("Node").set("name", "far0").save();
+      final MutableVertex far = database.newVertex("Node").set("name", "far").save();
+      final MutableEdge edge = near.newEdge("Link", far0, "code", "E1");
+      edge.set("code", "E2");
+      edge.set("@in", far.getIdentity());
+      moved[0] = edge.getIdentity();
+    });
+
+    final Index index = database.getSchema().getIndexByName("Link[code]");
+    assertThat(index.countEntries()).as("one edge, one entry - no entry left over from the create").isEqualTo(1L);
+    assertThat(lookup(index, "E2")).containsExactly(moved[0]);
+    assertThat(lookup(index, "E1")).isEmpty();
+    assertThat(scalar("select count() as n from Link")).isEqualTo(1L);
+    assertThat(database.countType("Link", false)).isEqualTo(1L);
+
+    assertIntegrityClean();
+  }
+
+  /**
+   * The BOUNDARY of the guarantee, measured rather than assumed, because it is the one case where
+   * {@code cleanUpBeforePhysicalDelete} cannot deliver: an indexed property whose value cannot be deserialized.
+   * <p>
+   * This fixture uses the #4420 shape - a corrupt length prefix on an inline STRING. The reader TOLERATES it by
+   * reporting the value as ABSENT rather than throwing (see {@code Issue4420TolerantDeleteTest}), so nothing here
+   * can learn the key the index actually holds, and the entry for the deleted record survives. That is not a
+   * regression this fix introduces and not one it can close: {@code LocalDatabase.deleteRecordNoLock} degrades
+   * identically on the same record, by design and with a logged warning. CHECK DATABASE does not detect a dangling
+   * LSM entry either ({@code totalErrors} 0, {@code corruptedIndexes} empty), so this test is what records the
+   * boundary instead.
+   * <p>
+   * What the move must still get right, and does: the record is removed, the counter stays truthful, and no key is
+   * fabricated for the replacement.
+   */
+  @Test
+  void movingAnEdgeWithAnUnreadablePropertyIsBestEffortLikeTheDeletePath() {
+    createSchema(false);
+
+    final RID[] rids = createTriangleWithOneEdge(CORRUPT_MARKER);
+    final RID edgeRID = rids[0], farRID = rids[2];
+
+    corruptPropertyLength(edgeRID);
+    // Reopen so the record is re-read from the corrupted page instead of the in-memory record cache. Every RID
+    // captured before this point still names the closed instance, so rebind them to the reopened one.
+    reopenDatabase();
+    final RID staleEdgeRID = RID.create(database, edgeRID.getBucketId(), edgeRID.getPosition());
+    final RID newInRID = RID.create(database, farRID.getBucketId(), farRID.getPosition());
+
+    final Index index = database.getSchema().getIndexByName("Link[code]");
+    final RID movedRID = moveEdgeIn(staleEdgeRID, newInRID);
+
+    database.transaction(
+        () -> assertThat(database.existsRecord(staleEdgeRID)).as("the old record is still removed").isFalse());
+    assertThat(scalar("select count() as n from Link")).as("a move is still not a duplication").isEqualTo(1L);
+    assertThat(database.countType("Link", false))
+        .as("and the counter stays truthful even on the degraded path").isEqualTo(1L);
+    assertThat(movedRID).isNotEqualTo(staleEdgeRID);
+
+    database.transaction(() -> assertThat((Object) movedRID.asEdge().get("code"))
+        .as("the unreadable value cannot be carried over, and must not be invented either").isNull());
+
+    // The boundary itself: the entry keyed by the unreadable value outlives the record. Asserted so that a future
+    // change able to recover the key (or a decision to fail the move instead) shows up here rather than silently.
+    assertThat(lookup(index, CORRUPT_MARKER))
+        .as("unreadable key: the stale entry survives, exactly as it does on the ordinary delete path")
+        .containsExactly(staleEdgeRID);
+  }
+
+  /**
    * {@code cleanUpBeforePhysicalDelete} returns early for a LIGHTWEIGHT edge, because {@code deleteEdge} performs
    * no physical removal for one: there is no index entry, no external value and no counted record, and folding a
    * {@code -1} would drift the cached bucket count the other way and persist that drift to
@@ -346,16 +434,68 @@ class Issue5779MoveEdgeIndexCleanupTest extends TestHelper {
    * {@code [edge, near, far]}.
    */
   private RID[] createTriangleWithOneEdge() {
+    return createTriangleWithOneEdge("E1");
+  }
+
+  private RID[] createTriangleWithOneEdge(final String code) {
     final RID[] rids = new RID[3];
     database.transaction(() -> {
       final MutableVertex near = database.newVertex("Node").set("name", "near").save();
       final MutableVertex far0 = database.newVertex("Node").set("name", "far0").save();
       final MutableVertex far = database.newVertex("Node").set("name", "far").save();
-      rids[0] = near.newEdge("Link", far0, "code", "E1").save().getIdentity();
+      rids[0] = near.newEdge("Link", far0, "code", code).save().getIdentity();
       rids[1] = near.getIdentity();
       rids[2] = far.getIdentity();
     });
     return rids;
+  }
+
+  /**
+   * The #4420 corruption shape, applied to the edge's indexed STRING property: the length-prefix varint of the
+   * inline value is overwritten with one that decodes above {@link Integer#MAX_VALUE}. The record's declared size
+   * in the page record table is left alone, so the record still loads - only deserializing that property fails.
+   * Lifted from {@code Issue4420TolerantDeleteTest}, which pins the same shape on the delete path.
+   */
+  private void corruptPropertyLength(final RID rid) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = rid.getBucketId();
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+    final byte[] marker = CORRUPT_MARKER.getBytes(StandardCharsets.UTF_8);
+
+    final Binary varintBuffer = new Binary();
+    // 4_294_967_245L == (2^32 - 51); cast to int it becomes -51, the exact value reported in issue #4420.
+    varintBuffer.putUnsignedNumber(4_294_967_245L);
+    final byte[] corruptVarint = varintBuffer.toByteArray();
+
+    db.transaction(() -> {
+      try {
+        // Page 0: the fixture puts a single edge in this bucket, so its slot is on the first page.
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, 0), pageSize, false);
+        final byte[] content = new byte[page.getContentSize()];
+        page.readByteArray(0, content);
+
+        final int markerStart = indexOf(content, marker);
+        assertThat(markerStart).as("marker value must be present inline in the page").isGreaterThan(0);
+
+        // The byte immediately before the inline value is its length varint; overwrite it (and the bytes it now
+        // spans) with the multi-byte corrupt length. The marker is long enough that this stays inside the record.
+        for (int i = 0; i < corruptVarint.length; i++)
+          page.writeByte(markerStart - 1 + i, corruptVarint[i]);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private static int indexOf(final byte[] haystack, final byte[] needle) {
+    outer:
+    for (int i = 0; i <= haystack.length - needle.length; i++) {
+      for (int j = 0; j < needle.length; j++)
+        if (haystack[i + j] != needle[j])
+          continue outer;
+      return i;
+    }
+    return -1;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/graph/Issue5779MoveEdgeIndexCleanupTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5779MoveEdgeIndexCleanupTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * #5779: {@code GraphEngine.moveEdge} re-points an edge by deleting the old edge record and creating a replacement,
@@ -145,6 +146,136 @@ class Issue5779MoveEdgeIndexCleanupTest extends TestHelper {
     database.transaction(() -> nearRID.asVertex().newEdge("Link", farRID.asVertex(), "code", "E1").save());
 
     assertThat(index.countEntries()).isEqualTo(1L);
+    assertIntegrityClean();
+  }
+
+  /**
+   * The OUT side takes the same route with {@code Vertex.DIRECTION.OUT}, and nothing about the cleanup is
+   * direction-specific - which is exactly why it is asserted rather than assumed.
+   */
+  @Test
+  void movingTheOutEndpointCleansTheOldRecordsIndexEntriesToo() {
+    createSchema(false);
+
+    final RID[] rids = createTriangleWithOneEdge();
+    final RID edgeRID = rids[0], farRID = rids[2];
+
+    final RID[] moved = new RID[1];
+    database.transaction(() -> {
+      final MutableEdge edge = edgeRID.asEdge().modify();
+      edge.set("@out", farRID);
+      moved[0] = edge.getIdentity();
+    });
+
+    final Index index = database.getSchema().getIndexByName("Link[code]");
+    assertThat(moved[0]).isNotEqualTo(edgeRID);
+    assertThat(index.countEntries()).isEqualTo(1L);
+    assertThat(lookup(index, "E1")).containsExactly(moved[0]);
+    database.transaction(() -> assertThat(moved[0].asEdge().getOut()).isEqualTo(farRID));
+
+    assertIntegrityClean();
+  }
+
+  /**
+   * A move that ALSO changes an indexed property in the same session. {@code DocumentIndexer.deleteDocument} builds
+   * the key it removes from the LIVE property values of the record handed to it, and after
+   * {@code edge.set("code", ...)} those are the new ones - the index still holds the old key. The cleanup therefore
+   * has to run against the state the index was built from, not against the caller's in-flight edits, or it removes
+   * a key that was never there and leaves the real entry dangling: the very leak this fix exists to close, reached
+   * through a different door.
+   */
+  @Test
+  void movingAnEdgeThatAlsoChangedItsIndexedPropertyCleansTheKeyTheIndexActuallyHolds() {
+    createSchema(false);
+
+    final RID[] rids = createTriangleWithOneEdge();
+    final RID edgeRID = rids[0], farRID = rids[2];
+
+    final RID[] moved = new RID[1];
+    database.transaction(() -> {
+      final MutableEdge edge = edgeRID.asEdge().modify();
+      edge.set("code", "E2");
+      edge.set("@in", farRID);
+      moved[0] = edge.getIdentity();
+    });
+
+    final Index index = database.getSchema().getIndexByName("Link[code]");
+    assertThat(lookup(index, "E1")).as("the key the record used to carry must be gone").isEmpty();
+    assertThat(lookup(index, "E2")).as("the key it carries now must name the surviving record")
+        .containsExactly(moved[0]);
+    assertThat(index.countEntries()).as("one edge, one entry").isEqualTo(1L);
+
+    assertIntegrityClean();
+  }
+
+  /**
+   * The same move, but with the indexed property already SAVED before it. The record's buffer stays frozen until
+   * commit (serialization is deferred), so it still describes {@code E1} while the index has already been moved to
+   * {@code E2} by that save - the committed buffer is the wrong pre-image here, and the transaction's indexed
+   * snapshot (#4935) is the right one.
+   */
+  @Test
+  void movingAnEdgeAfterAnIndexedPropertyWasAlreadySavedInTheSameTransaction() {
+    createSchema(false);
+
+    final RID[] rids = createTriangleWithOneEdge();
+    final RID edgeRID = rids[0], farRID = rids[2];
+
+    final RID[] moved = new RID[1];
+    database.transaction(() -> {
+      final MutableEdge edge = edgeRID.asEdge().modify();
+      edge.set("code", "E2");
+      edge.save();
+      edge.set("@in", farRID);
+      moved[0] = edge.getIdentity();
+    });
+
+    final Index index = database.getSchema().getIndexByName("Link[code]");
+    assertThat(lookup(index, "E1")).as("the committed key was already replaced by the save").isEmpty();
+    assertThat(lookup(index, "E2")).as("the key the index actually held must name the surviving record")
+        .containsExactly(moved[0]);
+    assertThat(index.countEntries()).as("one edge, one entry").isEqualTo(1L);
+
+    assertIntegrityClean();
+  }
+
+  /**
+   * {@code cleanUpBeforePhysicalDelete} returns early for a LIGHTWEIGHT edge, because {@code deleteEdge} performs
+   * no physical removal for one: there is no index entry, no external value and no counted record, and folding a
+   * {@code -1} would drift the cached bucket count the other way and persist that drift to
+   * {@code statistics.json}. That branch is currently UNREACHABLE, and this test is what says so out loud - both
+   * doors into {@code moveEdge} are shut for a lightweight edge, and if either is ever opened this fails and
+   * points at the guard that is then load-bearing rather than defensive.
+   */
+  @Test
+  void aLightweightEdgeCannotReachMoveEdgeAtAll() {
+    database.getSchema().createVertexType("Node", BUCKETS).createProperty("name", Type.STRING);
+    database.getSchema().buildEdgeType().withName("Link").withTotalBuckets(BUCKETS).withLightweight(true).create();
+
+    final RID[] rids = new RID[2];
+    database.transaction(() -> {
+      final MutableVertex near = database.newVertex("Node").set("name", "near").save();
+      final MutableVertex far0 = database.newVertex("Node").set("name", "far0").save();
+      near.newEdge("Link", far0);
+      rids[0] = near.getIdentity();
+      rids[1] = far0.getIdentity();
+    });
+
+    assertThat(database.countType("Link", false))
+        .as("a lightweight edge allocates no record, so there is nothing for the cleanup to account for")
+        .isEqualTo(0L);
+
+    // Door 1: a persisted lightweight edge reached through its endpoint's list cannot be made mutable at all.
+    database.transaction(() -> assertThatThrownBy(
+        () -> rids[0].asVertex().getEdges(Vertex.DIRECTION.OUT, "Link").iterator().next().asEdge().modify())
+        .isInstanceOf(IllegalStateException.class).hasMessageContaining("cannot be modified"));
+
+    // Door 2: the MutableLightEdge newEdge() hands back inside the creating session refuses set() outright, so
+    // the "@in"/"@out" override in MutableEdge - the only caller of moveEdge - is never entered.
+    database.transaction(() -> assertThatThrownBy(
+        () -> rids[0].asVertex().modify().newEdge("Link", rids[1].asVertex()).set("@in", rids[0]))
+        .isInstanceOf(IllegalStateException.class).hasMessageContaining("LIGHTWEIGHT"));
+
     assertIntegrityClean();
   }
 

--- a/engine/src/test/java/com/arcadedb/graph/Issue5779MoveEdgeIndexCleanupTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5779MoveEdgeIndexCleanupTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5779: {@code GraphEngine.moveEdge} re-points an edge by deleting the old edge record and creating a replacement,
+ * and it reaches the removal through the public {@code GraphEngine.deleteEdge(Edge)}. That method performs the
+ * PHYSICAL removal only - it is normally entered from {@code LocalDatabase.deleteRecordNoLock}, which has already
+ * cleaned the record's index entries and its EXTERNAL property values by the time the edge arrives. {@code moveEdge}
+ * is the one caller that does not come that way, so the old record's index entries survived it.
+ * <p>
+ * It used to look harmless because the bucket normally hands the just-freed slot straight back to the replacement,
+ * leaving the stale entry pointing at a new record carrying the same key - indistinguishable from a correct entry.
+ * That is an allocation coincidence, not an invariant. The fixtures below break it the way production would: the
+ * edge type has SEVERAL buckets and the default round-robin selection puts the replacement in a DIFFERENT bucket
+ * from the record just deleted, so the stale entry names a RID that no longer resolves.
+ * <p>
+ * The assertions go through {@code Index.countEntries()} and a raw {@code get()} on the index rather than through a
+ * query: {@code SELECT} skips entries whose RID does not resolve, which is exactly what hides this leak.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5779MoveEdgeIndexCleanupTest extends TestHelper {
+
+  private static final int BUCKETS = 4;
+
+  /**
+   * The leak itself, on a NOTUNIQUE index: after the move the index must hold exactly one entry for the edge's key,
+   * and that entry must name the surviving record.
+   */
+  @Test
+  void movingAnEdgeCleansTheOldRecordsIndexEntries() {
+    createSchema(false);
+
+    final RID[] rids = createTriangleWithOneEdge();
+    final RID edgeRID = rids[0], farRID = rids[2];
+
+    final Index index = database.getSchema().getIndexByName("Link[code]");
+    assertThat(index.countEntries()).as("one edge, one index entry").isEqualTo(1L);
+
+    final RID movedRID = moveEdgeIn(edgeRID, farRID);
+
+    assertThat(movedRID).as("the replacement must land in a different bucket, otherwise the fixture proves nothing")
+        .isNotEqualTo(edgeRID);
+
+    assertThat(index.countEntries())
+        .as("the entry of the deleted record must be gone: one edge, one entry").isEqualTo(1L);
+
+    final List<RID> found = lookup(index, "E1");
+    assertThat(found).as("the single surviving entry must name the replacement record").containsExactly(movedRID);
+
+    database.transaction(() -> {
+      assertThat(database.existsRecord(edgeRID)).as("the old record is deleted").isFalse();
+      assertThat(database.countType("Link", false)).as("a move is not a duplication").isEqualTo(1L);
+    });
+
+    assertIntegrityClean();
+  }
+
+  /**
+   * The sharper consequence of the same leak. The stale entry named a RID in a bucket whose slot is free, so an
+   * UNRELATED edge created afterwards can be handed that exact slot - and then a lookup of the OLD key silently
+   * returns the unrelated record. This is the failure mode that is worse than a plain dangling entry, because
+   * nothing about the result looks wrong.
+   */
+  @Test
+  void aFreedSlotReusedByAnUnrelatedEdgeIsNotReturnedForTheOldKey() {
+    createSchema(false);
+
+    final RID[] rids = createTriangleWithOneEdge();
+    final RID edgeRID = rids[0], nearRID = rids[1], farRID = rids[2];
+
+    moveEdgeIn(edgeRID, farRID);
+
+    // Fill every bucket of the type so the freed slot of the deleted record is certainly handed out again.
+    database.transaction(() -> {
+      final Vertex near = nearRID.asVertex();
+      final Vertex far = farRID.asVertex();
+      for (int i = 0; i < BUCKETS * 3; i++)
+        near.newEdge("Link", far, "code", "OTHER" + i).save();
+    });
+
+    final Index index = database.getSchema().getIndexByName("Link[code]");
+    final List<RID> found = lookup(index, "E1");
+
+    assertThat(found).as("the moved edge's key must resolve to exactly one record").hasSize(1);
+    database.transaction(() -> assertThat(found.getFirst().asEdge().getString("code"))
+        .as("a stale entry pointing at a reused slot returns a record carrying somebody else's key").isEqualTo("E1"));
+
+    assertIntegrityClean();
+  }
+
+  /**
+   * A UNIQUE index turns the leak from a silent wrong answer into a hard failure: the stale entry keeps the old key
+   * taken, so a later legitimate insert of that key is rejected as a duplicate even though the record that owned it
+   * is gone.
+   */
+  @Test
+  void aUniqueIndexAcceptsTheKeyOfAMovedEdgeAfterItIsFreed() {
+    createSchema(true);
+
+    final RID[] rids = createTriangleWithOneEdge();
+    final RID edgeRID = rids[0], nearRID = rids[1], farRID = rids[2];
+
+    moveEdgeIn(edgeRID, farRID);
+
+    final Index index = database.getSchema().getIndexByName("Link[code]");
+    assertThat(index.countEntries()).as("a unique index must not hold two entries for one key").isEqualTo(1L);
+
+    // Deleting the moved edge frees the key for good; re-inserting it must be accepted.
+    database.transaction(() -> lookup(index, "E1").getFirst().asEdge().delete());
+    database.transaction(() -> nearRID.asVertex().newEdge("Link", farRID.asVertex(), "code", "E1").save());
+
+    assertThat(index.countEntries()).isEqualTo(1L);
+    assertIntegrityClean();
+  }
+
+  /**
+   * The same bypass, on the bucket record counter. {@code deleteRecordNoLock} folds a {@code -1} for the record it
+   * removes and the create path folds a {@code +1}, so a move is net zero. Reaching the removal through
+   * {@code deleteEdge} skipped the {@code -1} only, and the counter is what {@code count(*)} reads - and it is
+   * persisted to {@code statistics.json}, so the drift survives a reopen. Asserted against a full scan
+   * ({@code count()}), which is ground truth.
+   */
+  @Test
+  void movingAnEdgeLeavesTheBucketRecordCounterAtTheNumberOfEdgesThatExist() {
+    createSchema(false);
+
+    final RID[] rids = createTriangleWithOneEdge();
+    final RID edgeRID = rids[0], farRID = rids[2];
+
+    moveEdgeIn(edgeRID, farRID);
+
+    assertThat(scalar("select count() as n from Link")).as("ground truth: one edge survives the move").isEqualTo(1L);
+    assertThat(scalar("select count(*) as n from Link"))
+        .as("count(*) reads the cached bucket counter: a move must not inflate it").isEqualTo(1L);
+    assertThat(database.countType("Link", false)).isEqualTo(1L);
+  }
+
+  /**
+   * And on EXTERNAL property values. {@code moveEdge} writes FRESH external records for the replacement, so the
+   * ones owned by the record it deletes have to go with it or they are orphaned in the paired bucket -
+   * {@code deleteRecordNoLock} cascade-deletes them, {@code deleteEdge} does not. {@code CHECK DATABASE} counts
+   * exactly this leak.
+   */
+  @Test
+  void movingAnEdgeCascadeDeletesTheOldRecordsExternalValues() {
+    final VertexType node = database.getSchema().createVertexType("Node", BUCKETS);
+    node.createProperty("name", Type.STRING);
+    database.getSchema().createEdgeType("Link", BUCKETS).createProperty("blob", Type.STRING).setExternal(true);
+
+    final RID[] rids = new RID[3];
+    database.transaction(() -> {
+      final MutableVertex near = database.newVertex("Node").set("name", "near").save();
+      final MutableVertex far0 = database.newVertex("Node").set("name", "far0").save();
+      final MutableVertex far = database.newVertex("Node").set("name", "far").save();
+      rids[0] = near.newEdge("Link", far0, "blob", "x".repeat(4096)).save().getIdentity();
+      rids[1] = near.getIdentity();
+      rids[2] = far.getIdentity();
+    });
+
+    final RID movedRID = moveEdgeIn(rids[0], rids[2]);
+
+    database.transaction(() -> assertThat(movedRID.asEdge().getString("blob"))
+        .as("the replacement must still carry the external value").isEqualTo("x".repeat(4096)));
+
+    assertOrphanedExternalRecords(0L);
+    assertIntegrityClean();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private void createSchema(final boolean unique) {
+    final VertexType node = database.getSchema().createVertexType("Node", BUCKETS);
+    node.createProperty("name", Type.STRING);
+    database.getSchema().createEdgeType("Link", BUCKETS).createProperty("code", Type.STRING);
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, unique, "Link", "code");
+  }
+
+  /**
+   * Three vertices and a single {@code near -> far0} edge carrying the indexed key {@code E1}. Returns
+   * {@code [edge, near, far]}.
+   */
+  private RID[] createTriangleWithOneEdge() {
+    final RID[] rids = new RID[3];
+    database.transaction(() -> {
+      final MutableVertex near = database.newVertex("Node").set("name", "near").save();
+      final MutableVertex far0 = database.newVertex("Node").set("name", "far0").save();
+      final MutableVertex far = database.newVertex("Node").set("name", "far").save();
+      rids[0] = near.newEdge("Link", far0, "code", "E1").save().getIdentity();
+      rids[1] = near.getIdentity();
+      rids[2] = far.getIdentity();
+    });
+    return rids;
+  }
+
+  /**
+   * Re-points the IN endpoint of {@code edgeRID} at {@code newInRID} through the embedded API and returns the RID of
+   * the replacement record.
+   */
+  private RID moveEdgeIn(final RID edgeRID, final RID newInRID) {
+    final RID[] moved = new RID[1];
+    database.transaction(() -> {
+      final MutableEdge edge = edgeRID.asEdge().modify();
+      // set("@in") IS the move: GraphEngine.moveEdge saves the replacement itself and re-points this instance at it,
+      // so there is nothing left to save afterwards.
+      edge.set("@in", newInRID);
+      moved[0] = edge.getIdentity();
+    });
+    return moved[0];
+  }
+
+  private List<RID> lookup(final Index index, final String key) {
+    final List<RID> result = new ArrayList<>();
+    database.transaction(() -> {
+      final IndexCursor cursor = index.get(new Object[] { key });
+      while (cursor.hasNext()) {
+        final var next = cursor.next();
+        if (next != null)
+          result.add(next.getIdentity());
+      }
+    });
+    return result;
+  }
+
+  private long scalar(final String sql) {
+    try (final ResultSet rs = database.query("sql", sql)) {
+      return ((Number) rs.next().getProperty("n")).longValue();
+    }
+  }
+
+  private void assertOrphanedExternalRecords(final long expected) {
+    try (final ResultSet rs = database.command("sql", "check database")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        assertThat(longProperty(row, "orphanedExternalRecords"))
+            .as("check database orphanedExternalRecords: " + row.toJSON()).isEqualTo(expected);
+      }
+    }
+  }
+
+  private void assertIntegrityClean() {
+    try (final ResultSet rs = database.command("sql", "check database")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        assertThat(longProperty(row, "autoFix")).as("check database autoFix: " + row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "totalErrors")).as("check database totalErrors: " + row.toJSON()).isEqualTo(0L);
+      }
+    }
+  }
+
+  private static long longProperty(final Result row, final String name) {
+    final Object value = row.getProperty(name);
+    return value == null ? 0L : ((Number) value).longValue();
+  }
+}


### PR DESCRIPTION
Closes #5779

## Summary

`GraphEngine.moveEdge` re-points an edge by deleting the old edge record and creating a replacement, and it reaches the removal through the **public** `GraphEngine.deleteEdge(Edge)`. That method does the *physical* removal only - it is normally entered from `LocalDatabase.deleteRecordNoLock`, which has already cleaned the record's index entries, cascade-deleted its EXTERNAL property values and folded the `-1` into the bucket record counter by the time the edge arrives. `moveEdge` is the one caller that does not come that way, so none of that happened for the record it deletes. This PR discharges that obligation explicitly in a new private `GraphEngine.cleanUpBeforePhysicalDelete(MutableEdge)`, called just before `deleteEdge(edge)`, which keeps the "physical removal only" contract of the public `deleteEdge(Edge)` intact instead of weakening it for one caller (the approach the issue suggested).

## Why it was not "benign after all"

The issue filed this as latent, on the measurement that the bucket normally hands the just-freed slot straight back to the replacement, so the stale entry lands on a new record carrying the same key and is indistinguishable from a correct one. That coincidence does **not** survive the default schema. `RoundRobinBucketSelectionStrategy` (the default for every type) advances one bucket per create, so on an edge type with more than one bucket the replacement lands in a *different* bucket and the old entry names a RID that is gone. The three failure modes the issue predicted all reproduce on a 4-bucket edge type, and one of them is a hard user-visible failure today:

| Fixture | Before | After |
|---|---|---|
| `NOTUNIQUE` index, one edge moved | `countEntries()` = **2**, `get("E1")` = `[#14:0, #13:0]` | 1 entry, naming the surviving record |
| Freed slot handed to an unrelated edge | lookup of the old key returns **two** records, one of them somebody else's | exactly one, carrying the right key |
| `UNIQUE` index | **`DuplicatedKeyException: Duplicated key [E1] ... already assigned to record #13:0`** - the move is impossible | move succeeds, one entry |

The UNIQUE case means moving an edge (`MutableEdge.set("@in"/"@out")`, i.e. `UPDATE ... SET @in`) has been outright broken on any edge type carrying a unique index on an edge property, not merely fragile.

## The two "check while there" items, both confirmed real

Both were listed as unverified in the issue. Both are fixed here, each with a test proven to fail when only its part of the fix is reverted.

1. **EXTERNAL property values.** `moveEdge` writes fresh external records for the replacement while the old ones survive. `CHECK DATABASE` reports `orphanedExternalRecords: 1` after a single move of an edge with an EXTERNAL property; 0 with the fix.
2. **Bucket record counter.** `deleteRecordNoLock` folds `-1` for the record it removes and the create path folds `+1`, so a move is net zero. Going through `deleteEdge` skipped the `-1` only, so `count(*)` (which reads the cached counter, and which is persisted to `statistics.json`) reported **2** for a type holding **1** edge after one move - and the drift survives a reopen. `count()`, a real scan, correctly said 1.

## The one item deliberately NOT changed

**Delete/create events still do not fire.** The issue noted this is currently a side effect of the route taken rather than a decision; it is now a decision, documented at the site. A move is not a delete, and - decisive - `deleteRecordNoLock` lets a listener *veto* the removal by returning `false` from `onBeforeDelete`. Routing the move through the database would let a veto abort the removal while `moveEdge` went on to create the replacement anyway, turning a move into a silent duplication. That is why `cleanUpBeforePhysicalDelete` mirrors `deleteRecordNoLock`'s bookkeeping rather than calling it.

Lightweight edges are excluded from the whole cleanup: `deleteEdge(Edge)` skips the physical removal for them, so there is no index entry, no external value and no counted record, and folding a `-1` would drift the counter the other way.

The long comment inside `deleteEdge(Edge)` that #5772 added to describe the hazard is rewritten to state the caller precondition and point at where it is now discharged, instead of describing an unfixed leak.

## A third defect, found during review: the index cleanup was reading the wrong image

`DocumentIndexer.deleteDocument` builds the keys it removes from the LIVE property values of the record handed to it, and `moveEdge` is entered from `MutableEdge.set("@in"/"@out")` - so a caller that changes an indexed property in the same session (`edge.set("code","E2"); edge.set("@in", v)`) had it remove a key the index never held, leaving the real entry dangling. The same leak, through a different door. `indexedImageOf(MutableEdge)` now resolves the image the index was actually built from, in the order and for the reason `LocalDatabase.updateRecord` does (#4935):

1. `TransactionContext.getLastIndexedSnapshot(rid)` when an earlier `save()` in this transaction already moved the index forward. Serialization is deferred, so after `set("code","E2"); save(); set("@in", v)` the record's frozen buffer still says `E1` while the index holds `E2` - the buffer is the *wrong* pre-image in that case.
2. otherwise an immutable record over that frozen buffer.
3. otherwise the live instance. Defensive: verified unreachable from `moveEdge` by making the branch throw and watching the class still pass.

## The boundary of the guarantee

An indexed property whose value cannot be **deserialized** (the #4420 shape: a corrupt length prefix) is reported by the reader as ABSENT rather than throwing, so nothing can learn the key the index holds and that entry outlives the record. Measured: `lookup(marker)` returns the deleted RID, and `CHECK DATABASE` does not detect a dangling LSM entry (`totalErrors 0`, `corruptedIndexes []`). Not introduced here and not closable here - `deleteRecordNoLock` degrades identically on the same record, by design. Pinned by a test rather than left implicit.

## Test plan

New: `engine/src/test/java/com/arcadedb/graph/Issue5779MoveEdgeIndexCleanupTest.java` (11 tests). All assertions go through `Index.countEntries()` and a raw `Index.get()` rather than a query, because `SELECT` skips entries whose RID does not resolve - which is exactly what hid this leak.

- [ ] `mvn -pl engine test -Dtest=Issue5779MoveEdgeIndexCleanupTest` - 11/11 green.
- [ ] Every non-trivial branch of the fix was individually reverted to prove the matching test fails **and the others do not**: the index cleanup (3 tests), the external cascade (`movingAnEdgeCascadeDeletesTheOldRecordsExternalValues`), the counter delta (the two counter assertions), the pre-image resolution (`movingAnEdgeThatAlsoChangedItsIndexedPropertyCleansTheKeyTheIndexActuallyHolds`), and the snapshot lookup within it (`movingAnEdgeAfterAnIndexedPropertyWasAlreadySavedInTheSameTransaction`).
- [ ] The fixtures assert the replacement landed in a **different** bucket (`isNotEqualTo(edgeRID)`) before asserting anything else, so a future change to bucket selection cannot silently turn these into no-ops.
- [ ] Coverage: NOTUNIQUE leak, freed-slot reuse by an unrelated edge, UNIQUE duplicate rejection, `@in` and `@out`, indexed property changed during the move, changed and saved before the move, edge created in the same transaction, EXTERNAL cascade, bucket-counter drift, corrupted-buffer boundary, lightweight-edge unreachability.
- [ ] Regression: `mvn -pl engine test -Dtest='com.arcadedb.graph.*Test,com.arcadedb.index.**.*Test,com.arcadedb.database.**.*Test,UpdateEdgeTest,QueryTest'` - 1697 tests, 0 failures, 1 skipped.
- [ ] `CHECK DATABASE` clean (`totalErrors` 0, `autoFix` 0) in every fixture except the corrupted-buffer one, where the leak it cannot see is asserted explicitly.

## Adjacent finding, not fixed here

Calling `edge.save()` after `edge.set("@in", newRID)` throws `IllegalStateException: Cannot read original buffer for record #N:0`. `moveEdge` already saves the replacement and re-identifies the instance onto it via `updateIdentity`, which nulls the buffer, so the subsequent `save()` takes the update path on a record it has no pre-image for. The natural embedded-API call sequence is therefore broken. Out of scope for the index leak; worth its own issue.
