### PR TITLE
fix(#5849): reject a backslash in MCPToolUtils.quoteIdentifier()

### DIFF
--- a/docs/5849-mcp-quoteidentifier-backslash-escape.md
+++ b/docs/5849-mcp-quoteidentifier-backslash-escape.md
@@ -1,4 +1,4 @@
-# Issue #5849 — MCPToolUtils.quoteIdentifier() does not escape backslashes
+# Issue #5849: MCPToolUtils.quoteIdentifier() does not escape backslashes
 
 ## Root cause
 
@@ -38,7 +38,7 @@ identifier's value for Cypher call sites rather than merely quoting it.
 
 - `mcp/src/main/java/com/arcadedb/mcp/tools/MCPToolUtils.java`: `quoteIdentifier` also rejects a
   backslash; javadoc updated to explain why.
-- `mcp/src/test/java/com/arcadedb/mcp/MCPToolUtilsTest.java`: two new regression tests —
+- `mcp/src/test/java/com/arcadedb/mcp/MCPToolUtilsTest.java`: two new regression tests,
   `rejectsBackslashToBlockSqlEscapeAmbiguity` (the exact `X\` case from the issue) and
   `rejectsBackslashInTheMiddleOfAnIdentifier`.
 
@@ -49,3 +49,21 @@ identifier's value for Cypher call sites rather than merely quoting it.
 - Full `mcp` module test suite (`mvn -pl mcp test`): 294/294 pass, no failures or errors, no regressions.
 - `quoteIdentifier` is used only inside the `mcp` module (`SampleRecordsTool`, `UpsertRelationshipTool`,
   `MCPToolUtils` itself), so the `mcp` module test suite is the full affected surface.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6026
+
+## Review cycles
+
+- **Cycle 1** (head `e5c1a77`): `claude[bot]` posted an issue-comment review (not a `reviews`/inline-comment
+  entry) approving the change with no blocking issues. It confirmed the grammar-level claims (SQL
+  `QUOTED_IDENTIFIER` treats backslash as an escape char, Cypher `ESCAPED_SYMBOLIC_NAME` does not), confirmed
+  the reject-over-escape design tradeoff was sound for a single shared helper, and called out one nit: the
+  tracking doc's title used an em dash where sibling docs use a colon or hyphen, conflicting with the repo's
+  stated no-em-dash convention. Applied: retitled the doc and removed a second em dash found in the same
+  file. No deferred items.
+
+## Final state
+
+See PR #6026 for the outcome of the review cycle(s) following this push.

--- a/docs/5849-mcp-quoteidentifier-backslash-escape.md
+++ b/docs/5849-mcp-quoteidentifier-backslash-escape.md
@@ -62,8 +62,22 @@ https://github.com/ArcadeData/arcadedb/pull/6026
   the reject-over-escape design tradeoff was sound for a single shared helper, and called out one nit: the
   tracking doc's title used an em dash where sibling docs use a colon or hyphen, conflicting with the repo's
   stated no-em-dash convention. Applied: retitled the doc and removed a second em dash found in the same
-  file. No deferred items.
+  file. No deferred items. Pushed as `5a254d3`.
+
+- **Cycle 2** (head `5a254d3`): `claude[bot]` posted a second issue-comment review, independently
+  re-verifying the same two grammar rules and the call-site claims, and concluded "No blocking issues
+  found." It raised one non-blocking suggestion: add an integration-level test that exercises the fix
+  through an actual call site (e.g. `SampleRecordsTool` or `UpsertRelationshipTool` rejecting a
+  trailing-backslash name end-to-end), rather than only the unit-level `MCPToolUtils.quoteIdentifier` calls.
+  **Skipped, with rationale**: the reviewer itself framed this as "not blocking... worth considering," and
+  both call sites are one-line delegations straight into `quoteIdentifier` with no intervening logic of
+  their own, so an end-to-end test would exercise the same code path the unit tests already cover directly,
+  without adding meaningfully different coverage. Left as a documented option for a future call site that
+  does more than delegate. No code or doc change applied for this item, so this cycle closed with a clean
+  (empty) diff.
 
 ## Final state
 
-See PR #6026 for the outcome of the review cycle(s) following this push.
+**clean-approval.** Two review cycles ran; cycle 1's actionable nit was applied and pushed, cycle 2's bot
+review found no blocking issues and its one suggestion was a documented, justified skip. No deferred items
+remain for the developer.

--- a/docs/5849-mcp-quoteidentifier-backslash-escape.md
+++ b/docs/5849-mcp-quoteidentifier-backslash-escape.md
@@ -1,0 +1,51 @@
+# Issue #5849 — MCPToolUtils.quoteIdentifier() does not escape backslashes
+
+## Root cause
+
+`MCPToolUtils.quoteIdentifier()` makes an identifier safe for inclusion in a generated statement by
+rejecting a literal back-tick and wrapping the value in back-ticks. That is correct for Cypher, whose
+lexer (`ESCAPED_SYMBOLIC_NAME`) escapes a back-tick by doubling it and gives a backslash no special
+meaning. It is not correct for the SQL dialect: the SQL lexer's `QUOTED_IDENTIFIER` rule treats a
+backslash as an escape character, so an identifier ending in `\` escapes the closing back-tick and lets
+the lexer run past the intended end of the token.
+
+`quoteIdentifier` is shared by both dialects (Cypher call sites: `appendNodeMerge`, `appendSetClause`,
+`UpsertRelationshipTool`; SQL call site: `SampleRecordsTool.sampleType`), so a guard that is correct only
+for Cypher leaves the SQL call site with a broken safety contract.
+
+## Impact on 26.8.1
+
+Not independently exploitable today: `SampleRecordsTool` only reaches `quoteIdentifier` with a type name
+that already exists in the schema (`existsType` check) and appends only an `int` limit after it, so there
+is no second identifier or literal for a trailing backslash to swallow. The practical effect on main was a
+confusing parse failure instead of a clean rejection when sampling a type whose name ends in `\`. The
+report is explicit that a second SQL call site rendering two identifiers, or a literal after the
+identifier, would turn the same helper into an injection primitive.
+
+## Fix
+
+`quoteIdentifier` now rejects a backslash the same way it already rejects a back-tick, instead of passing
+it through. This keeps the helper's contract dialect-agnostic and correct for whichever caller uses it,
+at the cost of identifiers containing a backslash not being reachable through the MCP tools (backslash is
+not a realistic character in a type/property name in practice, and no existing test or code path relies
+on it).
+
+Dialect-specific escaping (doubling backslashes) was considered and rejected: Cypher's lexer does not
+treat a doubled backslash as an unescape sequence, so escaping that way would silently change the
+identifier's value for Cypher call sites rather than merely quoting it.
+
+## Changes
+
+- `mcp/src/main/java/com/arcadedb/mcp/tools/MCPToolUtils.java`: `quoteIdentifier` also rejects a
+  backslash; javadoc updated to explain why.
+- `mcp/src/test/java/com/arcadedb/mcp/MCPToolUtilsTest.java`: two new regression tests —
+  `rejectsBackslashToBlockSqlEscapeAmbiguity` (the exact `X\` case from the issue) and
+  `rejectsBackslashInTheMiddleOfAnIdentifier`.
+
+## Test results
+
+- `MCPToolUtilsTest`: 6/6 pass (4 pre-existing + 2 new). The 2 new tests were confirmed to fail against
+  the pre-fix code (`Expecting code to raise a throwable`), proving they reproduce the bug.
+- Full `mcp` module test suite (`mvn -pl mcp test`): 294/294 pass, no failures or errors, no regressions.
+- `quoteIdentifier` is used only inside the `mcp` module (`SampleRecordsTool`, `UpsertRelationshipTool`,
+  `MCPToolUtils` itself), so the `mcp` module test suite is the full affected surface.

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/MCPToolUtils.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/MCPToolUtils.java
@@ -138,11 +138,18 @@ public class MCPToolUtils {
   }
 
   /**
-   * Quotes an identifier (type name, relationship type, or property key) for safe inclusion in a Cypher
-   * statement. Cypher cannot bind identifiers as parameters, so they are backtick-quoted here. An identifier
-   * that is null, blank, or itself contains a backtick is rejected, which guarantees the quoting cannot be
-   * escaped and no clause can be injected through an identifier. Values are never routed through this method;
-   * they are always bound as parameters.
+   * Quotes an identifier (type name, relationship type, or property key) for safe inclusion in a Cypher or
+   * SQL statement. Neither dialect can bind identifiers as parameters, so they are backtick-quoted here. An
+   * identifier that is null, blank, or itself contains a backtick is rejected, which guarantees the quoting
+   * cannot be escaped and no clause can be injected through an identifier. Values are never routed through
+   * this method; they are always bound as parameters.
+   * <p>
+   * A backslash is rejected as well, even though it is not special to the Cypher lexer. The SQL lexer
+   * ({@code QUOTED_IDENTIFIER}) treats a backslash as an escape character inside a backtick-quoted token, so
+   * an identifier ending in {@code \} would escape the closing backtick and let the lexer run past the
+   * intended end of the token, absorbing whatever SQL follows it into the identifier (issue #5849). This
+   * helper is shared by both dialects and cannot tell which one a given call site targets, so it rejects the
+   * character unconditionally rather than escaping it per dialect.
    *
    * @param kind human-readable label for the identifier, used only in the rejection message
    * @param raw  the identifier as supplied by the caller
@@ -151,8 +158,8 @@ public class MCPToolUtils {
   public static String quoteIdentifier(final String kind, final String raw) {
     if (raw == null || raw.isBlank())
       throw new IllegalArgumentException("The " + kind + " must not be null or blank");
-    if (raw.indexOf('`') >= 0)
-      throw new IllegalArgumentException("The " + kind + " contains a backtick, which is not supported");
+    if (raw.indexOf('`') >= 0 || raw.indexOf('\\') >= 0)
+      throw new IllegalArgumentException("The " + kind + " contains a backtick or backslash, which is not supported");
     return "`" + raw + "`";
   }
 

--- a/mcp/src/test/java/com/arcadedb/mcp/MCPToolUtilsTest.java
+++ b/mcp/src/test/java/com/arcadedb/mcp/MCPToolUtilsTest.java
@@ -52,4 +52,25 @@ class MCPToolUtilsTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("backtick");
   }
