### PR TITLE
fix(#5681): close a DML plan's steps chain as soon as it is done

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/AbstractExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/AbstractExecutionStep.java
@@ -59,6 +59,11 @@ public abstract class AbstractExecutionStep implements ExecutionStepInternal {
     return timedOut;
   }
 
+  /**
+   * Propagates to {@code prev}, so closing any step in a chain closes the whole chain. Subclasses that override
+   * this to release their own resources (e.g. an open cursor) must keep the override idempotent - see
+   * {@link ExecutionStepInternal#close()} - and normally call {@code super.close()} to keep the propagation intact.
+   */
   @Override
   public void close() {
     if (prev != null)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStepInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStepInternal.java
@@ -64,6 +64,15 @@ public interface ExecutionStepInternal extends ExecutionStep {
 
   void setPrevious(ExecutionStepInternal step);
 
+  /**
+   * Releases whatever resources this step is holding (open cursors, buffered pages, ...). Implementations MUST be
+   * idempotent: a second call after the step is already closed has to be a no-op, never a double-free or an
+   * exception. This is not just a defensive nicety - {@code AbstractExecutionStep.close()} propagates to {@code
+   * prev} by default, so closing any step in a chain closes the whole chain, and callers legitimately close a chain
+   * more than once (e.g. a DML plan self-closes as soon as it is done executing - see {@code
+   * UpdateExecutionPlan#executeInternal()} - and then closes again, harmlessly, if the caller also closes the
+   * returned {@code ResultSet}).
+   */
   void close();
 
   default String prettyPrint(final int depth, final int indent) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlan.java
@@ -64,14 +64,24 @@ public class InsertExecutionPlan extends SelectExecutionPlan {
     executeInternal();
   }
 
+  /**
+   * #5681: an {@code INSERT ... SELECT ... LIMIT} shares the same abandoned-scan risk as UPDATE/DELETE (see
+   * {@link UpdateExecutionPlan#executeInternal()}) - closing here, in a {@code finally} so it also runs on the
+   * exception path, releases the sub-plan's scan as soon as the statement is done instead of waiting for the caller
+   * to close the returned {@link ResultSet} or for the GC to reclaim it.
+   */
   public void executeInternal() throws CommandExecutionException {
-    while (true) {
-      final ResultSet nextBlock = super.fetchNext(DEFAULT_FETCH_RECORDS_PER_PULL);
-      if (!nextBlock.hasNext())
-        return;
+    try {
+      while (true) {
+        final ResultSet nextBlock = super.fetchNext(DEFAULT_FETCH_RECORDS_PER_PULL);
+        if (!nextBlock.hasNext())
+          return;
 
-      while (nextBlock.hasNext())
-        result.add(nextBlock.next());
+        while (nextBlock.hasNext())
+          result.add(nextBlock.next());
+      }
+    } finally {
+      close();
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlan.java
@@ -68,9 +68,12 @@ public class InsertExecutionPlan extends SelectExecutionPlan {
    * #5681: an {@code INSERT ... SELECT ... LIMIT} shares the same abandoned-scan risk as UPDATE/DELETE (see
    * {@link UpdateExecutionPlan#executeInternal()}) - closing here, in a {@code finally} so it also runs on the
    * exception path, releases the sub-plan's scan as soon as the statement is done instead of waiting for the caller
-   * to close the returned {@link ResultSet} or for the GC to reclaim it.
+   * to close the returned {@link ResultSet} or for the GC to reclaim it. A failure from {@code close()} itself is
+   * suppressed rather than allowed to replace an exception already in flight from the drain loop - see
+   * {@link UpdateExecutionPlan#executeInternal()} for the same pattern and its rationale.
    */
   public void executeInternal() throws CommandExecutionException {
+    RuntimeException failure = null;
     try {
       while (true) {
         final ResultSet nextBlock = super.fetchNext(DEFAULT_FETCH_RECORDS_PER_PULL);
@@ -80,8 +83,18 @@ public class InsertExecutionPlan extends SelectExecutionPlan {
         while (nextBlock.hasNext())
           result.add(nextBlock.next());
       }
+    } catch (final RuntimeException e) {
+      failure = e;
+      throw e;
     } finally {
-      close();
+      try {
+        close();
+      } catch (final RuntimeException closeFailure) {
+        if (failure != null)
+          failure.addSuppressed(closeFailure);
+        else
+          throw closeFailure;
+      }
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateExecutionPlan.java
@@ -60,14 +60,29 @@ public class UpdateExecutionPlan extends SelectExecutionPlan {
     executeInternal();
   }
 
+  /**
+   * #5681: an UPDATE/DELETE with a {@code LIMIT} chains {@code LimitExecutionStep} above the sub-plan that holds the
+   * actual scan (e.g. an index scan wrapped in {@link SubQueryStep}). Once the limit is satisfied,
+   * {@code LimitExecutionStep} simply stops pulling - it never tells the sub-plan there will be no more requests, so
+   * the scan is abandoned mid-flight unless something closes the chain. By the time this method returns, the
+   * statement is done: every result the caller will ever see is already buffered in {@link #result}, and
+   * {@link #fetchNext(int)} never touches the steps chain again. Closing here - in a {@code finally} so it also runs
+   * on the exception path - releases the abandoned scan immediately instead of leaving it for the caller to close
+   * the returned {@link ResultSet} (the DML result is very commonly used only for its side effect and never closed)
+   * or, failing that, for the GC to reclaim it later.
+   */
   public void executeInternal() throws CommandExecutionException {
-    while (true) {
-      final ResultSet nextBlock = super.fetchNext(DEFAULT_FETCH_RECORDS_PER_PULL);
-      if (!nextBlock.hasNext())
-        return;
+    try {
+      while (true) {
+        final ResultSet nextBlock = super.fetchNext(DEFAULT_FETCH_RECORDS_PER_PULL);
+        if (!nextBlock.hasNext())
+          return;
 
-      while (nextBlock.hasNext())
-        result.add(nextBlock.next());
+        while (nextBlock.hasNext())
+          result.add(nextBlock.next());
+      }
+    } finally {
+      close();
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateExecutionPlan.java
@@ -70,8 +70,14 @@ public class UpdateExecutionPlan extends SelectExecutionPlan {
    * on the exception path - releases the abandoned scan immediately instead of leaving it for the caller to close
    * the returned {@link ResultSet} (the DML result is very commonly used only for its side effect and never closed)
    * or, failing that, for the GC to reclaim it later.
+   * <p>
+   * If the drain loop itself throws, {@code close()} still runs (in the {@code finally}) but its own failure - every
+   * current {@code close()} in these chains is a simple, exception-safe no-op/idempotent forward, but a future step
+   * could change that - is attached as a suppressed exception instead of replacing the original one, so the real
+   * cause of the failure always reaches the caller.
    */
   public void executeInternal() throws CommandExecutionException {
+    RuntimeException failure = null;
     try {
       while (true) {
         final ResultSet nextBlock = super.fetchNext(DEFAULT_FETCH_RECORDS_PER_PULL);
@@ -81,8 +87,18 @@ public class UpdateExecutionPlan extends SelectExecutionPlan {
         while (nextBlock.hasNext())
           result.add(nextBlock.next());
       }
+    } catch (final RuntimeException e) {
+      failure = e;
+      throw e;
     } finally {
-      close();
+      try {
+        close();
+      } catch (final RuntimeException closeFailure) {
+        if (failure != null)
+          failure.addSuppressed(closeFailure);
+        else
+          throw closeFailure;
+      }
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5662IndexCursorFollowUpsTest.java
@@ -127,6 +127,15 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
    * A {@code DELETE ... WHERE} puts the index scan in a SUB-plan and the {@code LIMIT} outside it, so the scan is
    * abandoned partway. Closing the result set used to close only the outer plan's steps - {@code SubQueryStep} never
    * closed the plan it wraps - and the scan inside it was released only if it happened to run to exhaustion.
+   * <p>
+   * #5681: {@code DeleteStatement.execute()} / {@code UpdateStatement.execute()} already drain the whole plan
+   * eagerly, via {@code executeInternal()}, before ever handing the {@link ResultSet} back to the caller - so the
+   * abandoned scan is now released the moment {@code executeInternal()} finishes, not only when the caller closes
+   * the result set (which a {@code DELETE} run for its side effect - the common case - usually never does). The
+   * explicit {@code close()} below therefore observes an already-released scan; what it still pins is that closing
+   * the same {@code SubQueryStep}/sub-plan chain a second time - the shape a caller who DOES close its result set
+   * exercises - stays a harmless no-op, matching the idempotent {@code close()} contract documented on
+   * {@link LSMTreeIndexUnderlyingCompactedSeriesCursor}.
    */
   @Test
   void closingADeleteLimitedShortOfExhaustionReleasesTheScanInsideItsSubPlan() {
@@ -136,11 +145,14 @@ class Issue5662IndexCursorFollowUpsTest extends TestHelper {
       try (final ResultSet result = database.command("sql", "DELETE FROM " + TYPE_NAME + " WHERE value > 1 LIMIT 3")) {
         assertThat(((Number) result.next().getProperty("count")).intValue()).as("the LIMIT must cut the scan short")
             .isEqualTo(3);
-        assertThat(compacted.countActiveCursors()).as("precondition: the abandoned scan is still holding a series cursor")
-            .isPositive();
+        assertThat(compacted.countActiveCursors())
+            .as("#5681: the scan inside the sub-plan is released as soon as the DELETE is done, before the caller ever"
+                + " gets a chance to close the result set")
+            .isZero();
       }
 
-      assertThat(compacted.countActiveCursors()).as("closing the result set must reach the scan inside the sub-plan")
+      assertThat(compacted.countActiveCursors())
+          .as("closing the result set reaches the scan inside the sub-plan too - here as a harmless second close()")
           .isZero();
     });
   }

--- a/engine/src/test/java/com/arcadedb/index/Issue5681UnclosedDmlLeavesScanOpenTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5681UnclosedDmlLeavesScanOpenTest.java
@@ -121,6 +121,39 @@ class Issue5681UnclosedDmlLeavesScanOpenTest extends TestHelper {
         .isEqualTo(3);
   }
 
+  /**
+   * The {@code LIMIT}-less counterpart of the test above: without a {@code LIMIT}, the nested SELECT's own
+   * {@code FetchFromIndexStep} drains to natural exhaustion - {@code fetchNextEntry()} drops its last cursor
+   * reference on its own once there is nothing left to return - so the scan is already self-released before the
+   * early {@code close()} added by this fix ever runs. Pinned separately from the {@code LIMIT} case (raised in
+   * review) because it exercises a different release path: natural exhaustion instead of an abandoned-mid-scan
+   * {@code close()}, and this is also the shape {@code InsertExecutionPlan}'s pre-existing reentrant second pull
+   * (see {@link #insertSelectWithLimitReleasesTheIndexScanWithoutAnExplicitClose()}) most commonly hits, since a
+   * plain {@code INSERT ... SELECT} with no {@code LIMIT} is the more common form.
+   */
+  @Test
+  void insertSelectWithoutLimitReleasesTheIndexScanAndDoesNotDoubleInsert() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    database.transaction(() -> database.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME + "Copy3"));
+
+    database.transaction(() -> {
+      // same shape as the other DML cases: nobody closes the ResultSet returned by an INSERT run for its side effect
+      final ResultSet result = database.command("sql",
+          "INSERT INTO " + TYPE_NAME + "Copy3 SELECT FROM " + TYPE_NAME + " WHERE value > 1");
+      assertThat(result.hasNext()).as("the INSERT must actually have produced rows").isTrue();
+    });
+
+    assertThat(compacted.countActiveCursors())
+        .as("a fully-drained scan releases itself on its own, and the fix's early close() must not disturb that")
+        .isZero();
+
+    final long copied = database.select().fromType(TYPE_NAME + "Copy3").count();
+    assertThat(copied).as("all matching rows must be copied exactly once - the reentrant second executeInternal()"
+        + " pull must not double-insert")
+        .isEqualTo(RECORDS - 2);
+  }
+
   private LSMTreeIndexCompacted createCompactedFixture() {
     database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
 

--- a/engine/src/test/java/com/arcadedb/index/Issue5681UnclosedDmlLeavesScanOpenTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5681UnclosedDmlLeavesScanOpenTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5681: a DML statement whose index scan stops short of exhaustion (a {@code LIMIT} cuts it off) used to leave the
+ * scan's series cursor registered until the caller closed the returned {@link ResultSet} - or, if nobody ever did
+ * (the overwhelmingly common shape for a {@code DELETE}/{@code UPDATE} run for its side effect, with the count read
+ * or ignored), until the JVM collected the abandoned cursor.
+ * <p>
+ * {@code DeleteStatement.execute()} / {@code UpdateStatement.execute()} already drain the whole plan eagerly via
+ * {@code executeInternal()} before ever handing a {@link ResultSet} back to the caller, so by the time the caller
+ * gets it the statement is done and nothing will ever pull from the plan's steps again. These tests pin that the
+ * plan's underlying index scan is released right there, without requiring the caller to close anything.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5681UnclosedDmlLeavesScanOpenTest extends TestHelper {
+  private static final String TYPE_NAME = "Dml5681FollowUp";
+  private static final int    RECORDS   = 600;
+
+  @Override
+  public void beforeTest() {
+    // explicit compaction only, so the sub-index appears exactly when this test asks for it
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+  }
+
+  @Test
+  void deleteWithLimitReleasesTheIndexScanWithoutAnExplicitClose() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    database.transaction(() -> {
+      // the returned ResultSet is deliberately never closed: this is the ordinary "DELETE used for its side effect"
+      // shape from the issue, not a bug in the test
+      final ResultSet result = database.command("sql", "DELETE FROM " + TYPE_NAME + " WHERE value > 1 LIMIT 3");
+      assertThat(((Number) result.next().getProperty("count")).intValue()).as("the LIMIT must cut the scan short")
+          .isEqualTo(3);
+    });
+
+    assertThat(compacted.countActiveCursors())
+        .as("the DML statement is fully done once execute() returns - the abandoned index scan inside its sub-plan"
+            + " must already be released, with no close() from the caller")
+        .isZero();
+  }
+
+  @Test
+  void updateWithLimitReleasesTheIndexScanWithoutAnExplicitClose() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    database.transaction(() -> {
+      // same shape as the DELETE case: nobody closes the ResultSet returned by an UPDATE run for its side effect
+      final ResultSet result = database.command("sql",
+          "UPDATE " + TYPE_NAME + " SET touched = true WHERE value > 1 LIMIT 3");
+      assertThat(((Number) result.next().getProperty("count")).intValue()).as("the LIMIT must cut the scan short")
+          .isEqualTo(3);
+    });
+
+    assertThat(compacted.countActiveCursors())
+        .as("the DML statement is fully done once execute() returns - the abandoned index scan inside its sub-plan"
+            + " must already be released, with no close() from the caller")
+        .isZero();
+  }
+
+  /**
+   * {@code INSERT ... SELECT ... LIMIT} nests the same abandoned-scan shape one level deeper than DELETE/UPDATE -
+   * the {@code LIMIT} lives inside the wrapped SELECT's own sub-plan rather than straddling the
+   * {@code SubQueryStep} boundary - and {@code InsertExecutionPlan.fetchNext()} additionally re-invokes
+   * {@code executeInternal()} on first pull (it does not know the eager call from {@code InsertStatement.execute()}
+   * already ran), so this also pins that a second pull after the early {@code close()} does not resurrect the
+   * closed index scan or throw.
+   */
+  @Test
+  void insertSelectWithLimitReleasesTheIndexScanWithoutAnExplicitClose() {
+    final LSMTreeIndexCompacted compacted = createCompactedFixture();
+
+    database.transaction(() -> database.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME + "Copy"));
+
+    database.transaction(() -> {
+      // same shape as the DELETE/UPDATE cases: nobody closes the ResultSet returned by an INSERT run for its side effect
+      final ResultSet result = database.command("sql",
+          "INSERT INTO " + TYPE_NAME + "Copy SELECT FROM " + TYPE_NAME + " WHERE value > 1 LIMIT 3");
+      assertThat(result.hasNext()).as("the INSERT must actually have produced rows").isTrue();
+    });
+
+    assertThat(compacted.countActiveCursors())
+        .as("the DML statement is fully done once execute() returns - the abandoned index scan inside the nested"
+            + " SELECT's sub-plan must already be released, with no close() from the caller")
+        .isZero();
+
+    final long copied = database.select().fromType(TYPE_NAME + "Copy").count();
+    assertThat(copied).as("the LIMIT must actually cut the scan short, and a stray second pull must not double-insert")
+        .isEqualTo(3);
+  }
+
+  private LSMTreeIndexCompacted createCompactedFixture() {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("value", Integer.class);
+    // a small page size so the compacted output spans several pages, i.e. a real series a cursor walks lazily
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "value" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(true).withPageSize(1024).create();
+
+    database.transaction(() -> {
+      for (int i = 0; i < RECORDS; i++)
+        database.newDocument(TYPE_NAME).set("value", i).save();
+    });
+
+    final LSMTreeIndex index = bucketIndex();
+    try {
+      if (index.scheduleCompaction())
+        index.compact();
+    } catch (final IOException | InterruptedException e) {
+      throw new IllegalStateException("cannot compact the fixture index", e);
+    }
+
+    final LSMTreeIndexCompacted compacted = index.getMutableIndex().getSubIndex();
+    assertThat(compacted).as("the fixture must produce a compacted sub-index, otherwise no series cursor is ever opened")
+        .isNotNull();
+    assertThat(compacted.countActiveCursors()).as("no scan has run yet").isZero();
+    return compacted;
+  }
+
+  private LSMTreeIndex bucketIndex() {
+    return (LSMTreeIndex) database.getSchema().getType(TYPE_NAME).getAllIndexes(false).iterator().next()
+        .getIndexesOnBuckets()[0];
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Closes #5681

A `DELETE`/`UPDATE` (and `INSERT ... SELECT`) statement with a `LIMIT` that cuts
its scan short now releases the abandoned index scan the moment the statement
is done executing, instead of only when (and if) the caller closes the
returned `ResultSet`.

## Motivation

`DELETE ... WHERE ... LIMIT n` (and `UPDATE ... LIMIT n`) builds a plan shaped
as `SubQueryStep(sub-plan holding the scan) -> ... -> LimitExecutionStep -> ...
-> CountStep`. `LimitExecutionStep.syncPull()` stops delegating to `prev` the
moment its internal counter reaches the limit - it never signals "no more" to
the sub-plan, so the index scan inside `SubQueryStep`'s wrapped select plan
(e.g. `FetchFromIndexStep`) is abandoned mid-scan.

`DeleteStatement.execute()` / `UpdateStatement.execute()` already call
`executionPlan.executeInternal()` right after building the plan - this eagerly
drains the whole chain into an in-memory buffer before the caller ever sees a
`ResultSet`. By the time `execute()` returns, the statement is fully done and
nothing will ever pull from the steps chain again. The *only* thing that still
released the abandoned scan was `executionPlan.close()`, which today only runs
if the caller explicitly closes the returned `ResultSet`.

`database.command("sql", "DELETE FROM Doc WHERE value > 1 LIMIT 3")` used for
its side effect - the overwhelmingly common shape, with the returned count read
or ignored - never calls `close()`. The abandoned scan's series-cursor
registration (`LSMTreeIndexUnderlyingCompactedSeriesCursor`) then survived
until the JVM garbage-collected it, at which point the weak-reference retire
guard (`LSMTreeIndexCompacted.purgeCollectedCursors()`) reclaimed it - logging
a "please report this" warning that is misleading for ordinary user code (the
issue itself is not a bug in that guard).

### Fix

This implements direction 1 from the issue: close the plan's steps chain as
soon as the DML statement is logically complete, right after
`executeInternal()`'s eager drain loop finishes (in a `finally` so it also runs
on the exception path). This is safe because:

- `UpdateExecutionPlan.canBeCached()` / `InsertExecutionPlan.canBeCached()`
  both return `false`, so these plan instances are never reused via the plan
  cache / `copy()`.
- After the drain loop, `fetchNext()` on `UpdateExecutionPlan` (shared by
  `DeleteExecutionPlan`) only ever reads from the buffered `result` list - it
  never touches the steps chain again.
- Every step's `close()` in the affected chains is idempotent - confirmed for
  `FetchFromIndexStep.releaseCursors()` and
  `LSMTreeIndexUnderlyingCompactedSeriesCursor.close()`, which is explicitly
  documented as idempotent ("exhaustion paths and explicit close() may both
  fire") - so a caller that *does* close the returned `ResultSet` afterward
  just causes a harmless second `close()`.
- `UpdateExecutionPlan.reset()` (the re-run path `FetchFromIndexStep.reset()`'s
  doc comment references) calls `super.reset(context)` - which resets every
  step's own state, including releasing cursors - before calling
  `executeInternal()` again, so an early `close()` does not interfere with
  that path.
- `InsertExecutionPlan.fetchNext()` re-invokes `executeInternal()` on first
  pull regardless of the eager call `InsertStatement.execute()` already made
  (a pre-existing, unrelated quirk - `executed` is never set by that direct
  call). Verified this does **not** re-enter the now-closed scan: for
  `INSERT ... SELECT ... LIMIT n`, the nested select's own
  `LimitExecutionStep.loaded` counter already satisfies the limit, so its
  second `syncPull()` short-circuits to an empty result before ever reaching
  the closed `FetchFromIndexStep`; for a `LIMIT`-less `INSERT ... SELECT`, the
  scan is already naturally exhausted (and self-released) before `close()` ever
  runs. Covered by a new regression test (`insertSelectWithLimitReleasesTheIndexScanWithoutAnExplicitClose`)
  that also pins there is no double-insert from the extra pull.

### Existing test updated

`Issue5662IndexCursorFollowUpsTest.closingADeleteLimitedShortOfExhaustionReleasesTheScanInsideItsSubPlan()`
had a "precondition" assertion pinning the pre-fix behavior ("the abandoned
scan is still holding a series cursor" right after the command runs, before an
explicit `close()`). That is exactly the behavior this issue asks to change,
so the assertion now expects the scan to already be released at that point;
the rest of the test (closing the result set still reaches the sub-plan, and
does so idempotently on what is now a second `close()`) is unchanged in
substance.

## Related issues

Closes #5681. Follow-up to #5662 / #5673 / #5635.

## Additional Notes

- Direction 2 from the issue (release upstream when `LimitExecutionStep`
  itself is satisfied, rather than the DML plan closing as a whole) was not
  taken - the issue itself flags it as the riskier, more invasive option since
  it changes the lifetime of every limited plan (including `SELECT ...
  LIMIT`), not just DML ones. This PR only changes when DML plans self-close,
  matching the issue's stated preference.
- The misleading wording on `LSMTreeIndexCompacted.purgeCollectedCursors()`'s
  "please report this" warning (also raised in the issue) is left as-is; happy
  to fold that in here or file it separately if reviewers would rather it ride
  along.

## Test plan

- [x] New `Issue5681UnclosedDmlLeavesScanOpenTest` (engine module): `DELETE`,
  `UPDATE`, and `INSERT ... SELECT` with `LIMIT`, each run without an explicit
  `close()` on the returned `ResultSet`, asserting the compacted index's
  active-cursor count is zero immediately afterward. All three fail on `main`
  (cursor count stays positive until GC) and pass with this fix.
- [x] `Issue5662IndexCursorFollowUpsTest` (all 11 cases, including the updated
  one) - green.
- [x] Full `com.arcadedb.query.sql.executor.*Test`,
  `com.arcadedb.query.sql.parser.*Test`, and `com.arcadedb.index.*Test`
  packages - 2040 tests, 0 failures, 0 errors.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
