### PR TITLE
fix: reject NaN narrowing (#5970), fix LSM close-during-compaction test race (#5971), dedupe HA resync-retry helper (#5977)

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -88,6 +88,15 @@ public interface IndexInternal extends Index {
   default void releaseBackgroundResources() {
   }
 
+  /**
+   * Closes the index files. The caller must guarantee that every page committed against this index has already
+   * reached disk (e.g. {@code PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(database)}) before calling
+   * this: a page still queued for asynchronous flush (the default, see {@code TransactionContext.asyncFlush})
+   * finds its file closed underneath it, is left unflushed, and turns the WAL-preserving recovery that follows
+   * into a torn page instead of a clean replay (issue #5971). {@code LocalDatabase}'s own close path satisfies
+   * this by construction - it never calls this method directly, closing index files only via
+   * {@code FileManager.close()} once the database-wide flush has completed.
+   */
   void close();
 
   void drop();

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -541,6 +541,12 @@ public enum Type {
           return string.isEmpty() ? 0L : Long.parseLong(string);
         else if (DateUtils.isDate(value))
           return DateUtils.dateTimeToTimestamp(value, ChronoUnit.MILLIS);
+        else if (isNaN((Number) value))
+          // LONG never goes through narrowToIntegral() - there is no narrower range to check, it IS the widest
+          // integral type - so it needs its own NaN guard (issue #5970).
+          throw new IllegalArgumentException(
+              "Value '" + value + "' is NaN and cannot be converted to type LONG" //
+                  + (property != null ? " for property '" + property.getName() + "'" : ""));
         else
           return ((Number) value).longValue();
 
@@ -785,6 +791,16 @@ public enum Type {
   }
 
   /**
+   * True when {@code value} is a {@link Double} or {@link Float} holding {@code NaN}. Per the JLS narrowing-
+   * conversion rules {@code Double.NaN.longValue()}/{@code Float.NaN.longValue()} return {@code 0}, which is
+   * in-range for every integral target type, so every narrowing path (not just {@link #narrowToIntegral}) must
+   * check this explicitly instead of trusting the range check to catch it (issue #5970).
+   */
+  private static boolean isNaN(final Number value) {
+    return (value instanceof Double doubleValue && doubleValue.isNaN()) || (value instanceof Float floatValue && floatValue.isNaN());
+  }
+
+  /**
    * Range-checks {@code value} before narrowing it to a smaller integral type ({@code BYTE}, {@code SHORT} or
    * {@code INTEGER}). Narrowing with a plain {@code .intValue()}/{@code .shortValue()}/{@code .byteValue()} wraps
    * two's-complement on overflow instead of rejecting - {@code 3000000000L} silently became {@code -1294967296} -
@@ -801,7 +817,7 @@ public enum Type {
    */
   private static Number narrowToIntegral(final Number value, final long min, final long max, final String targetType,
       final Property property) {
-    if (value instanceof Double doubleValue && doubleValue.isNaN() || value instanceof Float floatValue && floatValue.isNaN())
+    if (isNaN(value))
       throw new IllegalArgumentException(
           "Value '" + value + "' is NaN and cannot be converted to type " + targetType //
               + (property != null ? " for property '" + property.getName() + "'" : ""));

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -794,9 +794,18 @@ public enum Type {
    * {@code Infinity}) is caught via the saturating conversion {@link Number#longValue()} already performs. A
    * {@link BigDecimal}/{@link BigInteger} can exceed even the long range, where {@code longValue()} truncates bits
    * instead of saturating, so those two types are range-checked directly against {@code long} bounds first.
+   * <p>
+   * {@code NaN} needs its own guard: per the JLS narrowing-conversion rules {@code Double.NaN.longValue()}/
+   * {@code Float.NaN.longValue()} return {@code 0}, which is in-range for every target type and would otherwise
+   * slip through the range check as a silent {@code 0} (issue #5970).
    */
   private static Number narrowToIntegral(final Number value, final long min, final long max, final String targetType,
       final Property property) {
+    if (value instanceof Double doubleValue && doubleValue.isNaN() || value instanceof Float floatValue && floatValue.isNaN())
+      throw new IllegalArgumentException(
+          "Value '" + value + "' is NaN and cannot be converted to type " + targetType //
+              + (property != null ? " for property '" + property.getName() + "'" : ""));
+
     final long longValue;
     if (value instanceof BigDecimal bigDecimal)
       longValue = bigDecimal.compareTo(BigDecimal.valueOf(Long.MAX_VALUE)) > 0 ? Long.MAX_VALUE

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue4960LSMCloseDuringCompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue4960LSMCloseDuringCompactionTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.index.lsm;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.engine.PageManager;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -54,6 +55,16 @@ class Issue4960LSMCloseDuringCompactionTest extends TestHelper {
         .orElseThrow();
 
     assertThat(lsm.scheduleCompaction()).isTrue();
+
+    // Issue #5971: the insert above commits with the default asyncFlush=true (TransactionContext), which only
+    // QUEUES the dirty pages on PageManagerFlushThread - it does not guarantee they have reached disk yet.
+    // IndexInternal.close()'s contract (see its Javadoc) is that the caller must not call it until pending pages
+    // are flushed; the real LocalDatabase close path honors this by running PageManager.waitAllPagesOfDatabaseAreFlushed()
+    // before ever closing index files. This test calls the index's close() directly and in isolation, so it must
+    // uphold that same precondition itself - otherwise the flush thread later finds the file closed under it
+    // (PageManager.flushPage() throws DatabaseMetadataException), the page is left unflushed, and the WAL-preserving
+    // recovery path that follows produces a torn index page instead of a clean one.
+    assertThat(PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(database)).isTrue();
 
     lsm.close();
 

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -555,6 +555,35 @@ class TypeTest extends TestHelper {
     assertThat(Type.convert(database, BigInteger.valueOf(42), Integer.class)).isEqualTo(42);
   }
 
+  /**
+   * Issue #5970: {@code Double.NaN.longValue()}/{@code Float.NaN.longValue()} return {@code 0} per the JLS
+   * narrowing-conversion rules, which is in-range for BYTE/SHORT/INTEGER, so the range check in
+   * {@code narrowToIntegral()} let a NaN through as a silent {@code 0} instead of rejecting it. Infinity was
+   * already caught (it saturates to {@code Long.MAX_VALUE}/{@code MIN_VALUE}, which is out of range); NaN needs
+   * its own guard.
+   */
+  @Test
+  void convertNaNToIntegralRejected() {
+    assertThatThrownBy(() -> Type.convert(database, Double.NaN, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Float.NaN, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Double.NaN, Short.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Float.NaN, Short.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Double.NaN, Byte.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Float.NaN, Byte.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    // INFINITY WAS ALREADY REJECTED BEFORE #5970 (IT SATURATES TO A LONG BOUNDARY, WHICH IS OUT OF RANGE) - COVERED
+    // HERE TOO SO A REGRESSION IN THE NEW NaN GUARD IS CAUGHT ALONGSIDE IT
+    assertThatThrownBy(() -> Type.convert(database, Double.POSITIVE_INFINITY, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Double.NEGATIVE_INFINITY, Integer.class))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
   @Test
   void convertToLong() {
     assertThat(Type.convert(database, 1L, Long.class)).isEqualTo(1L);

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -560,7 +560,8 @@ class TypeTest extends TestHelper {
    * narrowing-conversion rules, which is in-range for BYTE/SHORT/INTEGER, so the range check in
    * {@code narrowToIntegral()} let a NaN through as a silent {@code 0} instead of rejecting it. Infinity was
    * already caught (it saturates to {@code Long.MAX_VALUE}/{@code MIN_VALUE}, which is out of range); NaN needs
-   * its own guard.
+   * its own guard. LONG never goes through {@code narrowToIntegral()} (no narrower range to check) but has the
+   * identical {@code longValue()}-returns-0 gap, caught by a review round on the fix for this issue's first pass.
    */
   @Test
   void convertNaNToIntegralRejected() {
@@ -575,6 +576,10 @@ class TypeTest extends TestHelper {
     assertThatThrownBy(() -> Type.convert(database, Double.NaN, Byte.class))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> Type.convert(database, Float.NaN, Byte.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Double.NaN, Long.class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, Float.NaN, Long.class))
         .isInstanceOf(IllegalArgumentException.class);
     // INFINITY WAS ALREADY REJECTED BEFORE #5970 (IT SATURATES TO A LONG BOUNDARY, WHICH IS OUT OF RANGE) - COVERED
     // HERE TOO SO A REGRESSION IN THE NEW NaN GUARD IS CAUGHT ALONGSIDE IT

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
@@ -43,7 +43,8 @@ import java.util.logging.Level;
  */
 public abstract class BaseRaftHATest extends BaseGraphServerTest {
 
-  private static final int BASE_RAFT_PORT = 2434;
+  private static final int  BASE_RAFT_PORT          = 2434;
+  private static final long RESYNC_RETRY_TIMEOUT_MS = 30_000;
 
   /**
    * Returns the peer ID for a given server index in the test cluster.
@@ -317,8 +318,6 @@ public abstract class BaseRaftHATest extends BaseGraphServerTest {
     waitForReplicationIsCompleted(serverIndex);
     LogManager.instance().log(this, Level.INFO, "TEST: Server %d restarted and caught up", serverIndex);
   }
-
-  private static final long RESYNC_RETRY_TIMEOUT_MS = 30_000;
 
   /**
    * Runs {@code operation} against a freshly resolved handle for server {@code serverIndex}'s database, retrying

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
@@ -20,6 +20,8 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.exception.DatabaseIsClosedException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.HAServerPlugin;
@@ -30,6 +32,8 @@ import org.apache.ratis.protocol.RaftPeerId;
 
 import java.io.File;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.logging.Level;
 
 /**
@@ -312,5 +316,90 @@ public abstract class BaseRaftHATest extends BaseGraphServerTest {
     // Wait for the restarted peer to catch up to the current leader's last applied index
     waitForReplicationIsCompleted(serverIndex);
     LogManager.instance().log(this, Level.INFO, "TEST: Server %d restarted and caught up", serverIndex);
+  }
+
+  private static final long RESYNC_RETRY_TIMEOUT_MS = 30_000;
+
+  /**
+   * Runs {@code operation} against a freshly resolved handle for server {@code serverIndex}'s database, retrying
+   * with another freshly resolved handle while {@code operation} throws {@link DatabaseIsClosedException} - the
+   * shape a snapshot-reinstall resync leaves when it closes and reinstalls the database out from under a handle
+   * resolved (or held) before the resync ran (issue #5977).
+   * <p>
+   * Three independent HA ITs hit this once each: two reinvented this exact resolve-and-retry shape ad hoc
+   * ({@code Issue5492TruncateBatchNotReplicatedIT}, {@code Issue5655CypherCommitsOnInnerDatabaseIT}) and a third
+   * had no defense at all ({@code Issue5492SchemaWalNotShippedIT}, {@code RaftReadConsistencyBookmarkIT}). This is
+   * the shared version, so a new HA IT that queries a follower shortly after inducing a resync gets it for free
+   * instead of needing to know the trap exists.
+   * <p>
+   * {@code operation} must resolve nothing itself but the {@code Database} handed to it - it must not close over
+   * a handle obtained outside this method, or the retry cannot help it. A simpler "wait for any in-flight resync
+   * to finish, then resolve once" helper is not enough: the resync can start in the gap between that wait check
+   * and the use that follows it, so retrying on the actual failure is the only shape that is not itself racy.
+   */
+  protected <T> T withResyncRetry(final int serverIndex, final Function<Database, T> operation) {
+    final long deadline = System.currentTimeMillis() + RESYNC_RETRY_TIMEOUT_MS;
+    while (true) {
+      final Database db = getServerDatabase(serverIndex, getDatabaseName());
+      try {
+        return operation.apply(db);
+      } catch (final DatabaseIsClosedException e) {
+        if (System.currentTimeMillis() >= deadline)
+          throw e;
+        LogManager.instance().log(this, Level.INFO,
+            "TEST: database '%s' on server %d closed mid-operation (snapshot-reinstall resync); retrying with a fresh handle",
+            getDatabaseName(), serverIndex);
+        try {
+          Thread.sleep(250);
+        } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(ie);
+        }
+      }
+    }
+  }
+
+  /**
+   * Counts through a freshly resolved database handle. {@code count(id)} rather than {@code count(*)}: the
+   * latter reads a cached per-bucket counter, the wrong tool when the question is whether the pages themselves
+   * arrived. A single attempt - no retry of its own - so a {@link DatabaseIsClosedException} propagates to the
+   * caller, which is what {@link #awaitCountOn} relies on to treat a resync window as "try again shortly"
+   * rather than a hard failure.
+   */
+  protected long countOn(final int serverIndex, final String typeName) {
+    final Database db = getServerDatabase(serverIndex, getDatabaseName());
+    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + typeName).next().getProperty("cnt")).longValue();
+  }
+
+  /**
+   * Polls {@code supplier} until it returns {@code expected} or the deadline passes, then returns whatever was
+   * last read successfully.
+   * <p>
+   * On timeout it deliberately returns that last good reading rather than a sentinel, so the assertion reports
+   * the state the follower is actually stuck in - {@code but was: 0L}, the write never arrived - instead of a
+   * {@code -1L} that says only "the helper gave up" and hides which of the two happened. {@code -1} survives to
+   * the assertion only when every single attempt threw, which is itself the distinct diagnosis: the follower
+   * never became queryable at all.
+   */
+  protected long awaitValue(final long expected, final LongSupplier supplier) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + RESYNC_RETRY_TIMEOUT_MS;
+    long lastRead = -1;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        lastRead = supplier.getAsLong();
+        if (lastRead == expected)
+          return lastRead;
+      } catch (final RuntimeException e) {
+        // Mid-resync the database is closed and being reinstalled; keep polling until the deadline. The
+        // previous good reading is kept: it describes the follower better than the fact that one poll hit a
+        // resync window.
+      }
+      Thread.sleep(250);
+    }
+    return lastRead;
+  }
+
+  protected long awaitCountOn(final int serverIndex, final String typeName, final long expected) throws InterruptedException {
+    return awaitValue(expected, () -> countOn(serverIndex, typeName));
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5492SchemaWalNotShippedIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5492SchemaWalNotShippedIT.java
@@ -71,7 +71,6 @@ class Issue5492SchemaWalNotShippedIT extends BaseRaftHATest {
     final int followerIndex = 1 - leaderIndex;
 
     final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
-    final Database followerDb = getServerDatabase(followerIndex, getDatabaseName());
 
     // Create the type through the ordinary DDL path and let it replicate, so the backing files exist
     // on both nodes before the callback below writes into them. Without this the follower would drop
@@ -79,7 +78,10 @@ class Issue5492SchemaWalNotShippedIT extends BaseRaftHATest {
     leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
     leaderDb.command("sql", "INSERT INTO " + TYPE_NAME + " SET id = 0");
     waitForAllServers();
-    assertThat(countOn(followerDb)).as("baseline replicated before the callback").isEqualTo(1);
+    // Resolved through countOn(serverIndex, ...), not a handle cached before this point: a snapshot-reinstall
+    // resync can close and reinstall the follower's database at any time, and a stale handle then throws
+    // DatabaseIsClosedException, which reads like infrastructure noise rather than the resync it is (issue #5977).
+    assertThat(countOn(followerIndex, TYPE_NAME)).as("baseline replicated before the callback").isEqualTo(1);
 
     ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
 
@@ -94,10 +96,10 @@ class Issue5492SchemaWalNotShippedIT extends BaseRaftHATest {
       return null;
     });
 
-    assertThat(countOn(leaderDb)).as("leader applied the record written inside the callback").isEqualTo(2);
+    assertThat(countOn(leaderIndex, TYPE_NAME)).as("leader applied the record written inside the callback").isEqualTo(2);
 
     waitForAllServers();
-    assertThat(awaitCountOn(followerDb, 2))
+    assertThat(awaitCountOn(followerIndex, TYPE_NAME, 2))
         .as("WAL buffered inside recordFileChanges must reach the follower, not be discarded")
         .isEqualTo(2);
 
@@ -110,25 +112,8 @@ class Issue5492SchemaWalNotShippedIT extends BaseRaftHATest {
     assertThat(ArcadeStateMachine.TEST_WAL_GAP_COUNTER.get())
         .as("follower must see no WAL version gap after the callback's pages were replicated")
         .isZero();
-    assertThat(awaitCountOn(followerDb, 3))
+    assertThat(awaitCountOn(followerIndex, TYPE_NAME, 3))
         .as("follower converges with the leader after the subsequent ordinary write")
         .isEqualTo(3);
-  }
-
-  private long countOn(final Database db) {
-    // count() rather than count(*): the latter reads a cached per-bucket counter, which is the wrong
-    // tool when the question is whether the pages themselves arrived.
-    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + TYPE_NAME).next().getProperty("cnt"))
-        .longValue();
-  }
-
-  private long awaitCountOn(final Database db, final long expected) throws InterruptedException {
-    final long deadline = System.currentTimeMillis() + 30_000;
-    long count = countOn(db);
-    while (count != expected && System.currentTimeMillis() < deadline) {
-      Thread.sleep(250);
-      count = countOn(db);
-    }
-    return count;
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5492TruncateBatchNotReplicatedIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5492TruncateBatchNotReplicatedIT.java
@@ -173,34 +173,6 @@ class Issue5492TruncateBatchNotReplicatedIT extends BaseRaftHATest {
         .as("batch commits must replicate on the analyzed-query path too, not only through command()")
         .isZero();
   }
-
-  /**
-   * Counts through a freshly resolved database handle. A snapshot resync reinstalls the follower's database, so a
-   * handle cached before it throws {@code DatabaseIsClosed} - which reads like an infrastructure failure rather than
-   * the divergence that caused it.
-   */
-  private long countOn(final int serverIndex, final String typeName) {
-    // count(id) rather than count(*): the latter reads a cached per-bucket counter, which is the wrong tool
-    // when the question is whether the pages themselves arrived.
-    final Database db = getServerDatabase(serverIndex, getDatabaseName());
-    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + typeName).next().getProperty("cnt"))
-        .longValue();
-  }
-
-  private long awaitCountOn(final int serverIndex, final String typeName, final long expected) throws InterruptedException {
-    final long deadline = System.currentTimeMillis() + 30_000;
-    long count = -1;
-    while (System.currentTimeMillis() < deadline) {
-      try {
-        count = countOn(serverIndex, typeName);
-        if (count == expected)
-          return count;
-      } catch (final RuntimeException e) {
-        // Mid-resync the database is closed and being reinstalled; keep polling until the deadline.
-        count = -1;
-      }
-      Thread.sleep(250);
-    }
-    return count;
-  }
+  // countOn()/awaitCountOn() moved to BaseRaftHATest (issue #5977): this test was one of two independent
+  // reinventions of the same resolve-fresh-and-retry shape.
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
@@ -245,8 +245,9 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
   }
 
   /**
-   * True when the follower has both the type and an index covering {@code code}. Resolved through a fresh handle for
-   * the same reason as {@link #countOn}.
+   * True when the follower has both the type and an index covering {@code code}. Resolved through a fresh handle
+   * for the same reason as {@link BaseRaftHATest#countOn}: a stale handle cached across a snapshot-reinstall
+   * resync throws {@code DatabaseIsClosed}.
    */
   private boolean indexedPropertyExistsOn(final int serverIndex) {
     final Database db = getServerDatabase(serverIndex, getDatabaseName());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5655CypherCommitsOnInnerDatabaseIT.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.LongSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -236,18 +235,8 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
         .isTrue();
   }
 
-  /**
-   * Counts through a freshly resolved database handle. A snapshot resync reinstalls the follower's database, so a
-   * handle cached before it throws {@code DatabaseIsClosed} - which reads like an infrastructure failure rather than
-   * the divergence that caused it.
-   */
-  private long countOn(final int serverIndex, final String typeName) {
-    // count(id) rather than count(*): the latter reads a cached per-bucket counter, which is the wrong tool
-    // when the question is whether the pages themselves arrived.
-    final Database db = getServerDatabase(serverIndex, getDatabaseName());
-    return ((Number) db.command("sql", "SELECT count(id) AS cnt FROM " + typeName).next().getProperty("cnt"))
-        .longValue();
-  }
+  // countOn()/awaitCountOn()/awaitValue() moved to BaseRaftHATest (issue #5977): this test was one of two
+  // independent reinventions of the same resolve-fresh-and-retry shape.
 
   private long markedCountOn(final int serverIndex, final String typeName) {
     final Database db = getServerDatabase(serverIndex, getDatabaseName());
@@ -281,40 +270,8 @@ class Issue5655CypherCommitsOnInnerDatabaseIT extends BaseRaftHATest {
     return false;
   }
 
-  private long awaitCountOn(final int serverIndex, final String typeName, final long expected)
-      throws InterruptedException {
-    return await(expected, () -> countOn(serverIndex, typeName));
-  }
-
   private long awaitMarkedCountOn(final int serverIndex, final String typeName, final long expected)
       throws InterruptedException {
-    return await(expected, () -> markedCountOn(serverIndex, typeName));
-  }
-
-  /**
-   * Polls until the count reaches {@code expected} or the deadline passes, then returns whatever was last read
-   * successfully.
-   * <p>
-   * On timeout it deliberately returns that last good reading rather than a sentinel, so the assertion reports the
-   * state the follower is actually stuck in - {@code but was: 0L}, the write never arrived - instead of a
-   * {@code -1L} that says only "the helper gave up" and hides which of the two happened. {@code -1} survives to the
-   * assertion only when every single attempt threw, which is itself the distinct diagnosis: the follower never
-   * became queryable at all.
-   */
-  private long await(final long expected, final LongSupplier supplier) throws InterruptedException {
-    final long deadline = System.currentTimeMillis() + 30_000;
-    long lastRead = -1;
-    while (System.currentTimeMillis() < deadline) {
-      try {
-        lastRead = supplier.getAsLong();
-        if (lastRead == expected)
-          return lastRead;
-      } catch (final RuntimeException e) {
-        // Mid-resync the database is closed and being reinstalled; keep polling until the deadline. The previous
-        // good reading is kept: it describes the follower better than the fact that one poll hit a resync window.
-      }
-      Thread.sleep(250);
-    }
-    return lastRead;
+    return awaitValue(expected, () -> markedCountOn(serverIndex, typeName));
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReadConsistencyBookmarkIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReadConsistencyBookmarkIT.java
@@ -79,16 +79,22 @@ class RaftReadConsistencyBookmarkIT extends BaseRaftHATest {
 
     final long bookmark = leaderRaft.getLastAppliedIndex();
 
-    final Database followerDb = getServerDatabase(followerIndex, getDatabaseName());
-    try {
-      RaftReplicatedDatabase.applyReadConsistencyContext(
-          Database.READ_CONSISTENCY.READ_YOUR_WRITES, bookmark);
-      final var rs = followerDb.query("sql", "SELECT count(*) as cnt FROM ContextTest");
-      assertThat(rs.hasNext()).isTrue();
-      final long count = rs.next().getProperty("cnt");
-      assertThat(count).isEqualTo(20);
-    } finally {
-      RaftReplicatedDatabase.removeReadConsistencyContext();
-    }
+    // Resolved and retried through withResyncRetry(), not a handle cached before this point: a snapshot-
+    // reinstall resync can close and reinstall the follower's database at any time, and a stale handle then
+    // throws DatabaseIsClosedException, which reads like infrastructure noise rather than the resync it is
+    // (issue #5977).
+    final long count = withResyncRetry(followerIndex, followerDb -> {
+      try {
+        RaftReplicatedDatabase.applyReadConsistencyContext(
+            Database.READ_CONSISTENCY.READ_YOUR_WRITES, bookmark);
+        final var rs = followerDb.query("sql", "SELECT count(*) as cnt FROM ContextTest");
+        assertThat(rs.hasNext()).isTrue();
+        final long cnt = rs.next().getProperty("cnt");
+        return cnt;
+      } finally {
+        RaftReplicatedDatabase.removeReadConsistencyContext();
+      }
+    });
+    assertThat(count).isEqualTo(20);
   }
 }


### PR DESCRIPTION
## Summary

Three independent issue triages bundled into one PR since each is small and none touch overlapping code.

### #5970: `Type.convert()` NaN silently becomes 0

`Type.narrowToIntegral()` range-checks overflow before narrowing to `BYTE`/`SHORT`/`INTEGER`, but `Double.NaN.longValue()`/`Float.NaN.longValue()` return `0` per the JLS narrowing-conversion rules - in-range for every target type, so a NaN slipped through the range check as a silent `0` instead of being rejected. `Infinity` was already caught (it saturates to a `Long` boundary, which is out of range).

**Fix:** explicit `isNaN()` guard in `narrowToIntegral()`, same `IllegalArgumentException` shape as the existing range-check rejection.

### #5971: `Issue4960LSMCloseDuringCompactionTest` flaky - torn index page after close-during-compaction

Reported as a single CI observation, not yet reproduced locally. Root-caused by inspection + a reproduction:

The test calls `LSMTreeIndex.close()` directly on a live, open database, immediately after an insert transaction. That transaction's pages are still queued for **asynchronous** flush (`TransactionContext.asyncFlush` defaults to `true`, `TX_WAL_FLUSH` defaults to no-flush-at-commit) - closing the index's files early races `PageManagerFlushThread`, which later finds the file already closed (`PageManager.flushPage()` throws `DatabaseMetadataException`), leaves the page unflushed, and turns the WAL-preserving recovery that follows into a torn index page instead of a clean replay.

This is not a production bug: `IndexInternal.close()` has **zero** production callers today (grepped the whole repo) - `LocalDatabase`'s own close path deliberately avoids calling it directly (see the `#5418` comment in `closeDurableParts()`), closing index files only via `FileManager.close()` once `PageManager.waitAllPagesOfDatabaseAreFlushed()` has run. The regression test violated that undocumented precondition.

**Reproduction:** amplified the test's insert to 200k records (with auto-compaction disabled via config) so the flush thread could not possibly keep up with an immediate `close()` - reliably reproduced the exact CI log lines (`"Preserving the WAL files... not all pages reached the disk"` / `"closed with unflushed pages"`) with zero code changes, confirming the race.

**Fix:** the test now calls `PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(database)` before `close()`, matching the real close path's guarantee. Also documented the precondition directly on `IndexInternal.close()`'s Javadoc (previously only implied via `releaseBackgroundResources()`'s doc) so the next direct caller doesn't rediscover this by triggering corruption.

Verified: 5 consecutive runs clean before the fix reliably showed the WAL-preservation warning at amplified scale; 5 consecutive runs clean after, and the actual regression test at its original (small) scale runs clean 5/5 with no warnings.

### #5977: HA integration tests repeatedly trip `DatabaseIsClosedException` across a resync boundary

Three HA ITs hit `DatabaseIsClosedException` from querying/commanding a database handle obtained just before a snapshot-reinstall resync reinstalls the target database out from under it. Two ITs (`Issue5492TruncateBatchNotReplicatedIT`, `Issue5655CypherCommitsOnInnerDatabaseIT`) had already independently reinvented a resolve-fresh-and-retry fix for this; a third (`Issue5492SchemaWalNotShippedIT`) and `RaftReadConsistencyBookmarkIT` had no defense at all and are the ones the issue's CI runs actually caught failing.

The issue suggested a "wait for any in-flight resync to finish, then re-resolve" helper. That shape is still racy - a resync can start in the gap between the wait check and the use that follows it. The proven, already-working pattern in this codebase (independently arrived at twice) is **resolve fresh, retry on the actual failure** (`DatabaseIsClosedException`), which is what's implemented here.

**Fix:** moved the pattern into `BaseRaftHATest` as `withResyncRetry()` (general one-shot retry, for `RaftReadConsistencyBookmarkIT`'s single query), `countOn()`/`awaitValue()`/`awaitCountOn()` (the polling variant, for the count-convergence tests). All four HA IT classes now use the shared version instead of three divergent ad hoc copies (one of which was simply absent).

## Test plan

- [x] `TypeTest` (full class, including new `convertNaNToIntegralRejected` regression test) - pass
- [x] `Issue4960LSMCloseDuringCompactionTest` - pass, 5 consecutive runs
- [x] Reproduction test (amplified insert, no fix) - reliably reproduced the exact CI log lines; removed after confirming root cause and fix
- [x] `RaftReadConsistencyBookmarkIT` (both methods, including the previously-failing one) - pass
- [x] `Issue5492SchemaWalNotShippedIT` - pass
- [x] `Issue5492TruncateBatchNotReplicatedIT` (dedup regression check) - pass
- [x] `Issue5655CypherCommitsOnInnerDatabaseIT` (dedup regression check) - pass
- [x] Full `mvn compile` + `test-compile` across `engine`, `server`, `ha-raft` - clean
- [x] Full `com.arcadedb.schema.**` + `com.arcadedb.index.**` suite in `engine` (254 test classes) - 0 failures

Fixes #5970, #5971, #5977

Claude-Session: https://claude.ai/code/session_01YEu5VG1ATFVFtxDWsRhdpj