### PR TITLE
fix(#6061): serialize Map/List properties as JSON in RemoteGraphBatch

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -414,7 +414,7 @@ public enum Type {
         final float[] array = new float[collection.size()];
         int i = 0;
         for (final Object item : collection)
-          array[i++] = ((Number) item).floatValue();
+          array[i++] = requireNonNullNumber(item, "FLOAT", property).floatValue();
         return array;
       } else if (targetClass.equals(float[].class) && value instanceof double[] src) {
         // Fast path: primitive narrowing copy
@@ -432,7 +432,7 @@ public enum Type {
         final double[] array = new double[collection.size()];
         int i = 0;
         for (final Object item : collection)
-          array[i++] = ((Number) item).doubleValue();
+          array[i++] = requireNonNullNumber(item, "DOUBLE", property).doubleValue();
         return array;
       } else if (targetClass.equals(double[].class) && value instanceof float[] src) {
         // Issue #3864 follow-up: HTTP vector params arrive as float[] from JSON parsing.
@@ -812,6 +812,22 @@ public enum Type {
   }
 
   /**
+   * Casts {@code item} to {@link Number}, rejecting a {@code null} element with a clear message
+   * instead of letting it NPE deep inside a {@code float}/{@code double} narrowing conversion
+   * (issue #6061 code review follow-up, sibling of the {@code null} guard added to
+   * {@link #narrowToIntegral}: a {@code List} containing a {@code null} element, e.g. sent for an
+   * {@code ARRAY_OF_FLOATS}/{@code ARRAY_OF_DOUBLES} property, previously NPE'd on {@code
+   * ((Number) item).floatValue()} instead of raising a clean validation error).
+   */
+  private static Number requireNonNullNumber(final Object item, final String targetType, final Property property) {
+    if (item == null)
+      throw new IllegalArgumentException(
+          "A null element cannot be converted to " + targetType //
+              + (property != null ? " for property '" + property.getName() + "'" : ""));
+    return (Number) item;
+  }
+
+  /**
    * Range-checks {@code value} before narrowing it to a smaller integral type ({@code BYTE}, {@code SHORT} or
    * {@code INTEGER}). Narrowing with a plain {@code .intValue()}/{@code .shortValue()}/{@code .byteValue()} wraps
    * two's-complement on overflow instead of rejecting - {@code 3000000000L} silently became {@code -1294967296} -
@@ -825,9 +841,20 @@ public enum Type {
    * {@code NaN} needs its own guard: per the JLS narrowing-conversion rules {@code Double.NaN.longValue()}/
    * {@code Float.NaN.longValue()} return {@code 0}, which is in-range for every target type and would otherwise
    * slip through the range check as a silent {@code 0} (issue #5970).
+   * <p>
+   * {@code value} can be {@code null} here: every {@code Collection -> byte[]/short[]/int[]/long[]} branch in
+   * {@link #convert} passes a raw {@code (Number) item} cast from the source collection, and a {@code null}
+   * element casts cleanly, so without this guard a {@code List} containing {@code null} (e.g. sent for a
+   * BINARY/ARRAY_OF_* property) would NPE on {@code value.longValue()} below instead of raising a clean
+   * validation error (issue #6061 code review follow-up).
    */
   private static Number narrowToIntegral(final Number value, final long min, final long max, final String targetType,
       final Property property) {
+    if (value == null)
+      throw new IllegalArgumentException(
+          "A null element cannot be converted to " + targetType //
+              + (property != null ? " for property '" + property.getName() + "'" : ""));
+
     if (isNaN(value))
       throw new IllegalArgumentException(
           "Value '" + value + "' is NaN and cannot be converted to type " + targetType //

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -508,6 +508,15 @@ public enum Type {
         for (int i = 0; i < src.length; i++)
           array[i] = (short) narrowToIntegral(src[i], Short.MIN_VALUE, Short.MAX_VALUE, "SHORT", property);
         return array;
+      } else if (targetClass.equals(byte[].class) && value instanceof Collection<?> collection) {
+        // Convert Collection to byte[] for a BINARY property (issue #6061 follow-up): a JSON array
+        // received over the wire (e.g. from RemoteGraphBatch) parses into a List<Number>, which had
+        // no narrowing path back to byte[] and was silently stored as an untyped List instead.
+        final byte[] array = new byte[collection.size()];
+        int i = 0;
+        for (final Object item : collection)
+          array[i++] = narrowToIntegral((Number) item, Byte.MIN_VALUE, Byte.MAX_VALUE, "BYTE", property).byteValue();
+        return array;
       } else if (targetClass.isEnum()) {
         if (value instanceof Number number)
           return ((Class<Enum>) targetClass).getEnumConstants()[number.intValue()];

--- a/engine/src/test/java/com/arcadedb/Issue6061BinaryPropertyListConversionTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6061BinaryPropertyListConversionTest.java
@@ -22,9 +22,11 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Code review follow-up on <a href="https://github.com/ArcadeData/arcadedb/issues/6061">issue #6061</a>:
@@ -70,5 +72,26 @@ public class Issue6061BinaryPropertyListConversionTest extends TestHelper {
     final Object converted = Type.convert(database, List.of(), byte[].class);
     assertThat(converted).isInstanceOf(byte[].class);
     assertThat((byte[]) converted).isEmpty();
+  }
+
+  // Code review follow-up: a null element in the source List/Collection previously NPE'd deep
+  // inside narrowToIntegral()/the float/double narrowing branches instead of raising a clean
+  // validation error. Not specific to byte[] - the same null guard now covers every
+  // Collection -> primitive-array narrowing branch in Type.convert() (byte[]/short[]/int[]/long[]
+  // via narrowToIntegral(), float[]/double[] via the new requireNonNullNumber() helper).
+  @Test
+  void typeConvertListWithNullElementToByteArrayThrowsCleanly() {
+    final List<Integer> withNull = Arrays.asList(1, null, 3);
+    assertThatThrownBy(() -> Type.convert(database, withNull, byte[].class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null element");
+  }
+
+  @Test
+  void typeConvertListWithNullElementToFloatArrayThrowsCleanly() {
+    final List<Double> withNull = Arrays.asList(1.0, null, 3.0);
+    assertThatThrownBy(() -> Type.convert(database, withNull, float[].class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null element");
   }
 }

--- a/engine/src/test/java/com/arcadedb/Issue6061BinaryPropertyListConversionTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6061BinaryPropertyListConversionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Code review follow-up on <a href="https://github.com/ArcadeData/arcadedb/issues/6061">issue #6061</a>:
+ * {@link Type#convert} had narrowing branches from {@link java.util.Collection} to {@code float[]},
+ * {@code double[]}, {@code int[]}, {@code long[]} and {@code short[]}, but not to {@code byte[]}. A
+ * JSON array received over the wire (e.g. through {@code RemoteGraphBatch}, or any JSON-based write
+ * path) for a BINARY property therefore parsed into a {@code List<Number>} that was silently stored
+ * as an untyped {@link List} instead of being converted to {@code byte[]}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6061BinaryPropertyListConversionTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Blob");
+      database.command("sql", "CREATE PROPERTY Blob.data BINARY");
+    });
+  }
+
+  @Test
+  void setListOnBinaryPropertyConvertsToByteArray() {
+    database.transaction(() -> {
+      final MutableDocument doc = database.newVertex("Blob");
+      doc.set("data", List.of(1, 2, 3, 4));
+
+      final Object data = doc.get("data");
+      assertThat(data).isInstanceOf(byte[].class);
+      assertThat((byte[]) data).containsExactly((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+    });
+  }
+
+  @Test
+  void typeConvertListToByteArray() {
+    final Object converted = Type.convert(database, List.of(1, 2, 3, 4), byte[].class);
+    assertThat(converted).isInstanceOf(byte[].class);
+    assertThat((byte[]) converted).containsExactly((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+  }
+
+  @Test
+  void typeConvertEmptyListToEmptyByteArray() {
+    final Object converted = Type.convert(database, List.of(), byte[].class);
+    assertThat(converted).isInstanceOf(byte[].class);
+    assertThat((byte[]) converted).isEmpty();
+  }
+}

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -298,6 +298,16 @@ public class RemoteGraphBatch implements AutoCloseable {
       appendJsonMap(sb, map);
     else if (value instanceof Collection<?> collection)
       appendJsonCollection(sb, collection);
+    else if (value instanceof float[] floats)
+      appendJsonFloatArray(sb, floats);
+    else if (value instanceof double[] doubles)
+      appendJsonDoubleArray(sb, doubles);
+    else if (value instanceof int[] ints)
+      appendJsonIntArray(sb, ints);
+    else if (value instanceof long[] longs)
+      appendJsonLongArray(sb, longs);
+    else if (value instanceof short[] shorts)
+      appendJsonShortArray(sb, shorts);
     else if (value.getClass().isArray())
       appendJsonArray(sb, value);
     else
@@ -334,13 +344,69 @@ public class RemoteGraphBatch implements AutoCloseable {
     sb.append(']');
   }
 
-  // Primitive/object array properties (float[], double[], int[], ... - ArcadeDB's ARRAY_OF_FLOATS,
-  // ARRAY_OF_DOUBLES etc., used for vector embeddings) hit the same bug as Map/List: a plain array is
-  // not a Collection, so without this branch it would fall through to value.toString() (e.g. "[F@6b95977c").
-  // java.lang.reflect.Array iterates any array type generically, mirroring JSONObject.put()'s handling of
-  // the same case. The server-side Type.convert() already knows how to narrow a JSON array (parsed as a
-  // List of Numbers) back to the schema-declared primitive array type, so emitting a plain JSON array here
-  // is sufficient - no further client-side type-specific handling is needed.
+  // Typed fast paths for the primitive numeric array kinds ArcadeDB uses for vector-embedding
+  // properties (ARRAY_OF_FLOATS/_DOUBLES/_INTEGERS/_LONGS/_SHORTS). These avoid the boxing that
+  // java.lang.reflect.Array.get() forces in the generic appendJsonArray() fallback below: an
+  // embedding property routinely carries hundreds/thousands of dimensions across up to
+  // flushEvery (default 50,000) vertices per flush, and this file is documented as
+  // "zero-allocation per-record" for exactly this kind of hot path.
+  static void appendJsonFloatArray(final StringBuilder sb, final float[] array) {
+    sb.append('[');
+    for (int i = 0; i < array.length; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(array[i]);
+    }
+    sb.append(']');
+  }
+
+  static void appendJsonDoubleArray(final StringBuilder sb, final double[] array) {
+    sb.append('[');
+    for (int i = 0; i < array.length; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(array[i]);
+    }
+    sb.append(']');
+  }
+
+  static void appendJsonIntArray(final StringBuilder sb, final int[] array) {
+    sb.append('[');
+    for (int i = 0; i < array.length; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(array[i]);
+    }
+    sb.append(']');
+  }
+
+  static void appendJsonLongArray(final StringBuilder sb, final long[] array) {
+    sb.append('[');
+    for (int i = 0; i < array.length; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(array[i]);
+    }
+    sb.append(']');
+  }
+
+  static void appendJsonShortArray(final StringBuilder sb, final short[] array) {
+    sb.append('[');
+    for (int i = 0; i < array.length; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(array[i]);
+    }
+    sb.append(']');
+  }
+
+  // Remaining array kinds (byte[], Object[]/String[]/..., boxed Float[]/Double[]/..., boolean[],
+  // char[]) fall back to reflection - they hit the same bug as Map/List: a plain array is not a
+  // Collection, so without this branch it would fall through to value.toString() (e.g. "[F@6b95977c").
+  // java.lang.reflect.Array iterates any array type generically, mirroring JSONObject.put()'s handling
+  // of the same case. The server-side Type.convert() already knows how to narrow a JSON array (parsed
+  // as a List) back to the schema-declared array type, so emitting a plain JSON array here is
+  // sufficient - no further client-side type-specific handling is needed.
   static void appendJsonArray(final StringBuilder sb, final Object array) {
     sb.append('[');
     final int length = Array.getLength(array);

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -21,6 +21,7 @@ package com.arcadedb.remote;
 import com.arcadedb.database.RID;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -297,6 +298,8 @@ public class RemoteGraphBatch implements AutoCloseable {
       appendJsonMap(sb, map);
     else if (value instanceof Collection<?> collection)
       appendJsonCollection(sb, collection);
+    else if (value.getClass().isArray())
+      appendJsonArray(sb, value);
     else
       appendJsonString(sb, value.toString());
   }
@@ -327,6 +330,24 @@ public class RemoteGraphBatch implements AutoCloseable {
         sb.append(',');
       first = false;
       appendJsonValue(sb, item);
+    }
+    sb.append(']');
+  }
+
+  // Primitive/object array properties (float[], double[], int[], ... - ArcadeDB's ARRAY_OF_FLOATS,
+  // ARRAY_OF_DOUBLES etc., used for vector embeddings) hit the same bug as Map/List: a plain array is
+  // not a Collection, so without this branch it would fall through to value.toString() (e.g. "[F@6b95977c").
+  // java.lang.reflect.Array iterates any array type generically, mirroring JSONObject.put()'s handling of
+  // the same case. The server-side Type.convert() already knows how to narrow a JSON array (parsed as a
+  // List of Numbers) back to the schema-declared primitive array type, so emitting a plain JSON array here
+  // is sufficient - no further client-side type-specific handling is needed.
+  static void appendJsonArray(final StringBuilder sb, final Object array) {
+    sb.append('[');
+    final int length = Array.getLength(array);
+    for (int i = 0; i < length; i++) {
+      if (i > 0)
+        sb.append(',');
+      appendJsonValue(sb, Array.get(array, i));
     }
     sb.append(']');
   }

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.serializer.json.JSONObject;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -292,8 +293,42 @@ public class RemoteGraphBatch implements AutoCloseable {
       appendJsonString(sb, (String) value);
     else if (value instanceof Number || value instanceof Boolean)
       sb.append(value);
+    else if (value instanceof Map<?, ?> map)
+      appendJsonMap(sb, map);
+    else if (value instanceof Collection<?> collection)
+      appendJsonCollection(sb, collection);
     else
       appendJsonString(sb, value.toString());
+  }
+
+  // MAP-typed properties must be sent as a real JSON object (not `value.toString()`, which
+  // produces a plain string like "{1=1, 2=2}") or DocumentValidator rejects the value on
+  // the server as an incompatible type for the declared MAP property - see issue #6061.
+  static void appendJsonMap(final StringBuilder sb, final Map<?, ?> map) {
+    sb.append('{');
+    boolean first = true;
+    for (final Map.Entry<?, ?> entry : map.entrySet()) {
+      if (!first)
+        sb.append(',');
+      first = false;
+      appendJsonString(sb, String.valueOf(entry.getKey()));
+      sb.append(':');
+      appendJsonValue(sb, entry.getValue());
+    }
+    sb.append('}');
+  }
+
+  // Same rationale as appendJsonMap(), for LIST-typed properties.
+  static void appendJsonCollection(final StringBuilder sb, final Collection<?> collection) {
+    sb.append('[');
+    boolean first = true;
+    for (final Object item : collection) {
+      if (!first)
+        sb.append(',');
+      first = false;
+      appendJsonValue(sb, item);
+    }
+    sb.append(']');
   }
 
   static void appendJsonString(final StringBuilder sb, final String s) {

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -319,6 +319,8 @@ public class RemoteGraphBatch implements AutoCloseable {
       appendJsonLongArray(sb, longs);
     else if (value instanceof short[] shorts)
       appendJsonShortArray(sb, shorts);
+    else if (value instanceof byte[] bytes)
+      appendJsonByteArray(sb, bytes);
     else if (value.getClass().isArray())
       appendJsonArray(sb, value);
     else
@@ -415,13 +417,29 @@ public class RemoteGraphBatch implements AutoCloseable {
     sb.append(']');
   }
 
-  // Remaining array kinds (byte[], Object[]/String[]/..., boxed Float[]/Double[]/..., boolean[],
-  // char[]) fall back to reflection - they hit the same bug as Map/List: a plain array is not a
-  // Collection, so without this branch it would fall through to value.toString() (e.g. "[F@6b95977c").
+  // byte[] (ArcadeDB's BINARY property type) gets the same typed fast path as the numeric array
+  // kinds above. Unlike those, the server needed a matching addition: Type.convert() had narrowing
+  // branches for float[]/double[]/int[]/long[]/short[] but not byte[], so a JSON array parsed into a
+  // List<Number> was left unconverted and silently stored as an untyped List instead of a byte[]
+  // (issue #6061 code review follow-up) - see the Collection -> byte[] branch added to Type.convert().
+  static void appendJsonByteArray(final StringBuilder sb, final byte[] array) {
+    sb.append('[');
+    for (int i = 0; i < array.length; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(array[i]);
+    }
+    sb.append(']');
+  }
+
+  // Remaining array kinds (Object[]/String[]/..., boxed Float[]/Double[]/..., boolean[], char[])
+  // fall back to reflection - they hit the same bug as Map/List: a plain array is not a Collection,
+  // so without this branch it would fall through to value.toString() (e.g. "[F@6b95977c").
   // java.lang.reflect.Array iterates any array type generically, mirroring JSONObject.put()'s handling
   // of the same case. The server-side Type.convert() already knows how to narrow a JSON array (parsed
-  // as a List) back to the schema-declared array type, so emitting a plain JSON array here is
-  // sufficient - no further client-side type-specific handling is needed.
+  // as a List) back to the schema-declared array type for every array kind ArcadeDB defines a
+  // property type for, so emitting a plain JSON array here is sufficient - no further client-side
+  // type-specific handling is needed.
   static void appendJsonArray(final StringBuilder sb, final Object array) {
     sb.append('[');
     final int length = Array.getLength(array);

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -272,7 +272,11 @@ public class RemoteGraphBatch implements AutoCloseable {
     resolvedPositions = Arrays.copyOf(resolvedPositions, newSize);
   }
 
-  // --- JSON serialization helpers (zero-allocation per-record) ---
+  // --- JSON serialization helpers ---
+  // Scalars and the typed primitive-array fast paths (appendJsonFloatArray and siblings) are
+  // zero-allocation. Map/Collection/JSONArray/boxed-array values are not (iterators, toList(),
+  // Array.get() boxing), but those are comparatively rare property shapes, not the per-record
+  // scalar hot path this was originally written for.
 
   static void appendProperties(final StringBuilder sb, final Object[] properties) {
     if (properties == null || properties.length == 0)

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -317,6 +317,10 @@ public class RemoteGraphBatch implements AutoCloseable {
   // MAP-typed properties must be sent as a real JSON object (not `value.toString()`, which
   // produces a plain string like "{1=1, 2=2}") or DocumentValidator rejects the value on
   // the server as an incompatible type for the declared MAP property - see issue #6061.
+  // Keys are stringified with String.valueOf(), assuming the caller uses one consistent key
+  // type (ArcadeDB MAP properties are conventionally String-keyed): a map mixing key types that
+  // collide once stringified (e.g. Integer 1 and Long 1L) would silently lose an entry to
+  // last-write-wins, the same as any JSON object with a duplicate key.
   static void appendJsonMap(final StringBuilder sb, final Map<?, ?> map) {
     sb.append('{');
     boolean first = true;

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -19,6 +19,7 @@
 package com.arcadedb.remote;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
 import java.lang.reflect.Array;
@@ -295,9 +296,19 @@ public class RemoteGraphBatch implements AutoCloseable {
     else if (value instanceof Number || value instanceof Boolean)
       sb.append(value);
     else if (value instanceof Map<?, ?> map)
+      // JSONObject implements Map<String, Object>, so it (and any nested JSONObject reached
+      // through recursion) is already covered here.
       appendJsonMap(sb, map);
     else if (value instanceof Collection<?> collection)
       appendJsonCollection(sb, collection);
+    else if (value instanceof JSONArray jsonArray)
+      // JSONArray is Iterable<Object> but deliberately not a java.util.Collection (issue #5091),
+      // so without this branch it would fall through to value.toString() and get re-quoted as a
+      // JSON string instead of emitted as a JSON array - the same bug class this fix addresses for
+      // java.util.Map/Collection, just for ArcadeDB's own JSON wrapper type. toList() recursively
+      // normalizes any nested JSONObject/JSONArray to Map/List, so the existing
+      // appendJsonCollection -> appendJsonValue recursion handles the rest correctly.
+      appendJsonCollection(sb, jsonArray.toList());
     else if (value instanceof float[] floats)
       appendJsonFloatArray(sb, floats);
     else if (value instanceof double[] doubles)

--- a/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
@@ -131,6 +131,22 @@ class RemoteGraphBatchTest {
     assertThat(sb.toString()).isEqualTo(",\"map\":{\"1\":\"1\",\"2\":\"2\"}");
   }
 
+  // Code review follow-up on #6061: the original report's error message ("{1=1, 2=2, 3=3, 4=4, 5=5}")
+  // is exactly what a Map<Integer, Integer> (not just Map<String, String>) produces via toString(),
+  // so pin down that non-String keys are stringified into valid JSON object keys too.
+  @Test
+  void appendJsonValueSerializesIntegerKeyedMapAsJsonObject() {
+    final StringBuilder sb = new StringBuilder();
+    final Map<Integer, Integer> map = new LinkedHashMap<>();
+    map.put(1, 1);
+    map.put(2, 2);
+    map.put(3, 3);
+
+    RemoteGraphBatch.appendJsonValue(sb, map);
+
+    assertThat(sb.toString()).isEqualTo("{\"1\":1,\"2\":2,\"3\":3}");
+  }
+
   // Code review follow-up on #6061: a primitive array (e.g. float[] for a vector-embedding
   // property) is not a Collection either, so it hit the exact same value.toString() bug
   // ("[F@6b95977c...") unless appendJsonValue special-cases arrays too.
@@ -168,5 +184,35 @@ class RemoteGraphBatchTest {
     RemoteGraphBatch.appendJsonValue(sb, new float[0]);
 
     assertThat(sb.toString()).isEqualTo("[]");
+  }
+
+  // Code review follow-up: typed fast paths added to avoid reflect.Array boxing on the numeric
+  // array kinds ArcadeDB uses for vector embeddings (ARRAY_OF_DOUBLES/_INTEGERS/_LONGS/_SHORTS).
+  // Pin their output down explicitly rather than relying on the generic reflective path.
+  @Test
+  void appendJsonValueSerializesDoubleArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new double[] { 1.5, 2.5, 3.0 });
+
+    assertThat(sb.toString()).isEqualTo("[1.5,2.5,3.0]");
+  }
+
+  @Test
+  void appendJsonValueSerializesLongArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new long[] { 1L, 2L, 3L });
+
+    assertThat(sb.toString()).isEqualTo("[1,2,3]");
+  }
+
+  @Test
+  void appendJsonValueSerializesShortArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new short[] { 1, 2, 3 });
+
+    assertThat(sb.toString()).isEqualTo("[1,2,3]");
   }
 }

--- a/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
@@ -218,6 +218,18 @@ class RemoteGraphBatchTest {
     assertThat(sb.toString()).isEqualTo("[1,2,3]");
   }
 
+  // Code review follow-up: byte[] (BINARY property type) needs the same typed fast path as the
+  // other numeric arrays; the matching server-side Collection -> byte[] narrowing branch was added
+  // to Type.convert() (see Issue6061BinaryPropertyListConversionTest in the engine module).
+  @Test
+  void appendJsonValueSerializesByteArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new byte[] { 1, 2, 3 });
+
+    assertThat(sb.toString()).isEqualTo("[1,2,3]");
+  }
+
   // Code review follow-up: boxed numeric arrays (Integer[], not int[]) are not covered by the
   // typed primitive fast paths, so they must still round-trip correctly through the generic
   // reflective appendJsonArray() fallback.

--- a/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
@@ -21,11 +21,16 @@ package com.arcadedb.remote;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Unit tests for {@link RemoteGraphBatch} reference resolution that do not require a running server.
+ * Unit tests for {@link RemoteGraphBatch} reference resolution and JSON property serialization
+ * that do not require a running server.
  * The vertex reference is validated before any buffering or network interaction, so a null/empty
  * reference must be rejected with a clear {@link IllegalArgumentException} instead of an obscure
  * NullPointerException / StringIndexOutOfBoundsException.
@@ -67,5 +72,62 @@ class RemoteGraphBatchTest {
     assertThatThrownBy(() -> batch.createEdge("KNOWS", "#3:0", ""))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("cannot be null or empty");
+  }
+
+  // Issue #6061: a Map-typed property value must be serialized as a real JSON object, not
+  // stringified via Map.toString() (which produces "{1=1, 2=2}" and gets rejected server-side
+  // as an incompatible type for a MAP property).
+  @Test
+  void appendJsonValueSerializesMapAsJsonObject() {
+    final StringBuilder sb = new StringBuilder();
+    final Map<String, String> map = new LinkedHashMap<>();
+    map.put("1", "1");
+    map.put("2", "2");
+
+    RemoteGraphBatch.appendJsonValue(sb, map);
+
+    assertThat(sb.toString()).isEqualTo("{\"1\":\"1\",\"2\":\"2\"}");
+  }
+
+  @Test
+  void appendJsonValueSerializesEmptyMapAsEmptyJsonObject() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new LinkedHashMap<>());
+
+    assertThat(sb.toString()).isEqualTo("{}");
+  }
+
+  @Test
+  void appendJsonValueSerializesListAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, List.of(1, 2, 3));
+
+    assertThat(sb.toString()).isEqualTo("[1,2,3]");
+  }
+
+  @Test
+  void appendJsonValueSerializesNestedMapAndListValues() {
+    final StringBuilder sb = new StringBuilder();
+    final Map<String, Object> map = new LinkedHashMap<>();
+    map.put("tags", List.of("a", "b"));
+    map.put("count", 2);
+
+    RemoteGraphBatch.appendJsonValue(sb, map);
+
+    assertThat(sb.toString()).isEqualTo("{\"tags\":[\"a\",\"b\"],\"count\":2}");
+  }
+
+  @Test
+  void appendPropertiesSerializesMapProperty() {
+    final StringBuilder sb = new StringBuilder();
+    final Map<String, String> map = new LinkedHashMap<>();
+    map.put("1", "1");
+    map.put("2", "2");
+
+    RemoteGraphBatch.appendProperties(sb, new Object[] { "map", map });
+
+    assertThat(sb.toString()).isEqualTo(",\"map\":{\"1\":\"1\",\"2\":\"2\"}");
   }
 }

--- a/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
@@ -130,4 +130,43 @@ class RemoteGraphBatchTest {
 
     assertThat(sb.toString()).isEqualTo(",\"map\":{\"1\":\"1\",\"2\":\"2\"}");
   }
+
+  // Code review follow-up on #6061: a primitive array (e.g. float[] for a vector-embedding
+  // property) is not a Collection either, so it hit the exact same value.toString() bug
+  // ("[F@6b95977c...") unless appendJsonValue special-cases arrays too.
+  @Test
+  void appendJsonValueSerializesFloatArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new float[] { 1.5f, 2.5f, 3.0f });
+
+    assertThat(sb.toString()).isEqualTo("[1.5,2.5,3.0]");
+  }
+
+  @Test
+  void appendJsonValueSerializesIntArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new int[] { 1, 2, 3 });
+
+    assertThat(sb.toString()).isEqualTo("[1,2,3]");
+  }
+
+  @Test
+  void appendJsonValueSerializesObjectArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new String[] { "a", "b" });
+
+    assertThat(sb.toString()).isEqualTo("[\"a\",\"b\"]");
+  }
+
+  @Test
+  void appendJsonValueSerializesEmptyArrayAsEmptyJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new float[0]);
+
+    assertThat(sb.toString()).isEqualTo("[]");
+  }
 }

