### PR TITLE
fix: BucketIterator.fetchNext() off-by-one and exception swallowing (#6014, #6015)

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -150,13 +150,30 @@ public class BucketIterator implements Iterator<Record> {
             (!forwardDirection && currentRecordInPage > -1)
         ) {
           try {
-            final int recordPositionInPage = (int) currentPage.readUnsignedInt(
-                LocalBucket.PAGE_RECORD_TABLE_OFFSET + currentRecordInPage * INT_SERIALIZED_SIZE);
-            if (recordPositionInPage == 0)
-              // CLEANED CORRUPTED RECORD
-              continue;
+            final int recordPositionInPage;
+            final long[] recordSize;
+            try {
+              recordPositionInPage = (int) currentPage.readUnsignedInt(
+                  LocalBucket.PAGE_RECORD_TABLE_OFFSET + currentRecordInPage * INT_SERIALIZED_SIZE);
+              if (recordPositionInPage == 0)
+                // CLEANED CORRUPTED RECORD
+                continue;
 
-            final long[] recordSize = currentPage.readNumberAndSize(recordPositionInPage);
+              recordSize = currentPage.readNumberAndSize(recordPositionInPage);
+            } catch (final RuntimeException e) {
+              // CORRUPTED SLOT-TABLE ENTRY OR RECORD HEADER: these two calls only ever touch raw page bytes (no
+              // application/listener code runs here), so an out-of-bounds read (IndexOutOfBoundsException /
+              // IllegalArgumentException / BufferUnderflowException depending on which Binary accessor caught it
+              // first) is provably page corruption, the same "bad slot" signal as the RECORD_POSITION==0 case
+              // just above. Skip it like SerializationException below, scoped narrowly to just these two reads so
+              // it cannot also catch a bug from database.lookupByRID()/AfterRecordReadListener (#6015).
+              skippedRecords++;
+              final String msg = "Error on loading record #%d:%d (error: %s)".formatted(currentPage.pageId.getFileId(),
+                  (nextPageNumber * bucket.getMaxRecordsInPage()) + currentRecordInPage, e.getMessage());
+              LogManager.instance().log(this, Level.SEVERE, msg);
+              continue;
+            }
+
             if (recordSize[0] > 0 || recordSize[0] == LocalBucket.FIRST_CHUNK) {
               // NOT DELETED
               final RID rid = new RID(bucket.fileId,

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SerializationException;
 import com.arcadedb.log.LogManager;
@@ -88,11 +89,13 @@ public class BucketIterator implements Iterator<Record> {
 
   /**
    * Number of records skipped so far for a known, tolerated corruption reason - a corrupted on-disk record
-   * ({@link SerializationException}) or page-layer corruption in a raw slot/pointer read, both via
+   * ({@link SerializationException}), page-layer corruption in a raw slot/pointer read, or a multi-page record
+   * whose chunk chain {@link LocalBucket#isChunkChainBroken} confirms is structurally broken - all via
    * {@link #logSkippedRecord(Exception)} in {@link #fetchNext()}. A correctness-sensitive caller (e.g. an exact
    * {@code COUNT}) can check this after exhausting the iterator to detect a truncated result; it is not
-   * incremented for the benign concurrent-delete race handled by {@link RecordNotFoundException}, nor for any
-   * other exception, which propagates instead of being counted here (#6015).
+   * incremented for the benign concurrent-delete race handled by {@link RecordNotFoundException}, nor for a
+   * {@link ConcurrentModificationException} not confirmed as a broken chain (transient contention propagates
+   * instead so a retry can resolve it), nor for any other exception, which likewise propagates (#6015).
    */
   public long getSkippedRecordCount() {
     return skippedRecords;
@@ -100,8 +103,10 @@ public class BucketIterator implements Iterator<Record> {
 
   /**
    * Counts and logs a record slot skipped for a known, tolerated reason: a corrupted on-disk record
-   * ({@link SerializationException}) or page-layer corruption in a raw slot/pointer read (an unchecked exception
-   * from a {@code BasePage.read*}/{@code Binary} accessor - see the two call sites in {@link #fetchNext()}).
+   * ({@link SerializationException}), page-layer corruption in a raw slot/pointer read (an unchecked exception
+   * from a {@code BasePage.read*}/{@code Binary} accessor), or a confirmed structurally-broken multi-page chunk
+   * chain ({@link ConcurrentModificationException} where {@link LocalBucket#isChunkChainBroken} returns
+   * {@code true}) - see the call sites in {@link #fetchNext()}.
    */
   private void logSkippedRecord(final Exception e) {
     skippedRecords++;
@@ -192,7 +197,21 @@ public class BucketIterator implements Iterator<Record> {
               if (!bucket.existsRecord(rid))
                 continue;
 
-              nextBatch[writeIndex++] = database.lookupByRID(rid, false);
+              try {
+                nextBatch[writeIndex++] = database.lookupByRID(rid, false);
+              } catch (final ConcurrentModificationException e) {
+                if (!bucket.isChunkChainBroken(rid))
+                  // TRANSIENT CONTENTION, NOT PROVEN CORRUPTION: loadMultiPageRecord() throws this after
+                  // exhausting TX_RETRIES, but exhausted retries alone do not prove the chain is broken - its
+                  // page-version validation also fails under ordinary concurrent writes to OTHER records sharing
+                  // the chain's pages. Propagate so the caller's retry machinery (if any) re-runs, the same
+                  // disambiguation LocalDatabase.deleteRecordInternal() already applies to this exception.
+                  throw e;
+                // CONFIRMED STRUCTURALLY BROKEN CHAIN: a version-blind walk (isChunkChainBroken) found a genuinely
+                // bad continuation pointer, not just a version mismatch - this is corruption, not contention.
+                writeIndex--; // UNDO THE RESERVED SLOT: THE FAILED CALL DID NOT WRITE INTO IT
+                logSkippedRecord(e);
+              }
 
             } else if (recordSize[0] == LocalBucket.RECORD_PLACEHOLDER_POINTER) {
               // PLACEHOLDER
@@ -209,7 +228,18 @@ public class BucketIterator implements Iterator<Record> {
                 continue;
               }
 
-              final Binary view = bucket.getRecordInternal(new RID(bucket.fileId, placeholderTargetPosition), true);
+              final RID placeholderTargetRid = new RID(bucket.fileId, placeholderTargetPosition);
+              final Binary view;
+              try {
+                view = bucket.getRecordInternal(placeholderTargetRid, true);
+              } catch (final ConcurrentModificationException e) {
+                if (!bucket.isChunkChainBroken(placeholderTargetRid))
+                  // TRANSIENT CONTENTION, NOT PROVEN CORRUPTION: see the identical disambiguation on the
+                  // NOT-DELETED branch above.
+                  throw e;
+                logSkippedRecord(e);
+                continue;
+              }
 
               if (view == null)
                 continue;
@@ -225,9 +255,11 @@ public class BucketIterator implements Iterator<Record> {
           } catch (final SerializationException e) {
             // KNOWN-CORRUPT ON-DISK RECORD: log and skip so one bad record does not abort an otherwise healthy
             // full scan (the CHECK DATABASE-shaped case). Every OTHER exception - including one from a
-            // user-supplied AfterRecordReadListener/trigger - is deliberately NOT caught here and propagates
-            // instead, so a real bug surfaces where it can be diagnosed or retried instead of silently looking
-            // like "this bucket has fewer records" (#6015; see #5976 for a listener bug this used to hide).
+            // user-supplied AfterRecordReadListener/trigger, and a ConcurrentModificationException not confirmed
+            // as a broken chunk chain by the two dedicated catches above - is deliberately NOT caught here and
+            // propagates instead, so a real bug (or genuine contention needing a real retry) surfaces where it
+            // can be diagnosed or retried instead of silently looking like "this bucket has fewer records"
+            // (#6015; see #5976 for a listener bug this used to hide).
             logSkippedRecord(e);
           } finally {
             if (forwardDirection)

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -22,6 +22,8 @@ import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.exception.SerializationException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.security.SecurityDatabaseUser;
 
@@ -45,7 +47,8 @@ public class BucketIterator implements Iterator<Record> {
   int      totalPages;
   int      currentRecordInPage;
   long     browsed     = 0;
-  private int writeIndex = 0;
+  private int  writeIndex     = 0;
+  private long skippedRecords = 0;
 
   BucketIterator(final LocalBucket bucket, final boolean forwardDirection) {
     final DatabaseInternal db = bucket.getDatabase();
@@ -83,6 +86,17 @@ public class BucketIterator implements Iterator<Record> {
     recordCountInCurrentPage = currentPage.readShort(LocalBucket.PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
   }
 
+  /**
+   * Number of records skipped so far because they were found corrupted on disk (see the
+   * {@link SerializationException} branch in {@link #fetchNext()}). A correctness-sensitive caller (e.g. an
+   * exact {@code COUNT}) can check this after exhausting the iterator to detect a truncated result; it is not
+   * incremented for the benign concurrent-delete race handled by {@link RecordNotFoundException}, nor for any
+   * other exception, which propagates instead of being counted here (#6015).
+   */
+  public long getSkippedRecordCount() {
+    return skippedRecords;
+  }
+
   @Override
   public boolean hasNext() {
     if (limit > -1 && browsed >= limit)
@@ -115,7 +129,7 @@ public class BucketIterator implements Iterator<Record> {
         if (currentPage == null) {
           if (forwardDirection) {
             // MOVE FORWARD
-            if (nextPageNumber > totalPages)
+            if (nextPageNumber >= totalPages)
               return null;
           } else {
             // MOVE BACKWARDS
@@ -169,7 +183,17 @@ public class BucketIterator implements Iterator<Record> {
                   database.getSchema().getType(database.getSchema().getTypeNameByBucketId(rid.getBucketId())), rid,
                   view, null);
             }
-          } catch (final Exception e) {
+          } catch (final RecordNotFoundException e) {
+            // BENIGN RACE: the record existed a moment ago when bucket.existsRecord(rid) was checked above, but
+            // was concurrently deleted before lookupByRID()/getRecordInternal() executed. Skip it silently, the
+            // same way the other "turned out to be gone" checks in this loop already do with a plain `continue`.
+          } catch (final SerializationException e) {
+            // KNOWN-CORRUPT ON-DISK RECORD: log and skip so one bad record does not abort an otherwise healthy
+            // full scan (the CHECK DATABASE-shaped case). Every OTHER exception - including one from a
+            // user-supplied AfterRecordReadListener/trigger - is deliberately NOT caught here and propagates
+            // instead, so a real bug surfaces where it can be diagnosed or retried instead of silently looking
+            // like "this bucket has fewer records" (#6015; see #5976 for a listener bug this used to hide).
+            skippedRecords++;
             final String msg = "Error on loading record #%d:%d (error: %s)".formatted(currentPage.pageId.getFileId(),
                 (nextPageNumber * bucket.getMaxRecordsInPage()) + currentRecordInPage, e.getMessage());
             LogManager.instance().log(this, Level.SEVERE, msg);

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -209,7 +209,10 @@ public class BucketIterator implements Iterator<Record> {
                   throw e;
                 // CONFIRMED STRUCTURALLY BROKEN CHAIN: a version-blind walk (isChunkChainBroken) found a genuinely
                 // bad continuation pointer, not just a version mismatch - this is corruption, not contention.
-                writeIndex--; // UNDO THE RESERVED SLOT: THE FAILED CALL DID NOT WRITE INTO IT
+                // UNDO THE RESERVED SLOT: per JLS 15.26.1, `nextBatch[writeIndex++] = ...` evaluates the array
+                // index (incrementing writeIndex) BEFORE the right-hand side, so the increment already happened
+                // even though lookupByRID() threw before ever writing into that slot. Do not "simplify" this away.
+                writeIndex--;
                 logSkippedRecord(e);
               }
 

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -87,14 +87,27 @@ public class BucketIterator implements Iterator<Record> {
   }
 
   /**
-   * Number of records skipped so far because they were found corrupted on disk (see the
-   * {@link SerializationException} branch in {@link #fetchNext()}). A correctness-sensitive caller (e.g. an
-   * exact {@code COUNT}) can check this after exhausting the iterator to detect a truncated result; it is not
+   * Number of records skipped so far for a known, tolerated corruption reason - a corrupted on-disk record
+   * ({@link SerializationException}) or page-layer corruption in a raw slot/pointer read, both via
+   * {@link #logSkippedRecord(Exception)} in {@link #fetchNext()}. A correctness-sensitive caller (e.g. an exact
+   * {@code COUNT}) can check this after exhausting the iterator to detect a truncated result; it is not
    * incremented for the benign concurrent-delete race handled by {@link RecordNotFoundException}, nor for any
    * other exception, which propagates instead of being counted here (#6015).
    */
   public long getSkippedRecordCount() {
     return skippedRecords;
+  }
+
+  /**
+   * Counts and logs a record slot skipped for a known, tolerated reason: a corrupted on-disk record
+   * ({@link SerializationException}) or page-layer corruption in a raw slot/pointer read (an unchecked exception
+   * from a {@code BasePage.read*}/{@code Binary} accessor - see the two call sites in {@link #fetchNext()}).
+   */
+  private void logSkippedRecord(final Exception e) {
+    skippedRecords++;
+    final String msg = "Error on loading record #%d:%d (error: %s)".formatted(currentPage.pageId.getFileId(),
+        (nextPageNumber * bucket.getMaxRecordsInPage()) + currentRecordInPage, e.getMessage());
+    LogManager.instance().log(this, Level.SEVERE, msg);
   }
 
   @Override
@@ -167,10 +180,7 @@ public class BucketIterator implements Iterator<Record> {
               // first) is provably page corruption, the same "bad slot" signal as the RECORD_POSITION==0 case
               // just above. Skip it like SerializationException below, scoped narrowly to just these two reads so
               // it cannot also catch a bug from database.lookupByRID()/AfterRecordReadListener (#6015).
-              skippedRecords++;
-              final String msg = "Error on loading record #%d:%d (error: %s)".formatted(currentPage.pageId.getFileId(),
-                  (nextPageNumber * bucket.getMaxRecordsInPage()) + currentRecordInPage, e.getMessage());
-              LogManager.instance().log(this, Level.SEVERE, msg);
+              logSkippedRecord(e);
               continue;
             }
 
@@ -189,9 +199,17 @@ public class BucketIterator implements Iterator<Record> {
               final RID rid = new RID(bucket.fileId,
                   ((long) nextPageNumber) * bucket.getMaxRecordsInPage() + currentRecordInPage);
 
-              final Binary view = bucket.getRecordInternal(
-                  new RID(bucket.fileId,
-                      currentPage.readLong((int) (recordPositionInPage + recordSize[1]))), true);
+              final long placeholderTargetPosition;
+              try {
+                // Same page-bytes-only shape as the slot-table resolution above: no application/listener code
+                // runs in this call, so a corrupted pointer field is page corruption, not an application bug.
+                placeholderTargetPosition = currentPage.readLong((int) (recordPositionInPage + recordSize[1]));
+              } catch (final RuntimeException e) {
+                logSkippedRecord(e);
+                continue;
+              }
+
+              final Binary view = bucket.getRecordInternal(new RID(bucket.fileId, placeholderTargetPosition), true);
 
               if (view == null)
                 continue;
@@ -210,10 +228,7 @@ public class BucketIterator implements Iterator<Record> {
             // user-supplied AfterRecordReadListener/trigger - is deliberately NOT caught here and propagates
             // instead, so a real bug surfaces where it can be diagnosed or retried instead of silently looking
             // like "this bucket has fewer records" (#6015; see #5976 for a listener bug this used to hide).
-            skippedRecords++;
-            final String msg = "Error on loading record #%d:%d (error: %s)".formatted(currentPage.pageId.getFileId(),
-                (nextPageNumber * bucket.getMaxRecordsInPage()) + currentRecordInPage, e.getMessage());
-            LogManager.instance().log(this, Level.SEVERE, msg);
+            logSkippedRecord(e);
           } finally {
             if (forwardDirection)
               currentRecordInPage++;

--- a/engine/src/test/java/com/arcadedb/engine/BucketIteratorBrokenChunkChainTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/BucketIteratorBrokenChunkChainTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the third round of code review on #6015's fix: a {@code ConcurrentModificationException}
+ * from {@code LocalBucket.loadMultiPageRecord()} is not proof of corruption by itself - it also fires after
+ * {@code TX_RETRIES} exhausted retries under ordinary transient contention on a healthy record (see
+ * {@code LocalDatabase.deleteRecordInternal}'s identical disambiguation, and its precedent test
+ * {@code BrokenMultiPageRecordDeleteTest}). {@code BucketIterator.fetchNext()} must therefore not treat every
+ * such exception as "known corruption, skip and count" - only one that {@link LocalBucket#isChunkChainBroken}
+ * confirms is a genuinely broken chain. This test reproduces the corrupted-chain half of that disambiguation:
+ * the healthy half (a non-broken chain must never report broken, so a transient conflict keeps propagating) is
+ * covered by {@code BrokenMultiPageRecordDeleteTest.forceDeleteRemovesBrokenMultiPageRecordWhilePlainDeleteRetries}'s
+ * existing assertion on {@code isChunkChainBroken}, which both that test and this one's production code path
+ * share.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BucketIteratorBrokenChunkChainTest extends TestHelper {
+
+  private static final String TYPE = "LargeRecord";
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // This test deliberately injects on-disk corruption, which the post-test integrity check would (correctly) flag.
+    return false;
+  }
+
+  @Test
+  void confirmedBrokenChunkChainIsSkippedNotPropagated() {
+    final RID broken = createBrokenMultiPageVertex();
+
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(broken.getBucketId());
+    assertThat(bucket.isChunkChainBroken(broken))
+        .as("sanity check: the corruption must actually be a confirmed-broken chain for this test to be meaningful")
+        .isTrue();
+
+    // REPEATABLE_READ forces database.lookupByRID() to eagerly load content (and so eagerly call
+    // loadMultiPageRecord()) inside BucketIterator.fetchNext(), the same shape needed to actually exercise the
+    // catch under test: under the default READ_COMMITTED, lookupByRID(rid, false) returns a lazy record shell
+    // and never touches the broken chain during the scan at all.
+    database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+    try {
+      database.transaction(() -> {
+        final BucketIterator iterator = (BucketIterator) bucket.iterator();
+        int count = 0;
+        while (iterator.hasNext()) {
+          iterator.next();
+          count++;
+        }
+
+        assertThat(count).as("the two healthy records must still be returned, the scan must not abort").isEqualTo(2);
+        assertThat(iterator.getSkippedRecordCount())
+            .as("the confirmed-broken chunk chain must be counted as skipped instead of aborting the scan")
+            .isEqualTo(1);
+      });
+    } finally {
+      database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED);
+    }
+  }
+
+  /**
+   * Creates a genuine multi-page vertex at position 0, then corrupts the FIRST_CHUNK's continuation pointer so
+   * the chunk chain is broken at chunk 0 (points to a page well beyond the file). Reopens so the record is
+   * re-read from the corrupted page, not the in-memory cache. Returns the RID of the broken record. Adapted from
+   * {@code com.arcadedb.BrokenMultiPageRecordDeleteTest}'s identical technique.
+   */
+  private RID createBrokenMultiPageVertex() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final int[] bucketIdHolder = new int[1];
+    db.transaction(() -> {
+      final VertexType type = db.getSchema().createVertexType(TYPE, 1);
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("data", Type.STRING);
+      bucketIdHolder[0] = type.getBuckets(false).getFirst().getFileId();
+    });
+
+    final int bucketId = bucketIdHolder[0];
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(bucketId)).getPageSize();
+
+    // A payload several pages long guarantees a multi-page (FIRST_CHUNK) record spanning multiple chunks.
+    final String bigData = "x".repeat(pageSize * 4);
+
+    final RID[] rids = new RID[3];
+    db.transaction(() -> {
+      // Insert the big record FIRST so it lands at position 0 (page 0, slot 0).
+      rids[0] = db.newVertex(TYPE).set("id", 0).set("data", bigData).save().getIdentity();
+      rids[1] = db.newVertex(TYPE).set("id", 1).set("data", "small1").save().getIdentity();
+      rids[2] = db.newVertex(TYPE).set("id", 2).set("data", "small2").save().getIdentity();
+    });
+
+    assertThat(rids[0].getPosition()).isEqualTo(0L);
+
+    corruptFirstChunkPointer(bucketId);
+
+    reopenDatabase();
+
+    return rids[0];
+  }
+
+  /**
+   * Overwrites the next-chunk pointer of the FIRST_CHUNK at page 0 / slot 0 with a value pointing to a page far
+   * beyond the file, breaking the chain at chunk 0.
+   */
+  private void corruptFirstChunkPointer(final int bucketId) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(bucketId)).getPageSize();
+    final int maxRecordsInPage = ((LocalBucket) db.getSchema().getBucketById(bucketId)).getMaxRecordsInPage();
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, bucketId, 0), pageSize, false);
+        // PAGE_RECORD_TABLE_OFFSET == PAGE_RECORD_COUNT_IN_PAGE_OFFSET(0) + SHORT_SERIALIZED_SIZE; slot 0 holds
+        // the content-relative offset of the first record.
+        final int recordOffset = (int) page.readUnsignedInt(Binary.SHORT_SERIALIZED_SIZE);
+
+        // Confirm the record really is a multi-page head: FIRST_CHUNK (-2) is zigzag-encoded as the single byte 0x03.
+        assertThat(page.readByte(recordOffset)).as("record must be a multi-page FIRST_CHUNK").isEqualTo((byte) 3);
+
+        // Layout after the marker: [chunkSize:int][nextChunkPointer:long][content...]. Point the continuation to
+        // a page that does not exist so the chain is broken at chunk 0.
+        final int nextChunkPointerOffset = recordOffset + 1 + Binary.INT_SERIALIZED_SIZE;
+        page.writeLong(nextChunkPointerOffset, 1_000_000L * maxRecordsInPage);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/BucketIteratorCorruptedSlotTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/BucketIteratorCorruptedSlotTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.DocumentType;
+
+import org.junit.jupiter.api.Test;
+
+import static com.arcadedb.database.Binary.INT_SERIALIZED_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the page-layer corruption case raised in code review on #6015's fix: the raw
+ * {@code BasePage.readUnsignedInt()}/{@code readNumberAndSize()} calls that resolve a slot's record position and
+ * size only ever touch page bytes (no application/listener code runs there), so a corrupted slot-table entry
+ * landing outside the page's valid bounds must be treated like any other known-corrupt record - logged, counted
+ * via {@link BucketIterator#getSkippedRecordCount()}, and skipped - rather than propagate and abort the whole
+ * scan the way a bug in {@code AfterRecordReadListener}/application code correctly does after #6015's fix.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class BucketIteratorCorruptedSlotTest extends TestHelper {
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // This test deliberately injects on-disk corruption, which the post-test integrity check would (correctly) flag.
+    return false;
+  }
+
+  @Test
+  void corruptedSlotTableEntryIsSkippedNotPropagated() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("CorruptedSlotTest", 1);
+
+    database.begin();
+    database.newDocument("CorruptedSlotTest").set("id", 1).save();
+    database.newDocument("CorruptedSlotTest").set("id", 2).save();
+    database.commit();
+
+    final LocalBucket bucket = (LocalBucket) type.getBuckets(false).getFirst();
+    assertThat(bucket.pageCount.get()).as("both records must fit on a single page").isEqualTo(1);
+
+    database.begin();
+    final MutablePage page = ((DatabaseInternal) database).getTransaction()
+        .getPageToModify(new PageId((DatabaseInternal) database, bucket.getFileId(), 0), bucket.getPageSize(), false);
+    // POINT THE SECOND RECORD'S SLOT-TABLE ENTRY WELL PAST THE END OF THE PAGE: readNumberAndSize() will hit
+    // Binary.position()'s bounds check and throw, simulating a torn write that corrupted the slot-table entry
+    // itself rather than the record body (which is what SerializationException guards against).
+    page.writeUnsignedInt(LocalBucket.PAGE_RECORD_TABLE_OFFSET + INT_SERIALIZED_SIZE, (long) bucket.getPageSize() * 1000);
+    database.commit();
+
+    final BucketIterator iterator = (BucketIterator) bucket.iterator();
+    int count = 0;
+    while (iterator.hasNext()) {
+      iterator.next();
+      count++;
+    }
+
+    assertThat(count).as("the uncorrupted record must still be returned, the scan must not abort").isEqualTo(1);
+    assertThat(iterator.getSkippedRecordCount())
+        .as("the corrupted slot must be counted as skipped instead of silently disappearing or aborting the scan")
+        .isEqualTo(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/BucketIteratorPhantomPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/BucketIteratorPhantomPageTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Record;
+import com.arcadedb.schema.DocumentType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6014: {@code BucketIterator.fetchNext()}'s forward-scan termination check used
+ * {@code nextPageNumber > totalPages} instead of {@code >=}, so a full forward iteration went on to fetch one
+ * page past the bucket's valid range. {@code TransactionContext.getPage()} delegates that out-of-range fetch to
+ * {@code PageManager.getImmutablePage(..., createIfNotExists=true)}, which silently synthesizes a blank page for
+ * a {@link PageId} that does not correspond to any real page and caches it in {@code PageManager}'s global read
+ * cache.
+ */
+class BucketIteratorPhantomPageTest extends TestHelper {
+
+  @Test
+  void forwardIterationDoesNotCachePhantomPageAfterLastPage() {
+    final DocumentType type = database.getSchema().createDocumentType("PhantomPageTest", 1);
+
+    database.begin();
+    database.newDocument("PhantomPageTest").set("id", 1).save();
+    database.commit();
+
+    final LocalBucket bucket = (LocalBucket) type.getBuckets(false).getFirst();
+    final int totalPages = bucket.pageCount.get();
+    assertThat(totalPages).as("one small record must fit on a single freshly-created page").isEqualTo(1);
+
+    final PageManager pageManager = ((DatabaseInternal) database).getPageManager();
+    final PageId phantomPageId = new PageId((DatabaseInternal) database, bucket.getFileId(), totalPages);
+
+    final Iterator<Record> iterator = bucket.iterator();
+    while (iterator.hasNext())
+      iterator.next();
+
+    assertThat(pageManager.readCache.containsKey(phantomPageId))
+        .as("forward iteration must not synthesize/cache a page past the bucket's valid range (#6014)")
+        .isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/event/Issue6015BucketIteratorSwallowedExceptionTest.java
+++ b/engine/src/test/java/com/arcadedb/event/Issue6015BucketIteratorSwallowedExceptionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.event;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.Record;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for #6015.
+ * <p>
+ * {@code BucketIterator.fetchNext()} used to catch every {@code Exception} raised while materializing a record -
+ * including an arbitrary bug in a user-supplied {@link AfterRecordReadListener} - log it at {@code SEVERE}, and
+ * silently drop the record from the result. The caller could not tell "this bucket legitimately has fewer
+ * records" from "a record failed to load and was skipped": this is exactly what turned #5976's real
+ * {@code IllegalArgumentException} into a misleading {@code NoSuchElementException} several layers up.
+ * <p>
+ * The fix narrows the catch to {@link com.arcadedb.exception.RecordNotFoundException} (a benign concurrent-delete
+ * race) and {@link com.arcadedb.exception.SerializationException} (a known-corrupt on-disk record, still logged
+ * and skipped so one bad record does not abort an otherwise healthy full scan). Every other exception - such as
+ * this test's simulated listener bug - now propagates out of the iterator instead of being swallowed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6015BucketIteratorSwallowedExceptionTest extends TestHelper implements AfterRecordReadListener {
+
+  private static final String TYPE_NAME = "Issue6015Type";
+
+  @Test
+  void listenerBugDuringScanPropagatesInsteadOfLookingLikeAnEmptyBucket() {
+    final VertexType type = database.getSchema().createVertexType(TYPE_NAME);
+    type.getEvents().registerListener((AfterRecordReadListener) this);
+
+    database.transaction(() -> database.newVertex(TYPE_NAME).set("id", 1).save());
+
+    // REPEATABLE_READ forces content (and therefore AfterRecordReadListener) to be loaded eagerly by
+    // lookupByRID() inside BucketIterator.fetchNext(), the same shape #5976 needed to surface the bug.
+    database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+    try {
+      assertThatThrownBy(() -> database.transaction(() -> database.iterateType(TYPE_NAME, true).next()))
+          .as("a real bug in a read listener must surface, not be silently swallowed as \"the bucket is empty\"")
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("simulated listener bug");
+    } finally {
+      database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED);
+    }
+  }
+
+  @Override
+  public Record onAfterRead(final Record record) {
+    throw new IllegalStateException("simulated listener bug (#6015)");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two independent bugs in `BucketIterator.fetchNext()`, both found while investigating #5976 (fixed in #6013).

**#6014 - off-by-one past the bucket's valid range**

The forward-scan termination check used `nextPageNumber > totalPages` instead of `>=`. `totalPages` is a page *count*, so when `nextPageNumber == totalPages` (one past the last real page) the check let the iterator fetch a page that does not exist. `TransactionContext.getPage()` delegates to `PageManager.getImmutablePage(..., createIfNotExists=true)`, which silently synthesizes a blank page for that nonexistent `PageId` and caches it in `PageManager`'s global read cache - a wasted fetch on every forward bucket iteration, plus a phantom cache entry.

Fix: `nextPageNumber >= totalPages`.

**#6015 - exceptions during record materialization were silently swallowed**

The `catch (final Exception e)` block around record materialization caught everything, logged it at `SEVERE`, and dropped the record from the batch. The caller couldn't tell "this bucket legitimately has fewer records" from "N records failed to load and were skipped" - exactly what turned #5976's real `IllegalArgumentException` (a listener re-entrancy bug) into a misleading `NoSuchElementException` several layers up.

I surveyed the call sites and the two exception shapes that can actually reach that catch block:
- `NeedRetryException`/`ConcurrentModificationException` (the issue's suggested "propagate transient/retryable" case) cannot actually occur on a plain read - `PageManager.checkPageVersion()` only runs at commit time. That specific proposal doesn't have a real target.
- `RecordNotFoundException` is a genuinely benign race (record concurrently deleted between the `existsRecord()` check and the lookup a couple of lines later) - already how the rest of this loop treats "turned out to be gone".
- `SerializationException` is the project's own signal for a corrupt-on-disk record - a `CHECK DATABASE`-shaped problem where skipping one bad record and continuing the scan is the right call.
- Everything else (arbitrary `RuntimeException`, e.g. from a user-supplied `AfterRecordReadListener`/trigger, or any future bug) is not a case this iterator can safely reason about generically, so it now propagates instead of being hidden. This matches the project's own prior fix for the same shape of problem in #5656 (`EXISTS{}` swallowing hid a retryable exception).

Added `getSkippedRecordCount()` so a correctness-sensitive caller can detect the corrupt-record-skip case after exhausting the iterator.

## Testing

- `BucketIteratorPhantomPageTest` (new): creates a single-page bucket, exhausts a forward iteration, asserts `PageManager`'s read cache never gains an entry for `PageId(bucket, totalPages)`. Fails before the fix, passes after.
- `Issue6015BucketIteratorSwallowedExceptionTest` (new): registers an `AfterRecordReadListener` that throws `IllegalStateException`, scans the type under `REPEATABLE_READ` (forcing eager content load, same shape as #5976), and asserts the exception now propagates instead of the scan silently looking empty (`NoSuchElementException` from `MultiIterator`, reproduced against the pre-fix code before applying the fix). Fails before the fix, passes after.
- Ran `Issue5976AfterReadReentrancyRaceTest` (the existing regression test for the bug this exact swallow-and-log behavior used to hide) plus the `CheckDatabase*` suite, `RecordEncryptionTest`, `LSMTreeFullTextIndexTest`, and the `Select*`/scan-execution test suites in the `engine` module - all green.

## Test plan

- [x] `mvn -pl engine -am compile` passes
- [x] New regression tests reproduce both bugs against the pre-fix code and pass against the fix
- [x] `Issue5976AfterReadReentrancyRaceTest` still passes (the narrowed catch doesn't regress the prior fix)
- [x] `CheckDatabase*`, `RecordEncryptionTest`, `LSMTreeFullTextIndexTest`, `Select*` execution suites all green

Closes #6014, closes #6015.