### PR TITLE
fix: batch fixes for #5934, #5937, #5958

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -289,13 +289,17 @@ public class DatabaseChecker {
         // Same file-locking coverage AND retry-on-contention as RebuildIndexStatement.buildIndex(): holding the
         // lock across both the drop and the create prevents a concurrent writer from observing the index
         // gone-then-back, and retrying survives tryLockFiles's LockTimeoutException (a NeedRetryException) on a
-        // busy database.
+        // busy database. rebuildMetadata/ownerTypeIndex are captured once, before the loop (unlike
+        // RebuildIndexStatement, which recomputes the equivalent state inside its per-attempt loop) - both read
+        // idx before ANY attempt's drop, so this is just a hoist, not a behavior change.
         //
         // Shares a known, pre-existing race with RebuildIndexStatement's identically-shaped retry (not introduced
-        // here): retrying re-enters the whole drop+create body, so a NeedRetryException raised deep inside
-        // create()'s bucket scan - after the drop already committed - restarts from a dropped index rather than
-        // from the point of failure. A proper fix (skip the drop on retry, or scope the retry to lock acquisition
-        // only) belongs in both call sites together, not this one in isolation.
+        // here): dropIndex() itself is safe to repeat (LocalSchema.dropIndexInternal no-ops once the name is
+        // already gone), but a NeedRetryException raised deep inside create()'s bucket scan - AFTER a prior
+        // attempt's drop already committed - means the next attempt's create() runs a second time following that
+        // same drop, rather than resuming from the point create() actually failed. A proper fix (clean up a
+        // partially-built index before retrying, or scope the retry to lock acquisition only) belongs in both
+        // call sites together, not this one in isolation.
         boolean rebuilt = false;
         NeedRetryException lastRetryFailure = null;
         for (int attempt = 1; attempt <= LOCK_MAX_ATTEMPTS; attempt++) {

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -286,17 +286,17 @@ public class DatabaseChecker {
         final IndexMetadata rebuildMetadata = IndexMetadata.reconstructForRebuild((IndexInternal) idx, typeName,
             propNames.toArray(new String[0]));
 
-        // Same file-locking coverage as RebuildIndexStatement.buildIndex(): the drop and the rebuild below touch
-        // the index's own file(s) plus, through the drop, the owning TypeIndex's bookkeeping. Without holding
-        // the lock across both steps a concurrent writer could observe the index gone-then-back with entries
-        // missing, or the commit-time lock-coverage check could throw on the newly-created file.
+        // Same file-locking coverage AND retry-on-contention as RebuildIndexStatement.buildIndex(): holding the
+        // lock across both the drop and the create prevents a concurrent writer from observing the index
+        // gone-then-back, and retrying survives tryLockFiles's LockTimeoutException (a NeedRetryException) on a
+        // busy database. Unlike RebuildIndexStatement, which silently returns once attempts are exhausted, this
+        // rethrows so CHECK DATABASE FIX fails loudly instead of quietly leaving the index unrepaired.
         //
-        // Retried like RebuildIndexStatement.buildIndex() retries the same lock: TransactionManager.tryLockFiles
-        // throws LockTimeoutException (a NeedRetryException) on contention, and widening the locked section to
-        // cover both the drop and the create - the whole point of this fix - widens the window a concurrent
-        // writer can contend on. Unlike RebuildIndexStatement, which silently returns once maxAttempts is
-        // exhausted, this rethrows: CHECK DATABASE FIX should fail loudly rather than quietly leave the index
-        // unrepaired and still report success.
+        // Shares a known, pre-existing race with RebuildIndexStatement's identically-shaped retry (not introduced
+        // here): retrying re-enters the whole drop+create body, so a NeedRetryException raised deep inside
+        // create()'s bucket scan - after the drop already committed - restarts from a dropped index rather than
+        // from the point of failure. A proper fix (skip the drop on retry, or scope the retry to lock acquisition
+        // only) belongs in both call sites together, not this one in isolation.
         for (int attempt = 1; attempt <= LOCK_MAX_ATTEMPTS; attempt++) {
           try {
             database.executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -295,13 +295,21 @@ public class DatabaseChecker {
           indexMetadata = geoMeta;
         }
 
-        database.getSchema().dropIndex(idx.getName());
+        // Same file-locking coverage as RebuildIndexStatement.buildIndex(): the drop and the rebuild below touch
+        // the index's own file(s) plus, through the drop, the owning TypeIndex's bookkeeping. Without holding
+        // the lock across both steps a concurrent writer could observe the index gone-then-back with entries
+        // missing, or the commit-time lock-coverage check could throw on the newly-created file.
+        final IndexMetadata rebuildMetadata = indexMetadata;
+        database.executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
+          database.getSchema().dropIndex(idx.getName());
 
-        database.getSchema().buildBucketIndex(typeName, bucketName, propNames.toArray(new String[propNames.size()]))
-            .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy)
-            .withMetadata(indexMetadata)
-            .withIndexName(ownerTypeIndex != null ? ownerTypeIndex.getName() : null)
-            .create();
+          database.getSchema().buildBucketIndex(typeName, bucketName, propNames.toArray(new String[propNames.size()]))
+              .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy)
+              .withMetadata(rebuildMetadata)
+              .withIndexName(ownerTypeIndex != null ? ownerTypeIndex.getName() : null)
+              .create();
+          return null;
+        });
 
         stepTick();
       }

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.DatabaseOperationException;
+import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.GraphDatabaseChecker;
 import com.arcadedb.index.Index;
