### PR TITLE
Improve security in polyglot host-class lookup filtering

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
@@ -18,7 +18,15 @@
  */
 package com.arcadedb.query.polyglot;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
 /**
@@ -43,6 +51,18 @@ import java.util.function.Predicate;
  * {@code Timer} (spawns host threads outside GraalVM's thread policy) and {@code ServiceLoader}. Keeping the deny-list
  * inside the engine means an embedder who configures a broad allow-list still cannot reach a process, a file, a
  * socket, the reflection API or the class loader.
+ * <p>
+ * A bare (non-wildcard) {@code DENIED} entry names one exact class, so it does not by itself cover a subclass that
+ * lives elsewhere in an allow-listed package - {@code java.util.PropertyResourceBundle} and
+ * {@code java.util.ListResourceBundle} both extend the denied {@code java.util.ResourceBundle} and inherit its
+ * classpath-reading {@code getBundle(String)} factory, yet neither name matches the {@code "java.util.ResourceBundle"}
+ * pattern (GHSA-j57p-qmrh-v7xv). To close that gap, a class admitted by name is additionally checked by walking its
+ * resolved superclass and interface hierarchy: if any ancestor's name matches a <i>precise</i> deny entry - one that
+ * pins a single type, i.e. a bare class name or a {@code Type$*} nested-type pattern - the class is rejected too. A
+ * package-wildcard entry ({@code pkg.*} or {@code pkg.**}) is deliberately excluded from this walk: it already
+ * matches every class in that namespace by name regardless of hierarchy, and applying it during the walk would also
+ * catch unrelated marker interfaces that merely happen to live in a denied package (e.g. {@code java.io.Serializable},
+ * implemented by most collection classes) and reject classes that were never meant to be denied.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -116,6 +136,10 @@ public class HostClassLookupFilter implements Predicate<String> {
 
   private final String[] allowed;
   private final String[] denied;
+  /** Subset of {@link #denied} that pins a single type (bare class name or {@code Type$*}), used for the hierarchy walk. */
+  private final String[] preciseDenied;
+  /** Per-instance cache of {@link #inheritsAPreciselyDeniedType(String)}, keyed by class name. */
+  private final Map<String, Boolean> hierarchyDenialCache = new ConcurrentHashMap<>();
 
   public HostClassLookupFilter(final Collection<String> allowedPatterns, final Collection<String> extraDeniedPatterns) {
     this.allowed = allowedPatterns == null || allowedPatterns.isEmpty() ?
@@ -131,6 +155,12 @@ public class HostClassLookupFilter implements Predicate<String> {
       for (final String pattern : extraDeniedPatterns)
         this.denied[i++] = pattern;
     }
+
+    final List<String> precise = new ArrayList<>();
+    for (final String pattern : this.denied)
+      if (isPreciseTypePattern(pattern))
+        precise.add(pattern);
+    this.preciseDenied = precise.toArray(new String[precise.size()]);
   }
 
   @Override