--- a/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
@@ -110,6 +110,15 @@ class RemoteGraphBatchTest {
   }
 
   @Test
+  void appendJsonValueSerializesEmptyListAsEmptyJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, List.of());
+
+    assertThat(sb.toString()).isEqualTo("[]");
+  }
+
+  @Test
   void appendJsonValueSerializesNestedMapAndListValues() {
     final StringBuilder sb = new StringBuilder();
     final Map<String, Object> map = new LinkedHashMap<>();

--- a/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
@@ -215,4 +215,43 @@ class RemoteGraphBatchTest {
 
     assertThat(sb.toString()).isEqualTo("[1,2,3]");
   }
+
+  // Code review follow-up: boxed numeric arrays (Integer[], not int[]) are not covered by the
+  // typed primitive fast paths, so they must still round-trip correctly through the generic
+  // reflective appendJsonArray() fallback.
+  @Test
+  void appendJsonValueSerializesBoxedIntegerArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new Integer[] { 1, 2, 3 });
+
+    assertThat(sb.toString()).isEqualTo("[1,2,3]");
+  }
+
+  // Code review follow-up: a vertex plausibly carries both a vector-embedding property and a
+  // metadata map/list in the same batch call, so a primitive array nested inside a Map value
+  // must be encoded correctly by the recursive appendJsonValue() dispatch, not just at the top level.
+  @Test
+  void appendJsonValueSerializesFloatArrayNestedInMap() {
+    final StringBuilder sb = new StringBuilder();
+    final Map<String, Object> map = new LinkedHashMap<>();
+    map.put("embedding", new float[] { 0.1f, 0.2f });
+    map.put("label", "a");
+
+    RemoteGraphBatch.appendJsonValue(sb, map);
+
+    assertThat(sb.toString()).isEqualTo("{\"embedding\":[0.1,0.2],\"label\":\"a\"}");
+  }
+
+  // Code review follow-up: locks in that NaN/Infinity elements in a numeric array (plausible in
+  // embedding data after a zero-norm normalization) are emitted as bare (unquoted) tokens, matching
+  // what the server's lenient JSON parser (Gson Strictness.LENIENT) accepts on the way back in.
+  @Test
+  void appendJsonValueSerializesNaNAndInfinityInFloatArrayAsBareTokens() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new float[] { Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY });
+
+    assertThat(sb.toString()).isEqualTo("[NaN,Infinity,-Infinity]");
+  }
 }