@@ -49,6 +50,8 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class DatabaseChecker {
+  // Matches RebuildIndexStatement.MAX_ATTEMPTS: the lock-contention retry bound for the index-rebuild file lock.
+  private static final int          LOCK_MAX_ATTEMPTS = 5;
   private final DatabaseInternal    database;
   private       int                 verboseLevel = 1;
   private       boolean             fix          = false;
@@ -287,16 +290,37 @@ public class DatabaseChecker {
         // the index's own file(s) plus, through the drop, the owning TypeIndex's bookkeeping. Without holding
         // the lock across both steps a concurrent writer could observe the index gone-then-back with entries
         // missing, or the commit-time lock-coverage check could throw on the newly-created file.
-        database.executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
-          database.getSchema().dropIndex(idx.getName());
+        //
+        // Retried like RebuildIndexStatement.buildIndex() retries the same lock: TransactionManager.tryLockFiles
+        // throws LockTimeoutException (a NeedRetryException) on contention, and widening the locked section to
+        // cover both the drop and the create - the whole point of this fix - widens the window a concurrent
+        // writer can contend on. Unlike RebuildIndexStatement, which silently returns once maxAttempts is
+        // exhausted, this rethrows: CHECK DATABASE FIX should fail loudly rather than quietly leave the index
+        // unrepaired and still report success.
+        for (int attempt = 1; attempt <= LOCK_MAX_ATTEMPTS; attempt++) {
+          try {
+            database.executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
+              database.getSchema().dropIndex(idx.getName());
 
-          database.getSchema().buildBucketIndex(typeName, bucketName, propNames.toArray(new String[propNames.size()]))
-              .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy)
-              .withMetadata(rebuildMetadata)
-              .withIndexName(ownerTypeIndex != null ? ownerTypeIndex.getName() : null)
-              .create();
-          return null;
-        });
+              database.getSchema().buildBucketIndex(typeName, bucketName, propNames.toArray(new String[propNames.size()]))
+                  .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy)
+                  .withMetadata(rebuildMetadata)
+                  .withIndexName(ownerTypeIndex != null ? ownerTypeIndex.getName() : null)
+                  .create();
+              return null;
+            });
+            break;
+          } catch (final NeedRetryException e) {
+            if (attempt == LOCK_MAX_ATTEMPTS)
+              throw e;
+            try {
+              Thread.sleep(200 + 200L * attempt);
+            } catch (final InterruptedException ie) {
+              Thread.currentThread().interrupt();
+              throw e;
+            }
+          }
+        }
 
         stepTick();
       }

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -278,20 +278,22 @@ public class DatabaseChecker {
         final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
 
         // Same defect class fixed in RebuildIndexStatement.buildIndex() for issue #5791/#4732: capture the owning
-        // TypeIndex's name and reconstruct type-specific metadata BEFORE the drop below, otherwise a single-bucket
-        // type (the common default) loses its explicitly-named TypeIndex wrapper and a FULL_TEXT/GEOSPATIAL index
-        // reverts to default analyzer/precision settings every time this repairs one of their bucket sub-indexes.
+        // TypeIndex's name BEFORE the drop below, otherwise a single-bucket type (the common default) loses its
+        // explicitly-named TypeIndex wrapper. Safe to read once, outside the retry loop below: it is a plain name
+        // read off idx, unaffected by how many attempts the rebuild takes.
         final TypeIndex ownerTypeIndex = ((IndexInternal) idx).getTypeIndex();
-
-        final IndexMetadata rebuildMetadata = IndexMetadata.reconstructForRebuild((IndexInternal) idx, typeName,
-            propNames.toArray(new String[0]));
 
         // Same file-locking coverage AND retry-on-contention as RebuildIndexStatement.buildIndex(): holding the
         // lock across both the drop and the create prevents a concurrent writer from observing the index
         // gone-then-back, and retrying survives tryLockFiles's LockTimeoutException (a NeedRetryException) on a
-        // busy database. rebuildMetadata/ownerTypeIndex are captured once, before the loop (unlike
-        // RebuildIndexStatement, which recomputes the equivalent state inside its per-attempt loop) - both read
-        // idx before ANY attempt's drop, so this is just a hoist, not a behavior change.
+        // busy database.
+        //
+        // reconstructForRebuild(...) is called PER ATTEMPT, inside the loop, matching RebuildIndexStatement -
+        // NOT hoisted above it like ownerTypeIndex. For FULL_TEXT it returns a fresh FullTextIndexMetadata with
+        // its BM25 corpus counters zeroed; buildBucketIndex().create() mutates that exact instance in place as
+        // it indexes each record. A single shared instance reused across attempts would still carry attempt N's
+        // partial counts into attempt N+1's create() call, inflating totalDocs/sumDocLength (and so skewing BM25
+        // relevance scoring) on any FULL_TEXT index whose rebuild needed more than one attempt.
         //
         // Shares a known, pre-existing race with RebuildIndexStatement's identically-shaped retry (not introduced
         // here): dropIndex() itself is safe to repeat (LocalSchema.dropIndexInternal no-ops once the name is
@@ -304,6 +306,8 @@ public class DatabaseChecker {
         NeedRetryException lastRetryFailure = null;
         for (int attempt = 1; attempt <= LOCK_MAX_ATTEMPTS; attempt++) {
           try {
+            final IndexMetadata rebuildMetadata = IndexMetadata.reconstructForRebuild((IndexInternal) idx, typeName,
+                propNames.toArray(new String[0]));
             database.executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
               database.getSchema().dropIndex(idx.getName());
 

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -28,9 +28,13 @@ import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.GraphDatabaseChecker;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.FullTextIndexMetadata;
+import com.arcadedb.schema.GeoIndexMetadata;
+import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.LocalEdgeType;
 import com.arcadedb.schema.LocalVertexType;
@@ -272,10 +276,32 @@ public class DatabaseChecker {
         final int pageSize = ((IndexInternal) idx).getPageSizeForNewFile();
         final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
 
+        // Same defect class fixed in RebuildIndexStatement.buildIndex() for issue #5791/#4732: capture the owning
+        // TypeIndex's name and reconstruct type-specific metadata BEFORE the drop below, otherwise a single-bucket
+        // type (the common default) loses its explicitly-named TypeIndex wrapper and a FULL_TEXT/GEOSPATIAL index
+        // reverts to default analyzer/precision settings every time this repairs one of their bucket sub-indexes.
+        final TypeIndex ownerTypeIndex = ((IndexInternal) idx).getTypeIndex();
+
+        IndexMetadata indexMetadata = ((IndexInternal) idx).getMetadata();
+        if (indexType == Schema.INDEX_TYPE.FULL_TEXT) {
+          final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, propNames.toArray(new String[0]), -1);
+          ftMeta.fromJSON(((IndexInternal) idx).toJSON());
+          ftMeta.setCounters(0L, 0L);
+          indexMetadata = ftMeta;
+        } else if (indexType == Schema.INDEX_TYPE.GEOSPATIAL) {
+          final GeoIndexMetadata geoMeta = new GeoIndexMetadata(typeName, propNames.toArray(new String[0]), -1);
+          geoMeta.fromJSON(((IndexInternal) idx).toJSON());
+          geoMeta.setTokenization(GeoIndexMetadata.DEFAULT_TOKENIZATION);
+          indexMetadata = geoMeta;
+        }
+
         database.getSchema().dropIndex(idx.getName());
 
         database.getSchema().buildBucketIndex(typeName, bucketName, propNames.toArray(new String[propNames.size()]))
-            .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy).create();
+            .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy)
+            .withMetadata(indexMetadata)
+            .withIndexName(ownerTypeIndex != null ? ownerTypeIndex.getName() : null)
+            .create();
 
         stepTick();
       }

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -342,14 +342,21 @@ public class DatabaseChecker {
 
         // Isolated per index rather than letting the exhausted retry unwind out of check(): this loop repairs
         // potentially many indexes plus whatever checkDocuments/checkVertices/checkEdges already found and fixed,
-        // and none of that should be discarded because ONE index stayed lock-contended on a busy database. Report
-        // it (this class's "reported, never silent" convention - see the manual-index warning above) and correct
-        // the rebuiltIndexes claim instead of pretending the rebuild happened.
+        // and none of that should be discarded because retrying ONE index ran out of attempts. Report it (this
+        // class's "reported, never silent" convention - see the manual-index warning above) and correct the
+        // rebuiltIndexes claim instead of pretending the rebuild happened.
+        //
+        // The warning deliberately does not claim lock contention as the cause: exhaustion can also follow the
+        // pre-existing race documented above the loop (a NeedRetryException from deep inside a LATER attempt's
+        // create(), after an EARLIER attempt's drop already committed), in which case the index may now be
+        // missing rather than merely unrebuilt - lastRetryFailure.getMessage() is surfaced so the operator can
+        // tell which one actually happened, instead of a blanket "due to lock contention" that would be wrong
+        // for the second case.
         if (!rebuilt) {
           rebuildIndexes.remove(idx.getName());
-          addWarning("index '" + idx.getName() + "': could not be rebuilt after " + LOCK_MAX_ATTEMPTS
-              + " attempts due to lock contention (error: " + lastRetryFailure.getMessage()
-              + "). Run CHECK DATABASE FIX again once the affected index/type is quiescent");
+          addWarning("index '" + idx.getName() + "' did not finish rebuilding after " + LOCK_MAX_ATTEMPTS
+              + " attempts (error: " + lastRetryFailure.getMessage() + "). It may be missing until CHECK DATABASE "
+              + "FIX is run again; verify with `SELECT FROM schema:indexes WHERE name = '" + idx.getName() + "'`");
         }
 
         stepTick();

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -266,6 +266,11 @@ public class DatabaseChecker {
 
     if (fix)
       for (final Index idx : affectedIndexes) {
+        // bucketName/indexType/unique/propNames/typeName/pageSize/nullStrategy are all read once here, before the
+        // retry loop below, rather than recomputed per attempt the way RebuildIndexStatement.buildIndex() does.
+        // That is safe: every one of them is a plain, idempotent read off idx/schema state fixed before the first
+        // drop, with no mutable accumulator behind it - unlike rebuildMetadata just below, which for FULL_TEXT
+        // wraps a live BM25 counter and for that reason IS recomputed per attempt.
         final String bucketName = database.getSchema().getBucketById(idx.getAssociatedBucketId()).getName();
         final Schema.INDEX_TYPE indexType = idx.getType();
         final boolean unique = idx.isUnique();

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -32,8 +32,6 @@ import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
-import com.arcadedb.schema.FullTextIndexMetadata;
-import com.arcadedb.schema.GeoIndexMetadata;
 import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.LocalEdgeType;
@@ -282,24 +280,13 @@ public class DatabaseChecker {
         // reverts to default analyzer/precision settings every time this repairs one of their bucket sub-indexes.
         final TypeIndex ownerTypeIndex = ((IndexInternal) idx).getTypeIndex();
 
-        IndexMetadata indexMetadata = ((IndexInternal) idx).getMetadata();
-        if (indexType == Schema.INDEX_TYPE.FULL_TEXT) {
-          final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, propNames.toArray(new String[0]), -1);
-          ftMeta.fromJSON(((IndexInternal) idx).toJSON());
-          ftMeta.setCounters(0L, 0L);
-          indexMetadata = ftMeta;
-        } else if (indexType == Schema.INDEX_TYPE.GEOSPATIAL) {
-          final GeoIndexMetadata geoMeta = new GeoIndexMetadata(typeName, propNames.toArray(new String[0]), -1);
-          geoMeta.fromJSON(((IndexInternal) idx).toJSON());
-          geoMeta.setTokenization(GeoIndexMetadata.DEFAULT_TOKENIZATION);
-          indexMetadata = geoMeta;
-        }
+        final IndexMetadata rebuildMetadata = IndexMetadata.reconstructForRebuild((IndexInternal) idx, typeName,
+            propNames.toArray(new String[0]));
 
         // Same file-locking coverage as RebuildIndexStatement.buildIndex(): the drop and the rebuild below touch
         // the index's own file(s) plus, through the drop, the owning TypeIndex's bookkeeping. Without holding
         // the lock across both steps a concurrent writer could observe the index gone-then-back with entries
         // missing, or the commit-time lock-coverage check could throw on the newly-created file.
-        final IndexMetadata rebuildMetadata = indexMetadata;
         database.executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
           database.getSchema().dropIndex(idx.getName());
 

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -289,14 +289,15 @@ public class DatabaseChecker {
         // Same file-locking coverage AND retry-on-contention as RebuildIndexStatement.buildIndex(): holding the
         // lock across both the drop and the create prevents a concurrent writer from observing the index
         // gone-then-back, and retrying survives tryLockFiles's LockTimeoutException (a NeedRetryException) on a
-        // busy database. Unlike RebuildIndexStatement, which silently returns once attempts are exhausted, this
-        // rethrows so CHECK DATABASE FIX fails loudly instead of quietly leaving the index unrepaired.
+        // busy database.
         //
         // Shares a known, pre-existing race with RebuildIndexStatement's identically-shaped retry (not introduced
         // here): retrying re-enters the whole drop+create body, so a NeedRetryException raised deep inside
         // create()'s bucket scan - after the drop already committed - restarts from a dropped index rather than
         // from the point of failure. A proper fix (skip the drop on retry, or scope the retry to lock acquisition
         // only) belongs in both call sites together, not this one in isolation.
+        boolean rebuilt = false;
+        NeedRetryException lastRetryFailure = null;
         for (int attempt = 1; attempt <= LOCK_MAX_ATTEMPTS; attempt++) {
           try {
             database.executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
@@ -309,17 +310,33 @@ public class DatabaseChecker {
                   .create();
               return null;
             });
+            rebuilt = true;
             break;
           } catch (final NeedRetryException e) {
+            lastRetryFailure = e;
             if (attempt == LOCK_MAX_ATTEMPTS)
-              throw e;
+              break;
             try {
               Thread.sleep(200 + 200L * attempt);
             } catch (final InterruptedException ie) {
+              // An interrupt is a request to stop, not contention to ride out: honor it immediately rather than
+              // trying the remaining indexes.
               Thread.currentThread().interrupt();
               throw e;
             }
           }
+        }
+
+        // Isolated per index rather than letting the exhausted retry unwind out of check(): this loop repairs
+        // potentially many indexes plus whatever checkDocuments/checkVertices/checkEdges already found and fixed,
+        // and none of that should be discarded because ONE index stayed lock-contended on a busy database. Report
+        // it (this class's "reported, never silent" convention - see the manual-index warning above) and correct
+        // the rebuiltIndexes claim instead of pretending the rebuild happened.
+        if (!rebuilt) {
+          rebuildIndexes.remove(idx.getName());
+          addWarning("index '" + idx.getName() + "': could not be rebuilt after " + LOCK_MAX_ATTEMPTS
+              + " attempts due to lock contention (error: " + lastRetryFailure.getMessage()
+              + "). Run CHECK DATABASE FIX again once the affected index/type is quiescent");
         }
 
         stepTick();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/Cypher25AntlrParser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/Cypher25AntlrParser.java
@@ -82,14 +82,16 @@ public class Cypher25AntlrParser {
     try {
       final Cypher25Lexer lexer = new Cypher25Lexer(CharStreams.fromString(query));
 
-      // Custom error handling. Attached BEFORE checkDeprecatedSyntax below, which calls tokens.fill() and so
-      // eagerly lexes the whole input up front: without a listener here, a lexer-level error (an unterminated
-      // string, a malformed escape sequence, an unrecognized character) is handled by ANTLR's default
-      // ConsoleErrorListener - prints to stderr, never throws - and default lexer recovery drops the offending
-      // token and carries on, which can silently produce a different CypherStatement instead of a clear syntax
-      // error (issue #5958, same failure class fixed for the SQL engine in #5957/#5951).
+      // Custom error handling, shared by lexer and parser (CypherErrorListener is stateless). Attached to the
+      // lexer BEFORE checkDeprecatedSyntax below, which calls tokens.fill() and so eagerly lexes the whole input
+      // up front: without a listener here, a lexer-level error (an unterminated string, a malformed escape
+      // sequence, an unrecognized character) is handled by ANTLR's default ConsoleErrorListener - prints to
+      // stderr, never throws - and default lexer recovery drops the offending token and carries on, which can
+      // silently produce a different CypherStatement instead of a clear syntax error (issue #5958, same failure
+      // class fixed for the SQL engine in #5957/#5951).
+      final CypherErrorListener errorListener = new CypherErrorListener();
       lexer.removeErrorListeners();
-      lexer.addErrorListener(new CypherErrorListener());
+      lexer.addErrorListener(errorListener);
 
       final CommonTokenStream tokens = new CommonTokenStream(lexer);
 
@@ -102,7 +104,7 @@ public class Cypher25AntlrParser {
 
       // Custom error handling
       parser.removeErrorListeners();
-      parser.addErrorListener(new CypherErrorListener());
+      parser.addErrorListener(errorListener);
 
       // Bound expression nesting depth so a pathologically nested/long query fails with a normal parse
       // error instead of a StackOverflowError (issue #5851)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/Cypher25AntlrParser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/Cypher25AntlrParser.java
@@ -81,6 +81,16 @@ public class Cypher25AntlrParser {
 
     try {
       final Cypher25Lexer lexer = new Cypher25Lexer(CharStreams.fromString(query));
+
+      // Custom error handling. Attached BEFORE checkDeprecatedSyntax below, which calls tokens.fill() and so
+      // eagerly lexes the whole input up front: without a listener here, a lexer-level error (an unterminated
+      // string, a malformed escape sequence, an unrecognized character) is handled by ANTLR's default
+      // ConsoleErrorListener - prints to stderr, never throws - and default lexer recovery drops the offending
+      // token and carries on, which can silently produce a different CypherStatement instead of a clear syntax
+      // error (issue #5958, same failure class fixed for the SQL engine in #5957/#5951).
+      lexer.removeErrorListeners();
+      lexer.addErrorListener(new CypherErrorListener());
+
       final CommonTokenStream tokens = new CommonTokenStream(lexer);
 
       // Reject deprecated/legacy Cypher syntax with an actionable hint before the generic ANTLR parse,

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -42,8 +42,6 @@ import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
-import com.arcadedb.schema.FullTextIndexMetadata;
-import com.arcadedb.schema.GeoIndexMetadata;
 import com.arcadedb.schema.IndexBuilder;
 import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.LocalDocumentType;
@@ -324,29 +322,12 @@ public class RebuildIndexStatement extends DDLStatement {
         // answers the current page size unless it is not legal to create with, in which case it repairs it.
         final int pageSize = ((IndexInternal) idx).getPageSizeForNewFile();
         final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
-        // Get index metadata (includes vector-specific settings like dimensions, similarity, etc.)
-        IndexMetadata indexMetadata = ((IndexInternal) idx).getMetadata();
-
-        // FULL_TEXT indexes carry their configuration (analyzers, similarity, BM25 parameters) in a FullTextIndexMetadata
-        // subtype, but getMetadata() returns the generic base IndexMetadata. Reconstruct the full-text metadata from the index's
-        // persisted JSON so the rebuilt index preserves its settings; the builder rejects a plain IndexMetadata for FULL_TEXT
-        // (issue #4732, which otherwise crashed AFTER the old index had already been dropped, leaving it gone). Reset the BM25
-        // corpus counters to zero so the re-index pass recomputes them from scratch instead of doubling the persisted totals.
-        if (type == Schema.INDEX_TYPE.FULL_TEXT) {
-          final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, propertyNames.toArray(new String[0]), -1);
-          ftMeta.fromJSON(((IndexInternal) idx).toJSON());
-          ftMeta.setCounters(0L, 0L);
-          indexMetadata = ftMeta;
-        } else if (type == Schema.INDEX_TYPE.GEOSPATIAL) {
-          // Same defect as #4732 for FULL_TEXT: the generic IndexMetadata carries no `precision`, so a rebuild silently
-          // reset a non-default GeoHash resolution. Rebuilding also re-reads every record, which is the one safe moment
-          // to publish the compact FRONTIER layout on an index created before 26.8.1 (#5478).
-          final GeoIndexMetadata geoMeta = new GeoIndexMetadata(typeName, propertyNames.toArray(new String[0]), -1);
-          geoMeta.fromJSON(((IndexInternal) idx).toJSON());
-          geoMeta.setTokenization(GeoIndexMetadata.DEFAULT_TOKENIZATION);
-          indexMetadata = geoMeta;
-        }
-        final IndexMetadata rebuildMetadata = indexMetadata;
+        // Get index metadata (includes vector-specific settings like dimensions, similarity, etc.), reconstructing
+        // FULL_TEXT/GEOSPATIAL from the index's persisted JSON so the rebuild preserves their type-specific
+        // settings (issue #4732/#5478) instead of the generic IndexMetadata getMetadata() would otherwise return.
+        // Shared with DatabaseChecker's auto-fix rebuild path (issue #5934).
+        final IndexMetadata rebuildMetadata = IndexMetadata.reconstructForRebuild((IndexInternal) idx, typeName,
+            propertyNames.toArray(new String[0]));
 
         final boolean typeIndexRebuild = typeName != null && idx instanceof TypeIndex;
 

--- a/engine/src/main/java/com/arcadedb/schema/IndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexMetadata.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.schema;
 
+import com.arcadedb.index.IndexInternal;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
@@ -327,5 +328,40 @@ public class IndexMetadata {
       if (COLLATION_CI.equals(c))
         return true;
     return false;
+  }
+
+  /**
+   * Reconstructs the metadata an index rebuild should carry over, for the two index types whose configuration
+   * {@link com.arcadedb.index.IndexInternal#getMetadata()} does not capture. {@code FULL_TEXT} and {@code GEOSPATIAL}
+   * keep their type-specific settings (analyzer, BM25 parameters, GeoHash precision) in a subtype the generic
+   * {@code IndexMetadata} does not carry, so a rebuild that passed {@code getMetadata()} straight through silently
+   * reset them to defaults (issue #4732). Reconstructing from the index's persisted JSON recovers them. FULL_TEXT's
+   * BM25 corpus counters are reset to zero so the re-index pass recomputes them from scratch instead of doubling the
+   * persisted totals; GEOSPATIAL's tokenization is reset to {@link GeoIndexMetadata#DEFAULT_TOKENIZATION}, which is
+   * also the one safe moment (a full re-read of every record) to publish the compact FRONTIER layout on an index
+   * created before 26.8.1 (#5478).
+   * <p>
+   * Shared by {@code RebuildIndexStatement.buildIndex()} and {@code DatabaseChecker}'s auto-fix rebuild path, which
+   * both drop and recreate a corrupted or explicitly-rebuilt index the same way (issue #5934).
+   *
+   * @param idx           the index being rebuilt, read before it is dropped
+   * @param typeName      the type name the rebuilt index will be created against
+   * @param propertyNames the property names the rebuilt index will be created against
+   */
+  public static IndexMetadata reconstructForRebuild(final IndexInternal idx, final String typeName,
+      final String[] propertyNames) {
+    final Schema.INDEX_TYPE type = idx.getType();
+    if (type == Schema.INDEX_TYPE.FULL_TEXT) {
+      final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, propertyNames, -1);
+      ftMeta.fromJSON(idx.toJSON());
+      ftMeta.setCounters(0L, 0L);
+      return ftMeta;
+    } else if (type == Schema.INDEX_TYPE.GEOSPATIAL) {
+      final GeoIndexMetadata geoMeta = new GeoIndexMetadata(typeName, propertyNames, -1);
+      geoMeta.fromJSON(idx.toJSON());
+      geoMeta.setTokenization(GeoIndexMetadata.DEFAULT_TOKENIZATION);
+      return geoMeta;
+    }
+    return idx.getMetadata();
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixPreservesIndexMetadataTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixPreservesIndexMetadataTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.FullTextIndexMetadata;
+import com.arcadedb.schema.GeoIndexMetadata;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5934: {@code CHECK DATABASE FIX} drops and rebuilds a bucket sub-index whose bucket held a
+ * corrupted record, through the same {@code dropIndex} + rebuild sequence {@code RebuildIndexStatement} used before
+ * issues #5791/#4732 were fixed for it (see {@code RebuildIndexPreservesNameTest}) - but
+ * {@link com.arcadedb.engine.DatabaseChecker}'s auto-fix path never received the equivalent fix: it called
+ * {@code buildBucketIndex(...)} with no {@code withIndexName(...)} and no {@code withMetadata(...)} at all. On a
+ * single-bucket type (the common default) dropping the only sub-index also drops the owning {@link TypeIndex}
+ * wrapper, so an explicitly-named index silently reverted to the auto-derived {@code typeName[properties]} form, and
+ * a {@code FULL_TEXT}/{@code GEOSPATIAL} index lost its analyzer/precision settings, every time {@code CHECK DATABASE
+ * FIX} repaired one of their bucket sub-indexes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseFixPreservesIndexMetadataTest extends TestHelper {
+
+  @Test
+  void fixPreservesNameAndAnalyzerOnFullTextIndex() {
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.title STRING");
+      final Result inserted = database.command("sql", "INSERT INTO Doc SET title = 'java database tutorial'").next();
+      database.command("sql", "CREATE INDEX ftDocTitle ON Doc (title) FULL_TEXT METADATA "
+          + "{\"analyzer\": \"org.apache.lucene.analysis.core.KeywordAnalyzer\"}");
+      victim.set(inserted.toElement().getIdentity());
+    });
+
+    corruptRecordTypeByte(victim.get());
+
+    final ResultSet result = database.command("sql", "check database fix");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<Long>getProperty("autoFix") > 0L).isTrue();
+
+    database.transaction(() -> {
+      assertThat(database.getSchema().existsIndex("ftDocTitle")).isTrue();
+      assertThat(database.getSchema().existsIndex("Doc[title]")).isFalse();
+
+      final TypeIndex idx = (TypeIndex) database.getSchema().getIndexByName("ftDocTitle");
+      assertThat(idx.getType()).isEqualTo(Schema.INDEX_TYPE.FULL_TEXT);
+      final FullTextIndexMetadata metadata = (FullTextIndexMetadata) idx.getMetadataForNewFile();
+      assertThat(metadata.getAnalyzerClass()).isEqualTo("org.apache.lucene.analysis.core.KeywordAnalyzer");
+    });
+  }
+
+  @Test
+  void fixPreservesNameAndPrecisionOnGeospatialIndex() {
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Place");
+      database.command("sql", "CREATE PROPERTY Place.location STRING");
+      final Result inserted = database.command("sql", "INSERT INTO Place SET location = 'POINT (9.19 45.46)'").next();
+      database.command("sql", "CREATE INDEX geoPlaceLocation ON Place (location) GEOSPATIAL METADATA {\"precision\": 8}");
+      victim.set(inserted.toElement().getIdentity());
+    });
+
+    corruptRecordTypeByte(victim.get());
+
+    final ResultSet result = database.command("sql", "check database fix");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<Long>getProperty("autoFix") > 0L).isTrue();
+
+    database.transaction(() -> {
+      assertThat(database.getSchema().existsIndex("geoPlaceLocation")).isTrue();
+      assertThat(database.getSchema().existsIndex("Place[location]")).isFalse();
+
+      final TypeIndex idx = (TypeIndex) database.getSchema().getIndexByName("geoPlaceLocation");
+      assertThat(idx.getType()).isEqualTo(Schema.INDEX_TYPE.GEOSPATIAL);
+      final GeoIndexMetadata metadata = (GeoIndexMetadata) idx.getMetadataForNewFile();
+      assertThat(metadata.getPrecision()).isEqualTo(8);
+    });
+  }
+
+  /**
+   * Overwrites the record-type byte of {@code rid} with a value no {@code RecordFactory} branch knows, so the record
+   * still occupies its slot and still has a valid size but cannot be materialised - the precise, page-layout-agnostic
+   * corruption shape used by {@code CheckDatabaseRecordScopeTest.corruptRecordTypeByte}.
+   */
+  private void corruptRecordTypeByte(final RID rid) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = rid.getBucketId();
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
+
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
+        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
+        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
+        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
+        final long[] recordSize = page.readNumberAndSize(recordOffset);
+        page.writeByte((int) (recordOffset + recordSize[1]), (byte) 99);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixPreservesIndexMetadataTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixPreservesIndexMetadataTest.java
@@ -108,6 +108,36 @@ class CheckDatabaseFixPreservesIndexMetadataTest extends TestHelper {
   }
 
   /**
+   * Rounds out {@link #fixPreservesNameAndAnalyzerOnFullTextIndex}/{@link #fixPreservesNameAndPrecisionOnGeospatialIndex}
+   * with the plain (non-FULL_TEXT/non-GEOSPATIAL) case: {@code RebuildIndexPreservesNameTest} covers this shape for
+   * {@code REBUILD INDEX}, but {@code CHECK DATABASE FIX}'s rebuild path had no equivalent coverage of its own for
+   * the {@code TypeIndex}-name-loss half of #5934 in isolation from the metadata-loss half.
+   */
+  @Test
+  void fixPreservesExplicitNameOnPlainIndex() {
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      final Result inserted = database.command("sql", "INSERT INTO Doc SET name = 'alpha'").next();
+      database.command("sql", "CREATE INDEX myNamedIdx ON Doc (name) NOTUNIQUE");
+      victim.set(inserted.toElement().getIdentity());
+    });
+
+    corruptRecordTypeByte(victim.get());
+
+    final ResultSet result = database.command("sql", "check database fix");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<Long>getProperty("autoFix") > 0L).isTrue();
+
+    database.transaction(() -> {
+      assertThat(database.getSchema().existsIndex("myNamedIdx")).isTrue();
+      assertThat(database.getSchema().existsIndex("Doc[name]")).isFalse();
+      assertThat(database.getSchema().getIndexByName("myNamedIdx").getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
+    });
+  }
+
+  /**
    * Overwrites the record-type byte of {@code rid} with a value no {@code RecordFactory} branch knows, so the record
    * still occupies its slot and still has a valid size but cannot be materialised - the precise, page-layout-agnostic
    * corruption shape used by {@code CheckDatabaseRecordScopeTest.corruptRecordTypeByte}.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/parser/Cypher25AntlrParserLexerListenerTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/parser/Cypher25AntlrParserLexerListenerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.parser;
+
+import com.arcadedb.exception.CommandParsingException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5958: {@code Cypher25AntlrParser.parseQuery()} attached a
+ * {@link CypherErrorListener} to the {@code Cypher25Parser} but never to the {@code Cypher25Lexer}, unlike the SQL
+ * side ({@code SQLAntlrParser}, fixed for the same gap by #5951/#5957). A lexer-level tokenization failure - an
+ * unterminated string, an unterminated block comment, an unterminated backtick-quoted name - was therefore left to
+ * ANTLR's default {@code ConsoleErrorListener} (prints to stderr, never throws), with the lexer's default recovery
+ * silently emitting whatever token its {@code ErrorChar : . ;} catch-all rule produces and carrying on.
+ * <p>
+ * On the CURRENT grammar this is caught downstream: {@code ErrorChar} always yields <em>some</em> token for any
+ * input character, so the lexer never truly fails to tokenize, and the garbled token stream that results from an
+ * unterminated construct almost always fails the parser's own grammar rules - which is why every case below already
+ * threw a {@link CommandParsingException} before this fix, just via the parser's listener rather than the lexer's
+ * (confirmed by running this exact test against the pre-fix code). The fix is still correct to make: it is dead
+ * code that costs nothing to attach, it matches the SQL side for maintainers reading both, and it is the difference
+ * between "still throws" and "silently parses something else" the moment a future grammar change adds a lexer rule
+ * that CAN fail to complete a token (the way SQL's {@code \\uXXXX} escape validation does) - {@code EscapeSequence}
+ * here currently accepts any character after a backslash, which is why no such rule exists today. This test pins
+ * the "still throws" behavior so a future grammar change is caught the moment it stops holding.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Cypher25AntlrParserLexerListenerTest {
+
+  private final Cypher25AntlrParser parser = new Cypher25AntlrParser();
+
+  @Test
+  void unterminatedStringLiteralRaisesParsingException() {
+    assertThatThrownBy(() -> parser.parseQuery("RETURN 'unterminated string"))
+        .isInstanceOf(CommandParsingException.class);
+  }
+
+  @Test
+  void unterminatedStringLiteralInsideWhereClauseRaisesParsingException() {
+    assertThatThrownBy(() -> parser.parseQuery("MATCH (n) WHERE n.name = 'oops RETURN n"))
+        .isInstanceOf(CommandParsingException.class);
+  }
+
+  @Test
+  void unterminatedBlockCommentRaisesParsingException() {
+    assertThatThrownBy(() -> parser.parseQuery("/* unterminated comment\nRETURN 1"))
+        .isInstanceOf(CommandParsingException.class);
+  }
+
+  @Test
+  void unterminatedBacktickQuotedNameRaisesParsingException() {
+    assertThatThrownBy(() -> parser.parseQuery("RETURN `unterminated backtick"))
+        .isInstanceOf(CommandParsingException.class);
+  }
+}

--- a/gremlin-it/src/test/java/com/arcadedb/gremlin/antlr/AntlrAtnMismatchTranslationTest.java
+++ b/gremlin-it/src/test/java/com/arcadedb/gremlin/antlr/AntlrAtnMismatchTranslationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin.antlr;
+
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.gremlin.ArcadeGremlin;
+import org.junit.jupiter.api.Test;
+
+import java.io.InvalidClassException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5937: the plain (unshaded) {@code arcadedb-gremlin} Maven coordinate puts TinkerPop's
+ * precompiled, ANTLR-4.9.1-generated grammar classes ({@code GremlinLexer}/{@code GremlinQueryParser}, "v3 ATN") on
+ * the same classpath as the engine's own ANTLR 4.13.2 runtime ("v4 ATN"). The first textual Gremlin query then
+ * fails with a raw {@code ExceptionInInitializerError} wrapping {@code UnsupportedOperationException} wrapping
+ * {@code java.io.InvalidClassException: ... ATN; Could not deserialize ATN with version 3 (expected 4)} - a
+ * confusing crash deep in ANTLR internals that gives no hint that the fix is to depend on the
+ * {@code arcadedb-gremlin:shaded} classifier instead.
+ * <p>
+ * {@code ArcadeGremlin.translateAntlrAtnMismatch(LinkageError)} (private, reached via reflection here) recognizes
+ * that specific cause-chain shape and turns it into an actionable {@link CommandExecutionException}. This test
+ * exercises the translation directly with a synthetic exception chain of that exact shape, rather than by
+ * reproducing the real classpath conflict: {@code AntlrCoexistenceIT} in this same package already proves the
+ * shaded classpath this module tests against does NOT hit the conflict, and the module-wide {@code gremlin/pom.xml}
+ * {@code skipTests} (see its Surefire config comment) means the plain/unshaded classpath that WOULD hit it never
+ * runs any test here either. The translation logic itself needs no real ANTLR grammar class to be exercised, so a
+ * synthetic chain is both sufficient and the only practical way to pin it in this module layout.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class AntlrAtnMismatchTranslationTest {
+
+  @Test
+  void atnVersionMismatchIsTranslatedToAnActionableMessage() throws Exception {
+    final LinkageError error = atnMismatchError();
+
+    final CommandExecutionException translated = (CommandExecutionException) invokeTranslate(error);
+
+    assertThat(translated.getCause()).isSameAs(error);
+    assertThat(translated.getMessage())
+        .contains("arcadedb-gremlin:shaded")
+        .contains("ATN")
+        .contains("#5937");
+  }
+
+  @Test
+  void anUnrelatedLinkageErrorIsRethrownUnchanged() {
+    final LinkageError unrelated = new NoClassDefFoundError("some/other/Class");
+
+    assertThatThrownBy(() -> invokeTranslate(unrelated))
+        .isInstanceOf(InvocationTargetException.class)
+        .extracting(Throwable::getCause)
+        .isSameAs(unrelated);
+  }
+
+  /** {@code ExceptionInInitializerError -> UnsupportedOperationException -> InvalidClassException}, matching #5937. */
+  private static LinkageError atnMismatchError() {
+    final InvalidClassException invalidClass =
+        new InvalidClassException("org.antlr.v4.runtime.atn.ATN", "Could not deserialize ATN with version 3 (expected 4)");
+    final UnsupportedOperationException unsupported = new UnsupportedOperationException(invalidClass);
+    final ExceptionInInitializerError error = new ExceptionInInitializerError(unsupported);
+    return error;
+  }
+
+  private static Object invokeTranslate(final LinkageError error) throws Exception {
+    final Method method = ArcadeGremlin.class.getDeclaredMethod("translateAntlrAtnMismatch", LinkageError.class);
+    method.setAccessible(true);
+    return method.invoke(null, error);
+  }
+}

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
@@ -47,6 +47,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropert
 
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
+import java.io.InvalidClassException;
 import java.util.*;
 import java.util.logging.Level;
 
@@ -150,6 +151,10 @@ public class ArcadeGremlin extends ArcadeQuery {
       final Throwable root = getRootCause(e);
       final String reason = root.getMessage() != null ? root.getMessage() : root.getClass().getName();
       throw new CommandExecutionException("Error on executing gremlin query: " + reason, e);
+    } catch (final CommandParsingException | CommandExecutionException e) {
+      // Already classified by translateAntlrAtnMismatch() (or a nested call), including the actionable
+      // ATN-mismatch message: rethrow as-is instead of burying it under a second, generic wrapper.
+      throw e;
     } catch (final Exception e) {
       throw new CommandExecutionException("Error on executing command", e);
     }
@@ -177,6 +182,48 @@ public class ArcadeGremlin extends ArcadeQuery {
     while (root.getCause() != null && root.getCause() != root)
       root = root.getCause();
     return root;
+  }
+
+  /**
+   * Recognizes the ANTLR "v3 ATN" vs "v4 ATN" deserialization mismatch (see the caller) by walking the cause chain
+   * for a {@link InvalidClassException} naming ANTLR's {@code atn.ATN} class, and turns it into an actionable
+   * {@link CommandExecutionException}. Any other {@link LinkageError} is rethrown unchanged: this must not mask an
+   * unrelated classloading failure under a misleading Gremlin-specific message.
+   * <p>
+   * Matched by suffix, not full equality against the unshaded {@code org.antlr.v4.runtime.atn.ATN} name: this very
+   * source file ships inside the {@code :shaded} artifact too, and the shade plugin's relocation rewrites string
+   * constants that look like a relocated class's FQCN - including this literal - to
+   * {@code com.arcadedb.gremlin.shaded.org.antlr.v4.runtime.atn.ATN} in that build. A full-equality match would
+   * silently stop matching in the shaded jar; matching {@code *.runtime.atn.ATN} survives either prefix, which is
+   * also how {@code AntlrAtnMismatchTranslationTest} in {@code gremlin-it} exercises this method (that module only
+   * has the shaded jar on its classpath - see the module-wide Surefire skip explained in {@code gremlin/pom.xml}).
+   * <p>
+   * Walks via {@link ExceptionInInitializerError#getException()}, not {@link Throwable#getCause()}: this is the
+   * exact shape the JVM raises when a static initializer throws (as {@code GremlinLexer.<clinit>} does here), and
+   * {@code ExceptionInInitializerError} predates the standard cause-chaining API - its constructor calls
+   * {@code super((Throwable) null)}, so the inherited {@code getCause()} always answers {@code null} and silently
+   * ends the walk one hop too early.
+   */
+  private static CommandExecutionException translateAntlrAtnMismatch(final LinkageError error) {
+    for (Throwable c = error; c != null; ) {
+      if (c instanceof final InvalidClassException ice
+          && ice.classname != null && ice.classname.endsWith(".runtime.atn.ATN")) {
+        return new CommandExecutionException(
+            "Cannot execute a textual Gremlin query: the ANTLR runtime on the classpath cannot deserialize "
+                + "TinkerPop's precompiled Gremlin grammar (mismatched ATN serialization format). This happens "
+                + "when the plain 'com.arcadedb:arcadedb-gremlin' Maven coordinate is used on a classpath that "
+                + "also carries ArcadeDB's own ANTLR runtime (e.g. via arcadedb-engine), which is a newer, "
+                + "incompatible version. Depend on the 'com.arcadedb:arcadedb-gremlin:shaded' classifier instead, "
+                + "which bundles a relocated, matching ANTLR runtime for TinkerPop's grammar. The fluent Java "
+                + "Traversal API (ArcadeGraph.open(db).traversal()...) is unaffected; only textual/string Gremlin "
+                + "queries need the shaded classifier. See issue #5937 for details.", error);
+      }
+      final Throwable next = c instanceof final ExceptionInInitializerError eiie ? eiie.getException() : c.getCause();
+      if (next == c)
+        break;
+      c = next;
+    }
+    throw error;
   }
 
   public static Map<String, Object> getStringObjectMap(final Map<Object, Object> originalMap) {
@@ -243,6 +290,10 @@ public class ArcadeGremlin extends ArcadeQuery {
           return operationTypes;
         }
       };
+    } catch (final CommandParsingException | CommandExecutionException e) {
+      // Already classified by translateAntlrAtnMismatch() (or a nested call): rethrow as-is rather than
+      // relabeling a deployment/execution error (e.g. the ATN-mismatch message) as a parsing error.
+      throw e;
     } catch (Exception e) {
       throw new CommandParsingException("Error on parsing command", e);
     }
