### PR TITLE
fix: batch fixes for #6037, #6040, #6041

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -490,3 +490,32 @@ vertex does not cover it. Those lookups now go through `CSRCountUtils.findAccele
 declines a partial view.
 
 [#5757](https://github.com/ArcadeData/arcadedb/issues/5757)
+
+## `CHECK DATABASE FIX` and `REBUILD INDEX` no longer silently lose an index under sustained lock contention (#6040, #6041)
+
+Both `RebuildIndexStatement.buildIndex()` and `DatabaseChecker`'s auto-fix index-rebuild path retry a
+`dropIndex()` + `create()` body as one unit when the index's file lock is contended. That retry loop charged a
+lock-acquisition failure - the lock timed out before the body ever ran, so nothing was touched - and a failure
+raised *after* that same attempt's `dropIndex()` had already committed - the index is now gone - against the
+identical, small attempt budget. Exhausting retries while in the second state left the index permanently
+missing, discoverable only by noticing it was gone.
+
+Both call sites now track whether the drop actually ran on any attempt and switch to a larger retry budget
+(4x) once it has, favoring "never silently lose an index" over a bounded worst-case runtime. Under sustained
+contention, `REBUILD INDEX` and `CHECK DATABASE FIX` can now take several minutes per index rather than the
+previous ~28 seconds before giving up - `CHECK DATABASE FIX` in particular repeats this per affected index, so
+a fix run against a database with several contended indexes can take noticeably longer under load than before
+this change. `RebuildIndexStatement.buildIndex()` also now throws on exhaustion instead of silently returning
+as if the rebuild had succeeded; `DatabaseChecker`'s warning states which of the two cases occurred instead of
+a blanket "lock contention" message that was misleading for the second case.
+
+[#6040](https://github.com/ArcadeData/arcadedb/issues/6040), [#6041](https://github.com/ArcadeData/arcadedb/issues/6041)
+
+## `field.toLowerCase() IN [...]` now uses a `COLLATE CI` index (#6037)
+
+`field.toLowerCase() = 'value'` and `field.toLowerCase() BETWEEN a AND b` already recognized a case-insensitive
+index and used it instead of a full scan; the equally common `IN` shape did not, and fell back to a bucket
+scan even when a `COLLATE CI` index existed. `InCondition.isIndexAware()` gained the same recognition,
+reusing the existing field-pattern check `BinaryCondition`/`BetweenCondition` already share.
+
+[#6037](https://github.com/ArcadeData/arcadedb/issues/6037)

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -52,6 +52,11 @@ import java.util.stream.Collectors;
 public class DatabaseChecker {
   // Matches RebuildIndexStatement.MAX_ATTEMPTS: the lock-contention retry bound for the index-rebuild file lock.
   private static final int          LOCK_MAX_ATTEMPTS = 5;
+  // Matches RebuildIndexStatement.POST_DROP_ATTEMPT_MULTIPLIER (#6040): once an attempt's dropIndex() has actually
+  // committed, exhausting the retry budget leaves the index missing rather than merely unrebuilt, so that state
+  // gets a larger budget than a plain lock-acquisition timeout, where nothing was touched and giving up simply
+  // leaves the index exactly as it was.
+  private static final int          LOCK_POST_DROP_ATTEMPT_MULTIPLIER = 4;
   private final DatabaseInternal    database;
   private       int                 verboseLevel = 1;
   private       boolean             fix          = false;
@@ -300,26 +305,33 @@ public class DatabaseChecker {
         // partial counts into attempt N+1's create() call, inflating totalDocs/sumDocLength (and so skewing BM25
         // relevance scoring) on any FULL_TEXT index whose rebuild needed more than one attempt.
         //
-        // Shares a known, pre-existing race with RebuildIndexStatement's identically-shaped retry (not introduced
-        // here): dropIndex() itself is safe to repeat (LocalSchema.dropIndexInternal no-ops once the name is
-        // already gone), but a NeedRetryException raised deep inside create()'s bucket scan - AFTER a prior
-        // attempt's drop already committed - means the next attempt's create() runs a second time following that
-        // same drop, rather than resuming from the point create() actually failed. A proper fix (clean up a
-        // partially-built index before retrying, or scope the retry to lock acquisition only) belongs in both
-        // call sites together, not this one in isolation.
+        // #6040: dropIndex() itself is safe to repeat (LocalSchema.dropIndexInternal no-ops once the name is
+        // already gone), but a NeedRetryException raised deep inside create()'s bucket scan - AFTER this same
+        // attempt's drop already committed - left every subsequent attempt retrying to recover from a
+        // self-inflicted "index currently gone" state, not merely waiting out lock contention, while being
+        // charged against the very same LOCK_MAX_ATTEMPTS budget as a lock timeout that touched nothing at all.
+        // indexDropped (sticky once true) tracks that distinction; once set, the exhaustion check below applies
+        // the larger LOCK_POST_DROP_ATTEMPT_MULTIPLIER budget instead of giving up at LOCK_MAX_ATTEMPTS.
         boolean rebuilt = false;
+        boolean indexDropped = false;
         NeedRetryException lastRetryFailure = null;
-        for (int attempt = 1; attempt <= LOCK_MAX_ATTEMPTS; attempt++) {
+        int attemptsUsed = 0;
+        for (int attempt = 1; ; attempt++) {
+          attemptsUsed = attempt;
+          // Effectively-final per iteration: set to true by the callback the instant its dropIndex() commits.
+          final boolean[] droppedThisAttempt = new boolean[1];
           try {
             final IndexMetadata rebuildMetadata = IndexMetadata.reconstructForRebuild((IndexInternal) idx, typeName,
                 propNames.toArray(new String[0]));
             database.executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
               database.getSchema().dropIndex(idx.getName());
+              droppedThisAttempt[0] = true;
 
               database.getSchema().buildBucketIndex(typeName, bucketName, propNames.toArray(new String[propNames.size()]))
                   .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy)
                   .withMetadata(rebuildMetadata)
                   .withIndexName(ownerTypeIndex != null ? ownerTypeIndex.getName() : null)
+                  .withMaxAttempts(LOCK_MAX_ATTEMPTS)
                   .create();
               return null;
             });
@@ -327,7 +339,11 @@ public class DatabaseChecker {
             break;
           } catch (final NeedRetryException e) {
             lastRetryFailure = e;
-            if (attempt == LOCK_MAX_ATTEMPTS)
+            if (droppedThisAttempt[0])
+              indexDropped = true;
+
+            final int budget = indexDropped ? LOCK_MAX_ATTEMPTS * LOCK_POST_DROP_ATTEMPT_MULTIPLIER : LOCK_MAX_ATTEMPTS;
+            if (attempt >= budget)
               break;
             try {
               Thread.sleep(200 + 200L * attempt);
@@ -346,17 +362,17 @@ public class DatabaseChecker {
         // class's "reported, never silent" convention - see the manual-index warning above) and correct the
         // rebuiltIndexes claim instead of pretending the rebuild happened.
         //
-        // The warning deliberately does not claim lock contention as the cause: exhaustion can also follow the
-        // pre-existing race documented above the loop (a NeedRetryException from deep inside a LATER attempt's
-        // create(), after an EARLIER attempt's drop already committed), in which case the index may now be
-        // missing rather than merely unrebuilt - lastRetryFailure.getMessage() is surfaced so the operator can
-        // tell which one actually happened, instead of a blanket "due to lock contention" that would be wrong
-        // for the second case.
+        // The warning's phrasing follows indexDropped (#6040): lock-acquisition exhaustion leaves the index
+        // exactly as it was, while post-drop exhaustion means the index is actually gone, not merely unrebuilt -
+        // lastRetryFailure.getMessage() is also surfaced so the operator can see the underlying cause either way.
         if (!rebuilt) {
           rebuildIndexes.remove(idx.getName());
-          addWarning("index '" + idx.getName() + "' did not finish rebuilding after " + LOCK_MAX_ATTEMPTS
-              + " attempts (error: " + lastRetryFailure.getMessage() + "). It may be missing until CHECK DATABASE "
-              + "FIX is run again; verify with `SELECT FROM schema:indexes WHERE name = '" + idx.getName() + "'`");
+          final String status = indexDropped ?
+              "the index was dropped but the rebuild could not complete; it is now missing" :
+              "the index lock could not be acquired; the index itself is unchanged";
+          addWarning("index '" + idx.getName() + "' did not finish rebuilding after " + attemptsUsed + " attempts (" + status
+              + ", error: " + lastRetryFailure.getMessage() + "). Verify with `SELECT FROM schema:indexes WHERE name = '"
+              + idx.getName() + "'` and run CHECK DATABASE FIX again if it is missing");
         }
 
         stepTick();

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -327,6 +327,12 @@ public class DatabaseChecker {
               database.getSchema().dropIndex(idx.getName());
               droppedThisAttempt[0] = true;
 
+              // Was missing entirely before #6040 (default maxAttempts=1, effectively no inner retry at all), unlike
+              // RebuildIndexStatement's identically-shaped call. This lets create()'s own bucket-scan contention
+              // resolve WITHOUT re-entering this outer loop, while the outer file lock from executeLockingFiles is
+              // still held - so a single outer attempt can now take noticeably longer than before (up to
+              // LOCK_MAX_ATTEMPTS internal retries with their own backoff) before it either succeeds or falls
+              // through to the outer catch below.
               database.getSchema().buildBucketIndex(typeName, bucketName, propNames.toArray(new String[propNames.size()]))
                   .withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy)
                   .withMetadata(rebuildMetadata)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