+
+  /**
+   * The SQL lexer (unlike the Cypher lexer) treats a backslash as an escape character inside a
+   * backtick-quoted identifier, so a value ending in {@code \} escapes the closing backtick and lets the
+   * lexer run past the intended end of the token. Rejecting the backslash here, the same way a literal
+   * backtick is rejected, keeps {@code quoteIdentifier} safe for both dialects that share it
+   * (see issue #5849).
+   */
+  @Test
+  void rejectsBackslashToBlockSqlEscapeAmbiguity() {
+    assertThatThrownBy(() -> MCPToolUtils.quoteIdentifier("type name", "X\\"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("backslash");
+  }
+
+  @Test
+  void rejectsBackslashInTheMiddleOfAnIdentifier() {
+    assertThatThrownBy(() -> MCPToolUtils.quoteIdentifier("property key", "a\\b"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("backslash");
+  }
 }


### PR DESCRIPTION
Closes #5849

## Summary

`MCPToolUtils.quoteIdentifier()` makes an identifier safe for a generated statement by rejecting a literal backtick and wrapping the value in backticks. That is sufficient for Cypher, whose lexer (`ESCAPED_SYMBOLIC_NAME`) escapes a backtick by doubling it and gives a backslash no special meaning. It is not sufficient for the SQL dialect: the SQL lexer's `QUOTED_IDENTIFIER` rule treats a backslash as an escape character, so an identifier ending in `\` escapes the closing backtick and lets the lexer run past the intended end of the token, absorbing whatever SQL follows it into the identifier.

`quoteIdentifier` is shared by both dialects (Cypher: `appendNodeMerge`, `appendSetClause`, `UpsertRelationshipTool`; SQL: `SampleRecordsTool.sampleType`), so a guard correct only for Cypher left the SQL call site with a broken safety contract. It was not independently exploitable on 26.8.1: `SampleRecordsTool` only reaches `quoteIdentifier` with a type name that already exists in the schema, and appends only an `int` limit after it, so there is no second identifier or literal for a trailing backslash to swallow. The practical effect on `main` was a confusing parse failure instead of a clean rejection when sampling a type whose name ends in `\`.

**Fix:** reject a backslash the same way the helper already rejects a backtick, instead of passing it through. This keeps the contract dialect-agnostic and correct regardless of which caller uses it. Dialect-specific escaping (doubling backslashes, matching what backtick-doubling does) was considered and rejected: Cypher's lexer does not treat a doubled backslash as an unescape sequence, so that approach would silently change the identifier's *value* for the Cypher call sites rather than merely quoting it.

## Changes

- `mcp/src/main/java/com/arcadedb/mcp/tools/MCPToolUtils.java`: `quoteIdentifier` also rejects a backslash; javadoc explains why.
- `mcp/src/test/java/com/arcadedb/mcp/MCPToolUtilsTest.java`: two new regression tests, including the exact `X\` case from the issue.
- `docs/5849-mcp-quoteidentifier-backslash-escape.md`: root-cause analysis and fix rationale.

## Test plan

- [x] `MCPToolUtilsTest.rejectsBackslashToBlockSqlEscapeAmbiguity` and `rejectsBackslashInTheMiddleOfAnIdentifier` confirmed to fail against the pre-fix code (`Expecting code to raise a throwable`), proving they reproduce the bug.
- [x] `MCPToolUtilsTest`: 6/6 pass after the fix.
- [x] Full `mcp` module suite (`mvn -pl mcp test`): 294/294 pass, no regressions. `quoteIdentifier` is used only inside the `mcp` module, so this is the full affected surface.