### PR TITLE
fix: batch fixes for #5972, #5976, #5978

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -74,6 +74,7 @@ import java.io.SequenceInputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -185,8 +186,15 @@ public class BoltNetworkExecutor extends Thread {
 
       state = State.NEGOTIATION;
 
-      // Perform handshake
-      if (!performHandshake()) {
+      // Perform handshake. Bound by the same pre-auth read timeout negotiateTransport() armed (issue #5978):
+      // a client that never completes the magic-bytes/version handshake must not hold this thread forever.
+      try {
+        if (!performHandshake())
+          return;
+      } catch (final EOFException | SocketException | SocketTimeoutException e) {
+        if (debug) {
+          LogManager.instance().log(this, Level.FINE, "BOLT connection closed during handshake: %s", e.getMessage());
+        }
         return;
       }
 
@@ -220,6 +228,15 @@ public class BoltNetworkExecutor extends Thread {
           // Client disconnected
           if (debug) {
             LogManager.instance().log(this, Level.FINE, "BOLT client disconnected: %s", e.getMessage());
+          }
+          break;
+        } catch (final SocketTimeoutException e) {
+          // No data received within the bounded pre-authentication window (issue #5978, mirroring #5912's
+          // fix for the Redis wrapper): close instead of holding the connection thread open indefinitely.
+          // Authenticated connections never reach here - their read timeout is lifted to infinite in
+          // markAuthenticated().
+          if (debug) {
+            LogManager.instance().log(this, Level.FINE, "BOLT closing idle unauthenticated connection %s", socket.getRemoteSocketAddress());
           }
           break;
         } catch (final Exception e) {
@@ -257,13 +274,15 @@ public class BoltNetworkExecutor extends Thread {
       Socket connectionSocket = socket;
       byte[] preReadBytes = null;
 
-      if (sslHelper != null && sslHelper.getTlsMode() != BoltSslHelper.TlsMode.DISABLED) {
-        // Bound transport detection and the TLS handshake with a read timeout so a stalled/hostile client
-        // cannot hold this connection thread (and its file descriptors) open forever.
-        final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
-        if (handshakeTimeout > 0)
-          socket.setSoTimeout(handshakeTimeout);
+      // Bound transport detection, the BOLT handshake and the AUTH/HELLO-LOGON phase that follows it with a
+      // read timeout (issue #5978, mirroring RedisNetworkExecutor's #5912 fix), so a stalled/hostile client
+      // cannot hold this connection thread (and its file descriptors) open forever. Lifted to infinite once
+      // authentication succeeds - see markAuthenticated() - and re-armed on LOGOFF - see markUnauthenticated().
+      final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+      if (handshakeTimeout > 0)
+        socket.setSoTimeout(handshakeTimeout);
 
+      if (sslHelper != null && sslHelper.getTlsMode() != BoltSslHelper.TlsMode.DISABLED) {
         final byte[] header = new byte[4];
         final InputStream rawIn = socket.getInputStream();
         int bytesRead = 0;
@@ -296,8 +315,11 @@ public class BoltNetworkExecutor extends Thread {
           preReadBytes = header;
         }
 
-        // Restore blocking semantics for the long-lived BOLT session.
-        connectionSocket.setSoTimeout(0);
+        // Keep the pre-auth window armed through AUTH/HELLO-LOGON: a layered SSLSocket does not reliably
+        // inherit the underlying socket's timeout, so re-apply it explicitly on whichever socket subsequent
+        // reads actually use. Lifted to infinite only once authentication succeeds (markAuthenticated()).
+        if (handshakeTimeout > 0)
+          connectionSocket.setSoTimeout(handshakeTimeout);
       }
 
       final InputStream inputStream = preReadBytes != null
@@ -541,6 +563,7 @@ public class BoltNetworkExecutor extends Thread {
    */
   private void handleLogoff() throws IOException {
     user = null;
+    markUnauthenticated();
     sendSuccess(Map.of());
     state = State.AUTHENTICATION;
   }
@@ -1728,12 +1751,48 @@ public class BoltNetworkExecutor extends Thread {
         state = State.FAILED;
         return false;
       }
+      markAuthenticated();
       return true;
     } catch (final ServerSecurityException e) {
       // Sanitize error message to avoid information disclosure
       sendFailure(BoltException.AUTHENTICATION_ERROR, "Authentication failed");
       state = State.FAILED;
       return false;
+    }
+  }
+
+  /**
+   * Lifts the pre-authentication read timeout (issue #5978, mirroring RedisNetworkExecutor.markAuthenticated
+   * from #5912): an authenticated BOLT client is expected to keep a long-lived, often idle connection open
+   * between requests, so the bounded handshake/auth window armed by {@link #negotiateTransport()} must not
+   * keep applying past a successful HELLO/LOGON.
+   */
+  private void markAuthenticated() {
+    try {
+      socket.setSoTimeout(0);
+    } catch (final SocketException e) {
+      // setSoTimeout() only throws on an already-broken/closed socket: there is nothing left to hold open in
+      // that case, so logging and moving on - rather than failing the whole authentication - is safe. The
+      // connection dies on its next read/write either way.
+      LogManager.instance().log(this, Level.FINE, "BOLT unable to lift the idle read timeout after authentication", e);
+    }
+  }
+
+  /**
+   * (Re-)arms the bounded pre-authentication read timeout (issue #5978, mirroring
+   * RedisNetworkExecutor.markUnauthenticated from #5912): a connection that authenticated once has its
+   * timeout lifted to infinite by {@link #markAuthenticated()}. If it then sends LOGOFF, {@code user} goes
+   * back to null - and without this, the infinite timeout would stay in place, breaking the invariant that
+   * "unauthenticated" always implies the bounded handshake timeout applies.
+   */
+  private void markUnauthenticated() {
+    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    try {
+      socket.setSoTimeout(Math.max(handshakeTimeout, 0));
+    } catch (final SocketException e) {
+      // As in markAuthenticated(): setSoTimeout() only throws on an already-broken/closed socket, so there is
+      // no live connection left for the un-restored timeout to matter on.
+      LogManager.instance().log(this, Level.FINE, "BOLT unable to restore the idle read timeout after LOGOFF", e);
     }
   }
 

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5978AuthTimeoutIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5978AuthTimeoutIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5978: unlike {@link RedisNetworkExecutor} (issue #5912),
+ * {@link BoltNetworkExecutor} left the AUTH/HELLO-LOGON phase - and, on a plaintext connection, the whole
+ * pre-auth handshake - completely unbounded, so a client that connects and never authenticates could hold
+ * the connection thread (and its file descriptor) open forever.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Bolt5978AuthTimeoutIT extends BaseGraphServerTest {
+
+  private static final int BOLT_PORT = GlobalConfiguration.BOLT_PORT.getValueAsInteger();
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Test
+  @Tag("slow")
+  void idlePostHandshakeUnauthenticatedConnectionIsClosedInsteadOfHeldOpenIndefinitely() throws IOException {
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(500);
+    try {
+      try (final Socket socket = new Socket()) {
+        socket.connect(new InetSocketAddress("localhost", BOLT_PORT), 5000);
+        // Safety bound for the test itself only, well above the lowered server-side timeout: if this fires
+        // instead of a clean EOF, the server is still holding the idle connection open.
+        socket.setSoTimeout(10_000);
+
+        completeHandshake(socket);
+        // Handshake is done, connection is in AUTHENTICATION state; never send HELLO/LOGON.
+        assertThat(socket.getInputStream().read()).isEqualTo(-1);
+      }
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+
+    // The listener/thread pool must still be healthy: a fresh connection behaves normally afterward.
+    assertBoltStillServesClients();
+  }
+
+  @Test
+  @Tag("slow")
+  void stalledBeforeHandshakeConnectionIsClosedInsteadOfHeldOpenIndefinitely() throws IOException {
+    // Even before the BOLT magic/version negotiation completes, the connection must be bounded - not just
+    // the subsequent AUTH/HELLO-LOGON phase.
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(500);
+    try {
+      try (final Socket socket = new Socket()) {
+        socket.connect(new InetSocketAddress("localhost", BOLT_PORT), 5000);
+        socket.setSoTimeout(10_000);
+        // Never send anything at all, not even the magic bytes.
+        assertThat(socket.getInputStream().read()).isEqualTo(-1);
+      }
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+
+    assertBoltStillServesClients();
+  }
+
+  @Test
+  @Tag("slow")
+  void authenticatedConnectionIsNotClosedWhileIdle() throws Exception {
+    // The pre-auth timeout must not keep applying once HELLO/LOGON succeeded: a BOLT client is expected to
+    // keep a long-lived, often idle connection open between queries (driver session pooling).
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(500);
+    try (final Driver driver = GraphDatabase.driver("bolt://localhost:" + BOLT_PORT,
+        AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS))) {
+      try (final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        assertThat(session.run("RETURN 1 AS value").hasNext()).isTrue();
+
+        Thread.sleep(1_500); // well over the lowered pre-auth timeout
+
+        assertThat(session.run("RETURN 1 AS value").hasNext()).isTrue();
+      }
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+  }
+
+  private void assertBoltStillServesClients() {
+    try (final Driver driver = GraphDatabase.driver("bolt://localhost:" + BOLT_PORT,
+        AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS))) {
+      try (final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        final Result result = session.run("RETURN 1 AS value");
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.next().get("value").asLong()).isEqualTo(1L);
+      }
+    }
+  }
+
+  /**
+   * Completes the BOLT magic-bytes + version-negotiation handshake so the connection reaches the
+   * AUTHENTICATION state, without sending HELLO.
+   */
+  private static void completeHandshake(final Socket socket) throws IOException {
+    final OutputStream out = socket.getOutputStream();
+    out.write(new byte[] { 0x60, 0x60, (byte) 0xB0, 0x17 }); // BOLT magic
+
+    // The real handshake always proposes 4 versions; only the first slot needs to be one the server
+    // supports (BoltNetworkExecutor.SUPPORTED_VERSIONS is package-private, visible here).
+    final int version = BoltNetworkExecutor.SUPPORTED_VERSIONS[0];
+    writeRawInt(out, version);
+    writeRawInt(out, 0);
+    writeRawInt(out, 0);
+    writeRawInt(out, 0);
+    out.flush();
+
+    // Read the 4-byte negotiated version response.
+    final byte[] response = new byte[4];
+    int read = 0;
+    while (read < 4) {
+      final int n = socket.getInputStream().read(response, read, 4 - read);
+      if (n == -1)
+        throw new IOException("Server closed the connection during handshake");
+      read += n;
+    }
+  }
+
+  private static void writeRawInt(final OutputStream out, final int value) throws IOException {
+    out.write((value >>> 24) & 0xFF);
+    out.write((value >>> 16) & 0xFF);
+    out.write((value >>> 8) & 0xFF);
+    out.write(value & 0xFF);
+  }
+}

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -387,3 +387,74 @@ validation against a large field value - can now fail with `TimeoutException` in
 `arcadedb.command.regexTimeout` for any database with that kind of workload.
 
 [#5886](https://github.com/ArcadeData/arcadedb/issues/5886)
+
+## A rare `NoSuchElementException` reading a record immediately after committing it under `REPEATABLE_READ` (#5976)
+
+`RecordEncryptionTest.encryption()` intermittently failed on CI with `NoSuchElementException` out of
+`MultiIterator.next()`, reading back a `BackAccount` vertex saved by the immediately preceding, already-committed
+transaction - single-threaded, no HA, no network. The failure was never reproduced locally, which pointed at a
+narrow timing window rather than a deterministic bug.
+
+The real error was hidden. `BucketIterator.fetchNext()` catches any exception thrown while materializing a
+record, logs it at `SEVERE`, and skips the slot - so a record that failed to load looked identical to an empty
+bucket to every caller, surfacing generically as "no records" instead of whatever actually went wrong.
+
+What actually went wrong: `TransactionContext.getPage()` decides whether a freshly loaded page is worth caching
+in its `REPEATABLE_READ` snapshot (`immutablePages`) by checking whether the page is "new" - and used
+`PaginatedComponentFile.getTotalPages()` (the physical on-disk file size) to decide. That lags a commit:
+`PageManager.writePages()` hands a committed page to the async flush thread and only bumps the in-memory
+`PaginatedComponent.pageCount` synchronously, so a just-committed, not-yet-physically-flushed page was
+(incorrectly) treated as "new" and left out of the cache. `ImmutableVertex.modify()` then used that same cache
+(via `hasPageForRecord()`) to decide whether a record needed a defensive reload - found it missing, and
+force-reloaded, which re-invokes every `AfterRecordReadListener` on the same record a second time, re-entrantly,
+before the first invocation had returned. The encryption listener decrypts a record's ciphertext in place inside
+`onAfterRead()`, starting with `record.asVertex().modify()` - not safe against being re-entered on itself: the
+inner (nested) call decrypts the ciphertext first, so the outer call then tries to Base64-decode the now-plaintext
+value and throws `IllegalArgumentException`, which `BucketIterator` swallows as described above.
+
+Fixed by having `getPage()` ask the owning `PaginatedComponent` for its own page count (bumped synchronously at
+commit, independent of flush timing) instead of the physical file size, so a committed page is cached for
+`REPEATABLE_READ` as soon as it is committed. `Issue5976AfterReadReentrancyRaceTest` reproduces the race
+deterministically by forcing the page cache to evict aggressively (`MAX_PAGE_RAM=0`) across a few thousand
+fresh single-page buckets: 500+ failures per 1000 iterations before the fix, zero after it.
+
+[#5976](https://github.com/ArcadeData/arcadedb/issues/5976)
+
+## `AbstractSQLMethod.getSyntax()` mis-rendered variadic methods (#5972)
+
+The shared default `getSyntax()` implementation built the optional-parameter suffix with a loop bounded by
+`i < maxParams`, which is never true once `maxParams` is `-1` - the sentinel every variadic SQL method
+(`removeall`, `append`, `include`, `exclude`, `remove`, `transform`) declares for "unlimited". Any variadic
+method that does not override `getSyntax()` itself - only `SQLMethodRemoveAll` in practice - therefore rendered
+a trailing `[]` regardless of how many extra parameters it actually accepts, e.g.
+`<field>.removeall(param1[])` instead of `<field>.removeall(param1[, param2]*)`. Cosmetic only (this string
+feeds documentation generation and exception messages, not parsing), but now handled explicitly for both the
+"at least one more" and "any number, including zero" shapes.
+
+[#5972](https://github.com/ArcadeData/arcadedb/issues/5972)
+
+## Redis/Bolt wire protocols: bounding the BOLT handshake/auth window (#5978)
+
+Follow-up from the #5912 fix that gave the Redis wire protocol a bounded pre-authentication read timeout (so an
+unauthenticated connection that never sends anything can't hold its thread open forever): `BoltNetworkExecutor`
+had no equivalent. `negotiateTransport()` only ever bounded the TLS-detection sub-step, then explicitly restored
+an infinite timeout before the BOLT handshake and the AUTH/HELLO-LOGON exchange even began - and for a
+plaintext-only listener (`arcadedb.bolt.ssl=DISABLED`, the default), no timeout was armed at all. A connected
+client that never completed the handshake or never authenticated could hold the connection thread open
+indefinitely, the same resource-exhaustion shape #5912 closed for Redis.
+
+Fixed by arming the same bounded `NETWORK_SOCKET_TIMEOUT` window across transport negotiation, the BOLT
+handshake and the AUTH/HELLO-LOGON phase - for both plaintext and TLS connections - lifting it to infinite only
+once authentication actually succeeds (mirroring `RedisNetworkExecutor.markAuthenticated`/`markUnauthenticated`),
+and re-arming it on `LOGOFF`. A `SocketTimeoutException` on that bounded window now closes the connection
+cleanly (matching the existing `EOFException`/`SocketException` handling) instead of surfacing as a `SEVERE`
+"BOLT connection error" log.
+
+Two other follow-ups filed alongside this one were evaluated and intentionally left as-is: an idle-timeout cap
+on already-authenticated Redis connections was judged not worth the deviation from real Redis semantics (which
+never times out an idle authenticated client) absent evidence it's a problem in practice; and the swallowed
+`SocketException` in `RedisNetworkExecutor.markUnauthenticated()` already carries a comment explaining why that
+failure mode is safe to ignore (the socket is already broken/closed) - the new `BoltNetworkExecutor` counterpart
+documents the same reasoning.
+
+[#5978](https://github.com/ArcadeData/arcadedb/issues/5978)

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -532,7 +532,10 @@ public class TransactionContext implements Transaction {
           // committed, not-yet-flushed page look "new", so it was never cached into immutablePages: a later
           // Record.modify() on that same record then saw hasPageForRecord() return false, forced an
           // unnecessary reload(), and re-fired AfterRecordReadListener re-entrantly on the same record.
-          final PaginatedComponent component = (PaginatedComponent) database.getSchema().getFileById(pageId.getFileId());
+          // getFileByIdIfExists(), NOT getFileById(): the latter throws SchemaException on an unregistered id
+          // instead of returning null, which would turn the "not cacheable, don't blow up the read" fallback
+          // below into a hard failure on this read path instead (code review on #6013).
+          final PaginatedComponent component = (PaginatedComponent) database.getSchema().getFileByIdIfExists(pageId.getFileId());
           final boolean isNewPage = component == null || pageId.getPageNumber() >= component.getTotalPages();
           if (!isNewPage)
             // CACHE THE IMMUTABLE PAGE ONLY IF IT IS NOT NEW

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -525,8 +525,15 @@ public class TransactionContext implements Transaction {
         case READ_COMMITTED:
           break;
         case REPEATABLE_READ:
-          final PaginatedComponentFile file = (PaginatedComponentFile) database.getFileManager().getFile(pageId.getFileId());
-          final boolean isNewPage = pageId.getPageNumber() >= file.getTotalPages();
+          // #5976: the component's OWN page count (bumped synchronously at commit time, see
+          // PaginatedComponent.updatePageCount()) is the authoritative "does this page exist" answer - unlike
+          // PaginatedComponentFile.getTotalPages() (physical on-disk file size), which lags behind a committed
+          // page until the async flush thread actually writes it. Using the physical size here made a just-
+          // committed, not-yet-flushed page look "new", so it was never cached into immutablePages: a later
+          // Record.modify() on that same record then saw hasPageForRecord() return false, forced an
+          // unnecessary reload(), and re-fired AfterRecordReadListener re-entrantly on the same record.
+          final PaginatedComponent component = (PaginatedComponent) database.getSchema().getFileById(pageId.getFileId());
+          final boolean isNewPage = component == null || pageId.getPageNumber() >= component.getTotalPages();
           if (!isNewPage)
             // CACHE THE IMMUTABLE PAGE ONLY IF IT IS NOT NEW
             immutablePages.put(pageId, (ImmutablePage) page);

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -534,7 +534,8 @@ public class TransactionContext implements Transaction {
           // unnecessary reload(), and re-fired AfterRecordReadListener re-entrantly on the same record.
           // getFileByIdIfExists(), NOT getFileById(): the latter throws SchemaException on an unregistered id
           // instead of returning null, which would turn the "not cacheable, don't blow up the read" fallback
-          // below into a hard failure on this read path instead (code review on #6013).
+          // below into a hard failure on this read path instead (code review on #6013). The cast is safe
+          // because PaginatedComponent is the only direct subclass of Component in the codebase.
           final PaginatedComponent component = (PaginatedComponent) database.getSchema().getFileByIdIfExists(pageId.getFileId());
           final boolean isNewPage = component == null || pageId.getPageNumber() >= component.getTotalPages();
           if (!isNewPage)

--- a/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
@@ -71,15 +71,26 @@ public abstract class AbstractSQLMethod implements SQLMethod {
       sb.append(i + 1);
     }
     if (minParams != maxParams) {
-      sb.append('[');
-      for (int i = minParams; i < maxParams; i++) {
-        if (i != 0) {
-          sb.append(", ");
+      if (maxParams == -1) {
+        // UNBOUNDED/VARIADIC: MIRRORS FunctionArity.describe()'S "AT LEAST N" PHRASING FOR THE EQUIVALENT CASE
+        if (minParams == 0) {
+          sb.append("[param1[, param2]*]");
+        } else {
+          sb.append("[, param");
+          sb.append(minParams + 1);
+          sb.append("]*");
         }
-        sb.append("param");
-        sb.append(i + 1);
+      } else {
+        sb.append('[');
+        for (int i = minParams; i < maxParams; i++) {
+          if (i != 0) {
+            sb.append(", ");
+          }
+          sb.append("param");
+          sb.append(i + 1);
+        }
+        sb.append(']');
       }
-      sb.append(']');
     }
     sb.append(')');
 

--- a/engine/src/test/java/com/arcadedb/event/Issue5976AfterReadReentrancyRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/event/Issue5976AfterReadReentrancyRaceTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.event;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.Record;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5976.
+ * <p>
+ * {@code RecordEncryptionTest.encryption()} intermittently threw {@code NoSuchElementException} out of
+ * {@code MultiIterator.next()} on CI, immediately after a {@code REPEATABLE_READ} transaction's very first read of
+ * a just-committed record. The real failure was hidden: {@code BucketIterator.fetchNext()} swallows any exception
+ * raised while materializing a record (logs it at {@code SEVERE} and skips the slot), so a record that failed to
+ * load looked identical to an empty bucket to the caller.
+ * <p>
+ * Root cause chain:
+ * <ol>
+ *   <li>{@code TransactionContext.getPage()} decided whether a page was "new" (and therefore not worth caching in
+ *   {@code immutablePages} for the {@code REPEATABLE_READ} snapshot) using {@code PaginatedComponentFile.getTotalPages()}
+ *   - the PHYSICAL on-disk file size. That lags a commit: {@code PageManager.writePages()} schedules the page for the
+ *   async flush thread and only the in-memory {@code PaginatedComponent.pageCount} is bumped synchronously.</li>
+ *   <li>A just-committed, not-yet-physically-flushed page was therefore treated as "new" and left out of
+ *   {@code immutablePages}.</li>
+ *   <li>{@code ImmutableVertex.modify()} uses {@code hasPageForRecord()} (which reads {@code immutablePages}) to
+ *   decide whether the record needs a defensive {@code reload()}. Missing from the cache, it force-reloaded -
+ *   re-invoking every {@code AfterRecordReadListener} on the same record a second time, re-entrantly, before the
+ *   first invocation had returned.</li>
+ *   <li>The encryption listener pattern - decrypting a record's ciphertext in place inside {@code onAfterRead()},
+ *   which calls {@code record.asVertex().modify()} as its first step - is not safe against that re-entrant second
+ *   call: the inner (nested) invocation decrypts the ciphertext first, so the outer invocation then tries to
+ *   Base64-decode the now-plaintext value and throws {@code IllegalArgumentException}, which {@code BucketIterator}
+ *   swallows.</li>
+ * </ol>
+ * The fix makes {@code TransactionContext.getPage()} use the component's own (synchronously updated) page count
+ * instead of the physical file size, so a committed page is cached for {@code REPEATABLE_READ} as soon as it is
+ * committed, regardless of async flush timing.
+ * <p>
+ * The race only shows up when the async flush thread has not yet caught up with a commit by the time the very next
+ * transaction reads the same page, which is a narrow window under normal load - hence "intermittent, CI-only,
+ * never reproduced locally" in the original report. This test recreates the exact shape (fresh single-page bucket,
+ * one record, immediately read back under {@code REPEATABLE_READ}, in a listener that calls {@code modify()} on
+ * itself) in a tight loop with the page cache forced to evict aggressively ({@code MAX_PAGE_RAM=0}), which widens
+ * the window enough to fail on effectively every run before the fix (500+ failures out of 1000 iterations) and
+ * zero after it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+public class Issue5976AfterReadReentrancyRaceTest extends TestHelper
+    implements BeforeRecordCreateListener, AfterRecordReadListener, BeforeRecordUpdateListener {
+
+  private static final String       PASSWORD      = "JustAPassword";
+  private static final String       ALGORITHM     = "AES/CBC/PKCS5Padding";
+  private static final String       SECRET        = "Nobody must know John and Zuck are brothers";
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+  private static final int          ITERATIONS    = 1500;
+
+  private SecretKey key;
+
+  @Test
+  void insertThenRepeatableReadImmediatelyAfterNeverThrowsNoSuchElementException() throws Exception {
+    key = RecordEncryptionTest.getKeyFromPassword(PASSWORD, "salt");
+
+    // Force the read-cache to evict as aggressively as possible: this widens the window between a page being
+    // committed (in-memory page count bumped synchronously) and it being physically flushed to disk (async, and
+    // the only thing PaginatedComponentFile.getTotalPages() reflects), which is exactly the race #5976 needs.
+    GlobalConfiguration.MAX_PAGE_RAM.setValue(0L);
+
+    int failures = 0;
+    for (int i = 0; i < ITERATIONS; i++) {
+      final int iterationIndex = i;
+      final String typeName = "BackAccount" + i;
+      final VertexType backAccount = database.getSchema().createVertexType(typeName);
+      backAccount.getEvents().registerListener((BeforeRecordCreateListener) this);
+      backAccount.getEvents().registerListener((AfterRecordReadListener) this);
+      backAccount.getEvents().registerListener((BeforeRecordUpdateListener) this);
+
+      database.transaction(() -> database.newVertex(typeName).set("secret", SECRET).save());
+
+      database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+      try {
+        database.transaction(() -> {
+          final Vertex v1 = database.iterateType(typeName, true).next().asVertex();
+          assertThat(v1.getString("secret")).as("iteration %d", iterationIndex).isEqualTo(SECRET);
+        });
+      } catch (final Exception e) {
+        failures++;
+      } finally {
+        database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED);
+      }
+    }
+
+    assertThat(failures).as("failed iterations out of %d", ITERATIONS).isZero();
+  }
+
+  @Override
+  public Record onAfterRead(final Record record) {
+    // MIRRORS RecordEncryptionTest'S LISTENER SHAPE: modify() FIRST, THEN DECRYPT IN PLACE. THIS IS WHAT MAKES THE
+    // LISTENER NON-REENTRANT-SAFE - THE BUG THIS TEST GUARDS AGAINST IS modify() TRIGGERING A NESTED RE-READ.
+    final MutableVertex doc = record.asVertex().modify();
+    try {
+      final byte[] ivBytes = Base64.getDecoder().decode(doc.getString("iv"));
+      final IvParameterSpec iv = new IvParameterSpec(ivBytes);
+      doc.set("secret", RecordEncryptionTest.decrypt(ALGORITHM, doc.getString("secret"), key, iv));
+      return doc;
+    } catch (final Exception e) {
+      throw new SecurityException(e);
+    }
+  }
+
+  @Override
+  public boolean onBeforeCreate(final Record record) {
+    final MutableVertex doc = record.asVertex().modify();
+    try {
+      final byte[] iv = new byte[16];
+      SECURE_RANDOM.nextBytes(iv);
+      final IvParameterSpec ivSpec = new IvParameterSpec(iv);
+      final String encrypted = RecordEncryptionTest.encrypt(ALGORITHM, doc.getString("secret"), key, ivSpec);
+      doc.set("secret", encrypted);
+      doc.set("iv", Base64.getEncoder().encodeToString(iv));
+    } catch (final Exception e) {
+      throw new SecurityException(e);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean onBeforeUpdate(final Record record) {
+    return onBeforeCreate(record);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/AbstractSQLMethodTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/AbstractSQLMethodTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class AbstractSQLMethodTest {
+
+  private static class DummyMethod extends AbstractSQLMethod {
+    DummyMethod(final int minParams, final int maxParams) {
+      super("dummy", minParams, maxParams);
+    }
+
+    @Override
+    public Object execute(final Object self, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
+      return null;
+    }
+  }
+
+  @Test
+  void syntaxWithFixedParamCount() {
+    assertThat(new DummyMethod(2, 2).getSyntax()).isEqualTo("<field>.dummy(param1, param2)");
+  }
+
+  @Test
+  void syntaxWithBoundedOptionalParams() {
+    assertThat(new DummyMethod(1, 3).getSyntax()).isEqualTo("<field>.dummy(param1[, param2, param3])");
+  }
+
+  @Test
+  void syntaxWithVariadicParamsAndRequiredMinimum() {
+    // REGRESSION FOR #5972: maxParams == -1 USED TO RENDER AN EMPTY "[]" REGARDLESS OF minParams
+    assertThat(new DummyMethod(1, -1).getSyntax()).isEqualTo("<field>.dummy(param1[, param2]*)");
+  }
+
+  @Test
+  void syntaxWithVariadicParamsAndNoRequiredMinimum() {
+    assertThat(new DummyMethod(0, -1).getSyntax()).isEqualTo("<field>.dummy([param1[, param2]*])");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodRemoveAllTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodRemoveAllTest.java
@@ -58,4 +58,10 @@ class SQLMethodRemoveAllTest {
     final List<String> result = (List<String>) method.execute(numbers, null, context, new Object[] { "$name" });
     assertThat(result).contains("two", "three");
   }
+
+  @Test
+  void syntaxDescribesVariadicParameters() {
+    // REGRESSION FOR #5972: THE SHARED DEFAULT USED TO RENDER AN EMPTY "[]" FOR maxParams == -1
+    assertThat(method.getSyntax()).isEqualTo("<field>.removeall(param1[, param2]*)");
+  }
 }


### PR DESCRIPTION
## Summary

Three independent, low-risk fixes bundled together per issue triage:

- **#5972** - `AbstractSQLMethod.getSyntax()` rendered an empty `[]` for variadic methods (`maxParams == -1`) instead of a meaningful `[, paramN]*` suffix. Cosmetic (feeds documentation generation / exception messages, not parsing), but the shared default is now correct for both the "at least N" and "zero or more" shapes.

- **#5976** - Root-caused the intermittent `NoSuchElementException` reported against `RecordEncryptionTest.encryption()` on CI. `TransactionContext.getPage()` decided whether a page was cacheable for a `REPEATABLE_READ` snapshot using `PaginatedComponentFile.getTotalPages()` (the **physical on-disk file size**), which lags a commit: the async flush thread hasn't necessarily written the page yet, even though the in-memory page count was already bumped synchronously at commit. A just-committed-but-not-yet-flushed page was therefore treated as "new" and skipped from the cache. `ImmutableVertex.modify()` then saw `hasPageForRecord()` return false and force-reloaded the record - re-invoking every `AfterRecordReadListener` on the same record a second time, re-entrantly, before the first invocation returned. The stock "decrypt on read" listener pattern (`record.asVertex().modify()` as its first line) isn't safe against that: the inner call decrypts first, so the outer call tries to re-decrypt already-plaintext data and throws - and `BucketIterator.fetchNext()` silently swallows that exception, making the record disappear from the iteration instead of surfacing the real error.

  Fixed by using the owning `PaginatedComponent`'s own (synchronously updated) page count instead of the physical file size. Added `Issue5976AfterReadReentrancyRaceTest`, which reproduces the race deterministically by forcing aggressive page-cache eviction across ~1500 fresh single-page buckets: 500+/1000 failures before the fix, 0/1000 (and 0/4000 in a wider local run) after it.

- **#5978** - `BoltNetworkExecutor` had no bounded pre-authentication read timeout, unlike `RedisNetworkExecutor` after #5912's fix for the same resource-exhaustion shape. Now arms the same bounded `NETWORK_SOCKET_TIMEOUT` window across transport negotiation, the BOLT handshake and the AUTH/HELLO-LOGON phase (for both plaintext and TLS connections), lifting it to infinite only once authentication succeeds and re-arming it on `LOGOFF`. Two smaller follow-ups from the same issue were evaluated and intentionally left as-is (see the release notes entry for why): an idle-timeout cap on already-authenticated Redis connections, and the swallowed `SocketException` in `markUnauthenticated()`, which already documents why that failure mode is safe.

Full narrative writeups are in `docs/release-26.9.1.md`.

## Test plan

- [x] New regression tests: `AbstractSQLMethodTest`, `SQLMethodRemoveAllTest#syntaxDescribesVariadicParameters`, `Issue5976AfterReadReentrancyRaceTest`, `Bolt5978AuthTimeoutIT`
- [x] `RecordEncryptionTest` (original issue's failing test) still green
- [x] Full `com.arcadedb.query.sql.method.**` package (45 classes) green
- [x] Broader Bolt suite (handshake/TLS/auth/session, 112 tests across 5 classes) green
- [x] Redis wire-protocol suite (`RedisRespCorrectnessTest`) green - confirms no regression to the #5912 pattern this mirrors
- [x] Broader transaction/isolation/page-cache regression sweep (70 tests across 15 classes, including `ACIDTransactionTest`, `TransactionIsolationTest`, `PageManagerReadCacheConsistencyTest`) green
- [x] Full reactor `mvn compile` green