### PR TITLE
Fix manual index properties serialization in schema queries

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaIndexDetailStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaIndexDetailStep.java
@@ -65,7 +65,9 @@ public class FetchFromSchemaIndexDetailStep extends AbstractExecutionStep {
       r.setProperty("indexType", index.getType());
       r.setProperty("typeName", index.getTypeName());
 
-      if (index.getPropertyNames() != null)
+      // A manual index is bound to no type and no properties, and IndexMetadata coerces the missing list to an empty one, so the
+      // key must be omitted on emptiness - a null check is never false (issue #6005).
+      if (!index.getPropertyNames().isEmpty())
         r.setProperty("properties", Collections.singletonList(index.getPropertyNames()));
 
       final List<String> keyTypes = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaIndexesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaIndexesStep.java
@@ -67,7 +67,9 @@ public class FetchFromSchemaIndexesStep extends AbstractExecutionStep {
             r.setProperty("name", index.getName());
             r.setProperty("indexType", index.getType());
             r.setProperty("typeName", index.getTypeName());
-            if (index.getPropertyNames() != null)
+            // A manual index is bound to no type and no properties, and IndexMetadata coerces the missing list to an empty one, so
+            // the key must be omitted on emptiness - a null check is never false (issue #6005).
+            if (!index.getPropertyNames().isEmpty())
               r.setProperty("properties", Collections.singletonList(index.getPropertyNames()));
 
             // KEY TYPES

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SchemaDetailQueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SchemaDetailQueryTest.java
@@ -196,6 +196,38 @@ class SchemaDetailQueryTest extends TestHelper {
     assertThat((boolean) listed.getProperty("valid")).isTrue();
   }
 
+  /**
+   * Issue #6005: a manual index is bound to no type and no properties, but {@code IndexMetadata} coerces the missing property list
+   * to an empty one, so {@code getPropertyNames()} is never null. The never-null guard therefore published
+   * {@code properties: [[]]} - an empty list wrapped in a singleton list - instead of omitting the key, on both the detail and the
+   * listing query.
+   */
+  @Test
+  void manualIndexOmitsEmptyProperties() {
+    database.getSchema().buildManualIndex("manualIdx", new Type[] { Type.STRING }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(false).create();
+
+    try (final ResultSet rs = database.query("sql", "SELECT FROM schema:index:manualIdx")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result r = rs.next();
+
+      assertThat((String) r.getProperty("name")).isEqualTo("manualIdx");
+      assertThat(r.hasProperty("properties")).isFalse();
+
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT FROM schema:indexes WHERE name = 'manualIdx'")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result r = rs.next();
+
+      assertThat((String) r.getProperty("name")).isEqualTo("manualIdx");
+      assertThat(r.hasProperty("properties")).isFalse();
+
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
   @Test
   void selectFromSchemaBucketDetailQuoted() {
     database.transaction(() -> database.getSchema().createDocumentType("QuotedBucketTestType"));


### PR DESCRIPTION
## What does this PR do?

Fixes the serialization of manual indexes in schema detail and listing queries. Manual indexes have no bound type or properties, but `IndexMetadata` coerces the missing property list to an empty one. The previous null check (`if (index.getPropertyNames() != null)`) would always pass, causing an empty list to be wrapped in a singleton list and serialized as `properties: [[]]` instead of being omitted entirely.

This PR changes the condition to check for emptiness (`if (!index.getPropertyNames().isEmpty())`) so that the `properties` key is only included when there are actual properties to report.

## Motivation

Issue #6005 - Manual indexes were incorrectly serializing an empty properties list instead of omitting the key entirely, which is inconsistent with the expected schema query output format.

## Related issues

- #6005

## Changes

- **FetchFromSchemaIndexDetailStep.java**: Changed null check to emptiness check for `index.getPropertyNames()`
- **FetchFromSchemaIndexesStep.java**: Changed null check to emptiness check for `index.getPropertyNames()`
- **SchemaDetailQueryTest.java**: Added regression test `manualIndexOmitsEmptyProperties()` that verifies manual indexes omit the `properties` key in both detail and listing queries

## Additional Notes

The fix is minimal and surgical - only the condition logic changes from a null check (which is never false due to `IndexMetadata` coercion) to an emptiness check. Both the detail query and listing query paths are updated consistently. The added test covers both query types to prevent regression.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios (detail query and listing query)

https://claude.ai/code/session_01CCSAMUNodvkBRpg7fCucLd