@@ -143,11 +173,68 @@ public class HostClassLookupFilter implements Predicate<String> {
       if (matches(className, denied[i]))
         return false;
 
+    boolean permitted = false;
     for (int i = 0; i < allowed.length; i++)
-      if (matches(className, allowed[i]))
-        return true;
+      if (matches(className, allowed[i])) {
+        permitted = true;
+        break;
+      }
+    if (!permitted)
+      return false;
 
+    // The class is admitted by name, but it may still inherit a capability from a denied ancestor it does not share
+    // a name with (GHSA-j57p-qmrh-v7xv).
+    return !hierarchyDenialCache.computeIfAbsent(className, this::inheritsAPreciselyDeniedType);
+  }
+
+  /**
+   * A pattern that pins a single named type: a bare class name (no trailing wildcard) or a {@code Type$*} nested-type
+   * entry. Package wildcards ({@code pkg.*}, {@code pkg.**}) are excluded because they already match every class in
+   * that namespace by name, independently of type hierarchy.
+   */
+  private static boolean isPreciseTypePattern(final String pattern) {
+    return !pattern.endsWith("*") || pattern.endsWith("$*");
+  }
+
+  /**
+   * Resolves {@code className} through this filter's classloader and walks its superclass and interface hierarchy
+   * (excluding the class itself, already checked by name), looking for an ancestor whose name matches one of
+   * {@link #preciseDenied}. An unresolvable class name (already rejected by every other host-class-lookup surface,
+   * since GraalVM cannot load it either) is not treated as inheriting anything denied.
+   */
+  private boolean inheritsAPreciselyDeniedType(final String className) {
+    final Class<?> resolved;
+    try {
+      resolved = Class.forName(className, false, HostClassLookupFilter.class.getClassLoader());
+    } catch (final Throwable ignored) {
+      return false;
+    }
+
+    final Set<Class<?>> visited = new HashSet<>();
+    final Deque<Class<?>> toVisit = new ArrayDeque<>();
+    addAncestors(toVisit, resolved);
+
+    while (!toVisit.isEmpty()) {
+      final Class<?> ancestor = toVisit.poll();
+      if (!visited.add(ancestor))
+        continue;
+
+      final String ancestorName = ancestor.getName();
+      for (final String pattern : preciseDenied)
+        if (matches(ancestorName, pattern))
+          return true;
+
+      addAncestors(toVisit, ancestor);
+    }
     return false;
+  }
+
+  private static void addAncestors(final Deque<Class<?>> toVisit, final Class<?> type) {
+    final Class<?> superclass = type.getSuperclass();
+    if (superclass != null)
+      toVisit.add(superclass);
+    for (final Class<?> iface : type.getInterfaces())
+      toVisit.add(iface);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
@@ -18,15 +18,17 @@
  */
 package com.arcadedb.query.polyglot;
 
+import com.arcadedb.utility.LRUCache;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
 /**
@@ -134,12 +136,20 @@ public class HostClassLookupFilter implements Predicate<String> {
       "com.oracle.truffle.**",                           //
   };
 
+  /**
+   * Bound on {@link #hierarchyDenialCache}. A {@code HostClassLookupFilter} instance is not short-lived - one is
+   * cached for the lifetime of a reusable {@code PolyglotQueryEngine}/{@code GraalPolyglotEngine} - so an
+   * unbounded cache keyed by attacker-suppliable class-name strings (including names that fail to resolve, which
+   * are cached too) would let a script exhaust memory by probing many distinct names in an allow-listed package.
+   */
+  private static final int HIERARCHY_CACHE_SIZE = 256;
+
   private final String[] allowed;
   private final String[] denied;
   /** Subset of {@link #denied} that pins a single type (bare class name or {@code Type$*}), used for the hierarchy walk. */
   private final String[] preciseDenied;
-  /** Per-instance cache of {@link #inheritsAPreciselyDeniedType(String)}, keyed by class name. */
-  private final Map<String, Boolean> hierarchyDenialCache = new ConcurrentHashMap<>();
+  /** Per-instance, size-bounded cache of {@link #inheritsAPreciselyDeniedType(String)}, keyed by class name. */
+  private final Map<String, Boolean> hierarchyDenialCache = Collections.synchronizedMap(new LRUCache<>(HIERARCHY_CACHE_SIZE));
 
   public HostClassLookupFilter(final Collection<String> allowedPatterns, final Collection<String> extraDeniedPatterns) {
     this.allowed = allowedPatterns == null || allowedPatterns.isEmpty() ?
@@ -184,7 +194,12 @@ public class HostClassLookupFilter implements Predicate<String> {
 
     // The class is admitted by name, but it may still inherit a capability from a denied ancestor it does not share
     // a name with (GHSA-j57p-qmrh-v7xv).
-    return !hierarchyDenialCache.computeIfAbsent(className, this::inheritsAPreciselyDeniedType);
+    Boolean deniedByHierarchy = hierarchyDenialCache.get(className);
+    if (deniedByHierarchy == null) {
+      deniedByHierarchy = inheritsAPreciselyDeniedType(className);
+      hierarchyDenialCache.put(className, deniedByHierarchy);
+    }
+    return !deniedByHierarchy;
   }
 
   /**
@@ -201,6 +216,11 @@ public class HostClassLookupFilter implements Predicate<String> {
    * (excluding the class itself, already checked by name), looking for an ancestor whose name matches one of
    * {@link #preciseDenied}. An unresolvable class name (already rejected by every other host-class-lookup surface,
    * since GraalVM cannot load it either) is not treated as inheriting anything denied.
+   * <p>
+   * This relies on GraalVM resolving {@code Java.type(...)} through the same classloader used here: neither
+   * {@code GraalPolyglotEngine} nor its {@code Context.Builder} ever calls {@code hostClassLoader(...)}, so the
+   * engine falls back to the embedding application's classloader, matching what is used below. If that ever
+   * changes, an unresolvable name would need to fail closed instead of being treated as non-denied.
    */
   private boolean inheritsAPreciselyDeniedType(final String className) {
     final Class<?> resolved;

--- a/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
@@ -226,7 +226,10 @@ public class HostClassLookupFilter implements Predicate<String> {
     final Class<?> resolved;
     try {
       resolved = Class.forName(className, false, HostClassLookupFilter.class.getClassLoader());
-    } catch (final Throwable ignored) {
+    } catch (final ClassNotFoundException | LinkageError ignored) {
+      // Does not resolve to a real class - the only expected failure shape for a name that already passed the
+      // by-name checks above. A broader catch would also swallow an unrelated VM error (e.g. OutOfMemoryError)
+      // as "not denied", which is not a safe default for a security check.
       return false;
     }
 

--- a/engine/src/test/java/com/arcadedb/query/polyglot/GraalPolyglotEngineHostClassLookupTest.java
+++ b/engine/src/test/java/com/arcadedb/query/polyglot/GraalPolyglotEngineHostClassLookupTest.java
@@ -109,4 +109,25 @@ class GraalPolyglotEngineHostClassLookupTest {
       assertThatThrownBy(() -> engine.eval("Java.type('java.util.Random');")).hasMessageContaining("java.util.Random");
     }
   }
+
+  /**
+   * GHSA-j57p-qmrh-v7xv, end-to-end on a real polyglot context: {@link HostClassLookupFilter}'s subclass-hierarchy
+   * check relies on GraalVM resolving {@code Java.type(...)} through the same classloader the filter uses to walk
+   * ancestors. The unit tests in {@code HostClassLookupFilterTest} exercise the filter directly; this exercises the
+   * actual bypass through a real {@code Context.eval(...)} call, so a future change to the engine's classloader
+   * wiring (e.g. an added {@code hostClassLoader(...)}) would surface here even if the filter's own tests still pass.
+   */
+  @Test
+  void aResourceBundleSubclassIsDeniedThroughARealContext() throws IOException {
+    try (final GraalPolyglotEngine engine = GraalPolyglotEngine.newBuilder(null,
+        PolyglotEngineManager.getInstance().getSharedEngine())//
+        .setLanguage("js")//
+        .setAllowedPackages(List.of("java.util.*"))//
+        .build()) {
+
+      assertThatThrownBy(() -> engine.eval("Java.type('java.util.ResourceBundle');")).hasMessageContaining("java.util.ResourceBundle");
+      assertThatThrownBy(() -> engine.eval("Java.type('java.util.PropertyResourceBundle');")).hasMessageContaining("java.util.PropertyResourceBundle");
+      assertThatThrownBy(() -> engine.eval("Java.type('java.util.ListResourceBundle');")).hasMessageContaining("java.util.ListResourceBundle");
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
@@ -144,4 +144,42 @@ class HostClassLookupFilterTest {
     assertThat(filter.test("java.lang.Runtime")).isFalse();
     assertThat(filter.test("java.io.File")).isFalse();
   }
+
+  /**
+   * GHSA-j57p-qmrh-v7xv: {@code java.util.ResourceBundle} is a bare (non-wildcard) entry in {@link HostClassLookupFilter#DENIED},
+   * so name-equality matching alone does not cover its two public JDK subclasses, both of which live directly in the
+   * allow-listed {@code java.util} package and inherit the denied static {@code getBundle(String)} factory.
+   */
+  @Test
+  void subclassesOfADeniedTypeAreRejectedEvenWhenAdmittedByName() {
+    final HostClassLookupFilter filter = new HostClassLookupFilter(ScriptTriggerExecutor.ALLOWED_PACKAGES, null);
+
+    assertThat(filter.test("java.util.ResourceBundle")).isFalse();
+    assertThat(filter.test("java.util.PropertyResourceBundle")).isFalse();
+    assertThat(filter.test("java.util.ListResourceBundle")).isFalse();
+  }
+
+  @Test
+  void hierarchyCheckDoesNotFalsePositiveOnCommonMarkerInterfaces() {
+    // Serializable/Cloneable/Comparable live in denied-by-wildcard packages (java.io.**) or are otherwise ubiquitous;
+    // an over-broad hierarchy walk must not reject every collection/value class that happens to implement them.
+    final HostClassLookupFilter filter = new HostClassLookupFilter(ScriptTriggerExecutor.ALLOWED_PACKAGES, null);
+
+    assertThat(filter.test("java.util.ArrayList")).isTrue();
+    assertThat(filter.test("java.util.HashMap")).isTrue();
+    assertThat(filter.test("java.util.UUID")).isTrue();
+    assertThat(filter.test("java.math.BigDecimal")).isTrue();
+    assertThat(filter.test("java.time.LocalDate")).isTrue();
+  }
+
+  @Test
+  void callerSuppliedRestrictionAlsoRejectsItsSubclasses() {
+    // A subclass of a caller-supplied (extra) denied type must be rejected too, not just the JDK built-in deny-list.
+    // java.util.Hashtable extends java.util.Dictionary; java.util.HashMap does not and must stay admitted.
+    final HostClassLookupFilter filter = new HostClassLookupFilter(List.of("java.util.*"), List.of("java.util.Dictionary"));
+
+    assertThat(filter.test("java.util.Dictionary")).isFalse();
+    assertThat(filter.test("java.util.Hashtable")).isFalse();
+    assertThat(filter.test("java.util.HashMap")).isTrue();
+  }
 }


### PR DESCRIPTION
## Summary
- Host-class checks in the polyglot script sandbox now also examine a resolved class's inherited superclasses and interfaces, not just its own name, when deciding whether a script may resolve it via `Java.type(...)`.
- Previously, a subclass living in an allow-listed package could inherit a capability from a denied ancestor type without matching any deny-list entry by name (name-only equality matching missed inheritance).
- The check is scoped to "precise" deny entries (a bare class name or a `Type$*` nested-type pattern) so it does not spuriously reject classes that merely implement a common marker interface living in a denied package (e.g. `Serializable`).

## Test plan
- [x] Added regression tests in `HostClassLookupFilterTest` covering the subclass-inheritance bypass, a false-positive guard for common marker interfaces, and a caller-supplied deny-list entry with a subclass
- [x] `mvn -pl engine -am test -Dtest=HostClassLookupFilterTest` — 11/11 pass
- [x] `mvn -pl engine -am test -Dtest="com.arcadedb.query.polyglot.**,com.arcadedb.schema.trigger.**,*Trigger*,*Polyglot*,*Function*"` — 2660/2660 pass, 0 failures/errors