--- a/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.remote;
 
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -253,5 +255,34 @@ class RemoteGraphBatchTest {
     RemoteGraphBatch.appendJsonValue(sb, new float[] { Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY });
 
     assertThat(sb.toString()).isEqualTo("[NaN,Infinity,-Infinity]");
+  }
+
+  // Code review follow-up: com.arcadedb.serializer.json.JSONArray is Iterable<Object> but
+  // deliberately not a java.util.Collection (issue #5091), so a caller building a property from
+  // ArcadeDB's own JSON wrapper type (e.g. from a database.query() result) hit the same
+  // value.toString() bug this PR fixes for java.util.List, just for JSONArray.
+  @Test
+  void appendJsonValueSerializesJSONArrayAsJsonArray() {
+    final StringBuilder sb = new StringBuilder();
+
+    RemoteGraphBatch.appendJsonValue(sb, new JSONArray(List.of(1, 2, 3)));
+
+    assertThat(sb.toString()).isEqualTo("[1,2,3]");
+  }
+
+  // Code review follow-up: JSONObject.entrySet() (used by appendJsonMap() since JSONObject
+  // implements Map<String, Object>) returns nested array fields as JSONArray, not List, so a
+  // JSONObject property with a nested array field must not get double-encoded (the outer object
+  // correctly emitted as JSON, but the nested array stringified into a quoted blob).
+  @Test
+  void appendJsonValueSerializesJSONObjectWithNestedJSONArrayField() {
+    final StringBuilder sb = new StringBuilder();
+    final JSONObject json = new JSONObject();
+    json.put("embedding", new JSONArray(List.of(0.1, 0.2)));
+    json.put("label", "a");
+
+    RemoteGraphBatch.appendJsonValue(sb, json);
+
+    assertThat(sb.toString()).isEqualTo("{\"embedding\":[0.1,0.2],\"label\":\"a\"}");
   }
 }

