### PR TITLE
fix(#5682): remove unreachable AndBlock machinery from DeleteFromIndexStep

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java
@@ -174,6 +174,13 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
     return null;
   }
 
+  /**
+   * #5682: {@code condition} is built by {@code DeleteExecutionPlanner.getKeyCondition()}, the only caller that
+   * constructs a {@link DeleteFromIndexStep}. That method always returns one flattened sub-block of an
+   * {@code AndBlock}, never the {@code AndBlock} itself, so an {@code AndBlock} can never reach here through SQL.
+   * It falls through to the same "not supported yet" rejection as any other condition shape this step doesn't
+   * handle, rather than getting a dedicated branch that no test could ever exercise.
+   */
   private void init(final BooleanExpression condition) throws IOException {
     if (condition == null) {
       processFlatIteration();
@@ -181,47 +188,13 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
       processBinaryCondition();
     } else if (condition instanceof BetweenCondition) {
       processBetweenCondition();
-    } else if (condition instanceof AndBlock) {
-      processAndBlock();
     } else {
       throw new CommandExecutionException("search for index for " + condition + " is not supported yet");
     }
   }
 
-  /**
-   * it's not key = [...] but a real condition on field names, already ordered (field names will be ignored)
-   */
-  private void processAndBlock() {
-    final PCollection fromKey = indexKeyFrom((AndBlock) condition, additional);
-    final PCollection toKey = indexKeyTo((AndBlock) condition, additional);
-    final boolean fromKeyIncluded = indexKeyFromIncluded((AndBlock) condition, additional);
-    final boolean toKeyIncluded = indexKeyToIncluded((AndBlock) condition, additional);
-    init(fromKey, fromKeyIncluded, toKey, toKeyIncluded);
-  }
-
   private void processFlatIteration() {
     cursor = index.iterator(isOrderAsc());
-  }
-
-  private void init(final PCollection fromKey, final boolean fromKeyIncluded, final PCollection toKey,
-                    final boolean toKeyIncluded) {
-    final Object secondValue = fromKey.execute((Result) null, context);
-    final Object thirdValue = toKey.execute((Result) null, context);
-
-    if (index.supportsOrderedIterations()) {
-      if (isOrderAsc())
-        cursor = index.range(true, new Object[]{secondValue}, fromKeyIncluded, new Object[]{thirdValue}, toKeyIncluded);
-      else
-        cursor = index.range(false, new Object[]{thirdValue}, fromKeyIncluded, new Object[]{secondValue},
-            toKeyIncluded);
-    } else {
-      // #5662: an index without ordered iterations used to get a branch of its own here, which opened a range() cursor
-      // and then overwrote it with an iterator() one on the very next line. It could never have worked: the only
-      // RangeIndex that answers false to supportsOrderedIterations() is a TypeIndex over a non-ordered bucket index,
-      // and BOTH of those calls raise UnsupportedOperationException on one. Removing it costs nothing and lets the
-      // error below say which condition could not be evaluated, instead of only that the index is not ordered.
-      throw new UnsupportedOperationException("Cannot evaluate " + this.condition + " on index " + index);
-    }
   }
 
   private void processBetweenCondition() {
@@ -269,90 +242,6 @@ public class DeleteFromIndexStep extends AbstractExecutionStep {
 
   protected boolean isOrderAsc() {
     return orderAsc;
-  }
-
-  private PCollection indexKeyFrom(final AndBlock keyCondition, final BinaryCondition additional) {
-    final PCollection result = new PCollection(-1);
-    for (final BooleanExpression exp : keyCondition.getSubBlocks()) {
-      if (exp instanceof BinaryCondition binaryCondition) {
-        final BinaryCompareOperator operator = binaryCondition.getOperator();
-        if ((operator instanceof EqualsCompareOperator) || (operator instanceof GtOperator) || (operator instanceof GeOperator)) {
-          result.add(binaryCondition.getRight());
-        } else if (additional != null) {
-          result.add(additional.getRight());
-        }
-      } else {
-        throw new UnsupportedOperationException("Cannot execute index query with " + exp);
-      }
-    }
-    return result;
-  }
-
-  private PCollection indexKeyTo(final AndBlock keyCondition, final BinaryCondition additional) {
-    final PCollection result = new PCollection(-1);
-    for (final BooleanExpression exp : keyCondition.getSubBlocks()) {
-      if (exp instanceof BinaryCondition binaryCondition) {
-        final BinaryCondition binaryCond = binaryCondition;
-        final BinaryCompareOperator operator = binaryCond.getOperator();
-        if ((operator instanceof EqualsCompareOperator) || (operator instanceof LtOperator) || (operator instanceof LeOperator)) {
-          result.add(binaryCond.getRight());
-        } else if (additional != null) {
-          result.add(additional.getRight());
-        }
-      } else {
-        throw new UnsupportedOperationException("Cannot execute index query with " + exp);
-      }
-    }
-    return result;
-  }
-
-  private boolean indexKeyFromIncluded(final AndBlock keyCondition, final BinaryCondition additional) {
-    final BooleanExpression exp = keyCondition.getSubBlocks().getLast();
-    if (exp instanceof BinaryCondition binaryCondition) {
-      final BinaryCompareOperator operator = binaryCondition.getOperator();
-      final BinaryCompareOperator additionalOperator = additional == null ? null : additional.getOperator();
-      if (isGreaterOperator(operator)) {
-        return isIncludeOperator(operator);
-      } else
-        return additionalOperator == null || (isIncludeOperator(additionalOperator) && isGreaterOperator(additionalOperator));
-    } else {
-      throw new UnsupportedOperationException("Cannot execute index query with " + exp);
-    }
-  }
-
-  private boolean isGreaterOperator(final BinaryCompareOperator operator) {
-    if (operator == null) {
-      return false;
-    }
-    return operator instanceof GeOperator || operator instanceof GtOperator;
-  }
-
-  private boolean isLessOperator(final BinaryCompareOperator operator) {
-    if (operator == null) {
-      return false;
-    }
-    return operator instanceof LeOperator || operator instanceof LtOperator;
-  }
-
-  private boolean isIncludeOperator(final BinaryCompareOperator operator) {
-    if (operator == null) {
-      return false;
-    }
-    return operator instanceof GeOperator || operator instanceof LeOperator;
-  }
-
-  private boolean indexKeyToIncluded(final AndBlock keyCondition, final BinaryCondition additional) {
-    final BooleanExpression exp = keyCondition.getSubBlocks().get(keyCondition.getSubBlocks().size() - 1);
-    if (exp instanceof BinaryCondition binaryCondition) {
-      final BinaryCompareOperator operator = binaryCondition.getOperator();
-      final BinaryCompareOperator additionalOperator = additional == null ? null : additional.getOperator();
-      if (isLessOperator(operator)) {
-        return isIncludeOperator(operator);
-      } else
-        return additionalOperator == null || (isIncludeOperator(additionalOperator) && isLessOperator(additionalOperator));
-    } else {
-      throw new UnsupportedOperationException("Cannot execute index query with " + exp);
-    }
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DeleteFromIndexStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DeleteFromIndexStepTest.java
@@ -19,10 +19,14 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.index.RangeIndex;
+import com.arcadedb.query.sql.parser.AndBlock;
 import com.arcadedb.schema.Schema;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for DeleteFromIndexStep.
@@ -392,5 +396,32 @@ class DeleteFromIndexStepTest extends TestHelper {
     final ResultSet result = database.query("sql", "SELECT count(*) as cnt FROM DeleteTest15");
     assertThat(result.next().<Long>getProperty("cnt")).isEqualTo(9L); // 15 - 6 (5 to 10 inclusive)
     result.close();
+  }
+
+  /**
+   * #5682: {@code DeleteExecutionPlanner.getKeyCondition()} - the only place that builds a
+   * {@code DeleteFromIndexStep} - always hands it one flattened {@code BooleanExpression} sub-block,
+   * never the {@code AndBlock} that wraps them, so an {@code AndBlock} condition can never reach the step
+   * through SQL. This constructs the step directly with one to pin down what must happen if that
+   * invariant is ever violated: the same "not supported yet" rejection every other unhandled condition
+   * shape already gets, not a silent dead-code path with no test behind it.
+   */
+  @Test
+  void andBlockConditionIsRejectedAsUnsupported() {
+    database.getSchema().createDocumentType("DeleteTest16");
+    database.command("sql", "CREATE PROPERTY DeleteTest16.value INTEGER");
+    final RangeIndex index = (RangeIndex) database.getSchema()
+        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "DeleteTest16", "value");
+
+    database.transaction(() -> {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+
+      final DeleteFromIndexStep step = new DeleteFromIndexStep(index, new AndBlock(-1), null, null, context);
+
+      assertThatThrownBy(() -> step.syncPull(context, 1))
+          .isInstanceOf(CommandExecutionException.class)
+          .hasMessageContaining("not supported yet");
+    });
   }
 }


### PR DESCRIPTION
## What does this PR do?

Removes ~90 lines of unreachable `AndBlock` handling from `DeleteFromIndexStep`
(`engine/src/main/java/com/arcadedb/query/sql/executor/DeleteFromIndexStep.java`)
and adds a regression test that pins down the correct behavior if that shape
ever reaches the step again.

Closes #5682

## Motivation

`DeleteFromIndexStep` is built in exactly one place -
`DeleteExecutionPlanner.handleIndexAsTarget()`, for a
`DELETE FROM INDEX:<name> WHERE ...` statement. The `keyCondition` it passes
in comes from `getKeyCondition(andBlock)`, which returns **one sub-expression**
of the flattened `AndBlock`, never the `AndBlock` itself:

```java
private BooleanExpression getKeyCondition(final AndBlock andBlock) {
  for (final BooleanExpression exp : andBlock.getSubBlocks()) {
    final String str = exp.toString();
    if (str.length() < 5) continue;
    if ("key ".equalsIgnoreCase(str.substring(0, 4))) return exp;
  }
  return null;
}
```

So in `DeleteFromIndexStep.init(BooleanExpression)` the
`condition instanceof AndBlock` arm could never be taken, and everything only
reachable from it was dead: `processAndBlock()`, the 4-arg
`init(PCollection, boolean, PCollection, boolean)`, `indexKeyFrom()` /
`indexKeyTo()` / `indexKeyFromIncluded()` / `indexKeyToIncluded()`, and
`isGreaterOperator()` / `isLessOperator()` / `isIncludeOperator()`.

The issue laid out two ways to resolve the ambiguity: delete the dead code, or
wire it up (which would require changing the planner to intentionally produce
composite key conditions, plus new tests for behavior that has never run).
This PR takes the first option, per the issue's own reasoning: the surviving
`else` branch in `init(BooleanExpression)` already raises
`CommandExecutionException("search for index for ... is not supported yet")`
for every condition shape it doesn't handle - that's exactly the outcome an
`AndBlock` should get too, the same as any other unsupported shape. Wiring it
up would be a feature decision (does `DELETE FROM INDEX:` need to support
composite range keys?), not a bug fix, and folding that into this change would
widen a focused cleanup into a judgment call the issue explicitly warned
against.

Before this fix, constructing the step directly with an `AndBlock` condition
didn't hit the "not supported yet" rejection at all - it fell into
`processAndBlock()` -> `indexKeyFromIncluded()`, which called
`getSubBlocks().getLast()` on an empty list and threw a bare
`NoSuchElementException`. That's the concrete evidence the branch was not
just unreachable but, had it become reachable by some future change to
`getKeyCondition()`, would have misbehaved with an unrelated exception instead
of the intended message.

The separate fragility the issue also flagged - `getKeyCondition()` and
`getRidCondition()` deciding planner behavior off `exp.toString()` starting
with `"key "` / `"rid "` - is left alone here; it's a pre-existing, standalone
concern and out of scope for this cleanup.

## Related issues

Closes #5682

## Additional Notes

No behavior change on any path reachable from SQL: `DELETE FROM INDEX:` with
an equality, comparison, or `BETWEEN` key condition (with or without a `rid`
sub-condition) works exactly as before. Verified with the full
`com.arcadedb.query.sql.executor` package (702 tests, 0 failures).

## Checklist

- [x] I have run the build using `mvn clean package` command (targeted:
      `engine` module compile + relevant test suites; see test plan)
- [x] My unit tests cover both failure and success scenarios

## Test plan

- `DeleteFromIndexStepTest#andBlockConditionIsRejectedAsUnsupported` (new):
  constructs `DeleteFromIndexStep` directly with an `AndBlock` condition -
  the one shape the real planner can never produce - and asserts it raises
  `CommandExecutionException` with "not supported yet", instead of the
  `NoSuchElementException` it raised before this fix.
- Confirmed the new test fails red against the pre-fix code
  (`NoSuchElementException` from `indexKeyFromIncluded`), then passes green
  after the dead code was removed.
- Full existing `DeleteFromIndexStepTest` suite (16 tests) still green -
  equality, `>`, `>=`, `<`, `<=`, `BETWEEN`, string keys, empty index, no
  matches, ascending/descending order.
- `DeleteFromIndexStepCloseTest` (2 tests) still green - cursor-release
  behavior on `DELETE FROM INDEX:` untouched.
- `SQLExecutorLowCoverageTest`, `SQLExecutorAdditionalCoverageTest`,
  `DeleteExecutionStepTest`, `DeleteStatementTest`,
  `SelectIndexRangeWithDeletesTest`, `CheckSafeDeleteStepTest` all green.
- Full `com.arcadedb.query.sql.executor` package: 702 tests, 0 failures, 0
  errors.
