### PR TITLE
fix: recognize IPv6 transition encodings in the reserved-address block-list

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -26,6 +26,7 @@ import com.arcadedb.serializer.BinaryComparator;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.Callable;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.IPAddressBlocklist;
 import com.arcadedb.utility.SystemVariableResolver;
 
 import java.io.ByteArrayOutputStream;
@@ -552,9 +553,7 @@ public enum GlobalConfiguration {
       resolved IP address of the target host and re-checked on every redirect hop to prevent Server-Side Request Forgery (SSRF). \
       Defaults to loopback, private (RFC 1918), link-local (including the cloud metadata address 169.254.169.254), carrier-grade \
       NAT, multicast and reserved ranges. Set to an empty string to disable IP filtering (not recommended).""",
-      String.class,
-      "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,0.0.0.0/8,100.64.0.0/10,192.0.0.0/24,198.18.0.0/15,"
-          + "224.0.0.0/4,240.0.0.0/4,255.255.255.255/32,::1/128,::/128,fe80::/10,fc00::/7,ff00::/8"),
+      String.class, IPAddressBlocklist.DEFAULT_RESERVED_RANGES),
 
   OPENCYPHER_ID_BUCKET_BITS("arcadedb.opencypher.idBucketBits", SCOPE.JVM,
       """

--- a/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
+++ b/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
@@ -131,14 +131,25 @@ public class IPAddressBlocklist {
 
   /**
    * Returns true if the given address falls inside any configured range. An empty block-list never blocks.
+   * <p>
+   * The raw address is matched first, before any transition-encoding unwrap: a range list can legitimately contain
+   * a literal 16-byte IPv6 entry (e.g. {@code ::1/128}, or a whole transition prefix like {@code 2002::/16}) that
+   * targets the address as written, and {@link Cidr#matches} rejects on a byte-length mismatch alone, so unwrapping
+   * unconditionally before matching would let the 4-byte normalized form silently shadow that entry. The unwrapped
+   * form is tried only as a fallback, once the raw address didn't match anything.
    */
   public boolean isBlocked(final InetAddress address) {
     if (address == null)
       return false;
-    final byte[] addr = normalize(address.getAddress());
+    final byte[] raw = address.getAddress();
     for (final Cidr range : ranges)
-      if (range.matches(addr))
+      if (range.matches(raw))
         return true;
+    final byte[] normalized = normalize(raw);
+    if (normalized != raw)
+      for (final Cidr range : ranges)
+        if (range.matches(normalized))
+          return true;
     return false;
   }
 

--- a/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
+++ b/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
@@ -20,6 +20,7 @@ package com.arcadedb.utility;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -27,12 +28,29 @@ import java.util.List;
  * to non-public or otherwise restricted IP addresses (loopback, RFC 1918 private ranges, link-local/cloud-metadata,
  * carrier-grade NAT, multicast, reserved, ...) as a defense against Server-Side Request Forgery (SSRF).
  * <p>
- * IPv4-mapped IPv6 addresses (::ffff:a.b.c.d) are normalized to their embedded IPv4 form before matching so an
- * attacker cannot bypass an IPv4 range by expressing the same address in IPv6 notation.
+ * An IPv6 address that merely encodes an IPv4 address is normalized to that plain IPv4 form before matching, so an
+ * attacker cannot bypass an IPv4 range by expressing the same address through an IPv6 transition mechanism. Four
+ * encodings are recognised: IPv4-mapped ({@code ::ffff:a.b.c.d}, RFC 4291 2.5.5.2), NAT64
+ * ({@code 64:ff9b::/96}, RFC 6052), 6to4 ({@code 2002::/16}, RFC 3056) and Teredo
+ * ({@code 2001::/32}, RFC 4380 - the embedded IPv4 is bitwise-inverted). This closes the bypass in
+ * GHSA-67m7-7w7g-mpmh, where none of those encodings tripped the flag-based checks a caller ran instead of this class.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class IPAddressBlocklist {
+  /**
+   * The reserved/private ranges every SSRF guard in the codebase blocks by default: loopback, RFC 1918 private,
+   * link-local (including the cloud metadata address 169.254.169.254), carrier-grade NAT, IETF protocol assignments,
+   * benchmarking, multicast, reserved and broadcast, for both IPv4 and IPv6.
+   */
+  public static final String DEFAULT_RESERVED_RANGES =
+      "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,0.0.0.0/8,100.64.0.0/10,192.0.0.0/24,198.18.0.0/15,"
+          + "224.0.0.0/4,240.0.0.0/4,255.255.255.255/32,::1/128,::/128,fe80::/10,fc00::/7,ff00::/8";
+
+  private static final Cidr NAT64_PREFIX       = parseCidr("64:ff9b::/96");
+  private static final Cidr SIX_TO_FOUR_PREFIX = parseCidr("2002::/16");
+  private static final Cidr TEREDO_PREFIX      = parseCidr("2001::/32");
+
   private final List<Cidr> ranges;
 
   private record Cidr(byte[] network, int prefixBits) {
@@ -74,6 +92,14 @@ public class IPAddressBlocklist {
       }
     }
     return new IPAddressBlocklist(ranges);
+  }
+
+  /**
+   * Returns a freshly-parsed block-list of {@link #DEFAULT_RESERVED_RANGES}. Callers that check many addresses
+   * should parse once and reuse the instance rather than calling this per address.
+   */
+  public static IPAddressBlocklist defaultReservedRanges() {
+    return parse(DEFAULT_RESERVED_RANGES);
   }
 
   private static Cidr parseCidr(final String entry) {
@@ -120,14 +146,32 @@ public class IPAddressBlocklist {
   }
 
   /**
-   * Collapses an IPv4-mapped IPv6 address (::ffff:a.b.c.d) to its 4-byte IPv4 form so IPv4 ranges still apply.
+   * Collapses an IPv6 address that merely encodes an IPv4 address (IPv4-mapped, NAT64, 6to4 or Teredo) to that
+   * 4-byte IPv4 form, so an IPv4 range still applies to the same address expressed through IPv6.
    */
   private static byte[] normalize(final byte[] addr) {
-    if (addr.length == 16 && isIPv4Mapped(addr)) {
+    if (addr.length != 16)
+      return addr;
+
+    if (isIPv4Mapped(addr))
+      return Arrays.copyOfRange(addr, 12, 16);
+
+    // NAT64 Well-Known Prefix 64:ff9b::/96 (RFC 6052): IPv4 at bytes 12-15.
+    if (NAT64_PREFIX.matches(addr))
+      return Arrays.copyOfRange(addr, 12, 16);
+
+    // 6to4 2002::/16 (RFC 3056): IPv4 at bytes 2-5.
+    if (SIX_TO_FOUR_PREFIX.matches(addr))
+      return Arrays.copyOfRange(addr, 2, 6);
+
+    // Teredo 2001::/32 (RFC 4380): IPv4 at bytes 12-15, bitwise-inverted.
+    if (TEREDO_PREFIX.matches(addr)) {
       final byte[] v4 = new byte[4];
-      System.arraycopy(addr, 12, v4, 0, 4);
+      for (int i = 0; i < 4; i++)
+        v4[i] = (byte) (~addr[12 + i] & 0xff);
       return v4;
     }
+
     return addr;
   }
 

--- a/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
+++ b/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
@@ -52,6 +52,9 @@ public class IPAddressBlocklist {
   private static final Cidr SIX_TO_FOUR_PREFIX = parseCidr("2002::/16");
   private static final Cidr TEREDO_PREFIX      = parseCidr("2001::/32");
 
+  // The block-list is immutable, so parse DEFAULT_RESERVED_RANGES exactly once and hand out the same instance.
+  private static final IPAddressBlocklist DEFAULT_RESERVED_RANGES_INSTANCE = parse(DEFAULT_RESERVED_RANGES);
+
   private final List<Cidr> ranges;
 
   private record Cidr(byte[] network, int prefixBits) {
@@ -96,11 +99,11 @@ public class IPAddressBlocklist {
   }
 
   /**
-   * Returns a freshly-parsed block-list of {@link #DEFAULT_RESERVED_RANGES}. Callers that check many addresses
-   * should parse once and reuse the instance rather than calling this per address.
+   * Returns the shared, immutable block-list of {@link #DEFAULT_RESERVED_RANGES}, parsed once at class-init.
+   * Safe to call per address: every caller gets the same instance, so there is no reparse cost to guard against.
    */
   public static IPAddressBlocklist defaultReservedRanges() {
-    return parse(DEFAULT_RESERVED_RANGES);
+    return DEFAULT_RESERVED_RANGES_INSTANCE;
   }
 
   private static Cidr parseCidr(final String entry) {

--- a/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
+++ b/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
@@ -146,7 +146,7 @@ public class IPAddressBlocklist {
       if (range.matches(raw))
         return true;
     final byte[] normalized = normalize(raw);
-    if (normalized != raw)
+    if (normalized != null)
       for (final Cidr range : ranges)
         if (range.matches(normalized))
           return true;
@@ -160,11 +160,12 @@ public class IPAddressBlocklist {
   /**
    * Collapses an IPv6 address that merely encodes an IPv4 address (IPv4-mapped, the deprecated IPv4-compatible
    * form, NAT64, 6to4 or Teredo) to that 4-byte IPv4 form, so an IPv4 range still applies to the same address
-   * expressed through IPv6.
+   * expressed through IPv6. Returns {@code null}, not the input array, when none of those encodings apply: the
+   * caller uses that to skip re-matching a form identical to the one already checked.
    */
   private static byte[] normalize(final byte[] addr) {
     if (addr.length != 16)
-      return addr;
+      return null;
 
     if (isIPv4Mapped(addr) || isIPv4Compatible(addr))
       return Arrays.copyOfRange(addr, 12, 16);
@@ -185,7 +186,7 @@ public class IPAddressBlocklist {
       return v4;
     }
 
-    return addr;
+    return null;
   }
 
   private static boolean isIPv4Mapped(final byte[] b) {

--- a/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
+++ b/engine/src/main/java/com/arcadedb/utility/IPAddressBlocklist.java
@@ -29,11 +29,12 @@ import java.util.List;
  * carrier-grade NAT, multicast, reserved, ...) as a defense against Server-Side Request Forgery (SSRF).
  * <p>
  * An IPv6 address that merely encodes an IPv4 address is normalized to that plain IPv4 form before matching, so an
- * attacker cannot bypass an IPv4 range by expressing the same address through an IPv6 transition mechanism. Four
- * encodings are recognised: IPv4-mapped ({@code ::ffff:a.b.c.d}, RFC 4291 2.5.5.2), NAT64
- * ({@code 64:ff9b::/96}, RFC 6052), 6to4 ({@code 2002::/16}, RFC 3056) and Teredo
- * ({@code 2001::/32}, RFC 4380 - the embedded IPv4 is bitwise-inverted). This closes the bypass in
- * GHSA-67m7-7w7g-mpmh, where none of those encodings tripped the flag-based checks a caller ran instead of this class.
+ * attacker cannot bypass an IPv4 range by expressing the same address through an IPv6 transition mechanism. Five
+ * encodings are recognised: IPv4-mapped ({@code ::ffff:a.b.c.d}, RFC 4291 2.5.5.2), the deprecated IPv4-compatible
+ * form ({@code ::a.b.c.d}, RFC 4291 2.5.5.1), NAT64 ({@code 64:ff9b::/96}, RFC 6052), 6to4 ({@code 2002::/16},
+ * RFC 3056) and Teredo ({@code 2001::/32}, RFC 4380 - the embedded IPv4 is bitwise-inverted). This closes the
+ * bypass in GHSA-67m7-7w7g-mpmh, where none of those encodings tripped the flag-based checks a caller ran instead
+ * of this class.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -146,14 +147,15 @@ public class IPAddressBlocklist {
   }
 
   /**
-   * Collapses an IPv6 address that merely encodes an IPv4 address (IPv4-mapped, NAT64, 6to4 or Teredo) to that
-   * 4-byte IPv4 form, so an IPv4 range still applies to the same address expressed through IPv6.
+   * Collapses an IPv6 address that merely encodes an IPv4 address (IPv4-mapped, the deprecated IPv4-compatible
+   * form, NAT64, 6to4 or Teredo) to that 4-byte IPv4 form, so an IPv4 range still applies to the same address
+   * expressed through IPv6.
    */
   private static byte[] normalize(final byte[] addr) {
     if (addr.length != 16)
       return addr;
 
-    if (isIPv4Mapped(addr))
+    if (isIPv4Mapped(addr) || isIPv4Compatible(addr))
       return Arrays.copyOfRange(addr, 12, 16);
 
     // NAT64 Well-Known Prefix 64:ff9b::/96 (RFC 6052): IPv4 at bytes 12-15.
@@ -180,6 +182,19 @@ public class IPAddressBlocklist {
       if (b[i] != 0)
         return false;
     return (b[10] & 0xFF) == 0xFF && (b[11] & 0xFF) == 0xFF;
+  }
+
+  /**
+   * The deprecated "IPv4-compatible IPv6 address" form (RFC 4291 2.5.5.1: {@code ::a.b.c.d}, no {@code ffff}
+   * marker in bytes 10-11, unlike the still-current IPv4-mapped form). No real allocated global-unicast range
+   * starts with 96 zero bits (those all begin {@code 2000::/3}), so treating any such address as an embedded
+   * IPv4 payload cannot misclassify legitimate public IPv6 traffic.
+   */
+  private static boolean isIPv4Compatible(final byte[] b) {
+    for (int i = 0; i < 12; i++)
+      if (b[i] != 0)
+        return false;
+    return true;
   }
 
   private static boolean isNumericAddress(final String host) {

--- a/engine/src/test/java/com/arcadedb/utility/IPAddressBlocklistTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/IPAddressBlocklistTest.java
@@ -92,6 +92,26 @@ class IPAddressBlocklistTest {
   }
 
   /**
+   * Code review on the transition-encoding unwrap found that normalizing the probe address unconditionally, before
+   * matching, lets the unwrap silently pre-empt a literal 16-byte IPv6 CIDR entry: {@code isBlocked} converts
+   * {@code ::1} to the 4-byte form {@code 0.0.0.1} before the loop runs, and {@code Cidr.matches} rejects a 4-byte
+   * probe against a 16-byte network on the length check alone, so a custom block-list of just {@code ::1/128}
+   * (with no {@code 0.0.0.0/8} entry to catch the unwrapped fallback) never matches {@code ::1}. This only stayed
+   * invisible for {@link #DEFAULT} because {@code 0.0.0.0/8} happens to be present there too. A custom, narrower
+   * list - exactly what {@code OPENCYPHER_LOAD_CSV_BLOCKED_IP_RANGES} is designed to accept - has no such safety net.
+   */
+  @Test
+  void literalIPv6CidrEntryIsNotShadowedByTheUnwrap() throws Exception {
+    assertThat(IPAddressBlocklist.parse("::1/128").isBlocked(ip("::1"))).isTrue();
+    assertThat(IPAddressBlocklist.parse("::/128").isBlocked(ip("::"))).isTrue();
+    assertThat(IPAddressBlocklist.parse("64:ff9b::/96").isBlocked(ip("64:ff9b::c0a8:0101"))).isTrue();
+    assertThat(IPAddressBlocklist.parse("2002::/16").isBlocked(ip("2002:c0a8:0101::1"))).isTrue();
+    assertThat(IPAddressBlocklist.parse("2001::/32").isBlocked(ip("2001:0000:4136:e378:8000:63bf:3f57:fefe"))).isTrue();
+    // A literal range for a different transition prefix must still not match an address outside it.
+    assertThat(IPAddressBlocklist.parse("2002::/16").isBlocked(ip("64:ff9b::c0a8:0101"))).isFalse();
+  }
+
+  /**
    * GHSA-67m7-7w7g-mpmh: IPv6 transition mechanisms (NAT64, 6to4, Teredo) each embed an IPv4 address inside an
    * IPv6 literal through a different, non-{@code ::ffff:}-prefixed encoding. None of these tripped
    * {@code isIPv4Mapped}, so a private/loopback/link-local IPv4 payload smuggled through one of them reached the

--- a/engine/src/test/java/com/arcadedb/utility/IPAddressBlocklistTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/IPAddressBlocklistTest.java
@@ -31,9 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class IPAddressBlocklistTest {
 
-  private static final String DEFAULT =
-      "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,0.0.0.0/8,100.64.0.0/10,192.0.0.0/24,198.18.0.0/15,"
-          + "224.0.0.0/4,240.0.0.0/4,255.255.255.255/32,::1/128,::/128,fe80::/10,fc00::/7,ff00::/8";
+  private static final String DEFAULT = IPAddressBlocklist.DEFAULT_RESERVED_RANGES;
 
   private static InetAddress ip(final String literal) throws UnknownHostException {
     return InetAddress.getByName(literal);
@@ -78,6 +76,47 @@ class IPAddressBlocklistTest {
     assertThat(bl.isBlocked(ip("::ffff:127.0.0.1"))).isTrue();
     assertThat(bl.isBlocked(ip("::ffff:169.254.169.254"))).isTrue();
     assertThat(bl.isBlocked(ip("::ffff:8.8.8.8"))).isFalse();
+  }
+
+  /**
+   * GHSA-67m7-7w7g-mpmh: IPv6 transition mechanisms (NAT64, 6to4, Teredo) each embed an IPv4 address inside an
+   * IPv6 literal through a different, non-{@code ::ffff:}-prefixed encoding. None of these tripped
+   * {@code isIPv4Mapped}, so a private/loopback/link-local IPv4 payload smuggled through one of them reached the
+   * SSRF guard unblocked. Addresses below reuse the exact examples from the advisory.
+   */
+  @Test
+  void blocksIPv6TransitionAddressBypass() throws Exception {
+    final IPAddressBlocklist bl = IPAddressBlocklist.parse(DEFAULT);
+
+    // NAT64 (RFC 6052), 64:ff9b::/96, IPv4 at bytes 12-15.
+    assertThat(bl.isBlocked(ip("64:ff9b::c0a8:0101"))).isTrue();  // embeds 192.168.1.1
+    assertThat(bl.isBlocked(ip("64:ff9b::a9fe:a9fe"))).isTrue();  // embeds 169.254.169.254 (cloud metadata)
+    assertThat(bl.isBlocked(ip("64:ff9b::7f00:1"))).isTrue();     // embeds 127.0.0.1
+
+    // 6to4 (RFC 3056), 2002::/16, IPv4 at bytes 2-5.
+    assertThat(bl.isBlocked(ip("2002:c0a8:0101::1"))).isTrue();   // embeds 192.168.1.1
+    assertThat(bl.isBlocked(ip("2002:a9fe:a9fe::1"))).isTrue();   // embeds 169.254.169.254
+
+    // Teredo (RFC 4380), 2001::/32, IPv4 at bytes 12-15, bitwise-inverted.
+    assertThat(bl.isBlocked(ip("2001:0000:4136:e378:8000:63bf:3f57:fefe"))).isTrue(); // embeds 192.168.1.1
+  }
+
+  @Test
+  void allowsIPv6TransitionAddressesEmbeddingPublicIPv4() throws Exception {
+    final IPAddressBlocklist bl = IPAddressBlocklist.parse(DEFAULT);
+
+    assertThat(bl.isBlocked(ip("64:ff9b::808:808"))).isFalse();    // NAT64 for 8.8.8.8
+    assertThat(bl.isBlocked(ip("2002:0808:0808::1"))).isFalse();   // 6to4 for 8.8.8.8
+    // Teredo for 8.8.8.8: embedded bytes are ~8,~8,~8,~8 = f7f7f7f7
+    assertThat(bl.isBlocked(ip("2001:0000:0000:0000:0000:0000:f7f7:f7f7"))).isFalse();
+  }
+
+  @Test
+  void defaultReservedRangesFactoryMatchesConstant() throws Exception {
+    final IPAddressBlocklist bl = IPAddressBlocklist.defaultReservedRanges();
+    assertThat(bl.isBlocked(ip("169.254.169.254"))).isTrue();
+    assertThat(bl.isBlocked(ip("64:ff9b::a9fe:a9fe"))).isTrue();
+    assertThat(bl.isBlocked(ip("8.8.8.8"))).isFalse();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/utility/IPAddressBlocklistTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/IPAddressBlocklistTest.java
@@ -79,6 +79,19 @@ class IPAddressBlocklistTest {
   }
 
   /**
+   * The deprecated "IPv4-compatible IPv6 address" form (RFC 4291 2.5.5.1, {@code ::a.b.c.d}) has no {@code ffff}
+   * marker, so it is a distinct case from the still-current IPv4-mapped form above. Flagged by code review on the
+   * original GHSA-67m7-7w7g-mpmh fix as a residual gap in the same encoding family.
+   */
+  @Test
+  void blocksDeprecatedIPv4CompatibleBypass() throws Exception {
+    final IPAddressBlocklist bl = IPAddressBlocklist.parse(DEFAULT);
+    assertThat(bl.isBlocked(ip("::127.0.0.1"))).isTrue();
+    assertThat(bl.isBlocked(ip("::169.254.169.254"))).isTrue();
+    assertThat(bl.isBlocked(ip("::8.8.8.8"))).isFalse();
+  }
+
+  /**
    * GHSA-67m7-7w7g-mpmh: IPv6 transition mechanisms (NAT64, 6to4, Teredo) each embed an IPv4 address inside an
    * IPv6 literal through a different, non-{@code ::ffff:}-prefixed encoding. None of these tripped
    * {@code isIPv4Mapped}, so a private/loopback/link-local IPv4 payload smuggled through one of them reached the

--- a/engine/src/test/java/com/arcadedb/utility/IPAddressBlocklistTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/IPAddressBlocklistTest.java
@@ -152,6 +152,16 @@ class IPAddressBlocklistTest {
     assertThat(bl.isBlocked(ip("8.8.8.8"))).isFalse();
   }
 
+  /**
+   * Review suggestion: memoize {@code defaultReservedRanges()} as a true singleton (the block-list is immutable)
+   * instead of relying on every caller remembering to cache it, so a future caller can't accidentally reparse per
+   * request without noticing.
+   */
+  @Test
+  void defaultReservedRangesIsMemoizedAsASingleton() {
+    assertThat(IPAddressBlocklist.defaultReservedRanges()).isSameAs(IPAddressBlocklist.defaultReservedRanges());
+  }
+
   @Test
   void emptyBlocklistNeverBlocks() throws Exception {
     assertThat(IPAddressBlocklist.parse("").isEmpty()).isTrue();

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImportSecurityValidator.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImportSecurityValidator.java
@@ -19,6 +19,7 @@
 package com.arcadedb.integration.importer;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.utility.IPAddressBlocklist;
 import com.arcadedb.utility.SafeHttpFetcher;
 
 import java.io.File;
@@ -47,9 +48,10 @@ import java.nio.file.Path;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class ImportSecurityValidator {
-  private static final String RESOURCE_SEPARATOR = ":::";
-  private static final String FILE_PREFIX        = "file://";
-  private static final String CLASSPATH_PREFIX   = "classpath://";
+  private static final String             RESOURCE_SEPARATOR = ":::";
+  private static final String             FILE_PREFIX        = "file://";
+  private static final String             CLASSPATH_PREFIX   = "classpath://";
+  private static final IPAddressBlocklist RESERVED_ADDRESSES = IPAddressBlocklist.defaultReservedRanges();
 
   private ImportSecurityValidator() {
   }
@@ -157,26 +159,16 @@ public class ImportSecurityValidator {
 
   /**
    * Returns {@code true} if the address belongs to a network range that must not be reachable through
-   * {@code IMPORT DATABASE} (loopback, link-local, site-local/private, wildcard, multicast, IPv6 ULA
-   * or IPv4 CGNAT).
+   * {@code IMPORT DATABASE} (loopback, link-local, site-local/private, wildcard, multicast, IPv6 ULA,
+   * IPv4 CGNAT, or an IPv6 transition encoding - IPv4-mapped, NAT64, 6to4, Teredo - of any of the above).
    * <p>
-   * The blocked-range logic mirrors {@code PostServerCommandHandler.isBlockedHost} in the server
-   * module; keep the two in sync when adding ranges.
+   * Delegates to {@link IPAddressBlocklist#defaultReservedRanges()}, the single shared implementation also used
+   * by {@code PostServerCommandHandler.isBlockedHost} in the server module and by {@code LOAD CSV}. A previous
+   * version duplicated this logic ad-hoc in each caller, which is how GHSA-67m7-7w7g-mpmh happened: the IPv6
+   * transition encodings were added to fix that GHSA in {@link IPAddressBlocklist} but a duplicate copy would
+   * have needed the exact same fix applied twice, by hand, forever.
    */
   static boolean isBlockedAddress(final InetAddress address) {
-    if (address.isLoopbackAddress()         // 127.0.0.0/8, ::1
-        || address.isLinkLocalAddress()     // 169.254.0.0/16 (cloud metadata), fe80::/10
-        || address.isSiteLocalAddress()     // 10/8, 172.16/12, 192.168/16
-        || address.isAnyLocalAddress()      // 0.0.0.0, ::
-        || address.isMulticastAddress())    // 224.0.0.0/4, ff00::/8
-      return true;
-
-    // InetAddress flags miss two modern private ranges, so check the raw bytes explicitly.
-    final byte[] bytes = address.getAddress();
-    // IPv6 Unique Local Addresses (ULA) fc00::/7 (RFC 4193).
-    if (bytes.length == 16 && (bytes[0] & 0xfe) == 0xfc)
-      return true;
-    // IPv4 Carrier-Grade NAT (CGNAT) 100.64.0.0/10 (RFC 6598).
-    return bytes.length == 4 && (bytes[0] & 0xff) == 100 && (bytes[1] & 0xc0) == 64;
+    return RESERVED_ADDRESSES.isBlocked(address);
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/ImportSecurityValidatorTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/ImportSecurityValidatorTest.java
@@ -61,6 +61,34 @@ class ImportSecurityValidatorTest {
         .isInstanceOf(SecurityException.class);
   }
 
+  /**
+   * GHSA-67m7-7w7g-mpmh: an IPv6 literal that merely encodes a blocked IPv4 address through a transition mechanism
+   * (NAT64, 6to4, Teredo) must be rejected exactly like the plain IPv4 form. These reuse the advisory's own PoC
+   * addresses, which embed the AWS/GCP/Azure metadata address 169.254.169.254 and the private address 192.168.1.1.
+   */
+  @Test
+  void blocksIPv6TransitionAddressEncodingBlockedIPv4() {
+    // NAT64 (RFC 6052) for 169.254.169.254
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://[64:ff9b::a9fe:a9fe]/latest/meta-data/"))
+        .isInstanceOf(SecurityException.class);
+    // NAT64 (RFC 6052) for 192.168.1.1
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://[64:ff9b::c0a8:0101]/x"))
+        .isInstanceOf(SecurityException.class);
+    // 6to4 (RFC 3056) for 192.168.1.1
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://[2002:c0a8:0101::1]/x"))
+        .isInstanceOf(SecurityException.class);
+    // Teredo (RFC 4380) for 192.168.1.1
+    assertThatThrownBy(
+        () -> ImportSecurityValidator.validateRemoteURL("http://[2001:0000:4136:e378:8000:63bf:3f57:fefe]/x"))
+        .isInstanceOf(SecurityException.class);
+  }
+
+  @Test
+  void allowsIPv6TransitionAddressEncodingPublicIPv4() {
+    // NAT64 for the public address 8.8.8.8 must not be blocked.
+    assertThatNoException().isThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://[64:ff9b::808:808]/x"));
+  }
+
   @Test
   void allowsPublicAddress() {
     // A public literal IP does not require DNS resolution and must be allowed

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -40,6 +40,7 @@ import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.IPAddressBlocklist;
 import io.micrometer.core.instrument.Metrics;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
@@ -94,6 +95,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   private static final String RESTORE_DATABASE     = "restore database";
   private static final String IMPORT_DATABASE      = "import database";
   private static final String PROFILER             = "profiler";
+
+  private static final IPAddressBlocklist RESERVED_ADDRESSES = IPAddressBlocklist.defaultReservedRanges();
 
   public PostServerCommandHandler(final HttpServer httpServer) {
     super(httpServer);
@@ -535,25 +538,16 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
    * resolves to a mix of public and private addresses is still rejected. An unresolvable host is
    * treated as blocked.
    * <p>
-   * The blocked-range logic mirrors {@code ImportSecurityValidator.isBlockedAddress} in the
-   * (test-scoped, reflectively-loaded) integration module; keep the two in sync when adding ranges.
+   * Delegates to {@link IPAddressBlocklist#defaultReservedRanges()}, the single shared implementation also used
+   * by {@code ImportSecurityValidator.isBlockedAddress} in the integration module and by {@code LOAD CSV}. A
+   * previous version duplicated this logic ad-hoc; see {@code ImportSecurityValidator.isBlockedAddress} for why
+   * that was the root cause of GHSA-67m7-7w7g-mpmh. Package-private for direct unit testing.
    */
-  private static boolean isBlockedHost(final String host) {
+  static boolean isBlockedHost(final String host) {
     try {
-      for (final InetAddress addr : InetAddress.getAllByName(host)) {
-        if (addr.isLoopbackAddress() || addr.isAnyLocalAddress() || addr.isLinkLocalAddress()
-            || addr.isSiteLocalAddress() || addr.isMulticastAddress())
+      for (final InetAddress addr : InetAddress.getAllByName(host))
+        if (RESERVED_ADDRESSES.isBlocked(addr))
           return true;
-
-        // InetAddress flags miss two modern private ranges, so check the raw bytes explicitly.
-        final byte[] bytes = addr.getAddress();
-        // IPv6 Unique Local Addresses (ULA) fc00::/7 (RFC 4193).
-        if (bytes.length == 16 && (bytes[0] & 0xfe) == 0xfc)
-          return true;
-        // IPv4 Carrier-Grade NAT (CGNAT) 100.64.0.0/10 (RFC 6598).
-        if (bytes.length == 4 && (bytes[0] & 0xff) == 100 && (bytes[1] & 0xc0) == 64)
-          return true;
-      }
       return false;
     } catch (final UnknownHostException e) {
       return true;

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerSsrfTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerSsrfTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for {@link PostServerCommandHandler#isBlockedHost(String)}, the SSRF guard for client-supplied
+ * restore/import URLs (no server startup required: the method is a pure function of the host string).
+ * <p>
+ * GHSA-67m7-7w7g-mpmh: an IPv6 literal that merely encodes a blocked IPv4 address through a transition mechanism
+ * (NAT64, 6to4, Teredo) bypassed the previous flag-based checks. {@code isBlockedHost} now delegates to the same
+ * {@link com.arcadedb.utility.IPAddressBlocklist} used by {@code ImportSecurityValidator.isBlockedAddress}, whose
+ * own test covers the transition-address unwrapping exhaustively; these assert the handler's wiring to it.
+ */
+class PostServerCommandHandlerSsrfTest {
+
+  @Test
+  void blocksPlainPrivateAndLoopbackHosts() {
+    assertThat(PostServerCommandHandler.isBlockedHost("127.0.0.1")).isTrue();
+    assertThat(PostServerCommandHandler.isBlockedHost("169.254.169.254")).isTrue();
+    assertThat(PostServerCommandHandler.isBlockedHost("192.168.1.1")).isTrue();
+    assertThat(PostServerCommandHandler.isBlockedHost("10.0.0.5")).isTrue();
+  }
+
+  @Test
+  void blocksIPv6TransitionAddressEncodingBlockedIPv4() {
+    // NAT64 (RFC 6052) for 169.254.169.254 (cloud metadata)
+    assertThat(PostServerCommandHandler.isBlockedHost("64:ff9b::a9fe:a9fe")).isTrue();
+    // NAT64 (RFC 6052) for 192.168.1.1
+    assertThat(PostServerCommandHandler.isBlockedHost("64:ff9b::c0a8:0101")).isTrue();
+    // 6to4 (RFC 3056) for 192.168.1.1
+    assertThat(PostServerCommandHandler.isBlockedHost("2002:c0a8:0101::1")).isTrue();
+    // Teredo (RFC 4380) for 192.168.1.1
+    assertThat(PostServerCommandHandler.isBlockedHost("2001:0000:4136:e378:8000:63bf:3f57:fefe")).isTrue();
+  }
+
+  @Test
+  void allowsPublicHostsIncludingTransitionEncodedOnes() {
+    assertThat(PostServerCommandHandler.isBlockedHost("8.8.8.8")).isFalse();
+    // NAT64 for the public address 8.8.8.8 must not be blocked.
+    assertThat(PostServerCommandHandler.isBlockedHost("64:ff9b::808:808")).isFalse();
+  }
+
+  @Test
+  void blocksUnresolvableHost() {
+    assertThat(PostServerCommandHandler.isBlockedHost("this-host-does-not-exist.invalid")).isTrue();
+  }
+}


### PR DESCRIPTION
## Summary

- `ImportSecurityValidator.isBlockedAddress` and `PostServerCommandHandler.isBlockedHost` each carried their own copy of the reserved/private-address check used for `IMPORT DATABASE` and server restore/import URLs. Neither recognized an IPv6 address that merely *encodes* an IPv4 address through a transition mechanism (NAT64 `64:ff9b::/96`, 6to4 `2002::/16`, Teredo `2001::/32`), so a private/loopback/link-local IPv4 expressed that way passed both checks unblocked.
- `IPAddressBlocklist` (already the shared CIDR matcher `LOAD CSV` uses) now unwraps all four IPv4-in-IPv6 encodings - IPv4-mapped, NAT64, 6to4, Teredo - before matching, and both callers delegate to a single shared, cached instance instead of duplicating the flag-based logic. This removes the "keep the two in sync" hazard the old code's own comments called out, and folds in a few reserved ranges (IETF protocol assignments, benchmarking, broadcast) the flag-based checks never covered.
- `GlobalConfiguration.OPENCYPHER_LOAD_CSV_BLOCKED_IP_RANGES`'s default now references the same constant instead of duplicating the CIDR string a third time.

## Test plan

- [x] New unit tests in `IPAddressBlocklistTest` cover the NAT64/6to4/Teredo unwrap (positive: blocked; negative: a transition address encoding a *public* IPv4 stays allowed).
- [x] New end-to-end tests in `ImportSecurityValidatorTest` exercise `validateRemoteURL` with bracketed IPv6-literal URLs.
- [x] New `PostServerCommandHandlerSsrfTest` unit test (`isBlockedHost` demoted from `private` to package-private for direct testability) covers the same cases for the server restore/import path.
- [x] `PostServerCommandHandlerIT` (23 tests) and `OpenCypherLoadCSVTest` (26 tests) still pass unchanged.
- [x] Full `compile`/`test-compile` across `engine`, `integration`, `server` is clean.