### PR TITLE
fix(#6033): BETWEEN on a COLLATE CI index now uses the index when wrapped in .toLowerCase()

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
@@ -180,8 +180,15 @@ public class BetweenCondition extends BooleanExpression {
   public boolean isIndexAware(final IndexSearchInfo info) {
     if (!info.allowsRange())
       return false;
-    if (!first.isBaseIdentifier() || !info.getField().equals(first.getDefaultAlias().getStringValue()))
+
+    final boolean matchesField = first.isBaseIdentifier() && info.getField().equals(first.getDefaultAlias().getStringValue());
+    // CI index optimization: match field.toLowerCase() BETWEEN a AND b against a CI index on field
+    final boolean matchesLowerCaseField = !matchesField
+        && info.isCaseInsensitive()
+        && BinaryCondition.isFieldWithLowerCaseMethod(first, info.getField());
+    if (!matchesField && !matchesLowerCaseField)
       return false;
+
     return second.isEarlyCalculated(info.getContext()) && third.isEarlyCalculated(info.getContext());
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
@@ -324,8 +324,10 @@ public class BinaryCondition extends BooleanExpression {
   /**
    * Checks if an expression matches the pattern: field.toLowerCase() — a base identifier
    * followed by a single toLowerCase() method call with no further chaining.
+   * <p>
+   * Package-private so {@link BetweenCondition} can reuse it for the same CI-index optimization on ranges.
    */
-  private static boolean isFieldWithLowerCaseMethod(final Expression expr, final String expectedField) {
+  static boolean isFieldWithLowerCaseMethod(final Expression expr, final String expectedField) {
     if (expr == null || expr.getMathExpression() == null)
       return false;
     if (!(expr.getMathExpression() instanceof final BaseExpression base))

--- a/engine/src/test/java/com/arcadedb/index/Issue6033BetweenToLowerCaseCiIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6033BetweenToLowerCaseCiIndexTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6033: {@code BETWEEN} on a case-insensitive ({@code COLLATE CI}) indexed column already
+ * uses the index for the bare {@code field BETWEEN a AND b} shape (fixed by #6018), but the equally common
+ * {@code field.toLowerCase() BETWEEN a AND b} shape - the CI-index analogue of the {@code field.toLowerCase() =
+ * 'value'} pattern that {@link com.arcadedb.query.sql.parser.BinaryCondition} already recognizes - fell through to
+ * a full bucket scan because {@code BetweenCondition.isIndexAware()} had no equivalent branch.
+ *
+ * <p>Note: ArcadeDB SQL has no bare {@code LOWER(field)} function (only the {@code field.toLowerCase()} method
+ * call) - the issue's repro uses that syntax, which does not parse. The underlying planner defect is real and is
+ * reproduced here with the syntax ArcadeDB actually supports.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6033BetweenToLowerCaseCiIndexTest {
+  private static final String DB_PATH = "target/databases/Issue6033BetweenToLowerCaseCiIndexTest";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  private String plan(final String query, final Object... params) {
+    return database.query("sql", query, params).getExecutionPlan().get().prettyPrint(0, 3);
+  }
+
+  @Test
+  void betweenOnLowerCaseWrappedCiIndexedColumnUsesTheIndex() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      database.command("sql", "CREATE INDEX ON Product (name COLLATE CI) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = 'Apple'");
+      database.command("sql", "INSERT INTO Product SET name = 'BANANA'");
+      database.command("sql", "INSERT INTO Product SET name = 'cherry'");
+      database.command("sql", "INSERT INTO Product SET name = 'Watermelon'");
+    });
+
+    database.transaction(() -> {
+      final String planString = plan("EXPLAIN SELECT name FROM Product WHERE name.toLowerCase() BETWEEN 'a' AND 'c'");
+      assertThat(planString).contains("FETCH FROM INDEX");
+      assertThat(planString).doesNotContain("SCAN WITH FILTER");
+
+      final List<String> names = new ArrayList<>();
+      final ResultSet rs = database.query("sql", "SELECT name FROM Product WHERE name.toLowerCase() BETWEEN 'a' AND 'c'");
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+
+      // case-insensitively, "apple" and "banana" fall in ['a'..'c'], "cherry" and "watermelon" do not
+      assertThat(names).containsExactlyInAnyOrder("Apple", "BANANA");
+    });
+  }
+
+  @Test
+  void betweenOnLowerCaseWrappedCiIndexedColumnMatchesNonIndexedEquivalent() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      database.command("sql", "CREATE PROPERTY Product.code STRING"); // not indexed, used as the control
+
+      database.command("sql", "CREATE INDEX ON Product (name COLLATE CI) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = 'Apple', code = 'Apple'");
+      database.command("sql", "INSERT INTO Product SET name = 'BANANA', code = 'BANANA'");
+      database.command("sql", "INSERT INTO Product SET name = 'cherry', code = 'cherry'");
+      database.command("sql", "INSERT INTO Product SET name = 'Watermelon', code = 'Watermelon'");
+    });
+
+    database.transaction(() -> {
+      final List<String> indexed = new ArrayList<>();
+      final ResultSet rsIndexed = database.query("sql", "SELECT name FROM Product WHERE name.toLowerCase() BETWEEN 'a' AND 'c'");
+      while (rsIndexed.hasNext())
+        indexed.add(rsIndexed.next().getProperty("name"));
+
+      final List<String> nonIndexed = new ArrayList<>();
+      final ResultSet rsNonIndexed = database.query("sql", "SELECT code AS name FROM Product WHERE code.toLowerCase() BETWEEN 'a' AND 'c'");
+      while (rsNonIndexed.hasNext())
+        nonIndexed.add(rsNonIndexed.next().getProperty("name"));
+
+      indexed.sort(String::compareTo);
+      nonIndexed.sort(String::compareTo);
+      assertThat(indexed).isEqualTo(nonIndexed);
+    });
+  }
+
+  @Test
+  void plainLowerFunctionSyntaxFromTheIssueIsNotSupportedByArcadeDbSql() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      database.command("sql", "CREATE INDEX ON Product (name COLLATE CI) NOTUNIQUE");
+      database.command("sql", "INSERT INTO Product SET name = 'Apple'");
+    });
+
+    database.transaction(() -> assertThat(
+        org.assertj.core.api.Assertions.catchThrowable(
+            () -> database.query("sql", "SELECT * FROM Product WHERE LOWER(name) BETWEEN 'a' AND 'c'").hasNext()))
+        .isInstanceOf(com.arcadedb.exception.CommandExecutionException.class)
+        .hasMessageContaining("Unknown function name 'LOWER'"));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue6033BetweenToLowerCaseCiIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6033BetweenToLowerCaseCiIndexTest.java
@@ -129,6 +129,61 @@ class Issue6033BetweenToLowerCaseCiIndexTest {
   }
 
   @Test