@@ -299,7 +350,18 @@ public class ArcadeGremlin extends ArcadeQuery {
       if (parameters != null)
         bindings.putAll(parameters);
 
-      result = gremlinEngineImpl.eval(query, bindings);
+      try {
+        result = gremlinEngineImpl.eval(query, bindings);
+      } catch (final LinkageError error) {
+        // TinkerPop's gremlin-language grammar classes (GremlinLexer/GremlinQueryParser) are precompiled with
+        // ANTLR 4.9.1 ("v3 ATN" serialization). The plain (unshaded) arcadedb-gremlin Maven coordinate puts them
+        // on the same classpath as the engine's own ANTLR 4.13.2 runtime ("v4 ATN"), which cannot deserialize
+        // them: their static initializer throws ExceptionInInitializerError (LinkageError, so none of the
+        // Exception catches below would ever see it) the first time this branch runs, then NoClassDefFoundError
+        // on every retry. Detect that specific shape and fail with an actionable message instead of leaking a
+        // raw ATNDeserializer stack trace (issue #5937).
+        throw translateAntlrAtnMismatch(error);
+      }
 
     } else if ("groovy".equals(gremlinEngine)) {
       // GROOVY ENGINE - INSECURE, LOG WARNING

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
@@ -219,7 +219,9 @@ public class ArcadeGremlin extends ArcadeQuery {
                 + "queries need the shaded classifier. See issue #5937 for details.", error);
       }
       final Throwable next = c instanceof final ExceptionInInitializerError eiie ? eiie.getException() : c.getCause();
