### PR TITLE
fix(#5924): widen unchecked numeric narrowing in OpenCypher procedures package

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3868,7 +3868,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
    *
    * @return List of pairs containing RID and similarity score
    */
-  public List<Pair<RID, Float>> findNeighborsFromVector(final float[] queryVector, final int k, final int efSearch,
+  public List<Pair<RID, Float>> findNeighborsFromVector(final float[] queryVector, int k, final int efSearch,
       final Set<RID> allowedRIDs) {
     // Track search metrics
     final long startTime = System.currentTimeMillis();
@@ -3892,6 +3892,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
       // Issue #3679: rebuild graph if needed (sync for first build or small graphs, async for large graphs)
       rebuildGraphBeforeSearch();
+
+      // Issue #5924: clamp k against the total addressable candidate count (persisted + delta) instead
+      // of trusting the caller's raw value. Several call sites below treat k as an eager allocation size
+      // - the ArrayList results buffers, and mergeWithDeltaScan's own `new PriorityQueue<>(k, ...)` - so a
+      // caller-controlled k near Integer.MAX_VALUE (reachable once an overflowing Cypher/SQL argument
+      // saturates instead of wrapping) would otherwise attempt a multi-GB allocation. A stale read of
+      // vectorIndex.size()/deltaVectors.size() here only makes the clamp slightly conservative, never
+      // unsafe, so it deliberately isn't taken under the read lock below.
+      k = Math.min(k, Math.max(vectorIndex.size(), 0) + deltaVectors.size());
 
       boolean readLockHeld = false;
       lock.readLock().lock();
@@ -4347,7 +4356,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
    *
    * @return List of pairs containing RID and approximate similarity score
    */
-  public List<Pair<RID, Float>> findNeighborsFromVectorApproximate(final float[] queryVector, final int k,
+  public List<Pair<RID, Float>> findNeighborsFromVectorApproximate(final float[] queryVector, int k,
       final Set<RID> allowedRIDs) {
     // Check if PQ is available
     if (pqVectors == null || productQuantization == null) {
@@ -4376,6 +4385,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
       // Ensure graph is available (lazy-load from disk if needed)
       ensureGraphAvailable();
+
+      // Issue #5924: see findNeighborsFromVector's matching clamp - k drives the same eager
+      // ArrayList/PriorityQueue allocation sizes below, so it needs the same bound.
+      k = Math.min(k, Math.max(vectorIndex.size(), 0) + deltaVectors.size());
 
       lock.readLock().lock();
       try {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -30,6 +30,7 @@ import com.arcadedb.graph.NeighborView;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -152,6 +153,21 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
 
     throw new IllegalArgumentException(
         getName() + "(): " + paramName + " must be a map, got " + arg.getClass().getSimpleName());
+  }
+
+  /**
+   * Narrows a config/argument {@link Number} to {@code int}, failing loudly instead of silently
+   * saturating or wrapping when the value is out of range. Use for algorithm tuning knobs (iteration
+   * counts, embedding dimensions, cluster/degree thresholds, ...) where an out-of-range value should
+   * be rejected rather than reinterpreted - unlike a result-count bound (e.g. top-k, maxDepth), there
+   * is no sensible "as many as possible" reading for these.
+   */
+  protected int extractInt(final Number value, final String paramName) {
+    try {
+      return NumberUtils.toIntExact(value);
+    } catch (final ArithmeticException e) {
+      throw new IllegalArgumentException(getName() + "(): " + paramName + " is out of range for an int: " + value);
+    }
   }
 
   /** @see GraphEngine#getAllVertices(Database, String[]) */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -166,7 +166,7 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     try {
       return NumberUtils.toIntExact(value);
     } catch (final ArithmeticException e) {
-      throw new IllegalArgumentException(getName() + "(): " + paramName + " is out of range for an int: " + value);
+      throw new IllegalArgumentException(getName() + "(): " + paramName + " is out of range for an int: " + value, e);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
@@ -26,6 +26,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -99,7 +100,7 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
     final Vertex startNode = extractVertex(args[0], "startNode");
     final Vertex endNode = extractVertex(args[1], "endNode");
     final String[] relTypes = extractRelTypes(args[2]);
-    final int maxDepth = ((Number) args[3]).intValue();
+    final int maxDepth = NumberUtils.saturateToInt((Number) args[3]);
     final Map<String, Object> options = args.length > 4 ? extractMap(args[4], "options") : null;
     final Set<String> skipRelTypes = extractSkipTypes(options, "skipRelTypes");
     final Set<String> skipVertexTypes = extractSkipTypes(options, "skipVertexTypes");

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
@@ -104,7 +104,7 @@ public class AlgoArticleRank extends AbstractAlgoProcedure {
     final double dampingFactor = config != null && config.get("dampingFactor") instanceof Number num ?
         num.doubleValue() : 0.85;
     final int maxIterations = config != null && config.get("maxIterations") instanceof Number num ?
-        num.intValue() : 20;
+        extractInt(num, "maxIterations") : 20;
     final double tolerance = config != null && config.get("tolerance") instanceof Number num ?
         num.doubleValue() : 0.0001;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBFS.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBFS.java
@@ -27,6 +27,7 @@ import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -98,7 +99,7 @@ public class AlgoBFS extends AbstractAlgoProcedure {
     final Vertex startNode     = extractVertex(args[0], "startNode");
     final String[] relTypes    = args.length > 1 ? extractRelTypes(args[1]) : null;
     final Vertex.DIRECTION dir = args.length > 2 ? parseDirection(extractString(args[2], "direction")) : Vertex.DIRECTION.BOTH;
-    final int maxDepth         = args.length > 3 ? ((Number) args[3]).intValue() : Integer.MAX_VALUE;
+    final int maxDepth         = args.length > 3 ? NumberUtils.saturateToInt((Number) args[3]) : Integer.MAX_VALUE;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClique.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClique.java
@@ -87,7 +87,7 @@ public class AlgoClique extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final int minSize       = args.length > 1 ? ((Number) args[1]).intValue() : 3;
+    final int minSize       = args.length > 1 ? extractInt((Number) args[1], "minSize") : 3;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoCommonNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoCommonNeighbors.java
@@ -84,7 +84,7 @@ public class AlgoCommonNeighbors extends AbstractAlgoProcedure {
     final Vertex sourceVertex  = extractVertex(args[0], "node");
     final String[] relTypes    = args.length > 1 ? extractRelTypes(args[1]) : null;
     final Vertex.DIRECTION dir = args.length > 2 ? parseDirection(extractString(args[2], "direction")) : Vertex.DIRECTION.BOTH;
-    final int cutoff           = args.length > 3 ? ((Number) args[3]).intValue() : 1;
+    final int cutoff           = args.length > 3 ? extractInt((Number) args[3], "cutoff") : 1;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDFS.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDFS.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,7 +91,7 @@ public class AlgoDFS extends AbstractAlgoProcedure {
     final Vertex startNode     = extractVertex(args[0], "startNode");
     final String[] relTypes    = args.length > 1 ? extractRelTypes(args[1]) : null;
     final Vertex.DIRECTION dir = args.length > 2 ? parseDirection(extractString(args[2], "direction")) : Vertex.DIRECTION.BOTH;
-    final int maxDepth         = args.length > 3 ? ((Number) args[3]).intValue() : Integer.MAX_VALUE;
+    final int maxDepth         = args.length > 3 ? NumberUtils.saturateToInt((Number) args[3]) : Integer.MAX_VALUE;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoEigenvectorCentrality.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoEigenvectorCentrality.java
@@ -80,7 +80,7 @@ public class AlgoEigenvectorCentrality extends AbstractAlgoProcedure {
 
     final String[] relTypes    = args.length > 0 ? extractRelTypes(args[0]) : null;
     final Vertex.DIRECTION dir = args.length > 1 ? parseDirection(extractString(args[1], "direction")) : Vertex.DIRECTION.BOTH;
-    final int maxIterations    = args.length > 2 ? ((Number) args[2]).intValue() : 20;
+    final int maxIterations    = args.length > 2 ? extractInt((Number) args[2], "maxIterations") : 20;
     final double tolerance     = args.length > 3 ? ((Number) args[3]).doubleValue() : 1e-6;
 
     final Database db = context.getDatabase();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoFastRP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoFastRP.java
@@ -97,8 +97,8 @@ public class AlgoFastRP extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
-    final int dimensions = config != null && config.get("dimensions") instanceof Number n ? n.intValue() : 128;
-    final int iterations = config != null && config.get("iterations") instanceof Number n ? n.intValue() : 4;
+    final int dimensions = config != null && config.get("dimensions") instanceof Number n ? extractInt(n, "dimensions") : 128;
+    final int iterations = config != null && config.get("iterations") instanceof Number n ? extractInt(n, "iterations") : 4;
     final double normStrength = config != null && config.get("normalization") instanceof Number n ? n.doubleValue() : 0.0;
     final double selfInfluence = config != null && config.get("selfInfluence") instanceof Number n ? n.doubleValue() : 0.0;
     final long seed = config != null && config.get("seed") instanceof Number n ? n.longValue() : -1L;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGraphSAGE.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGraphSAGE.java
@@ -94,8 +94,8 @@ public class AlgoGraphSAGE extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
-    final int outDim = config != null && config.get("embeddingDimension") instanceof Number n ? n.intValue() : 64;
-    final int layers = config != null && config.get("layers") instanceof Number n ? n.intValue() : 2;
+    final int outDim = config != null && config.get("embeddingDimension") instanceof Number n ? extractInt(n, "embeddingDimension") : 64;
+    final int layers = config != null && config.get("layers") instanceof Number n ? extractInt(n, "layers") : 2;
     final long seed = config != null && config.get("seed") instanceof Number n ? n.longValue() : -1L;
     final String[] relTypes = config != null ? extractRelTypes(config.get("relTypes")) : null;
     final Vertex.DIRECTION dir = parseDirection(config != null ? (String) config.get("direction") : null);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHITS.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHITS.java
@@ -80,7 +80,7 @@ public class AlgoHITS extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes    = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final int maxIterations    = args.length > 1 ? ((Number) args[1]).intValue() : 20;
+    final int maxIterations    = args.length > 1 ? extractInt((Number) args[1], "maxIterations") : 20;
     final double tolerance     = args.length > 2 ? ((Number) args[2]).doubleValue() : 1e-6;
 
     final Database db = context.getDatabase();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHashGNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHashGNN.java
@@ -93,8 +93,8 @@ public class AlgoHashGNN extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
-    final int embDim = config != null && config.get("embeddingDimension") instanceof Number n ? n.intValue() : 128;
-    final int iterations = config != null && config.get("iterations") instanceof Number n ? n.intValue() : 4;
+    final int embDim = config != null && config.get("embeddingDimension") instanceof Number n ? extractInt(n, "embeddingDimension") : 128;
+    final int iterations = config != null && config.get("iterations") instanceof Number n ? extractInt(n, "iterations") : 4;
     final long seed = config != null && config.get("seed") instanceof Number n ? n.longValue() : -1L;
     final String[] relTypes = config != null ? extractRelTypes(config.get("relTypes")) : null;
     final Vertex.DIRECTION dir = parseDirection(config != null ? (String) config.get("direction") : null);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHierarchicalClustering.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHierarchicalClustering.java
@@ -83,7 +83,7 @@ public class AlgoHierarchicalClustering extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final int numClusters = args.length > 1 && args[1] instanceof Number n ? n.intValue() : 2;
+    final int numClusters = args.length > 1 && args[1] instanceof Number n ? extractInt(n, "numClusters") : 2;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximization.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximization.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,7 +81,7 @@ public class AlgoInfluenceMaximization extends AbstractAlgoProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final int k = args[0] instanceof Number n ? extractInt(n, "k") : 1;
+    final int k = args[0] instanceof Number n ? NumberUtils.saturateToInt(n) : 1;
     final String[] relTypes = args.length > 1 ? extractRelTypes(args[1]) : null;
     final int simulations = args.length > 2 && args[2] instanceof Number n ? extractInt(n, "simulations") : 100;
     final double propagationProbability = args.length > 3 && args[3] instanceof Number n ? n.doubleValue() : 0.1;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximization.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximization.java
@@ -80,9 +80,9 @@ public class AlgoInfluenceMaximization extends AbstractAlgoProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final int k = args[0] instanceof Number n ? n.intValue() : 1;
+    final int k = args[0] instanceof Number n ? extractInt(n, "k") : 1;
     final String[] relTypes = args.length > 1 ? extractRelTypes(args[1]) : null;
-    final int simulations = args.length > 2 && args[2] instanceof Number n ? n.intValue() : 100;
+    final int simulations = args.length > 2 && args[2] instanceof Number n ? extractInt(n, "simulations") : 100;
     final double propagationProbability = args.length > 3 && args[3] instanceof Number n ? n.doubleValue() : 0.1;
 
     final Database db = context.getDatabase();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
@@ -91,7 +91,7 @@ public class AlgoKNN extends AbstractAlgoProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final int k                = args.length > 0 && args[0] instanceof Number num ? NumberUtils.saturateToInt(num) : 10;
+    final int rawK             = args.length > 0 && args[0] instanceof Number num ? NumberUtils.saturateToInt(num) : 10;
     final String[] relTypes    = args.length > 1 ? extractRelTypes(args[1]) : null;
     final Vertex.DIRECTION dir = args.length > 2 ? parseDirection(extractString(args[2], "direction")) : Vertex.DIRECTION.BOTH;
 
@@ -103,6 +103,10 @@ public class AlgoKNN extends AbstractAlgoProcedure {
     final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
+    // Clamp to the graph size: there can never be more than n-1 neighbours, and sizing the
+    // per-node top-k arrays directly off an unclamped rawK risks a multi-GB allocation attempt
+    // for a huge k (e.g. algo.knn(2147483648)).
+    final int k = Math.min(rawK, n);
     final int[][] adj = graph.adjacency(dir, relTypes);
 
     // Build BitSets for O(1) intersection

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -90,7 +91,7 @@ public class AlgoKNN extends AbstractAlgoProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final int k                = args.length > 0 && args[0] instanceof Number num ? num.intValue() : 10;
+    final int k                = args.length > 0 && args[0] instanceof Number num ? NumberUtils.saturateToInt(num) : 10;
     final String[] relTypes    = args.length > 1 ? extractRelTypes(args[1]) : null;
     final Vertex.DIRECTION dir = args.length > 2 ? parseDirection(extractString(args[2], "direction")) : Vertex.DIRECTION.BOTH;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -140,9 +140,13 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
       }
     }
 
-    // Yen's k-shortest paths
-    final List<int[]> kPaths     = new ArrayList<>(k);
-    final List<Double> kWeights  = new ArrayList<>(k);
+    // Yen's k-shortest paths. The loop below (`for (int ki = 1; ki < k; ki++)`) terminates as soon
+    // as no more candidate paths exist, so k itself is safe to leave unbounded (saturating a huge k
+    // to "as many k-shortest-paths as exist" is the right reading here) - but it must not be used
+    // directly as an eager ArrayList capacity, since that risks a multi-GB allocation attempt for a
+    // huge k (e.g. algo.kShortestPaths(a, b, 2147483648)) that will never be filled.
+    final List<int[]> kPaths     = new ArrayList<>(Math.min(k, n));
+    final List<Double> kWeights  = new ArrayList<>(Math.min(k, n));
 
     // Find first shortest path with Dijkstra
     final int[] firstPath = dijkstra(weightMatrix, n, startIdx, endIdx, null);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -27,6 +27,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,7 +90,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
 
     final Vertex startNode        = extractVertex(args[0], "startNode");
     final Vertex endNode          = extractVertex(args[1], "endNode");
-    final int k                   = ((Number) args[2]).intValue();
+    final int k                   = NumberUtils.saturateToInt((Number) args[2]);
     final String[] relTypes       = args.length > 3 ? extractRelTypes(args[3]) : null;
     final String weightProperty   = args.length > 4 ? extractString(args[4], "weightProperty") : null;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKTruss.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKTruss.java
@@ -82,7 +82,7 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final int kParam = args.length > 1 && args[1] instanceof Number n ? n.intValue() : 3;
+    final int kParam = args.length > 1 && args[1] instanceof Number n ? extractInt(n, "k") : 3;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKatz.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKatz.java
@@ -85,7 +85,7 @@ public class AlgoKatz extends AbstractAlgoProcedure {
 
     final String[] relTypes    = args.length > 0 ? extractRelTypes(args[0]) : null;
     final double alpha         = args.length > 1 ? ((Number) args[1]).doubleValue() : 0.005;
-    final int maxIterations    = args.length > 2 ? ((Number) args[2]).intValue() : 100;
+    final int maxIterations    = args.length > 2 ? extractInt((Number) args[2], "maxIterations") : 100;
     final double tolerance     = args.length > 3 ? ((Number) args[3]).doubleValue() : 1e-6;
 
     final Database db = context.getDatabase();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLabelPropagation.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLabelPropagation.java
@@ -100,7 +100,7 @@ public class AlgoLabelPropagation extends AbstractAlgoProcedure {
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
     final int maxIterations = config != null && config.get("maxIterations") instanceof Number n ?
-        n.intValue() : 10;
+        extractInt(n, "maxIterations") : 10;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLeiden.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLeiden.java
@@ -81,7 +81,7 @@ public class AlgoLeiden extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final int maxIterations = args.length > 1 && args[1] instanceof Number n ? n.intValue() : 10;
+    final int maxIterations = args.length > 1 && args[1] instanceof Number n ? extractInt(n, "maxIterations") : 10;
     final double resolution = args.length > 2 && args[2] instanceof Number n ? n.doubleValue() : 1.0;
 
     final Database db = context.getDatabase();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
@@ -98,7 +98,7 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
     final int maxIterations = config != null && config.get("maxIterations") instanceof Number n ?
-        n.intValue() : 10;
+        extractInt(n, "maxIterations") : 10;
     final double tolerance = config != null && config.get("tolerance") instanceof Number n ?
         n.doubleValue() : 0.0001;
     final String weightProperty = config != null ? (String) config.get("weightProperty") : null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
@@ -101,13 +101,13 @@ public class AlgoMaxKCut extends AbstractAlgoProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final int k = args[0] instanceof Number kn ? kn.intValue() : 2;
+    final int k = args[0] instanceof Number kn ? extractInt(kn, "k") : 2;
     if (k < 2)
       throw new IllegalArgumentException(getName() + "(): k must be ≥ 2, got " + k);
 
     final Map<String, Object> config = args.length > 1 ? extractMap(args[1], "config") : null;
-    final int maxIter = config != null && config.get("maxIterations") instanceof Number n ? n.intValue() : 100;
-    final int restarts = config != null && config.get("restarts") instanceof Number n ? n.intValue() : 3;
+    final int maxIter = config != null && config.get("maxIterations") instanceof Number n ? extractInt(n, "maxIterations") : 100;
+    final int restarts = config != null && config.get("restarts") instanceof Number n ? extractInt(n, "restarts") : 3;
     final String weightProperty = config != null ? (String) config.get("weightProperty") : null;
     final long seed = config != null && config.get("seed") instanceof Number n ? n.longValue() : -1L;
     final String[] relTypes = config != null ? extractRelTypes(config.get("relTypes")) : null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoNode2Vec.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoNode2Vec.java
@@ -99,12 +99,12 @@ public class AlgoNode2Vec extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
-    final int dim = config != null && config.get("embeddingDimension") instanceof Number n ? n.intValue() : 128;
-    final int walkLen = config != null && config.get("walkLength") instanceof Number n ? n.intValue() : 80;
-    final int walksPerNode = config != null && config.get("walksPerNode") instanceof Number n ? n.intValue() : 10;
-    final int epochs = config != null && config.get("iterations") instanceof Number n ? n.intValue() : 1;
-    final int window = config != null && config.get("windowSize") instanceof Number n ? n.intValue() : 10;
-    final int negSamples = config != null && config.get("negSamples") instanceof Number n ? n.intValue() : 5;
+    final int dim = config != null && config.get("embeddingDimension") instanceof Number n ? extractInt(n, "embeddingDimension") : 128;
+    final int walkLen = config != null && config.get("walkLength") instanceof Number n ? extractInt(n, "walkLength") : 80;
+    final int walksPerNode = config != null && config.get("walksPerNode") instanceof Number n ? extractInt(n, "walksPerNode") : 10;
+    final int epochs = config != null && config.get("iterations") instanceof Number n ? extractInt(n, "iterations") : 1;
+    final int window = config != null && config.get("windowSize") instanceof Number n ? extractInt(n, "windowSize") : 10;
+    final int negSamples = config != null && config.get("negSamples") instanceof Number n ? extractInt(n, "negSamples") : 5;
     final double lr0 = config != null && config.get("learningRate") instanceof Number n ? n.doubleValue() : 0.025;
     final double p = config != null && config.get("p") instanceof Number n ? n.doubleValue() : 1.0;
     final double q = config != null && config.get("q") instanceof Number n ? n.doubleValue() : 1.0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -103,7 +103,7 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
     final double dampingFactor = config != null && config.get("dampingFactor") instanceof Number n ?
         n.doubleValue() : 0.85;
     final int maxIterations = config != null && config.get("maxIterations") instanceof Number n ?
-        n.intValue() : 20;
+        extractInt(n, "maxIterations") : 20;
     final double tolerance = config != null && config.get("tolerance") instanceof Number n ?
         n.doubleValue() : 0.0001;
     final String weightProperty = config != null ? (String) config.get("weightProperty") : null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPersonalizedPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPersonalizedPageRank.java
@@ -85,7 +85,7 @@ public class AlgoPersonalizedPageRank extends AbstractAlgoProcedure {
     final Vertex sourceVertex = extractVertex(args[0], "sourceNode");
     final String[] relTypes = args.length > 1 ? extractRelTypes(args[1]) : null;
     final double dampingFactor = args.length > 2 && args[2] instanceof Number n ? n.doubleValue() : 0.85;
-    final int maxIterations = args.length > 3 && args[3] instanceof Number n ? n.intValue() : 20;
+    final int maxIterations = args.length > 3 && args[3] instanceof Number n ? extractInt(n, "maxIterations") : 20;
     final double tolerance = args.length > 4 && args[4] instanceof Number n ? n.doubleValue() : 1e-6;
 
     final Database db = context.getDatabase();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRandomWalk.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRandomWalk.java
@@ -84,7 +84,7 @@ public class AlgoRandomWalk extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Vertex startVertex = extractVertex(args[0], "startNode");
-    final int steps = ((Number) args[1]).intValue();
+    final int steps = extractInt((Number) args[1], "steps");
     final String[] relTypes   = args.length > 2 ? extractRelTypes(args[2]) : null;
     final Vertex.DIRECTION dir = args.length > 3 ? parseDirection(extractString(args[3], "direction")) : Vertex.DIRECTION.BOTH;
     final long seed = args.length > 4 ? ((Number) args[4]).longValue() : System.currentTimeMillis();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRichClub.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRichClub.java
@@ -79,7 +79,7 @@ public class AlgoRichClub extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final int minDegree = args.length > 1 && args[1] instanceof Number n ? n.intValue() : 2;
+    final int minDegree = args.length > 1 && args[1] instanceof Number n ? extractInt(n, "minDegree") : 2;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSLPA.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSLPA.java
@@ -94,7 +94,7 @@ public class AlgoSLPA extends AbstractAlgoProcedure {
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
 
     final int iterations = config != null && config.get("iterations") instanceof Number num ?
-        num.intValue() : 20;
+        extractInt(num, "iterations") : 20;
     final double threshold = config != null && config.get("threshold") instanceof Number num ?
         num.doubleValue() : 0.1;
     final long seedVal = config != null && config.get("seed") instanceof Number num ?

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSimRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSimRank.java
@@ -85,7 +85,7 @@ public class AlgoSimRank extends AbstractAlgoProcedure {
     final Vertex nodeB       = extractVertex(args[1], "nodeB");
     final String[] relTypes  = args.length > 2 ? extractRelTypes(args[2]) : null;
     final double decayFactor = args.length > 3 ? ((Number) args[3]).doubleValue() : 0.8;
-    final int maxIterations  = args.length > 4 ? ((Number) args[4]).intValue() : 5;
+    final int maxIterations  = args.length > 4 ? extractInt((Number) args[4], "maxIterations") : 5;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoVoteRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoVoteRank.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,7 +80,7 @@ public class AlgoVoteRank extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
-    final int topK          = args.length > 1 ? ((Number) args[1]).intValue() : Integer.MAX_VALUE;
+    final int topK          = args.length > 1 ? NumberUtils.saturateToInt((Number) args[1]) : Integer.MAX_VALUE;
 
     final Database db = context.getDatabase();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
@@ -31,6 +31,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.Pair;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
@@ -98,7 +99,7 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
     validateArgs(args);
 
     final String indexSpec = args[0].toString();
-    final int limit = args[1] instanceof Number n ? n.intValue() : Integer.parseInt(args[1].toString());
+    final int limit = args[1] instanceof Number n ? NumberUtils.saturateToInt(n) : Integer.parseInt(args[1].toString());
 
     Object key = args[2];
     if (key == null)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
@@ -26,6 +26,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -85,8 +86,8 @@ public class PathExpand extends AbstractPathProcedure {
     final Vertex startNode = extractVertex(args[0], "startNode");
     final String[] relTypes = extractRelTypes(args[1]);
     final String[] labelFilter = extractLabels(args[2]);
-    final int minDepth = ((Number) args[3]).intValue();
-    final int maxDepth = ((Number) args[4]).intValue();
+    final int minDepth = NumberUtils.saturateToInt((Number) args[3]);
+    final int maxDepth = NumberUtils.saturateToInt((Number) args[4]);
 
     if (minDepth < 0) {
       throw new IllegalArgumentException(getName() + "(): minDepth must be non-negative");

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayList;
@@ -97,10 +98,10 @@ public class PathExpandConfig extends AbstractPathProcedure {
     // Extract configuration options
     final String[] relTypes = extractRelTypes(config.get("relationshipFilter"));
     final String[] labelFilter = extractLabels(config.get("labelFilter"));
-    final int minLevel = config.containsKey("minLevel") ? ((Number) config.get("minLevel")).intValue() : 0;
-    final int maxLevel = config.containsKey("maxLevel") ? ((Number) config.get("maxLevel")).intValue() : Integer.MAX_VALUE;
+    final int minLevel = config.containsKey("minLevel") ? NumberUtils.saturateToInt((Number) config.get("minLevel")) : 0;
+    final int maxLevel = config.containsKey("maxLevel") ? NumberUtils.saturateToInt((Number) config.get("maxLevel")) : Integer.MAX_VALUE;
     final boolean bfs = config.containsKey("bfs") ? (Boolean) config.get("bfs") : true;
-    final int limit = config.containsKey("limit") ? ((Number) config.get("limit")).intValue() : Integer.MAX_VALUE;
+    final int limit = config.containsKey("limit") ? NumberUtils.saturateToInt((Number) config.get("limit")) : Integer.MAX_VALUE;
 
     // Expand paths
     final List<List<Object>> allPaths = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
@@ -26,8 +26,8 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-
 import com.arcadedb.utility.NumberUtils;
+
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayList;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
@@ -26,8 +26,8 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-import com.arcadedb.utility.NumberUtils;
 
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayList;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;
@@ -93,7 +94,7 @@ public class PathSpanningTree extends AbstractPathProcedure {
 
     final String[] relTypes = extractRelTypes(config.get("relationshipFilter"));
     final String[] labelFilter = extractLabels(config.get("labelFilter"));
-    final int maxLevel = config.containsKey("maxLevel") ? ((Number) config.get("maxLevel")).intValue() : Integer.MAX_VALUE;
+    final int maxLevel = config.containsKey("maxLevel") ? NumberUtils.saturateToInt((Number) config.get("maxLevel")) : Integer.MAX_VALUE;
 
     // BFS to build spanning tree
     final List<List<Object>> allPaths = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
@@ -26,8 +26,8 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-import com.arcadedb.utility.NumberUtils;
 
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
@@ -26,8 +26,8 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-
 import com.arcadedb.utility.NumberUtils;
+
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;
@@ -94,7 +95,7 @@ public class PathSubgraphAll extends AbstractPathProcedure {
 
     final String[] relTypes = extractRelTypes(config.get("relationshipFilter"));
     final String[] labelFilter = extractLabels(config.get("labelFilter"));
-    final int maxLevel = config.containsKey("maxLevel") ? ((Number) config.get("maxLevel")).intValue() : Integer.MAX_VALUE;
+    final int maxLevel = config.containsKey("maxLevel") ? NumberUtils.saturateToInt((Number) config.get("maxLevel")) : Integer.MAX_VALUE;
 
     // BFS to find all reachable nodes and relationships
     final Set<Vertex> reachableNodes = new HashSet<>();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
@@ -27,8 +27,8 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-import com.arcadedb.utility.NumberUtils;
 
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
@@ -27,8 +27,8 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-
 import com.arcadedb.utility.NumberUtils;
+
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;
@@ -93,7 +94,7 @@ public class PathSubgraphNodes extends AbstractPathProcedure {
 
     final String[] relTypes = extractRelTypes(config.get("relationshipFilter"));
     final String[] labelFilter = extractLabels(config.get("labelFilter"));
-    final int maxLevel = config.containsKey("maxLevel") ? ((Number) config.get("maxLevel")).intValue() : Integer.MAX_VALUE;
+    final int maxLevel = config.containsKey("maxLevel") ? NumberUtils.saturateToInt((Number) config.get("maxLevel")) : Integer.MAX_VALUE;
 
     // BFS to find all reachable nodes
     final Set<Vertex> reachableNodes = new HashSet<>();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
@@ -26,8 +26,8 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-import com.arcadedb.utility.NumberUtils;
 
+import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
@@ -26,8 +26,8 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-
 import com.arcadedb.utility.NumberUtils;
+
 import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayDeque;

--- a/engine/src/main/java/com/arcadedb/utility/NumberUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/NumberUtils.java
@@ -75,4 +75,30 @@ public class NumberUtils {
       return Integer.MIN_VALUE;
     return (int) longValue;
   }
+
+  /**
+   * Narrows a numeric value to an int, throwing {@link ArithmeticException} if it does not fit -
+   * the strict counterpart to {@link #saturateToInt(Number)}. Use this for parameters where an
+   * out-of-range value should fail loudly rather than saturate or wrap, because a saturated/wrapped
+   * value would still look plausible and silently drive a degenerate computation (e.g. an iteration
+   * count, embedding dimension, or cluster count) instead of an obviously-bounded result (e.g. LIMIT).
+   * `BigInteger`/`BigDecimal` are compared by magnitude directly for the same reason as
+   * {@link #saturateToInt(Number)}: `Number.longValue()` on one of those far outside the `Long` range
+   * is documented as lossy in an unspecified way.
+   */
+  public static int toIntExact(final Number value) {
+    if (value instanceof BigInteger bigInteger) {
+      if (bigInteger.compareTo(BIGINTEGER_MAX_INT) > 0 || bigInteger.compareTo(BIGINTEGER_MIN_INT) < 0)
+        throw new ArithmeticException("integer overflow: " + bigInteger);
+      return bigInteger.intValue();
+    }
+
+    if (value instanceof BigDecimal bigDecimal) {
+      if (bigDecimal.compareTo(BIGDECIMAL_MAX_INT) > 0 || bigDecimal.compareTo(BIGDECIMAL_MIN_INT) < 0)
+        throw new ArithmeticException("integer overflow: " + bigDecimal);
+      return bigDecimal.intValue();
+    }
+
+    return Math.toIntExact(value.longValue());
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCallVectorNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCallVectorNeighborsTest.java
@@ -168,6 +168,29 @@ class CypherCallVectorNeighborsTest extends TestHelper {
   }
 
   @Test
+  void queryNodesKAboveIntRangeDoesNotAttemptHugeAllocation() {
+    // Issue #5924 code review: the Cypher-supplied `k` (limit) used to narrow via .intValue(), so a
+    // Long above Integer.MAX_VALUE wrapped to a small/negative int and failed fast. After the fix it
+    // saturates to Integer.MAX_VALUE, which LSMVectorIndex.findNeighborsFromVector now clamps against
+    // the index's actual vector count before using it to size result buffers - otherwise this would
+    // attempt a multi-GB allocation instead of returning the 5 available neighbours.
+    final Map<String, Object> params = new HashMap<>();
+    params.put("vec", new float[]{0.0f, 0.0f, 1.0f});
+    params.put("k", 2147483648L);
+
+    try (ResultSet results = database.query("opencypher",
+        "CALL db.index.vector.queryNodes('Doc[embedding]', $k, $vec) YIELD node, score RETURN node.name AS name, score",
+        params)) {
+
+      final List<String> names = new ArrayList<>();
+      while (results.hasNext())
+        names.add(results.next().getProperty("name"));
+
+      assertThat(names).hasSize(5);
+    }
+  }
+
+  @Test
   void queryNodesWithReturnPattern() {
     // Exact Neo4j pattern from the user's benchmark query
     final Map<String, Object> params = new HashMap<>();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBFSTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBFSTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -113,6 +114,23 @@ class AlgoBFSTest {
     assertThat(results).hasSize(2);
     for (final Result r : results)
       assertThat(((Number) r.getProperty("depth")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void bfsMaxDepthAboveIntRangeIsTreatedAsUnbounded() {
+    // Issue #5924: maxDepth used to narrow via .intValue(), so a Long above Integer.MAX_VALUE
+    // wrapped to a negative int and every node failed the "depth >= maxDepth" cutoff check
+    // immediately, silently returning 0 reachable nodes instead of the whole graph.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (start:Node {name: 'A'}) CALL algo.bfs(start, null, 'OUT', $maxDepth) YIELD node, depth RETURN node.name AS name, depth",
+        Map.of("maxDepth", 2147483648L));
+
+    final List<Result> results = new ArrayList<>();
+    while (rs.hasNext())
+      results.add(rs.next());
+
+    // All 4 reachable nodes, same as the unbounded (default) case
+    assertThat(results).hasSize(4);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximizationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoInfluenceMaximizationTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -158,5 +159,23 @@ class AlgoInfluenceMaximizationTest {
     // Can't return more seeds than there are nodes
     assertThat(count).isLessThanOrEqualTo(6);
     assertThat(count).isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  void influenceMaximizationKAboveIntRangeReturnsAllNodes() {
+    // Issue #5924 code review: k is clamped via Math.min(k, n) right after computation (same as
+    // AlgoKNN/AlgoVoteRank's top-k parameters), so a Long above Integer.MAX_VALUE can safely saturate
+    // to "as many seed nodes as the graph has" instead of throwing - consistent with the other
+    // top-k-shaped parameters in this package rather than the structural-knob bucket.
+    final ResultSet rs = database.query("opencypher",
+        "CALL algo.influenceMaximization($k) YIELD nodeId, rank, marginalGain RETURN nodeId, rank, marginalGain",
+        Map.of("k", 2147483648L));
+
+    int count = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      count++;
+    }
+    assertThat(count).isEqualTo(6);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNNTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNNTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -103,5 +104,22 @@ class AlgoKNNTest {
       final double sim = ((Number) rs.next().getProperty("similarity")).doubleValue();
       assertThat(sim).isGreaterThan(0.0);
     }
+  }
+
+  @Test
+  void knnKAboveIntRangeDoesNotAttemptHugeAllocation() {
+    // Issue #5924 code review: k used to size per-node top-k arrays (`new double[k]`, `new int[k]`)
+    // with no clamp against the graph's node count. A Long above Integer.MAX_VALUE saturates via
+    // NumberUtils.saturateToInt() to Integer.MAX_VALUE, which - unclamped - would attempt a multi-GB
+    // allocation per node instead of returning "as many neighbours as exist" (at most n-1 per node).
+    final ResultSet rs = database.query("opencypher",
+        "CALL algo.knn($k, 'KNOWS', 'BOTH') YIELD node1, node2, similarity RETURN node1, node2, similarity",
+        Map.of("k", 2147483648L));
+
+    final List<Result> results = new ArrayList<>();
+    while (rs.hasNext())
+      results.add(rs.next());
+
+    assertThat(results).isNotEmpty();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPathsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPathsTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -134,5 +135,26 @@ class AlgoKShortestPathsTest {
     final Result result = rs.next();
     final Object val = result.getProperty("rank");
     assertThat(((Number) val).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void kShortestPathsKAboveIntRangeDoesNotAttemptHugeAllocation() {
+    // Issue #5924 code review: k used to size the kPaths/kWeights ArrayLists' initial capacity
+    // directly (`new ArrayList<>(k)`). A Long above Integer.MAX_VALUE saturates via
+    // NumberUtils.saturateToInt() to Integer.MAX_VALUE, which - used as a raw capacity hint - would
+    // attempt a multi-GB allocation instead of returning "as many shortest paths as exist" (the
+    // Yen's-algorithm loop terminates on its own once no more candidate paths remain).
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (a:City {name:'A'}), (d:City {name:'D'}) \
+        CALL algo.kShortestPaths(a, d, $k, 'ROAD', 'dist') YIELD path, weight, rank \
+        RETURN path, weight, rank ORDER BY rank ASC""",
+        Map.of("k", 2147483648L));
+
+    final List<Result> results = new ArrayList<>();
+    while (rs.hasNext())
+      results.add(rs.next());
+
+    assertThat(results).isNotEmpty();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRankTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for the algo.pagerank Cypher procedure.
@@ -232,6 +233,20 @@ class AlgoPageRankTest {
     assertThat(sum).isBetween(0.9, 1.1);
 
     gav.shutdown();
+  }
+
+  @Test
+  void pageRankMaxIterationsAboveIntRangeThrows() {
+    // Issue #5924: maxIterations used to narrow via .intValue(), so a Long above Integer.MAX_VALUE
+    // wrapped into a small/negative int and silently ran a degenerate (or zero-iteration)
+    // computation instead of failing. It must now be rejected loudly.
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("opencypher",
+          "CALL algo.pagerank({maxIterations: $mi}) YIELD node, score RETURN node",
+          Map.of("mi", 2147483648L));
+      while (rs.hasNext())
+        rs.next();
+    }).hasStackTraceContaining("maxIterations");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRandomWalkTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRandomWalkTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for the algo.randomWalk Cypher procedure.
@@ -92,6 +93,25 @@ class AlgoRandomWalkTest {
     final List<Object> nodes = (List<Object>) path.get("nodes");
     // start node + 5 steps = 6 nodes in the path
     assertThat(nodes).hasSize(6);
+  }
+
+  @Test
+  void randomWalkStepsAboveIntRangeThrows() {
+    // Issue #5924: steps used to narrow via .intValue() straight into `new int[steps + 1]`. A Long
+    // above Integer.MAX_VALUE (e.g. 2147483648) wrapped to Integer.MIN_VALUE, which then threw a
+    // confusing NegativeArraySizeException from deep inside the walk instead of a clear, immediate
+    // rejection of the out-of-range argument.
+    assertThatThrownBy(() -> {
+      final ResultSet rs = database.query("opencypher",
+          """
+          MATCH (a:Node {name: 'A'}) \
+          CALL algo.randomWalk(a, $steps) \
+          YIELD path, steps \
+          RETURN path, steps""",
+          Map.of("steps", 2147483648L));
+      while (rs.hasNext())
+        rs.next();
+    }).hasStackTraceContaining("steps");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfigTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfigTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.path;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the path.expandConfig Cypher procedure.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PathExpandConfigTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-path-expandconfig");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("KNOWS");
+
+    // Chain: A -KNOWS-> B -KNOWS-> C
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      a.newEdge("KNOWS", b, true, (Object[]) null).save();
+      b.newEdge("KNOWS", c, true, (Object[]) null).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  private int countPaths(final ResultSet rs) {
+    int count = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      count++;
+    }
+    return count;
+  }
+
+  @Test
+  void expandConfigRespectsMaxLevel() {
+    // maxLevel:1 → only the start node (level 0) and its direct neighbour (level 1): 2 paths
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {name:'A'}) CALL path.expandConfig(a, {relationshipFilter:'KNOWS', maxLevel: 1}) YIELD path RETURN path");
+    assertThat(countPaths(rs)).isEqualTo(2);
+  }
+
+  @Test
+  void expandConfigMaxLevelAboveIntRangeIsTreatedAsUnbounded() {
+    // Issue #5924: maxLevel used to narrow via .intValue(), so a Long above Integer.MAX_VALUE
+    // wrapped to a negative int and the "currentLevel <= maxLevel" loop guard failed on the very
+    // first iteration, silently returning 0 paths instead of the whole unbounded expansion.
+    final int unboundedCount;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {name:'A'}) CALL path.expandConfig(a, {relationshipFilter:'KNOWS'}) YIELD path RETURN path")) {
+      unboundedCount = countPaths(rs);
+    }
+    assertThat(unboundedCount).isEqualTo(3); // levels 0, 1, 2
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {name:'A'}) CALL path.expandConfig(a, {relationshipFilter:'KNOWS', maxLevel: $maxLevel}) YIELD path RETURN path",
+        Map.of("maxLevel", 2147483648L))) {
+      assertThat(countPaths(rs)).isEqualTo(unboundedCount);
+    }
+  }
+
+  @Test
+  void expandConfigLimitAboveIntRangeIsTreatedAsUnbounded() {
+    // Issue #5924: same narrowing bug on `limit` - a Long above Integer.MAX_VALUE used to wrap to a
+    // negative int, and "allPaths.size() < limit" is false for every non-negative size, so the
+    // expansion produced 0 paths instead of the whole unbounded result.
+    final int unboundedCount;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {name:'A'}) CALL path.expandConfig(a, {relationshipFilter:'KNOWS'}) YIELD path RETURN path")) {
+      unboundedCount = countPaths(rs);
+    }
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {name:'A'}) CALL path.expandConfig(a, {relationshipFilter:'KNOWS', limit: $limit}) YIELD path RETURN path",
+        Map.of("limit", 2147483648L))) {
+      assertThat(countPaths(rs)).isEqualTo(unboundedCount);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/NumberUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/NumberUtilsTest.java
@@ -138,4 +138,37 @@ class NumberUtilsTest {
 
     assertThat(NumberUtils.saturateToInt(BigDecimal.valueOf(7))).isEqualTo(7);
   }
+
+  @Test
+  void toIntExactWithValueInRangeIsUnchanged() {
+    assertThat(NumberUtils.toIntExact(42)).isEqualTo(42);
+    assertThat(NumberUtils.toIntExact(-42)).isEqualTo(-42);
+    assertThat(NumberUtils.toIntExact(Integer.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
+    assertThat(NumberUtils.toIntExact(Integer.MIN_VALUE)).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test
+  void toIntExactWithLongBeyondIntRangeThrows() {
+    // Issue #5924 - algorithm tuning knobs (iteration counts, embedding dimensions, ...) must fail
+    // loudly on overflow rather than saturate/wrap into a plausible-looking value that silently
+    // drives a degenerate computation.
+    assertThatThrownBy(() -> NumberUtils.toIntExact(Integer.MAX_VALUE + 1L))
+        .isInstanceOf(ArithmeticException.class);
+    assertThatThrownBy(() -> NumberUtils.toIntExact(Long.MIN_VALUE))
+        .isInstanceOf(ArithmeticException.class);
+  }
+
+  @Test
+  void toIntExactWithBigIntegerBeyondLongRangeThrows() {
+    final BigInteger huge = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN);
+    assertThatThrownBy(() -> NumberUtils.toIntExact(huge)).isInstanceOf(ArithmeticException.class);
+    assertThat(NumberUtils.toIntExact(BigInteger.valueOf(7))).isEqualTo(7);
+  }
+
+  @Test
+  void toIntExactWithBigDecimalBeyondLongRangeThrows() {
+    final BigDecimal huge = BigDecimal.valueOf(Long.MAX_VALUE).multiply(BigDecimal.TEN);
+    assertThatThrownBy(() -> NumberUtils.toIntExact(huge)).isInstanceOf(ArithmeticException.class);
+    assertThat(NumberUtils.toIntExact(BigDecimal.valueOf(7))).isEqualTo(7);
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to the unchecked-numeric-narrowing family (#5900, #5905, #5906, #5919, PR #5921). A grep for `.intValue()`/`.floatValue()` across `engine/src/main/java/com/arcadedb/query/opencypher/procedures/` (path/traversal procedures and graph algorithm procedures) turned up 49 sites that narrow a user-supplied config/argument `Number` to a smaller type without a range check, so a value outside the narrower type's range silently wraps instead of erroring/saturating - the same class of bug as #5919's `LIMIT 2147483648` returning 0 rows.

## Approach

Per the issue's own suggested triage, sites are bucketed by role rather than fixed uniformly:

- **Result-count/depth bounds that mirror SQL's `LIMIT`/`SKIP`** (`maxDepth`, `maxLevel`, `minLevel`, `limit`, top-k parameters like `AlgoKNN`'s `k` and `AlgoVoteRank`'s `topK`): `NumberUtils.saturateToInt()` (added in PR #5921), consistent with the `Integer.MAX_VALUE` "unbounded" default these sites already use - saturating an overflowing bound to `MAX_VALUE` is exactly the existing "no limit" semantics, so it's not a behavior change at the boundary, just a correct one.
- **Algorithm structural knobs** (iteration counts, embedding dimensions, walk lengths, cluster/degree thresholds, `k` where it defines algorithm shape rather than an output-count bound): a new `NumberUtils.toIntExact()`, which **throws** instead of saturating/wrapping. Unlike a count bound, there's no sensible "as many as possible" reading for e.g. `maxIterations` or `embeddingDimension` - a saturated value would still look plausible and silently drive a degenerate computation (0 iterations, a multi-GB embedding array, `new int[]` with a wrapped-negative size) instead of failing loudly. Exposed via a new `AbstractAlgoProcedure.extractInt(Number, String)` helper that turns the `ArithmeticException` into an `IllegalArgumentException` naming the offending parameter.

One site is explicitly **excluded**, matching the issue's own methodology for the GraphSON/ArcadeIoRegistry exclusions: `DbIndexVectorQueryNodes.java`'s `((Number) objArray[i]).floatValue()` narrows a query-vector coordinate to `float` because `LSMVectorIndex` stores vectors as `float[]` natively - narrowing to the index's actual declared precision is correct, not an unchecked-width bug.

## Test plan

- [x] `NumberUtilsTest` - unit tests for the new `toIntExact()`, mirroring the existing `saturateToInt()` coverage (int-range values, `Long` overflow, `BigInteger`/`BigDecimal` beyond `Long` range)
- [x] `AlgoPageRankTest#pageRankMaxIterationsAboveIntRangeThrows` - `maxIterations` above `Integer.MAX_VALUE` now throws instead of silently narrowing into a degenerate iteration count
- [x] `AlgoRandomWalkTest#randomWalkStepsAboveIntRangeThrows` - `steps` above `Integer.MAX_VALUE` now throws a clear error instead of a confusing `NegativeArraySizeException` from the wrapped-negative `new int[steps + 1]` allocation
- [x] `AlgoBFSTest#bfsMaxDepthAboveIntRangeIsTreatedAsUnbounded` - `maxDepth` above `Integer.MAX_VALUE` now returns all reachable nodes instead of 0
- [x] `PathExpandConfigTest` (new file - this procedure had no prior test coverage) - `maxLevel` and `limit` above `Integer.MAX_VALUE` are treated as unbounded, matching the no-config-set case

Each of these five regression tests was verified to fail against the pre-fix narrowing (confirmed by temporarily reverting the fix logic in isolation) and pass after.

- [x] Full `com.arcadedb.query.opencypher.procedures.**` test suite: 590 tests, 0 failures/errors (no regressions from the bucket split)
- [x] `mvn -pl engine -am compile` / `test-compile`: clean

Fixes #5924.