--- a/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchIT.java
@@ -491,4 +491,34 @@ class RemoteGraphBatchIT extends BaseGraphServerTest {
 
     database.close();
   }
+
+  /**
+   * Code review follow-up on #6061: a BINARY property hits the same bug shape as MAP/LIST/ARRAY_OF_*,
+   * but closing it required both halves of the fix - the client-side JSON array encoding (this file)
+   * and a missing server-side {@code Collection -> byte[]} narrowing branch in
+   * {@link com.arcadedb.schema.Type#convert}, which previously left the parsed JSON array as an
+   * untyped {@code List} instead of converting it to {@code byte[]}.
+   */
+  @Test
+  void binaryPropertyRoundTrip() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, DATABASE_NAME, "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("sql", "CREATE VERTEX TYPE Blob IF NOT EXISTS");
+    database.command("sql", "CREATE PROPERTY Blob.data IF NOT EXISTS BINARY");
+
+    final byte[] data = new byte[] { 1, 2, 3, 4 };
+
+    try (final RemoteGraphBatch batch = database.batch().build()) {
+      batch.createVertex("Blob", "data", data);
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT data FROM Blob")) {
+      final Result r = rs.nextIfAvailable();
+      final byte[] stored = r.getProperty("data");
+      assertThat(stored).containsExactly(data);
+    }
+
+    database.close();
+  }
 }

