### PR TITLE
fix: batch fixes for #6020, #6032, #6045

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -572,3 +572,46 @@ newest-first globally. It is not an ordering guarantee - it never was, on either
 needs an exact order must sort or read through an index on a timestamp property.
 
 [#6044](https://github.com/ArcadeData/arcadedb/issues/6044)
+
+## `Type.convert()`: narrowing an array of `double`/`float`/`long` to a smaller integral array no longer silently corrupts values (#6020)
+
+The scalar narrowing path (`Byte`/`Short`/`Integer`/`Long`) already rejects `NaN` and an out-of-range value
+instead of wrapping it (#5905, #5970), but the array-narrowing branches - `double[]`/`float[]`/`long[]` source
+to `int[]`/`long[]`/`short[]` target - did a raw element-wise cast with neither check.
+`Type.convert(db, new double[]{Double.NaN}, int[].class)` returned `{0}`, and narrowing a `long[]` value like
+`3_000_000_000L` to `short[]` wrapped via plain two's-complement truncation to a wrong in-range value, both with
+no error. Every element now goes through the same `narrowToIntegral()` the scalar path uses.
+
+[#6020](https://github.com/ArcadeData/arcadedb/issues/6020)
+
+## Vector index test suite: a diagnostic timeout added for a stuck rebuild couldn't fire in the tests it was meant to help diagnose (#6032)
+
+A same-day fix bounded `startAsyncGraphRebuild()`'s semaphore acquire at
+`arcadedb.vectorIndex.rebuildPermitTimeoutMs` (default 600s) with a diagnostic `WARNING` on timeout, so a future
+stuck rebuild would be traceable instead of hanging silently. But `LSMVectorIndexRebuildTest` and
+`LSMVectorIndexRecoveryTest`'s own Awaitility ceiling was a flat 300s - half the production timeout - so their
+assertion always gave up and failed *before* the production wait could reach its own timeout and log anything.
+Reconfirmed three times (PR #5960, #5980, #6019) with no permit-timeout warning ever appearing in any of the
+failing runs. Both test ceilings are now derived from the production setting's default plus a 60s margin instead
+of a second, independently-drifting hardcoded constant.
+
+[#6032](https://github.com/ArcadeData/arcadedb/issues/6032)
+
+## Polyglot host-class deny-list: the hierarchy check now covers wildcard-only-denied ancestors too (#6045)
+
+Follow-up hardening from #6042. `HostClassLookupFilter`'s ancestor-hierarchy walk (closing GHSA-j57p-qmrh-v7xv)
+originally excluded every package-wildcard `DENIED` entry (e.g. `java.security.**`) to avoid false-positiving on
+marker interfaces that merely happen to live in a denied package, such as `java.io.Serializable`. That also let a
+*capability-bearing* ancestor reachable only through a wildcard entry slip through undetected if inherited by an
+allow-listed subclass. Auditing the JDK classpath reachable from `ScriptTriggerExecutor.ALLOWED_PACKAGES` found
+the concrete instance: `java.util.PropertyPermission` - admitted by name under `java.util.*` - extends
+`java.security.BasicPermission` extends `java.security.Permission`, both wildcard-denied by `java.security.**`
+and pinned by no precise entry.
+
+The walk now checks an ancestor against every `DENIED` entry, wildcard or precise, except a short, explicit list
+of inert marker interfaces (`Serializable`, `Cloneable`, `Comparable`, `AutoCloseable`) that grant no capability
+of their own - closing the gap without reintroducing the collateral-damage false positives the original exclusion
+guarded against. Not a known exploitable bypass in the current built-in allow-lists; a completeness fix for any
+embedder configuring a broader one via `HostClassLookupFilter`'s public constructor.
+
+[#6045](https://github.com/ArcadeData/arcadedb/issues/6045)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -596,8 +596,8 @@ stuck rebuild would be traceable instead of hanging silently. But `LSMVectorInde
 `LSMVectorIndexRecoveryTest`'s own Awaitility ceiling was a flat 300s - half the production timeout - so their
 assertion always gave up and failed *before* the production wait could reach its own timeout and log anything.
 Reconfirmed three times (PR #5960, #5980, #6019) with no permit-timeout warning ever appearing in any of the
-failing runs. Both test ceilings are now derived from the production setting's default plus a 60s margin instead
-of a second, independently-drifting hardcoded constant.
+failing runs. Both test ceilings are now derived from the production setting's own live value plus a 60s margin
+instead of a second, independently-drifting hardcoded constant.
 
 [#6032](https://github.com/ArcadeData/arcadedb/issues/6032)
 

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -573,7 +573,7 @@ needs an exact order must sort or read through an index on a timestamp property.
 
 [#6044](https://github.com/ArcadeData/arcadedb/issues/6044)
 
-## `Type.convert()`: narrowing an array of `double`/`float`/`long` to a smaller integral array no longer silently corrupts values (#6020)
+## `Type.convert()`: narrowing an array or Collection of `double`/`float`/`long` to a smaller integral array no longer silently corrupts values (#6020)
 
 The scalar narrowing path (`Byte`/`Short`/`Integer`/`Long`) already rejects `NaN` and an out-of-range value
 instead of wrapping it (#5905, #5970), but the array-narrowing branches - `double[]`/`float[]`/`long[]` source
@@ -581,6 +581,10 @@ to `int[]`/`long[]`/`short[]` target - did a raw element-wise cast with neither 
 `Type.convert(db, new double[]{Double.NaN}, int[].class)` returned `{0}`, and narrowing a `long[]` value like
 `3_000_000_000L` to `short[]` wrapped via plain two's-complement truncation to a wrong in-range value, both with
 no error. Every element now goes through the same `narrowToIntegral()` the scalar path uses.
+
+Code review on the fix caught the same bug one branch over: the sibling `Collection` (e.g. `List<Double>` - the
+shape JSON deserialization typically produces) -> `int[]`/`long[]`/`short[]` branches had the identical raw
+`.intValue()`/`.longValue()`/`.shortValue()` cast and were left out of the first pass entirely. Fixed the same way.
 
 [#6020](https://github.com/ArcadeData/arcadedb/issues/6020)
 
@@ -609,9 +613,9 @@ the concrete instance: `java.util.PropertyPermission` - admitted by name under `
 and pinned by no precise entry.
 
 The walk now checks an ancestor against every `DENIED` entry, wildcard or precise, except a short, explicit list
-of inert marker interfaces (`Serializable`, `Cloneable`, `Comparable`, `AutoCloseable`) that grant no capability
-of their own - closing the gap without reintroducing the collateral-damage false positives the original exclusion
-guarded against. Not a known exploitable bypass in the current built-in allow-lists; a completeness fix for any
-embedder configuring a broader one via `HostClassLookupFilter`'s public constructor.
+of inert marker interfaces (`Serializable`, `Closeable`, `Cloneable`, `Comparable`, `AutoCloseable`) that grant no
+capability of their own - closing the gap without reintroducing the collateral-damage false positives the original
+exclusion guarded against. Not a known exploitable bypass in the current built-in allow-lists; a completeness fix
+for any embedder configuring a broader one via `HostClassLookupFilter`'s public constructor.
 
 [#6045](https://github.com/ArcadeData/arcadedb/issues/6045)

--- a/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
@@ -141,16 +141,22 @@ public class HostClassLookupFilter implements Predicate<String> {
   };
 
   /**
-   * Ancestors the hierarchy walk in {@link #inheritsADeniedType(String)} must never reject on, even though they are
-   * only reachable through a package-wildcard {@code DENIED} entry ({@code java.io.**} / {@code java.lang.**}-shaped
-   * families). Each is a marker or structural interface: it grants no capability of its own (no I/O, no reflection,
-   * no process/thread control), it is merely ubiquitous - implemented by most collection and value classes - so
-   * checking it would rediscover the exact false-positive the original wildcard exclusion was written to avoid
-   * (issue #6045). {@code java.io.Closeable} is here alongside {@code AutoCloseable} for the same reason: it lives
-   * inside the now-fully-checked {@code java.io.**} family, extends {@code AutoCloseable}, and is exactly as inert
-   * (its one method just signals "release a resource" - it does not itself grant one). Keep this list to interfaces
-   * that are provably inert; anything with a method that could do real work (e.g. {@code java.util.EventListener})
-   * does not belong here.
+   * Ancestors the hierarchy walk in {@link #inheritsADeniedType(String)} must never reject on. Each is a marker or
+   * structural interface: it grants no capability of its own (no I/O, no reflection, no process/thread control), it
+   * is merely ubiquitous - implemented by most collection and value classes - so checking it would rediscover the
+   * exact false-positive the original wildcard exclusion was written to avoid (issue #6045).
+   * <p>
+   * {@code Serializable} and {@code Closeable} are the two that are actually reachable through a wildcard match
+   * today, both living inside the fully-checked {@code java.io.**} family - {@code Closeable} extends
+   * {@code AutoCloseable} and is exactly as inert (its one method just signals "release a resource" - it does not
+   * itself grant one). {@code Cloneable}, {@code Comparable} and {@code AutoCloseable} live in {@code java.lang},
+   * which {@link #DENIED} has no full-package wildcard for today (only precise entries naming individual
+   * {@code java.lang} classes) - so none of the three can currently be hit by a wildcard match at all. They are
+   * listed anyway, defensively: {@code DENIED} gaining a {@code java.lang.**}-shaped entry, or a caller supplying
+   * one of these three as an {@code extraDeniedPatterns} wildcard via the public constructor, would otherwise
+   * reintroduce the exact false positive this list exists to prevent. Keep this list to interfaces that are
+   * provably inert; anything with a method that could do real work (e.g. {@code java.util.EventListener}) does not
+   * belong here.
    */
   private static final Set<String> SAFE_MARKER_ANCESTORS = Set.of( //
       "java.io.Serializable",                            //

--- a/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
@@ -288,9 +288,16 @@ public class HostClassLookupFilter implements Predicate<String> {
       toVisit.add(iface);
   }
 
-  /** A package-wildcard entry ({@code pkg.*} or {@code pkg.**}), as opposed to one pinning a single named type. */
-  private static boolean isWildcardPattern(final String pattern) {
-    return pattern.endsWith("*");
+  /**
+   * A package-wildcard entry ({@code pkg.*} or {@code pkg.**}), as opposed to one pinning a single named type. A
+   * {@code Type$*} nested-type entry (e.g. {@code ProcessBuilder$*}) also ends with {@code *} but pins every
+   * nested type of one specific enclosing class, not a package - it is precise, not a wildcard (issue #6045
+   * review: without this exclusion, a future {@code Type$*} entry naming a {@link #SAFE_MARKER_ANCESTORS} type's
+   * enclosing class would be incorrectly treated as a wildcard and get the safe-marker exception it should not
+   * have). Package-private, like {@link #matches(String, String)}, so it can be unit-tested directly.
+   */
+  static boolean isWildcardPattern(final String pattern) {
+    return pattern.endsWith("*") && !pattern.endsWith("$*");
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
@@ -146,11 +146,15 @@ public class HostClassLookupFilter implements Predicate<String> {
    * families). Each is a marker or structural interface: it grants no capability of its own (no I/O, no reflection,
    * no process/thread control), it is merely ubiquitous - implemented by most collection and value classes - so
    * checking it would rediscover the exact false-positive the original wildcard exclusion was written to avoid
-   * (issue #6045). Keep this list to interfaces that are provably inert; anything with a method that could do real
-   * work (e.g. {@code java.util.EventListener}) does not belong here.
+   * (issue #6045). {@code java.io.Closeable} is here alongside {@code AutoCloseable} for the same reason: it lives
+   * inside the now-fully-checked {@code java.io.**} family, extends {@code AutoCloseable}, and is exactly as inert
+   * (its one method just signals "release a resource" - it does not itself grant one). Keep this list to interfaces
+   * that are provably inert; anything with a method that could do real work (e.g. {@code java.util.EventListener})
+   * does not belong here.
    */
   private static final Set<String> SAFE_MARKER_ANCESTORS = Set.of( //
       "java.io.Serializable",                            //
+      "java.io.Closeable",                                //
       "java.lang.Cloneable",                              //
       "java.lang.Comparable",                             //
       "java.lang.AutoCloseable"                           //

--- a/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
@@ -141,10 +141,12 @@ public class HostClassLookupFilter implements Predicate<String> {
   };
 
   /**
-   * Ancestors the hierarchy walk in {@link #inheritsADeniedType(String)} must never reject on. Each is a marker or
-   * structural interface: it grants no capability of its own (no I/O, no reflection, no process/thread control), it
-   * is merely ubiquitous - implemented by most collection and value classes - so checking it would rediscover the
-   * exact false-positive the original wildcard exclusion was written to avoid (issue #6045).
+   * Ancestors the hierarchy walk in {@link #inheritsADeniedType(String)} must never reject on through a
+   * <i>wildcard</i> {@code DENIED} match (a precise entry naming one of these directly still applies - see that
+   * method's javadoc). Each is a marker or structural interface: it grants no capability of its own (no I/O, no
+   * reflection, no process/thread control), it is merely ubiquitous - implemented by most collection and value
+   * classes - so checking it against a wildcard would rediscover the exact false-positive the original wildcard
+   * exclusion was written to avoid (issue #6045).
    * <p>
    * {@code Serializable} and {@code Closeable} are the two that are actually reachable through a wildcard match
    * today, both living inside the fully-checked {@code java.io.**} family - {@code Closeable} extends
@@ -227,9 +229,14 @@ public class HostClassLookupFilter implements Predicate<String> {
   /**
    * Resolves {@code className} through this filter's classloader and walks its superclass and interface hierarchy
    * (excluding the class itself, already checked by name), looking for an ancestor whose name matches any entry in
-   * {@link #denied} - precise or package-wildcard alike - other than one of the inert {@link #SAFE_MARKER_ANCESTORS}.
-   * An unresolvable class name (already rejected by every other host-class-lookup surface, since GraalVM cannot load
-   * it either) is not treated as inheriting anything denied.
+   * {@link #denied} - precise or package-wildcard alike. A {@link #SAFE_MARKER_ANCESTORS} ancestor only defeats a
+   * <i>wildcard</i> match: it exists to stop a package-wildcard entry from catching a marker interface that merely
+   * happens to live in that package, not to make the ancestor immune to an entry that names it directly. If a
+   * {@code DENIED} entry (built-in or caller-supplied via {@code extraDeniedPatterns}) ever pins one of these five
+   * interfaces precisely - a deliberate choice by whoever configured it - that precise entry still wins.
+   * <p>
+   * An unresolvable class name (already rejected by every other host-class-lookup surface, since GraalVM cannot
+   * load it either) is not treated as inheriting anything denied.
    * <p>
    * This relies on GraalVM resolving {@code Java.type(...)} through the same classloader used here: neither
    * {@code GraalPolyglotEngine} nor its {@code Context.Builder} ever calls {@code hostClassLoader(...)}, so the
@@ -257,10 +264,16 @@ public class HostClassLookupFilter implements Predicate<String> {
         continue;
 
       final String ancestorName = ancestor.getName();
-      if (!SAFE_MARKER_ANCESTORS.contains(ancestorName))
-        for (final String pattern : denied)
-          if (matches(ancestorName, pattern))
-            return true;
+      final boolean isSafeMarker = SAFE_MARKER_ANCESTORS.contains(ancestorName);
+      for (final String pattern : denied) {
+        if (!matches(ancestorName, pattern))
+          continue;
+        if (isSafeMarker && isWildcardPattern(pattern))
+          // The safe-marker exception only ever defeats a wildcard match - a precise entry naming this ancestor
+          // directly was a deliberate choice and still applies.
+          continue;
+        return true;
+      }
 
       addAncestors(toVisit, ancestor);
     }
@@ -273,6 +286,11 @@ public class HostClassLookupFilter implements Predicate<String> {
       toVisit.add(superclass);
     for (final Class<?> iface : type.getInterfaces())
       toVisit.add(iface);
+  }
+
+  /** A package-wildcard entry ({@code pkg.*} or {@code pkg.**}), as opposed to one pinning a single named type. */
+  private static boolean isWildcardPattern(final String pattern) {
+    return pattern.endsWith("*");
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/polyglot/HostClassLookupFilter.java
@@ -21,12 +21,10 @@ package com.arcadedb.query.polyglot;
 import com.arcadedb.utility.LRUCache;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -59,12 +57,18 @@ import java.util.function.Predicate;
  * {@code java.util.ListResourceBundle} both extend the denied {@code java.util.ResourceBundle} and inherit its
  * classpath-reading {@code getBundle(String)} factory, yet neither name matches the {@code "java.util.ResourceBundle"}
  * pattern (GHSA-j57p-qmrh-v7xv). To close that gap, a class admitted by name is additionally checked by walking its
- * resolved superclass and interface hierarchy: if any ancestor's name matches a <i>precise</i> deny entry - one that
- * pins a single type, i.e. a bare class name or a {@code Type$*} nested-type pattern - the class is rejected too. A
- * package-wildcard entry ({@code pkg.*} or {@code pkg.**}) is deliberately excluded from this walk: it already
- * matches every class in that namespace by name regardless of hierarchy, and applying it during the walk would also
- * catch unrelated marker interfaces that merely happen to live in a denied package (e.g. {@code java.io.Serializable},
- * implemented by most collection classes) and reject classes that were never meant to be denied.
+ * resolved superclass and interface hierarchy: if any ancestor's name matches <b>any</b> {@code DENIED} entry -
+ * precise or package-wildcard alike - the class is rejected too.
+ * <p>
+ * A first version of this walk excluded package-wildcard entries entirely, on the reasoning that a wildcard like
+ * {@code java.io.**} already matches every class in that namespace by name, so applying it during the walk would
+ * only add false positives - chiefly the handful of marker interfaces that happen to live in a denied package (e.g.
+ * {@code java.io.Serializable}, implemented by most collection classes) but grant no capability of their own. That
+ * reasoning has a hole: a class admitted by name that extends/implements a <i>capability-bearing</i> ancestor which
+ * is reachable only through a wildcard entry - not also pinned by a precise one - would slip through undetected
+ * (issue #6045). Excluding wildcards wholesale threw out the capability-bearing case to avoid the marker-interface
+ * case. Instead, {@link #SAFE_MARKER_ANCESTORS} names the specific handful of capability-free ancestors the walk
+ * must not reject on, and every other ancestor - wildcard-denied or precisely-denied - is checked.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -137,6 +141,22 @@ public class HostClassLookupFilter implements Predicate<String> {
   };
 
   /**
+   * Ancestors the hierarchy walk in {@link #inheritsADeniedType(String)} must never reject on, even though they are
+   * only reachable through a package-wildcard {@code DENIED} entry ({@code java.io.**} / {@code java.lang.**}-shaped
+   * families). Each is a marker or structural interface: it grants no capability of its own (no I/O, no reflection,
+   * no process/thread control), it is merely ubiquitous - implemented by most collection and value classes - so
+   * checking it would rediscover the exact false-positive the original wildcard exclusion was written to avoid
+   * (issue #6045). Keep this list to interfaces that are provably inert; anything with a method that could do real
+   * work (e.g. {@code java.util.EventListener}) does not belong here.
+   */
+  private static final Set<String> SAFE_MARKER_ANCESTORS = Set.of( //
+      "java.io.Serializable",                            //
+      "java.lang.Cloneable",                              //
+      "java.lang.Comparable",                             //
+      "java.lang.AutoCloseable"                           //
+  );
+
+  /**
    * Bound on {@link #hierarchyDenialCache}. A {@code HostClassLookupFilter} instance is not short-lived - one is
    * cached for the lifetime of a reusable {@code PolyglotQueryEngine}/{@code GraalPolyglotEngine} - so an
    * unbounded cache keyed by attacker-suppliable class-name strings (including names that fail to resolve, which
@@ -146,9 +166,7 @@ public class HostClassLookupFilter implements Predicate<String> {
 
   private final String[] allowed;
   private final String[] denied;
-  /** Subset of {@link #denied} that pins a single type (bare class name or {@code Type$*}), used for the hierarchy walk. */
-  private final String[] preciseDenied;
-  /** Per-instance, size-bounded cache of {@link #inheritsAPreciselyDeniedType(String)}, keyed by class name. */
+  /** Per-instance, size-bounded cache of {@link #inheritsADeniedType(String)}, keyed by class name. */
   private final Map<String, Boolean> hierarchyDenialCache = Collections.synchronizedMap(new LRUCache<>(HIERARCHY_CACHE_SIZE));
 
   public HostClassLookupFilter(final Collection<String> allowedPatterns, final Collection<String> extraDeniedPatterns) {
@@ -165,12 +183,6 @@ public class HostClassLookupFilter implements Predicate<String> {
       for (final String pattern : extraDeniedPatterns)
         this.denied[i++] = pattern;
     }
-
-    final List<String> precise = new ArrayList<>();
-    for (final String pattern : this.denied)
-      if (isPreciseTypePattern(pattern))
-        precise.add(pattern);
-    this.preciseDenied = precise.toArray(new String[precise.size()]);
   }
 
   @Override
@@ -193,36 +205,28 @@ public class HostClassLookupFilter implements Predicate<String> {
       return false;
 
     // The class is admitted by name, but it may still inherit a capability from a denied ancestor it does not share
-    // a name with (GHSA-j57p-qmrh-v7xv).
+    // a name with (GHSA-j57p-qmrh-v7xv, and the wildcard-ancestor completeness fix from issue #6045).
     Boolean deniedByHierarchy = hierarchyDenialCache.get(className);
     if (deniedByHierarchy == null) {
-      deniedByHierarchy = inheritsAPreciselyDeniedType(className);
+      deniedByHierarchy = inheritsADeniedType(className);
       hierarchyDenialCache.put(className, deniedByHierarchy);
     }
     return !deniedByHierarchy;
   }
 
   /**
-   * A pattern that pins a single named type: a bare class name (no trailing wildcard) or a {@code Type$*} nested-type
-   * entry. Package wildcards ({@code pkg.*}, {@code pkg.**}) are excluded because they already match every class in
-   * that namespace by name, independently of type hierarchy.
-   */
-  private static boolean isPreciseTypePattern(final String pattern) {
-    return !pattern.endsWith("*") || pattern.endsWith("$*");
-  }
-
-  /**
    * Resolves {@code className} through this filter's classloader and walks its superclass and interface hierarchy
-   * (excluding the class itself, already checked by name), looking for an ancestor whose name matches one of
-   * {@link #preciseDenied}. An unresolvable class name (already rejected by every other host-class-lookup surface,
-   * since GraalVM cannot load it either) is not treated as inheriting anything denied.
+   * (excluding the class itself, already checked by name), looking for an ancestor whose name matches any entry in
+   * {@link #denied} - precise or package-wildcard alike - other than one of the inert {@link #SAFE_MARKER_ANCESTORS}.
+   * An unresolvable class name (already rejected by every other host-class-lookup surface, since GraalVM cannot load
+   * it either) is not treated as inheriting anything denied.
    * <p>
    * This relies on GraalVM resolving {@code Java.type(...)} through the same classloader used here: neither
    * {@code GraalPolyglotEngine} nor its {@code Context.Builder} ever calls {@code hostClassLoader(...)}, so the
    * engine falls back to the embedding application's classloader, matching what is used below. If that ever
    * changes, an unresolvable name would need to fail closed instead of being treated as non-denied.
    */
-  private boolean inheritsAPreciselyDeniedType(final String className) {
+  private boolean inheritsADeniedType(final String className) {
     final Class<?> resolved;
     try {
       resolved = Class.forName(className, false, HostClassLookupFilter.class.getClassLoader());
@@ -243,9 +247,10 @@ public class HostClassLookupFilter implements Predicate<String> {
         continue;
 
       final String ancestorName = ancestor.getName();
-      for (final String pattern : preciseDenied)
-        if (matches(ancestorName, pattern))
-          return true;
+      if (!SAFE_MARKER_ANCESTORS.contains(ancestorName))
+        for (final String pattern : denied)
+          if (matches(ancestorName, pattern))
+            return true;
 
       addAncestors(toVisit, ancestor);
     }

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -450,7 +450,7 @@ public enum Type {
         final int[] array = new int[collection.size()];
         int i = 0;
         for (final Object item : collection)
-          array[i++] = ((Number) item).intValue();
+          array[i++] = narrowToIntegral((Number) item, Integer.MIN_VALUE, Integer.MAX_VALUE, "INTEGER", property).intValue();
         return array;
       } else if (targetClass.equals(int[].class) && value instanceof long[] src) {
         final int[] array = new int[src.length];
@@ -468,11 +468,12 @@ public enum Type {
           array[i] = narrowToIntegral(src[i], Integer.MIN_VALUE, Integer.MAX_VALUE, "INTEGER", property).intValue();
         return array;
       } else if (targetClass.equals(long[].class) && value instanceof Collection<?> collection) {
-        // Convert Collection to long[]
+        // Convert Collection to long[]. LONG is the widest integral type, so only the NaN guard applies (no
+        // narrower range to check - see narrowToIntegral()).
         final long[] array = new long[collection.size()];
         int i = 0;
         for (final Object item : collection)
-          array[i++] = ((Number) item).longValue();
+          array[i++] = narrowToIntegral((Number) item, Long.MIN_VALUE, Long.MAX_VALUE, "LONG", property).longValue();
         return array;
       } else if (targetClass.equals(long[].class) && value instanceof double[] src) {
         // LONG is the widest integral type, so only the NaN guard applies (no narrower range to check - see narrowToIntegral()).
@@ -490,7 +491,7 @@ public enum Type {
         final short[] array = new short[collection.size()];
         int i = 0;
         for (final Object item : collection)
-          array[i++] = ((Number) item).shortValue();
+          array[i++] = narrowToIntegral((Number) item, Short.MIN_VALUE, Short.MAX_VALUE, "SHORT", property).shortValue();
         return array;
       } else if (targetClass.equals(short[].class) && value instanceof long[] src) {
         final short[] array = new short[src.length];

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -455,17 +455,17 @@ public enum Type {
       } else if (targetClass.equals(int[].class) && value instanceof long[] src) {
         final int[] array = new int[src.length];
         for (int i = 0; i < src.length; i++)
-          array[i] = (int) src[i];
+          array[i] = narrowToIntegral(src[i], Integer.MIN_VALUE, Integer.MAX_VALUE, "INTEGER", property).intValue();
         return array;
       } else if (targetClass.equals(int[].class) && value instanceof double[] src) {
         final int[] array = new int[src.length];
         for (int i = 0; i < src.length; i++)
-          array[i] = (int) src[i];
+          array[i] = narrowToIntegral(src[i], Integer.MIN_VALUE, Integer.MAX_VALUE, "INTEGER", property).intValue();
         return array;
       } else if (targetClass.equals(int[].class) && value instanceof float[] src) {
         final int[] array = new int[src.length];
         for (int i = 0; i < src.length; i++)
-          array[i] = (int) src[i];
+          array[i] = narrowToIntegral(src[i], Integer.MIN_VALUE, Integer.MAX_VALUE, "INTEGER", property).intValue();
         return array;
       } else if (targetClass.equals(long[].class) && value instanceof Collection<?> collection) {
         // Convert Collection to long[]
@@ -475,14 +475,15 @@ public enum Type {
           array[i++] = ((Number) item).longValue();
         return array;
       } else if (targetClass.equals(long[].class) && value instanceof double[] src) {
+        // LONG is the widest integral type, so only the NaN guard applies (no narrower range to check - see narrowToIntegral()).
         final long[] array = new long[src.length];
         for (int i = 0; i < src.length; i++)
-          array[i] = (long) src[i];
+          array[i] = narrowToIntegral(src[i], Long.MIN_VALUE, Long.MAX_VALUE, "LONG", property).longValue();
         return array;
       } else if (targetClass.equals(long[].class) && value instanceof float[] src) {
         final long[] array = new long[src.length];
         for (int i = 0; i < src.length; i++)
-          array[i] = (long) src[i];
+          array[i] = narrowToIntegral(src[i], Long.MIN_VALUE, Long.MAX_VALUE, "LONG", property).longValue();
         return array;
       } else if (targetClass.equals(short[].class) && value instanceof Collection<?> collection) {
         // Convert Collection to short[]
@@ -494,17 +495,17 @@ public enum Type {
       } else if (targetClass.equals(short[].class) && value instanceof long[] src) {
         final short[] array = new short[src.length];
         for (int i = 0; i < src.length; i++)
-          array[i] = (short) src[i];
+          array[i] = narrowToIntegral(src[i], Short.MIN_VALUE, Short.MAX_VALUE, "SHORT", property).shortValue();
         return array;
       } else if (targetClass.equals(short[].class) && value instanceof double[] src) {
         final short[] array = new short[src.length];
         for (int i = 0; i < src.length; i++)
-          array[i] = (short) src[i];
+          array[i] = narrowToIntegral(src[i], Short.MIN_VALUE, Short.MAX_VALUE, "SHORT", property).shortValue();
         return array;
       } else if (targetClass.equals(short[].class) && value instanceof float[] src) {
         final short[] array = new short[src.length];
         for (int i = 0; i < src.length; i++)
-          array[i] = (short) src[i];
+          array[i] = narrowToIntegral(src[i], Short.MIN_VALUE, Short.MAX_VALUE, "SHORT", property).shortValue();
         return array;
       } else if (targetClass.isEnum()) {
         if (value instanceof Number number)

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -84,8 +84,19 @@ class LSMVectorIndexRebuildTest extends TestHelper {
    * case. {@code REBUILD_SEMAPHORE} (JVM-wide, one permit) is shared by every vector index in the whole Surefire
    * fork, so a slow rebuild left over from an unrelated, already-finished test class can still be holding the
    * permit when this class's own tests start.
+   * <p>
+   * Raised again, from a flat 300s to {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}'s default (600s) plus a 60s
+   * margin (issue #6032): a same-day fix (commit {@code e1aa64203}) bounded {@code startAsyncGraphRebuild()}'s
+   * semaphore acquire at 600s with a diagnostic WARNING on timeout, specifically so a stuck rebuild would be
+   * diagnosable in a future recurrence. But this class's own 300s ceiling - half the production timeout - meant
+   * the Awaitility assertion always gave up and failed 300s *before* the production wait could even reach its own
+   * timeout and log anything, so the fix's diagnostic benefit could never fire for exactly the tests it was meant
+   * to help diagnose (confirmed 3 times: PR #5960, #5980, #6019 - no permit-timeout WARNING ever appeared in any
+   * of those failing runs). Deriving the bound from the production config instead of a second hardcoded constant
+   * also means the two can never silently drift apart again the way the flat 300s did.
    */
-  private static final Duration REBUILD_SETTLE_TIMEOUT = Duration.ofSeconds(300);
+  private static final Duration REBUILD_SETTLE_TIMEOUT =
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);
 
   // Issue #3147: REBUILD INDEX preserves vector metadata (dimensions, similarity, maxConnections, beamWidth, idPropertyName) instead of recreating with dimensions=0.
   @Test

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -97,6 +97,10 @@ class LSMVectorIndexRebuildTest extends TestHelper {
    * never silently drift apart again the way the flat 300s did - and stays honest about what the production wait
    * will actually do even in the (currently hypothetical) case where something else in this JVM changes the
    * setting before this field initializes.
+   * <p>
+   * Invariant this relies on: nothing in this class may change {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}
+   * before this static field is initialized (i.e. before the class's first test runs) - a future test added here
+   * that does so in a static initializer would silently change this ceiling too.
    */
   private static final Duration REBUILD_SETTLE_TIMEOUT =
       Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -98,9 +98,13 @@ class LSMVectorIndexRebuildTest extends TestHelper {
    * will actually do even in the (currently hypothetical) case where something else in this JVM changes the
    * setting before this field initializes.
    * <p>
-   * Invariant this relies on: nothing in this class may change {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}
-   * before this static field is initialized (i.e. before the class's first test runs) - a future test added here
-   * that does so in a static initializer would silently change this ceiling too.
+   * Invariant this relies on: nothing may change {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS} before this static
+   * field is initialized (i.e. before this class's first test runs). The setting is {@code SCOPE.JVM}, so this is
+   * not only about this class's own tests - any other test class in the same Surefire fork that changes it and
+   * does not reset it before this class loads could also shrink this ceiling. Not currently violated by anything
+   * in this class (or observed from another class in this codebase), but a future test added anywhere that sets
+   * this value in a static initializer, or a {@code @BeforeAll} that runs before this class loads, would silently
+   * change it too.
    */
   private static final Duration REBUILD_SETTLE_TIMEOUT =
       Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -107,7 +107,7 @@ class LSMVectorIndexRebuildTest extends TestHelper {
    * change it too.
    */
   private static final Duration REBUILD_SETTLE_TIMEOUT =
-      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsLong() + 60_000L);
 
   // Issue #3147: REBUILD INDEX preserves vector metadata (dimensions, similarity, maxConnections, beamWidth, idPropertyName) instead of recreating with dimensions=0.
   @Test

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -85,15 +85,18 @@ class LSMVectorIndexRebuildTest extends TestHelper {
    * fork, so a slow rebuild left over from an unrelated, already-finished test class can still be holding the
    * permit when this class's own tests start.
    * <p>
-   * Raised again, from a flat 300s to {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}'s default (600s) plus a 60s
-   * margin (issue #6032): a same-day fix (commit {@code e1aa64203}) bounded {@code startAsyncGraphRebuild()}'s
-   * semaphore acquire at 600s with a diagnostic WARNING on timeout, specifically so a stuck rebuild would be
-   * diagnosable in a future recurrence. But this class's own 300s ceiling - half the production timeout - meant
-   * the Awaitility assertion always gave up and failed 300s *before* the production wait could even reach its own
-   * timeout and log anything, so the fix's diagnostic benefit could never fire for exactly the tests it was meant
-   * to help diagnose (confirmed 3 times: PR #5960, #5980, #6019 - no permit-timeout WARNING ever appeared in any
-   * of those failing runs). Deriving the bound from the production config instead of a second hardcoded constant
-   * also means the two can never silently drift apart again the way the flat 300s did.
+   * Raised again, from a flat 300s to {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}'s effective value (600s
+   * unless something in this JVM overrode it) plus a 60s margin (issue #6032): a same-day fix (commit
+   * {@code e1aa64203}) bounded {@code startAsyncGraphRebuild()}'s semaphore acquire at 600s with a diagnostic
+   * WARNING on timeout, specifically so a stuck rebuild would be diagnosable in a future recurrence. But this
+   * class's own 300s ceiling - half the production timeout - meant the Awaitility assertion always gave up and
+   * failed 300s *before* the production wait could even reach its own timeout and log anything, so the fix's
+   * diagnostic benefit could never fire for exactly the tests it was meant to help diagnose (confirmed 3 times:
+   * PR #5960, #5980, #6019 - no permit-timeout WARNING ever appeared in any of those failing runs). Deriving the
+   * bound from the production config's own live value, instead of a second hardcoded constant, means the two can
+   * never silently drift apart again the way the flat 300s did - and stays honest about what the production wait
+   * will actually do even in the (currently hypothetical) case where something else in this JVM changes the
+   * setting before this field initializes.
    */
   private static final Duration REBUILD_SETTLE_TIMEOUT =
       Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
@@ -72,7 +72,8 @@ class LSMVectorIndexRecoveryTest extends TestHelper {
    * it) plus a 60s margin, rather than a second hardcoded 300s constant (issue #6032) - see the matching note on
    * {@code LSMVectorIndexRebuildTest.REBUILD_SETTLE_TIMEOUT} for why a ceiling below the production permit
    * timeout defeats that timeout's own diagnostic WARNING, and why reading the live config value instead of a
-   * copied-in default is the more honest derivation.
+   * copied-in default is the more honest derivation. Same invariant applies here: nothing in this class may
+   * change {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS} before this static field is initialized.
    */
   private static final Duration DELTA_BUFFER_DRAIN_TIMEOUT =
       Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
@@ -68,10 +68,11 @@ class LSMVectorIndexRecoveryTest extends TestHelper {
 
   /**
    * Ceiling for {@link #awaitEmptyDeltaBuffer(LSMVectorIndex)}. Derived from
-   * {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}'s default (600s) plus a 60s margin rather than a second
-   * hardcoded 300s constant (issue #6032) - see the matching note on
+   * {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}'s effective value (600s unless something in this JVM overrode
+   * it) plus a 60s margin, rather than a second hardcoded 300s constant (issue #6032) - see the matching note on
    * {@code LSMVectorIndexRebuildTest.REBUILD_SETTLE_TIMEOUT} for why a ceiling below the production permit
-   * timeout defeats that timeout's own diagnostic WARNING.
+   * timeout defeats that timeout's own diagnostic WARNING, and why reading the live config value instead of a
+   * copied-in default is the more honest derivation.
    */
   private static final Duration DELTA_BUFFER_DRAIN_TIMEOUT =
       Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
@@ -66,6 +66,16 @@ class LSMVectorIndexRecoveryTest extends TestHelper {
 
   private static final int EMBEDDING_DIM = 32;
 
+  /**
+   * Ceiling for {@link #awaitEmptyDeltaBuffer(LSMVectorIndex)}. Derived from
+   * {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}'s default (600s) plus a 60s margin rather than a second
+   * hardcoded 300s constant (issue #6032) - see the matching note on
+   * {@code LSMVectorIndexRebuildTest.REBUILD_SETTLE_TIMEOUT} for why a ceiling below the production permit
+   * timeout defeats that timeout's own diagnostic WARNING.
+   */
+  private static final Duration DELTA_BUFFER_DRAIN_TIMEOUT =
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);
+
   // Issue #3715: vectorNeighbors must not NPE when the HNSW graph still references ordinals of deleted vectors.
   @Test
   void vectorSearchAfterDeleteShouldNotThrowNPE() {
@@ -1703,7 +1713,7 @@ class LSMVectorIndexRecoveryTest extends TestHelper {
    */
   private void awaitEmptyDeltaBuffer(final LSMVectorIndex index) {
     Awaitility.await("the inactivity rebuild drains the delta buffer")
-        .atMost(Duration.ofSeconds(300))
+        .atMost(DELTA_BUFFER_DRAIN_TIMEOUT)
         .pollInterval(Duration.ofMillis(200))
         .untilAsserted(() -> assertThat(index.getStats().get("deltaVectorsCount"))
             .as("Delta buffer should be empty after inactivity rebuild")

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
@@ -71,9 +71,10 @@ class LSMVectorIndexRecoveryTest extends TestHelper {
    * {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS}'s effective value (600s unless something in this JVM overrode
    * it) plus a 60s margin, rather than a second hardcoded 300s constant (issue #6032) - see the matching note on
    * {@code LSMVectorIndexRebuildTest.REBUILD_SETTLE_TIMEOUT} for why a ceiling below the production permit
-   * timeout defeats that timeout's own diagnostic WARNING, and why reading the live config value instead of a
-   * copied-in default is the more honest derivation. Same invariant applies here: nothing in this class may
-   * change {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS} before this static field is initialized.
+   * timeout defeats that timeout's own diagnostic WARNING, why reading the live config value instead of a
+   * copied-in default is the more honest derivation, and why the {@code SCOPE.JVM} invariant this relies on -
+   * nothing changing {@code VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS} before this field initializes - is not scoped
+   * to just this class's own tests.
    */
   private static final Duration DELTA_BUFFER_DRAIN_TIMEOUT =
       Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRecoveryTest.java
@@ -77,7 +77,7 @@ class LSMVectorIndexRecoveryTest extends TestHelper {
    * to just this class's own tests.
    */
   private static final Duration DELTA_BUFFER_DRAIN_TIMEOUT =
-      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsInteger() + 60_000);
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsLong() + 60_000L);
 
   // Issue #3715: vectorNeighbors must not NPE when the HNSW graph still references ordinals of deleted vectors.
   @Test

--- a/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
@@ -172,6 +172,27 @@ class HostClassLookupFilterTest {
     assertThat(filter.test("java.time.LocalDate")).isTrue();
   }
 
+  /** Marker type used only by {@link #hierarchyCheckDoesNotFalsePositiveOnCloseable()}. */
+  private static final class ResourceHandle implements java.io.Closeable {
+    @Override
+    public void close() {
+      // Nothing to release - this type exists only to be resolved through Class.forName() by the test below.
+    }
+  }
+
+  /**
+   * {@code java.io.Closeable} lives inside the now-fully-checked {@code java.io.**} wildcard family (issue #6045
+   * code review) and extends {@code AutoCloseable}, so it needs the same explicit safe-marker treatment: its one
+   * method just signals "release a resource", it does not itself grant one. Without that entry, any allow-listed
+   * class implementing it for ordinary resource-management reasons would be newly, incorrectly rejected.
+   */
+  @Test
+  void hierarchyCheckDoesNotFalsePositiveOnCloseable() {
+    final HostClassLookupFilter filter = new HostClassLookupFilter(List.of("com.arcadedb.query.polyglot.**"), null);
+
+    assertThat(filter.test(ResourceHandle.class.getName())).isTrue();
+  }
+
   /**
    * Issue #6045: a first version of the hierarchy walk excluded every package-wildcard {@code DENIED} entry (e.g.
    * {@code java.security.**}), on the reasoning that it already matches every class in that namespace by name, so

--- a/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
@@ -194,6 +194,23 @@ class HostClassLookupFilterTest {
   }
 
   /**
+   * Issue #6045 code review: {@link HostClassLookupFilter#SAFE_MARKER_ANCESTORS} must only ever defeat a
+   * <i>wildcard</i> {@code DENIED} match - it exists to stop a package wildcard from catching a marker interface
+   * that merely happens to live in that package, not to make the interface immune to deny-listing altogether. A
+   * caller who deliberately, precisely denies {@code java.io.Serializable} itself (e.g. via
+   * {@code extraDeniedPatterns}) must still have every {@code Serializable}-implementing class rejected through
+   * the hierarchy walk, exactly like any other precisely-denied ancestor.
+   */
+  @Test
+  void safeMarkerExceptionDoesNotOverrideAPreciseDenyEntryNamingIt() {
+    final HostClassLookupFilter filter = new HostClassLookupFilter(ScriptTriggerExecutor.ALLOWED_PACKAGES, List.of("java.io.Serializable"));
+
+    assertThat(filter.test("java.util.UUID")).isFalse();
+    // A class NOT implementing Serializable must be unaffected by the caller's precise deny entry.
+    assertThat(filter.test("java.util.function.Function")).isTrue();
+  }
+
+  /**
    * Issue #6045: a first version of the hierarchy walk excluded every package-wildcard {@code DENIED} entry (e.g.
    * {@code java.security.**}), on the reasoning that it already matches every class in that namespace by name, so
    * checking it during the walk would only add false positives from marker interfaces. That also let a

--- a/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
@@ -172,6 +172,23 @@ class HostClassLookupFilterTest {
     assertThat(filter.test("java.time.LocalDate")).isTrue();
   }
 
+  /**
+   * Issue #6045: a first version of the hierarchy walk excluded every package-wildcard {@code DENIED} entry (e.g.
+   * {@code java.security.**}), on the reasoning that it already matches every class in that namespace by name, so
+   * checking it during the walk would only add false positives from marker interfaces. That also let a
+   * capability-bearing wildcard-only-denied ancestor slip through undetected if reached via an allow-listed
+   * subclass. {@code java.util.PropertyPermission} - admitted by name under {@code java.util.*} - extends
+   * {@code java.security.BasicPermission} extends {@code java.security.Permission}, both wildcard-denied by
+   * {@code java.security.**} and not pinned by any precise entry, so it was the concrete instance of the audited
+   * gap in the JDK classpath reachable from {@link ScriptTriggerExecutor#ALLOWED_PACKAGES}.
+   */
+  @Test
+  void hierarchyCheckAlsoCatchesAWildcardOnlyDeniedAncestor() {
+    final HostClassLookupFilter filter = new HostClassLookupFilter(ScriptTriggerExecutor.ALLOWED_PACKAGES, null);
+
+    assertThat(filter.test("java.util.PropertyPermission")).isFalse();
+  }
+
   @Test
   void callerSuppliedRestrictionAlsoRejectsItsSubclasses() {
     // A subclass of a caller-supplied (extra) denied type must be rejected too, not just the JDK built-in deny-list.

--- a/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/polyglot/HostClassLookupFilterTest.java
@@ -56,6 +56,21 @@ class HostClassLookupFilterTest {
     assertThat(HostClassLookupFilter.matches("java.math.BigInteger", "java.math.BigDecimal")).isFalse();
   }
 
+  /**
+   * Issue #6045 code review: a {@code Type$*} nested-type entry ends with {@code *} like a package wildcard, but
+   * pins every nested type of one specific enclosing class rather than a package - it is precise, not a wildcard,
+   * and must not be classified as one (only a wildcard match can be defeated by
+   * {@link HostClassLookupFilter#SAFE_MARKER_ANCESTORS}).
+   */
+  @Test
+  void wildcardPatternExcludesNestedTypePatterns() {
+    assertThat(HostClassLookupFilter.isWildcardPattern("java.io.**")).isTrue();
+    assertThat(HostClassLookupFilter.isWildcardPattern("java.util.*")).isTrue();
+    assertThat(HostClassLookupFilter.isWildcardPattern("java.lang.ProcessBuilder$*")).isFalse();
+    assertThat(HostClassLookupFilter.isWildcardPattern("java.util.ServiceLoader$*")).isFalse();
+    assertThat(HostClassLookupFilter.isWildcardPattern("java.math.BigDecimal")).isFalse();
+  }
+
   @Test
   void dotsAreLiteralAndNotRegexWildcards() {
     // "java.util.*" as a regex matched java<any char>util<anything>; literally it must not.

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -475,6 +475,12 @@ class TypeTest extends TestHelper {
    * issue text only reproduces it via double[]/float[] - {@code (int) 3_000_000_000L} wraps to {@code -1294967296}
    * via plain two's-complement bit truncation (long->int is not saturating, unlike double->int/long) - so it is
    * covered here too.
+   * <p>
+   * A {@code Collection} source (e.g. a {@code List<Double>} - the shape JSON deserialization typically produces)
+   * has the same defect for the {@code int[]}/{@code long[]}/{@code short[]} targets, found in code review of the
+   * first pass of this fix, which only routed the primitive-array-source branches through
+   * {@code narrowToIntegral()} and left the sibling {@code Collection}-source branches on a raw
+   * {@code .intValue()}/{@code .longValue()}/{@code .shortValue()} cast.
    */
   @Test
   void convertArrayNarrowingNaNAndOverflowRejected() {
@@ -513,7 +519,21 @@ class TypeTest extends TestHelper {
     assertThatThrownBy(() -> Type.convert(database, new long[] { 40_000L }, short[].class))
         .isInstanceOf(IllegalArgumentException.class);
 
-    // AN IN-RANGE VALUE IN A MULTI-ELEMENT ARRAY MUST STILL CONVERT, EVEN WHEN A LATER ELEMENT WOULD BE REJECTED
+    // Collection -> int[]/long[]/short[]: the sibling branches next to the primitive-array ones above had the
+    // identical raw-cast gap (caught in code review of this fix's first pass)
+    assertThatThrownBy(() -> Type.convert(database, List.of(Double.NaN), int[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, List.of(3_000_000_000.0), int[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, List.of(Double.NaN), long[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, List.of(Double.NaN), short[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, List.of(3_000_000_000.0), short[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // A SINGLE BAD ELEMENT REJECTS THE WHOLE ARRAY, EVEN WHEN SURROUNDED BY OTHERWISE IN-RANGE VALUES - THERE IS NO
+    // PARTIAL/BEST-EFFORT CONVERSION THAT WOULD SILENTLY DROP OR ZERO OUT JUST THE OFFENDING ELEMENT
     assertThatThrownBy(() -> Type.convert(database, new double[] { 1.0, Double.NaN, 3.0 }, int[].class))
         .isInstanceOf(IllegalArgumentException.class);
   }

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -444,6 +444,81 @@ class TypeTest extends TestHelper {
   }
 
   @Test
+  void convertDoubleArrayToIntArray() {
+    final Object result = Type.convert(database, new double[] { 1.0, 2.0, 3.0 }, int[].class);
+    assertThat(result).isInstanceOf(int[].class);
+    assertThat((int[]) result).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void convertFloatArrayToShortArray() {
+    final Object result = Type.convert(database, new float[] { 1.0f, 2.0f, 3.0f }, short[].class);
+    assertThat(result).isInstanceOf(short[].class);
+    assertThat((short[]) result).containsExactly((short) 1, (short) 2, (short) 3);
+  }
+
+  @Test
+  void convertDoubleArrayToLongArray() {
+    final Object result = Type.convert(database, new double[] { 1.0, 2.0, 3.0 }, long[].class);
+    assertThat(result).isInstanceOf(long[].class);
+    assertThat((long[]) result).containsExactly(1L, 2L, 3L);
+  }
+
+  /**
+   * Issue #6020: the array-narrowing branches of {@code Type.convert()} (double[]/float[]/long[] source ->
+   * int[]/long[]/short[] target) did a raw element-wise cast with no NaN or range check, unlike the scalar path
+   * fixed by #5905/#5970. {@code (short) 3_000_000_000.0} silently wrapped to a wrong in-range value, and
+   * {@code (int) Double.NaN} silently became {@code 0} - both would corrupt a stored value with no error. The
+   * fix routes every element through the same {@code narrowToIntegral()} used by the scalar branches.
+   * <p>
+   * A {@code long[]} source has the identical unguarded-wrap defect for int[]/short[] targets even though the
+   * issue text only reproduces it via double[]/float[] - {@code (int) 3_000_000_000L} wraps to {@code -1294967296}
+   * via plain two's-complement bit truncation (long->int is not saturating, unlike double->int/long) - so it is
+   * covered here too.
+   */
+  @Test
+  void convertArrayNarrowingNaNAndOverflowRejected() {
+    // double[]/float[] -> int[]: NaN
+    assertThatThrownBy(() -> Type.convert(database, new double[] { Double.NaN }, int[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new float[] { Float.NaN }, int[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    // double[]/float[] -> int[]: out of range (Java's double->int narrowing saturates instead of wrapping, but
+    // a typed column must reject it, not silently clip it, to match scalar INTEGER conversion behavior)
+    assertThatThrownBy(() -> Type.convert(database, new double[] { 3_000_000_000.0 }, int[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new float[] { 3_000_000_000.0f }, int[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // double[]/float[] -> short[]: NaN and out-of-range (two-step double->int->short DOES wrap:
+    // (short) 3_000_000_000.0 == -1, a wrong in-range value with no error)
+    assertThatThrownBy(() -> Type.convert(database, new double[] { Double.NaN }, short[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new float[] { Float.NaN }, short[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new double[] { 3_000_000_000.0 }, short[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new float[] { 3_000_000_000.0f }, short[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // double[]/float[] -> long[]: NaN only (LONG is the widest integral type, no narrower range to check)
+    assertThatThrownBy(() -> Type.convert(database, new double[] { Double.NaN }, long[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new float[] { Float.NaN }, long[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // long[] -> int[]/short[]: out of range wraps via plain bit truncation, not saturation
+    assertThatThrownBy(() -> Type.convert(database, new long[] { 3_000_000_000L }, int[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Type.convert(database, new long[] { 40_000L }, short[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // AN IN-RANGE VALUE IN A MULTI-ELEMENT ARRAY MUST STILL CONVERT, EVEN WHEN A LATER ELEMENT WOULD BE REJECTED
+    assertThatThrownBy(() -> Type.convert(database, new double[] { 1.0, Double.NaN, 3.0 }, int[].class))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void convertToEnum() {
     assertThat(Type.convert(database, "STRING", Type.class)).isEqualTo(Type.STRING);
     assertThat(Type.convert(database, 0, Type.class)).isEqualTo(Type.BOOLEAN);


### PR DESCRIPTION
## Summary

- **#6020** - `Type.convert()`'s array-narrowing branches (`double[]`/`float[]`/`long[]` source to `int[]`/`long[]`/`short[]` target) did a raw element-wise cast with no NaN or overflow guard, unlike the scalar path fixed by #5905/#5970. `(short) 3_000_000_000.0` silently wrapped to a wrong in-range value and `(int) Double.NaN` silently became `0`, both with no error. Every element now routes through the same `narrowToIntegral()` used by the scalar branches. Also covers the identical unguarded-wrap defect on `long[]` sources (not explicitly reproduced in the issue text, but the same defect class - `(int) 3_000_000_000L` wraps via plain bit truncation).
- **#6032** - `LSMVectorIndexRebuildTest`/`LSMVectorIndexRecoveryTest`'s Awaitility ceiling (300s) was half of `VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS`'s default (600s), so the diagnostic `WARNING` a same-day fix added for a stuck rebuild could never fire for exactly the tests it was meant to help diagnose - confirmed on 3 separate CI runs (PR #5960, #5980, #6019) with no permit-timeout warning in any of them. Both ceilings are now derived from the production setting's default plus a margin instead of an independently-drifting hardcoded constant.
- **#6045** - Follow-up hardening from #6042. `HostClassLookupFilter`'s ancestor-hierarchy walk excluded every package-wildcard `DENIED` entry to avoid false-positiving on ubiquitous marker interfaces (e.g. `java.io.Serializable`). That also let a capability-bearing ancestor reachable *only* through a wildcard entry slip through if inherited by an allow-listed subclass. Audit found a concrete instance: `java.util.PropertyPermission` (admitted by `java.util.*`) extends into `java.security.BasicPermission`/`Permission`, wildcard-denied by `java.security.**` and pinned by no precise entry (though `Permission` itself is not capability-bearing, so this was not an exploitable bypass). The walk now checks wildcard entries too, excluding a short explicit list of inert marker interfaces (`Serializable`, `Cloneable`, `Comparable`, `AutoCloseable`) so the original false-positive concern doesn't reappear.

## Test plan

- [x] `TypeTest` - added `convertDoubleArrayToIntArray`, `convertFloatArrayToShortArray`, `convertDoubleArrayToLongArray`, `convertArrayNarrowingNaNAndOverflowRejected` (123 tests, all passing)
- [x] `LSMVectorIndexRebuildTest` + `LSMVectorIndexRecoveryTest` - 38 tests, all passing
- [x] `HostClassLookupFilterTest` - added `hierarchyCheckAlsoCatchesAWildcardOnlyDeniedAncestor` regression test for the `PropertyPermission` finding (12 tests, all passing)
- [x] Full `engine` reactor compile + `schema.**`, `query.polyglot.**`, `index.vector.**`, `schema.trigger.**` packages (738 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)