### PR TITLE
fix(#5703): store an LSM_TREE LINK key as a compressed RID

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndexBucket.java
@@ -979,7 +979,7 @@ public class HashIndexBucket extends PaginatedComponent {
    * and hence half the pages - for free. See issue #5677.
    */
   static byte storageKeyType(final byte declaredBinaryType) {
-    return declaredBinaryType == BinaryTypes.TYPE_RID ? BinaryTypes.TYPE_COMPRESSED_RID : declaredBinaryType;
+    return BinaryTypes.getIndexStorageType(declaredBinaryType);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -831,7 +831,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
         final String newName = mutable.getName().substring(0, last_) + "_" + System.nanoTime();
 
         final LSMTreeIndexMutable newMutableIndex = new LSMTreeIndexMutable(this, database, newName, mutable.isUnique(),
-            database.getDatabasePath() + File.separator + newName, mutable.getKeyTypes(), mutable.getBinaryKeyTypes()
+            database.getDatabasePath() + File.separator + newName, mutable.getKeyTypes(), mutable.getStorageKeyTypes()
             , pageSize,
             LSMTreeIndexMutable.CURRENT_VERSION, compactedIndex);
         newMutableIndex.setStoreTermFrequency(mutable.isStoreTermFrequency());

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -88,8 +88,13 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
   protected       byte[]           binaryKeyTypes;
   /**
    * Binary type actually WRITTEN on the page for each key column. It differs from {@link #binaryKeyTypes} only for
-   * LINK columns - see {@link #storageKeyType(byte)} - and is persisted in the page-0 header, so each file keeps
-   * whatever encoding it was created with (#5703).
+   * LINK columns - see {@link BinaryTypes#getIndexStorageType(byte)} - and is persisted in the page-0 header, so each
+   * file keeps whatever encoding it was created with (#5703).
+   * <p>
+   * The remapping is safe for an ORDERED index because the LSM tree never compares raw key bytes: {@code compareKey}
+   * and {@code compareKeys} deserialize both operands and compare typed values, so key order is
+   * {@link RID#compareTo}'s and is unaffected by how many bytes the RID took on the page. (The one byte-level
+   * comparison, {@code comparator.compareBytes}, is the {@code TYPE_STRING} fast path, which no LINK column reaches.)
    * <p>
    * NOTE for anyone reading the HASH implementation alongside this one: the same two concepts are named the other
    * way round there. {@code HashIndexBucket.binaryKeyTypes} is the ON-PAGE encoding and its {@code declaredKeyTypes}
@@ -156,7 +161,7 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
     this.storageKeyTypes = new byte[keyTypes.length];
     for (int i = 0; i < keyTypes.length; i++) {
       this.binaryKeyTypes[i] = keyTypes[i].getBinaryType();
-      this.storageKeyTypes[i] = storageKeyType(this.binaryKeyTypes[i]);
+      this.storageKeyTypes[i] = BinaryTypes.getIndexStorageType(this.binaryKeyTypes[i]);
     }
 
     this.nullStrategy = nullStrategy;
@@ -237,19 +242,6 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
    */
   byte[] getStorageKeyTypes() {
     return storageKeyTypes;
-  }
-
-  /**
-   * The per-column encoding this index writes on its pages, from what the schema declared.
-   * <p>
-   * The remapping ({@code TYPE_RID} -> {@code TYPE_COMPRESSED_RID}, see
-   * {@link BinaryTypes#getIndexStorageType(byte)}) is safe for an ORDERED index because the LSM tree never compares
-   * raw key bytes: {@code compareKey} and {@code compareKeys} deserialize both operands and compare typed values, so
-   * key order is {@link RID#compareTo}'s and is unaffected by how many bytes the RID took on the page. See #5703,
-   * and #5677 for the HASH sibling.
-   */
-  static byte storageKeyType(final byte declaredBinaryType) {
-    return BinaryTypes.getIndexStorageType(declaredBinaryType);
   }
 
   /**
@@ -590,7 +582,9 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
   protected int getHeaderSize(final int pageNum) {
     int size = INT_SERIALIZED_SIZE + INT_SERIALIZED_SIZE + BYTE_SERIALIZED_SIZE + INT_SERIALIZED_SIZE;
     if (pageNum == 0)
-      size += INT_SERIALIZED_SIZE + BYTE_SERIALIZED_SIZE + binaryKeyTypes.length;
+      // storageKeyTypes, not binaryKeyTypes: this sizes what page 0 actually persists. The two arrays always have
+      // the same length, so this is a readability fix, not a behaviour change.
+      size += INT_SERIALIZED_SIZE + BYTE_SERIALIZED_SIZE + storageKeyTypes.length;
 
     return size;
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -80,7 +80,24 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
   protected final BinarySerializer serializer;
   protected final boolean          unique;
   protected       Type[]           keyTypes;
+  /**
+   * Binary type DECLARED by the schema for each key column. This is what {@link #getBinaryKeyTypes()} reports outward,
+   * what every typed comparison and key coercion uses, and what a caller's key is narrowed to. Use
+   * {@link #storageKeyTypes} for anything that touches the bytes on a page.
+   */
   protected       byte[]           binaryKeyTypes;
+  /**
+   * Binary type actually WRITTEN on the page for each key column. It differs from {@link #binaryKeyTypes} only for
+   * LINK columns - see {@link #storageKeyType(byte)} - and is persisted in the page-0 header, so each file keeps
+   * whatever encoding it was created with (#5703).
+   * <p>
+   * NOTE for anyone reading the HASH implementation alongside this one: the same two concepts are named the other
+   * way round there. {@code HashIndexBucket.binaryKeyTypes} is the ON-PAGE encoding and its {@code declaredKeyTypes}
+   * is the schema type. Here {@code binaryKeyTypes} keeps its original meaning - the schema type, which is what
+   * {@link #getBinaryKeyTypes()} has always reported - and the on-page encoding is this new field. Both classes
+   * report the schema type outward; only the field names disagree.
+   */
+  protected       byte[]           storageKeyTypes;
   protected       boolean[]        caseInsensitiveKeys;
   protected       NULL_STRATEGY    nullStrategy       = NULL_STRATEGY.SKIP;
   protected final AtomicLong       statsAdjacentSteps = new AtomicLong();
@@ -136,18 +153,23 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
     this.keyTypes = keyTypes;
 
     this.binaryKeyTypes = new byte[keyTypes.length];
-    for (int i = 0; i < keyTypes.length; i++)
+    this.storageKeyTypes = new byte[keyTypes.length];
+    for (int i = 0; i < keyTypes.length; i++) {
       this.binaryKeyTypes[i] = keyTypes[i].getBinaryType();
+      this.storageKeyTypes[i] = storageKeyType(this.binaryKeyTypes[i]);
+    }
 
     this.nullStrategy = nullStrategy;
     REMOVED_ENTRY_RID = new RID(-1, -1L);
   }
 
   /**
-   * Called at cloning time.
+   * Called at cloning time. The STORAGE types are what travels between the components of one index: a new file that
+   * belongs to an index already on disk (a compacted sub-index, or the mutable a split creates) must keep encoding
+   * keys the way the existing files do, so it inherits them instead of re-deriving them from the schema.
    */
   protected LSMTreeIndexAbstract(final LSMTreeIndex mainIndex, final DatabaseInternal database, final String name,
-      final boolean unique, final String filePath, final String ext, final Type[] keyTypes, final byte[] binaryKeyTypes,
+      final boolean unique, final String filePath, final String ext, final Type[] keyTypes, final byte[] storageKeyTypes,
       final int pageSize, final int version) throws IOException {
     super(database, name, filePath, TEMP_EXT + ext, ComponentFile.MODE.READ_WRITE, pageSize, version);
     this.mainIndex = mainIndex;
@@ -155,7 +177,8 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
     this.comparator = serializer.getComparator();
     this.unique = unique;
     this.keyTypes = keyTypes;
-    this.binaryKeyTypes = binaryKeyTypes;
+    this.storageKeyTypes = storageKeyTypes;
+    this.binaryKeyTypes = declaredKeyTypes(storageKeyTypes);
     REMOVED_ENTRY_RID = new RID(-1, -1L);
   }
 
@@ -206,6 +229,38 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
 
   public byte[] getBinaryKeyTypes() {
     return binaryKeyTypes;
+  }
+
+  /**
+   * The binary type each key column is encoded with ON THE PAGE. Only the components of this index need it; every
+   * outward consumer wants {@link #getBinaryKeyTypes()}, which reports what the schema declared.
+   */
+  byte[] getStorageKeyTypes() {
+    return storageKeyTypes;
+  }
+
+  /**
+   * The per-column encoding this index writes on its pages, from what the schema declared.
+   * <p>
+   * The remapping ({@code TYPE_RID} -> {@code TYPE_COMPRESSED_RID}, see
+   * {@link BinaryTypes#getIndexStorageType(byte)}) is safe for an ORDERED index because the LSM tree never compares
+   * raw key bytes: {@code compareKey} and {@code compareKeys} deserialize both operands and compare typed values, so
+   * key order is {@link RID#compareTo}'s and is unaffected by how many bytes the RID took on the page. See #5703,
+   * and #5677 for the HASH sibling.
+   */
+  static byte storageKeyType(final byte declaredBinaryType) {
+    return BinaryTypes.getIndexStorageType(declaredBinaryType);
+  }
+
+  /**
+   * Recovers the DECLARED types from the storage types a page header persisted. A header written before #5703
+   * declares {@code TYPE_RID} and maps to itself, which is what keeps an existing index reading its fixed-width keys.
+   */
+  static byte[] declaredKeyTypes(final byte[] storageKeyTypes) {
+    final byte[] declared = new byte[storageKeyTypes.length];
+    for (int i = 0; i < storageKeyTypes.length; i++)
+      declared[i] = BinaryTypes.getIndexDeclaredType(storageKeyTypes[i]);
+    return declared;
   }
 
   public boolean isDeletedEntry(final RID rid) {
@@ -398,7 +453,7 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
       final boolean notNull = version < 1 || buffer.getByte() == 1;
       if (notNull)
         // Keys are serialized in clear (see writeKeys): read them back without decryption.
-        serializer.deserializeValue(database, buffer, binaryKeyTypes[keyIndex], null, false);
+        serializer.deserializeValue(database, buffer, storageKeyTypes[keyIndex], null, false);
     }
 
     return buffer.position() - startsAt;
@@ -480,7 +535,7 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
       final boolean notNull = version < 1 || currentPageBuffer.getByte() == 1;
       if (notNull)
         // Keys are serialized in clear (see writeKeys): read them back without decryption.
-        key[keyIndex] = serializer.deserializeValue(database, currentPageBuffer, binaryKeyTypes[keyIndex], null, false);
+        key[keyIndex] = serializer.deserializeValue(database, currentPageBuffer, storageKeyTypes[keyIndex], null, false);
       else
         key[keyIndex] = null;
     }
@@ -518,8 +573,10 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
         // OPTIMIZATION: SPECIAL CASE, LAZY EVALUATE BYTE PER BYTE THE STRING
         result = comparator.compareBytes((byte[]) key, currentPageBuffer);
       } else {
-        // Keys are serialized in clear (see writeKeys): read them back without decryption.
-        final Object keyValue = serializer.deserializeValue(database, currentPageBuffer, binaryKeyTypes[keyIndex], null, false);
+        // Keys are serialized in clear (see writeKeys): read them back without decryption. The bytes are read with the
+        // STORAGE type and the resulting value compared under the DECLARED one, which is what makes the compressed RID
+        // encoding order-preserving: only the number of bytes changes, never the value the comparator sees.
+        final Object keyValue = serializer.deserializeValue(database, currentPageBuffer, storageKeyTypes[keyIndex], null, false);
         result = comparator.compare(key, binaryKeyTypes[keyIndex], keyValue, binaryKeyTypes[keyIndex]);
       }
 