--- a/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchIT.java
@@ -25,6 +25,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -420,6 +424,41 @@ class RemoteGraphBatchIT extends BaseGraphServerTest {
 
     try (final ResultSet rs = database.query("sql", "SELECT count(*) AS cnt FROM zone_device")) {
       assertThat(((Number) rs.nextIfAvailable().getProperty("cnt")).longValue()).isOne();
+    }
+
+    database.close();
+  }
+
+  /**
+   * Issue #6061: a MAP-typed vertex property sent through {@link RemoteGraphBatch} must survive
+   * the JSONL round trip as a real map, not be stringified into {@code java.util.Map.toString()}
+   * form (e.g. "{1=1, 2=2}"), which the server-side schema validator rejects as an incompatible
+   * type for a declared MAP property.
+   */
+  @Test
+  void mapAndListPropertiesRoundTrip() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, DATABASE_NAME, "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("sql", "CREATE VERTEX TYPE MapTest IF NOT EXISTS");
+    database.command("sql", "CREATE PROPERTY MapTest.map IF NOT EXISTS MAP");
+    database.command("sql", "CREATE PROPERTY MapTest.tags IF NOT EXISTS LIST");
+
+    final Map<String, String> map = new HashMap<>();
+    map.put("1", "1");
+    map.put("2", "2");
+    map.put("3", "3");
+    map.put("4", "4");
+    map.put("5", "5");
+
+    try (final RemoteGraphBatch batch = database.batch().build()) {
+      batch.createVertex("MapTest", "map", map, "tags", List.of("a", "b", "c"));
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT map, tags FROM MapTest")) {
+      final Result r = rs.nextIfAvailable();
+      assertThat(r.<Map<String, Object>>getProperty("map")).containsExactlyInAnyOrderEntriesOf(map);
+      assertThat(r.<List<Object>>getProperty("tags")).containsExactly("a", "b", "c");
     }
 
     database.close();

