### PR TITLE
docs(#6044): reset() caveat on InterleavedIterator, and why the order bounds are deterministic

### DIFF
--- a/engine/src/main/java/com/arcadedb/utility/InterleavedIterator.java
+++ b/engine/src/main/java/com/arcadedb/utility/InterleavedIterator.java
@@ -98,6 +98,13 @@ public class InterleavedIterator<T> implements ResettableIterator<T> {
     return value;
   }
 
+  /**
+   * Rewinds the rotation and every source that can be rewound. A source that is a plain {@link Iterator} cannot
+   * be, so it silently keeps its position and this iterator replays only what is left of it - the same limitation
+   * {@link MultiIterator#reset()} has. Every source the engine passes here is a {@code ResettableIterator}
+   * ({@code EdgeIterator}, {@code VertexIterator}, {@code RIDIterator} and their filtering variants all extend
+   * {@code ResettableIteratorBase}), so a full replay is what actually happens on every real call site.
+   */
   @Override
   public void reset() {
     for (final Iterator<T> source : sources)

--- a/engine/src/test/java/com/arcadedb/graph/Issue6044StripeIterationOrderTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6044StripeIterationOrderTest.java
@@ -100,6 +100,13 @@ class Issue6044StripeIterationOrderTest extends TestHelper {
 
     // (b) RANK-BOUNDED ERROR: every one of the newest 50 edges lands in the first 400 entries. Concatenation
     // scatters them over the whole list (one cluster per stripe, ~degree/stripes apart), so it cannot pass.
+    //
+    // The two bounds below are DETERMINISTIC, not sampled: the fixture inserts a fixed number of vertices in a
+    // fixed order into a fresh database, so the neighbour RIDs - and therefore StripeDirectory.stripeOf's
+    // placement of every edge - are the same on every run. They are stated loosely on purpose, well clear of the
+    // measured values (worst-placed ~140, ~88 of the newest 100 in the first 200), so that a change in bucket
+    // allocation that shifts the RIDs moves the numbers without failing the test; only a real regression in the
+    // rank/position relationship can cross them. Concatenation misses by an order of magnitude (worst ~1762).
     int worstOfTheNewest = 0;
     for (int rank = 0; rank < 50; rank++)
       worstOfTheNewest = Math.max(worstOfTheNewest, positionOf.get(sources.get(TOTAL - 1 - rank)));


### PR DESCRIPTION
Carries the code-review response for #6044 that missed the merge of #6047 - that PR was merged at its first commit, so these two comment additions never landed on `main`. Comments and javadoc only: **+14 lines, 0 deletions, no code change.**

Both points came from the `claude-review` pass on #6047:

1. **`InterleavedIterator.reset()` had no caveat.** `countEntries()` documents that a plain `Iterator` source cannot be counted without draining it, but `reset()` said nothing about the symmetric limitation - a plain `Iterator` cannot be rewound either, so `reset()` silently replays only what is left of it. The reviewer flagged that as a foot-gun for a future reuse of the class. Now documented, together with the fact that every source the engine passes is a `ResettableIterator` (`EdgeIterator`, `VertexIterator`, `RIDIterator` and their filtering variants all extend `ResettableIteratorBase`), so a full replay is what actually happens on every real call site.

2. **The order bounds in `Issue6044StripeIterationOrderTest` read as statistical.** They are not: a fresh database with a fixed insertion order produces the same neighbour RIDs and therefore the same `StripeDirectory.stripeOf` placement on every run. The comment now says so, and explains why the bounds are deliberately loose relative to the measured values (worst-placed ~140 against an asserted 400) - so a change in bucket allocation that shifts the RIDs moves the numbers without failing the test, while a real regression in the rank/position relationship still crosses them.

Verified on top of current `main`: compiles, and `InterleavedIteratorTest` + `Issue6044StripeIterationOrderTest` + `SuperNodeStripingTest` pass (31 tests, 0 failures).