### PR TITLE
fix(#6049): document that GAV neighbor order is unrelated to OLTP order

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
+++ b/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
@@ -71,6 +71,12 @@ import java.util.logging.Level;
  * the contract - but the classic layout happened to be exact, so this is written down rather than left to be
  * inferred. The maintenance walks (removal, counting, the integrity checker, export) deliberately keep plain
  * concatenation: order means nothing to them and one cursor beats {@code stripes} of them.
+ * <p>
+ * This guarantee is specific to these OLTP read walks. A {@link com.arcadedb.graph.olap.GraphAnalyticalView}
+ * (GAV) answering the same query goes through none of it: {@code CSRBuilder} sorts every vertex's neighbors
+ * ascending by dense node ID at build time regardless of how they were consumed from the OLTP list - promoted
+ * or not - so a GAV-backed read carries no relationship to this newest-first approximation. See
+ * {@link com.arcadedb.graph.olap.GraphAnalyticalView}'s class Javadoc.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/graph/olap/CSRBuilder.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/CSRBuilder.java
@@ -52,7 +52,12 @@ import java.util.logging.Level;
  *   <li>Detects property types and extracts property values into per-bucket {@link ColumnStore}</li>
  * </ul>
  * <b>Pass 2</b> (single scan): Iterates vertices again to fill CSR neighbor arrays
- * using prefix sums computed from Pass 1 degree counts.
+ * using prefix sums computed from Pass 1 degree counts. Each vertex's out-edges are read via
+ * {@code outList.entryIterator()}, which walks a promoted (striped) super-node's stripe chains
+ * concatenated rather than in any OLTP recency order - but that walk order never reaches a query:
+ * every node's neighbor slice is unconditionally sorted ascending by dense node ID in Phase C below,
+ * then permuted again by the BFS/RCM reordering in Phase D. The consumption order only affects how
+ * warm the OLTP pages are while this scan runs, never what a reader of the finished CSR sees.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -63,6 +63,19 @@ import java.util.logging.Level;
  *   <li>Optional auto-update on transaction commit</li>
  * </ul>
  * <p>
+ * <b>Neighbor order is unrelated to OLTP order.</b> {@link #getVertices}, {@link #getNeighborView} and
+ * {@link #scanNeighbors} always return a node's neighbors sorted ascending by internal dense node ID -
+ * further permuted by a one-time cache-locality renumbering at build time ({@code CSRBuilder}'s BFS/RCM
+ * pass) - never in edge-insertion or OLTP-recency order. This holds for every vertex, promoted
+ * super-node or not: it is what lets {@link #isConnectedTo}, {@link #countEdgesBetween},
+ * {@link #getMeanEdgesPerConnectedPair} and triangle counting binary-search or merge-join the adjacency
+ * arrays instead of scanning them. A query the planner can answer from either the OLTP edge list or a
+ * ready GAV (see {@code GAVExpandAll}/{@code GAVExpandInto}) may therefore return its rows in a different
+ * order depending on which path was chosen - by design, not as an artifact of the OLTP layout underneath
+ * (classic or striped/promoted - see {@link com.arcadedb.graph.StripedEdgeList}). An application that
+ * needs a specific result order must request it explicitly (e.g. {@code ORDER BY}) rather than relying on
+ * either path's default.
+ * <p>
  * Usage:
  * <pre>
  *   // Via builder (recommended)

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6049GAVSupernodeOrderTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6049GAVSupernodeOrderTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.StripeDirectory;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.VertexInternal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #6049: a {@link GraphAnalyticalView} was reported to return a promoted super-node's neighbours in the
+ * OLTP "concatenated stripe" order (the order #6044/#6047 removed from the direct OLTP iterators), which
+ * would make the same query return two different orders depending on whether the planner routed it through
+ * the CSR path or the OLTP path.
+ * <p>
+ * That diagnosis does not match the code: {@code CSRBuilder} never preserves the order it consumes
+ * {@code entryIterator()} in. Phase C of the build (`Arrays.sort` on every node's neighbour slice) has
+ * unconditionally re-sorted every forward/backward adjacency list by dense node ID since the CSR/GAV feature
+ * was first merged (#3618, see the pre-existing {@code sortedNeighbors} test), and Phase D permutes those IDs
+ * again for cache locality. Whatever order {@code entryIterator()} produces - concatenated, interleaved, or
+ * anything else - is discarded before a single query ever reads the CSR. Rewiring {@code CSRBuilder} onto the
+ * interleaved iterator from #6047 (the issue's proposed fix) would therefore be a no-op on the CSR's output.
+ * <p>
+ * These tests pin the actual, pre-existing contract for a <b>promoted</b> vertex: the CSR neighbour order is
+ * sorted ascending by dense node ID, exactly like the non-promoted case, and is independent of the OLTP
+ * layout underneath. The real - and correctly-diagnosed - property is that GAV order is simply unrelated to
+ * OLTP order for every vertex, promoted or not; that is documented on {@link GraphAnalyticalView} rather than
+ * "fixed", since matching OLTP's approximate-recency order would break the ascending-adjacency invariant that
+ * {@code isConnectedTo}/{@code countEdgesBetween}/{@code getMeanEdgesPerConnectedPair}/triangle counting rely
+ * on for binary search.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6049GAVSupernodeOrderTest extends TestHelper {
+  private static final int STRIPES   = 16;
+  private static final int THRESHOLD = 64;
+  private static final int TOTAL     = 500;
+
+  private int savedThreshold;
+  private int savedStripes;
+
+  @BeforeEach
+  void saveConfig() {
+    savedThreshold = GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.getValueAsInteger();
+    savedStripes = GlobalConfiguration.GRAPH_SUPERNODE_STRIPES.getValueAsInteger();
+  }
+
+  @AfterEach
+  void restoreConfig() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(savedThreshold);
+    GlobalConfiguration.GRAPH_SUPERNODE_STRIPES.setValue(savedStripes);
+  }
+
+  @Test
+  void gavNeighborOrderIsSortedForAPromotedSupernode() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(THRESHOLD);
+    GlobalConfiguration.GRAPH_SUPERNODE_STRIPES.setValue(STRIPES);
+
+    createSchema();
+    final RID hubRID = createHub();
+    insertEdges(hubRID, TOTAL);
+
+    // PRECONDITION: THE HUB MUST REALLY HAVE BEEN PROMOTED, OTHERWISE THE TEST PROVES NOTHING
+    assertThat(loadInHead(hubRID)).isInstanceOf(StripeDirectory.class);
+
+    final GraphAnalyticalView gav = new GraphAnalyticalView(database);
+    gav.build(new String[] { "Hub", "Src" }, new String[] { "LINK" });
+
+    final int hubId = gav.getNodeId(hubRID);
+    final int[] neighbors = gav.getVertices(hubId, Vertex.DIRECTION.IN, "LINK");
+
+    // NOTHING LOST, NOTHING DUPLICATED
+    assertThat(neighbors).hasSize(TOTAL);
+    assertThat(new HashSet<>(boxed(neighbors))).hasSize(TOTAL);
+
+    // THE CSR NEIGHBOUR ORDER IS ASCENDING BY DENSE NODE ID - the same invariant proven for a
+    // non-promoted hub by GraphAnalyticalViewTest#sortedNeighbors, now shown to also hold across
+    // promotion. If CSRBuilder ever started forwarding entryIterator()'s (or an interleaved
+    // iterator's) order into the CSR unsorted, this assertion is what would catch it.
+    for (int i = 1; i < neighbors.length; i++)
+      assertThat(neighbors[i]).isGreaterThan(neighbors[i - 1]);
+  }
+
+  @Test
+  void gavOrderIntentionallyDivergesFromButLosesNothingRelativeToOltpOrder() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(THRESHOLD);
+    GlobalConfiguration.GRAPH_SUPERNODE_STRIPES.setValue(STRIPES);
+
+    createSchema();
+    final RID hubRID = createHub();
+    insertEdges(hubRID, TOTAL);
+    assertThat(loadInHead(hubRID)).isInstanceOf(StripeDirectory.class);
+
+    // OLTP order: approximately newest-first, per #6047's InterleavedIterator.
+    final List<RID> oltpOrder = new ArrayList<>();
+    database.transaction(() -> {
+      for (final Iterator<Vertex> it = hubRID.asVertex(true).getVertices(Vertex.DIRECTION.IN, "LINK").iterator();
+           it.hasNext(); )
+        oltpOrder.add(it.next().getIdentity());
+    });
+
+    final GraphAnalyticalView gav = new GraphAnalyticalView(database);
+    gav.build(new String[] { "Hub", "Src" }, new String[] { "LINK" });
+
+    final int hubId = gav.getNodeId(hubRID);
+    final int[] neighborIds = gav.getVertices(hubId, Vertex.DIRECTION.IN, "LINK");
+    final List<RID> gavOrder = new ArrayList<>(neighborIds.length);
+    for (final int neighborId : neighborIds)
+      gavOrder.add(gav.getRID(neighborId));
+
+    // The two orders are genuinely different orderings of the same edge set (the property the issue
+    // observed is real), but neither loses or duplicates anything relative to the other.
+    assertThat(gavOrder).hasSize(TOTAL);
+    assertThat(gavOrder).containsExactlyInAnyOrderElementsOf(oltpOrder);
+    assertThat(gavOrder).isNotEqualTo(oltpOrder);
+  }
+
+  private static List<Integer> boxed(final int[] values) {
+    final List<Integer> list = new ArrayList<>(values.length);
+    for (final int v : values)
+      list.add(v);
+    return list;
+  }
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Hub", 1);
+      database.getSchema().createVertexType("Src", 8);
+      database.getSchema().createEdgeType("LINK", 8);
+    });
+  }
+
+  private RID createHub() {
+    final MutableVertex[] holder = new MutableVertex[1];
+    database.transaction(() -> {
+      holder[0] = database.newVertex("Hub");
+      holder[0].save();
+    });
+    return holder[0].getIdentity();
+  }
+
+  /** Inserts {@code count} edges Src-&gt;Hub, one transaction each. */
+  private void insertEdges(final RID hubRID, final int count) {
+    for (int i = 0; i < count; i++) {
+      database.transaction(() -> {
+        final MutableVertex src = database.newVertex("Src");
+        src.save();
+        src.newEdge("LINK", hubRID);
+      });
+    }
+  }
+
+  private Record loadInHead(final RID hubRID) {
+    final Record[] head = new Record[1];
+    database.transaction(() -> {
+      final RID headRID = ((VertexInternal) hubRID.asVertex(true)).getInEdgesHeadChunk();
+      head[0] = database.lookupByRID(headRID, true);
+    });
+    return head[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/olap/Issue6049GAVSupernodeOrderTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/Issue6049GAVSupernodeOrderTest.java
@@ -32,9 +32,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -102,7 +103,7 @@ class Issue6049GAVSupernodeOrderTest extends TestHelper {
 
     // NOTHING LOST, NOTHING DUPLICATED
     assertThat(neighbors).hasSize(TOTAL);
-    assertThat(new HashSet<>(boxed(neighbors))).hasSize(TOTAL);
+    assertThat(Arrays.stream(neighbors).boxed().collect(Collectors.toSet())).hasSize(TOTAL);
 
     // THE CSR NEIGHBOUR ORDER IS ASCENDING BY DENSE NODE ID - the same invariant proven for a
     // non-promoted hub by GraphAnalyticalViewTest#sortedNeighbors, now shown to also hold across
@@ -144,13 +145,6 @@ class Issue6049GAVSupernodeOrderTest extends TestHelper {
     assertThat(gavOrder).hasSize(TOTAL);
     assertThat(gavOrder).containsExactlyInAnyOrderElementsOf(oltpOrder);
     assertThat(gavOrder).isNotEqualTo(oltpOrder);
-  }
-
-  private static List<Integer> boxed(final int[] values) {
-    final List<Integer> list = new ArrayList<>(values.length);
-    for (final int v : values)
-      list.add(v);
-    return list;
   }
 
   private void createSchema() {


### PR DESCRIPTION
Closes #6049

## The issue's diagnosis does not match the code

#6049 (a follow-up to #6044/#6047) reported that a `GraphAnalyticalView` returns a promoted super-node's neighbors in the OLTP "concatenated stripe" order that #6044/#6047 removed from the direct OLTP read walks (`edgeIterator`/`vertexIterator`/`ridIterator`), and proposed rewiring `CSRBuilder` onto the interleaved iterator from #6047 as the fix.

That is not what happens. `CSRBuilder` never preserves the order it consumes `outList.entryIterator()` in:

- Phase C (`Arrays.sort` on every node's forward/backward neighbor slice) unconditionally re-sorts every adjacency list ascending by dense node ID, regardless of the order it was collected in.
- Phase D (BFS/RCM reordering) permutes those dense IDs again for cache locality.

This has been true since the CSR/GAV feature was first merged (#3618) — see `git log -S` on the `Arrays.sort(fwdNeighbors, fs, fe)` line, and the pre-existing `GraphAnalyticalViewTest#sortedNeighbors` test, which already asserts sorted output for a **non-promoted** hub. So implementing the issue's proposed fix (Option 1) would be a no-op on the CSR's actual output — whatever order `entryIterator()` produces is thrown away before a query ever sees it.

## What's actually true, and why it's not a bug

The real property is broader than the issue framed it: `GraphAnalyticalView`'s neighbor order has never had any relationship to OLTP order, for **any** vertex — promoted or not, not just super-nodes. It's a deliberate design choice: the ascending-by-node-ID adjacency is what lets `isConnectedTo`, `countEdgesBetween`, `getMeanEdgesPerConnectedPair`, and triangle counting (`PartitionedTriangleOp`) binary-search or merge-join the CSR arrays instead of scanning them. Matching OLTP's approximate-recency order would break that invariant for a property GAV never claimed to begin with.

The one part of the issue that *is* real: the query planner (`GAVExpandAll`/`GAVExpandInto`, `MatchGAVFusedStep`) can transparently substitute the CSR path for a plain `MATCH`/Cypher expansion when a ready view covers it, so the same query's result order can depend on a decision the user didn't make and can't see — confirmed by tracing `GraphTraversalProviderRegistry` into the Cypher/SQL executors. That part just wasn't undocumented because of stripe concatenation; it was undocumented, period.

## What this PR does instead

Documents the actual contract at the source rather than "fixing" something that isn't broken:

- `GraphAnalyticalView`'s class Javadoc now states explicitly that neighbor order is sorted by dense node ID (further permuted for locality), unrelated to OLTP order, and that the planner may route the same query through either path.
- `CSRBuilder`'s class Javadoc explains why `entryIterator()`'s consumption order is irrelevant to the CSR's output.
- `StripedEdgeList`'s Javadoc (added by #6047) cross-references `GraphAnalyticalView` so the two guarantees don't drift apart again.
- Verified the issue's own follow-up notes on `toJSON()` and `edgeIteratorConnectedTo()`: both are accurate as filed (debug/export dump with one caller; unaffected by concatenation because a neighbor hashes to at most one stripe per generation) — no code change needed there.

## Tests

`Issue6049GAVSupernodeOrderTest` (new) pins the actual behavior against a **promoted** super-node:
1. `gavNeighborOrderIsSortedForAPromotedSupernode` — CSR neighbor order stays strictly ascending by dense node ID after promotion, with nothing lost or duplicated. This is what would fail if `CSRBuilder` were ever wired to forward an interleaved (or any non-sorted) order into the CSR.
2. `gavOrderIntentionallyDivergesFromButLosesNothingRelativeToOltpOrder` — GAV order and OLTP order are genuinely different permutations of the same edge set, confirming the divergence is real but lossless.

Ran locally, both green:
```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- Issue6049GAVSupernodeOrderTest
Tests run: 134, Failures: 0, Errors: 0, Skipped: 0 -- GraphAnalyticalViewTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 -- Issue6044StripeIterationOrderTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- GraphAnalyticalViewRegistryTest
```
Full `engine` module `test-compile`/`compile` clean.

## Test plan
- [x] New regression test proving the actual (correct) invariant, not the issue's diagnosed one
- [x] Existing GAV/olap/#6044 suites pass unchanged
- [x] Full engine compile clean
- [x] No `System.out`/`System.err` left in changed files