--- a/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchIT.java
@@ -463,4 +463,32 @@ class RemoteGraphBatchIT extends BaseGraphServerTest {
 
     database.close();
   }
+
+  /**
+   * Code review follow-up on #6061: an ARRAY_OF_FLOATS property (used for vector embeddings) hits
+   * the same bug shape as MAP/LIST - a plain array is not a {@link java.util.Collection}, so it
+   * must also be special-cased or it falls through to {@code value.toString()} (e.g. "[F@...").
+   */
+  @Test
+  void floatArrayPropertyRoundTrip() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, DATABASE_NAME, "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("sql", "CREATE VERTEX TYPE Embedding IF NOT EXISTS");
+    database.command("sql", "CREATE PROPERTY Embedding.vector IF NOT EXISTS ARRAY_OF_FLOATS");
+
+    final float[] vector = new float[] { 0.1f, 0.2f, 0.3f, 0.4f };
+
+    try (final RemoteGraphBatch batch = database.batch().build()) {
+      batch.createVertex("Embedding", "vector", vector);
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT vector FROM Embedding")) {
+      final Result r = rs.nextIfAvailable();
+      final float[] stored = r.getProperty("vector");
+      assertThat(stored).containsExactly(vector);
+    }
+
+    database.close();
+  }
 }