+  void betweenOnLowerCaseWrappedFieldWithoutCiIndexFallsBackToScan() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      // plain index, no COLLATE CI: the CI-lowercase branch must not kick in
+      database.command("sql", "CREATE INDEX ON Product (name) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = 'Apple'");
+      database.command("sql", "INSERT INTO Product SET name = 'BANANA'");
+      database.command("sql", "INSERT INTO Product SET name = 'cherry'");
+    });
+
+    database.transaction(() -> {
+      final String planString = plan("EXPLAIN SELECT name FROM Product WHERE name.toLowerCase() BETWEEN 'a' AND 'c'");
+      assertThat(planString).contains("SCAN WITH FILTER");
+      assertThat(planString).doesNotContain("FETCH FROM INDEX");
+
+      final List<String> names = new ArrayList<>();
+      final ResultSet rs = database.query("sql", "SELECT name FROM Product WHERE name.toLowerCase() BETWEEN 'a' AND 'c'");
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+
+      assertThat(names).containsExactlyInAnyOrder("Apple", "BANANA");
+    });
+  }
+
+  @Test
+  void betweenOnChainedModifierAfterToLowerCaseOnCiIndexFallsBackToScan() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      database.command("sql", "CREATE INDEX ON Product (name COLLATE CI) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = ' Apple '");
+      database.command("sql", "INSERT INTO Product SET name = ' BANANA '");
+      database.command("sql", "INSERT INTO Product SET name = ' cherry '");
+    });
+
+    database.transaction(() -> {
+      // an extra modifier after toLowerCase() breaks the "field.toLowerCase()" pattern isFieldWithLowerCaseMethod()
+      // matches, so this must still fall back to a full scan rather than (incorrectly) using the CI index
+      final String planString = plan("EXPLAIN SELECT name FROM Product WHERE name.toLowerCase().trim() BETWEEN 'a' AND 'c'");
+      assertThat(planString).contains("SCAN WITH FILTER");
+      assertThat(planString).doesNotContain("FETCH FROM INDEX");
+
+      final List<String> names = new ArrayList<>();
+      final ResultSet rs = database.query("sql", "SELECT name FROM Product WHERE name.toLowerCase().trim() BETWEEN 'a' AND 'c'");
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+
+      assertThat(names).containsExactlyInAnyOrder(" Apple ", " BANANA ");
+    });
+  }
+
+  @Test
   void plainLowerFunctionSyntaxFromTheIssueIsNotSupportedByArcadeDbSql() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Product");

