### PR TITLE
fix(engine) #5757: the Cypher count push-downs anchor on an unlabelled node, and buildValidBuckets stops overloading null

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -458,3 +458,35 @@ failure mode is safe to ignore (the socket is already broken/closed) - the new `
 documents the same reasoning.
 
 [#5978](https://github.com/ArcadeData/arcadedb/issues/5978)
+
+## The Cypher count push-downs can anchor on an unlabelled node (#5757)
+
+`MATCH ()-[:TYPE]->() RETURN count(*)` - "how many edges of this type are there" - is the cheapest question
+there is to ask a graph, and it was the one shape the CSR count push-downs could not serve. Every operator
+walks out from one position of the pattern and enumerates the vertices that position accepts, which it built
+from the position's label; an unlabelled anchor left it with no set, which each operator read as an empty one
+and answered **0**. Issue #5715 closed that wrong answer by declining to build the operator at all, so the
+answer became right and the fast path went away.
+
+The two chain operators now read an absent anchor label for what it means - **every vertex** - on both paths:
+the CSR one seeds the whole node domain, and the OLTP one iterates every vertex type in the schema. That
+covers the plain chain, the chain with a `<>` inequality (whose self-loop subtraction anchors the same way),
+and the anti-join chain. The pair-join and degree-product operators still decline an unlabelled anchor, since
+they key a hash join and a degree product on the label itself, and the ordinary pipeline answers those.
+
+**The root cause is separated at the source.** `CSRCountUtils.buildValidBuckets` returned `null` both for "no
+label was given, so do not filter" and for "the label is declared on nothing, so nothing matches", and its
+callers disagreed about which one they held - that single overload produced *both* wrong answers found in
+#5715, one from each end of it. `null` now means only "no filter", an **empty** set means "matches nothing",
+and every consumer branches on `null` alone so an empty set falls through to a membership test that keeps
+nothing.
+
+**A view over some of the vertex types is no longer used where it cannot answer.** "Every vertex" is a claim
+about the graph rather than about a `GraphAnalyticalView`, so an operator anchored on it runs against the OLTP
+path unless the view's node domain is every vertex. The same reasoning applies to the per-vertex accelerator
+these OLTP paths consult: a view holding a subset of the vertex types answers for the vertices it maps with
+the adjacency it holds, which is missing every edge that leaves the view, and the fallback for an unmapped
+vertex does not cover it. Those lookups now go through `CSRCountUtils.findAcceleratingProvider`, which
+declines a partial view.
+
+[#5757](https://github.com/ArcadeData/arcadedb/issues/5757)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/AntiJoinChainOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/AntiJoinChainOp.java
@@ -22,7 +22,6 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.GraphTraversalProvider;
-import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.NeighborView;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.utility.IntHashSet;
@@ -103,10 +102,13 @@ public final class AntiJoinChainOp implements CountOp {
     return types.toArray(new String[0]);
   }
 
-  /** Every path here is enumerated from chain position 0, so an unlabelled first node leaves nothing to start from. */
+  /**
+   * Every path here is enumerated from chain position 0. With no label there the anchors are every vertex, which
+   * only a provider whose node domain <i>is</i> every vertex can enumerate (issue #5757).
+   */
   @Override
-  public boolean canEnumerateAnchors() {
-    return nodeLabels[0] != null;
+  public boolean requiresFullVertexCoverage() {
+    return nodeLabels[0] == null;
   }
 
   @Override
@@ -114,7 +116,7 @@ public final class AntiJoinChainOp implements CountOp {
     final int nodeCount = provider.getNodeCount();
     final int hops = edgeTypes.length;
 
-    // Pre-compute valid bucket sets for type filtering
+    // Pre-compute valid bucket sets for type filtering. null = unlabelled, so no filter.
     final IntHashSet[] validBuckets = new IntHashSet[hops + 1];
     for (int i = 0; i <= hops; i++)
       validBuckets[i] = CSRCountUtils.buildValidBuckets(db, nodeLabels[i]);
@@ -152,9 +154,9 @@ public final class AntiJoinChainOp implements CountOp {
         return result;
     }
 
-    // Per-source iteration from anchor (position 0)
-    final String anchorLabel = nodeLabels[0];
-    if (anchorLabel == null || !db.getSchema().existsType(anchorLabel))
+    // Per-source iteration from anchor (position 0). null accepts every vertex, empty accepts none (issue #5757).
+    final IntHashSet anchorBuckets = validBuckets[0];
+    if (anchorBuckets != null && anchorBuckets.isEmpty())
       return 0;
 
     final boolean anchorIsSource = antiJoinSourceIdx == 0;
@@ -164,18 +166,14 @@ public final class AntiJoinChainOp implements CountOp {
     for (int h = 0; h < laterIdx; h++)
       hopViews[h] = provider.getNeighborView(directions[h], edgeTypes[h]);
 
-    // Pre-compute bucket IDs for CSR-based anchor iteration and frontier filtering
-    final int[] bucketIds = new int[nodeCount];
-    for (int v = 0; v < nodeCount; v++)
-      bucketIds[v] = provider.getRID(v).getBucketId();
-    final IntHashSet anchorBuckets = CSRCountUtils.buildValidBuckets(db, anchorLabel);
-    if (anchorBuckets == null || anchorBuckets.isEmpty())
-      return 0;
+    // Pre-compute bucket IDs for CSR-based anchor iteration and frontier filtering. A pattern that labels no
+    // position needs none of them.
+    final int[] bucketIds = anyLabelled(validBuckets) ? precomputeBucketIds(provider, nodeCount) : null;
 
     long totalCount = 0;
 
     for (int anchorId = 0; anchorId < nodeCount; anchorId++) {
-      if (!anchorBuckets.contains(bucketIds[anchorId]))
+      if (anchorBuckets != null && !anchorBuckets.contains(bucketIds[anchorId]))
         continue;
 
       // Pre-compute anti-join neighbors for Case A (anchor is the anti-join source)
@@ -221,24 +219,19 @@ public final class AntiJoinChainOp implements CountOp {
     final int[] e1Nbrs = viewE1.neighbors();
     final int[] cNbrs = viewC.neighbors();
 
-    // Optional type filtering
-    final int[] bucketIds;
+    // Optional type filtering. null is "no label, so no filter"; an empty set is a label that matches nothing.
     final IntHashSet pos1Buckets = validBuckets[1];
     final IntHashSet pos2Buckets = validBuckets[2];
-    if ((pos1Buckets != null && !pos1Buckets.isEmpty()) || (pos2Buckets != null && !pos2Buckets.isEmpty())) {
-      bucketIds = new int[nodeCount];
-      for (int v = 0; v < nodeCount; v++)
-        bucketIds[v] = provider.getRID(v).getBucketId();
-    } else {
-      bucketIds = null;
-    }
+    if ((pos1Buckets != null && pos1Buckets.isEmpty()) || (pos2Buckets != null && pos2Buckets.isEmpty()))
+      return 0;
+    final int[] bucketIds = (pos1Buckets != null || pos2Buckets != null)
+        ? precomputeBucketIds(provider, nodeCount) : null;
 
     long total = 0;
 
     // Scan all E1 (middle) edges by iterating pos1 nodes
     for (int b = 0; b < nodeCount; b++) {
-      if (pos1Buckets != null && !pos1Buckets.isEmpty()
-          && !pos1Buckets.contains(bucketIds[b]))
+      if (pos1Buckets != null && !pos1Buckets.contains(bucketIds[b]))
         continue;
 
       final int e1Start = viewE1.offset(b);
@@ -255,8 +248,7 @@ public final class AntiJoinChainOp implements CountOp {
       for (int j = e1Start; j < e1End; j++) {
         final int c = e1Nbrs[j];
 
-        if (pos2Buckets != null && !pos2Buckets.isEmpty()
-            && !pos2Buckets.contains(bucketIds[c]))
+        if (pos2Buckets != null && !pos2Buckets.contains(bucketIds[c]))
           continue;
 
         // Get setC = E2 neighbors of c (tags of comment c)
@@ -274,6 +266,22 @@ public final class AntiJoinChainOp implements CountOp {
       }
     }
     return total;
+  }
+
+  /** Whether any position of the chain carries a label, i.e. whether per-node bucket ids are worth computing. */
+  private static boolean anyLabelled(final IntHashSet[] validBuckets) {
+    for (final IntHashSet buckets : validBuckets)
+      if (buckets != null)
+        return true;
+    return false;
+  }
+
+  /** Pre-computes bucket IDs for all CSR nodes. One-time O(nodeCount) cost, amortized across all anchors. */
+  private static int[] precomputeBucketIds(final GraphTraversalProvider provider, final int nodeCount) {
+    final int[] bucketIds = new int[nodeCount];
+    for (int v = 0; v < nodeCount; v++)
+      bucketIds[v] = provider.getRID(v).getBucketId();
+    return bucketIds;
   }
 
   private static long sortedIntersectionCount(final int[] a, int aStart, final int aEnd,
@@ -344,9 +352,10 @@ public final class AntiJoinChainOp implements CountOp {
         }
       }
 
-      // Apply type filter using pre-computed bucket IDs
+      // Apply type filter using pre-computed bucket IDs. An empty set is a label that matches nothing, so it
+      // empties the frontier rather than being read as "no filter" (issue #5757).
       final IntHashSet midBuckets = validBuckets[h + 1];
-      if (midBuckets != null && !midBuckets.isEmpty()) {
+      if (midBuckets != null) {
         int writePos = 0;
         for (int i = 0; i < pos; i++) {
           if (midBuckets.contains(bucketIds[nextFrontier[i]]))
@@ -443,14 +452,12 @@ public final class AntiJoinChainOp implements CountOp {
   @Override
   public long executeOLTP(final Database db) {
     final String anchorLabel = nodeLabels[0];
-    if (anchorLabel == null || !db.getSchema().existsType(anchorLabel))
-      return 0;
-
     final int hops = edgeTypes.length;
     final int checkPos = Math.max(antiJoinSourceIdx, antiJoinTargetIdx);
     final boolean anchorIsSource = antiJoinSourceIdx == 0;
 
-    // Verify all labels up to checkPos are defined (needed for map construction)
+    // Verify all labels up to checkPos are defined (needed for map construction). An unlabelled position - the
+    // anchor's included, since issue #5757 - is walked by the recursive path, which needs no per-label map.
     for (int i = 0; i <= checkPos; i++) {
       if (nodeLabels[i] == null || !db.getSchema().existsType(nodeLabels[i]))
         return executeOLTPRecursive(db);
@@ -458,14 +465,8 @@ public final class AntiJoinChainOp implements CountOp {
 
     // Pre-compute valid bucket IDs for type filtering at each position
     final IntHashSet[] validBuckets = new IntHashSet[hops + 1];
-    for (int i = 0; i <= hops; i++) {
-      if (nodeLabels[i] != null && db.getSchema().existsType(nodeLabels[i])) {
-        final IntHashSet s = new IntHashSet();
-        for (final int bid : db.getSchema().getType(nodeLabels[i]).getBucketIds(true))
-          s.add(bid);
-        validBuckets[i] = s;
-      }
-    }
+    for (int i = 0; i <= hops; i++)
+      validBuckets[i] = CSRCountUtils.buildValidBuckets(db, nodeLabels[i]);
 
     // Phase 1: Build neighbor RID maps for hops 0..checkPos-1.
     // Each map: vertex RID → RID[] of neighbors (filtered by target label buckets).
@@ -577,8 +578,9 @@ public final class AntiJoinChainOp implements CountOp {
     if (sourceLabel == null || !db.getSchema().existsType(sourceLabel))
       return map;
 
-    // Try GAV provider for accelerated neighbor lookups
-    final GraphTraversalProvider gavProvider = GraphTraversalProviderRegistry.findProvider(db, edgeType);
+    // Try GAV provider for accelerated neighbor lookups. One holding a subset of the vertex types is missing every
+    // edge that leaves the view, so it cannot answer for the vertices it does map (issue #5757).
+    final GraphTraversalProvider gavProvider = CSRCountUtils.findAcceleratingProvider(db, edgeType);
 
     for (final Iterator<? extends Identifiable> it = db.iterateType(sourceLabel, true); it.hasNext(); ) {
       final RID vertexRid = it.next().getIdentity();
@@ -617,8 +619,9 @@ public final class AntiJoinChainOp implements CountOp {
     if (sourceLabel == null || !db.getSchema().existsType(sourceLabel))
       return counts;
 
-    // Try GAV provider for accelerated degree counting
-    final GraphTraversalProvider gavProvider = GraphTraversalProviderRegistry.findProvider(db, edgeTypes);
+    // Try GAV provider for accelerated degree counting. See findAcceleratingProvider: a partial view undercounts
+    // the degree of every vertex it does map (issue #5757).
+    final GraphTraversalProvider gavProvider = CSRCountUtils.findAcceleratingProvider(db, edgeTypes);
 
     for (final Iterator<? extends Identifiable> it = db.iterateType(sourceLabel, true); it.hasNext(); ) {
       final RID vertexRid = it.next().getIdentity();
@@ -648,12 +651,9 @@ public final class AntiJoinChainOp implements CountOp {
    * Includes tail count optimization to avoid loading vertices at the last hops.
    */
   private long executeOLTPRecursive(final Database db) {
-    final String anchorLabel = nodeLabels[0];
-    if (anchorLabel == null || !db.getSchema().existsType(anchorLabel))
-      return 0;
-
+    // An unlabelled anchor starts from every vertex in the schema (issue #5757).
     long total = 0;
-    for (final Iterator<? extends Identifiable> it = db.iterateType(anchorLabel, true); it.hasNext(); ) {
+    for (final Iterator<? extends Identifiable> it = CSRCountUtils.iterateAnchors(db, nodeLabels[0]); it.hasNext(); ) {
       final Vertex anchor = it.next().asVertex();
       final Set<RID> antiJoinSet = new HashSet<>();
       for (final RID rid : anchor.getConnectedVertexRIDs(antiJoinDirection, antiJoinEdgeType))
@@ -683,14 +683,7 @@ public final class AntiJoinChainOp implements CountOp {
       return tailCount;
     }
 
-    final String targetLabel = nodeLabels[hopIndex + 1];
-    final IntHashSet targetBuckets;
-    if (targetLabel != null && db.getSchema().existsType(targetLabel)) {
-      targetBuckets = new IntHashSet();
-      for (final int bid : db.getSchema().getType(targetLabel).getBucketIds(true))
-        targetBuckets.add(bid);
-    } else
-      targetBuckets = null;
+    final IntHashSet targetBuckets = CSRCountUtils.buildValidBuckets(db, nodeLabels[hopIndex + 1]);
 
     long count = 0;
     for (final RID neighborRid : vertex.getConnectedVertexRIDs(directions[hopIndex], edgeTypes[hopIndex])) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountStep.java
@@ -51,7 +51,12 @@ public final class CSRCountStep extends AbstractExecutionStep {
     final long begin = context.isProfiling() ? System.nanoTime() : 0;
     try {
       final Database db = context.getDatabase();
-      final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db, op.edgeTypes());
+      GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db, op.edgeTypes());
+
+      // An operator anchored on "every vertex" can only be answered off a provider whose node domain is every
+      // vertex; one built over a subset of the vertex types would count a subset of the graph (issue #5757).
+      if (provider != null && op.requiresFullVertexCoverage() && !provider.coversVertexType(null))
+        provider = null;
 
       final long count;
       if (provider != null)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountUtils.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountUtils.java
@@ -19,13 +19,22 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.NeighborView;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.IntHashSet;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Shared static utilities for CSR count-push-down operators.
@@ -74,11 +83,18 @@ public final class CSRCountUtils {
 
   /**
    * Zeros out entries in counts where the node's bucket ID is not in the valid set.
+   * <p>
+   * A {@code null} set is "no filter" and leaves every count alone; an <b>empty</b> one is "matches nothing" and
+   * zeroes all of them. See {@link #buildValidBuckets}.
    */
   public static void filterByBuckets(final GraphTraversalProvider provider, final long[] counts,
       final IntHashSet validBuckets) {
-    if (validBuckets == null || validBuckets.isEmpty())
+    if (validBuckets == null)
       return;
+    if (validBuckets.isEmpty()) {
+      Arrays.fill(counts, 0L);
+      return;
+    }
     for (int v = 0; v < counts.length; v++) {
       if (counts[v] > 0) {
         final RID rid = provider.getRID(v);
@@ -90,11 +106,18 @@ public final class CSRCountUtils {
 
   /**
    * Zeros out entries using pre-computed bucket IDs (avoids per-node getRID calls).
+   * <p>
+   * {@code bucketIds} is read only when the filter can keep something, so a caller with no label on any position may
+   * pass {@code null} for it.
    */
   public static void filterByBuckets(final int[] bucketIds, final long[] counts,
       final IntHashSet validBuckets) {
-    if (validBuckets == null || validBuckets.isEmpty())
+    if (validBuckets == null)
       return;
+    if (validBuckets.isEmpty()) {
+      Arrays.fill(counts, 0L);
+      return;
+    }
     for (int v = 0; v < counts.length; v++) {
       if (counts[v] > 0 && !validBuckets.contains(bucketIds[v]))
         counts[v] = 0;
@@ -102,17 +125,85 @@ public final class CSRCountUtils {
   }
 
   /**
-   * Pre-computes the set of valid bucket IDs for a vertex type label.
+   * Pre-computes the set of bucket IDs a vertex type label's records live in.
+   * <p>
+   * <b>The two "nothing to filter on" answers are not the same answer</b>, and issue #5757 is that they used to
+   * share one {@code null}:
+   * <ul>
+   *   <li>{@code null} - <b>no label was given</b>, so the position accepts every vertex and nothing is filtered;</li>
+   *   <li>an <b>empty</b> set - a label was given and no record can carry it, so the position accepts nothing.</li>
+   * </ul>
+   * A caller that reads the empty set as "no filter" counts an unfiltered pattern, and one that reads the {@code
+   * null} as "no vertices" answers 0 for a pattern that does match. Both were live wrong answers in issue #5715, from
+   * the two ends of this one overload. Every consumer here now branches on {@code null} alone and lets an empty set
+   * fall through to the membership test, which keeps nothing.
    *
-   * @return bucket ID set, or null if no filtering needed
+   * @return null when no label was given, otherwise the label's bucket ids - empty when it is not a declared type
    */
   public static IntHashSet buildValidBuckets(final Database db, final String label) {
-    if (label == null || !db.getSchema().existsType(label))
+    if (label == null)
       return null;
     final IntHashSet buckets = new IntHashSet();
+    if (!db.getSchema().existsType(label))
+      return buckets;
     for (final var b : db.getSchema().getType(label).getBuckets(true))
       buckets.add(b.getFileId());
     return buckets;
+  }
+
+  /**
+   * The provider the OLTP paths may use to expand one vertex's neighbors, or null when none may be used.
+   * <p>
+   * These paths walk the vertices themselves and consult a provider per vertex, falling back to the edge list for
+   * any vertex the provider does not map. That fallback covers a vertex <b>outside</b> the provider's node domain,
+   * and nothing covers a vertex inside it whose neighbors are outside: {@code getNeighborIds} answers with the
+   * adjacency the view holds, and the edges leading out of the view are simply not in it. A view built over a
+   * subset of the vertex types is therefore not usable as a per-vertex accelerator at all, however well it covers
+   * the edge types, and the count has to come off the edge lists (issue #5757).
+   */
+  public static GraphTraversalProvider findAcceleratingProvider(final Database db, final String... edgeTypes) {
+    final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db, edgeTypes);
+    return provider != null && provider.coversVertexType(null) ? provider : null;
+  }
+
+  /**
+   * The vertices an anchor position starts from: the label's own when one was given, <b>every vertex in the
+   * schema</b> when none was (issue #5757).
+   * <p>
+   * An unlabelled anchor is what {@code MATCH ()-[:TYPE]->() RETURN count(*)} has, and there is no cheaper question
+   * to ask a graph. It used to leave every operator with no set to enumerate; "every vertex" is the set it means.
+   * Subtypes are reached through the labelled iterator's own polymorphism and, in the unlabelled walk, by iterating
+   * each declared vertex type non-polymorphically, so no vertex is visited twice.
+   *
+   * @return an iterator over the anchor vertices, empty when the label is declared on nothing
+   */
+  public static Iterator<? extends Identifiable> iterateAnchors(final Database db, final String label) {
+    if (label != null)
+      return db.getSchema().existsType(label) ? db.iterateType(label, true) : Collections.emptyIterator();
+
+    final List<String> vertexTypes = new ArrayList<>();
+    for (final DocumentType type : db.getSchema().getTypes())
+      if (type instanceof VertexType)
+        vertexTypes.add(type.getName());
+
+    return new Iterator<Identifiable>() {
+      private int                              nextType = 0;
+      private Iterator<? extends Identifiable> current  = Collections.emptyIterator();
+
+      @Override
+      public boolean hasNext() {
+        while (!current.hasNext() && nextType < vertexTypes.size())
+          current = db.iterateType(vertexTypes.get(nextType++), false);
+        return current.hasNext();
+      }
+
+      @Override
+      public Identifiable next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        return current.next();
+      }
+    };
   }
 
   /**
@@ -150,9 +241,9 @@ public final class CSRCountUtils {
         pos += neighbors.length;
       }
 
-      // Apply intermediate node type filter if specified
-      if (intermediateValidBuckets != null && intermediateValidBuckets[hop] != null
-          && !intermediateValidBuckets[hop].isEmpty()) {
+      // Apply intermediate node type filter if specified. An empty set is a label that matches nothing, so it drops
+      // the whole frontier rather than being read as "no filter" (issue #5757).
+      if (intermediateValidBuckets != null && intermediateValidBuckets[hop] != null) {
         int writePos = 0;
         for (int i = 0; i < pos; i++) {
           final RID rid = provider.getRID(next[i]);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountOp.java
@@ -45,17 +45,29 @@ public interface CountOp {
   /**
    * Whether this operator can enumerate the set of vertices it starts from.
    * <p>
-   * Every operator here anchors its walk on one labelled position of the pattern and enumerates that label's
-   * buckets - {@code MATCH (a:Person)-[:KNOWS]->(b)} starts from the {@code Person} vertices. An <b>unlabelled</b>
-   * anchor has no bucket set to enumerate, and each operator reads that missing set as an empty one and answers
-   * <b>0</b>, which for {@code MATCH (a)-[:KNOWS]->(b) RETURN count(*)} is a wrong answer rather than a slow one
-   * (issue #5715).
+   * An operator anchors its walk on one position of the pattern and enumerates the vertices that position accepts -
+   * {@code MATCH (a:Person)-[:KNOWS]->(b)} starts from the {@code Person} vertices. When that position carries no
+   * label the anchors are <b>every vertex</b>, and an operator that read the missing bucket set as an empty one
+   * answered <b>0</b> for a pattern that matches (issue #5715).
    * <p>
-   * An operator that cannot enumerate its anchors is not built at all, and the ordinary materialization pipeline -
-   * which starts from every vertex - answers the query instead.
+   * The two chain operators now enumerate the unlabelled case for what it is (issue #5757) and always answer true
+   * here. The ones that still cannot - they key a hash join or a degree product on the label itself - decline, are
+   * not built at all, and the ordinary materialization pipeline answers the query instead.
    */
   default boolean canEnumerateAnchors() {
     return true;
+  }
+
+  /**
+   * Whether this operator's anchors are <b>every vertex</b> rather than one label's, which makes it answerable off a
+   * {@link GraphTraversalProvider} only when that provider's node domain is every vertex too.
+   * <p>
+   * A view built over a subset of the vertex types is a perfectly good accelerator for a walk anchored on a label it
+   * holds, but "every vertex" is a claim about the graph rather than about the view, and a view holding some of them
+   * cannot make it. Such an operator runs against the OLTP path instead, which reads the schema (issue #5757).
+   */
+  default boolean requiresFullVertexCoverage() {
+    return false;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PairHashJoinOp.java
@@ -96,7 +96,9 @@ public final class PairHashJoinOp implements CountOp {
     final IntHashSet[] arm1Buckets = buildValidBucketSets(db, arm1IntermediateLabels);
     final IntHashSet[] arm2Buckets = buildValidBucketSets(db, arm2IntermediateLabels);
 
-    // Identify build-start nodes via bucket filtering on CSR (avoids OLTP iterateType)
+    // Identify build-start nodes via bucket filtering on CSR (avoids OLTP iterateType). The build start always
+    // carries a label - canEnumerateAnchors() declines the operator otherwise - so a null set cannot arrive here,
+    // and an empty one is a label no record can carry.
     final IntHashSet buildBuckets = CSRCountUtils.buildValidBuckets(db, buildStartLabel);
     if (buildBuckets == null || buildBuckets.isEmpty())
       return 0;
@@ -178,7 +180,7 @@ public final class PairHashJoinOp implements CountOp {
   public long executeOLTP(final Database db) {
     final HashMap<String, Long> pairCounts = new HashMap<>();
 
-    for (final Iterator<? extends Identifiable> it = db.iterateType(buildStartLabel, true); it.hasNext(); ) {
+    for (final Iterator<? extends Identifiable> it = CSRCountUtils.iterateAnchors(db, buildStartLabel); it.hasNext(); ) {
       final Vertex start = it.next().asVertex();
       final List<RID> ep1List = walkArmOLTP(db, start, arm1EdgeTypes, arm1Directions, arm1IntermediateLabels);
       final List<RID> ep2List = walkArmOLTP(db, start, arm2EdgeTypes, arm2Directions, arm2IntermediateLabels);
@@ -207,14 +209,8 @@ public final class PairHashJoinOp implements CountOp {
       final Vertex.DIRECTION[] directions, final String[] intermediateLabels) {
     List<RID> current = List.of(start.getIdentity());
     for (int hop = 0; hop < edgeTypes.length; hop++) {
-      final IntHashSet labelBuckets;
-      final String label = intermediateLabels != null ? intermediateLabels[hop] : null;
-      if (label != null && db.getSchema().existsType(label)) {
-        labelBuckets = new IntHashSet();
-        for (final int bid : db.getSchema().getType(label).getBucketIds(true))
-          labelBuckets.add(bid);
-      } else
-        labelBuckets = null;
+      final IntHashSet labelBuckets = CSRCountUtils.buildValidBuckets(db,
+          intermediateLabels != null ? intermediateLabels[hop] : null);
 
       final List<RID> next = new ArrayList<>();
       for (final RID rid : current) {
@@ -405,9 +401,9 @@ public final class PairHashJoinOp implements CountOp {
         for (int j = view.offset(nid), end = view.offsetEnd(nid); j < end; j++)
           next[pos++] = nbrs[j];
 
-      // Type filter using pre-computed bucketIds
-      if (intermediateBuckets != null && intermediateBuckets[hop] != null
-          && !intermediateBuckets[hop].isEmpty() && bucketIds != null) {
+      // Type filter using pre-computed bucketIds. An empty set is a label that matches nothing, so it empties the
+      // frontier rather than being read as "no filter" (issue #5757).
+      if (intermediateBuckets != null && intermediateBuckets[hop] != null && bucketIds != null) {
         int writePos = 0;
         for (int i = 0; i < pos; i++)
           if (intermediateBuckets[hop].contains(bucketIds[next[i]]))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PropagateChainOp.java
@@ -22,7 +22,6 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.GraphTraversalProvider;
-import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.NeighborView;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.DocumentType;
@@ -76,12 +75,14 @@ public final class PropagateChainOp implements CountOp {
   }
 
   /**
-   * The chain is walked from position 0, whose label is the only anchor set this operator knows how to build - unless
-   * the outer row already bound that position, which is an anchor set of exactly one and needs no label at all.
+   * The chain is walked from position 0. With no label there, the anchors are every vertex, which only a provider
+   * whose node domain <i>is</i> every vertex can enumerate (issue #5757). An unlabelled position seeded from the
+   * outer row's bound vertex (issue #5758) is still a single unlabelled anchor, so the same full-coverage
+   * requirement decides whether the seeded walk may use a CSR provider too.
    */
   @Override
-  public boolean canEnumerateAnchors() {
-    return anchorRid != null || nodeLabels[0] != null;
+  public boolean requiresFullVertexCoverage() {
+    return nodeLabels[0] == null;
   }
 
   @Override
@@ -92,7 +93,7 @@ public final class PropagateChainOp implements CountOp {
     final int nodeCount = provider.getNodeCount();
     final int hops = edgeTypes.length;
 
-    // Pre-compute valid bucket sets for type filtering at each level
+    // Pre-compute valid bucket sets for type filtering at each level. null = unlabelled, so no filter.
     final IntHashSet[] validBuckets = new IntHashSet[hops + 1];
     for (int i = 0; i <= hops; i++)
       validBuckets[i] = CSRCountUtils.buildValidBuckets(db, nodeLabels[i]);
@@ -108,18 +109,22 @@ public final class PropagateChainOp implements CountOp {
     if (inequalityIdxA >= 0 && inequalityIdxB >= 0
         && Math.min(inequalityIdxA, inequalityIdxB) == 0
         && hops <= 2)
-      return executePerSourceInequality(provider, db, nodeCount, validBuckets);
+      return executePerSourceInequality(provider, nodeCount, validBuckets);
 
     // Standard dense array propagation for chains without inequality
     // (or with inequality source not at position 0)
 
-    // Pre-compute bucket IDs once for all filtering operations
-    final int[] bucketIds = precomputeBucketIds(provider, nodeCount);
+    // Pre-compute bucket IDs once for all filtering operations. A pattern that labels no position needs none of
+    // them, and the scan costs one getRID per node.
+    final int[] bucketIds = anyLabelled(validBuckets) ? precomputeBucketIds(provider, nodeCount) : null;
 
-    // Initialize anchor counts via bucket filtering (avoids OLTP iterateType)
+    // Initialize anchor counts via bucket filtering (avoids OLTP iterateType). An unlabelled anchor accepts every
+    // vertex, which is the whole node domain (issue #5757).
     long[] current = new long[nodeCount];
     final IntHashSet anchorBuckets = validBuckets[0];
-    if (anchorBuckets != null) {
+    if (anchorBuckets == null)
+      Arrays.fill(current, 1L);
+    else {
       for (int v = 0; v < nodeCount; v++)
         if (anchorBuckets.contains(bucketIds[v]))
           current[v] = 1;
@@ -135,9 +140,17 @@ public final class PropagateChainOp implements CountOp {
       total += current[v];
 
     if (inequalityIdxA >= 0 && inequalityIdxB >= 0)
-      total -= countSelfLoopPaths(provider, db, validBuckets);
+      total -= countSelfLoopPaths(provider, validBuckets);
 
     return total;
+  }
+
+  /** Whether any position of the chain carries a label, i.e. whether per-node bucket ids are worth computing. */
+  private static boolean anyLabelled(final IntHashSet[] validBuckets) {
+    for (final IntHashSet buckets : validBuckets)
+      if (buckets != null)
+        return true;
+    return false;
   }
 
   /**
@@ -226,7 +239,7 @@ public final class PropagateChainOp implements CountOp {
    * For Q5 (16K tags × ~90 frontier nodes each): ~1.4M CSR ops vs ~6M for dense + self-loop.
    * For Q6 (10K persons × ~1.7K frontier nodes each): ~17M CSR ops (comparable to dense + self-loop).
    */
-  private long executePerSourceInequality(final GraphTraversalProvider provider, final Database db,
+  private long executePerSourceInequality(final GraphTraversalProvider provider,
       final int nodeCount, final IntHashSet[] validBuckets) {
     final int idxB = Math.max(inequalityIdxA, inequalityIdxB);
 
@@ -237,17 +250,18 @@ public final class PropagateChainOp implements CountOp {
 
     // Pre-compute bucket IDs for all nodes — eliminates per-node getRID calls during
     // frontier type filtering. One-time O(nodeCount) cost, amortized across all sources.
-    final int[] bucketIds = precomputeBucketIds(provider, nodeCount);
+    final int[] bucketIds = anyLabelled(validBuckets) ? precomputeBucketIds(provider, nodeCount) : null;
 
-    // Identify anchor nodes via bucket filtering (avoids db.iterateType OLTP reads)
-    final IntHashSet anchorBuckets = CSRCountUtils.buildValidBuckets(db, nodeLabels[0]);
-    if (anchorBuckets == null || anchorBuckets.isEmpty())
+    // Identify anchor nodes via bucket filtering (avoids db.iterateType OLTP reads). null accepts every vertex,
+    // empty accepts none (issue #5757).
+    final IntHashSet anchorBuckets = validBuckets[0];
+    if (anchorBuckets != null && anchorBuckets.isEmpty())
       return 0;
 
     long totalCount = 0;
 
     for (int srcId = 0; srcId < nodeCount; srcId++) {
-      if (!anchorBuckets.contains(bucketIds[srcId]))
+      if (anchorBuckets != null && !anchorBuckets.contains(bucketIds[srcId]))
         continue;
 
       // Expand from srcId through hops [0, idxB)
@@ -285,7 +299,7 @@ public final class PropagateChainOp implements CountOp {
     return totalCount;
   }
 
-  private long countSelfLoopPaths(final GraphTraversalProvider provider, final Database db,
+  private long countSelfLoopPaths(final GraphTraversalProvider provider,
       final IntHashSet[] validBuckets) {
     final int nodeCount = provider.getNodeCount();
     final int idxA = Math.min(inequalityIdxA, inequalityIdxB);
@@ -307,13 +321,16 @@ public final class PropagateChainOp implements CountOp {
     for (int h = 0; h < subChainLength; h++)
       subViews[h] = provider.getNeighborView(directions[idxA + h], edgeTypes[idxA + h]);
 
-    final String anchorLabel = nodeLabels[idxA];
-    if (anchorLabel == null || !db.getSchema().existsType(anchorLabel))
+    // The sub-chain is walked from every vertex the inequality's earlier position accepts: the label's own when it
+    // carries one, the whole node domain when it does not (issue #5757). Enumerating them off the CSR bucket ids
+    // rather than db.iterateType also keeps the self-loop subtraction from reading records.
+    final IntHashSet anchorBuckets = validBuckets[idxA];
+    if (anchorBuckets != null && anchorBuckets.isEmpty())
       return 0;
+    final int[] anchorBucketIds = anchorBuckets == null ? null : precomputeBucketIds(provider, nodeCount);
 
-    for (final Iterator<? extends Identifiable> it = db.iterateType(anchorLabel, true); it.hasNext(); ) {
-      final int vId = provider.getNodeId(it.next().getIdentity());
-      if (vId < 0)
+    for (int vId = 0; vId < nodeCount; vId++) {
+      if (anchorBuckets != null && !anchorBuckets.contains(anchorBucketIds[vId]))
         continue;
 
       long loopCount = countLoopsFromNode(provider, vId, subViews, idxA, subChainLength, validBuckets);
@@ -385,23 +402,21 @@ public final class PropagateChainOp implements CountOp {
     final int[] e1Nbrs = viewE1.neighbors();
     final int[] cNbrs = viewC.neighbors();
 
-    // Optional: filter middle edge endpoints by type
-    final int[] bucketIds;
+    // Optional: filter middle edge endpoints by type. null is "no label, so no filter"; an empty set is a label that
+    // matches nothing, and then no path exists to subtract at all (issue #5757).
     final IntHashSet pos1Buckets = validBuckets[1];
     final IntHashSet pos2Buckets = validBuckets[2];
-    if ((pos1Buckets != null && !pos1Buckets.isEmpty()) || (pos2Buckets != null && !pos2Buckets.isEmpty())) {
-      bucketIds = precomputeBucketIds(provider, nodeCount);
-    } else {
-      bucketIds = null;
-    }
+    if ((pos1Buckets != null && pos1Buckets.isEmpty()) || (pos2Buckets != null && pos2Buckets.isEmpty()))
+      return 0;
+    final int[] bucketIds = (pos1Buckets != null || pos2Buckets != null)
+        ? precomputeBucketIds(provider, nodeCount) : null;
 
     long selfLoop = 0;
 
     // Scan all E1 edges by iterating pos1 nodes
     for (int b = 0; b < nodeCount; b++) {
       // Check pos1 type filter
-      if (pos1Buckets != null && !pos1Buckets.isEmpty()
-          && !pos1Buckets.contains(bucketIds[b]))
+      if (pos1Buckets != null && !pos1Buckets.contains(bucketIds[b]))
         continue;
 
       final int e1Start = viewE1.offset(b);
@@ -418,8 +433,7 @@ public final class PropagateChainOp implements CountOp {
         final int c = e1Nbrs[j];
 
         // Check pos2 type filter
-        if (pos2Buckets != null && !pos2Buckets.isEmpty()
-            && !pos2Buckets.contains(bucketIds[c]))
+        if (pos2Buckets != null && !pos2Buckets.contains(bucketIds[c]))
           continue;
 
         // Get setC = E2 neighbors of c (pos3 candidates)
@@ -467,14 +481,14 @@ public final class PropagateChainOp implements CountOp {
     for (int h = 0; h < subChainLength; h++)
       subViews[h] = provider.getNeighborView(directions[h], edgeTypes[h]);
 
-    final int[] bucketIds = precomputeBucketIds(provider, nodeCount);
     final IntHashSet anchorBuckets = validBuckets[0];
-    if (anchorBuckets == null || anchorBuckets.isEmpty())
+    if (anchorBuckets != null && anchorBuckets.isEmpty())
       return 0;
+    final int[] bucketIds = anchorBuckets == null ? null : precomputeBucketIds(provider, nodeCount);
 
     long selfLoopTotal = 0;
     for (int vId = 0; vId < nodeCount; vId++) {
-      if (!anchorBuckets.contains(bucketIds[vId]))
+      if (anchorBuckets != null && !anchorBuckets.contains(bucketIds[vId]))
         continue;
       selfLoopTotal += countLoopsFromNode(provider, vId, subViews, 0, subChainLength, validBuckets);
     }
@@ -513,7 +527,7 @@ public final class PropagateChainOp implements CountOp {
     final int lastHopIdx = startHop + subChainLength - 1;
     final IntHashSet lastBuckets = validBuckets[lastHopIdx + 1];
     // If there are type filters at the target position and vId doesn't match, no self-loops possible
-    if (lastBuckets != null && !lastBuckets.isEmpty()) {
+    if (lastBuckets != null) {
       final RID vRid = provider.getRID(vId);
       if (!lastBuckets.contains(vRid.getBucketId()))
         return 0;
@@ -575,8 +589,8 @@ public final class PropagateChainOp implements CountOp {
       }
     }
 
-    // Apply type filter if needed
-    if (targetBuckets != null && !targetBuckets.isEmpty()) {
+    // Apply type filter if needed. An empty set is a label that matches nothing, so it empties the frontier.
+    if (targetBuckets != null) {
       int writePos = 0;
       for (int i = 0; i < pos; i++) {
         final RID rid = provider.getRID(next[i]);
@@ -622,7 +636,7 @@ public final class PropagateChainOp implements CountOp {
       }
     }
 
-    if (targetBuckets != null && !targetBuckets.isEmpty()) {
+    if (targetBuckets != null) {
       int writePos = 0;
       for (int i = 0; i < pos; i++) {
         if (targetBuckets.contains(bucketIds[next[i]]))
@@ -646,13 +660,16 @@ public final class PropagateChainOp implements CountOp {
 
   @Override
   public long executeOLTP(final Database db) {
-    // Try to find a GAV provider for accelerated neighbor lookups even in the OLTP path
-    final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db, edgeTypes);
+    // Try to find a GAV provider for accelerated neighbor lookups even in the OLTP path. One that holds a subset of
+    // the vertex types cannot serve: it answers for the vertices it maps with the adjacency it holds, which is
+    // missing every edge that leaves the view (issue #5757).
+    final GraphTraversalProvider provider = CSRCountUtils.findAcceleratingProvider(db, edgeTypes);
 
     // BFS count propagation: each unique vertex at each level is processed once,
     // with its count capturing path multiplicity. This reduces O(paths) traversals
     // to O(unique edges), which is dramatically faster for high-fanout chains.
     // E.g., Q5 with 13.8M paths but only ~3.5M unique edges: ~4x fewer OLTP scans.
+    // An unlabelled anchor starts from every vertex in the schema (issue #5757).
     RidLongHashMap current = new RidLongHashMap();
     if (anchorRid != null) {
       // A seeded anchor is an anchor set of one, and its label - if the body wrote one - filters it (issue #5758).
@@ -660,23 +677,12 @@ public final class PropagateChainOp implements CountOp {
         return 0;
       current.put(anchorRid, 1L);
     } else {
-      final String anchorLabel = nodeLabels[0];
-      if (anchorLabel == null || !db.getSchema().existsType(anchorLabel))
-        return 0;
-
-      for (final Iterator<? extends Identifiable> it = db.iterateType(anchorLabel, true); it.hasNext(); )
+      for (final Iterator<? extends Identifiable> it = CSRCountUtils.iterateAnchors(db, nodeLabels[0]); it.hasNext(); )
         current.put(it.next().getIdentity(), 1L);
     }
 
     for (int hop = 0; hop < edgeTypes.length; hop++) {
-      final String targetLabel = nodeLabels[hop + 1];
-      final IntHashSet targetBuckets;
-      if (targetLabel != null && db.getSchema().existsType(targetLabel)) {
-        targetBuckets = new IntHashSet();
-        for (final int bid : db.getSchema().getType(targetLabel).getBucketIds(true))
-          targetBuckets.add(bid);
-      } else
-        targetBuckets = null;
+      final IntHashSet targetBuckets = CSRCountUtils.buildValidBuckets(db, nodeLabels[hop + 1]);
 
       final RidLongHashMap next = new RidLongHashMap();
       final int h = hop;
@@ -733,13 +739,14 @@ public final class PropagateChainOp implements CountOp {
     final int idxB = Math.max(inequalityIdxA, inequalityIdxB);
     final int subLength = idxB - idxA;
 
-    final String anchorLabel = nodeLabels[idxA];
-    if (anchorLabel == null || !db.getSchema().existsType(anchorLabel))
-      return 0;
+    // One bucket set per sub-chain hop, built once rather than per anchor
+    final IntHashSet[] subChainBuckets = new IntHashSet[subLength];
+    for (int h = 0; h < subLength; h++)
+      subChainBuckets[h] = CSRCountUtils.buildValidBuckets(db, nodeLabels[idxA + h + 1]);
 
     long selfLoopTotal = 0;
 
-    for (final Iterator<? extends Identifiable> it = db.iterateType(anchorLabel, true); it.hasNext(); ) {
+    for (final Iterator<? extends Identifiable> it = CSRCountUtils.iterateAnchors(db, nodeLabels[idxA]); it.hasNext(); ) {
       final Vertex anchor = it.next().asVertex();
       final RID anchorRid = anchor.getIdentity();
 
@@ -750,14 +757,7 @@ public final class PropagateChainOp implements CountOp {
 
       for (int h = 0; h < subLength; h++) {
         final int hopIdx = idxA + h;
-        final String targetLabel = nodeLabels[hopIdx + 1];
-        final IntHashSet targetBuckets;
-        if (targetLabel != null && db.getSchema().existsType(targetLabel)) {
-          targetBuckets = new IntHashSet();
-          for (final int bid : db.getSchema().getType(targetLabel).getBucketIds(true))
-            targetBuckets.add(bid);
-        } else
-          targetBuckets = null;
+        final IntHashSet targetBuckets = subChainBuckets[h];
 
         final RidLongHashMap next = new RidLongHashMap();
         cur.forEach((bucketId, offset, pathCount) -> {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCountPushDownUnlabelledAnchorIssue5757Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCountPushDownUnlabelledAnchorIssue5757Test.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.opencypher.executor.steps.CSRCountUtils;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.IntHashSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5757, the follow-up to #5715.
+ * <p>
+ * Two things, both of them about a label that is not there:
+ * <ol>
+ *   <li><b>An unlabelled anchor.</b> Every count-push-down operator walks out from one position of the pattern.
+ *   {@code MATCH ()-[:TYPE]->() RETURN count(*)} labels none of them, which used to leave the operators with no set
+ *   to enumerate; #5715 fixed the wrong answer that produced by declining to build the operator at all, so the
+ *   cheapest question there is to ask a graph was the one shape the fast path could not serve. The two chain
+ *   operators now read the absent label for what it means - <b>every vertex</b> - on both the CSR and the OLTP
+ *   path.</li>
+ *   <li><b>The overload that caused it.</b> {@code CSRCountUtils.buildValidBuckets} returned {@code null} both for
+ *   "no label was given" and for "the label matches nothing", and its callers disagreed about which one they held.
+ *   The two answers are now distinguishable: {@code null} is no filter, an empty set is a filter that keeps
+ *   nothing.</li>
+ * </ol>
+ * Every count here is cross-checked against the row count of the same pattern projected without an aggregate, which
+ * is the ordinary materialization pipeline answering the same question. The chains deliberately use a distinct edge
+ * type per hop so that relationship isomorphism - which the push-downs do not model and the pipeline does - cannot
+ * make the two disagree for an unrelated reason.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherCountPushDownUnlabelledAnchorIssue5757Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Hub");
+      database.getSchema().createVertexType("Leaf");
+      database.getSchema().createVertexType("Idle");
+      database.getSchema().createEdgeType("LINKS");
+      database.getSchema().createEdgeType("BOND");
+      database.getSchema().createEdgeType("WIRE");
+
+      // Two labels carry edges, so an unlabelled anchor has to reach beyond any single type.
+      final MutableVertex h1 = database.newVertex("Hub").set("k", "h1").save();
+      final MutableVertex h2 = database.newVertex("Hub").set("k", "h2").save();
+      final MutableVertex l1 = database.newVertex("Leaf").set("k", "l1").save();
+      final MutableVertex l2 = database.newVertex("Leaf").set("k", "l2").save();
+      final MutableVertex l3 = database.newVertex("Leaf").set("k", "l3").save();
+
+      // Vertices with no edge at all: seeding "every vertex" must not turn them into rows.
+      for (int i = 1; i <= 4; i++)
+        database.newVertex("Idle").set("k", "i" + i).save();
+
+      h1.newEdge("LINKS", l1).save();
+      h1.newEdge("LINKS", l2).save();
+      h2.newEdge("LINKS", l1).save();
+      l1.newEdge("LINKS", h2).save();
+      l3.newEdge("LINKS", h1).save();
+
+      l1.newEdge("BOND", h1).save();
+      l2.newEdge("BOND", h2).save();
+      h2.newEdge("BOND", l3).save();
+
+      h1.newEdge("WIRE", h2).save();
+      l3.newEdge("WIRE", l1).save();
+      h2.newEdge("WIRE", h1).save();
+    });
+  }
+
+  // ===================================================================================================
+  // 1. an unlabelled anchor is served by the push-down, and answers what the pipeline answers
+  // ===================================================================================================
+
+  /**
+   * {@code MATCH ()-[:TYPE]->() RETURN count(*)} - "how many edges of this type are there" - is exactly the question
+   * the CSR operators exist for, and #5715 left it as the one shape they declined.
+   */
+  @Test
+  void anUnlabelledAnchorIsClaimedByTheChainPushDown() {
+    assertThat(explainOf("MATCH (a)-[:LINKS]->(b) RETURN count(*) AS c")).contains("COUNT CHAIN");
+    assertThat(explainOf("MATCH (a)-[:LINKS]->(b:Leaf) RETURN count(*) AS c")).contains("COUNT CHAIN");
+    assertThat(explainOf("MATCH ()-[:LINKS]->() RETURN count(*) AS c")).contains("COUNT CHAIN");
+  }
+
+  /** One hop, in every direction, with the label on neither end, on one end, or on both. */
+  @Test
+  void aSingleHopWithAnUnlabelledAnchorCountsEveryEdge() {
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b)", 5);
+    assertPushedDownCountMatchesThePipeline("MATCH (a)<-[:LINKS]-(b)", 5);
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]-(b)", 10);
+
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b:Leaf)", 3);
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b:Hub)", 2);
+
+    // The labelled shapes the operator always served, unchanged.
+    assertPushedDownCountMatchesThePipeline("MATCH (a:Hub)-[:LINKS]->(b)", 3);
+    assertPushedDownCountMatchesThePipeline("MATCH (a:Hub)-[:LINKS]->(b:Leaf)", 3);
+    assertPushedDownCountMatchesThePipeline("MATCH (a:Leaf)-[:LINKS]->(b:Hub)", 2);
+  }
+
+  /** A multi-hop chain: the anchor seeding is one step, every hop after it has to propagate from all of them. */
+  @Test
+  void aMultiHopChainWithAnUnlabelledAnchorCountsEveryPath() {
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b)-[:BOND]->(c)", 4);
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b)-[:BOND]->(c)-[:WIRE]->(d)", 4);
+    // A label further along the chain still filters, and the unlabelled anchor still starts everywhere.
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b:Leaf)-[:BOND]->(c)", 3);
+  }
+
+  /**
+   * With an inequality the operator subtracts the paths whose two ends are the same vertex, and that subtraction
+   * walks out from the inequality's earlier position - the unlabelled anchor again. Three of the four 3-hop paths
+   * here close on themselves, so a subtraction that enumerated nothing would answer 4 instead of 1.
+   */
+  @Test
+  void anInequalityOverAnUnlabelledAnchorSubtractsTheClosedPaths() {
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b)-[:BOND]->(c) WHERE a <> c", 3);
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b)-[:BOND]->(c)-[:WIRE]->(d) WHERE a <> d", 1);
+  }
+
+  /** The anti-join operator anchors the same way, and had the same {@code anchorLabel == null} reading. */
+  @Test
+  void anAntiJoinOverAnUnlabelledAnchorCountsEveryPath() {
+    assertPushedDownCountMatchesThePipeline(
+        "MATCH (a)-[:LINKS]->(b)-[:BOND]->(c) WHERE NOT (a)-[:WIRE]->(c)", 2);
+    assertPushedDownCountMatchesThePipeline(
+        "MATCH (a)-[:LINKS]->(b)-[:BOND]->(c) WHERE NOT (a)-[:WIRE]->(c) AND a <> c", 1);
+  }
+
+  /**
+   * The same answers off the CSR arrays. A view registered for the database moves every one of these from the OLTP
+   * branch of the operator to the dense-propagation one, which is where the "seed every node" reading of an absent
+   * anchor label lives.
+   */
+  @Test
+  void theCsrPathAgreesWithTheOltpPathOnEveryUnlabelledShape() {
+    final List<String> patterns = List.of(
+        "MATCH (a)-[:LINKS]->(b)",
+        "MATCH (a)<-[:LINKS]-(b)",
+        "MATCH (a)-[:LINKS]-(b)",
+        "MATCH (a)-[:LINKS]->(b:Leaf)",
+        "MATCH (a)-[:LINKS]->(b)-[:BOND]->(c)",
+        "MATCH (a)-[:LINKS]->(b)-[:BOND]->(c)-[:WIRE]->(d)",
+        "MATCH (a)-[:LINKS]->(b)-[:BOND]->(c) WHERE a <> c",
+        "MATCH (a)-[:LINKS]->(b)-[:BOND]->(c)-[:WIRE]->(d) WHERE a <> d",
+        "MATCH (a)-[:LINKS]->(b)-[:BOND]->(c) WHERE NOT (a)-[:WIRE]->(c)",
+        "MATCH (a)-[:LINKS]->(b)-[:BOND]->(c) WHERE NOT (a)-[:WIRE]->(c) AND a <> c");
+
+    final List<Long> withoutView = new ArrayList<>();
+    for (final String pattern : patterns)
+      withoutView.add(scalarOf(pattern + " RETURN count(*) AS c"));
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("everything")
+        .withVertexTypes("Hub", "Leaf", "Idle")
+        .withEdgeTypes("LINKS", "BOND", "WIRE")
+        .build();
+    try {
+      // Without a ready provider covering the edge types, every assertion below would re-run the OLTP path and
+      // compare it against itself.
+      assertThat(GraphTraversalProviderRegistry.awaitAll(database, 30, TimeUnit.SECONDS)).isTrue();
+      assertThat(GraphTraversalProviderRegistry.findProvider(database, "LINKS", "BOND", "WIRE")).isNotNull();
+
+      for (int i = 0; i < patterns.size(); i++)
+        assertThat(scalarOf(patterns.get(i) + " RETURN count(*) AS c")).as(patterns.get(i)).isEqualTo(withoutView.get(i));
+    } finally {
+      view.drop();
+    }
+  }
+
+  /**
+   * "Every vertex" is a claim about the graph, not about a view. A view built over one vertex type accelerates a
+   * walk anchored on a label it holds, but it cannot enumerate the anchors of an unlabelled one: its node domain is
+   * a subset of them. The operator falls back to the OLTP path rather than counting the subset.
+   */
+  @Test
+  void aViewThatHoldsSomeOfTheVerticesDoesNotAnswerAnUnlabelledAnchor() {
+    final GraphAnalyticalView partial = GraphAnalyticalView.builder(database)
+        .withName("hubs-only")
+        .withVertexTypes("Hub")
+        .withEdgeTypes("LINKS")
+        .build();
+    try {
+      assertThat(GraphTraversalProviderRegistry.awaitAll(database, 30, TimeUnit.SECONDS)).isTrue();
+      // The view IS offered to the operator - it covers the edge type - so the count below is saved by the
+      // coverage test rather than by there being no provider at all.
+      assertThat(GraphTraversalProviderRegistry.findProvider(database, "LINKS")).isNotNull();
+
+      // No LINKS edge joins two Hubs, so a view holding only Hubs would count 0 for a pattern with five matches.
+      assertThat(scalarOf("MATCH (a)-[:LINKS]->(b) RETURN count(*) AS c")).isEqualTo(5L);
+    } finally {
+      partial.drop();
+    }
+  }
+
+  /** Idle vertices carry no edge of any type: seeding every vertex must not turn them into rows. */
+  @Test
+  void verticesWithNoEdgeContributeNothing() {
+    assertThat(rowCountOf("MATCH (i:Idle) RETURN i.k AS c")).isEqualTo(4);
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b)", 5);
+  }
+
+  // ===================================================================================================
+  // 2. the helper no longer says "no filter" and "matches nothing" with the same null
+  // ===================================================================================================
+
+  /**
+   * The contract every operator here now reads. The two cases are separated at the source rather than at each of the
+   * dozen sites that consume it, which is what stops the class of bug rather than the two instances of it #5715
+   * found.
+   */
+  @Test
+  void buildValidBucketsSeparatesNoFilterFromMatchesNothing() {
+    // No label given: nothing to filter on.
+    assertThat(CSRCountUtils.buildValidBuckets(database, null)).isNull();
+
+    // A label no type declares: a filter that keeps nothing. Not null - that would read as "no filter".
+    final IntHashSet undeclared = CSRCountUtils.buildValidBuckets(database, "NoSuchLabel");
+    assertThat(undeclared).isNotNull();
+    assertThat(undeclared.isEmpty()).isTrue();
+
+    // A declared label: its own buckets.
+    final IntHashSet hub = CSRCountUtils.buildValidBuckets(database, "Hub");
+    assertThat(hub).isNotNull();
+    assertThat(hub.isEmpty()).isFalse();
+    for (final int bucketId : database.getSchema().getType("Hub").getBucketIds(true))
+      assertThat(hub.contains(bucketId)).isTrue();
+    assertThat(hub.contains(database.getSchema().getType("Leaf").getBucketIds(true).get(0))).isFalse();
+  }
+
+  /**
+   * And the consumer side of it: an empty set zeroes every count instead of being waved through as "no filter",
+   * which is the shape of the second wrong answer #5715 found.
+   */
+  @Test
+  void filterByBucketsKeepsNothingForAnEmptySet() {
+    final int[] bucketIds = { 3, 4, 5 };
+
+    final long[] noFilter = { 7L, 8L, 9L };
+    CSRCountUtils.filterByBuckets(bucketIds, noFilter, null);
+    assertThat(noFilter).containsExactly(7L, 8L, 9L);
+
+    final long[] matchesNothing = { 7L, 8L, 9L };
+    CSRCountUtils.filterByBuckets(bucketIds, matchesNothing, new IntHashSet());
+    assertThat(matchesNothing).containsExactly(0L, 0L, 0L);
+
+    final IntHashSet onlyFour = new IntHashSet();
+    onlyFour.add(4);
+    final long[] filtered = { 7L, 8L, 9L };
+    CSRCountUtils.filterByBuckets(bucketIds, filtered, onlyFour);
+    assertThat(filtered).containsExactly(0L, 8L, 0L);
+  }
+
+  /** A label the schema does not declare keeps answering 0, whichever end of the pattern carries it. */
+  @Test
+  void anUndeclaredLabelStillMatchesNothing() {
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b:NoSuchLabel)", 0);
+    assertPushedDownCountMatchesThePipeline("MATCH (a:NoSuchLabel)-[:LINKS]->(b)", 0);
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b:NoSuchLabel)-[:BOND]->(c)", 0);
+    assertPushedDownCountMatchesThePipeline("MATCH (a)-[:LINKS]->(b:Idle)", 0);
+  }
+
+  // ===================================================================================================
+  // helpers
+  // ===================================================================================================
+
+  /**
+   * Asserts the pushed-down count of the pattern, the row count the ordinary pipeline produces for the same pattern,
+   * and the expected value all agree. The pipeline reference is what makes the expected number more than a
+   * transcription of what the operator currently does.
+   */
+  private void assertPushedDownCountMatchesThePipeline(final String matchClause, final long expected) {
+    assertThat(scalarOf(matchClause + " RETURN count(*) AS c")).as(matchClause).isEqualTo(expected);
+    assertThat(rowCountOf(matchClause + " RETURN a")).as(matchClause + " (pipeline)").isEqualTo((int) expected);
+  }
+
+  /** The single {@code c} value of a one-row query. */
+  private long scalarOf(final String query) {
+    final List<Long> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        values.add(((Number) rs.next().getProperty("c")).longValue());
+    }
+    assertThat(values).as(query).hasSize(1);
+    return values.get(0);
+  }
+
+  /** The rendered execution plan of {@code EXPLAIN <query>}. */
+  private String explainOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+
+  /** How many rows the query produced, whatever they hold. */
+  private int rowCountOf(final String query) {
+    int rows = 0;
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        rows++;
+      }
+    }
+    return rows;
+  }
+}


### PR DESCRIPTION
Closes #5757

Follow-up to #5715 (PR #5737). Sections 1 and 2 of the issue - the ones it calls "worth doing" - are implemented here. Section 3 (`ORDER BY` over a single-row aggregate) is deliberately left alone; see the last section below.

## 1. An unlabelled anchor is now enumerated rather than declined

Every count-push-down operator walks out from one position of the pattern and enumerates the vertices that position accepts, and it built that set from the position's label. An unlabelled anchor left it with no set, which each operator read as an empty one and answered **0**. #5715 closed that wrong answer with `CountOp.canEnumerateAnchors()`, which declines to build the operator so the ordinary pipeline answers instead: right, but `MATCH ()-[:TYPE]->() RETURN count(*)` - the cheapest question there is to ask a graph, and exactly what the CSR operators exist for - was the one shape the fast path could not serve.

`PropagateChainOp` and `AntiJoinChainOp` now read an absent anchor label for what it means, **every vertex**, at all the sites the issue enumerates:

- **CSR path.** `PropagateChainOp.execute` seeds the whole node domain when `validBuckets[0] == null`; `executePerSourceInequality`, `countSelfLoopPaths`, `countSelfLoop3HopEdgeScan` and `countSelfLoopPerAnchorFallback` iterate every node instead of `return 0`. `AntiJoinChainOp.execute` and `executeEdgeScanAlgebraic` likewise.
- **OLTP path.** `executeOLTP`, `countSelfLoopPathsOLTP` and `executeOLTPRecursive` go through a new `CSRCountUtils.iterateAnchors(db, label)`, which iterates every declared vertex type non-polymorphically when the label is null (so no vertex is visited twice), the label's own polymorphic iterator when it is not, and nothing when the label is not declared.

`countSelfLoopPaths` also stops enumerating its anchors with `db.iterateType` and enumerates them off the CSR bucket ids like every other site in that class, so the self-loop subtraction no longer reads records on the CSR path.

`PairHashJoinOp` and `DegreeProductOp` still decline an unlabelled anchor - they key a hash join and a degree product on the label itself - and the ordinary pipeline answers those. `canEnumerateAnchors()` stays for them; its javadoc now says which operators answer it how, and why.

## 2. `buildValidBuckets` no longer says two things with one `null`

`CSRCountUtils.buildValidBuckets(db, label)` returned `null` both for **"no label was given, so do not filter"** and for **"the label is declared on nothing, so nothing matches"**, and its callers disagreed about which one they held. That single overload produced *both* wrong answers found in #5715, one from each end of it: anchor seeding read it as "no anchors" and answered 0 for a matching pattern, hop filtering read it as "no filter" and counted an unfiltered chain.

The two cases are now distinguishable at the source rather than at each of the dozen sites that consume it:

- `null` - no label, no filter;
- an **empty** set - a label that keeps nothing.

`filterByBuckets` (both overloads) zeroes every count for an empty set instead of returning early, and every frontier filter in `PropagateChainOp`, `AntiJoinChainOp`, `PairHashJoinOp` and `CSRCountUtils.walkArm` branches on `null` alone, letting an empty set fall through to a membership test that keeps nothing. Six hand-rolled copies of "build this label's bucket ids" across the OLTP paths were replaced by calls to the helper, so they inherit the distinction rather than re-introducing the overload.

Both #5715 wrong answers remain unreachable end to end - `mandatoryPatternElementIsEmpty` answers 0 before the operator is built - so this half is pinned by a direct unit test of the helper's contract rather than by a query, which is what the issue asks for: "a new operator, or a new construction path reaching an existing one, reintroduces the same class of bug with nothing to catch it."

## 3. A view holding some of the vertices is not asked "how many vertices are there"

Enabling the unlabelled anchor opened a question that could not arise before: "every vertex" is a claim about the **graph**, and a `GraphAnalyticalView` built over a subset of the vertex types cannot make it - its node domain is a subset of the anchors. `CountOp.requiresFullVertexCoverage()` (true exactly when the anchor is unlabelled) makes `CSRCountStep` fall back to the OLTP path unless `provider.coversVertexType(null)`.

The same reasoning turned out to apply to the per-vertex accelerator the OLTP paths themselves look up, and there it was already a wrong answer for a labelled anchor too: they consult the provider per vertex and fall back to the edge list for a vertex the provider does **not** map, but nothing covers a vertex *inside* the domain whose neighbors are outside it - `getNeighborIds` answers with the adjacency the view holds, and the edges leading out of the view are simply not in it. The test in this PR reproduces exactly that (a `Hub`-only view answered 2 instead of 5). `PropagateChainOp.executeOLTP`, `AntiJoinChainOp.buildNeighborRIDMap` and `AntiJoinChainOp.buildTailCounts` now go through `CSRCountUtils.findAcceleratingProvider`, which declines a partial view.

## Test plan

New `CypherCountPushDownUnlabelledAnchorIssue5757Test` - 11 tests. Every count is cross-checked against the row count the ordinary pipeline produces for the same pattern projected without an aggregate, and the chains use a distinct edge type per hop so that relationship isomorphism (which the push-downs do not model and the pipeline does) cannot make the two disagree for an unrelated reason.

- [x] `anUnlabelledAnchorIsClaimedByTheChainPushDown` - `EXPLAIN` names `COUNT CHAIN` for the shapes #5715 sent to the pipeline.
- [x] Single-hop (`OUT`, `IN`, `BOTH`; label on neither end, one end, both), multi-hop, inequality (2-hop per-source and 3-hop edge-scan self-loop subtraction), anti-join with and without an inequality.
- [x] `theCsrPathAgreesWithTheOltpPathOnEveryUnlabelledShape` - the same ten patterns with and without a full view, asserting a ready provider is actually found first so the comparison is not the OLTP path against itself.
- [x] `aViewThatHoldsSomeOfTheVerticesDoesNotAnswerAnUnlabelledAnchor` - a `Hub`-only view is offered to the operator and declined.
- [x] `buildValidBucketsSeparatesNoFilterFromMatchesNothing` and `filterByBucketsKeepsNothingForAnEmptySet` - the helper contract directly.
- [x] **Armed:** with the `src/main` changes stashed, 5 of the 11 fail (the two helper-contract tests, the `EXPLAIN` test, the partial-view test, and the CSR/OLTP agreement test).
- [x] **No regressions:** the full `engine` unit suite is green - 11635 tests, 0 failures, 0 errors - including `CypherCountPushDownPreconditionsIssue5715Test`, `GAVEligibilityTest` and `MatchGAVExpandIntoTest`.
- [x] **openCypher TCK** (its own lane, `-Dsurefire.includes=**/*Suite.java`): 3897 scenarios, 0 failures, 85 skipped - unchanged.

## Deliberately not done

**Section 3 of the issue (`ORDER BY`).** The issue itself rates it lowest ("Sections 1 and 2 are the ones worth doing"), and #5737's reasoning still holds: sorting by an aggregate alias is the ordinary pipeline's business, and `anOrderedCountIsStillCorrect` pins the answer. Accepting an `ORDER BY` whose every item resolves to the projected count alias remains available as a separate, purely-performance change.

**The pos0/pos3 filter in the 3-hop self-loop scans.** `PropagateChainOp.countSelfLoop3HopEdgeScan` and `AntiJoinChainOp.executeEdgeScanAlgebraic` apply the labels at positions 1 and 2 but not at 0 and 3, so a *labelled* anchor can over-subtract when a node reachable at the closing hop is not of the anchor's type. That is pre-existing and untouched here: with an unlabelled anchor there is no filter to apply, so this PR neither depends on it nor makes it worse. It wants its own reproducer and its own PR.

**The same partial-view hazard in sibling operators.** `CountEdgesStep`, `CountEdgesReturnStep`, `CountChainedEdgesStep`, `PartitionedTriangleOp` and `MatchRelationshipStep` all have the identical `nodeId >= 0 ? provider... : vertex...` shape and the identical exposure. Only the two chain operators are changed here, because only they are covered by this PR's test; the others need their own.

## Found on the way, filed separately

**#6010 - a `GraphAnalyticalView` makes the pipeline drop a `WHERE a <> c` inequality.** Not a count push-down bug and not caused by this change: with a view registered, `MATCH (a)-[:LINKS]->(b)-[:BOND]->(c) WHERE a <> c RETURN a.k` returns 4 rows where the same query without a view returns 3, and labelling the anchor does not change it. It surfaced here because the pre-change code answered the count for that pattern *through* the pipeline; with this PR the push-down answers it itself and gets it right, which masks the symptom for counts and leaves it everywhere else. Full reproducer in the issue.
