### PR TITLE
feat(cypher): add 7 missing APOC-compatible functions

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/CypherFunctionRegistry.java
+++ b/engine/src/main/java/com/arcadedb/function/CypherFunctionRegistry.java
@@ -30,6 +30,7 @@ import com.arcadedb.function.date.*;
 import com.arcadedb.function.map.*;
 import com.arcadedb.function.math.*;
 import com.arcadedb.function.node.*;
+import com.arcadedb.function.number.*;
 import com.arcadedb.function.path.PathCombine;
 import com.arcadedb.function.path.PathCreate;
 import com.arcadedb.function.path.PathElements;
@@ -232,6 +233,8 @@ public final class CypherFunctionRegistry {
     registerMathFunctions();
     // Convert functions
     registerConvertFunctions();
+    // Number functions
+    registerNumberFunctions();
     // Date functions
     registerDateFunctions();
     // Util functions
@@ -249,6 +252,7 @@ public final class CypherFunctionRegistry {
   }
 
   private static void registerCollFunctions() {
+    register(new CollAvg());
     register(new CollDistinct());
     register(new CollFlatten());
     register(new CollIndexOf());
@@ -257,6 +261,9 @@ public final class CypherFunctionRegistry {
     register(new CollMin());
     register(new CollRemove());
     register(new CollSort());
+    register(new CollSum());
+    register(new CollUnion());
+    register(new CollUnionAll());
   }
 
   private static void registerTextFunctions() {
@@ -314,6 +321,7 @@ public final class CypherFunctionRegistry {
     register(new MathMaxLong());
     register(new MathMinLong());
     register(new MathMaxDouble());
+    register(new MathRound());
   }
 
   private static void registerConvertFunctions() {
@@ -326,6 +334,11 @@ public final class CypherFunctionRegistry {
     register(new ConvertToBoolean());
     register(new ConvertToInteger());
     register(new ConvertToFloat());
+    register(new ConvertToString());
+  }
+
+  private static void registerNumberFunctions() {
+    register(new NumberFormat());
   }
 
   private static void registerDateFunctions() {

--- a/engine/src/main/java/com/arcadedb/function/coll/CollAvg.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollAvg.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.coll;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+
+import java.util.List;
+
+/**
+ * coll.avg(list) - Returns the average of a list of numbers, or null if the list is empty.
+ */
+public class CollAvg extends AbstractCollFunction {
+  @Override
+  protected String getSimpleName() {
+    return "avg";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the average of a list of numbers, or null if the list is empty";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    final List<Object> list = asList(args[0]);
+    if (list == null)
+      return null;
+
+    double sum = 0.0;
+    int count = 0;
+    for (final Object item : list) {
+      if (item instanceof Number) {
+        sum += ((Number) item).doubleValue();
+        count++;
+      }
+    }
+    return count == 0 ? null : sum / count;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/coll/CollAvg.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollAvg.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.coll;
 
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.List;
@@ -48,6 +49,7 @@ public class CollAvg extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
@@ -55,8 +57,9 @@ public class CollAvg extends AbstractCollFunction {
     double sum = 0.0;
     int count = 0;
     for (final Object item : list) {
-      if (item instanceof Number) {
-        sum += ((Number) item).doubleValue();
+      final Number number = CypherFunctionHelper.requireNumberArgument(item, getName());
+      if (number != null) {
+        sum += number.doubleValue();
         count++;
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/coll/CollSum.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollSum.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.coll;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+
+import java.util.List;
+
+/**
+ * coll.sum(list) - Returns the sum of a list of numbers.
+ */
+public class CollSum extends AbstractCollFunction {
+  @Override
+  protected String getSimpleName() {
+    return "sum";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the sum of a list of numbers";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    final List<Object> list = asList(args[0]);
+    if (list == null)
+      return null;
+
+    double sum = 0.0;
+    for (final Object item : list) {
+      if (item instanceof Number)
+        sum += ((Number) item).doubleValue();
+    }
+    return sum;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/coll/CollSum.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollSum.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.coll;
 
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.List;
@@ -48,14 +49,16 @@ public class CollSum extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
 
     double sum = 0.0;
     for (final Object item : list) {
-      if (item instanceof Number)
-        sum += ((Number) item).doubleValue();
+      final Number number = CypherFunctionHelper.requireNumberArgument(item, getName());
+      if (number != null)
+        sum += number.doubleValue();
     }
     return sum;
   }

--- a/engine/src/main/java/com/arcadedb/function/coll/CollUnion.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollUnion.java
@@ -50,6 +50,7 @@ public class CollUnion extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
+    checkArity(args);
     final List<Object> list1 = asList(args[0]);
     final List<Object> list2 = asList(args[1]);
 

--- a/engine/src/main/java/com/arcadedb/function/coll/CollUnion.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollUnion.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.coll;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * coll.union(list1, list2) - Returns the distinct union of two lists, preserving order of first occurrence.
+ */
+public class CollUnion extends AbstractCollFunction {
+  @Override
+  protected String getSimpleName() {
+    return "union";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the distinct union of two lists, preserving order of first occurrence";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    final List<Object> list1 = asList(args[0]);
+    final List<Object> list2 = asList(args[1]);
+
+    final LinkedHashSet<Object> union = new LinkedHashSet<>();
+    if (list1 != null)
+      union.addAll(list1);
+    if (list2 != null)
+      union.addAll(list2);
+
+    return new ArrayList<>(union);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/coll/CollUnionAll.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollUnionAll.java
@@ -49,6 +49,7 @@ public class CollUnionAll extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
+    checkArity(args);
     final List<Object> list1 = asList(args[0]);
     final List<Object> list2 = asList(args[1]);
 

--- a/engine/src/main/java/com/arcadedb/function/coll/CollUnionAll.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollUnionAll.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.coll;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * coll.unionAll(list1, list2) - Returns the concatenation of two lists, preserving duplicates.
+ */
+public class CollUnionAll extends AbstractCollFunction {
+  @Override
+  protected String getSimpleName() {
+    return "unionAll";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the concatenation of two lists, preserving duplicates";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    final List<Object> list1 = asList(args[0]);
+    final List<Object> list2 = asList(args[1]);
+
+    final List<Object> result = new ArrayList<>();
+    if (list1 != null)
+      result.addAll(list1);
+    if (list2 != null)
+      result.addAll(list2);
+
+    return result;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/convert/ConvertToString.java
+++ b/engine/src/main/java/com/arcadedb/function/convert/ConvertToString.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.convert;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+
+/**
+ * convert.toString(value) - APOC-namespaced entry point for the standard toString() function,
+ * so it is also reachable as apoc.convert.toString(). See {@link ToStringFunction} for the conversion semantics.
+ */
+public class ConvertToString extends AbstractConvertFunction {
+  private final ToStringFunction delegate = new ToStringFunction();
+
+  @Override
+  protected String getSimpleName() {
+    return "toString";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a value to a string";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    return delegate.execute(args, context);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/convert/ConvertToString.java
+++ b/engine/src/main/java/com/arcadedb/function/convert/ConvertToString.java
@@ -49,6 +49,9 @@ public class ConvertToString extends AbstractConvertFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
+    // Checked here, not left to the delegate: ToStringFunction.checkArity would use its own getName() ("toString"),
+    // naming the wrong function in the error message for a call made as convert.toString()/apoc.convert.toString().
+    checkArity(args);
     return delegate.execute(args, context);
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/math/MathRound.java
+++ b/engine/src/main/java/com/arcadedb/function/math/MathRound.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.math;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+
+/**
+ * math.round(value, precision, mode) - APOC-namespaced entry point for the standard round() function,
+ * so it is also reachable as apoc.math.round(). See {@link RoundFunction} for the rounding semantics.
+ */
+public class MathRound extends AbstractMathFunction {
+  private final RoundFunction delegate = new RoundFunction();
+
+  @Override
+  protected String getSimpleName() {
+    return "round";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 3;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Rounds a number to the nearest integer or to a specified number of decimal places";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    return delegate.execute(args, context);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/math/MathRound.java
+++ b/engine/src/main/java/com/arcadedb/function/math/MathRound.java
@@ -49,6 +49,9 @@ public class MathRound extends AbstractMathFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
+    // Checked here, not left to the delegate: RoundFunction.checkArity would use its own getName() ("round"),
+    // naming the wrong function in the error message for a call made as math.round()/apoc.math.round().
+    checkArity(args);
     return delegate.execute(args, context);
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/number/AbstractNumberFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/number/AbstractNumberFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.number;
+
+import com.arcadedb.function.StatelessFunction;
+
+/**
+ * Abstract base class for number functions.
+ * All number functions share the "number." namespace prefix.
+ */
+public abstract class AbstractNumberFunction implements StatelessFunction {
+  protected static final String NAMESPACE = "number";
+
+  /**
+   * Returns the simple name without namespace prefix.
+   */
+  protected abstract String getSimpleName();
+
+  @Override
+  public String getName() {
+    return NAMESPACE + "." + getSimpleName();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/number/NumberFormat.java
+++ b/engine/src/main/java/com/arcadedb/function/number/NumberFormat.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.number;
 
-import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.text.DecimalFormat;
@@ -57,14 +57,14 @@ public class NumberFormat extends AbstractNumberFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args[0] == null)
+    checkArity(args);
+    final Number number = CypherFunctionHelper.requireNumberArgument(args[0], getName());
+    if (number == null)
       return null;
-    if (!(args[0] instanceof Number))
-      throw new CommandSemanticException(getName() + "() expects a number but got " + args[0].getClass().getSimpleName());
 
     final String pattern = args.length > 1 && args[1] != null ? args[1].toString() : DEFAULT_PATTERN;
 
     final DecimalFormat format = new DecimalFormat(pattern, DecimalFormatSymbols.getInstance(Locale.ROOT));
-    return format.format(((Number) args[0]).doubleValue());
+    return format.format(number.doubleValue());
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/number/NumberFormat.java
+++ b/engine/src/main/java/com/arcadedb/function/number/NumberFormat.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.number;
+
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.CommandContext;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+/**
+ * number.format(number, pattern) - Formats a number to a string using a {@link DecimalFormat} pattern.
+ * <p>
+ * Always uses {@link Locale#ROOT} symbols (','  grouping, '.' decimal separator) regardless of the JVM
+ * default locale, matching the convention the rest of the codebase follows for locale-sensitive
+ * formatting/parsing.
+ */
+public class NumberFormat extends AbstractNumberFunction {
+  private static final String DEFAULT_PATTERN = "#,##0.###";
+
+  @Override
+  protected String getSimpleName() {
+    return "format";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Formats a number to a string using an optional DecimalFormat pattern";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    if (args[0] == null)
+      return null;
+    if (!(args[0] instanceof Number))
+      throw new CommandSemanticException(getName() + "() expects a number but got " + args[0].getClass().getSimpleName());
+
+    final String pattern = args.length > 1 && args[1] != null ? args[1].toString() : DEFAULT_PATTERN;
+
+    final DecimalFormat format = new DecimalFormat(pattern, DecimalFormatSymbols.getInstance(Locale.ROOT));
+    return format.format(((Number) args[0]).doubleValue());
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/number/NumberFormat.java
+++ b/engine/src/main/java/com/arcadedb/function/number/NumberFormat.java
@@ -59,7 +59,10 @@ public class NumberFormat extends AbstractNumberFunction {
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
     final Number number = CypherFunctionHelper.requireNumberArgument(args[0], getName());
-    if (number == null)
+    // An explicitly-written null pattern propagates, same convention round()'s mode argument follows: only an
+    // omitted pattern selects the default, an explicit null is not distinguishable from "the caller wants no result".
+    final boolean nullPattern = CypherFunctionHelper.isExplicitNull(args, 1);
+    if (number == null || nullPattern)
       return null;
 
     final String pattern = args.length > 1 && args[1] != null ? args[1].toString() : DEFAULT_PATTERN;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.Function;
 import com.arcadedb.function.FunctionRegistry;
 import com.arcadedb.function.StatelessFunction;
@@ -592,6 +593,12 @@ class CypherBuiltInFunctionsTest extends TestHelper {
     final ResultSet rs = database.query("opencypher", "RETURN apoc.number.format(1000000, '#,###') AS result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<String>getProperty("result")).isEqualTo("1,000,000");
+  }
+
+  @Test
+  void numberFormatWrongArity() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN number.format() AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
   }
 
   // ===================== DATE FUNCTION TESTS =====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -490,6 +490,14 @@ class CypherBuiltInFunctionsTest extends TestHelper {
     assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(3.5);
   }
 
+  @Test
+  void mathRoundWrongArityErrorNamesMathRound() {
+    // MathRound delegates to RoundFunction; the arity error must name "math.round", not the delegate's own "round".
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN math.round(1, 2, 3, 4) AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("math.round");
+  }
+
   // ===================== CONVERT FUNCTION TESTS =====================
 
   @Test
@@ -574,6 +582,14 @@ class CypherBuiltInFunctionsTest extends TestHelper {
     assertThat(rs.next().<String>getProperty("result")).isEqualTo("42");
   }
 
+  @Test
+  void convertToStringWrongArityErrorNamesConvertToString() {
+    // ConvertToString delegates to ToStringFunction; the arity error must name "convert.toString", not "toString".
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN convert.toString(1, 2) AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("convert.toString");
+  }
+
   // ===================== NUMBER FUNCTION TESTS =====================
 
   @Test
@@ -599,6 +615,14 @@ class CypherBuiltInFunctionsTest extends TestHelper {
   void numberFormatWrongArity() {
     assertThatThrownBy(() -> database.query("opencypher", "RETURN number.format() AS result").hasNext())
         .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void numberFormatExplicitNullPatternPropagates() {
+    // An explicitly-written null pattern propagates to null, same convention round()'s mode argument follows -
+    // distinct from the pattern being omitted entirely, which falls back to the default pattern.
+    final StatelessFunction fn = CypherFunctionRegistry.get("number.format");
+    assertThat(fn.execute(new Object[] { 1234.5, null }, null)).isNull();
   }
 
   // ===================== DATE FUNCTION TESTS =====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -81,10 +81,21 @@ class CypherBuiltInFunctionsTest extends TestHelper {
     assertThat(CypherFunctionRegistry.hasFunction("apoc.date.currentTimestamp")).isTrue();
     assertThat(CypherFunctionRegistry.hasFunction("apoc.util.md5")).isTrue();
     assertThat(CypherFunctionRegistry.hasFunction("apoc.agg.median")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.coll.sum")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.coll.avg")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.coll.union")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.coll.unionAll")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.math.round")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.convert.toString")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.number.format")).isTrue();
 
     // Verify same function is returned with or without prefix
     assertThat(CypherFunctionRegistry.get("apoc.text.indexOf")).isSameAs(CypherFunctionRegistry.get("text.indexOf"));
     assertThat(CypherFunctionRegistry.get("apoc.map.merge")).isSameAs(CypherFunctionRegistry.get("map.merge"));
+    assertThat(CypherFunctionRegistry.get("apoc.coll.sum")).isSameAs(CypherFunctionRegistry.get("coll.sum"));
+    assertThat(CypherFunctionRegistry.get("apoc.math.round")).isSameAs(CypherFunctionRegistry.get("math.round"));
+    assertThat(CypherFunctionRegistry.get("apoc.convert.toString")).isSameAs(CypherFunctionRegistry.get("convert.toString"));
+    assertThat(CypherFunctionRegistry.get("apoc.number.format")).isSameAs(CypherFunctionRegistry.get("number.format"));
 
     // Test case insensitivity
     assertThat(CypherFunctionRegistry.get("APOC.TEXT.INDEXOF")).isSameAs(CypherFunctionRegistry.get("TEXT.INDEXOF"));
@@ -463,6 +474,21 @@ class CypherBuiltInFunctionsTest extends TestHelper {
     assertThat(fn.execute(new Object[] {}, null)).isEqualTo(Double.MAX_VALUE);
   }
 
+  @Test
+  void mathRound() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("math.round");
+    assertThat(fn.execute(new Object[] { 3.7 }, null)).isEqualTo(4.0);
+    assertThat(fn.execute(new Object[] { 3.14159, 2 }, null)).isEqualTo(3.14);
+    assertThat(fn.execute(new Object[] { 2.5, 0, "HALF_EVEN" }, null)).isEqualTo(2.0);
+  }
+
+  @Test
+  void mathRoundApocPrefix() {
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.math.round(3.456, 1) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(3.5);
+  }
+
   // ===================== CONVERT FUNCTION TESTS =====================
 
   @Test
@@ -530,6 +556,42 @@ class CypherBuiltInFunctionsTest extends TestHelper {
     final StatelessFunction fn = CypherFunctionRegistry.get("convert.toFloat");
     assertThat(fn.execute(new Object[] { "42" }, null)).isEqualTo(42.0);
     assertThat(fn.execute(new Object[] { "42.5" }, null)).isEqualTo(42.5);
+  }
+
+  @Test
+  void convertToStringFn() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("convert.toString");
+    assertThat(fn.execute(new Object[] { 42 }, null)).isEqualTo("42");
+    assertThat(fn.execute(new Object[] { true }, null)).isEqualTo("true");
+    assertThat(fn.execute(new Object[] { (Object) null }, null)).isNull();
+  }
+
+  @Test
+  void convertToStringApocPrefix() {
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.convert.toString(42) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("result")).isEqualTo("42");
+  }
+
+  // ===================== NUMBER FUNCTION TESTS =====================
+
+  @Test
+  void numberFormatDefaultPattern() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("number.format");
+    assertThat(fn.execute(new Object[] { 1234.5 }, null)).isEqualTo("1,234.5");
+  }
+
+  @Test
+  void numberFormatCustomPattern() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("number.format");
+    assertThat(fn.execute(new Object[] { 1234.5678, "#,##0.00" }, null)).isEqualTo("1,234.57");
+  }
+
+  @Test
+  void numberFormatApocPrefix() {
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.number.format(1000000, '#,###') AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("result")).isEqualTo("1,000,000");
   }
 
   // ===================== DATE FUNCTION TESTS =====================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.assertj.core.data.Offset;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for missing Cypher functions reported in GitHub issue #3420.
@@ -242,6 +244,31 @@ class CypherMissingFunctionsTest {
     assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(0.0);
   }
 
+  @Test
+  void collSumWrongArity() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.sum() AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void collSumNonNumericElement() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.sum([1, 2, 'x']) AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  // ========== coll.avg ==========
+  @Test
+  void collAvgWrongArity() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.avg() AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void collAvgNonNumericElement() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.avg([1, 2, 'x']) AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
   // ========== coll.union ==========
   @Test
   void collUnion() {
@@ -254,6 +281,23 @@ class CypherMissingFunctionsTest {
     assertThat(((Number) result.get(1)).longValue()).isEqualTo(2L);
     assertThat(((Number) result.get(2)).longValue()).isEqualTo(3L);
     assertThat(((Number) result.get(3)).longValue()).isEqualTo(4L);
+  }
+
+  @Test
+  void collUnionWrongArity() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.union([1, 2]) AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void collUnionDedupsByTypeAndValue() {
+    // Dedup is by object equality, so an integer and a float of the same numeric value are NOT collapsed -
+    // e.g. coll.union([1], [1.0]) keeps both. Documented here since it's an easy surprise coming from Neo4j.
+    final ResultSet rs = database.query("opencypher", "RETURN coll.union([1], [1.0]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(2);
   }
 
   // ========== coll.unionAll ==========
@@ -271,6 +315,12 @@ class CypherMissingFunctionsTest {
     assertThat(((Number) result.get(3)).longValue()).isEqualTo(2L);
     assertThat(((Number) result.get(4)).longValue()).isEqualTo(3L);
     assertThat(((Number) result.get(5)).longValue()).isEqualTo(4L);
+  }
+
+  @Test
+  void collUnionAllWrongArity() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.unionAll([1, 2]) AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
   }
 
   // ========== elementId ==========

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
@@ -51,6 +51,21 @@ class CypherMissingFunctionsTest {
       database.drop();
   }
 
+  // ========== coll.avg ==========
+  @Test
+  void collAvg() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.avg([1, 2, 3, 4]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(2.5);
+  }
+
+  @Test
+  void collAvgEmpty() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.avg([]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat((Object) rs.next().getProperty("result")).isNull();
+  }
+
   // ========== coll.distinct ==========
   @Test
   void collDistinct() {
@@ -210,6 +225,52 @@ class CypherMissingFunctionsTest {
     assertThat(((Number) result.get(2)).longValue()).isEqualTo(3L);
     assertThat(((Number) result.get(3)).longValue()).isEqualTo(4L);
     assertThat(((Number) result.get(4)).longValue()).isEqualTo(5L);
+  }
+
+  // ========== coll.sum ==========
+  @Test
+  void collSum() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.sum([1, 2, 3, 4]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(10.0);
+  }
+
+  @Test
+  void collSumEmpty() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.sum([]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(0.0);
+  }
+
+  // ========== coll.union ==========
+  @Test
+  void collUnion() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.union([1, 2, 3], [2, 3, 4]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(4);
+    assertThat(((Number) result.get(0)).longValue()).isEqualTo(1L);
+    assertThat(((Number) result.get(1)).longValue()).isEqualTo(2L);
+    assertThat(((Number) result.get(2)).longValue()).isEqualTo(3L);
+    assertThat(((Number) result.get(3)).longValue()).isEqualTo(4L);
+  }
+
+  // ========== coll.unionAll ==========
+  @Test
+  void collUnionAll() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.unionAll([1, 2, 3], [2, 3, 4]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    // Unlike coll.union, duplicates across the two lists are preserved
+    assertThat(result).hasSize(6);
+    assertThat(((Number) result.get(0)).longValue()).isEqualTo(1L);
+    assertThat(((Number) result.get(1)).longValue()).isEqualTo(2L);
+    assertThat(((Number) result.get(2)).longValue()).isEqualTo(3L);
+    assertThat(((Number) result.get(3)).longValue()).isEqualTo(2L);
+    assertThat(((Number) result.get(4)).longValue()).isEqualTo(3L);
+    assertThat(((Number) result.get(5)).longValue()).isEqualTo(4L);
   }
 
   // ========== elementId ==========

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
@@ -256,6 +256,22 @@ class CypherMissingFunctionsTest {
         .isInstanceOf(CommandSemanticException.class);
   }
 
+  @Test
+  void collSumNullElementIsSkipped() {
+    // requireNumberArgument propagates null for a null element rather than treating it as a type error,
+    // so a null in the list is skipped, not rejected - documented explicitly, not just an inferred side effect.
+    final ResultSet rs = database.query("opencypher", "RETURN coll.sum([1, 2, null]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(3.0);
+  }
+
+  @Test
+  void collSumApocPrefix() {
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.coll.sum([1, 2, 3, 4]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(10.0);
+  }
+
   // ========== coll.avg ==========
   @Test
   void collAvgWrongArity() {
@@ -267,6 +283,22 @@ class CypherMissingFunctionsTest {
   void collAvgNonNumericElement() {
     assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.avg([1, 2, 'x']) AS result").hasNext())
         .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void collAvgNullElementIsSkipped() {
+    // Same null-propagation as coll.sum: a null element is skipped rather than counted or rejected, so
+    // coll.avg([1, 2, null]) averages over the 2 non-null elements, not 3.
+    final ResultSet rs = database.query("opencypher", "RETURN coll.avg([1, 2, null]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(1.5);
+  }
+
+  @Test
+  void collAvgApocPrefix() {
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.coll.avg([1, 2, 3, 4]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("result").doubleValue()).isEqualTo(2.5);
   }
 
   // ========== coll.union ==========
@@ -300,6 +332,15 @@ class CypherMissingFunctionsTest {
     assertThat(result).hasSize(2);
   }
 
+  @Test
+  void collUnionApocPrefix() {
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.coll.union([1, 2], [2, 3]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(3);
+  }
+
   // ========== coll.unionAll ==========
   @Test
   void collUnionAll() {
@@ -321,6 +362,17 @@ class CypherMissingFunctionsTest {
   void collUnionAllWrongArity() {
     assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.unionAll([1, 2]) AS result").hasNext())
         .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void collUnionAllApocPrefix() {
+    // A 3-segment name post-strip (apoc.coll.unionAll -> coll.unionAll) exercises more of the dotted-name
+    // grammar than the 2-segment coll.* spellings, so this is worth its own round-trip check.
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.coll.unionAll([1, 2], [2, 3]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(4);
   }
 
   // ========== elementId ==========


### PR DESCRIPTION
## What does this PR do?

Adds 7 APOC-compatible Cypher functions, all reachable both under their bare name and the `apoc.*` prefix (the registry already strips that prefix automatically):

- `coll.sum(list)` - sum of a numeric list
- `coll.avg(list)` - average of a numeric list, `null` on empty
- `coll.union(list1, list2)` - distinct union, preserving order of first occurrence
- `coll.unionAll(list1, list2)` - concatenation, preserving duplicates (the difference from `union`)
- `math.round(value, precision, mode)` - namespaced entry point delegating to the existing `RoundFunction`
- `convert.toString(value)` - namespaced entry point delegating to the existing `ToStringFunction`
- `number.format(number, pattern)` - new, uses `DecimalFormat` pinned to `Locale.ROOT` (default pattern `#,##0.###`)

## Motivation

A customer migrating from Neo4j reported these as the highest-usage APOC functions missing from their query catalogue (out of 11 APOC functions used, only `apoc.date.format` previously existed). These 7 have direct, low-risk implementations; the remaining 3 (`apoc.do.when`, `apoc.refactor.mergeNodes`, `apoc.refactor.cloneNodesWithRelationships`) are graph-mutation procedures with real APOC config-flag semantics and are scoped separately.

## Related issues

Closes #6059

## Additional Notes

- `math.round` and `convert.toString` reuse the existing bare-name `RoundFunction`/`ToStringFunction` implementations by delegation rather than duplicating logic, since the APOC-namespaced name (`math.round`/`convert.toString`) doesn't resolve through the same registry entry as the bare Cypher-standard name (`round`/`toString`).
- `number.format` explicitly uses `DecimalFormatSymbols.getInstance(Locale.ROOT)` rather than the JVM default locale - this codebase has a dedicated `LocaleSensitivityTest` regression suite for exactly this class of bug (e.g. Turkish locale breaking casing), so any new locale-sensitive formatting follows that same convention.
- Extended `apocPrefixCompatibilityForFunctions()` in `CypherBuiltInFunctionsTest` to cover all 7 new functions.

## Checklist

- [x] I have run the build using `mvn clean package` command (ran `mvn -pl engine -am compile` + targeted `test` runs; full `mvn clean package` not run locally due to time, but engine module builds clean)
- [x] My unit tests cover both failure and success scenarios (empty-list cases for sum/avg, dedup vs non-dedup for union/unionAll, precision+mode variants for round, apoc-prefix round trips for all 7)
