### PR TITLE
fix(sql): use CI index for lowercased BETWEEN

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
@@ -180,9 +180,11 @@ public class BetweenCondition extends BooleanExpression {
   public boolean isIndexAware(final IndexSearchInfo info) {
     if (!info.allowsRange())
       return false;
-    if (!first.isBaseIdentifier() || !info.getField().equals(first.getDefaultAlias().getStringValue()))
+    if (!second.isEarlyCalculated(info.getContext()) || !third.isEarlyCalculated(info.getContext()))
       return false;
-    return second.isEarlyCalculated(info.getContext()) && third.isEarlyCalculated(info.getContext());
+    if (first.isBaseIdentifier() && info.getField().equals(first.getDefaultAlias().getStringValue()))
+      return true;
+    return info.isCaseInsensitive() && BinaryCondition.isFieldWithLowerCaseMethod(first, info.getField());
   }
 
   public Expression resolveKeyFrom(final BinaryCondition additional) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
@@ -325,7 +325,7 @@ public class BinaryCondition extends BooleanExpression {
    * Checks if an expression matches the pattern: field.toLowerCase() — a base identifier
    * followed by a single toLowerCase() method call with no further chaining.
    */
-  private static boolean isFieldWithLowerCaseMethod(final Expression expr, final String expectedField) {
+  static boolean isFieldWithLowerCaseMethod(final Expression expr, final String expectedField) {
     if (expr == null || expr.getMathExpression() == null)
       return false;
     if (!(expr.getMathExpression() instanceof final BaseExpression base))

--- a/engine/src/test/java/com/arcadedb/index/Issue5966BetweenUsesIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5966BetweenUsesIndexTest.java
@@ -204,6 +204,33 @@ class Issue5966BetweenUsesIndexTest {
     });
   }
 
+  // #6033: the supported field.toLowerCase() form must retain BETWEEN's case-insensitive index optimization.
+  @Test
+  void toLowerCaseWrappedBetweenOnCaseInsensitiveIndexedColumnUsesIndex() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      database.command("sql", "CREATE INDEX ON Product (name COLLATE CI) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = 'Apple'");
+      database.command("sql", "INSERT INTO Product SET name = 'BANANA'");
+      database.command("sql", "INSERT INTO Product SET name = 'cherry'");
+      database.command("sql", "INSERT INTO Product SET name = 'Watermelon'");
+    });
+
+    database.transaction(() -> {
+      final String query = "SELECT name FROM Product WHERE name.toLowerCase() BETWEEN 'a' AND 'c'";
+      assertThat(plan("EXPLAIN " + query)).contains("FETCH FROM INDEX").doesNotContain("SCAN WITH FILTER");
+
+      final List<String> names = new ArrayList<>();
+      try (ResultSet rs = database.query("sql", query)) {
+        while (rs.hasNext())
+          names.add(rs.next().getProperty("name"));
+      }
+      assertThat(names).containsExactlyInAnyOrder("Apple", "BANANA");
+    });
+  }
+
   // #5966: BETWEEN as the FIRST field of a composite UNIQUE index, followed by a further equality field, must
   // also stop key-building at the range field and return correct results. UNIQUE inserts go through
   // LSMTreeIndex.convertKeys() for the constraint check, so this also exercises the refactored delegate on the


### PR DESCRIPTION
## Summary

- make `BetweenCondition` recognize `field.toLowerCase() BETWEEN low AND high` as range-index-aware for a case-insensitive (`COLLATE CI`) index
- reuse the existing lowercased-field matcher from `BinaryCondition`
- retain the existing requirements that the index support ordered ranges and both bounds be calculable before row evaluation
- add plan and result coverage proving the query uses the index and preserves inclusive, case-folded range semantics

## Syntax note

The issue example uses `LOWER(field)`, but the current SQL engine reports `Unknown function name 'LOWER'` for that spelling. ArcadeDB's supported equivalent is `field.toLowerCase()`, which reproduces the full-scan planner gap described in the issue. This PR fixes that valid query form without making an otherwise-unregistered function work only for one index-backed plan. I recorded the distinction in the issue for follow-up if a standard SQL `LOWER()` alias is desired.

## Tests

```bash
./mvnw -pl engine -Dtest='CaseInsensitiveIndexTest,Issue5966BetweenUsesIndexTest' test
```

17 focused tests passed.

Fixes #6033