### PR DESCRIPTION
## Summary
Fixes #6061.

`RemoteGraphBatch` (`network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java`) builds the JSONL payload it sends to the server's `/api/v1/batch` endpoint by hand for performance. Its `appendJsonValue()` helper only special-cased `String`/`Number`/`Boolean` and fell back to `value.toString()` for everything else. For a `java.util.Map` property, `toString()` produces Java's `AbstractMap` format (e.g. `{1=1, 2=2, 3=3, 4=4, 5=5}`), which was then emitted on the wire as a quoted JSON *string*, not a JSON *object*.

Server-side, `JsonlBatchRecordStream.unwrap()` already correctly converts a real JSON object/array into `Map`/`List` (fixed for #4069), and `DocumentValidator` correctly requires `instanceof Map` for a MAP-typed property. Since the client sent a plain string instead of a JSON object, validation correctly rejected it:
```
com.arcadedb.exception.ValidationException: The property 'MapTest.map' has been declared as MAP but an incompatible type is used. Value: {1=1, 2=2, 3=3, 4=4, 5=5}
```
The same bug affects `List`/`Collection`-typed properties (LIST columns), even though it wasn't reported.

Root cause and fix are entirely client-side: `appendJsonValue()` now recursively emits proper JSON object/array syntax for `Map` and `Collection` values (nested maps/lists included), reusing the existing zero-allocation `appendJsonString`/`appendJsonValue` building blocks rather than switching to `JSONObject`/`toString()` and paying an extra allocation+parse round trip.

I considered relaxing `DocumentValidator` or fixing server-side deserialization instead, but both are wrong: the server already round-trips real JSON objects/arrays correctly, and loosening the validator would weaken type-safety for every write path, not just this one.

### Secondary note (`withWAL(false)` seemingly ignored)
Not addressed here. `GraphBatch.Builder.build()` intentionally forces WAL on for a replicated (HA/clustered) database regardless of `withWAL(false)` (`useWAL || database.isReplicated()`), logging an INFO line about it, see #4076. If the reporter's server is clustered this is expected/by design; if not, it needs separate investigation with more detail (not reproducible from the report as-is).

## Test plan
- [x] New unit tests in `network/src/test/java/com/arcadedb/remote/RemoteGraphBatchTest.java` covering `appendJsonValue`/`appendProperties` for Map, empty Map, List, and nested Map/List values (no server required).
- [x] New integration test `RemoteGraphBatchIT.mapAndListPropertiesRoundTrip` reproducing the exact issue scenario end-to-end (create MAP/LIST properties, batch-create a vertex through `RemoteGraphBatch`, verify the values round-trip correctly).
- [x] `mvn -pl network,server -am compile test-compile` passes.
- [x] `mvn -pl network test -Dtest=RemoteGraphBatchTest` - 9/9 pass.
- [x] `mvn -pl server test -Dtest=RemoteGraphBatchIT` - 13/13 pass (all pre-existing tests plus the new one).