### PR TITLE
fix(#5758): seed the Cypher chain count push-down from a correlated body's bound anchor

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CypherReferencedVariables.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CypherReferencedVariables.java
@@ -33,10 +33,16 @@ import java.util.Set;
  * The question is asked by {@code CypherExecutionPlan} when a statement runs from a <b>seed row</b> - the body of a
  * {@code CALL { }} clause, or of an {@code EXISTS}/{@code COUNT}/{@code COLLECT} expression, handed the outer row as
  * its first input. The two count push-downs there answer from the schema and the CSR arrays and never look at the
- * incoming rows, so a body that reads one of the seeded names must not be answered by them: a body counting
- * {@code MATCH (n)-[:KNOWS]->(m)} with {@code n} already bound to one vertex would be given the count over every
- * {@code n} in the graph. A body that reads none of them keeps the fast path, because ignoring a row it never looks
- * at cannot change its answer (issue #5686).
+ * incoming rows, so a body that reads one of the seeded names must not be answered by their <b>enumerating</b> form:
+ * a body counting {@code MATCH (n)-[:KNOWS]->(m)} with {@code n} already bound to one vertex would be given the count
+ * over every {@code n} in the graph. A body that reads none of them keeps the fast path, because ignoring a row it
+ * never looks at cannot change its answer (issue #5686).
+ * <p>
+ * Which is why the names are returned rather than only a yes/no: a body that reads a seeded name at a position the
+ * chain operator can start its walk from keeps the push-down in its <b>seeded</b> form, walking from the bound RID
+ * instead of from a label's bucket set (issue #5758). Naming one variable too many still only costs the caller its
+ * optimization there - the position is looked for among the pattern's own variables, and a name that is not one of
+ * them anchors nothing.
  * <p>
  * <b>The two ways of being wrong are not equal.</b> Naming one variable too many costs a slower count. Missing one
  * gives a silently wrong count, which is the failure #5674 removed. So every shape this class does not model answers

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -21,6 +21,8 @@ package com.arcadedb.query.opencypher.executor;
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.graph.Vertex;
@@ -415,7 +417,8 @@ public class CypherExecutionPlan {
     final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
     final AbstractExecutionStep rootStep;
     if (clausesInOrder != null && !clausesInOrder.isEmpty())
-      rootStep = buildExecutionStepsWithOrder(context, clausesInOrder, seedStep, seedIsRead(seedRow), seedRow.getPropertyNames());
+      rootStep = buildExecutionStepsWithOrder(context, clausesInOrder, seedStep, seedCorrelationOf(seedRow),
+          seedRow.getPropertyNames());
     else
       rootStep = seedStep; // Fallback: just return the seed
 
@@ -469,7 +472,9 @@ public class CypherExecutionPlan {
       return null;
     if (statement.getSkip() != null || statement.getLimit() != null)
       return null;
-    if (seedIsRead(seedRow))
+
+    final SeedCorrelation correlation = seedCorrelationOf(seedRow);
+    if (!correlation.isSeedable())
       return null;
 
     // The outer statistics accumulator is deliberately not shared, for the reason executeWithSeedRow shares it only
@@ -481,7 +486,7 @@ public class CypherExecutionPlan {
     context.setInputParameters(parameters);
     setupFunctionResolver(context);
 
-    final AbstractExecutionStep countStep = tryCountPushDown(context, true);
+    final AbstractExecutionStep countStep = tryCountPushDown(context, true, correlation);
     if (countStep == null)
       return null;
 
@@ -494,17 +499,21 @@ public class CypherExecutionPlan {
   }
 
   /**
-   * Whether this statement could read anything the seed row carries, i.e. whether it is correlated to the enclosing
-   * query at all.
+   * <b>Which</b> of the names the seed row carries this statement could read, and the row that bound them - what the
+   * count push-downs need in order to decide whether the correlation is one they can start from.
    * <p>
    * The question is asked because of the two count push-downs in {@link #buildExecutionStepsWithOrder}: they answer
    * from the schema and the CSR arrays and never look at the incoming rows, so they are only valid for a body that
-   * does not read one. Asking whether the seed row <b>carries</b> a variable, rather than whether the body
-   * <b>reads</b> one, was correct but coarse - an uncorrelated body written inside a correlated query lost an O(1)
-   * count for a name it never mentions, once per outer row (issue #5686).
+   * does not read one, <i>or</i> for one whose every read name is a position the operator can seed itself from.
+   * Asking whether the seed row <b>carries</b> a variable, rather than whether the body <b>reads</b> one, was correct
+   * but coarse - an uncorrelated body written inside a correlated query lost an O(1) count for a name it never
+   * mentions, once per outer row (issue #5686). Asking only <i>whether</i> a name is read, rather than <i>which</i>,
+   * was the next step of the same coarseness: a genuinely correlated body lost the count too, where a bound anchor
+   * makes it an O(degree) read of the adjacency arrays rather than a scan (issue #5758).
    * <p>
-   * {@link CypherReferencedVariables} is deliberately unsure by default, so a shape it does not model answers "read"
-   * and the push-down is skipped exactly as before.
+   * {@link CypherReferencedVariables} is deliberately unsure by default, and an incomplete answer is reported here as
+   * {@link SeedCorrelation#isSeedable()} {@code == false}: no push-down at all, exactly as before. Only a complete
+   * answer can name the positions to seed, and naming them wrongly is what would give a wrong count.
    * <p>
    * The {@code statement} read here is <b>this plan's own</b>, and this plan is only ever built around the body -
    * {@link #executeWithSeedRow} is what a {@code CALL { }} clause and the three subquery expressions call, each on a
@@ -512,14 +521,79 @@ public class CypherExecutionPlan {
    * names of whoever produced it, which every seeded row would match: the question has to be put to the statement
    * that is about to ignore the seed.
    */
-  private boolean seedIsRead(final Result seedRow) {
-    final Set<String> seedNames = seedRow.getPropertyNames();
-    // referencesAny() answers this case too. Answering it here is what keeps a body seeded with nothing - the common
-    // one, a CALL { } importing nothing - from forcing the collection over the statement at all.
-    if (seedNames.isEmpty())
-      return false;
+  private SeedCorrelation seedCorrelationOf(final Result seedRow) {
+    if (seedRow == null)
+      return SeedCorrelation.UNCORRELATED;
 
-    return statement.getReferencedVariables().referencesAny(seedNames);
+    final Set<String> seedNames = seedRow.getPropertyNames();
+    // Answering this case here is what keeps a body seeded with nothing - the common one, a CALL { } importing
+    // nothing - from forcing the collection over the statement at all.
+    if (seedNames.isEmpty())
+      return SeedCorrelation.UNCORRELATED;
+
+    final CypherReferencedVariables referenced = statement.getReferencedVariables();
+    if (!referenced.isComplete())
+      return SeedCorrelation.UNKNOWN;
+
+    // Built without a mutable set for the shape that is almost always the whole of it - one seeded name read - since
+    // this runs once per outer row, including for the correlations that end up refused.
+    Set<String> readNames = null;
+    for (final String seedName : seedNames) {
+      if (!referenced.getNames().contains(seedName))
+        continue;
+      if (readNames == null)
+        readNames = Set.of(seedName);
+      else {
+        final Set<String> more = new HashSet<>(readNames);
+        more.add(seedName);
+        readNames = more;
+      }
+    }
+
+    return readNames == null ? SeedCorrelation.UNCORRELATED : new SeedCorrelation(seedRow, readNames);
+  }
+
+  /**
+   * How a seeded body relates to the row it was handed: not correlated at all, correlated through named positions a
+   * push-down may be able to seed itself from, or correlated in a way that cannot be described.
+   * <p>
+   * The three are kept apart rather than folded into a boolean because they lead to three different plans.
+   * {@link #UNCORRELATED} keeps every push-down, {@link #UNKNOWN} keeps none, and a named correlation keeps only the
+   * ones that can start from a bound anchor.
+   */
+  private static final class SeedCorrelation {
+    /** The body reads none of the seeded names, so the seed cannot change its answer (issue #5686). */
+    static final SeedCorrelation UNCORRELATED = new SeedCorrelation(null, Set.of());
+    /** The body's shape is one {@link CypherReferencedVariables} does not model, so what it reads is not known. */
+    static final SeedCorrelation UNKNOWN      = new SeedCorrelation(null, null);
+
+    private final Result      seedRow;
+    private final Set<String> readNames;
+
+    private SeedCorrelation(final Result seedRow, final Set<String> readNames) {
+      this.seedRow = seedRow;
+      this.readNames = readNames;
+    }
+
+    /** Whether a push-down may be built at all: false only for a correlation that could not be described. */
+    boolean isSeedable() {
+      return readNames != null;
+    }
+
+    /** Whether the body reads any seeded name. An unknown correlation answers yes, as the coarse guard did. */
+    boolean isCorrelated() {
+      return readNames == null || !readNames.isEmpty();
+    }
+
+    /** The seeded names the body reads. Empty when uncorrelated; never asked when unknown. */
+    Set<String> readNames() {
+      return readNames;
+    }
+
+    /** The value the outer row bound {@code name} to. */
+    Object boundValue(final String name) {
+      return seedRow.getProperty(name);
+    }
   }
 
   private static String buildResultKey(final Result result) {
@@ -1036,7 +1110,7 @@ public class CypherExecutionPlan {
    */
   private AbstractExecutionStep buildExecutionStepsWithOrder(final CommandContext context,
       final List<ClauseEntry> clausesInOrder) {
-    return buildExecutionStepsWithOrder(context, clausesInOrder, null, false, Set.of());
+    return buildExecutionStepsWithOrder(context, clausesInOrder, null, SeedCorrelation.UNCORRELATED, Set.of());
   }
 
   /**
@@ -1044,10 +1118,10 @@ public class CypherExecutionPlan {
    * When initialStep is provided (e.g., for CALL subqueries), it serves as the starting point
    * of the step chain, providing input rows to the first clause.
    *
-   * @param seedIsRead         whether this body reads anything the seed row carries, i.e. whether it is correlated
-   *                           to the enclosing query at all. A body that reads none of the seeded names is answered
-   *                           the same way with the seed as without it, which is what lets the count push-downs
-   *                           below still apply.
+   * @param correlation        which of the seeded names this body reads, and the row that bound them. A body that
+   *                           reads none of them is answered the same way with the seed as without it; a body that
+   *                           reads one at a position an operator can start its walk from is answered from that one
+   *                           anchor. Both are what let the count push-downs below still apply.
    * @param seedVariableNames  the seed row's own variable names, empty when there is no seed. Pre-populates
    *                           {@code boundVariables} the way an explicit leading {@code WITH} would: without it, a
    *                           body's first clause has no way to tell that one of its own pattern variables (a
@@ -1057,7 +1131,7 @@ public class CypherExecutionPlan {
    */
   private AbstractExecutionStep buildExecutionStepsWithOrder(final CommandContext context,
       final List<ClauseEntry> clausesInOrder,
-      final AbstractExecutionStep initialStep, final boolean seedIsRead, final Set<String> seedVariableNames) {
+      final AbstractExecutionStep initialStep, final SeedCorrelation correlation, final Set<String> seedVariableNames) {
     AbstractExecutionStep currentStep = initialStep;
 
     // Get function factory from evaluator for steps that need it
@@ -1069,21 +1143,24 @@ public class CypherExecutionPlan {
     final Set<String> boundVariables = new HashSet<>(seedVariableNames);
 
     // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
-    // never look at the incoming rows. That makes them wrong the moment the seed row binds one of those pattern
-    // variables - a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound to one vertex would be
-    // answered with the count over every `n` in the graph. So neither is attempted then; the ordinary pipeline, which
-    // consumes the seed, is used instead.
+    // never look at the incoming rows. That makes the enumerating form of them wrong the moment the seed row binds
+    // one of those pattern variables - a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound to one
+    // vertex would be answered with the count over every `n` in the graph.
     //
-    // A body that READS none of the seeded names is a different case and keeps the push-downs: an uncorrelated body -
-    // `MATCH (n:P) RETURN COLLECT { MATCH (m:Big) RETURN count(m) }`, or a `CALL { }` that imports nothing - has
-    // taken no name from the enclosing query, so ignoring the seed cannot change its answer and a large type keeps
-    // its O(1) count. What is read is decided by CypherReferencedVariables, which answers "read" for every shape it
-    // does not model, so being unsure costs the optimization rather than the correctness (issue #5686).
-    if (initialStep == null || !seedIsRead) {
+    // A body that READS none of the seeded names keeps them as they are: an uncorrelated body - `MATCH (n:P) RETURN
+    // COLLECT { MATCH (m:Big) RETURN count(m) }`, or a `CALL { }` that imports nothing - has taken no name from the
+    // enclosing query, so ignoring the seed cannot change its answer and a large type keeps its O(1) count (#5686).
+    //
+    // A body that reads one keeps the chain push-down in its SEEDED form: the walk starts from the RID the outer row
+    // bound rather than from a label's bucket set, which is the same question asked of one anchor instead of all of
+    // them, and an O(degree) read rather than a scan (#5758). Which names are read is decided by
+    // CypherReferencedVariables, which answers "unknown" for every shape it does not model, and an unknown
+    // correlation takes no push-down at all - being unsure costs the optimization rather than the correctness.
+    if (correlation.isSeedable()) {
       // OPTIMIZATION: the O(1) Type.count() push-down and the CSR one for chain/star/triangle/pair-join patterns.
       // Instead of materializing all paths (O(paths) memory), counts are propagated through the CSR arrays
       // level-by-level (O(nodes) memory). Critical for large-fanout chains.
-      final AbstractExecutionStep countStep = tryCountPushDown(context, false);
+      final AbstractExecutionStep countStep = tryCountPushDown(context, false, correlation);
       if (countStep != null)
         return countStep;
     }
@@ -4201,9 +4278,24 @@ public class CypherExecutionPlan {
    *                      {@link #countPushDownAlias}.
    */
   private AbstractExecutionStep tryCountPushDown(final CommandContext context, final boolean countRowsMode) {
-    AbstractExecutionStep step = tryCreateTypeCountOptimization(context, countRowsMode);
+    return tryCountPushDown(context, countRowsMode, SeedCorrelation.UNCORRELATED);
+  }
+
+  /**
+   * @param correlation which of the names the seed row carries this body reads, and the row that bound them. Only the
+   *                    chain operator can seed itself from a bound anchor, so a correlated body reaches that one
+   *                    alone; an uncorrelated one reaches every detector, as before.
+   */
+  private AbstractExecutionStep tryCountPushDown(final CommandContext context, final boolean countRowsMode,
+      final SeedCorrelation correlation) {
+    if (!correlation.isSeedable())
+      return null;
+
+    // The O(1) type counter answers "how many vertices carry this label", which is not a question a bound anchor
+    // narrows: a seeded MATCH (q:Q) is one vertex tested against a label, not a count over the label.
+    AbstractExecutionStep step = correlation.isCorrelated() ? null : tryCreateTypeCountOptimization(context, countRowsMode);
     if (step == null)
-      step = tryOptimizeCountStar(context, countRowsMode);
+      step = tryOptimizeCountStar(context, countRowsMode, correlation);
     if (step == null)
       return null;
     return applySkipAndLimit(step, context);
@@ -4277,8 +4369,13 @@ public class CypherExecutionPlan {
    * count item. {@code RETURN *} and a projection of several non-aggregating items are both accepted here, and both
    * are outside what {@code CypherUncorrelatedSubqueryCountPushDownIssue5686Test} asserts
    * {@link CypherReferencedVariables} models - that tie is about the other entry point and does not carry over to
-   * this one. What makes the widening safe is {@link #seedIsRead}, asked before this: an <b>uncorrelated</b> body's
-   * row count is its match count whatever it projects, because no projection can add or drop a row.
+   * this one. What makes the widening safe is that no projection can add or drop a row, so the row count is the match
+   * count whatever the body names - the seed row included, since a seeded body's projection cannot change how many
+   * matches there are either.
+   * <p>
+   * {@code RETURN *} is the one of these a <b>correlated</b> body never reaches: it makes
+   * {@link CypherReferencedVariables} incomplete, which {@link #seedCorrelationOf} reports as an unknown correlation,
+   * and an unknown correlation takes no push-down at all.
    * <p>
    * An item whose expression is null is read as "does not preserve", so an unmodelled projection costs the
    * optimization rather than the answer.
@@ -4300,7 +4397,8 @@ public class CypherExecutionPlan {
   /**
    * Unified entry point: tries all count-push-down patterns and wraps the result in a CSRCountStep.
    */
-  private AbstractExecutionStep tryOptimizeCountStar(final CommandContext context, final boolean countRowsMode) {
+  private AbstractExecutionStep tryOptimizeCountStar(final CommandContext context, final boolean countRowsMode,
+      final SeedCorrelation correlation) {
     final String alias = countPushDownAlias(countRowsMode);
     if (alias == null || !isMatchReturnOnlyStatement())
       return null;
@@ -4312,15 +4410,19 @@ public class CypherExecutionPlan {
     if (hasInlineNodePropertyOrDynamicLabel())
       return null;
 
-    CountOp op = tryDetectChainCountStar();
-    if (op == null)
+    CountOp op = tryDetectChainCountStar(context.getDatabase(), correlation);
+    // Only the chain operator can start its walk from an anchor the outer row bound. The star, triangle, pair-join
+    // and anti-join ones all derive their anchor set from a label, so a correlated body is left to the ordinary
+    // pipeline rather than answered over every vertex carrying that label (issue #5758).
+    if (op == null && !correlation.isCorrelated()) {
       op = tryDetectAntiJoinChainCountStar();
-    if (op == null)
-      op = tryDetectStarCountStar();
-    if (op == null)
-      op = tryDetectTriangleCountStar();
-    if (op == null)
-      op = tryDetectPairJoinCountStar();
+      if (op == null)
+        op = tryDetectStarCountStar();
+      if (op == null)
+        op = tryDetectTriangleCountStar();
+      if (op == null)
+        op = tryDetectPairJoinCountStar();
+    }
     if (op == null)
       return null;
 
@@ -4451,7 +4553,7 @@ public class CypherExecutionPlan {
     return false;
   }
 
-  private CountOp tryDetectChainCountStar() {
+  private CountOp tryDetectChainCountStar(final Database db, final SeedCorrelation correlation) {
     // Exactly one MATCH clause
     if (statement.getMatchClauses() == null || statement.getMatchClauses().size() != 1)
       return null;
@@ -4542,7 +4644,109 @@ public class CypherExecutionPlan {
         return null;
     }
 
-    return new PropagateChainOp(nodeLabels, edgeTypes, directions, inequalityIdxA, inequalityIdxB);
+    if (!correlation.isCorrelated())
+      return new PropagateChainOp(nodeLabels, edgeTypes, directions, inequalityIdxA, inequalityIdxB);
+
+    return seededChainOp(db, correlation, pathPattern, nodeLabels, edgeTypes, directions, inequalityVar1 != null);
+  }
+
+  /**
+   * The same chain walked from the vertex the outer row bound, or null when the correlation is not one anchor at one
+   * end of the chain.
+   * <p>
+   * The enumerating operator seeds its propagation from a label's bucket set, which is why a body reading a seeded
+   * name had to lose the push-down: {@code MATCH (q)-[:LINKS]->(x:Q) RETURN count(*)} with {@code q} bound would have
+   * been answered with the count over every {@code q} in the graph. A bound anchor does not make that count expensive
+   * though, it makes it cheaper - an O(degree) read of the adjacency arrays - so the guard narrows from "the body
+   * reads a seeded name" to "the body reads a seeded name at a position this operator cannot seed from" (issue
+   * #5758).
+   * <p>
+   * What it can seed from is <b>one</b> name, bound to <b>one</b> vertex, at <b>one</b> end of the chain:
+   * <ul>
+   * <li>Two seeded names are two anchor sets, and the propagation carries one.</li>
+   * <li>A name written at two positions - {@code (q)-[:LINKS]->(q)} - is an equality between the two ends that the
+   * propagation does not enforce; it would count every path, not the returning ones.</li>
+   * <li>A name in the middle of the chain would have to be walked outwards in both directions at once.</li>
+   * <li>A name read somewhere other than a node position - only in the projection, say - names no position at all,
+   * so {@code anchorIdx} stays -1 and the same test refuses it.</li>
+   * <li>An inequality is refused outright: its two positions are indexes into the chain, and the reversal below
+   * would have to renumber them for a case worth no complication.</li>
+   * </ul>
+   * The far end is reached by reversing the chain rather than by a second walk: {@code (a)-[:E]->(b)} counted from
+   * {@code b} is {@code (b)<-[:E]-(a)}, which is the same arrays read the other way. That is what keeps
+   * {@code COUNT { (:Person)-[:KNOWS]->(p) }} - "how many know me" - on the fast path alongside its mirror.
+   */
+  private CountOp seededChainOp(final Database db, final SeedCorrelation correlation, final PathPattern pathPattern,
+      final String[] nodeLabels, final String[] edgeTypes, final Vertex.DIRECTION[] directions,
+      final boolean hasInequality) {
+    if (!correlation.isSeedable() || hasInequality || correlation.readNames().size() != 1)
+      return null;
+
+    final String seededName = correlation.readNames().iterator().next();
+    final int hopCount = edgeTypes.length;
+
+    int anchorIdx = -1;
+    for (int i = 0; i <= hopCount; i++)
+      if (seededName.equals(pathPattern.getNode(i).getVariable())) {
+        if (anchorIdx >= 0)
+          return null;
+        anchorIdx = i;
+      }
+
+    if (anchorIdx != 0 && anchorIdx != hopCount)
+      return null;
+
+    final RID anchorRid = boundVertexRid(db, correlation.boundValue(seededName));
+    if (anchorRid == null)
+      return null;
+
+    if (anchorIdx == 0)
+      return new PropagateChainOp(nodeLabels, edgeTypes, directions, -1, -1, anchorRid);
+
+    return new PropagateChainOp(reversed(nodeLabels), reversed(edgeTypes), reversedDirections(directions), -1, -1,
+        anchorRid);
+  }
+
+  /**
+   * The RID of a bound value that is a vertex, or null for anything else.
+   * <p>
+   * A node pattern matches only vertices, so a name bound to a scalar, to a document or to an edge matches nothing.
+   * Rather than teach the operator to answer 0 for those, they are left to the ordinary pipeline, which is the only
+   * thing here that knows what each of them means - and which is what answered them before this existed.
+   */
+  private static RID boundVertexRid(final Database db, final Object value) {
+    Object bound = value;
+    if (bound instanceof Result result)
+      bound = result.getElement().orElse(null);
+    if (!(bound instanceof Identifiable identifiable))
+      return null;
+
+    final RID rid = identifiable.getIdentity();
+    if (rid == null)
+      return null;
+    return db.getSchema().getTypeByBucketId(rid.getBucketId()) instanceof VertexType ? rid : null;
+  }
+
+  private static String[] reversed(final String[] values) {
+    final String[] out = new String[values.length];
+    for (int i = 0; i < values.length; i++)
+      out[i] = values[values.length - 1 - i];
+    return out;
+  }
+
+  /** Reverses the hop order and flips each direction, so the chain reads identically from its far end. */
+  private static Vertex.DIRECTION[] reversedDirections(final Vertex.DIRECTION[] directions) {
+    final Vertex.DIRECTION[] out = new Vertex.DIRECTION[directions.length];
+    for (int i = 0; i < directions.length; i++) {
+      final Vertex.DIRECTION direction = directions[directions.length - 1 - i];
+      if (direction == Vertex.DIRECTION.OUT)
+        out[i] = Vertex.DIRECTION.IN;
+      else if (direction == Vertex.DIRECTION.IN)
+        out[i] = Vertex.DIRECTION.OUT;
+      else
+        out[i] = Vertex.DIRECTION.BOTH;
+    }
+    return out;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -4675,6 +4675,13 @@ public class CypherExecutionPlan {
    * The far end is reached by reversing the chain rather than by a second walk: {@code (a)-[:E]->(b)} counted from
    * {@code b} is {@code (b)<-[:E]-(a)}, which is the same arrays read the other way. That is what keeps
    * {@code COUNT { (:Person)-[:KNOWS]->(p) }} - "how many know me" - on the fast path alongside its mirror.
+   * <p>
+   * <b>The bound value is always the outer one.</b> The whole thing rests on the seeded name still meaning what the
+   * outer row bound, and what could break that is a body rebinding the name for itself. It cannot: the only clauses
+   * that bind a name to something other than a pattern position are {@code UNWIND} and {@code WITH}, and
+   * {@link #isMatchReturnOnlyStatement()} - asked by {@link #tryOptimizeCountStar} before any detector runs - admits
+   * nothing but {@code MATCH} and {@code RETURN}. A body's own {@code MATCH (q:Q)} written under an outer {@code q}
+   * is not a rebinding but the correlation itself, which is exactly what this seeds from.
    */
   private CountOp seededChainOp(final Database db, final SeedCorrelation correlation, final PathPattern pathPattern,
       final String[] nodeLabels, final String[] edgeTypes, final Vertex.DIRECTION[] directions,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOp.java
@@ -39,20 +39,34 @@ import java.util.function.Consumer;
  * using two {@code long[]} arrays indexed by dense node IDs.
  */
 public final class PropagateChainOp implements CountOp {
-  private final String[] nodeLabels;
-  private final String[] edgeTypes;
+  private final String[]           nodeLabels;
+  private final String[]           edgeTypes;
   private final Vertex.DIRECTION[] directions;
-  private final int inequalityIdxA;
-  private final int inequalityIdxB;
+  private final int                inequalityIdxA;
+  private final int                inequalityIdxB;
+  private final RID                anchorRid;
 
   public PropagateChainOp(final String[] nodeLabels, final String[] edgeTypes,
       final Vertex.DIRECTION[] directions,
       final int inequalityIdxA, final int inequalityIdxB) {
+    this(nodeLabels, edgeTypes, directions, inequalityIdxA, inequalityIdxB, null);
+  }
+
+  /**
+   * @param anchorRid the one vertex position 0 is already bound to, or null when position 0 is a label whose buckets
+   *                  are enumerated. A seeded anchor is what keeps the push-down for a <b>correlated</b> body: the
+   *                  outer row bound the start of the chain, so the same propagation runs from that single node
+   *                  instead of from every vertex carrying a label (issue #5758).
+   */
+  public PropagateChainOp(final String[] nodeLabels, final String[] edgeTypes,
+      final Vertex.DIRECTION[] directions,
+      final int inequalityIdxA, final int inequalityIdxB, final RID anchorRid) {
     this.nodeLabels = nodeLabels;
     this.edgeTypes = edgeTypes;
     this.directions = directions;
     this.inequalityIdxA = inequalityIdxA;
     this.inequalityIdxB = inequalityIdxB;
+    this.anchorRid = anchorRid;
   }
 
   @Override
@@ -60,14 +74,20 @@ public final class PropagateChainOp implements CountOp {
     return edgeTypes;
   }
 
-  /** The chain is walked from position 0, whose label is the only anchor set this operator knows how to build. */
+  /**
+   * The chain is walked from position 0, whose label is the only anchor set this operator knows how to build - unless
+   * the outer row already bound that position, which is an anchor set of exactly one and needs no label at all.
+   */
   @Override
   public boolean canEnumerateAnchors() {
-    return nodeLabels[0] != null;
+    return anchorRid != null || nodeLabels[0] != null;
   }
 
   @Override
   public long execute(final GraphTraversalProvider provider, final Database db) {
+    if (anchorRid != null)
+      return executeFromSeededAnchor(provider, db);
+
     final int nodeCount = provider.getNodeCount();
     final int hops = edgeTypes.length;
 
@@ -117,6 +137,68 @@ public final class PropagateChainOp implements CountOp {
       total -= countSelfLoopPaths(provider, db, validBuckets);
 
     return total;
+  }
+
+  /**
+   * The chain walked from the one vertex the outer row bound to position 0.
+   * <p>
+   * Nothing here is sized by the graph: the dense {@code long[nodeCount]} arrays of the enumerating path would be
+   * allocated once per outer row, which is the cost this push-down exists to avoid. The walk is a sparse frontier
+   * instead - one entry per partial path - and the <b>last</b> hop is never expanded at all, only counted, so a
+   * one-hop body costs a degree read of the anchor's adjacency and allocates nothing per neighbour.
+   * <p>
+   * A label written on the seeded position filters the bound vertex rather than naming a set to enumerate:
+   * {@code COUNT { (n:Q)-[:LINKS]->(:Q) }} under an {@code n} of another label is 0, not the count over {@code Q}.
+   */
+  private long executeFromSeededAnchor(final GraphTraversalProvider provider, final Database db) {
+    final int hops = edgeTypes.length;
+    final IntHashSet[] validBuckets = new IntHashSet[hops + 1];
+    for (int i = 0; i <= hops; i++)
+      validBuckets[i] = CSRCountUtils.buildValidBuckets(db, nodeLabels[i]);
+
+    if (!bucketMatches(validBuckets[0], anchorRid.getBucketId()))
+      return 0;
+
+    final int anchorId = provider.getNodeId(anchorRid);
+    if (anchorId < 0)
+      return 0;
+
+    int[] frontier = new int[] { anchorId };
+    for (int h = 0; h < hops - 1; h++) {
+      frontier = expandFrontier(provider, frontier, provider.getNeighborView(directions[h], edgeTypes[h]), h,
+          validBuckets[h + 1]);
+      if (frontier.length == 0)
+        return 0;
+    }
+
+    final int lastHop = hops - 1;
+    final IntHashSet targetBuckets = validBuckets[hops];
+    long total = 0;
+    if (targetBuckets == null || targetBuckets.isEmpty()) {
+      for (final int node : frontier)
+        total += provider.countEdges(node, directions[lastHop], edgeTypes[lastHop]);
+      return total;
+    }
+
+    final NeighborView lastView = provider.getNeighborView(directions[lastHop], edgeTypes[lastHop]);
+    if (lastView != null) {
+      final int[] nbrs = lastView.neighbors();
+      for (final int node : frontier)
+        for (int j = lastView.offset(node), end = lastView.offsetEnd(node); j < end; j++)
+          if (targetBuckets.contains(provider.getRID(nbrs[j]).getBucketId()))
+            total++;
+    } else {
+      for (final int node : frontier)
+        for (final int neighbor : provider.getNeighborIds(node, directions[lastHop], edgeTypes[lastHop]))
+          if (targetBuckets.contains(provider.getRID(neighbor).getBucketId()))
+            total++;
+    }
+    return total;
+  }
+
+  /** Whether a bucket passes a position's label filter, where a null or empty set means "no label was written". */
+  private static boolean bucketMatches(final IntHashSet validBuckets, final int bucketId) {
+    return validBuckets == null || validBuckets.isEmpty() || validBuckets.contains(bucketId);
   }
 
   /**
@@ -553,17 +635,24 @@ public final class PropagateChainOp implements CountOp {
     // Try to find a GAV provider for accelerated neighbor lookups even in the OLTP path
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db, edgeTypes);
 
-    final String anchorLabel = nodeLabels[0];
-    if (anchorLabel == null || !db.getSchema().existsType(anchorLabel))
-      return 0;
-
     // BFS count propagation: each unique vertex at each level is processed once,
     // with its count capturing path multiplicity. This reduces O(paths) traversals
     // to O(unique edges), which is dramatically faster for high-fanout chains.
     // E.g., Q5 with 13.8M paths but only ~3.5M unique edges: ~4x fewer OLTP scans.
     RidLongHashMap current = new RidLongHashMap();
-    for (final Iterator<? extends Identifiable> it = db.iterateType(anchorLabel, true); it.hasNext(); )
-      current.put(it.next().getIdentity(), 1L);
+    if (anchorRid != null) {
+      // A seeded anchor is an anchor set of one, and its label - if the body wrote one - filters it (issue #5758).
+      if (!bucketMatches(CSRCountUtils.buildValidBuckets(db, nodeLabels[0]), anchorRid.getBucketId()))
+        return 0;
+      current.put(anchorRid, 1L);
+    } else {
+      final String anchorLabel = nodeLabels[0];
+      if (anchorLabel == null || !db.getSchema().existsType(anchorLabel))
+        return 0;
+
+      for (final Iterator<? extends Identifiable> it = db.iterateType(anchorLabel, true); it.hasNext(); )
+        current.put(it.next().getIdentity(), 1L);
+    }
 
     for (int hop = 0; hop < edgeTypes.length; hop++) {
       final String targetLabel = nodeLabels[hop + 1];
@@ -700,6 +789,10 @@ public final class PropagateChainOp implements CountOp {
     sb.append("  ".repeat(Math.max(0, depth * indent)));
     sb.append("+ COUNT CHAIN PATHS (CSR count-push-down)\n");
     sb.append("  ".repeat(Math.max(0, depth * indent)));
+    if (anchorRid != null) {
+      sb.append("  seeded anchor: ").append(anchorRid).append('\n');
+      sb.append("  ".repeat(Math.max(0, depth * indent)));
+    }
     sb.append("  chain: ");
     for (int i = 0; i < edgeTypes.length; i++) {
       if (i > 0)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOp.java
@@ -25,6 +25,7 @@ import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.NeighborView;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.DocumentType;
 
 import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.RidLongHashMap;
@@ -151,13 +152,14 @@ public final class PropagateChainOp implements CountOp {
    * {@code COUNT { (n:Q)-[:LINKS]->(:Q) }} under an {@code n} of another label is 0, not the count over {@code Q}.
    */
   private long executeFromSeededAnchor(final GraphTraversalProvider provider, final Database db) {
-    final int hops = edgeTypes.length;
-    final IntHashSet[] validBuckets = new IntHashSet[hops + 1];
-    for (int i = 0; i <= hops; i++)
-      validBuckets[i] = CSRCountUtils.buildValidBuckets(db, nodeLabels[i]);
-
-    if (!bucketMatches(validBuckets[0], anchorRid.getBucketId()))
+    if (!anchorMatchesLabel(db, nodeLabels[0], anchorRid.getBucketId()))
       return 0;
+
+    final int hops = edgeTypes.length;
+    // Position 0 is one known bucket, tested above without building a set for it: this runs once per outer row.
+    final IntHashSet[] validBuckets = new IntHashSet[hops + 1];
+    for (int i = 1; i <= hops; i++)
+      validBuckets[i] = CSRCountUtils.buildValidBuckets(db, nodeLabels[i]);
 
     final int anchorId = provider.getNodeId(anchorRid);
     if (anchorId < 0)
@@ -196,9 +198,21 @@ public final class PropagateChainOp implements CountOp {
     return total;
   }
 
-  /** Whether a bucket passes a position's label filter, where a null or empty set means "no label was written". */
-  private static boolean bucketMatches(final IntHashSet validBuckets, final int bucketId) {
-    return validBuckets == null || validBuckets.isEmpty() || validBuckets.contains(bucketId);
+  /**
+   * Whether the one bucket a seeded anchor lives in passes the label written on its position.
+   * <p>
+   * The same question {@link CSRCountUtils#buildValidBuckets} answers for a whole level, and read the same way - a
+   * null or undeclared label builds no filter there, so it filters nothing here either - but asked of a single known
+   * bucket, so it walks the supertype chain instead of allocating a bucket set. That matters because a seeded
+   * operator is built and run once per outer row, where the enumerating one is built once per query.
+   */
+  private static boolean anchorMatchesLabel(final Database db, final String label, final int bucketId) {
+    if (label == null || !db.getSchema().existsType(label))
+      return true;
+
+    // A bucket belongs to exactly one type, so "in this label's polymorphic buckets" is "of this label or below it".
+    final DocumentType type = db.getSchema().getTypeByBucketId(bucketId);
+    return type != null && type.instanceOf(label);
   }
 
   /**
@@ -642,7 +656,7 @@ public final class PropagateChainOp implements CountOp {
     RidLongHashMap current = new RidLongHashMap();
     if (anchorRid != null) {
       // A seeded anchor is an anchor set of one, and its label - if the body wrote one - filters it (issue #5758).
-      if (!bucketMatches(CSRCountUtils.buildValidBuckets(db, nodeLabels[0]), anchorRid.getBucketId()))
+      if (!anchorMatchesLabel(db, nodeLabels[0], anchorRid.getBucketId()))
         return 0;
       current.put(anchorRid, 1L);
     } else {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCorrelatedCountPushDownIssue5758Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCorrelatedCountPushDownIssue5758Test.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5758: a <b>correlated</b> {@code COUNT { }} / {@code COLLECT { }} body lost both count
+ * push-downs and materialized one row per edge per outer row, where the bound anchor makes the same count an
+ * O(degree) read of the adjacency arrays.
+ * <p>
+ * #5686 restored the push-downs for a body that reads none of the seeded names, and #5737 extended that to
+ * {@code COUNT { }} bodies. Neither helped the ordinary shape - "each person and how many people they know" - because
+ * a body reading the seeded name was refused wholesale. What that guard is really protecting against is a body that
+ * reads a seeded name at a position the operator cannot start from: seeding the chain from the bound RID instead of
+ * from a label's bucket set answers exactly the same question, and answers it from one anchor rather than from every
+ * vertex carrying the label.
+ * <p>
+ * The plan choice is measured rather than timed, the way {@code CypherCountPushDownPreconditionsIssue5715Test} and
+ * {@code CypherUncorrelatedSubqueryCountPushDownIssue5686Test} measure it: a {@code readRecord} delta from
+ * {@code database.getStats()}. The ordinary pipeline reads one record per matched row, a seeded push-down reads the
+ * anchor's adjacency and nothing else, so the delta separates the two plans without a wall clock.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherCorrelatedCountPushDownIssue5758Test extends TestHelper {
+  /** Wide enough that "one read per matched row" and "one read per anchor" cannot be confused. */
+  private static final int FANOUT = 200;
+
+  @Override
+  protected void beginTest() {
+    // One hub with FANOUT outgoing edges, and one sink with FANOUT incoming ones: the two ends of a chain.
+    database.command("opencypher", "CREATE (:Hub {k: 1})");
+    database.command("opencypher", "MATCH (h:Hub) UNWIND range(1, " + FANOUT + ") AS i CREATE (h)-[:LINKS]->(:Leaf {k: i})");
+    database.command("opencypher", "CREATE (:Sink {k: 1})");
+    database.command("opencypher", "MATCH (s:Sink) UNWIND range(1, " + FANOUT + ") AS i CREATE (:Src {k: i})-[:PTS]->(s)");
+    // A second hop of a different type, so a two-hop chain can be pushed down: the chain detector refuses a repeated
+    // edge type without an inequality, so `-[:LINKS]->()-[:LINKS]->()` would never reach the seeded walk.
+    database.command("opencypher", "MATCH (l:Leaf), (s:Sink) WHERE l.k <= 3 CREATE (l)-[:TAGS]->(s)");
+
+    // A tiny chain for the correctness cases, kept apart from the wide fixture so the counts are readable.
+    database.command("opencypher", "CREATE (q1:Q {k: 1})-[:LINKS]->(q2:Q {k: 2})-[:LINKS]->(q3:Q {k: 3})");
+    // A vertex of another label, to check that a label written on the seeded anchor still filters.
+    database.command("opencypher", "CREATE (:Other {k: 1})");
+  }
+
+  // ===================================================================================================
+  // 1. the gap this closes: a correlated body keeps the push-down, seeded from the bound anchor
+  // ===================================================================================================
+
+  /**
+   * The issue's headline query. {@code COUNT { }} over a body whose only correlation is the anchor of the chain now
+   * costs the anchor's adjacency instead of one record per edge.
+   */
+  @Test
+  void aCountBodyAnchoredOnTheSeededVariableIsPushedDown() {
+    final String pushedDown = "MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Leaf) } AS c";
+    // The same count over the same edges, made unpushable by a predicate the operators cannot honor. It is the
+    // control for what the ordinary pipeline costs on this fixture.
+    final String ordinary = "MATCH (h:Hub) RETURN COUNT { MATCH (h)-[:LINKS]->(x:Leaf) WHERE x.k > 0 } AS c";
+
+    assertThat(countsOf(pushedDown)).containsExactly((long) FANOUT);
+    assertThat(countsOf(ordinary)).containsExactly((long) FANOUT);
+
+    final long ordinaryReads = recordsReadBy(ordinary);
+    assertThat(ordinaryReads).as("the control has to actually materialize the rows").isGreaterThanOrEqualTo(FANOUT);
+    assertThat(recordsReadBy(pushedDown)).as(pushedDown).isLessThan(ordinaryReads / 10);
+  }
+
+  /** The same gap through {@code COLLECT { }}, where the body spells the count out itself. */
+  @Test
+  void aCollectBodyAnchoredOnTheSeededVariableIsPushedDown() {
+    final String pushedDown = "MATCH (h:Hub) RETURN COLLECT { MATCH (h)-[:LINKS]->(x:Leaf) RETURN count(*) } AS c";
+    final String ordinary = "MATCH (h:Hub) RETURN COLLECT { MATCH (h)-[:LINKS]->(x:Leaf) WHERE x.k > 0 RETURN count(*) } AS c";
+
+    assertThat(collectOfLongs(pushedDown)).containsExactly((long) FANOUT);
+    assertThat(collectOfLongs(ordinary)).containsExactly((long) FANOUT);
+
+    final long ordinaryReads = recordsReadBy(ordinary);
+    assertThat(ordinaryReads).as("the control has to actually materialize the rows").isGreaterThanOrEqualTo(FANOUT);
+    assertThat(recordsReadBy(pushedDown)).as(pushedDown).isLessThan(ordinaryReads / 10);
+  }
+
+  /** And through a scoped {@code CALL (v) { }}, the third door onto the same plan. */
+  @Test
+  void aScopedCallBodyAnchoredOnTheImportedVariableIsPushedDown() {
+    final String pushedDown = "MATCH (h:Hub) CALL (h) { MATCH (h)-[:LINKS]->(x:Leaf) RETURN count(*) AS c } RETURN c";
+    final String ordinary =
+        "MATCH (h:Hub) CALL (h) { MATCH (h)-[:LINKS]->(x:Leaf) WHERE x.k > 0 RETURN count(*) AS c } RETURN c";
+
+    assertThat(countsOf(pushedDown)).containsExactly((long) FANOUT);
+    assertThat(countsOf(ordinary)).containsExactly((long) FANOUT);
+
+    final long ordinaryReads = recordsReadBy(ordinary);
+    assertThat(ordinaryReads).as("the control has to actually materialize the rows").isGreaterThanOrEqualTo(FANOUT);
+    assertThat(recordsReadBy(pushedDown)).as(pushedDown).isLessThan(ordinaryReads / 10);
+  }
+
+  /**
+   * The anchor does not have to be written first. {@code COUNT { (:Src)-[:PTS]->(s) }} - "how many point at me" - is
+   * the same chain walked the other way, and the seeded end is the one the walk starts from.
+   */
+  @Test
+  void aBodyWhoseSeededVariableIsTheChainsFarEndIsPushedDown() {
+    final String pushedDown = "MATCH (s:Sink) RETURN COUNT { (:Src)-[:PTS]->(s) } AS c";
+    final String ordinary = "MATCH (s:Sink) RETURN COUNT { MATCH (x:Src)-[:PTS]->(s) WHERE x.k > 0 } AS c";
+
+    assertThat(countsOf(pushedDown)).containsExactly((long) FANOUT);
+    assertThat(countsOf(ordinary)).containsExactly((long) FANOUT);
+
+    final long ordinaryReads = recordsReadBy(ordinary);
+    assertThat(ordinaryReads).as("the control has to actually materialize the rows").isGreaterThanOrEqualTo(FANOUT);
+    assertThat(recordsReadBy(pushedDown)).as(pushedDown).isLessThan(ordinaryReads / 10);
+  }
+
+  // ===================================================================================================
+  // 2. the answers, which are the whole point of not answering from the global count
+  // ===================================================================================================
+
+  /** A seeded anchor counts that anchor's paths, never the graph's. Both spellings, one and two hops. */
+  @Test
+  void aSeededChainCountsOnlyThePathsOutOfTheBoundAnchor() {
+    assertThat(collectOfLongs("MATCH (q:Q {k: 1}) RETURN COLLECT { MATCH (q)-[:LINKS]->(x:Q) RETURN count(*) } AS c"))
+        .containsExactly(1L);
+    assertThat(collectOfLongs("MATCH (q:Q {k: 2}) RETURN COLLECT { MATCH (q)-[:LINKS]->(x:Q) RETURN count(*) } AS c"))
+        .containsExactly(1L);
+    assertThat(collectOfLongs("MATCH (q:Q {k: 3}) RETURN COLLECT { MATCH (q)-[:LINKS]->(x:Q) RETURN count(*) } AS c"))
+        .containsExactly(0L);
+
+    // Every Q at once, so a plan answering from the global count would give 2 to each of the three rows.
+    assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (q)-[:LINKS]->(:Q) } AS c ORDER BY c"))
+        .containsExactly(0L, 1L, 1L);
+    assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (q)-[:LINKS]->(:Q)-[:LINKS]->(:Q) } AS c ORDER BY c"))
+        .containsExactly(0L, 0L, 1L);
+    assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (:Q)-[:LINKS]->(q) } AS c ORDER BY c"))
+        .containsExactly(0L, 1L, 1L);
+  }
+
+  /**
+   * A label written on the seeded anchor is a filter on the bound vertex, not a set to enumerate: the same body under
+   * an anchor of another label has to answer 0 rather than the count over the label it names.
+   */
+  @Test
+  void aLabelOnTheSeededAnchorFiltersTheBoundVertex() {
+    assertThat(countsOf("MATCH (n:Other) RETURN COUNT { (n:Q)-[:LINKS]->(:Q) } AS c")).containsExactly(0L);
+    assertThat(countsOf("MATCH (n:Q {k: 1}) RETURN COUNT { (n:Q)-[:LINKS]->(:Q) } AS c")).containsExactly(1L);
+    assertThat(countsOf("MATCH (n:Q {k: 1}) RETURN COUNT { (n:NoSuchLabel)-[:LINKS]->(:Q) } AS c")).containsExactly(0L);
+  }
+
+  /**
+   * Two hops from a seeded anchor, walked forwards and backwards. Only the last hop of a seeded walk is counted
+   * rather than expanded, so a two-hop chain is the shortest one that exercises the frontier in between.
+   * <p>
+   * The saving asserted here is only "no worse than the pipeline it replaced". Without a CSR provider the walk
+   * expands its intermediate frontier by reading records, exactly as the pipeline would; what it saves there is the
+   * materialization, not the reads. The read gap of the one-hop cases above reappears at two hops on the CSR arrays,
+   * where the frontier costs no record read at all - which is what the {@code GraphAnalyticalView} section covers.
+   */
+  @Test
+  void aTwoHopSeededChainIsCountedFromBothEnds() {
+    final String forwards = "MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Leaf)-[:TAGS]->(:Sink) } AS c";
+    final String backwards = "MATCH (s:Sink) RETURN COUNT { (:Hub)-[:LINKS]->(:Leaf)-[:TAGS]->(s) } AS c";
+    final String ordinary = "MATCH (h:Hub) RETURN COUNT { MATCH (h)-[:LINKS]->(x:Leaf)-[:TAGS]->(:Sink) "
+        + "WHERE x.k > 0 } AS c";
+
+    assertThat(countsOf(forwards)).containsExactly(3L);
+    assertThat(countsOf(backwards)).containsExactly(3L);
+    assertThat(countsOf(ordinary)).containsExactly(3L);
+
+    // A middle hop that matches nothing still collapses the whole chain.
+    assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Q)-[:TAGS]->(:Sink) } AS c")).containsExactly(0L);
+
+    final long ordinaryReads = recordsReadBy(ordinary);
+    assertThat(ordinaryReads).as("the control has to actually materialize the rows").isGreaterThanOrEqualTo(FANOUT);
+    assertThat(recordsReadBy(forwards)).as(forwards).isLessThanOrEqualTo(ordinaryReads);
+  }
+
+  /** A label on the far end still filters, and an absent one still matches nothing. */
+  @Test
+  void aLabelOnTheFarEndOfASeededChainStillFilters() {
+    assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Leaf) } AS c")).containsExactly((long) FANOUT);
+    assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Q) } AS c")).containsExactly(0L);
+    assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:NoSuchLabel) } AS c")).containsExactly(0L);
+    assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:NOSUCHTYPE]->(:Leaf) } AS c")).containsExactly(0L);
+  }
+
+  /** An undirected hop out of a seeded anchor counts both ways, as the ordinary pipeline does. */
+  @Test
+  void anUndirectedSeededHopCountsBothDirections() {
+    assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (q)-[:LINKS]-(:Q) } AS c ORDER BY c"))
+        .containsExactly(1L, 1L, 2L);
+  }
+
+  // ===================================================================================================
+  // 3. what stays on the ordinary pipeline, because the anchor set is not one the operator can seed
+  // ===================================================================================================
+
+  /**
+   * The seeded name has to be at one end of the chain and at one position only. A body binding it at both ends is a
+   * self-loop constraint the propagation does not enforce, and one binding it in the middle has two anchor sets.
+   */
+  @Test
+  void aSeededNameThatIsNotASingleEndOfTheChainIsNotPushedDown() {
+    // Both ends: only the self-loop paths match, and there are none.
+    assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (q)-[:LINKS]->(q) } AS c ORDER BY c"))
+        .containsExactly(0L, 0L, 0L);
+    // The middle of a two-hop chain.
+    assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (:Q)-[:LINKS]->(q)-[:LINKS]->(:Q) } AS c ORDER BY c"))
+        .containsExactly(0L, 0L, 1L);
+  }
+
+  /** Two seeded names read by one body leave two anchors to start from, so the body keeps the ordinary pipeline. */
+  @Test
+  void aBodyReadingTwoSeededNamesIsNotPushedDown() {
+    assertThat(countsOf("MATCH (a:Q {k: 1}), (b:Q {k: 2}) RETURN COUNT { (a)-[:LINKS]->(b) } AS c"))
+        .containsExactly(1L);
+    assertThat(countsOf("MATCH (a:Q {k: 1}), (b:Q {k: 3}) RETURN COUNT { (a)-[:LINKS]->(b) } AS c"))
+        .containsExactly(0L);
+  }
+
+  /** A seeded name read only outside the pattern names no anchor position, so nothing is seeded from it. */
+  @Test
+  void aSeededNameReadOnlyOutsideThePatternIsNotPushedDown() {
+    assertThat(collectOfLongs("MATCH (q:Q {k: 1}) RETURN COLLECT { MATCH (x:Q)-[:LINKS]->(y:Q) WHERE x.k = q.k "
+        + "RETURN count(*) } AS c")).containsExactly(1L);
+  }
+
+  /** A bound value that is not a vertex matches no node pattern, whichever plan answers it. */
+  @Test
+  void aSeededNameBoundToANonVertexMatchesNothing() {
+    assertThat(countsOf("UNWIND [1, 2] AS p RETURN COUNT { (p)-[:LINKS]->(:Q) } AS c"))
+        .containsExactly(0L, 0L);
+  }
+
+  /**
+   * The guard #5674 put there in the first place, restated for the shape that still needs it: an uncorrelated body
+   * under a correlated query is answered by the global count, a correlated one never is.
+   */
+  @Test
+  void anUncorrelatedBodyIsStillAnsweredByTheGlobalCount() {
+    assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (:Q)-[:LINKS]->(:Q) } AS c"))
+        .containsExactly(2L, 2L, 2L);
+    assertThat(collectOfLongs("MATCH (q:Q) RETURN COLLECT { MATCH (a:Q)-[:LINKS]->(b:Q) RETURN count(*) } AS c"))
+        .containsExactly(2L, 2L, 2L);
+  }
+
+  /** The type-count push-down is not seedable, and a body correlated through it still answers per anchor. */
+  @Test
+  void aSeededSingleNodeBodyIsNotAnsweredByTheTypeCounter() {
+    assertThat(collectOfLongs("MATCH (q:Q {k: 1}) RETURN COLLECT { MATCH (q:Q) RETURN count(q) } AS c"))
+        .containsExactly(1L);
+    assertThat(countsOf("MATCH (q:Q {k: 1}) RETURN COUNT { MATCH (q:Q) } AS c")).containsExactly(1L);
+    assertThat(countsOf("MATCH (n:Other) RETURN COUNT { MATCH (n:Q) } AS c")).containsExactly(0L);
+  }
+
+  // ===================================================================================================
+  // 4. the same answers off the CSR arrays, which is the branch the fast path is for
+  // ===================================================================================================
+
+  /**
+   * {@code CSRCountStep} picks {@code execute} over {@code executeOLTP} on whether a provider covers the edge types,
+   * and a plain unit-test database has none - so every case above runs the OLTP walk and the seeded CSR walk would go
+   * untested. A {@link GraphAnalyticalView} over the fixture supplies one, and the answers have to be the same ones.
+   */
+  @Test
+  void theSeededChainAnswersTheSameOffTheCsrArrays() {
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("issue5758-view")
+        .withVertexTypes("Hub", "Leaf", "Sink", "Src", "Q", "Other")
+        .withEdgeTypes("LINKS", "PTS", "TAGS")
+        .build();
+    try {
+      // The condition CSRCountStep itself branches on: without this the assertions below would re-test the OLTP walk.
+      assertThat(GraphTraversalProviderRegistry.findProvider(database, "LINKS"))
+          .as("the view has to be the provider the count step finds").isNotNull();
+      assertThat(GraphTraversalProviderRegistry.findProvider(database, "PTS")).isNotNull();
+
+      assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Leaf) } AS c")).containsExactly((long) FANOUT);
+      // No label on the far end: the hop is counted by degree rather than filtered neighbour by neighbour.
+      assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->() } AS c")).containsExactly((long) FANOUT);
+      assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Q) } AS c")).containsExactly(0L);
+      assertThat(countsOf("MATCH (s:Sink) RETURN COUNT { (:Src)-[:PTS]->(s) } AS c")).containsExactly((long) FANOUT);
+
+      assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (q)-[:LINKS]->(:Q) } AS c ORDER BY c"))
+          .containsExactly(0L, 1L, 1L);
+      assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (q)-[:LINKS]->(:Q)-[:LINKS]->(:Q) } AS c ORDER BY c"))
+          .containsExactly(0L, 0L, 1L);
+      assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (:Q)-[:LINKS]->(q) } AS c ORDER BY c"))
+          .containsExactly(0L, 1L, 1L);
+      assertThat(countsOf("MATCH (q:Q) RETURN COUNT { (q)-[:LINKS]-(:Q) } AS c ORDER BY c"))
+          .containsExactly(1L, 1L, 2L);
+
+      assertThat(countsOf("MATCH (n:Other) RETURN COUNT { (n:Q)-[:LINKS]->(:Q) } AS c")).containsExactly(0L);
+      assertThat(collectOfLongs("MATCH (h:Hub) RETURN COLLECT { MATCH (h)-[:LINKS]->(x:Leaf) RETURN count(*) } AS c"))
+          .containsExactly((long) FANOUT);
+
+      // Two hops, which is where the seeded walk expands a frontier rather than counting a degree.
+      assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Leaf)-[:TAGS]->(:Sink) } AS c"))
+          .containsExactly(3L);
+      assertThat(countsOf("MATCH (s:Sink) RETURN COUNT { (:Hub)-[:LINKS]->(:Leaf)-[:TAGS]->(s) } AS c"))
+          .containsExactly(3L);
+      assertThat(countsOf("MATCH (h:Hub) RETURN COUNT { (h)-[:LINKS]->(:Q)-[:TAGS]->(:Sink) } AS c"))
+          .containsExactly(0L);
+    } finally {
+      view.drop();
+    }
+  }
+
+  // ===================================================================================================
+  // helpers
+  // ===================================================================================================
+
+  /** The {@code c} column of every row, as longs. */
+  private List<Long> countsOf(final String query) {
+    final List<Long> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        values.add(((Number) rs.next().getProperty("c")).longValue());
+    }
+    return values;
+  }
+
+  /** Every element of every {@code c} list, as longs. */
+  private List<Long> collectOfLongs(final String query) {
+    final List<Long> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        for (final Object value : (List<Object>) row.getProperty("c"))
+          values.add(((Number) value).longValue());
+      }
+    }
+    return values;
+  }
+
+  /** The records the query materialized: the anchor's adjacency alone when a seeded push-down answered it. */
+  private long recordsReadBy(final String query) {
+    final long before = readRecords();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next().getPropertyNames();
+    }
+    return readRecords() - before;
+  }
+
+  private long readRecords() {
+    return ((Number) database.getStats().get("readRecord")).longValue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCorrelatedCountPushDownIssue5758Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCorrelatedCountPushDownIssue5758Test.java
@@ -251,6 +251,22 @@ class CypherCorrelatedCountPushDownIssue5758Test extends TestHelper {
         + "RETURN count(*) } AS c")).containsExactly(1L);
   }
 
