### PR TITLE
fix(cypher): compare graph entities by identity

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
+import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.query.opencypher.query.OpenCypherQueryEngine;
@@ -144,6 +145,18 @@ public class ComparisonExpression implements BooleanExpression {
       final long leftEncoded = IdFunction.encodeRidAsLong(new RID(leftStr));
       final long rightEncoded = rightNum.longValue();
       return numericCompare(leftEncoded, rightEncoded);
+    }
+
+    // Graph entities compare by record identity even when different implementations represent them.
+    // This is common when a Graph Analytical View vertex is compared with a regular OLTP vertex (#6010).
+    if (left instanceof Identifiable leftIdentifiable
+        && right instanceof Identifiable rightIdentifiable) {
+      final boolean equal = leftIdentifiable.getIdentity().equals(rightIdentifiable.getIdentity());
+      if (operator == Operator.EQUALS)
+        return equal;
+      if (operator == Operator.NOT_EQUALS)
+        return !equal;
+      return null;
     }
 
     // Temporal comparison. Coerce native java.time / java.util.Date operands into Cypher temporal

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -1167,6 +1167,64 @@ class GraphAnalyticalViewTest extends TestHelper {
     gav.drop();
   }
 
+  @Test
+  void cypherGAVPreservesNodeInequalityBetweenChainVariables() {
+    database.getSchema().createVertexType("Hub");
+    database.getSchema().createVertexType("Leaf");
+    database.getSchema().createEdgeType("LINKS");
+    database.getSchema().createEdgeType("BOND");
+
+    database.begin();
+    final MutableVertex h1 = database.newVertex("Hub").set("k", "h1").save();
+    final MutableVertex h2 = database.newVertex("Hub").set("k", "h2").save();
+    final MutableVertex l1 = database.newVertex("Leaf").set("k", "l1").save();
+    final MutableVertex l2 = database.newVertex("Leaf").set("k", "l2").save();
+    final MutableVertex l3 = database.newVertex("Leaf").set("k", "l3").save();
+
+    h1.newEdge("LINKS", l1).save();
+    h1.newEdge("LINKS", l2).save();
+    h2.newEdge("LINKS", l1).save();
+    l1.newEdge("LINKS", h2).save();
+    l3.newEdge("LINKS", h1).save();
+
+    l1.newEdge("BOND", h1).save();
+    l2.newEdge("BOND", h2).save();
+    h2.newEdge("BOND", l3).save();
+    database.commit();
+
+    final String query =
+        "MATCH (a:Hub)-[:LINKS]->(b)-[:BOND]->(c) WHERE a <> c " +
+            "RETURN a.k AS x, c.k AS y ORDER BY x, y";
+
+    final List<String> baseline = new ArrayList<>();
+    try (ResultSet resultSet = database.command("cypher", query)) {
+      while (resultSet.hasNext()) {
+        final var result = resultSet.next();
+        baseline.add(result.getProperty("x") + "->" + result.getProperty("y"));
+      }
+    }
+    assertThat(baseline).containsExactly("h1->h2", "h2->h1");
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("nodeInequality")
+        .withVertexTypes("Hub", "Leaf")
+        .withEdgeTypes("LINKS", "BOND")
+        .build();
+
+    final List<String> accelerated = new ArrayList<>();
+    try (ResultSet resultSet = database.command("cypher", "PROFILE " + query)) {
+      while (resultSet.hasNext()) {
+        final var result = resultSet.next();
+        accelerated.add(result.getProperty("x") + "->" + result.getProperty("y"));
+      }
+      assertThat(resultSet.getExecutionPlan()).isPresent();
+      assertThat(resultSet.getExecutionPlan().orElseThrow().prettyPrint(0, 2)).contains("provider=nodeInequality");
+    }
+    assertThat(accelerated).containsExactlyElementsOf(baseline);
+
+    gav.drop();
+  }
+
   // --- Columnar storage tests ---
 
   @Test


### PR DESCRIPTION
## Summary

- compare graph entities by record identity before considering their concrete Java classes
- preserve `=` and `<>` semantics when a Graph Analytical View (GAV) vertex is compared with a regular online transaction processing (OLTP) vertex
- add an end-to-end regression that compares ordinary and GAV-backed results and verifies the GAV provider was selected

## Root cause

The traditional Cypher plan can bind one chain endpoint as a regular vertex and another as a `GAVVertex`. `ComparisonExpression` previously used `equals()` only when both operands had the same concrete Java class. It therefore treated two wrappers for the same graph record as different, making `a <> c` incorrectly true for a self-path.

## Tests

```bash
./mvnw -pl engine -Dtest='GraphAnalyticalViewTest#cypherGAVPreservesNodeInequalityBetweenChainVariables+cypherTraditionalPathWithWhereAndGAV' test
```

Fixes #6010