@@ -361,6 +361,15 @@ public class InCondition extends BooleanExpression {
       }
     }
 
+    // CI index optimization: match field.toLowerCase() IN [values] against a CI index on field
+    // (mirrors BinaryCondition/BetweenCondition's identical branch for = and BETWEEN, #6037)
+    if (info.isCaseInsensitive() && BinaryCondition.isFieldWithLowerCaseMethod(left, info.getField())) {
+      if (rightMathExpression != null)
+        return rightMathExpression.isEarlyCalculated(info.getContext());
+      else
+        return rightParam != null;
+    }
+
     // Handle inverted syntax for BY-ITEM indexes: value IN list_field
     // For "1 IN nums" or "2 IN nums.a", rightMathExpression should contain the field
     if (rightMathExpression != null && info.isIndexByItem()) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -421,7 +421,11 @@ public class RebuildIndexStatement extends DDLStatement {
         if (droppedThisAttempt[0])
           indexDropped = true;
 
-        final int budget = indexDropped ? maxAttempts * POST_DROP_ATTEMPT_MULTIPLIER : maxAttempts;
+        // maxAttempts is user-supplied (REBUILD INDEX ... WITH maxAttempts = ...), unbounded at parse time - clamp
+        // the multiplication through long arithmetic so an extreme value can't overflow budget negative, which
+        // would make the very next NeedRetryException throw immediately instead of honoring the requested attempts.
+        final int budget = indexDropped ?
+            (int) Math.min((long) maxAttempts * POST_DROP_ATTEMPT_MULTIPLIER, Integer.MAX_VALUE) : maxAttempts;
         if (attempt >= budget) {
           // #6040: exhaustion after the index has actually been dropped must not pass silently - unlike the old
           // behavior of falling off the end of this method, which left the caller believing the REBUILD succeeded
@@ -438,6 +442,9 @@ public class RebuildIndexStatement extends DDLStatement {
         try {
           Thread.sleep(200 + 200L * attempt);
         } catch (InterruptedException ex) {
+          // An interrupt is a request to stop, not contention to ride out: honor it immediately rather than
+          // trying further attempts.
+          Thread.currentThread().interrupt();
           throw e;
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -429,7 +429,7 @@ public class RebuildIndexStatement extends DDLStatement {
           // reported the same way for a consistent contract: REBUILD INDEX either succeeds or throws.
           final String reason = indexDropped ?
               "the index was dropped but the rebuild could not complete (error: " + e.getMessage() + "). "
-                  + "The index is now missing - retry `REBUILD INDEX `" + idx.getName() + "`` once the contention clears" :
+                  + "The index is now missing - retry `REBUILD INDEX " + idx.getName() + "` once the contention clears" :
               "the index lock could not be acquired (error: " + e.getMessage() + "). The index itself is unchanged";
           throw new CommandExecutionException(
               "Cannot rebuild index '" + idx.getName() + "' after " + attempt + " attempts: " + reason);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -54,7 +54,14 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 public class RebuildIndexStatement extends DDLStatement {
-  private static final int                         MAX_ATTEMPTS = 5;
+  private static final int                         MAX_ATTEMPTS                    = 5;
+  // Once an attempt's dropIndex() has actually committed, giving up leaves the index missing rather than merely
+  // unrebuilt (#6040): a NeedRetryException raised deep inside create()'s bucket scan on THAT attempt (as opposed
+  // to one raised by executeLockingFiles's own tryLockFiles, before anything was touched) means every subsequent
+  // attempt is retrying to recover from a self-inflicted "index currently gone" state, not merely waiting out lock
+  // contention. That state deserves a larger retry budget than the lock-acquisition case, where nothing was lost
+  // and giving up simply leaves the index exactly as it was.
+  private static final int                         POST_DROP_ATTEMPT_MULTIPLIER    = 4;
   public               boolean                     all          = false;
   public               Identifier                  name;
   public               Expression                  key;
@@ -300,7 +307,14 @@ public class RebuildIndexStatement extends DDLStatement {
           "Use synchronous execution (awaitResponse=true) or run the command directly.");
     }
 
-    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+    // Sticky once true (#6040): sees whether ANY attempt so far got past its own dropIndex() call, so exhaustion
+    // is judged against the right budget below - extended once the index has actually been dropped, not just the
+    // lock-acquisition budget that applies while it is still safely untouched.
+    boolean indexDropped = false;
+
+    for (int attempt = 1; ; attempt++) {
+      // Effectively-final per iteration: set to true by the callback below the instant its dropIndex() commits.
+      final boolean[] droppedThisAttempt = new boolean[1];
       try {
         // Check if index is INVALID (e.g., interrupted build with WAL disabled)
         if (!((IndexInternal) idx).isValid()) {
@@ -374,6 +388,7 @@ public class RebuildIndexStatement extends DDLStatement {
 
         ((DatabaseInternal) database).executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
           database.getSchema().dropIndex(idx.getName());
+          droppedThisAttempt[0] = true;
 
           if (typeIndexRebuild) {
             // Preserve the logical index's own name (issue #5791, follow-up to #4732/#4139): without this the
@@ -403,6 +418,23 @@ public class RebuildIndexStatement extends DDLStatement {
         return;
 
       } catch (NeedRetryException e) {
+        if (droppedThisAttempt[0])
+          indexDropped = true;
+
+        final int budget = indexDropped ? maxAttempts * POST_DROP_ATTEMPT_MULTIPLIER : maxAttempts;
+        if (attempt >= budget) {
+          // #6040: exhaustion after the index has actually been dropped must not pass silently - unlike the old
+          // behavior of falling off the end of this method, which left the caller believing the REBUILD succeeded
+          // while the index was actually gone. A pre-drop exhaustion (lock contention only, nothing touched) is
+          // reported the same way for a consistent contract: REBUILD INDEX either succeeds or throws.
+          final String reason = indexDropped ?
+              "the index was dropped but the rebuild could not complete (error: " + e.getMessage() + "). "
+                  + "The index is now missing - retry `REBUILD INDEX `" + idx.getName() + "`` once the contention clears" :
+              "the index lock could not be acquired (error: " + e.getMessage() + "). The index itself is unchanged";
+          throw new CommandExecutionException(
+              "Cannot rebuild index '" + idx.getName() + "' after " + attempt + " attempts: " + reason);
+        }
+
         try {
           Thread.sleep(200 + 200L * attempt);
         } catch (InterruptedException ex) {

--- a/engine/src/test/java/com/arcadedb/TestHelper.java
+++ b/engine/src/test/java/com/arcadedb/TestHelper.java
@@ -18,10 +18,16 @@
  */
 package com.arcadedb;
 
+import com.arcadedb.database.Binary;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
 import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -34,8 +40,11 @@ import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -236,5 +245,69 @@ public abstract class TestHelper {
       db.close();
 
     assertThat(activeDatabases.isEmpty()).as("Found active databases: " + activeDatabases).isTrue();
+  }
+
+  /**
+   * Overwrites the record-type byte of {@code rid} with a value no {@code RecordFactory} branch knows, so the
+   * record still occupies its slot and still has a valid size but cannot be materialised - a corruption shape
+   * shared by tests that need a record {@code CHECK DATABASE} can find but not load (e.g. an index-rebuild
+   * trigger), as opposed to a missing or truncated one.
+   */
+  protected static void corruptRecordTypeByte(final DatabaseInternal db, final RID rid) {
+    final int fileId = rid.getBucketId();
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
+
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
+        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
+        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
+        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
+        final long[] recordSize = page.readNumberAndSize(recordOffset);
+        page.writeByte((int) (recordOffset + recordSize[1]), (byte) 99);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  /**
+   * Holds {@code fileIds} locked for {@code holdMillis} via {@code DatabaseInternal.executeLockingFiles} - the same
+   * primitive production lock-contention retry paths (e.g. index rebuild) use - on a requester (this thread)
+   * distinct from whichever thread started it, to deterministically force a {@code LockTimeoutException} there.
+   */
+  public static final class LockHoldingThread extends Thread {
+    private final DatabaseInternal            db;
+    private final List<Integer>               fileIds;
+    private final long                        holdMillis;
+    public final  CountDownLatch              lockAcquired = new CountDownLatch(1);
+    public final  AtomicReference<Throwable>  error        = new AtomicReference<>();
+
+    public LockHoldingThread(final DatabaseInternal db, final List<Integer> fileIds, final long holdMillis) {
+      super("lock-holder");
+      this.db = db;
+      this.fileIds = fileIds;
+      this.holdMillis = holdMillis;
+      setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+      try {
+        db.executeLockingFiles(fileIds, () -> {
+          lockAcquired.countDown();
+          Thread.sleep(holdMillis);
+          return null;
+        });
+      } catch (final Throwable t) {
+        error.set(t);
+        lockAcquired.countDown();
+      }
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixPreservesIndexMetadataTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixPreservesIndexMetadataTest.java
@@ -19,10 +19,6 @@
 package com.arcadedb.database;
 
 import com.arcadedb.TestHelper;
-import com.arcadedb.engine.LocalBucket;
-import com.arcadedb.engine.MutablePage;
-import com.arcadedb.engine.PageId;
-import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -62,7 +58,7 @@ class CheckDatabaseFixPreservesIndexMetadataTest extends TestHelper {
       victim.set(inserted.toElement().getIdentity());
     });
 
-    corruptRecordTypeByte(victim.get());
+    corruptRecordTypeByte((DatabaseInternal) database, victim.get());
 
     final ResultSet result = database.command("sql", "check database fix");
     assertThat(result.hasNext()).isTrue();
@@ -90,7 +86,7 @@ class CheckDatabaseFixPreservesIndexMetadataTest extends TestHelper {
       victim.set(inserted.toElement().getIdentity());
     });
 
-    corruptRecordTypeByte(victim.get());
+    corruptRecordTypeByte((DatabaseInternal) database, victim.get());
 
     final ResultSet result = database.command("sql", "check database fix");
     assertThat(result.hasNext()).isTrue();
@@ -124,7 +120,7 @@ class CheckDatabaseFixPreservesIndexMetadataTest extends TestHelper {
       victim.set(inserted.toElement().getIdentity());
     });
 
-    corruptRecordTypeByte(victim.get());
+    corruptRecordTypeByte((DatabaseInternal) database, victim.get());
 
     final ResultSet result = database.command("sql", "check database fix");
     assertThat(result.hasNext()).isTrue();
@@ -134,35 +130,6 @@ class CheckDatabaseFixPreservesIndexMetadataTest extends TestHelper {
       assertThat(database.getSchema().existsIndex("myNamedIdx")).isTrue();
       assertThat(database.getSchema().existsIndex("Doc[name]")).isFalse();
       assertThat(database.getSchema().getIndexByName("myNamedIdx").getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
-    });
-  }
-
-  /**
-   * Overwrites the record-type byte of {@code rid} with a value no {@code RecordFactory} branch knows, so the record
-   * still occupies its slot and still has a valid size but cannot be materialised - the precise, page-layout-agnostic
-   * corruption shape used by {@code CheckDatabaseRecordScopeTest.corruptRecordTypeByte}.
-   */
-  private void corruptRecordTypeByte(final RID rid) {
-    final DatabaseInternal db = (DatabaseInternal) database;
-    final int fileId = rid.getBucketId();
-    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
-    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
-    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
-
-    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
-    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
-
-    db.transaction(() -> {
-      try {
-        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
-        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
-        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
-        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
-        final long[] recordSize = page.readNumberAndSize(recordOffset);
-        page.writeByte((int) (recordOffset + recordSize[1]), (byte) 99);
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/DatabaseCheckerIndexRebuildLockContentionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DatabaseCheckerIndexRebuildLockContentionTest.java
@@ -19,7 +19,6 @@
 package com.arcadedb.engine;
 
 import com.arcadedb.TestHelper;
-import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.index.IndexInternal;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,11 +44,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * uncontended happy path.
  *
  * <p>Contention is induced deterministically by holding the target bucket sub-index's file lock from a second
- * thread via the same {@code DatabaseInternal.executeLockingFiles} primitive {@code DatabaseChecker} itself uses -
- * exactly the mechanism suggested in the issue. {@code LocalDatabase.executeLockingFiles} waits a hardcoded 5
- * seconds per attempt before raising a {@code LockTimeoutException} (a {@code NeedRetryException}), which is what
- * makes both tests here multi-second: {@code @Tag("slow")} routes them to the slow lane rather than the regular
- * unit-test one.
+ * thread via {@link TestHelper.LockHoldingThread}, which wraps the same {@code DatabaseInternal.executeLockingFiles}
+ * primitive {@code DatabaseChecker} itself uses - exactly the mechanism suggested in the issue.
+ * {@code LocalDatabase.executeLockingFiles} waits a hardcoded 5 seconds per attempt before raising a
+ * {@code LockTimeoutException} (a {@code NeedRetryException}), which is what makes both tests here multi-second:
+ * {@code @Tag("slow")} routes them to the slow lane rather than the regular unit-test one.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -79,12 +77,12 @@ class DatabaseCheckerIndexRebuildLockContentionTest extends TestHelper {
       victim.set(inserted.toElement().getIdentity());
     });
 
-    corruptRecordTypeByte(victim.get());
-
     final DatabaseInternal db = (DatabaseInternal) database;
+    corruptRecordTypeByte(db, victim.get());
+
     final List<Integer> fileIds = bucketSubIndexFileIds(db);
 
-    final HoldingThread holder = new HoldingThread(db, fileIds, 5_300);
+    final LockHoldingThread holder = new LockHoldingThread(db, fileIds, 5_300);
     holder.start();
     try {
       assertThat(holder.lockAcquired.await(5, TimeUnit.SECONDS))
@@ -134,13 +132,13 @@ class DatabaseCheckerIndexRebuildLockContentionTest extends TestHelper {
       victim.set(inserted.toElement().getIdentity());
     });
 
-    corruptRecordTypeByte(victim.get());
-
     final DatabaseInternal db = (DatabaseInternal) database;
+    corruptRecordTypeByte(db, victim.get());
+
     final List<Integer> fileIds = bucketSubIndexFileIds(db);
 
     // Worst case for 5 attempts: 5 * 5000ms wait + (400+600+800+1000)ms backoff = 27800ms. Held comfortably past it.
-    final HoldingThread holder = new HoldingThread(db, fileIds, 29_000);
+    final LockHoldingThread holder = new LockHoldingThread(db, fileIds, 29_000);
     holder.start();
     try {
       assertThat(holder.lockAcquired.await(5, TimeUnit.SECONDS))
@@ -187,69 +185,5 @@ class DatabaseCheckerIndexRebuildLockContentionTest extends TestHelper {
     final List<IndexInternal> subIndexes = typeIdx.getSubIndexes();
     assertThat(subIndexes).as("single-bucket type: exactly one bucket sub-index").hasSize(1);
     return subIndexes.get(0).getFileIds();
-  }
-
-  /**
-   * Holds {@code fileIds} locked for {@code holdMillis} via the same {@code executeLockingFiles} primitive
-   * {@code DatabaseChecker} uses, on a requester (this thread) distinct from the test's main thread that runs FIX.
-   */
-  private static final class HoldingThread extends Thread {
-    private final DatabaseInternal            db;
-    private final List<Integer>               fileIds;
-    private final long                        holdMillis;
-    final          CountDownLatch             lockAcquired = new CountDownLatch(1);
-    final          AtomicReference<Throwable> error        = new AtomicReference<>();
-
-    HoldingThread(final DatabaseInternal db, final List<Integer> fileIds, final long holdMillis) {
-      super("lock-holder");
-      this.db = db;
-      this.fileIds = fileIds;
-      this.holdMillis = holdMillis;
-      setDaemon(true);
-    }
-
-    @Override
-    public void run() {
-      try {
-        db.executeLockingFiles(fileIds, () -> {
-          lockAcquired.countDown();
-          Thread.sleep(holdMillis);
-          return null;
-        });
-      } catch (final Throwable t) {
-        error.set(t);
-        lockAcquired.countDown();
-      }
-    }
-  }
-
-  /**
-   * Overwrites the record-type byte of {@code rid} with a value no {@code RecordFactory} branch knows, so the record
-   * still occupies its slot and still has a valid size but cannot be materialised - the precise, page-layout-agnostic
-   * corruption shape used by {@code CheckDatabaseRecordScopeTest.corruptRecordTypeByte} and
-   * {@code CheckDatabaseFixPreservesIndexMetadataTest.corruptRecordTypeByte}.
-   */
-  private void corruptRecordTypeByte(final RID rid) {
-    final DatabaseInternal db = (DatabaseInternal) database;
-    final int fileId = rid.getBucketId();
-    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
-    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
-    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
-
-    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
-    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
-
-    db.transaction(() -> {
-      try {
-        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
-        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
-        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
-        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
-        final long[] recordSize = page.readNumberAndSize(recordOffset);
-        page.writeByte((int) (recordOffset + recordSize[1]), (byte) 99);
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/DatabaseCheckerIndexRebuildLockContentionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DatabaseCheckerIndexRebuildLockContentionTest.java
@@ -56,9 +56,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DatabaseCheckerIndexRebuildLockContentionTest extends TestHelper {
 
   /**
-   * Holds the lock for just over the single hardcoded 5s {@code tryLockFiles} timeout, forcing exactly one
-   * {@code LockTimeoutException} on FIX's first attempt, then releases in time for attempt 2 to acquire almost
-   * immediately and complete the rebuild - the retry-then-succeed branch #6041 asks for.
+   * Holds the lock comfortably past the single hardcoded 5s {@code tryLockFiles} timeout (1s margin over it,
+   * against scheduling jitter on a loaded CI runner - see {@code engine/CLAUDE.md} on that timeout being "a common
+   * source of intermittent failures in contention tests"), forcing exactly one {@code LockTimeoutException} on
+   * FIX's first attempt. The release still lands far short of attempt 2's own 5s window (which starts after a
+   * ~400ms backoff), so attempt 2 acquires quickly and completes the rebuild - the retry-then-succeed branch #6041
+   * asks for.
    */
   @Test
   void fixRetriesThroughTransientLockContentionAndSucceeds() throws Exception {
@@ -82,7 +85,7 @@ class DatabaseCheckerIndexRebuildLockContentionTest extends TestHelper {
 
     final List<Integer> fileIds = bucketSubIndexFileIds(db);
 
-    final LockHoldingThread holder = new LockHoldingThread(db, fileIds, 5_300);
+    final LockHoldingThread holder = new LockHoldingThread(db, fileIds, 6_000);
     holder.start();
     try {
       assertThat(holder.lockAcquired.await(5, TimeUnit.SECONDS))

--- a/engine/src/test/java/com/arcadedb/engine/DatabaseCheckerIndexRebuildLockContentionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DatabaseCheckerIndexRebuildLockContentionTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for #6041 (follow-up from #6031/#6040): {@code DatabaseChecker}'s auto-fix index-rebuild loop
+ * gained a ~50-line retry/backoff/per-index-isolation block in #6031, and #6040 then reworked it to distinguish a
+ * lock-acquisition failure (nothing touched) from a failure after that attempt's {@code dropIndex()} already
+ * committed (extended retry budget, since giving up there leaves the index missing). Neither shape had ANY test
+ * coverage before this class - {@code CheckDatabaseFixPreservesIndexMetadataTest} only exercises the
+ * uncontended happy path.
+ *
+ * <p>Contention is induced deterministically by holding the target bucket sub-index's file lock from a second
+ * thread via the same {@code DatabaseInternal.executeLockingFiles} primitive {@code DatabaseChecker} itself uses -
+ * exactly the mechanism suggested in the issue. {@code LocalDatabase.executeLockingFiles} waits a hardcoded 5
+ * seconds per attempt before raising a {@code LockTimeoutException} (a {@code NeedRetryException}), which is what
+ * makes both tests here multi-second: {@code @Tag("slow")} routes them to the slow lane rather than the regular
+ * unit-test one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class DatabaseCheckerIndexRebuildLockContentionTest extends TestHelper {
+
+  /**
+   * Holds the lock for just over the single hardcoded 5s {@code tryLockFiles} timeout, forcing exactly one
+   * {@code LockTimeoutException} on FIX's first attempt, then releases in time for attempt 2 to acquire almost
+   * immediately and complete the rebuild - the retry-then-succeed branch #6041 asks for.
+   */
+  @Test
+  void fixRetriesThroughTransientLockContentionAndSucceeds() throws Exception {
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      // Index created BEFORE the inserts: CREATE INDEX's bulk-scan build only sees already-committed data, so
+      // creating it after inserting in the SAME transaction would miss records inserted earlier in that same,
+      // still-open transaction. Once the index exists, ordinary inserts maintain it incrementally as they happen.
+      database.command("sql", "CREATE INDEX myIdx ON Doc (name) NOTUNIQUE");
+      final Result inserted = database.command("sql", "INSERT INTO Doc SET name = 'alpha'").next();
+      // Not corrupted: survives the fix (which deletes the unrecoverable 'alpha' record), used below to prove the
+      // rebuilt index is actually queryable afterwards rather than merely present.
+      database.command("sql", "INSERT INTO Doc SET name = 'beta'");
+      victim.set(inserted.toElement().getIdentity());
+    });
+
+    corruptRecordTypeByte(victim.get());
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final List<Integer> fileIds = bucketSubIndexFileIds(db);
+
+    final HoldingThread holder = new HoldingThread(db, fileIds, 5_300);
+    holder.start();
+    try {
+      assertThat(holder.lockAcquired.await(5, TimeUnit.SECONDS))
+          .as("background thread must acquire the lock before FIX runs").isTrue();
+
+      final ResultSet result = database.command("sql", "check database fix");
+      assertThat(result.hasNext()).isTrue();
+      final Result row = result.next();
+      assertThat(row.<Long>getProperty("autoFix")).isGreaterThan(0L);
+      // rebuiltIndexes names the BUCKET sub-index DatabaseChecker actually rebuilds (e.g. "Doc_0_<nanoTime>"),
+      // not the logical TypeIndex wrapper "myIdx" - it must be non-empty, i.e. the rebuild was recorded as done.
+      @SuppressWarnings("unchecked")
+      final Set<String> rebuiltIndexes = (Set<String>) row.getProperty("rebuiltIndexes");
+      assertThat(rebuiltIndexes).isNotEmpty();
+    } finally {
+      holder.join(15_000);
+    }
+    assertThat(holder.isAlive()).isFalse();
+    assertThat(holder.error.get()).isNull();
+
+    database.transaction(() -> {
+      assertThat(database.getSchema().existsIndex("myIdx")).isTrue();
+      final String planString = plan("EXPLAIN SELECT FROM Doc WHERE name = 'beta'");
+      assertThat(planString).contains("FETCH FROM INDEX");
+      final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE name = 'beta'");
+      assertThat(rs.hasNext()).isTrue();
+    });
+  }
+
+  /**
+   * Holds the lock past the worst-case total of all 5 attempts (5 * 5s wait + backoff between them), so every
+   * attempt is a pure lock-acquisition failure - the retry-exhaustion branch #6041 asks for. Because none of the 5
+   * attempts ever got past {@code tryLockFiles}, {@code dropIndex()} never ran on any of them: per #6040 this is
+   * exactly the case where exhaustion must leave the index exactly as it was, not missing.
+   */
+  @Test
+  void fixExhaustsRetryOnSustainedLockContentionAndLeavesIndexUntouched() throws Exception {
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      // See fixRetriesThroughTransientLockContentionAndSucceeds for why the index must be created before inserting.
+      database.command("sql", "CREATE INDEX myIdx ON Doc (name) NOTUNIQUE");
+      final Result inserted = database.command("sql", "INSERT INTO Doc SET name = 'alpha'").next();
+      // Not corrupted: used below to prove the untouched index is still queryable after exhaustion.
+      database.command("sql", "INSERT INTO Doc SET name = 'beta'");
+      victim.set(inserted.toElement().getIdentity());
+    });
+
+    corruptRecordTypeByte(victim.get());
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final List<Integer> fileIds = bucketSubIndexFileIds(db);
+
+    // Worst case for 5 attempts: 5 * 5000ms wait + (400+600+800+1000)ms backoff = 27800ms. Held comfortably past it.
+    final HoldingThread holder = new HoldingThread(db, fileIds, 29_000);
+    holder.start();
+    try {
+      assertThat(holder.lockAcquired.await(5, TimeUnit.SECONDS))
+          .as("background thread must acquire the lock before FIX runs").isTrue();
+
+      final ResultSet result = database.command("sql", "check database fix");
+      assertThat(result.hasNext()).isTrue();
+      final Result row = result.next();
+
+      // rebuiltIndexes/warnings name the BUCKET sub-index DatabaseChecker actually rebuilds (e.g.
+      // "Doc_0_<nanoTime>"), not the logical TypeIndex wrapper "myIdx": it must report NO rebuild happened, with a
+      // matching warning explaining why.
+      @SuppressWarnings("unchecked")
+      final Set<String> rebuiltIndexes = (Set<String>) row.getProperty("rebuiltIndexes");
+      assertThat(rebuiltIndexes).isEmpty();
+
+      @SuppressWarnings("unchecked")
+      final Set<String> warnings = (Set<String>) row.getProperty("warnings");
+      assertThat(warnings).anyMatch(w -> w.contains("did not finish rebuilding")
+          && w.contains("the index lock could not be acquired; the index itself is unchanged"));
+    } finally {
+      holder.join(35_000);
+    }
+    assertThat(holder.isAlive()).isFalse();
+    assertThat(holder.error.get()).isNull();
+
+    // #6040: a pure lock-acquisition exhaustion must never have touched the index - it is still there, unchanged,
+    // and still answers queries through it (not merely present-but-broken).
+    database.transaction(() -> {
+      assertThat(database.getSchema().existsIndex("myIdx")).isTrue();
+      final String planString = plan("EXPLAIN SELECT FROM Doc WHERE name = 'beta'");
+      assertThat(planString).contains("FETCH FROM INDEX");
+      final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE name = 'beta'");
+      assertThat(rs.hasNext()).isTrue();
+    });
+  }
+
+  private String plan(final String query) {
+    return database.query("sql", query).getExecutionPlan().get().prettyPrint(0, 3);
+  }
+
+  private static List<Integer> bucketSubIndexFileIds(final DatabaseInternal db) {
+    final TypeIndex typeIdx = (TypeIndex) db.getSchema().getIndexByName("myIdx");
+    final List<IndexInternal> subIndexes = typeIdx.getSubIndexes();
+    assertThat(subIndexes).as("single-bucket type: exactly one bucket sub-index").hasSize(1);
+    return subIndexes.get(0).getFileIds();
+  }
+
+  /**
+   * Holds {@code fileIds} locked for {@code holdMillis} via the same {@code executeLockingFiles} primitive
+   * {@code DatabaseChecker} uses, on a requester (this thread) distinct from the test's main thread that runs FIX.
+   */
+  private static final class HoldingThread extends Thread {
+    private final DatabaseInternal            db;
+    private final List<Integer>               fileIds;
+    private final long                        holdMillis;
+    final          CountDownLatch             lockAcquired = new CountDownLatch(1);
+    final          AtomicReference<Throwable> error        = new AtomicReference<>();
+
+    HoldingThread(final DatabaseInternal db, final List<Integer> fileIds, final long holdMillis) {
+      super("lock-holder");
+      this.db = db;
+      this.fileIds = fileIds;
+      this.holdMillis = holdMillis;
+      setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+      try {
+        db.executeLockingFiles(fileIds, () -> {
+          lockAcquired.countDown();
+          Thread.sleep(holdMillis);
+          return null;
+        });
+      } catch (final Throwable t) {
+        error.set(t);
+        lockAcquired.countDown();
+      }
+    }
+  }
+
+  /**
+   * Overwrites the record-type byte of {@code rid} with a value no {@code RecordFactory} branch knows, so the record
+   * still occupies its slot and still has a valid size but cannot be materialised - the precise, page-layout-agnostic
+   * corruption shape used by {@code CheckDatabaseRecordScopeTest.corruptRecordTypeByte} and
+   * {@code CheckDatabaseFixPreservesIndexMetadataTest.corruptRecordTypeByte}.
+   */
+  private void corruptRecordTypeByte(final RID rid) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = rid.getBucketId();
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
+
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
+        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
+        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
+        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
+        final long[] recordSize = page.readNumberAndSize(recordOffset);
+        page.writeByte((int) (recordOffset + recordSize[1]), (byte) 99);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue6037InToLowerCaseCiIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6037InToLowerCaseCiIndexTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6037: {@code field.toLowerCase() = 'value'} and {@code field.toLowerCase() BETWEEN a AND b}
+ * already use a {@code COLLATE CI} index (via {@link com.arcadedb.query.sql.parser.BinaryCondition} and, since
+ * #6036, {@link com.arcadedb.query.sql.parser.BetweenCondition}), but the equally common
+ * {@code field.toLowerCase() IN [...]} shape fell through to a full bucket scan because
+ * {@link com.arcadedb.query.sql.parser.InCondition#isIndexAware} had no equivalent branch.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6037InToLowerCaseCiIndexTest {
+  private static final String DB_PATH = "target/databases/Issue6037InToLowerCaseCiIndexTest";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  private String plan(final String query, final Object... params) {
+    return database.query("sql", query, params).getExecutionPlan().get().prettyPrint(0, 3);
+  }
+
+  @Test
+  void inOnLowerCaseWrappedCiIndexedColumnUsesTheIndex() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      database.command("sql", "CREATE INDEX ON Product (name COLLATE CI) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = 'Apple'");
+      database.command("sql", "INSERT INTO Product SET name = 'BANANA'");
+      database.command("sql", "INSERT INTO Product SET name = 'cherry'");
+      database.command("sql", "INSERT INTO Product SET name = 'Watermelon'");
+    });
+
+    database.transaction(() -> {
+      final String planString = plan("EXPLAIN SELECT name FROM Product WHERE name.toLowerCase() IN ['apple', 'banana']");
+      assertThat(planString).contains("FETCH FROM INDEX");
+      assertThat(planString).doesNotContain("SCAN WITH FILTER");
+
+      final List<String> names = new ArrayList<>();
+      final ResultSet rs = database.query("sql", "SELECT name FROM Product WHERE name.toLowerCase() IN ['apple', 'banana']");
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+
+      assertThat(names).containsExactlyInAnyOrder("Apple", "BANANA");
+    });
+  }
+
+  @Test
+  void inOnLowerCaseWrappedCiIndexedColumnMatchesNonIndexedEquivalent() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      database.command("sql", "CREATE PROPERTY Product.code STRING"); // not indexed, used as the control
+
+      database.command("sql", "CREATE INDEX ON Product (name COLLATE CI) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = 'Apple', code = 'Apple'");
+      database.command("sql", "INSERT INTO Product SET name = 'BANANA', code = 'BANANA'");
+      database.command("sql", "INSERT INTO Product SET name = 'cherry', code = 'cherry'");
+      database.command("sql", "INSERT INTO Product SET name = 'Watermelon', code = 'Watermelon'");
+    });
+
+    database.transaction(() -> {
+      final List<String> indexed = new ArrayList<>();
+      final ResultSet rsIndexed = database.query("sql",
+          "SELECT name FROM Product WHERE name.toLowerCase() IN ['apple', 'cherry']");
+      while (rsIndexed.hasNext())
+        indexed.add(rsIndexed.next().getProperty("name"));
+
+      final List<String> nonIndexed = new ArrayList<>();
+      final ResultSet rsNonIndexed = database.query("sql",
+          "SELECT code AS name FROM Product WHERE code.toLowerCase() IN ['apple', 'cherry']");
+      while (rsNonIndexed.hasNext())
+        nonIndexed.add(rsNonIndexed.next().getProperty("name"));
+
+      indexed.sort(String::compareTo);
+      nonIndexed.sort(String::compareTo);
+      assertThat(indexed).isEqualTo(nonIndexed);
+    });
+  }
+
+  @Test
+  void inOnLowerCaseWrappedFieldWithoutCiIndexFallsBackToScan() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      // plain index, no COLLATE CI: the CI-lowercase branch must not kick in
+      database.command("sql", "CREATE INDEX ON Product (name) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = 'Apple'");
+      database.command("sql", "INSERT INTO Product SET name = 'BANANA'");
+      database.command("sql", "INSERT INTO Product SET name = 'cherry'");
+    });
+
+    database.transaction(() -> {
+      final String planString = plan("EXPLAIN SELECT name FROM Product WHERE name.toLowerCase() IN ['apple', 'banana']");
+      assertThat(planString).contains("SCAN WITH FILTER");
+      assertThat(planString).doesNotContain("FETCH FROM INDEX");
+
+      final List<String> names = new ArrayList<>();
+      final ResultSet rs = database.query("sql", "SELECT name FROM Product WHERE name.toLowerCase() IN ['apple', 'banana']");
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+
+      assertThat(names).containsExactlyInAnyOrder("Apple", "BANANA");
+    });
+  }
+
+  @Test
+  void inOnChainedModifierAfterToLowerCaseOnCiIndexFallsBackToScan() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Product");
+      database.command("sql", "CREATE PROPERTY Product.name STRING");
+      database.command("sql", "CREATE INDEX ON Product (name COLLATE CI) NOTUNIQUE");
+
+      database.command("sql", "INSERT INTO Product SET name = ' Apple '");
+      database.command("sql", "INSERT INTO Product SET name = ' BANANA '");
+      database.command("sql", "INSERT INTO Product SET name = ' cherry '");
+    });
+
+    database.transaction(() -> {
+      // an extra modifier after toLowerCase() breaks the "field.toLowerCase()" pattern isFieldWithLowerCaseMethod()
+      // matches, so this must still fall back to a full scan rather than (incorrectly) using the CI index
+      final String planString = plan("EXPLAIN SELECT name FROM Product WHERE name.toLowerCase().trim() IN ['apple', 'banana']");
+      assertThat(planString).contains("SCAN WITH FILTER");
+      assertThat(planString).doesNotContain("FETCH FROM INDEX");
+
+      final List<String> names = new ArrayList<>();
+      final ResultSet rs = database.query("sql",
+          "SELECT name FROM Product WHERE name.toLowerCase().trim() IN ['apple', 'banana']");
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+
+      assertThat(names).containsExactlyInAnyOrder(" Apple ", " BANANA ");
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/RebuildIndexLockExhaustionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/RebuildIndexLockExhaustionTest.java
@@ -40,7 +40,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>Uses {@code maxAttempts = 1} so a single forced {@code LockTimeoutException} (held from a second thread via
  * {@link TestHelper.LockHoldingThread}, which wraps the same {@code DatabaseInternal.executeLockingFiles}
  * primitive the statement itself uses) immediately exhausts the budget - this is a pure lock-acquisition failure,
- * so the index must come out of it completely untouched.
+ * so the index must come out of it completely untouched. The hold time is 1s past the hardcoded 5s
+ * {@code tryLockFiles} timeout, as margin against scheduling jitter on a loaded CI runner (see
+ * {@code engine/CLAUDE.md} on that timeout being "a common source of intermittent failures in contention tests").
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -59,7 +61,7 @@ class RebuildIndexLockExhaustionTest extends TestHelper {
     final DatabaseInternal db = (DatabaseInternal) database;
     final List<Integer> fileIds = ((IndexInternal) db.getSchema().getIndexByName("myIdx")).getFileIds();
 
-    final LockHoldingThread holder = new LockHoldingThread(db, fileIds, 5_300);
+    final LockHoldingThread holder = new LockHoldingThread(db, fileIds, 6_000);
     holder.start();
     try {
       assertThat(holder.lockAcquired.await(5, TimeUnit.SECONDS))

--- a/engine/src/test/java/com/arcadedb/index/RebuildIndexLockExhaustionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/RebuildIndexLockExhaustionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for #6040: before this fix, {@code RebuildIndexStatement.buildIndex()} silently fell off the end
+ * of the method once its retry budget was exhausted, so a caller of {@code REBUILD INDEX} had no way to tell a
+ * failed rebuild from a successful one. It now throws, matching the fact that the statement is a synchronous DDL
+ * command that either succeeds or reports why it didn't.
+ *
+ * <p>Uses {@code maxAttempts = 1} so a single forced {@code LockTimeoutException} (held from a second thread via
+ * the same {@code DatabaseInternal.executeLockingFiles} primitive the statement itself uses) immediately exhausts
+ * the budget - this is a pure lock-acquisition failure, so the index must come out of it completely untouched.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class RebuildIndexLockExhaustionTest extends TestHelper {
+
+  @Test
+  void rebuildThrowsAndLeavesIndexUntouchedWhenLockCannotBeAcquired() throws Exception {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE INDEX myIdx ON Doc (name) NOTUNIQUE");
+      database.command("sql", "INSERT INTO Doc SET name = 'alpha'");
+    });
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final List<Integer> fileIds = ((IndexInternal) db.getSchema().getIndexByName("myIdx")).getFileIds();
+
+    final HoldingThread holder = new HoldingThread(db, fileIds, 5_300);
+    holder.start();
+    try {
+      assertThat(holder.lockAcquired.await(5, TimeUnit.SECONDS))
+          .as("background thread must acquire the lock before REBUILD INDEX runs").isTrue();
+
+      // executeDDL wraps every failure (pre-existing behavior, unrelated to #6040) into an IndexException; the
+      // CommandExecutionException this fix raises on exhaustion survives as its cause and its message.
+      assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX myIdx WITH maxAttempts = 1"))
+          .isInstanceOf(IndexException.class)
+          .hasMessageContaining("Cannot rebuild index 'myIdx'")
+          .hasMessageContaining("the index lock could not be acquired")
+          .hasMessageContaining("The index itself is unchanged")
+          .cause().isInstanceOf(CommandExecutionException.class);
+    } finally {
+      holder.join(15_000);
+    }
+    assertThat(holder.isAlive()).isFalse();
+    assertThat(holder.error.get()).isNull();
+
+    database.transaction(() -> {
+      assertThat(database.getSchema().existsIndex("myIdx")).isTrue();
+      final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE name = 'alpha'");
+      assertThat(rs.hasNext()).isTrue();
+    });
+  }
+
+  /**
+   * Holds {@code fileIds} locked for {@code holdMillis} via the same {@code executeLockingFiles} primitive
+   * {@code RebuildIndexStatement} uses, on a requester (this thread) distinct from the test's main thread.
+   */
+  private static final class HoldingThread extends Thread {
+    private final DatabaseInternal            db;
+    private final List<Integer>               fileIds;
+    private final long                        holdMillis;
+    final          CountDownLatch             lockAcquired = new CountDownLatch(1);
+    final          AtomicReference<Throwable> error        = new AtomicReference<>();
+
+    HoldingThread(final DatabaseInternal db, final List<Integer> fileIds, final long holdMillis) {
+      super("lock-holder");
+      this.db = db;
+      this.fileIds = fileIds;
+      this.holdMillis = holdMillis;
+      setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+      try {
+        db.executeLockingFiles(fileIds, () -> {
+          lockAcquired.countDown();
+          Thread.sleep(holdMillis);
+          return null;
+        });
+      } catch (final Throwable t) {
+        error.set(t);
+        lockAcquired.countDown();
+      }
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/RebuildIndexLockExhaustionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/RebuildIndexLockExhaustionTest.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -40,8 +38,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * command that either succeeds or reports why it didn't.
  *
  * <p>Uses {@code maxAttempts = 1} so a single forced {@code LockTimeoutException} (held from a second thread via
- * the same {@code DatabaseInternal.executeLockingFiles} primitive the statement itself uses) immediately exhausts
- * the budget - this is a pure lock-acquisition failure, so the index must come out of it completely untouched.
+ * {@link TestHelper.LockHoldingThread}, which wraps the same {@code DatabaseInternal.executeLockingFiles}
+ * primitive the statement itself uses) immediately exhausts the budget - this is a pure lock-acquisition failure,
+ * so the index must come out of it completely untouched.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -60,7 +59,7 @@ class RebuildIndexLockExhaustionTest extends TestHelper {
     final DatabaseInternal db = (DatabaseInternal) database;
     final List<Integer> fileIds = ((IndexInternal) db.getSchema().getIndexByName("myIdx")).getFileIds();
 
-    final HoldingThread holder = new HoldingThread(db, fileIds, 5_300);
+    final LockHoldingThread holder = new LockHoldingThread(db, fileIds, 5_300);
     holder.start();
     try {
       assertThat(holder.lockAcquired.await(5, TimeUnit.SECONDS))
@@ -85,39 +84,5 @@ class RebuildIndexLockExhaustionTest extends TestHelper {
       final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE name = 'alpha'");
       assertThat(rs.hasNext()).isTrue();
     });
-  }
-
-  /**
-   * Holds {@code fileIds} locked for {@code holdMillis} via the same {@code executeLockingFiles} primitive
-   * {@code RebuildIndexStatement} uses, on a requester (this thread) distinct from the test's main thread.
-   */
-  private static final class HoldingThread extends Thread {
-    private final DatabaseInternal            db;
-    private final List<Integer>               fileIds;
-    private final long                        holdMillis;
-    final          CountDownLatch             lockAcquired = new CountDownLatch(1);
-    final          AtomicReference<Throwable> error        = new AtomicReference<>();
-
-    HoldingThread(final DatabaseInternal db, final List<Integer> fileIds, final long holdMillis) {
-      super("lock-holder");
-      this.db = db;
-      this.fileIds = fileIds;
-      this.holdMillis = holdMillis;
-      setDaemon(true);
-    }
-
-    @Override
-    public void run() {
-      try {
-        db.executeLockingFiles(fileIds, () -> {
-          lockAcquired.countDown();
-          Thread.sleep(holdMillis);
-          return null;
-        });
-      } catch (final Throwable t) {
-        error.set(t);
-        lockAcquired.countDown();
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary

- **#6040**: `RebuildIndexStatement.buildIndex()` and `DatabaseChecker`'s auto-fix index-rebuild loop each retry a `dropIndex()` + `create()` body as a single unit inside `executeLockingFiles`. Both charged a plain lock-acquisition failure (`tryLockFiles` times out, nothing has been touched yet) and a failure raised *after* that same attempt's `dropIndex()` already committed (the index is now gone) against the identical small attempt budget. Exhausting retries while in the second state left the index permanently missing rather than merely unrebuilt.

  Fix: both call sites now track (via a flag set inside the locked callback) whether the drop actually committed on any attempt. Once it has, a larger post-drop retry budget applies (`POST_DROP_ATTEMPT_MULTIPLIER` / `LOCK_POST_DROP_ATTEMPT_MULTIPLIER`, 4x) instead of giving up at the lock-acquisition ceiling. `RebuildIndexStatement.buildIndex()` also now **throws** `CommandExecutionException` on exhaustion instead of silently falling off the end of the method - the old behavior let a failed `REBUILD INDEX` look identical to a successful one to the caller. `DatabaseChecker`'s warning message now states explicitly which of the two cases occurred ("the index lock could not be acquired; the index itself is unchanged" vs. "the index was dropped but the rebuild could not complete; it is now missing") instead of a blanket message that was wrong for the second case. `DatabaseChecker` was also missing `.withMaxAttempts(...)` on its `buildBucketIndex()` call entirely (default 1) - `RebuildIndexStatement` already passed it through - so `DatabaseChecker` had no inner absorption of transient bucket-scan contention at all; this is now aligned between the two call sites.

  Considered (and rejected) alternatives: locking the bucket's own file for the full rebuild duration would eliminate the race at the root, but the existing narrow lock scope (index files only) is a deliberate design choice documented at the call site - it lets writers keep hitting the bucket while a rebuild runs. Widening it would trade a rare retry-exhaustion edge case for routinely blocking live traffic on every rebuild, which is a worse trade for the common case. A build-under-a-temporary-name-then-atomic-swap redesign would remove the missing-index window entirely, but no rename primitive exists in the index/schema layer today, and one sub-index temporarily duplicated per bucket during the swap has real correctness implications for UNIQUE validation and the query planner that are out of proportion to a narrow contention window that's now bounded and clearly reported either way.

- **#6041**: added lock-contention regression coverage for both retry loops (previously zero, as the issue notes). Tests hold the target index's file lock from a second thread via the same `DatabaseInternal.executeLockingFiles` primitive the production code itself uses, deterministically forcing at least one `LockTimeoutException`:
  - `DatabaseCheckerIndexRebuildLockContentionTest`: retry-then-succeed (hold just past the single 5s `tryLockFiles` timeout, then release) and retry-exhaustion (hold past the worst-case total of all 5 attempts, ~27.8s) - the latter also asserts the index comes out completely untouched, per #6040's fix.
  - `RebuildIndexLockExhaustionTest`: the new throw-on-exhaustion contract for `REBUILD INDEX`, using `maxAttempts = 1` to keep it to a single 5.3s wait.

  Both are tagged `@Tag("slow")` since they're inherently multi-second (`executeLockingFiles` waits a hardcoded 5s per attempt). Verified each test fails against the pre-fix code and passes against the fix.

- **#6037**: `InCondition.isIndexAware()` gained the same `field.toLowerCase()` CI-index recognition `BinaryCondition`/`BetweenCondition` already have (reusing the existing package-private `BinaryCondition.isFieldWithLowerCaseMethod()`), so `field.toLowerCase() IN [...]` uses a `COLLATE CI` index instead of a full scan. Audited the `Contains*Condition` family (`ContainsCondition`, `ContainsAllCondition`, `ContainsAnyCondition`, `ContainsValueCondition`) as the issue suggested: none has the same gap, because their indexed field is always a `Collection`/`Map` (BY-ITEM/BY-VALUE/BY-KEY indexes), and `.toLowerCase()` cannot syntactically apply to those - only to a scalar `String` field. No code change needed there; noted in the test class Javadoc.

## Test plan

- [x] `Issue6037InToLowerCaseCiIndexTest` (new, TDD): `field.toLowerCase() IN [...]` uses the index on a `COLLATE CI` index, matches the non-indexed equivalent, falls back to scan without CI collation, and falls back to scan when a modifier is chained after `toLowerCase()`. Verified it fails without the fix (`SCAN WITH FILTER` instead of `FETCH FROM INDEX`).
- [x] `DatabaseCheckerIndexRebuildLockContentionTest` (new): retry-then-succeed and retry-exhaustion-leaves-index-untouched, both against real lock contention. Verified the exhaustion test fails against the pre-#6040 `DatabaseChecker` (missing the new warning phrasing).
- [x] `RebuildIndexLockExhaustionTest` (new): `REBUILD INDEX ... WITH maxAttempts = 1` throws `IndexException` (wrapping the new `CommandExecutionException`) on exhaustion and leaves the index untouched/queryable. Verified it fails against the pre-#6040 `RebuildIndexStatement` (old code just returned with no exception).
- [x] Existing `Issue6033BetweenToLowerCaseCiIndexTest`, `CaseInsensitiveIndexTest`, `Issue5966BetweenUsesIndexTest`, `Issue5932IndexedRangeTypedBoundsTest` still pass.
- [x] `CheckDatabaseFixPreservesIndexMetadataTest`, `CheckDatabaseTest`, `CheckDatabaseRecordScopeTest`, `CheckDatabaseSinglePassTest`, `CheckDatabaseProgressTest`, `CheckDatabaseExtendedTest`, `RebuildIndexPreservesNameTest` still pass.
- [x] Full `engine` module test suite (`mvn test -DexcludedGroups=slow,benchmark,vector`, 11505 tests) passes except one pre-existing, unrelated flake (`Issue5326ApplyChangesPendingFlushTest`, a page-pipeline-flush test untouched by this diff - passes in isolation, confirmed not caused by this change).
- [x] Full compile of `engine` succeeds.