### PR TITLE
Fix (#6028): duplicate INSERT execution plan runs

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlan.java
@@ -71,7 +71,7 @@ public class InsertExecutionPlan extends SelectExecutionPlan {
    * to close the returned {@link ResultSet} or for the GC to reclaim it. A failure from {@code close()} itself is
    * suppressed rather than allowed to replace an exception already in flight from the drain loop - see
    * {@link UpdateExecutionPlan#executeInternal()} for the same pattern and its rationale.
-  */
+   */
   public void executeInternal() throws CommandExecutionException {
     executed = true;
     RuntimeException failure = null;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlan.java
@@ -71,8 +71,9 @@ public class InsertExecutionPlan extends SelectExecutionPlan {
    * to close the returned {@link ResultSet} or for the GC to reclaim it. A failure from {@code close()} itself is
    * suppressed rather than allowed to replace an exception already in flight from the drain loop - see
    * {@link UpdateExecutionPlan#executeInternal()} for the same pattern and its rationale.
-   */
+  */
   public void executeInternal() throws CommandExecutionException {
+    executed = true;
     RuntimeException failure = null;
     try {
       while (true) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
@@ -55,20 +55,27 @@ public class InsertStatementExecutionTest extends TestHelper {
     assertInsertExecutionPlanRunsOnce(statement -> statement.execute(database, Map.of(), null, false));
   }
 
+  @Test
+  void insertExecutionPlanRunsOnceAfterReset() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    final AtomicInteger executions = new AtomicInteger();
+    final InsertExecutionPlan executionPlan = countingExecutionPlan(context, executions);
+
+    executionPlan.reset(context);
+    final ResultSet result = executionPlan.fetchNext(1);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    assertThat(executions.get()).isEqualTo(1);
+  }
+
   private void assertInsertExecutionPlanRunsOnce(final Function<InsertStatement, ResultSet> executeStatement) {
     final AtomicInteger executions = new AtomicInteger();
     final InsertStatement statement = new InsertStatement(-1) {
       @Override
       public InsertExecutionPlan createExecutionPlan(final CommandContext context) {
-        final InsertExecutionPlan executionPlan = new InsertExecutionPlan(context);
-        executionPlan.chain(new AbstractExecutionStep(context) {
-          @Override
-          public ResultSet syncPull(final CommandContext context, final int nRecords) {
-            executions.incrementAndGet();
-            return new InternalResultSet();
-          }
-        });
-        return executionPlan;
+        return countingExecutionPlan(context, executions);
       }
     };
 
@@ -77,6 +84,18 @@ public class InsertStatementExecutionTest extends TestHelper {
     result.close();
 
     assertThat(executions.get()).isEqualTo(1);
+  }
+
+  private InsertExecutionPlan countingExecutionPlan(final CommandContext context, final AtomicInteger executions) {
+    final InsertExecutionPlan executionPlan = new InsertExecutionPlan(context);
+    executionPlan.chain(new AbstractExecutionStep(context) {
+      @Override
+      public ResultSet syncPull(final CommandContext context, final int nRecords) {
+        executions.incrementAndGet();
+        return new InternalResultSet();
+      }
+    });
+    return executionPlan;
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.query.sql.parser.InsertStatement;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -30,6 +31,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -40,6 +43,40 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class InsertStatementExecutionTest extends TestHelper {
   public InsertStatementExecutionTest() {
     autoStartTx = true;
+  }
+
+  @Test
+  void insertExecutionPlanRunsOnceWithPositionalParameters() {
+    assertInsertExecutionPlanRunsOnce(statement -> statement.execute(database, new Object[0], null, false));
+  }
+
+  @Test
+  void insertExecutionPlanRunsOnceWithNamedParameters() {
+    assertInsertExecutionPlanRunsOnce(statement -> statement.execute(database, Map.of(), null, false));
+  }
+
+  private void assertInsertExecutionPlanRunsOnce(final Function<InsertStatement, ResultSet> executeStatement) {
+    final AtomicInteger executions = new AtomicInteger();
+    final InsertStatement statement = new InsertStatement(-1) {
+      @Override
+      public InsertExecutionPlan createExecutionPlan(final CommandContext context) {
+        final InsertExecutionPlan executionPlan = new InsertExecutionPlan(context);
+        executionPlan.chain(new AbstractExecutionStep(context) {
+          @Override
+          public ResultSet syncPull(final CommandContext context, final int nRecords) {
+            executions.incrementAndGet();
+            return new InternalResultSet();
+          }
+        });
+        return executionPlan;
+      }
+    };
+
+    final ResultSet result = executeStatement.apply(statement);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    assertThat(executions.get()).isEqualTo(1);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
@@ -70,6 +70,23 @@ public class InsertStatementExecutionTest extends TestHelper {
     assertThat(executions.get()).isEqualTo(1);
   }
 
+  // ScriptLineStep.syncPull() also calls executeInternal() eagerly before fetchNext(), the same shape as
+  // InsertStatement.execute() - an INSERT run as a line of a batch script hits this path, not the other two.
+  @Test
+  void insertExecutionPlanRunsOnceInsideScriptLineStep() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    final AtomicInteger executions = new AtomicInteger();
+    final InsertExecutionPlan executionPlan = countingExecutionPlan(context, executions);
+
+    final ScriptLineStep scriptLineStep = new ScriptLineStep(executionPlan, context);
+    final ResultSet result = scriptLineStep.syncPull(context, 1);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    assertThat(executions.get()).isEqualTo(1);
+  }
+
   private void assertInsertExecutionPlanRunsOnce(final Function<InsertStatement, ResultSet> executeStatement) {
     final AtomicInteger executions = new AtomicInteger();
     final InsertStatement statement = new InsertStatement(-1) {


### PR DESCRIPTION
## What does this PR do?

Marks `InsertExecutionPlan` as executed when its eager `executeInternal()` path runs. This prevents the `LocalResultSet` constructor from traversing the same plan a second time when it immediately fetches the first block. The same guard now also remains armed after `reset()` eagerly reruns the plan.

Regression coverage exercises both `InsertStatement.execute` overloads and the reset-then-fetch path, verifying that the plan is pulled exactly once in each case.

## Motivation

`InsertStatement.execute` eagerly runs the plan before constructing a `LocalResultSet`, while `InsertExecutionPlan.fetchNext` used an `executed` flag that was only armed by the lazy path. As a result, every INSERT traversed its execution plan twice. The reset path had the same shape: it eagerly executed the plan but left the flag clear for the following fetch.

## Related issues

Fixes #6028

## Additional Notes

Validation performed on the latest `main`:

- `.\mvnw.cmd -pl engine "-Dtest=InsertStatementExecutionTest,InsertStatementTest,InsertExecutionStepTest,InsertContentEmptyArrayTest,InsertReturnTest" test` (60 tests, 0 failures, 2 skipped)
- `.\mvnw.cmd -pl engine -DskipTests package`
- `git diff --check`

Before the production change, the eager-execution regressions failed with `expected: 1 but was: 2`.

AI assistance was used during investigation or implementation.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both eager execution entry points and the reset path affected by this issue