--- a/engine/src/test/java/com/arcadedb/index/Issue6033BetweenToLowerCaseCiIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6033BetweenToLowerCaseCiIndexTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.index;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Regression test for #6033: {@code BETWEEN} on a case-insensitive ({@code COLLATE CI}) indexed column already
@@ -136,9 +138,8 @@ class Issue6033BetweenToLowerCaseCiIndexTest {
     });
 
     database.transaction(() -> assertThat(
-        org.assertj.core.api.Assertions.catchThrowable(
-            () -> database.query("sql", "SELECT * FROM Product WHERE LOWER(name) BETWEEN 'a' AND 'c'").hasNext()))
-        .isInstanceOf(com.arcadedb.exception.CommandExecutionException.class)
+        catchThrowable(() -> database.query("sql", "SELECT * FROM Product WHERE LOWER(name) BETWEEN 'a' AND 'c'").hasNext()))
+        .isInstanceOf(CommandExecutionException.class)
         .hasMessageContaining("Unknown function name 'LOWER'"));
   }
 }


### PR DESCRIPTION
## Summary

Fixes #6033, a follow-up to #5966/#6018.

`BinaryCondition.isIndexAware()` already has a CI-index optimization that matches `field.toLowerCase() = 'value'` against a `COLLATE CI` index. `BetweenCondition.isIndexAware()` (added in #6018) only mirrored the plain-identifier branch, so `field.toLowerCase() BETWEEN a AND b` fell through to a full bucket scan instead of using the index, unlike the bare `field BETWEEN a AND b` shape which #6018 already fixed.

**Note on the issue's repro syntax**: the issue's example uses `LOWER(name) BETWEEN 'a' AND 'c'`. ArcadeDB SQL has no bare `LOWER(...)` function - only the `.toLowerCase()` method call - so that literal query throws `CommandExecutionException: Unknown function name 'LOWER'` rather than silently scanning. The underlying planner defect is real, though, and reproduces with the syntax ArcadeDB actually supports: `name.toLowerCase() BETWEEN 'a' AND 'c'`. The added test covers both: the real bug with the supported syntax, and documents that the issue's literal syntax isn't valid ArcadeDB SQL.

## Fix

`BetweenCondition.isIndexAware()` gets a second branch analogous to `BinaryCondition`'s, gated the same way (`info.isCaseInsensitive()`, both bounds `isEarlyCalculated`). Rather than duplicating the field-pattern-matching logic, `BinaryCondition.isFieldWithLowerCaseMethod()` is widened from `private` to package-private and reused directly - both classes live in `com.arcadedb.query.sql.parser`, so no new shared utility class is warranted for two call sites in the same package.

## Test plan

- [x] New regression test `Issue6033BetweenToLowerCaseCiIndexTest` (TDD - written first, confirmed it failed before the fix with a `SCAN WITH FILTER` plan, confirmed it passes after with `FETCH FROM INDEX`)
  - `name.toLowerCase() BETWEEN 'a' AND 'c'` on a CI index uses the index and returns correctly case-folded results
  - indexed vs. non-indexed equivalent query return identical results
  - documents that the issue's literal `LOWER(...)` syntax is not supported by ArcadeDB SQL
- [x] Existing `Issue5966BetweenUsesIndexTest`, `CaseInsensitiveIndexTest`, `Issue5932IndexedRangeTypedBoundsTest` still pass
- [x] Broader sweep over `com.arcadedb.index.**`, `com.arcadedb.query.sql.parser.**`, `com.arcadedb.query.sql.executor.**` - no failures