+  /**
+   * A seeded push-down reads the value the <b>outer</b> row bound, so a body able to bind names for itself would
+   * break it. None can reach it: the detectors are only asked about a body made of nothing but {@code MATCH} and
+   * {@code RETURN}, which leaves out the two clauses that bind - {@code UNWIND} and {@code WITH}.
+   * <p>
+   * The {@code UNWIND} below is what makes this an assertion rather than a restatement: it multiplies the body's rows
+   * by two, so a plan that answered from the chain alone would say 1 where the pipeline says 2.
+   */
+  @Test
+  void aBodyThatCouldBindNamesOfItsOwnNeverReachesTheSeededPushDown() {
+    assertThat(countsOf("MATCH (q:Q {k: 1}) RETURN COUNT { UNWIND [1, 2] AS z MATCH (q)-[:LINKS]->(x:Q) RETURN x } AS c"))
+        .containsExactly(2L);
+    assertThat(countsOf("MATCH (q:Q {k: 1}) RETURN COUNT { MATCH (q)-[:LINKS]->(x:Q) WITH x AS y RETURN y } AS c"))
+        .containsExactly(1L);
+  }
+
   /** A bound value that is not a vertex matches no node pattern, whichever plan answers it. */
   @Test
   void aSeededNameBoundToANonVertexMatchesNothing() {


### PR DESCRIPTION
Closes #5758

## The gap

Both Cypher count push-downs were all-or-nothing about correlation. #5686 restored them for an *uncorrelated* body written under a correlated query and #5737 extended that to `COUNT { }` bodies, but a genuinely *correlated* body still fell back to materialization - including the most ordinary graph query there is:

```cypher
MATCH (p:Person) RETURN p.name, COUNT { (p)-[:KNOWS]->(:Person) } AS friends
MATCH (q:Q {k: 1}) RETURN COLLECT { MATCH (q)-[:LINKS]->(x:Q) RETURN count(*) } AS c
```

Both materialized one row per edge per outer row to count them.

The guard was correct: the operators answer from the schema and the CSR arrays and never look at the incoming rows, so answering `MATCH (q)-[:LINKS]->(x:Q) RETURN count(*)` with `q` already bound would return the count over *every* `q` in the graph. But a bound anchor does not make that count expensive - it makes it cheaper. It is an O(degree) read of the adjacency arrays, not a scan.

## The change

The guard narrows from "the body reads a seeded name" to "the body reads a seeded name at a position the operator cannot seed from".

**1. `CypherReferencedVariables` is consulted for *which* names, not just *whether*.** `CypherExecutionPlan.seedIsRead(Result)` becomes `seedCorrelationOf(Result)`, returning a small `SeedCorrelation` with three states rather than a boolean:

| state | meaning | push-downs kept |
|---|---|---|
| `UNCORRELATED` | the body reads none of the seeded names | all of them (unchanged, #5686) |
| named correlation | the body reads these seeded names, bound by this row | the chain one, in its seeded form |
| `UNKNOWN` | `CypherReferencedVariables` is incomplete for this shape | none (unchanged) |

An incomplete collection can no longer be read as "correlated but describable" - it takes no push-down at all, so being unsure still costs the optimization rather than the correctness.

**2. `PropagateChainOp` gained a seeded anchor.** With an `anchorRid` it walks from that one vertex instead of seeding the propagation from position 0's bucket set. Both backends were taught it:

- **CSR** (`executeFromSeededAnchor`): nothing is sized by the graph. The dense `long[nodeCount]` arrays of the enumerating path would be allocated once per outer row, which is the cost this exists to avoid, so the walk is a sparse `int[]` frontier and the **last hop is never expanded, only counted** (`countEdges`, or a filtered neighbour count when the far position carries a label). A one-hop body is a degree read that allocates nothing per neighbour.
- **OLTP** (`executeOLTP`): the `iterateType` seeding of the `RidLongHashMap` is replaced by the single anchor; the rest of the BFS is unchanged.

`canEnumerateAnchors()` now also passes for an unlabelled position 0 when it is seeded - a bound anchor *is* an anchor set, of exactly one, which is precisely what #5715 found missing for the unlabelled case.

**3. The far end is reached by reversing the chain.** `COUNT { (:Person)-[:KNOWS]->(p) }` - "how many know me" - is the same arrays read the other way, so when the seeded name sits at the last position the label/type/direction arrays are reversed (and each direction flipped) and the same seeded walk runs. No second code path.

## What stays on the ordinary pipeline

The seeded operator can start from **one** name, bound to **one** vertex, at **one** end of the chain. Everything else is refused and answered exactly as before:

- two seeded names read by one body (`COUNT { (a)-[:LINKS]->(b) }`) - two anchor sets, the propagation carries one;
- a name at two positions (`COUNT { (q)-[:LINKS]->(q) }`) - an equality between the ends that the propagation does not enforce;
- a name in the middle of a chain - it would have to be walked outwards both ways at once;
- a name read only outside the pattern (in the projection, say) - it names no position, so nothing is seeded;
- a body carrying an inequality (`WHERE a <> b`) - its two operands are chain indexes that the reversal would have to renumber;
- a value bound to something that is not a vertex - a node pattern matches no scalar, document or edge, and the pipeline is the only thing here that knows what each of those means;
- the star, triangle, pair-join and anti-join operators - all of them derive their anchor set from a label, so a correlated body never reaches them;
- the O(1) `Type.count()` push-down - "how many vertices carry this label" is not a question a bound anchor narrows, so a seeded `MATCH (q:Q)` stays on the pipeline (`RETURN COLLECT { MATCH (q:Q) RETURN count(q) }` still answers 1, not the type count).

A label written on the seeded position filters the bound vertex rather than naming a set to enumerate: `COUNT { (n:Q)-[:LINKS]->(:Q) }` under an `n` of another label is 0.

## Test plan

New: `engine/src/test/java/com/arcadedb/query/opencypher/CypherCorrelatedCountPushDownIssue5758Test` (16 tests). The plan choice is measured, not timed, the way #5715 and #5686 measure it: a `readRecord` delta from `database.getStats()`, against a control that is the *same count over the same edges* made unpushable by a predicate the operators cannot honor.

- [x] the four doors onto the seeded plan - `COUNT { }`, `COLLECT { }`, scoped `CALL (v) { }`, and the reversed `COUNT { (:Src)-[:PTS]->(s) }` - each read less than a tenth of what their control reads over a 200-edge fanout (before the fix: identical plans, ~406 reads each)
- [x] answers per anchor rather than per graph, at one and two hops, forwards and backwards, directed and undirected
- [x] a label on the seeded anchor filters the bound vertex; a label on the far end filters the neighbours; an absent label or edge type is 0
- [x] every refusal listed above is asserted to give the pipeline's answer
- [x] the same answers off the CSR arrays: a `GraphAnalyticalView` is registered so `CSRCountStep` picks `execute` over `executeOLTP`, with `GraphTraversalProviderRegistry.findProvider(...)` asserted non-null first - a plain unit-test database has no provider, so without this the seeded CSR walk would never run
- [x] both new branches proven reachable by a temporary canary throw: the CSR walk fires only in the view test, the OLTP one in 8 others, and the multi-hop frontier expansion fires in the two-hop CSR case
- [x] `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**'` - 8124 tests, 0 failures
- [x] openCypher TCK (`-Dsurefire.includes='**/*Suite.java'`) - 3897 tests, 0 failures
- [x] full `arcadedb-engine` unit lane (`-DexcludedGroups=slow,benchmark,vector`)

## Notes for follow-up

- #5757 proposes letting these operators anchor on *no* label by enumerating every vertex. This lands the other half of the same question - where the anchor set comes from - as a constructor argument on `PropagateChainOp` rather than as an abstraction, so #5757 is the natural place to introduce the anchor-set type both can plug into.
- A seeded name in the **middle** of a chain is still refused. It is answerable by walking the two halves outward and multiplying, but that is a different operator shape.
- Multi-hop seeded chains gain nothing in reads on the OLTP path: the intermediate frontier costs one record read per node either way. The saving there is the materialization, not the reads; the read gap is a CSR property, and the test asserts each accordingly.