-      if (next == c)
+      // Reference-identity cycle guard (a throwable can be its own cause/exception): Objects.equals(), not ==,
+      // to satisfy static analysis - Throwable does not override equals(), so the two are behaviorally identical.
+      if (Objects.equals(next, c))
         break;
       c = next;
     }

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
@@ -317,6 +317,12 @@ public class ArcadeGremlin extends ArcadeQuery {
 
     if ("auto".equals(gremlinEngine) || "java".equals(gremlinEngine)) {
       // TRY THE NATIVE JAVA ENGINE FIRST
+      // NOTE: this catch only sees ScriptException. An ATN-mismatch CommandExecutionException from
+      // translateAntlrAtnMismatch() (issue #5937) is unchecked and propagates straight past it, so 'auto' mode
+      // fails fast on that classpath defect too instead of silently falling back to the insecure Groovy engine
+      // below - intentional, not an oversight: the defect is a deployment/packaging problem, not a query the
+      // Java engine merely can't parse, and papering over it with Groovy would undermine the point of failing
+      // clearly in the first place.
       try {
         return executeStatement("java", analysis);
       } catch (ScriptException e) {


### PR DESCRIPTION
## Summary

- **#5934**: `CHECK DATABASE FIX`'s index-rebuild path dropped and rebuilt a corrupted bucket sub-index with no `withIndexName(...)`/`withMetadata(...)`, the same defect #5925 fixed for `REBUILD INDEX`. On a single-bucket type (the common default) dropping the only sub-index also drops the owning `TypeIndex` wrapper, so an explicitly-named index silently reverted to the auto-derived `typeName[properties]` form, and a `FULL_TEXT`/`GEOSPATIAL` index lost its analyzer/precision settings, every time the check repaired one of their bucket sub-indexes. Mirrors `RebuildIndexStatement.buildIndex()`'s fix.
- **#5937**: the plain (unshaded) `arcadedb-gremlin` Maven coordinate crashed with a raw `ExceptionInInitializerError`/`InvalidClassException` the first time it ran a textual Gremlin query. A downstream consumer's classpath resolves only the engine's ANTLR 4.13.2 runtime (gremlin's own 4.9.1 dependency is `optional`, so it isn't inherited transitively), while TinkerPop's precompiled grammar (`GremlinLexer`/`GremlinQueryParser`) needs ANTLR 4.9.1's ATN format. Per discussion, implemented the **fail-fast** option (of the three the issue proposed): `ArcadeGremlin` now recognizes that specific failure shape and raises an actionable `CommandExecutionException` pointing at the `arcadedb-gremlin:shaded` classifier, instead of leaking ANTLR internals. Textual Gremlin still requires the shaded classifier - this only makes the failure diagnosable. The fluent Java Traversal API is unaffected either way.
- **#5958**: `Cypher25AntlrParser` attached its `CypherErrorListener` to the parser but never to the lexer, unlike `SQLAntlrParser` after #5951/#5957. Fixed for consistency and to guard against future grammar changes (verified: the current grammar's `ErrorChar : . ;` catch-all means every reachable malformed-lexical case today already surfaces via the parser's listener, so this is defense-in-depth rather than a fix for an currently-reproducible silent-wrong-parse; the regression test pins that lexically malformed input still raises `CommandParsingException`).

## Test plan

- [x] `CheckDatabaseFixPreservesIndexMetadataTest` (new): corrupts a vertex record via the precise record-type-byte technique used by `CheckDatabaseRecordScopeTest`, runs `CHECK DATABASE FIX`, and asserts a named `FULL_TEXT`/`GEOSPATIAL` index keeps its name and analyzer/precision settings. Verified it fails without the fix (reverted `DatabaseChecker.java` and reran: 1 failure + 1 NPE).
- [x] Existing `CheckDatabaseTest`, `CheckDatabaseRecordScopeTest`, `CheckDatabaseSinglePassTest`, `CheckDatabaseProgressTest`, `CheckDatabaseExtendedTest`, `RebuildIndexPreservesNameTest` (53 tests) still pass.
- [x] `AntlrAtnMismatchTranslationTest` (new, in `gremlin-it`): unit-tests the translation logic via reflection with a synthetic exception chain matching the issue's exact shape, and confirms an unrelated `LinkageError` is rethrown unchanged. Independently verified end-to-end against a real downstream-consumer classpath (fresh throwaway Maven project depending only on `arcadedb-gremlin` + `arcadedb-network`) that the fix returns the actionable message.
- [x] `AntlrCoexistenceIT` (pre-existing) still passes, confirming the shaded classpath is unaffected.
- [x] `ArcadeGremlinAnalyzeTest`, `ArcadeGremlinEngineSelectionTest`, `GremlinParameterizedAnalyzeTest`, `GremlinTest` (45 tests via `gremlin-it`) still pass.
- [x] `Cypher25AntlrParserLexerListenerTest` (new): unterminated string/comment/backtick all raise `CommandParsingException`.
- [x] `CypherSyntaxErrorMessageTest`, `OpenCypherStringEscapeTest`, `Issue4141DeprecatedSyntaxTest`, `OpenCypherBasicTest`, `CypherTest`, `OpenCypherExecutionTest`, `CypherBacktickedVariableTest`, `CypherMapBackticksTest` (55 tests) still pass.
- [x] Full compile of `engine`, `network`, `integration`, `server`, `gremlin`, `gremlin-it` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)