@@ -865,7 +922,7 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
           result = comparator.compareBytes((byte[]) keys[keyIndex], currentPageBuffer);
         } else {
           // Keys are serialized in clear (see writeKeys): read them back without decryption.
-          final Object key = serializer.deserializeValue(database, currentPageBuffer, keyType, null, false);
+          final Object key = serializer.deserializeValue(database, currentPageBuffer, storageKeyTypes[keyIndex], null, false);
           result = comparator.compare(keys[keyIndex], keyType, key, keyType);
         }
 
@@ -957,7 +1014,7 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
         // Index keys must be deterministic (issue #5142/#4137): encryption uses a fresh random IV per call, so encrypting
         // keys would yield different ciphertext each time and break the ordered key comparison. Keys are always serialized
         // in clear; the record content they point to remains encrypted.
-        serializer.serializeValue(database, buffer, binaryKeyTypes[i], value, false);
+        serializer.serializeValue(database, buffer, storageKeyTypes[i], value, false);
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -141,8 +141,8 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
    */
   public LSMTreeIndexCompacted(final LSMTreeIndex mainIndex, final DatabaseInternal database, final String name,
       final boolean unique, final String filePath,
-      final Type[] keyTypes, final byte[] binaryKeyTypes, final int pageSize) throws IOException {
-    super(mainIndex, database, name, unique, filePath, unique ? UNIQUE_INDEX_EXT : NOTUNIQUE_INDEX_EXT, keyTypes, binaryKeyTypes,
+      final Type[] keyTypes, final byte[] storageKeyTypes, final int pageSize) throws IOException {
+    super(mainIndex, database, name, unique, filePath, unique ? UNIQUE_INDEX_EXT : NOTUNIQUE_INDEX_EXT, keyTypes, storageKeyTypes,
         pageSize,
         LSMTreeIndexMutable.CURRENT_VERSION);
   }
@@ -405,9 +405,11 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     if (txPageCounter == 0) {
       pos += currentPage.writeInt(pos, -1); // SUB-INDEX FILE ID
 
-      currentPage.writeByte(pos++, (byte) binaryKeyTypes.length);
-      for (int i = 0; i < binaryKeyTypes.length; ++i)
-        currentPage.writeByte(pos++, binaryKeyTypes[i]);
+      // The STORAGE types, for the same reason as in LSMTreeIndexMutable.createNewPage: this is the encoding the
+      // entries on this page actually use.
+      currentPage.writeByte(pos++, (byte) storageKeyTypes.length);
+      for (int i = 0; i < storageKeyTypes.length; ++i)
+        currentPage.writeByte(pos++, storageKeyTypes[i]);
     }
 
     updatePageCount(txPageCounter + 1);
@@ -502,10 +504,10 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
           // bound; descending keeps series below the (upper) fromKeys bound. The opposite (far) bound is enforced by
           // LSMTreeIndexCursor's toKeys termination. Without this, a series lying wholly inside [fromKeys, toKeys] -
           // containing neither endpoint - produced no cursor and every interior series was silently dropped (#5214).
-          iterator = new LSMTreeIndexUnderlyingCompactedSeriesCursor(this, startingPageNumber, lastPageNumber, binaryKeyTypes,
+          iterator = new LSMTreeIndexUnderlyingCompactedSeriesCursor(this, startingPageNumber, lastPageNumber, storageKeyTypes,
               ascendingOrder, -1);
       } else
-        iterator = new LSMTreeIndexUnderlyingCompactedSeriesCursor(this, startingPageNumber, lastPageNumber, binaryKeyTypes,
+        iterator = new LSMTreeIndexUnderlyingCompactedSeriesCursor(this, startingPageNumber, lastPageNumber, storageKeyTypes,
             ascendingOrder, -1);
 
       if (iterator != null)
@@ -578,7 +580,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
           ++posInPage;
       }
 
-      iterator = new LSMTreeIndexUnderlyingCompactedSeriesCursor(this, startingPageNumber, lastPageNumber, binaryKeyTypes,
+      iterator = new LSMTreeIndexUnderlyingCompactedSeriesCursor(this, startingPageNumber, lastPageNumber, storageKeyTypes,
           ascendingOrder, posInPage);
     }
     return iterator;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -73,9 +73,9 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
    * Called at cloning time.
    */
   protected LSMTreeIndexMutable(final LSMTreeIndex mainIndex, final DatabaseInternal database, final String name,
-      final boolean unique, final String filePath, final Type[] keyTypes, final byte[] binaryKeyTypes, final int pageSize,
+      final boolean unique, final String filePath, final Type[] keyTypes, final byte[] storageKeyTypes, final int pageSize,
       final int version, final LSMTreeIndexCompacted subIndex) throws IOException {
-    super(mainIndex, database, name, unique, filePath, unique ? UNIQUE_INDEX_EXT : NOTUNIQUE_INDEX_EXT, keyTypes, binaryKeyTypes,
+    super(mainIndex, database, name, unique, filePath, unique ? UNIQUE_INDEX_EXT : NOTUNIQUE_INDEX_EXT, keyTypes, storageKeyTypes,
         pageSize, version);
     this.subIndex = subIndex;
     minPagesToScheduleACompaction = database.getConfiguration()
@@ -116,10 +116,14 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
 
       pos += INT_SERIALIZED_SIZE;
 
+      // The header carries the STORAGE type of each key column, so this file keeps whatever encoding it was created
+      // with: one written before #5703 declares TYPE_RID and goes on reading fixed-width LINK keys.
       final int len = currentPage.readByte(pos++);
-      this.binaryKeyTypes = new byte[len];
+      this.storageKeyTypes = new byte[len];
       for (int i = 0; i < len; ++i)
-        this.binaryKeyTypes[i] = currentPage.readByte(pos++);
+        this.storageKeyTypes[i] = currentPage.readByte(pos++);
+
+      this.binaryKeyTypes = declaredKeyTypes(this.storageKeyTypes);
 
       this.keyTypes = new Type[len];
       for (int i = 0; i < len; ++i)
@@ -132,6 +136,9 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
         subIndex = (LSMTreeIndexCompacted) database.getSchema().getFileById(subIndexFileId);
         subIndex.mainIndex = mainIndex;
         subIndex.binaryKeyTypes = binaryKeyTypes;
+        // The sub-index never reads its own header: every file of one index is created with, and keeps, the mutable's
+        // encoding (createNewForCompaction passes it on), so inheriting it here is what the pages actually hold.
+        subIndex.storageKeyTypes = storageKeyTypes;
         // The flag is not persisted in the page header: a sub-index materialised by the component factory defaults to false. It
         // must match this index, because it decides whether the tf/docLength varints trailing every posting are consumed when a
         // value is read back. A mismatch desynchronises the value stream and silently decodes the rest of the entry as garbage.
@@ -208,7 +215,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     final String newName = componentName.substring(0, last_) + "_" + System.nanoTime();
 
     final LSMTreeIndexCompacted compacted = new LSMTreeIndexCompacted(mainIndex, database, newName, unique,
-        database.getDatabasePath() + File.separator + newName, keyTypes, binaryKeyTypes, pageSize);
+        database.getDatabasePath() + File.separator + newName, keyTypes, storageKeyTypes, pageSize);
     compacted.setStoreTermFrequency(isStoreTermFrequency());
     return compacted;
   }
@@ -255,7 +262,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
   public LSMTreeIndexUnderlyingPageCursor newPageIterator(final int pageId, final int currentEntryInPage,
       final boolean ascendingOrder) throws IOException {
     final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
-    return new LSMTreeIndexUnderlyingPageCursor(this, page, currentEntryInPage, getHeaderSize(pageId), binaryKeyTypes,
+    return new LSMTreeIndexUnderlyingPageCursor(this, page, currentEntryInPage, getHeaderSize(pageId), storageKeyTypes,
         getCount(page), ascendingOrder);
   }
 
@@ -366,9 +373,11 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     if (txPageCounter == 0) {
       pos += currentPage.writeInt(pos, subIndex != null ? subIndex.getFileId() : -1); // SUB-INDEX FILE ID
 
-      currentPage.writeByte(pos++, (byte) binaryKeyTypes.length);
-      for (int i = 0; i < binaryKeyTypes.length; ++i)
-        currentPage.writeByte(pos++, binaryKeyTypes[i]);
+      // Persist the STORAGE type, not the declared one: it is what the pages of THIS file are encoded with, and what
+      // onAfterLoad has to honour so a pre-#5703 file keeps reading its fixed-width LINK keys.
+      currentPage.writeByte(pos++, (byte) storageKeyTypes.length);
+      for (int i = 0; i < storageKeyTypes.length; ++i)
+        currentPage.writeByte(pos++, storageKeyTypes[i]);
     }
 
     ++currentMutablePages;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexUnderlyingAbstractCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexUnderlyingAbstractCursor.java
@@ -24,6 +24,14 @@ import com.arcadedb.serializer.BinarySerializer;
 
 public abstract class LSMTreeIndexUnderlyingAbstractCursor {
   protected final LSMTreeIndexAbstract index;
+  /**
+   * The index's STORAGE key types ({@link LSMTreeIndexAbstract#storageKeyTypes}), because a cursor's first job is to
+   * decode page bytes. Subclasses then reuse this same array as the type argument of
+   * {@link LSMTreeIndexMutable#compareKeys}, which is only correct while {@link com.arcadedb.serializer.BinaryComparator}
+   * orders {@code TYPE_COMPRESSED_RID} and {@code TYPE_RID} identically - it does, they share one branch. Should that
+   * ever stop being true, these cursors need the declared types threaded in alongside, the way
+   * {@link LSMTreeIndexAbstract#compareKey} already keeps the two apart (#5703).
+   */
   protected final byte[]               keyTypes;
   protected final BinarySerializer     serializer;
   protected final int                  totalKeys;

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
@@ -83,6 +83,29 @@ public class BinaryTypes {
   public final static byte GEOMETRY_SUBTYPE_LINESTRING = 4; // LineString: numPoints(int), [x,y]* (n*2 doubles)
   public final static byte GEOMETRY_SUBTYPE_POLYGON   = 5; // Polygon: numPoints(int), [x,y]* (n*2 doubles)
 
+  /**
+   * Maps the binary type an index key column DECLARES (what the schema says, what the index reports outward and what
+   * a caller's key is narrowed to) to the binary type the index actually writes on its pages.
+   * <p>
+   * The only remapping is {@link #TYPE_RID} - the encoding of {@code Type.LINK}, and therefore of an edge type's
+   * {@code @out}/{@code @in} endpoints - to {@link #TYPE_COMPRESSED_RID}: the fixed {@code putInt(bucketId)} +
+   * {@code putLong(position)} form costs 12 bytes per column against the 2-7 of the varint form that indexes already
+   * use for every entry <i>value</i>. Both encodings are deterministic and injective, and both deserialize to the
+   * same {@code RID}, so neither hashing (HASH, #5677) nor ordered comparison (LSM, #5703) is affected.
+   */
+  public static byte getIndexStorageType(final byte declaredType) {
+    return declaredType == TYPE_RID ? TYPE_COMPRESSED_RID : declaredType;
+  }
+
+  /**
+   * Inverse of {@link #getIndexStorageType(byte)}, for reading back a storage type an index persisted. The mapping is
+   * unambiguous because no {@code Type} declares {@link #TYPE_COMPRESSED_RID}, so that byte can only mean "a LINK
+   * column stored compressed".
+   */
+  public static byte getIndexDeclaredType(final byte storageType) {
+    return storageType == TYPE_COMPRESSED_RID ? TYPE_RID : storageType;
+  }
+
   public static byte getTypeFromValue(final Object value, final Property propertyType) {
     final byte type;
 

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue5703LsmLinkKeyCompressedRidTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue5703LsmLinkKeyCompressedRidTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.RangeIndex;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.BinaryTypes;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #5703: an {@code LSM_TREE} index used to spend a fixed 12 bytes per {@code LINK} key column
+ * ({@code TYPE_RID} = {@code putInt(bucketId)} + {@code putLong(position)}), while the very same RID costs 2-7
+ * bytes in the varint {@code TYPE_COMPRESSED_RID} form the index already uses for every entry <i>value</i>.
+ * On the composite {@code (@out,@in)} key that motivates an endpoint-keyed unique index that is 24 bytes of key
+ * against a whole-entry cost of roughly 37, so it dominates the page.
+ * <p>
+ * The narrower encoding is safe for an ORDERED index only because the LSM tree never compares raw key bytes: it
+ * deserializes both sides and compares typed values ({@code LSMTreeIndexAbstract.compareKey}), so key order comes
+ * from {@link RID#compareTo} and not from the byte layout. These tests pin that down - order, range bounds and
+ * lookups over LINK keys must be identical to what the fixed-width encoding produced - plus the two traps the
+ * sibling HASH fix (#5677) already hit:
+ * <ul>
+ *   <li>the type reported OUTWARD must stay the schema type ({@code TYPE_RID}), otherwise coercing
+ *       {@code WHERE link = "#150:5"} into a RID breaks with a {@code ClassCastException};</li>
+ *   <li>an index already on disk must keep the encoding ITS OWN page header declares, so a database written
+ *       before this change keeps reading its 12-byte keys.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5703LsmLinkKeyCompressedRidTest extends TestHelper {
+  /** Bytes a single fixed-width LINK column costs on the page: 1 null flag + putInt(bucketId) + putLong(position). */
+  private static final int LEGACY_BYTES_PER_LINK_COLUMN = 1 + Binary.INT_SERIALIZED_SIZE + Binary.LONG_SERIALIZED_SIZE;
+
+  @Test
+  void linkKeyIsStoredCompressedYetStillReportedAsRid() {
+    createEndpointIndexedGraph(64);
+
+    final LSMTreeIndexMutable mutable = firstPopulatedMutableIndex("INITIATED[@out,@in]");
+
+    // ON THE PAGE: the varint form
+    assertThat(mutable.storageKeyTypes).containsExactly(BinaryTypes.TYPE_COMPRESSED_RID, BinaryTypes.TYPE_COMPRESSED_RID);
+    // OUTWARD: still exactly what the schema declares, so key coercion keeps working (the #5677 trap)
+    assertThat(mutable.getBinaryKeyTypes()).containsExactly(BinaryTypes.TYPE_RID, BinaryTypes.TYPE_RID);
+    assertThat(mutable.getKeyTypes()).containsExactly(Type.LINK, Type.LINK);
+
+    // ...and the bytes really are narrower on the page, which is the whole point of the issue.
+    database.transaction(() -> assertThat(firstEntryKeySize(mutable)).isLessThan(2 * LEGACY_BYTES_PER_LINK_COLUMN));
+  }
+
+  @Test
+  void orderedIterationOverLinkKeysFollowsRidOrder() {
+    final List<RID> targets = createLinkIndexedDocuments(400);
+
+    final List<RID> sorted = new ArrayList<>(targets);
+    Collections.sort(sorted);
+
+    final RangeIndex index = (RangeIndex) singleBucketIndex("Doc[ref]");
+
+    database.transaction(() -> {
+      assertThat(keysOf(index.iterator(true))).containsExactlyElementsOf(sorted);
+
+      final List<RID> descending = new ArrayList<>(sorted);
+      Collections.reverse(descending);
+      assertThat(keysOf(index.iterator(false))).containsExactlyElementsOf(descending);
+
+      // A BOUNDED RANGE must select exactly the same slice the fixed-width encoding selected.
+      final RID from = sorted.get(50);
+      final RID to = sorted.get(150);
+      assertThat(keysOf(index.range(true, new Object[] { from }, true, new Object[] { to }, true)))
+          .containsExactlyElementsOf(sorted.subList(50, 151));
+
+      // ...and the exclusive bounds must drop exactly the two endpoints.
+      assertThat(keysOf(index.range(true, new Object[] { from }, false, new Object[] { to }, false)))
+          .containsExactlyElementsOf(sorted.subList(51, 150));
+    });
+  }
+
+  @Test
+  void everyLinkKeyIsFoundByAnExactLookup() {
+    final List<RID> targets = createLinkIndexedDocuments(400);
+    final Index index = database.getSchema().getIndexByName("Doc[ref]");
+
+    database.transaction(() -> {
+      for (final RID target : targets)
+        try (final IndexCursor cursor = index.get(new Object[] { target })) {
+          assertThat(cursor.hasNext()).as("lookup of %s", target).isTrue();
+          assertThat(cursor.next().getRecord().asDocument().get("ref")).isEqualTo(target);
+        }
+    });
+  }
+
+  @Test
+  void compactionPreservesLinkKeyOrderAndLookups() throws Exception {
+    // A small index page so a few thousand entries really do span several pages: LSMTreeIndexCompactor refuses to
+    // run below 2, and compact() itself returns false unless a compaction was scheduled first - so without both of
+    // these the "after compaction" assertions below would never see a compacted sub-index at all.
+    final List<RID> targets = createLinkIndexedDocuments(4_000, 8192);
+
+    final LSMTreeIndex lsmIndex = (LSMTreeIndex) singleBucketIndex("Doc[ref]");
+    assertThat(lsmIndex.getMutableIndex().getTotalPages()).as("mutable pages before compaction").isGreaterThan(1);
+    assertThat(lsmIndex.getMutableIndex().getSubIndex()).as("not compacted yet").isNull();
+
+    assertThat(lsmIndex.scheduleCompaction()).isTrue();
+    assertThat(lsmIndex.compact()).as("compaction ran").isTrue();
+
+    final LSMTreeIndex compacted = (LSMTreeIndex) singleBucketIndex("Doc[ref]");
+    assertThat(compacted.getMutableIndex().getSubIndex()).as("compacted sub-index").isNotNull();
+
+    final List<RID> sorted = new ArrayList<>(targets);
+    Collections.sort(sorted);
+
+    database.transaction(() -> {
+      assertThat(keysOf(compacted.iterator(true))).containsExactlyElementsOf(sorted);
+      for (final RID target : targets)
+        try (final IndexCursor cursor = compacted.get(new Object[] { target })) {
+          assertThat(cursor.hasNext()).as("lookup of %s after compaction", target).isTrue();
+        }
+    });
+  }
+
+  @Test
+  void compositeEndpointUniqueIndexStillRejectsDuplicates() {
+    createEndpointIndexedGraph(16);
+
+    final RID[] endpoints = new RID[2];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account").set("code", "HUB2").save();
+      final MutableVertex leaf = database.newVertex("Account").set("code", "LEAF2").save();
+      hub.newEdge("INITIATED", leaf).save();
+      endpoints[0] = hub.getIdentity();
+      endpoints[1] = leaf.getIdentity();
+    });
+
+    assertThatThrownBy(() -> database.transaction(() -> database.lookupByRID(endpoints[0], true).asVertex().modify()
+        .newEdge("INITIATED", database.lookupByRID(endpoints[1], true).asVertex()).save()))
+        .isInstanceOf(DuplicatedKeyException.class);
+
+    final Index index = database.getSchema().getIndexByName("INITIATED[@out,@in]");
+    database.transaction(() -> {
+      try (final IndexCursor found = index.get(new Object[] { endpoints[0], endpoints[1] })) {
+        assertThat(found.hasNext()).isTrue();
+      }
+      // THE REVERSED PAIR IS A DIFFERENT KEY: the composite order must survive the narrower encoding.
+      try (final IndexCursor reversed = index.get(new Object[] { endpoints[1], endpoints[0] })) {
+        assertThat(reversed.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void aLinkKeyIsStillCoercedFromItsStringForm() {
+    final List<RID> targets = createLinkIndexedDocuments(8);
+    final RID target = targets.getFirst();
+
+    // #5677's regression in the sibling implementation: reporting the STORAGE type outward made the engine
+    // coerce "#1:0" against TYPE_COMPRESSED_RID, whose class mapping is undefined, and throw.
+    try (final ResultSet result = database.query("sql", "SELECT FROM Doc WHERE ref = ?", target.toString())) {
+      assertThat(result.stream().count()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void anIndexWrittenWithFixedWidthKeysKeepsUsingThem() throws Exception {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc", 1);
+      database.getSchema().createVertexType("Target", 1);
+      database.getSchema().getType("Doc").createProperty("ref", Type.LINK);
+      database.getSchema().buildTypeIndex("Doc", new String[] { "ref" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
+    });
+
+    final String fileName = ((LSMTreeIndex) singleBucketIndex("Doc[ref]")).getMutableIndex().getName();
+    database.close();
+
+    // Rewrite the key-type byte page 0 declares back to the pre-#5703 fixed-width type, which is exactly the
+    // state a database created by an older engine is in. Asserting the current value first keeps the test
+    // honest if the page-0 layout ever moves.
+    downgradeFirstKeyTypeOnPageZero(fileName);
+
+    database = factory.open();
+
+    final LSMTreeIndexMutable mutable = ((LSMTreeIndex) singleBucketIndex("Doc[ref]")).getMutableIndex();
+    assertThat(mutable.storageKeyTypes).containsExactly(BinaryTypes.TYPE_RID);
+    assertThat(mutable.getBinaryKeyTypes()).containsExactly(BinaryTypes.TYPE_RID);
+    assertThat(mutable.getKeyTypes()).containsExactly(Type.LINK);
+
+    final List<RID> targets = new ArrayList<>();
+    database.transaction(() -> {
+      for (int i = 0; i < 200; i++) {
+        final RID target = database.newVertex("Target").set("id", i).save().getIdentity();
+        targets.add(target);
+        database.newDocument("Doc").set("ref", target).save();
+      }
+    });
+
+    final List<RID> sorted = new ArrayList<>(targets);
+    Collections.sort(sorted);
+
+    final RangeIndex index = (RangeIndex) singleBucketIndex("Doc[ref]");
+    database.transaction(() -> {
+      assertThat(keysOf(index.iterator(true))).containsExactlyElementsOf(sorted);
+      // AND THE KEYS REALLY ARE THE WIDE ONES: one column, fixed 12 bytes plus the null flag.
+      assertThat(firstEntryKeySize(mutable)).isEqualTo(LEGACY_BYTES_PER_LINK_COLUMN);
+    });
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+
+  private void createEndpointIndexedGraph(final int edges) {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      database.getSchema().createEdgeType("INITIATED");
+      database.getSchema().buildTypeIndex("INITIATED", new String[] { "@out", "@in" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+    });
+
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Account").set("code", "HUB").save();
+      for (int i = 0; i < edges; i++)
+        hub.newEdge("INITIATED", database.newVertex("Account").set("code", "L" + i).save()).save();
+    });
+  }
+
+  /**
+   * Creates {@code count} documents, each linking a distinct vertex, indexed by an LSM index on the LINK property.
+   * Both types get a single bucket so the index has exactly one underlying LSM tree and its iteration order is the
+   * global one, with no cursor merge in between.
+   */
+  private List<RID> createLinkIndexedDocuments(final int count) {
+    return createLinkIndexedDocuments(count, 0);
+  }
+
+  private List<RID> createLinkIndexedDocuments(final int count, final int indexPageSize) {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc", 1);
+      database.getSchema().createVertexType("Target", 1);
+      database.getSchema().getType("Doc").createProperty("ref", Type.LINK);
+      final var builder = database.getSchema().buildTypeIndex("Doc", new String[] { "ref" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false);
+      if (indexPageSize > 0)
+        builder.withPageSize(indexPageSize);
+      builder.create();
+    });
+
+    final List<RID> targets = new ArrayList<>(count);
+    database.transaction(() -> {
+      // Positions climb past the 1-, 2- and 3-byte varint widths, so the encoding under test is exercised at the
+      // widths where a byte-order-based comparison would diverge from RID order.
+      for (int i = 0; i < count; i++) {
+        final RID target = database.newVertex("Target").set("id", i).save().getIdentity();
+        targets.add(target);
+        database.newDocument("Doc").set("ref", target).save();
+      }
+    });
+    return targets;
+  }
+
+  private IndexInternal singleBucketIndex(final String indexName) {
+    final IndexInternal[] subIndexes = ((TypeIndex) database.getSchema().getIndexByName(indexName)).getIndexesOnBuckets();
+    assertThat(subIndexes).hasSize(1);
+    return subIndexes[0];
+  }
+
+  private LSMTreeIndexMutable firstPopulatedMutableIndex(final String indexName) {
+    for (final IndexInternal sub : ((TypeIndex) database.getSchema().getIndexByName(indexName)).getIndexesOnBuckets())
+      if (sub.countEntries() > 0)
+        return ((LSMTreeIndex) sub).getMutableIndex();
+    throw new AssertionError("No populated underlying index found for '" + indexName + "'");
+  }
+
+  private static List<RID> keysOf(final IndexCursor cursor) {
+    final List<RID> keys = new ArrayList<>();
+    try (cursor) {
+      while (cursor.hasNext()) {
+        cursor.next();
+        keys.add((RID) cursor.getKeys()[0]);
+      }
+    }
+    return keys;
+  }
+
+  /** Bytes the FIRST entry of page 0 spends on its key, read back through the index's own key reader. */
+  private int firstEntryKeySize(final LSMTreeIndexMutable mutable) {
+    try {
+      final BasePage page = ((DatabaseInternal) database).getTransaction()
+          .getPage(new PageId(database, mutable.getFileId(), 0), mutable.getPageSize());
+      final Binary buffer = new Binary(page.slice());
+      final int startIndexArray = mutable.getHeaderSize(0);
+      assertThat(mutable.getCount(page)).isPositive();
+      buffer.position(buffer.getInt(startIndexArray));
+      return mutable.getSerializedKeySize(buffer, mutable.getBinaryKeyTypes().length);
+    } catch (final IOException e) {
+      throw new IllegalStateException("Cannot read page 0 of index " + mutable.getName(), e);
+    }
+  }
+
+  /**
+   * Flips the first key-type byte of page 0 from the compressed form back to the fixed-width one, simulating an
+   * index file written before #5703. Page 0's layout is
+   * {@code [pageHeader][int][int][byte][int][subIndexFileId:int][numKeys:byte][keyType:byte]*}.
+   */
+  private void downgradeFirstKeyTypeOnPageZero(final String fileName) throws Exception {
+    final File[] candidates = new File(getDatabasePath()).listFiles((dir, name) -> name.startsWith(fileName + "."));
+    assertThat(candidates).isNotNull().hasSize(1);
+
+    final int keyTypesOffset = BasePage.PAGE_HEADER_SIZE //
+        + Binary.INT_SERIALIZED_SIZE + Binary.INT_SERIALIZED_SIZE + Binary.BYTE_SERIALIZED_SIZE + Binary.INT_SERIALIZED_SIZE //
+        + Binary.INT_SERIALIZED_SIZE  // sub-index file id
+        + Binary.BYTE_SERIALIZED_SIZE; // number of key columns
+
+    try (final RandomAccessFile file = new RandomAccessFile(candidates[0], "rw")) {
+      file.seek(keyTypesOffset - Binary.BYTE_SERIALIZED_SIZE);
+      assertThat(file.readByte()).as("number of key columns on page 0").isEqualTo((byte) 1);
+      assertThat(file.readByte()).as("key type on page 0").isEqualTo(BinaryTypes.TYPE_COMPRESSED_RID);
+      file.seek(keyTypesOffset);
+      file.writeByte(BinaryTypes.TYPE_RID);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue5703LsmLinkKeyCompressedRidTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue5703LsmLinkKeyCompressedRidTest.java
@@ -37,9 +37,9 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryTypes;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/engine/src/test/java/com/arcadedb/index/lsm/LsmLinkKeyEncodingBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/LsmLinkKeyEncodingBenchmark.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.serializer.BinarySerializer;
+import com.arcadedb.serializer.BinaryTypes;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The measurement issue #5703 asked for before anything was changed: how much of an {@code LSM_TREE} index keyed on
+ * {@code (@out,@in)} is spent on the LINK keys, and how much of that the varint {@code TYPE_COMPRESSED_RID} form
+ * gives back.
+ * <p>
+ * It reports three things per run: what the keys cost under each encoding for the very RIDs that were indexed, what
+ * the mutable index file actually occupies, and the resulting bytes per entry. The key figures are computed by
+ * serializing the same RIDs both ways, so the comparison does not depend on which encoding the build under test
+ * happens to use, and the run stays meaningful as a "did the saving hold?" check after the change.
+ * <p>
+ * <b>Measured answer (50k edges, one hub, destinations created in order):</b> keys cost 24.0 bytes/entry fixed-width
+ * against 5.9 compressed - a 75% cut on the key bytes. The whole entry (4-byte pointer slot + 2 null flags + keys +
+ * value count + compressed value RID) costs about 36.7 bytes under the fixed-width encoding, so the saving is
+ * roughly half of everything the index occupies: the same 50k entries went from 7 mutable pages to 4. That is not
+ * small relative to the per-entry overhead the LSM format carries, which is what decided #5703 in favour of making
+ * the change rather than closing it on the numbers.
+ * <p>
+ * The absolute saving shrinks as a database grows - a position in the billions needs 5 varint bytes rather than 2 -
+ * but the fixed form still costs 12 per column, so the compressed form stays ahead at every size.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class LsmLinkKeyEncodingBenchmark {
+  private static final int EDGES        = Integer.parseInt(System.getProperty("edges", "50000"));
+  private static final int EDGES_PER_TX = Integer.parseInt(System.getProperty("edgesPerTx", "100"));
+
+  @Test
+  void reportsWhatTheLinkKeysOfAnEndpointIndexCost() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/lsmLinkKeyEncoding");
+    if (factory.exists())
+      factory.open().drop();
+
+    final Database database = factory.create();
+    try {
+      final List<Vertex> leaves = new ArrayList<>(EDGES);
+      final Vertex[] hub = new Vertex[1];
+
+      database.transaction(() -> {
+        database.getSchema().createVertexType("Account");
+        database.getSchema().createEdgeType("INITIATED");
+        database.getSchema().buildTypeIndex("INITIATED", new String[] { "@out", "@in" })
+            .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+      });
+
+      database.transaction(() -> hub[0] = database.newVertex("Account").set("code", "HUB").save());
+      for (int i = 0; i < EDGES; i += EDGES_PER_TX) {
+        final int from = i;
+        database.transaction(() -> {
+          for (int j = from; j < Math.min(from + EDGES_PER_TX, EDGES); j++)
+            leaves.add(database.newVertex("Account").set("code", "L" + j).save());
+        });
+      }
+      for (int i = 0; i < EDGES; i += EDGES_PER_TX) {
+        final int from = i;
+        database.transaction(() -> {
+          final MutableVertex source = hub[0].modify();
+          for (int j = from; j < Math.min(from + EDGES_PER_TX, EDGES); j++)
+            source.newEdge("INITIATED", leaves.get(j)).save();
+        });
+      }
+
+      final BinarySerializer serializer = ((DatabaseInternal) database).getSerializer();
+      final Binary scratch = new Binary(64);
+      long fixedWidthKeyBytes = 0;
+      long compressedKeyBytes = 0;
+      for (int j = 0; j < EDGES; j++)
+        for (final RID rid : new RID[] { hub[0].getIdentity(), leaves.get(j).getIdentity() }) {
+          scratch.clear();
+          serializer.serializeValue(database, scratch, BinaryTypes.TYPE_RID, rid);
+          fixedWidthKeyBytes += scratch.size();
+          scratch.clear();
+          serializer.serializeValue(database, scratch, BinaryTypes.TYPE_COMPRESSED_RID, rid);
+          compressedKeyBytes += scratch.size();
+        }
+
+      long mutablePages = 0;
+      long indexed = 0;
+      for (final IndexInternal sub : ((TypeIndex) database.getSchema().getIndexByName("INITIATED[@out,@in]")).getIndexesOnBuckets()) {
+        final LSMTreeIndexMutable mutable = ((LSMTreeIndex) sub).getMutableIndex();
+        mutablePages += mutable.getTotalPages();
+        indexed += sub.countEntries();
+      }
+
+      // System.out, not LogManager: a benchmark's numbers ARE its output, and LogManager INFO does not surface in a
+      // surefire run, which makes the measurement invisible.
+      System.out.printf("%n===== #5703 LSM LINK key encoding (edges=%d) =====%n", EDGES);
+      System.out.printf("  entries indexed        %d%n", indexed);
+      System.out.printf("  key bytes fixed-width  %d (%.2f /entry)%n", fixedWidthKeyBytes, fixedWidthKeyBytes / (double) EDGES);
+      System.out.printf("  key bytes compressed   %d (%.2f /entry)%n", compressedKeyBytes, compressedKeyBytes / (double) EDGES);
+      System.out.printf("  saving on key bytes    %.1f%%%n",
+          100.0 * (fixedWidthKeyBytes - compressedKeyBytes) / fixedWidthKeyBytes);
+      System.out.printf("  mutable index pages    %d (%.2f bytes/entry)%n", mutablePages,
+          mutablePages * (double) pageSizeOf(database) / EDGES);
+
+      assertThat(indexed).isEqualTo(EDGES);
+      assertThat(compressedKeyBytes).isLessThan(fixedWidthKeyBytes);
+    } finally {
+      database.drop();
+    }
+  }
+
+  private static int pageSizeOf(final Database database) {
+    return ((LSMTreeIndex) ((TypeIndex) database.getSchema().getIndexByName("INITIATED[@out,@in]")).getIndexesOnBuckets()[0])
+        .getMutableIndex().getPageSize();
+  }
+}


### PR DESCRIPTION
Closes #5703

## The measurement the issue asked for, first

`LsmLinkKeyEncodingBenchmark` (new, `@Tag("benchmark")`) builds a `(@out,@in)` UNIQUE `LSM_TREE` index over 50k
edges and reports what the LINK keys cost under each encoding. The two figures are computed by serializing the very
RIDs that were indexed both ways, so the comparison does not depend on which encoding the build under test happens
to use:

```
===== #5703 LSM LINK key encoding (edges=50000) =====
  entries indexed        50000
  key bytes fixed-width  1200000 (24.00 /entry)
  key bytes compressed   294179 (5.88 /entry)
  saving on key bytes    75.5%
```

The rest of the entry is a 4-byte pointer slot, 2 null flags, a value count and the (already compressed) value RID.
Measured on the unmodified engine, 50k entries filled **7 mutable pages of 262144 bytes** = ~36.7 bytes/entry, of
which 24 were the keys. So the saving is not marginal relative to the per-entry overhead the LSM format already
carries: it is roughly **half of everything the index occupies**, and the same 50k entries now fit in **4 pages**.
That is the test the issue set for deciding between "do it" and "close it on the numbers", and it comes out on the
"do it" side.

## What changed

`LSM_TREE` now stores a `LINK` key column as `TYPE_COMPRESSED_RID` (two varints) instead of `TYPE_RID`
(`putInt(bucketId)` + `putLong(position)`, 12 bytes fixed), matching what `HASH` has done since #5677.

The split #5677 introduced for the same reason is mirrored here, keeping the field name the LSM side already uses:

* `binaryKeyTypes` keeps its existing meaning - the **schema** type. It is what `getBinaryKeyTypes()` reports
  outward, what every typed comparison uses and what a caller's key is narrowed to. Nothing about it changes.
* `storageKeyTypes` (new) is the encoding written **on the page**. Only the five byte-level serialize/deserialize
  sites in `LSMTreeIndexAbstract` and the two page-cursor constructions use it.

(The two classes name these the other way round - `HashIndexBucket.binaryKeyTypes` is its *on-page* array. Both
report the schema type outward; a note on the new field says so, since reading them side by side is otherwise a
trap.) The `TYPE_RID -> TYPE_COMPRESSED_RID` mapping and its inverse now live in `BinaryTypes` and both index
families call it, rather than each keeping a copy.

### Why this is safe for an *ordered* index

The issue asked for this to be proven rather than assumed. It holds because **the LSM tree never compares raw key
bytes**: `compareKey`/`compareKeys` deserialize both operands and compare typed values, so key order is
`RID.compareTo`'s and is unaffected by how many bytes the RID took on the page. The only byte-wise comparison in the
package (`comparator.compareBytes`) is the `TYPE_STRING` fast path, which no LINK column reaches. `BinaryComparator`
already ordered `TYPE_COMPRESSED_RID` and `TYPE_RID` identically, including a mixed pair.

The four compatibility hazards the issue listed are handled as follows:

* **`getBinaryKeyTypes()`, `TypeIndex`, `MultiIndexCursor`, `FetchFromIndexStep`** keep seeing `TYPE_RID`, so
  coercing `WHERE link = "#150:5"` into a RID still works. That is the `ClassCastException` #5677 hit; there is a
  test for it here.
* **The page-0 header now persists the STORAGE type**, and `onAfterLoad` honours whatever it reads. An index written
  before this change declares `TYPE_RID`, so it keeps reading and writing its fixed-width keys forever - no
  migration, no rewrite, no mixed-encoding file. The declared types are recovered from the storage types
  (`TYPE_COMPRESSED_RID -> TYPE_RID`), which is unambiguous because no `Type` declares `TYPE_COMPRESSED_RID`.
* **`LSMTreeIndexCompacted` never reads its own header** - it inherits the mutable's arrays in `onAfterLoad` and
  receives them in `createNewForCompaction`. Both now carry the storage types, so every file of one index keeps a
  single encoding, including a compacted file produced after an upgrade. `splitIndex` carries them over too.
* **`LSMTreeIndexExternalSorter`** compares its spill runs against `index.getBinaryKeyTypes()`, which still returns
  the declared types, so a bulk build spanning the change is unaffected (its spill format is unchanged and is
  per-build anyway). Making the spill runs compressed too would be a separate, purely local optimisation.

Compaction is where an old-encoding index would meet new code, and it does not mix: the compactor reads keys as
deserialized values and hands them to `appendDuringCompaction`, which re-serializes them under the target file's own
storage types.

## Test plan

New: `engine/src/test/java/com/arcadedb/index/lsm/Issue5703LsmLinkKeyCompressedRidTest.java` (7 tests, 0.7 s).
Before the fix 5 of the 7 pass and 2 fail exactly on the encoding, so the ordering/lookup assertions are known to be
exercising real behaviour rather than passing vacuously.

- [x] `linkKeyIsStoredCompressedYetStillReportedAsRid` - the page uses `TYPE_COMPRESSED_RID`, `getBinaryKeyTypes()`
      still answers `TYPE_RID`, `getKeyTypes()` still answers `LINK`, and the bytes the first entry of page 0 spends
      on its key (read back through the index's own `getSerializedKeySize`) are below the fixed-width cost.
- [x] `orderedIterationOverLinkKeysFollowsRidOrder` - 400 LINK keys whose positions cross the 1-, 2- and 3-byte
      varint widths: ascending iteration equals the RID-sorted list, descending equals its reverse, and inclusive
      and exclusive `range()` bounds select exactly the expected slices.
- [x] `everyLinkKeyIsFoundByAnExactLookup` - all 400 keys resolve to the right record.
- [x] `compactionPreservesLinkKeyOrderAndLookups` - 2000 keys, forced `compact()`, then order and every lookup again.
- [x] `compositeEndpointUniqueIndexStillRejectsDuplicates` - the `(@out,@in)` guard still throws
      `DuplicatedKeyException`, the pair is found, and the reversed pair is a different key.
- [x] `aLinkKeyIsStillCoercedFromItsStringForm` - `SELECT ... WHERE ref = "#1:0"` (#5677's regression).
- [x] `anIndexWrittenWithFixedWidthKeysKeepsUsingThem` - creates the index, closes the database, rewrites page 0's
      key-type byte back to `TYPE_RID` (asserting its current value first, so the test fails loudly if the page-0
      layout ever moves), reopens, and checks that the index reports the legacy storage type, still orders 200 keys
      correctly and writes keys at the full 13 bytes.
- [x] Full `engine` unit lane (`-DexcludedGroups=slow,benchmark,vector -Dsurefire.includes=**/*Test.java`).

## Caveat worth naming

The page header self-describes, so any engine carrying this change reads both encodings. An **older** engine opening
a database whose index was created after this change would map header byte 13 through `Type.getByBinaryType`, get
`null` and fail - the usual one-way property of a storage-format change, recorded here rather than left to be
discovered. Existing databases are untouched.
