### PR TITLE
feat(#6060): add apoc.do.when, apoc.refactor.mergeNodes, apoc.refactor.cloneNodesWithRelationships

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/CypherProcedureRegistry.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/CypherProcedureRegistry.java
@@ -99,11 +99,11 @@ import com.arcadedb.query.opencypher.procedures.meta.MetaSchema;
 import com.arcadedb.query.opencypher.procedures.meta.MetaStats;
 import com.arcadedb.query.opencypher.procedures.path.PathExpand;
 import com.arcadedb.query.opencypher.procedures.path.PathExpandConfig;
-import com.arcadedb.query.opencypher.procedures.refactor.RefactorCloneNodesWithRelationships;
-import com.arcadedb.query.opencypher.procedures.refactor.RefactorMergeNodes;
 import com.arcadedb.query.opencypher.procedures.path.PathSpanningTree;
 import com.arcadedb.query.opencypher.procedures.path.PathSubgraphAll;
 import com.arcadedb.query.opencypher.procedures.path.PathSubgraphNodes;
+import com.arcadedb.query.opencypher.procedures.refactor.RefactorCloneNodesWithRelationships;
+import com.arcadedb.query.opencypher.procedures.refactor.RefactorMergeNodes;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/CypherProcedureRegistry.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/CypherProcedureRegistry.java
@@ -89,6 +89,7 @@ import com.arcadedb.query.opencypher.procedures.algo.AlgoTopologicalSort;
 import com.arcadedb.query.opencypher.procedures.algo.AlgoTriangleCount;
 import com.arcadedb.query.opencypher.procedures.algo.AlgoVoteRank;
 import com.arcadedb.query.opencypher.procedures.algo.AlgoWCC;
+import com.arcadedb.query.opencypher.procedures.control.DoWhen;
 import com.arcadedb.query.opencypher.procedures.merge.MergeNode;
 import com.arcadedb.query.opencypher.procedures.merge.MergeRelationship;
 import com.arcadedb.query.opencypher.procedures.meta.MetaGraph;
@@ -98,6 +99,8 @@ import com.arcadedb.query.opencypher.procedures.meta.MetaSchema;
 import com.arcadedb.query.opencypher.procedures.meta.MetaStats;
 import com.arcadedb.query.opencypher.procedures.path.PathExpand;
 import com.arcadedb.query.opencypher.procedures.path.PathExpandConfig;
+import com.arcadedb.query.opencypher.procedures.refactor.RefactorCloneNodesWithRelationships;
+import com.arcadedb.query.opencypher.procedures.refactor.RefactorMergeNodes;
 import com.arcadedb.query.opencypher.procedures.path.PathSpanningTree;
 import com.arcadedb.query.opencypher.procedures.path.PathSubgraphAll;
 import com.arcadedb.query.opencypher.procedures.path.PathSubgraphNodes;
@@ -293,6 +296,10 @@ public final class CypherProcedureRegistry {
     registerMetaProcedures();
     // Database index procedures (Neo4j compatibility)
     registerDbProcedures();
+    // Control-flow procedures (APOC compatibility)
+    registerControlProcedures();
+    // Refactor procedures (APOC compatibility)
+    registerRefactorProcedures();
   }
 
   private static void registerMergeProcedures() {
@@ -389,5 +396,14 @@ public final class CypherProcedureRegistry {
     register(new MetaStats());
     register(new MetaNodeTypeProperties());
     register(new MetaRelTypeProperties());
+  }
+
+  private static void registerControlProcedures() {
+    register(new DoWhen());
+  }
+
+  private static void registerRefactorProcedures() {
+    register(new RefactorMergeNodes());
+    register(new RefactorCloneNodesWithRelationships());
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
@@ -49,6 +49,19 @@ import java.util.stream.Stream;
  * silently pick a branch rather than surfacing the caller's mistake.
  * </p>
  * <p>
+ * {@code ifQuery} is type-checked unconditionally, even on a call where {@code condition} is false and
+ * {@code ifQuery} never runs - a malformed call fails the same way regardless of which branch is taken,
+ * rather than only failing once someone happens to trigger the true branch. {@code elseQuery} differs
+ * only in that {@code null} is accepted, meaning "no else branch": the call yields zero rows rather than
+ * running anything.
+ * </p>
+ * <p>
+ * {@code ifQuery}/{@code elseQuery} run as Cypher against this database with whatever privileges the
+ * caller already has - same as real APOC's {@code apoc.do.when}/{@code apoc.cypher.doIt}, and no more
+ * of a new risk than any other place in the engine that runs a caller-supplied command string. As with
+ * those, never build either argument by concatenating untrusted input.
+ * </p>
+ * <p>
  * Example:
  * <pre>
  * CALL apoc.do.when(size($list) > 0, 'RETURN $list[0] AS first', 'RETURN null AS first', {list: $list})

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.control;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.query.QueryEngine;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Procedure: do.when(condition, ifQuery, elseQuery, params)
+ * <p>
+ * Runs {@code ifQuery} when {@code condition} is true, {@code elseQuery} otherwise, both given as
+ * Cypher query strings, with {@code params} bound into the sub-query as named parameters. Each row
+ * the sub-query produces is yielded as a map under {@code value}. The sub-query is dispatched to
+ * {@link Database#query} or {@link Database#command} depending on whether it is read-only, so both
+ * read and write sub-queries work without the caller having to say which.
+ * </p>
+ * <p>
+ * Example:
+ * <pre>
+ * CALL apoc.do.when(size($list) > 0, 'RETURN $list[0] AS first', 'RETURN null AS first', {list: $list})
+ * YIELD value
+ * RETURN value.first
+ * </pre>
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
+ */
+public class DoWhen implements CypherProcedure {
+  public static final String NAME = "do.when";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 4;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 4;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Runs ifQuery when condition is true, elseQuery otherwise, binding params into the sub-query.";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("value");
+  }
+
+  @Override
+  public boolean isWriteProcedure() {
+    return true;
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    validateArgs(args);
+
+    final boolean condition = extractBoolean(args[0]);
+    final String ifQuery = extractString(args[1], "ifQuery");
+    final String elseQuery = args[2] == null ? "" : args[2].toString();
+    final Map<String, Object> params = extractMap(args[3]);
+
+    final String query = condition ? ifQuery : elseQuery;
+    if (query == null || query.isBlank())
+      return Stream.empty();
+
+    final Database database = context.getDatabase();
+    final QueryEngine queryEngine = database.getQueryEngine("opencypher");
+    final boolean idempotent = queryEngine.analyze(query).isIdempotent();
+
+    final ResultSet resultSet = idempotent ?
+        database.query("opencypher", query, params) :
+        database.command("opencypher", query, params);
+
+    final List<Result> rows = new ArrayList<>();
+    while (resultSet.hasNext()) {
+      final Result row = resultSet.next();
+      final ResultInternal wrapped = new ResultInternal();
+      wrapped.setProperty("value", row.toMap());
+      rows.add(wrapped);
+    }
+    resultSet.close();
+
+    return rows.stream();
+  }
+
+  private boolean extractBoolean(final Object arg) {
+    if (arg instanceof Boolean b)
+      return b;
+    throw new IllegalArgumentException(getName() + "(): condition must be a boolean, got " +
+        (arg == null ? "null" : arg.getClass().getSimpleName()));
+  }
+
+  private String extractString(final Object arg, final String paramName) {
+    if (arg == null)
+      throw new IllegalArgumentException(getName() + "(): " + paramName + " cannot be null");
+    return arg.toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> extractMap(final Object arg) {
+    if (arg == null)
+      return Collections.emptyMap();
+    if (!(arg instanceof Map))
+      throw new IllegalArgumentException(getName() + "(): params must be a map, got " + arg.getClass().getSimpleName());
+    return (Map<String, Object>) arg;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
@@ -102,18 +102,17 @@ public class DoWhen implements CypherProcedure {
     final QueryEngine queryEngine = database.getQueryEngine("opencypher");
     final boolean idempotent = queryEngine.analyze(query).isIdempotent();
 
-    final ResultSet resultSet = idempotent ?
-        database.query("opencypher", query, params) :
-        database.command("opencypher", query, params);
-
     final List<Result> rows = new ArrayList<>();
-    while (resultSet.hasNext()) {
-      final Result row = resultSet.next();
-      final ResultInternal wrapped = new ResultInternal();
-      wrapped.setProperty("value", row.toMap());
-      rows.add(wrapped);
+    try (final ResultSet resultSet = idempotent ?
+        database.query("opencypher", query, params) :
+        database.command("opencypher", query, params)) {
+      while (resultSet.hasNext()) {
+        final Result row = resultSet.next();
+        final ResultInternal wrapped = new ResultInternal();
+        wrapped.setProperty("value", row.toMap());
+        rows.add(wrapped);
+      }
     }
-    resultSet.close();
 
     return rows.stream();
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
@@ -42,6 +42,13 @@ import java.util.stream.Stream;
  * read and write sub-queries work without the caller having to say which.
  * </p>
  * <p>
+ * {@code condition} must be a literal {@code Boolean} - unlike real APOC, which coerces other
+ * truthy/falsy values. Cypher boolean expressions (comparisons, {@code AND}/{@code OR}, {@code IS
+ * NULL}, ...) already evaluate to {@code Boolean}, so this only rejects a caller passing something
+ * else entirely (a string, a number, a list), which is intentional: a coerced non-boolean would
+ * silently pick a branch rather than surfacing the caller's mistake.
+ * </p>
+ * <p>
  * Example:
  * <pre>
  * CALL apoc.do.when(size($list) > 0, 'RETURN $list[0] AS first', 'RETURN null AS first', {list: $list})
@@ -91,7 +98,7 @@ public class DoWhen implements CypherProcedure {
 
     final boolean condition = extractBoolean(args[0]);
     final String ifQuery = extractString(args[1], "ifQuery");
-    final String elseQuery = args[2] == null ? "" : args[2].toString();
+    final String elseQuery = args[2] == null ? "" : extractString(args[2], "elseQuery");
     final Map<String, Object> params = extractMap(args[3]);
 
     final String query = condition ? ifQuery : elseQuery;
@@ -125,9 +132,10 @@ public class DoWhen implements CypherProcedure {
   }
 
   private String extractString(final Object arg, final String paramName) {
-    if (arg == null)
-      throw new IllegalArgumentException(getName() + "(): " + paramName + " cannot be null");
-    return arg.toString();
+    if (!(arg instanceof String s))
+      throw new IllegalArgumentException(getName() + "(): " + paramName + " must be a string, got " +
+          (arg == null ? "null" : arg.getClass().getSimpleName()));
+    return s;
   }
 
   @SuppressWarnings("unchecked")

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationships.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationships.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.refactor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableEdge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Procedure: refactor.cloneNodesWithRelationships(nodes, config)
+ * <p>
+ * Clones each given node - a new vertex of the same type carrying the same properties - together with
+ * every relationship touching it in either direction. A relationship whose other endpoint is also being
+ * cloned reconnects the two clones rather than the originals; a relationship to a node outside the given
+ * list reconnects the clone to that same original node. The source nodes and their relationships are
+ * left untouched.
+ * </p>
+ * <p>
+ * {@code config.skipProperties}, when given, is a list of property names excluded from the clone.
+ * </p>
+ * <p>
+ * Example:
+ * <pre>
+ * MATCH (a:Person {name:'A'}), (b:Person {name:'B'})
+ * CALL apoc.refactor.cloneNodesWithRelationships([a, b], {})
+ * YIELD input, output, error
+ * RETURN input, output, error
+ * </pre>
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
+ */
+public class RefactorCloneNodesWithRelationships implements CypherProcedure {
+  public static final String NAME = "refactor.cloneNodesWithRelationships";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Clones each given node together with every relationship touching it.";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("input", "output", "error");
+  }
+
+  @Override
+  public boolean isWriteProcedure() {
+    return true;
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    validateArgs(args);
+
+    final List<Vertex> nodes = extractVertices(args[0]);
+    final Set<String> skipProperties = extractSkipProperties(args[1]);
+    final Database database = context.getDatabase();
+
+    final Map<RID, Vertex> cloneOf = new LinkedHashMap<>();
+    final List<Result> results = new ArrayList<>();
+
+    for (final Vertex original : nodes) {
+      try {
+        final MutableVertex clone = database.newVertex(original.getTypeName());
+        for (final String propertyName : original.getPropertyNames()) {
+          if (skipProperties.contains(propertyName))
+            continue;
+          clone.set(propertyName, original.get(propertyName));
+        }
+        clone.save();
+        cloneOf.put(original.getIdentity(), clone);
+        results.add(row(original, clone, null));
+      } catch (final Exception e) {
+        results.add(row(original, null, e.getMessage()));
+      }
+    }
+
+    final Set<RID> processedEdges = new HashSet<>();
+    for (final Vertex original : nodes) {
+      if (!cloneOf.containsKey(original.getIdentity()))
+        continue;
+
+      for (final Edge edge : original.getEdges()) {
+        if (!processedEdges.add(edge.getIdentity()))
+          continue;
+        cloneEdge(edge, cloneOf);
+      }
+    }
+
+    return results.stream();
+  }
+
+  private void cloneEdge(final Edge edge, final Map<RID, Vertex> cloneOf) {
+    final RID originalOut = edge.getOut();
+    final RID originalIn = edge.getIn();
+
+    final Vertex newOutVertex = cloneOf.containsKey(originalOut) ? cloneOf.get(originalOut) : originalOut.asVertex(true);
+    final Identifiable newInTarget = cloneOf.containsKey(originalIn) ? cloneOf.get(originalIn) : originalIn;
+
+    final MutableEdge newEdge = newOutVertex.newEdge(edge.getTypeName(), newInTarget);
+    final Map<String, Object> properties = edge.propertiesAsMap();
+    if (!properties.isEmpty())
+      newEdge.set(properties);
+    newEdge.save();
+  }
+
+  private Result row(final Vertex input, final Vertex output, final String error) {
+    final ResultInternal result = new ResultInternal();
+    result.setProperty("input", input);
+    result.setProperty("output", output);
+    result.setProperty("error", error);
+    return result;
+  }
+
+  private List<Vertex> extractVertices(final Object arg) {
+    if (!(arg instanceof List<?> list))
+      throw new IllegalArgumentException(getName() + "(): nodes must be a list, got " +
+          (arg == null ? "null" : arg.getClass().getSimpleName()));
+
+    final List<Vertex> vertices = new ArrayList<>();
+    for (final Object item : list) {
+      if (!(item instanceof Vertex vertex))
+        throw new IllegalArgumentException(getName() + "(): every element of nodes must be a node, got " +
+            (item == null ? "null" : item.getClass().getSimpleName()));
+      vertices.add(vertex);
+    }
+    return vertices;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Set<String> extractSkipProperties(final Object configArg) {
+    if (!(configArg instanceof Map))
+      return Collections.emptySet();
+
+    final Object skip = ((Map<String, Object>) configArg).get("skipProperties");
+    if (!(skip instanceof List))
+      return Collections.emptySet();
+
+    final Set<String> result = new HashSet<>();
+    for (final Object item : (List<?>) skip)
+      if (item != null)
+        result.add(item.toString());
+    return result;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationships.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationships.java
@@ -25,6 +25,7 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -37,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.stream.Stream;
 
 /**
@@ -47,6 +49,12 @@ import java.util.stream.Stream;
  * cloned reconnects the two clones rather than the originals; a relationship to a node outside the given
  * list reconnects the clone to that same original node. The source nodes and their relationships are
  * left untouched.
+ * </p>
+ * <p>
+ * Both phases are best-effort per item, never aborting the whole call: a node that fails to clone gets
+ * its own {@code (input, null, error)} row and is excluded from the second, edge-cloning phase, and an
+ * edge that fails to clone (e.g. a unique-index conflict on the new edge) is skipped rather than losing
+ * the yield rows already produced for the nodes that did clone successfully.
  * </p>
  * <p>
  * {@code config.skipProperties}, when given, is a list of property names excluded from the clone.
@@ -100,8 +108,9 @@ public class RefactorCloneNodesWithRelationships implements CypherProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final List<Vertex> nodes = extractVertices(args[0]);
-    final Set<String> skipProperties = extractSkipProperties(args[1]);
+    final List<Vertex> nodes = RefactorProcedureArgs.extractVertices(getName(), args[0]);
+    final Map<String, Object> config = RefactorProcedureArgs.extractConfig(getName(), args[1]);
+    final Set<String> skipProperties = extractSkipProperties(config);
     final Database database = context.getDatabase();
 
     final Map<RID, Vertex> cloneOf = new LinkedHashMap<>();
@@ -131,7 +140,13 @@ public class RefactorCloneNodesWithRelationships implements CypherProcedure {
       for (final Edge edge : original.getEdges()) {
         if (!processedEdges.add(edge.getIdentity()))
           continue;
-        cloneEdge(edge, cloneOf);
+        try {
+          cloneEdge(edge, cloneOf);
+        } catch (final Exception e) {
+          // best-effort: one bad edge (e.g. a unique-index conflict on the new edge) must not cost
+          // the rows already produced for the nodes that cloned successfully
+          LogManager.instance().log(this, Level.WARNING, "Error cloning edge %s while executing %s()", e, edge.getIdentity(), getName());
+        }
       }
     }
 
@@ -160,27 +175,8 @@ public class RefactorCloneNodesWithRelationships implements CypherProcedure {
     return result;
   }
 
-  private List<Vertex> extractVertices(final Object arg) {
-    if (!(arg instanceof List<?> list))
-      throw new IllegalArgumentException(getName() + "(): nodes must be a list, got " +
-          (arg == null ? "null" : arg.getClass().getSimpleName()));
-
-    final List<Vertex> vertices = new ArrayList<>();
-    for (final Object item : list) {
-      if (!(item instanceof Vertex vertex))
-        throw new IllegalArgumentException(getName() + "(): every element of nodes must be a node, got " +
-            (item == null ? "null" : item.getClass().getSimpleName()));
-      vertices.add(vertex);
-    }
-    return vertices;
-  }
-
-  @SuppressWarnings("unchecked")
-  private Set<String> extractSkipProperties(final Object configArg) {
-    if (!(configArg instanceof Map))
-      return Collections.emptySet();
-
-    final Object skip = ((Map<String, Object>) configArg).get("skipProperties");
+  private Set<String> extractSkipProperties(final Map<String, Object> config) {
+    final Object skip = config.get("skipProperties");
     if (!(skip instanceof List))
       return Collections.emptySet();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationships.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationships.java
@@ -53,8 +53,10 @@ import java.util.stream.Stream;
  * <p>
  * Both phases are best-effort per item, never aborting the whole call: a node that fails to clone gets
  * its own {@code (input, null, error)} row and is excluded from the second, edge-cloning phase, and an
- * edge that fails to clone (e.g. a unique-index conflict on the new edge) is skipped rather than losing
- * the yield rows already produced for the nodes that did clone successfully.
+ * edge that fails to clone (e.g. a mandatory-property violation on the new edge) is skipped rather than
+ * losing the yield rows already produced for the nodes that did clone successfully. Note this covers
+ * failures raised synchronously on {@code save()} - a UNIQUE index violation is NOT one of them, since
+ * ArcadeDB defers uniqueness checking to commit time, so it still fails the whole transaction.
  * </p>
  * <p>
  * {@code config.skipProperties}, when given, is a list of property names excluded from the clone.
@@ -143,8 +145,8 @@ public class RefactorCloneNodesWithRelationships implements CypherProcedure {
         try {
           cloneEdge(edge, cloneOf);
         } catch (final Exception e) {
-          // best-effort: one bad edge (e.g. a unique-index conflict on the new edge) must not cost
-          // the rows already produced for the nodes that cloned successfully
+          // best-effort: one bad edge (e.g. a mandatory-property violation on the new edge) must not
+          // cost the rows already produced for the nodes that cloned successfully
           LogManager.instance().log(this, Level.WARNING, "Error cloning edge %s while executing %s()", e, edge.getIdentity(), getName());
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodes.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.query.opencypher.procedures.refactor;
 
-import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableEdge;
@@ -30,7 +29,6 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,7 +99,7 @@ public class RefactorMergeNodes implements CypherProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final List<Vertex> nodes = deduplicateByIdentity(RefactorProcedureArgs.extractVertices(getName(), args[0]));
+    final List<Vertex> nodes = RefactorProcedureArgs.extractVertices(getName(), args[0]);
     if (nodes.size() < 2)
       throw new CommandSemanticException(getName() + "(): at least two distinct nodes are required to merge");
 
@@ -123,20 +121,6 @@ public class RefactorMergeNodes implements CypherProcedure {
     }
 
     return createResultStream(survivorMutable);
-  }
-
-  /**
-   * Collapses repeated identities to their first occurrence, keeping insertion order. Without this, a
-   * node listed twice among the absorbed ones (e.g. {@code mergeNodes([a, b, b], {})}) would be
-   * processed a second time after already being merged away, and {@code absorbed.modify()} would raise
-   * an uncaught {@link com.arcadedb.exception.RecordNotFoundException} instead of a clean validation
-   * error - or, if it reappears as the survivor's own identity, a redundant no-op self-merge.
-   */
-  private List<Vertex> deduplicateByIdentity(final List<Vertex> nodes) {
-    final Map<RID, Vertex> byIdentity = new LinkedHashMap<>();
-    for (final Vertex node : nodes)
-      byIdentity.putIfAbsent(node.getIdentity(), node);
-    return new ArrayList<>(byIdentity.values());
   }
 
   private void mergeProperties(final MutableVertex survivor, final Vertex absorbed, final String policy) {
@@ -166,6 +150,9 @@ public class RefactorMergeNodes implements CypherProcedure {
             combined.add(absorbedValue);
           survivor.set(propertyName, combined);
         }
+        // unreachable in practice - extractPropertiesPolicy validates policy against VALID_POLICIES
+        // before mergeProperties is ever called; kept as a defensive fallback against the two drifting
+        // apart under a future edit, e.g. a new call site that skips extractPropertiesPolicy
         default -> throw new CommandSemanticException(getName() + "(): unknown properties policy '" + policy + "'");
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodes.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.refactor;
+
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableEdge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Procedure: refactor.mergeNodes(nodes, config)
+ * <p>
+ * Merges a list of nodes into the first one (the survivor). Every incoming and outgoing edge of the
+ * other nodes (the absorbed nodes) is rewired onto the survivor - an edge that connected two nodes
+ * both being merged becomes a self-relationship on the survivor - and the absorbed nodes are then
+ * deleted.
+ * </p>
+ * <p>
+ * {@code config.properties} controls how a property present on both the survivor and an absorbed node
+ * is resolved: {@code "overwrite"} (the absorbed node's value wins, the default), {@code "discard"}
+ * (the survivor's original value is kept) or {@code "combine"} (both values are kept as a list). A
+ * property present only on an absorbed node is always copied onto the survivor.
+ * </p>
+ * <p>
+ * Example:
+ * <pre>
+ * MATCH (a:Person {name:'A'}), (b:Person {name:'B'})
+ * CALL apoc.refactor.mergeNodes([a, b], {properties: 'combine'})
+ * YIELD node
+ * RETURN node
+ * </pre>
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
+ */
+public class RefactorMergeNodes implements CypherProcedure {
+  public static final String NAME = "refactor.mergeNodes";
+
+  private static final Set<String> VALID_POLICIES = Set.of("overwrite", "discard", "combine");
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 2;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 2;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Merges a list of nodes into the first one, rewiring their edges and deleting the absorbed nodes.";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("node");
+  }
+
+  @Override
+  public boolean isWriteProcedure() {
+    return true;
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    validateArgs(args);
+
+    final List<Vertex> nodes = extractVertices(args[0]);
+    if (nodes.size() < 2)
+      throw new CommandSemanticException(getName() + "(): at least two nodes are required to merge");
+
+    final Map<String, Object> config = extractMap(args[1]);
+    final String globalPolicy = extractPropertiesPolicy(config);
+
+    final Vertex survivor = nodes.get(0);
+    MutableVertex survivorMutable = survivor.modify();
+
+    for (int i = 1; i < nodes.size(); i++) {
+      final Vertex absorbed = nodes.get(i);
+      if (absorbed.getIdentity().equals(survivorMutable.getIdentity()))
+        continue;
+
+      mergeProperties(survivorMutable, absorbed, globalPolicy);
+      survivorMutable.save();
+
+      rewireEdges(absorbed, survivorMutable);
+
+      absorbed.modify().delete();
+    }
+
+    return createResultStream(survivorMutable);
+  }
+
+  private void mergeProperties(final MutableVertex survivor, final Vertex absorbed, final String policy) {
+    for (final String propertyName : absorbed.getPropertyNames()) {
+      final Object absorbedValue = absorbed.get(propertyName);
+
+      if (!survivor.getPropertyNames().contains(propertyName)) {
+        survivor.set(propertyName, absorbedValue);
+        continue;
+      }
+
+      switch (policy) {
+        case "overwrite" -> survivor.set(propertyName, absorbedValue);
+        case "discard" -> {
+          // keep the survivor's original value
+        }
+        case "combine" -> {
+          final Object survivorValue = survivor.get(propertyName);
+          final List<Object> combined = new ArrayList<>();
+          if (survivorValue instanceof List<?> list)
+            combined.addAll(list);
+          else
+            combined.add(survivorValue);
+          if (absorbedValue instanceof List<?> list)
+            combined.addAll(list);
+          else
+            combined.add(absorbedValue);
+          survivor.set(propertyName, combined);
+        }
+        default -> throw new CommandSemanticException(getName() + "(): unknown properties policy '" + policy + "'");
+      }
+    }
+  }
+
+  private void rewireEdges(final Vertex absorbed, final MutableVertex survivor) {
+    final List<Edge> edgesToRewire = new ArrayList<>();
+    for (final Edge edge : absorbed.getEdges())
+      edgesToRewire.add(edge);
+
+    for (final Edge edge : edgesToRewire) {
+      final MutableEdge mutableEdge = edge.modify();
+      if (mutableEdge.getOut().equals(absorbed.getIdentity()))
+        mutableEdge.set("@out", survivor.getIdentity());
+      if (mutableEdge.getIn().equals(absorbed.getIdentity()))
+        mutableEdge.set("@in", survivor.getIdentity());
+    }
+  }
+
+  private Stream<Result> createResultStream(final Vertex node) {
+    final ResultInternal result = new ResultInternal();
+    result.setProperty("node", node);
+    return Stream.of(result);
+  }
+
+  private List<Vertex> extractVertices(final Object arg) {
+    if (!(arg instanceof List<?> list))
+      throw new IllegalArgumentException(getName() + "(): nodes must be a list, got " +
+          (arg == null ? "null" : arg.getClass().getSimpleName()));
+
+    final List<Vertex> vertices = new ArrayList<>();
+    for (final Object item : list) {
+      if (!(item instanceof Vertex vertex))
+        throw new IllegalArgumentException(getName() + "(): every element of nodes must be a node, got " +
+            (item == null ? "null" : item.getClass().getSimpleName()));
+      vertices.add(vertex);
+    }
+    return vertices;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> extractMap(final Object arg) {
+    if (arg == null)
+      return Collections.emptyMap();
+    if (!(arg instanceof Map))
+      throw new IllegalArgumentException(getName() + "(): config must be a map, got " + arg.getClass().getSimpleName());
+    return (Map<String, Object>) arg;
+  }
+
+  private String extractPropertiesPolicy(final Map<String, Object> config) {
+    final Object raw = config.get("properties");
+    if (raw == null)
+      return "overwrite";
+    final String policy = raw.toString();
+    if (!VALID_POLICIES.contains(policy))
+      throw new CommandSemanticException(getName() + "(): unknown properties policy '" + policy + "'");
+    return policy;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodes.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher.procedures.refactor;
 
+import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableEdge;
@@ -29,7 +30,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -100,20 +101,18 @@ public class RefactorMergeNodes implements CypherProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final List<Vertex> nodes = extractVertices(args[0]);
+    final List<Vertex> nodes = deduplicateByIdentity(RefactorProcedureArgs.extractVertices(getName(), args[0]));
     if (nodes.size() < 2)
-      throw new CommandSemanticException(getName() + "(): at least two nodes are required to merge");
+      throw new CommandSemanticException(getName() + "(): at least two distinct nodes are required to merge");
 
-    final Map<String, Object> config = extractMap(args[1]);
+    final Map<String, Object> config = RefactorProcedureArgs.extractConfig(getName(), args[1]);
     final String globalPolicy = extractPropertiesPolicy(config);
 
     final Vertex survivor = nodes.get(0);
-    MutableVertex survivorMutable = survivor.modify();
+    final MutableVertex survivorMutable = survivor.modify();
 
     for (int i = 1; i < nodes.size(); i++) {
       final Vertex absorbed = nodes.get(i);
-      if (absorbed.getIdentity().equals(survivorMutable.getIdentity()))
-        continue;
 
       mergeProperties(survivorMutable, absorbed, globalPolicy);
       survivorMutable.save();
@@ -124,6 +123,20 @@ public class RefactorMergeNodes implements CypherProcedure {
     }
 
     return createResultStream(survivorMutable);
+  }
+
+  /**
+   * Collapses repeated identities to their first occurrence, keeping insertion order. Without this, a
+   * node listed twice among the absorbed ones (e.g. {@code mergeNodes([a, b, b], {})}) would be
+   * processed a second time after already being merged away, and {@code absorbed.modify()} would raise
+   * an uncaught {@link com.arcadedb.exception.RecordNotFoundException} instead of a clean validation
+   * error - or, if it reappears as the survivor's own identity, a redundant no-op self-merge.
+   */
+  private List<Vertex> deduplicateByIdentity(final List<Vertex> nodes) {
+    final Map<RID, Vertex> byIdentity = new LinkedHashMap<>();
+    for (final Vertex node : nodes)
+      byIdentity.putIfAbsent(node.getIdentity(), node);
+    return new ArrayList<>(byIdentity.values());
   }
 
   private void mergeProperties(final MutableVertex survivor, final Vertex absorbed, final String policy) {
@@ -176,30 +189,6 @@ public class RefactorMergeNodes implements CypherProcedure {
     final ResultInternal result = new ResultInternal();
     result.setProperty("node", node);
     return Stream.of(result);
-  }
-
-  private List<Vertex> extractVertices(final Object arg) {
-    if (!(arg instanceof List<?> list))
-      throw new IllegalArgumentException(getName() + "(): nodes must be a list, got " +
-          (arg == null ? "null" : arg.getClass().getSimpleName()));
-
-    final List<Vertex> vertices = new ArrayList<>();
-    for (final Object item : list) {
-      if (!(item instanceof Vertex vertex))
-        throw new IllegalArgumentException(getName() + "(): every element of nodes must be a node, got " +
-            (item == null ? "null" : item.getClass().getSimpleName()));
-      vertices.add(vertex);
-    }
-    return vertices;
-  }
-
-  @SuppressWarnings("unchecked")
-  private Map<String, Object> extractMap(final Object arg) {
-    if (arg == null)
-      return Collections.emptyMap();
-    if (!(arg instanceof Map))
-      throw new IllegalArgumentException(getName() + "(): config must be a map, got " + arg.getClass().getSimpleName());
-    return (Map<String, Object>) arg;
   }
 
   private String extractPropertiesPolicy(final Map<String, Object> config) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorProcedureArgs.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorProcedureArgs.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.refactor;
+
+import com.arcadedb.graph.Vertex;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Argument-extraction helpers shared by the {@code refactor.*} procedures, which all take a
+ * {@code (nodes, config)} argument shape.
+ */
+final class RefactorProcedureArgs {
+  private RefactorProcedureArgs() {
+  }
+
+  static List<Vertex> extractVertices(final String procedureName, final Object arg) {
+    if (!(arg instanceof List<?> list))
+      throw new IllegalArgumentException(procedureName + "(): nodes must be a list, got " +
+          (arg == null ? "null" : arg.getClass().getSimpleName()));
+
+    final List<Vertex> vertices = new ArrayList<>();
+    for (final Object item : list) {
+      if (!(item instanceof Vertex vertex))
+        throw new IllegalArgumentException(procedureName + "(): every element of nodes must be a node, got " +
+            (item == null ? "null" : item.getClass().getSimpleName()));
+      vertices.add(vertex);
+    }
+    return vertices;
+  }
+
+  @SuppressWarnings("unchecked")
+  static Map<String, Object> extractConfig(final String procedureName, final Object arg) {
+    if (arg == null)
+      return Collections.emptyMap();
+    if (!(arg instanceof Map))
+      throw new IllegalArgumentException(procedureName + "(): config must be a map, got " + arg.getClass().getSimpleName());
+    return (Map<String, Object>) arg;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorProcedureArgs.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorProcedureArgs.java
@@ -18,10 +18,12 @@
  */
 package com.arcadedb.query.opencypher.procedures.refactor;
 
+import com.arcadedb.database.RID;
 import com.arcadedb.graph.Vertex;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -33,19 +35,28 @@ final class RefactorProcedureArgs {
   private RefactorProcedureArgs() {
   }
 
+  /**
+   * Parses {@code arg} into a list of distinct nodes, collapsing a repeated identity to its first
+   * occurrence (keeping insertion order). Neither {@code mergeNodes} nor {@code cloneNodesWithRelationships}
+   * has a sound way to handle the same node appearing twice - {@code mergeNodes} would re-absorb an
+   * already-deleted record, and {@code cloneNodesWithRelationships} would silently orphan one of the two
+   * resulting clones (its edges all land on whichever clone {@code cloneOf} was overwritten with last) -
+   * so both are better served by treating the list as a set of nodes than by either crashing or producing
+   * an output the caller has no way to detect is incomplete.
+   */
   static List<Vertex> extractVertices(final String procedureName, final Object arg) {
     if (!(arg instanceof List<?> list))
       throw new IllegalArgumentException(procedureName + "(): nodes must be a list, got " +
           (arg == null ? "null" : arg.getClass().getSimpleName()));
 
-    final List<Vertex> vertices = new ArrayList<>();
+    final Map<RID, Vertex> byIdentity = new LinkedHashMap<>();
     for (final Object item : list) {
       if (!(item instanceof Vertex vertex))
         throw new IllegalArgumentException(procedureName + "(): every element of nodes must be a node, got " +
             (item == null ? "null" : item.getClass().getSimpleName()));
-      vertices.add(vertex);
+      byIdentity.putIfAbsent(vertex.getIdentity(), vertex);
     }
-    return vertices;
+    return new ArrayList<>(byIdentity.values());
   }
 
   @SuppressWarnings("unchecked")

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/control/DoWhenTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/control/DoWhenTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.control;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the apoc.do.when Cypher procedure (registered as "do.when").
+ */
+class DoWhenTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-do-when");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Person");
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void registeredUnderBothPlainAndApocPrefixedName() {
+    assertThat(CypherProcedureRegistry.hasProcedure("do.when")).isTrue();
+    assertThat(CypherProcedureRegistry.hasProcedure("apoc.do.when")).isTrue();
+    assertThat(CypherProcedureRegistry.get("apoc.do.when")).isSameAs(CypherProcedureRegistry.get("do.when"));
+  }
+
+  @Test
+  void trueConditionRunsIfQuery() {
+    final ResultSet rs = database.query("opencypher",
+        "CALL apoc.do.when(true, 'RETURN 1 AS x', 'RETURN 2 AS x', {}) YIELD value RETURN value");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Map<String, Object> value = (Map<String, Object>) rs.next().getProperty("value");
+    assertThat(value.get("x")).isEqualTo(1L);
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
+  void falseConditionRunsElseQuery() {
+    final ResultSet rs = database.query("opencypher",
+        "CALL apoc.do.when(false, 'RETURN 1 AS x', 'RETURN 2 AS x', {}) YIELD value RETURN value");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Map<String, Object> value = (Map<String, Object>) rs.next().getProperty("value");
+    assertThat(value.get("x")).isEqualTo(2L);
+  }
+
+  @Test
+  void emptyElseQueryOnFalseConditionYieldsNoRows() {
+    final ResultSet rs = database.query("opencypher",
+        "CALL apoc.do.when(false, 'RETURN 1 AS x', '', {}) YIELD value RETURN value");
+
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  @Test
+  void paramsAreBoundIntoSubQuery() {
+    final ResultSet rs = database.query("opencypher",
+        "CALL apoc.do.when(true, 'RETURN $name AS greeting', '', {name: 'hello'}) YIELD value RETURN value");
+
+    final Map<String, Object> value = (Map<String, Object>) rs.next().getProperty("value");
+    assertThat(value.get("greeting")).isEqualTo("hello");
+  }
+
+  @Test
+  void writeSubQueryIsPersisted() {
+    final ResultSet rs = database.query("opencypher",
+        "CALL apoc.do.when(true, \"CREATE (n:Person {name: 'Bob'}) RETURN n\", '', {}) YIELD value RETURN value");
+    assertThat(rs.hasNext()).isTrue();
+    rs.next();
+
+    final ResultSet check = database.query("opencypher", "MATCH (p:Person {name: 'Bob'}) RETURN p");
+    assertThat(check.hasNext()).isTrue();
+  }
+
+  @Test
+  void wrongArgumentCountThrows() {
+    assertThatThrownBy(() -> database.query("opencypher", "CALL apoc.do.when(true, 'RETURN 1') YIELD value RETURN value").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/control/DoWhenTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/control/DoWhenTest.java
@@ -114,4 +114,32 @@ class DoWhenTest {
     assertThatThrownBy(() -> database.query("opencypher", "CALL apoc.do.when(true, 'RETURN 1') YIELD value RETURN value").hasNext())
         .isInstanceOf(CommandSemanticException.class);
   }
+
+  @Test
+  void nonBooleanConditionThrows() {
+    assertThatThrownBy(() -> database.query("opencypher",
+        "CALL apoc.do.when(1, 'RETURN 1 AS x', '', {}) YIELD value RETURN value").hasNext())
+        .hasCauseInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void nonStringIfQueryThrows() {
+    assertThatThrownBy(() -> database.query("opencypher",
+        "CALL apoc.do.when(true, 1, '', {}) YIELD value RETURN value").hasNext())
+        .hasCauseInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void nonStringElseQueryThrows() {
+    assertThatThrownBy(() -> database.query("opencypher",
+        "CALL apoc.do.when(false, 'RETURN 1 AS x', 1, {}) YIELD value RETURN value").hasNext())
+        .hasCauseInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void nonMapParamsThrows() {
+    assertThatThrownBy(() -> database.query("opencypher",
+        "CALL apoc.do.when(true, 'RETURN 1 AS x', '', 'not-a-map') YIELD value RETURN value").hasNext())
+        .hasCauseInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationshipsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationshipsTest.java
@@ -166,6 +166,36 @@ class RefactorCloneNodesWithRelationshipsTest {
   }
 
   @Test
+  void duplicateNodeInTheListProducesOneCloneWithAllItsEdges() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex external = database.newVertex("Person").set("name", "External").save();
+    a.newEdge("KNOWS", external, "since", 2020L).save();
+    database.commit();
+
+    // Before nodes were deduplicated, [a,a] created TWO clones but cloneOf (keyed by the original's
+    // identity) only remembered the second, so the edge phase wired every one of 'a's edges onto that
+    // second clone while the first clone - still yielded with error=null - silently got none.
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}) CALL apoc.refactor.cloneNodesWithRelationships([a,a], {}) "
+            + "YIELD input, output, error RETURN input, output, error");
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+    database.commit();
+
+    assertThat(rows).hasSize(1);
+    final Vertex output = rows.get(0).getProperty("output");
+
+    final ResultSet clonedEdges = database.query("opencypher",
+        "MATCH (c:Person)-[r:KNOWS]->(e:Person {name:'External'}) WHERE id(c) = $cloneId RETURN r.since AS since",
+        java.util.Map.of("cloneId", output.getIdentity().toString()));
+    assertThat(clonedEdges.hasNext()).isTrue();
+    assertThat(clonedEdges.next().<Long>getProperty("since")).isEqualTo(2020L);
+  }
+
+  @Test
   void nonMapConfigThrows() {
     database.begin();
     database.newVertex("Person").set("name", "A").save();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationshipsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationshipsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.refactor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the apoc.refactor.cloneNodesWithRelationships Cypher procedure
+ * (registered as "refactor.cloneNodesWithRelationships").
+ * <p>
+ * The procedure mutates the graph, so every CALL runs inside an explicit transaction that is fully
+ * consumed and committed before any assertion - see {@link RefactorMergeNodesTest} class Javadoc for
+ * why CypherProcedure execution needs that.
+ * </p>
+ */
+class RefactorCloneNodesWithRelationshipsTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-refactor-clone-nodes");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void registeredUnderBothPlainAndApocPrefixedName() {
+    assertThat(CypherProcedureRegistry.hasProcedure("refactor.cloneNodesWithRelationships")).isTrue();
+    assertThat(CypherProcedureRegistry.hasProcedure("apoc.refactor.cloneNodesWithRelationships")).isTrue();
+    assertThat(CypherProcedureRegistry.get("apoc.refactor.cloneNodesWithRelationships"))
+        .isSameAs(CypherProcedureRegistry.get("refactor.cloneNodesWithRelationships"));
+  }
+
+  @Test
+  void clonesNodeWithSameTypeAndProperties() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").set("age", 30L).save();
+    database.commit();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}) CALL apoc.refactor.cloneNodesWithRelationships([a], {}) YIELD input, output, error RETURN input, output, error");
+    final Result result = rs.next();
+    final Object error = result.getProperty("error");
+    final Vertex input = result.getProperty("input");
+    final Vertex output = result.getProperty("output");
+    database.commit();
+
+    assertThat(error).isNull();
+    assertThat(output.getIdentity()).isNotEqualTo(input.getIdentity());
+    assertThat(output.getTypeName()).isEqualTo("Person");
+    assertThat(output.getString("name")).isEqualTo("A");
+    assertThat(output.getLong("age")).isEqualTo(30L);
+  }
+
+  @Test
+  void clonedRelationshipToExternalNodePointsAtOriginalExternalNode() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex external = database.newVertex("Person").set("name", "External").save();
+    a.newEdge("KNOWS", external, "since", 2020L).save();
+    database.commit();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}) CALL apoc.refactor.cloneNodesWithRelationships([a], {}) YIELD output RETURN output");
+    final Vertex clone = rs.next().getProperty("output");
+    database.commit();
+
+    final ResultSet edges = database.query("opencypher",
+        "MATCH (c:Person)-[r:KNOWS]->(e:Person {name:'External'}) WHERE id(c) = $cloneId RETURN r.since AS since",
+        java.util.Map.of("cloneId", clone.getIdentity().toString()));
+    assertThat(edges.hasNext()).isTrue();
+    assertThat(edges.next().<Long>getProperty("since")).isEqualTo(2020L);
+
+    // original relationship must be untouched
+    final ResultSet originalEdges = database.query("opencypher",
+        "MATCH (a:Person {name:'A'})-[r:KNOWS]->(e:Person {name:'External'}) RETURN r");
+    assertThat(originalEdges.hasNext()).isTrue();
+  }
+
+  @Test
+  void relationshipBetweenTwoClonedNodesConnectsTheTwoClones() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    a.newEdge("KNOWS", b, "since", 2021L).save();
+    database.commit();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) "
+            + "CALL apoc.refactor.cloneNodesWithRelationships([a,b], {}) YIELD input, output RETURN input, output");
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+    database.commit();
+
+    Vertex cloneOfA = null;
+    Vertex cloneOfB = null;
+    for (final Result row : rows) {
+      final Vertex input = row.getProperty("input");
+      final Vertex output = row.getProperty("output");
+      if ("A".equals(input.getString("name")))
+        cloneOfA = output;
+      else if ("B".equals(input.getString("name")))
+        cloneOfB = output;
+    }
+
+    assertThat(cloneOfA).isNotNull();
+    assertThat(cloneOfB).isNotNull();
+
+    boolean cloneToCloneEdgeFound = false;
+    for (final com.arcadedb.graph.Edge e : cloneOfA.getEdges(Vertex.DIRECTION.OUT, "KNOWS")) {
+      if (e.getIn().equals(cloneOfB.getIdentity())) {
+        cloneToCloneEdgeFound = true;
+        assertThat(e.getLong("since")).isEqualTo(2021L);
+      }
+    }
+    assertThat(cloneToCloneEdgeFound).isTrue();
+
+    // original relationship between a and b must be untouched
+    final ResultSet originalEdges = database.query("opencypher",
+        "MATCH (a:Person {name:'A'})-[r:KNOWS]->(b:Person {name:'B'}) RETURN r");
+    assertThat(originalEdges.hasNext()).isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationshipsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationshipsTest.java
@@ -175,4 +175,100 @@ class RefactorCloneNodesWithRelationshipsTest {
         "MATCH (a:Person {name:'A'}) CALL apoc.refactor.cloneNodesWithRelationships([a], 'not-a-map') YIELD output RETURN output").hasNext())
         .hasCauseInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  void skipPropertiesExcludesGivenPropertyFromTheClone() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").set("secret", "s3cr3t").save();
+    database.commit();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}) "
+            + "CALL apoc.refactor.cloneNodesWithRelationships([a], {skipProperties: ['secret']}) YIELD output RETURN output");
+    final Vertex output = rs.next().getProperty("output");
+    database.commit();
+
+    assertThat(output.getString("name")).isEqualTo("A");
+    assertThat(output.getPropertyNames()).doesNotContain("secret");
+  }
+
+  @Test
+  void nodeCloneFailureProducesPopulatedErrorFieldWithoutLosingOtherRows() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").set("requiredTag", "present").save();
+    database.newVertex("Person").set("name", "B").save();
+    database.commit();
+
+    // A mandatory-property constraint is validated synchronously on save() (LocalDatabase.createRecordNoLock
+    // calls MutableDocument.validate() before the record is written), unlike a UNIQUE index violation, which
+    // ArcadeDB defers to commit time - so this is the reliable way to force RefactorCloneNodesWithRelationships
+    // .execute()'s per-node try/catch to actually fire. Both 'A' and 'B' predate the constraint, so it is only
+    // enforced against the NEW record the clone creates: 'A' copies a value for it and clones fine, 'B' never
+    // had one set and fails clone validation.
+    database.getSchema().getType("Person").createProperty("requiredTag", String.class).setMandatory(true);
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) "
+            + "CALL apoc.refactor.cloneNodesWithRelationships([a,b], {}) YIELD input, output, error RETURN input, output, error");
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+    database.commit();
+
+    assertThat(rows).hasSize(2);
+    Result rowForA = null;
+    Result rowForB = null;
+    for (final Result row : rows) {
+      final Vertex input = row.getProperty("input");
+      if (a.getIdentity().equals(input.getIdentity()))
+        rowForA = row;
+      else
+        rowForB = row;
+    }
+
+    final Object errorForA = rowForA.getProperty("error");
+    final Vertex outputForA = rowForA.getProperty("output");
+    assertThat(errorForA).isNull();
+    assertThat(outputForA).isNotNull();
+
+    final Object outputForB = rowForB.getProperty("output");
+    final String errorForB = rowForB.getProperty("error");
+    assertThat(outputForB).isNull();
+    assertThat(errorForB).isNotBlank();
+  }
+
+  @Test
+  void edgeCloneFailureIsSkippedWithoutLosingTheNodeYieldRow() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex external = database.newVertex("Person").set("name", "External").save();
+    a.newEdge("KNOWS", external, (Object[]) null).save();
+    database.commit();
+
+    // Same mandatory-property mechanism as nodeCloneFailureProducesPopulatedErrorFieldWithoutLosingOtherRows
+    // above, applied to the edge-clone phase: the original edge predates the constraint and never set the
+    // property, so cloning it (which only copies properties the original actually has) creates a new edge
+    // missing a now-mandatory property, failing validation synchronously in cloneEdge()'s try/catch.
+    database.getSchema().getType("KNOWS").createProperty("requiredCode", String.class).setMandatory(true);
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}) CALL apoc.refactor.cloneNodesWithRelationships([a], {}) "
+            + "YIELD input, output, error RETURN input, output, error");
+    final Result result = rs.next();
+    final Object error = result.getProperty("error");
+    final Vertex output = result.getProperty("output");
+    database.commit();
+
+    // the node row survives even though its only edge failed to clone
+    assertThat(error).isNull();
+    assertThat(output).isNotNull();
+
+    final ResultSet clonedEdges = database.query("opencypher",
+        "MATCH (c:Person)-[r:KNOWS]->(e:Person {name:'External'}) WHERE id(c) = $cloneId RETURN r",
+        java.util.Map.of("cloneId", output.getIdentity().toString()));
+    assertThat(clonedEdges.hasNext()).isFalse();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationshipsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorCloneNodesWithRelationshipsTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for the apoc.refactor.cloneNodesWithRelationships Cypher procedure
@@ -162,5 +163,16 @@ class RefactorCloneNodesWithRelationshipsTest {
     final ResultSet originalEdges = database.query("opencypher",
         "MATCH (a:Person {name:'A'})-[r:KNOWS]->(b:Person {name:'B'}) RETURN r");
     assertThat(originalEdges.hasNext()).isTrue();
+  }
+
+  @Test
+  void nonMapConfigThrows() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").save();
+    database.commit();
+
+    assertThatThrownBy(() -> database.command("opencypher",
+        "MATCH (a:Person {name:'A'}) CALL apoc.refactor.cloneNodesWithRelationships([a], 'not-a-map') YIELD output RETURN output").hasNext())
+        .hasCauseInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodesTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.refactor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the apoc.refactor.mergeNodes Cypher procedure (registered as "refactor.mergeNodes").
+ * <p>
+ * The procedure mutates the graph, so every CALL runs inside an explicit transaction that is fully
+ * consumed and committed before any assertion - CypherProcedure execution is lazy (it runs on the
+ * first {@code ResultSet.next()} pull) and is not auto-committed by the engine the way built-in write
+ * clauses like SET/DELETE/CREATE are, so leaving it for an assertion to trigger would both run it
+ * outside the transaction and, on assertion failure, leave the transaction open for teardown.
+ * </p>
+ */
+class RefactorMergeNodesTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-refactor-merge-nodes");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void registeredUnderBothPlainAndApocPrefixedName() {
+    assertThat(CypherProcedureRegistry.hasProcedure("refactor.mergeNodes")).isTrue();
+    assertThat(CypherProcedureRegistry.hasProcedure("apoc.refactor.mergeNodes")).isTrue();
+    assertThat(CypherProcedureRegistry.get("apoc.refactor.mergeNodes")).isSameAs(CypherProcedureRegistry.get("refactor.mergeNodes"));
+  }
+
+  @Test
+  void survivorIsTheFirstNodeAndAbsorbedNodeIsDeleted() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    database.commit();
+    final String aId = a.getIdentity().toString();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) CALL apoc.refactor.mergeNodes([a,b], {}) YIELD node RETURN node");
+    final Result result = rs.next();
+    final String survivorId = result.getVertex().get().getIdentity().toString();
+    database.commit();
+
+    assertThat(survivorId).isEqualTo(aId);
+    assertThatThrownBy(() -> database.lookupByRID(b.getIdentity(), true))
+        .isInstanceOf(RecordNotFoundException.class);
+  }
+
+  @Test
+  void overwritePolicyLetsAbsorbedValueWin() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").set("age", 30L).save();
+    database.newVertex("Person").set("name", "B").set("age", 25L).save();
+    database.commit();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) "
+            + "CALL apoc.refactor.mergeNodes([a,b], {properties: 'overwrite'}) YIELD node RETURN node.age AS age");
+    final Long age = rs.next().getProperty("age");
+    database.commit();
+
+    assertThat(age).isEqualTo(25L);
+  }
+
+  @Test
+  void discardPolicyKeepsSurvivorsOriginalValue() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").set("age", 30L).save();
+    database.newVertex("Person").set("name", "B").set("age", 25L).save();
+    database.commit();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) "
+            + "CALL apoc.refactor.mergeNodes([a,b], {properties: 'discard'}) YIELD node RETURN node.age AS age");
+    final Long age = rs.next().getProperty("age");
+    database.commit();
+
+    assertThat(age).isEqualTo(30L);
+  }
+
+  @Test
+  void combinePolicyProducesListOfBothValues() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").set("tag", "x").save();
+    database.newVertex("Person").set("name", "B").set("tag", "y").save();
+    database.commit();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) "
+            + "CALL apoc.refactor.mergeNodes([a,b], {properties: 'combine'}) YIELD node RETURN node.tag AS tag");
+    final Object tag = rs.next().getProperty("tag");
+    database.commit();
+
+    assertThat(tag).isEqualTo(java.util.List.of("x", "y"));
+  }
+
+  @Test
+  void edgesFromAbsorbedNodeAreRewiredToSurvivor() {
+    database.begin();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    database.newVertex("Person").set("name", "A").save();
+    final MutableVertex c = database.newVertex("Person").set("name", "C").save();
+    b.newEdge("KNOWS", c, "since", 2020L).save();
+    database.commit();
+
+    // properties: 'discard' keeps the survivor's own 'name' (both nodes carry that property, and
+    // the default 'overwrite' policy would otherwise rename the survivor to 'B' along with everything
+    // else absorbed from it) so the post-merge node stays reachable by MATCH {name:'A'}.
+    database.begin();
+    database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) "
+            + "CALL apoc.refactor.mergeNodes([a,b], {properties: 'discard'}) YIELD node RETURN node").next();
+    database.commit();
+
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person {name:'A'})-[r:KNOWS]->(c:Person {name:'C'}) RETURN r.since AS since");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Long>getProperty("since")).isEqualTo(2020L);
+  }
+
+  @Test
+  void edgeBetweenMergedNodesBecomesSelfRelationshipOnSurvivor() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    a.newEdge("KNOWS", b, "since", 2020L).save();
+    database.commit();
+
+    database.begin();
+    database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) "
+            + "CALL apoc.refactor.mergeNodes([a,b], {properties: 'discard'}) YIELD node RETURN node").next();
+    database.commit();
+
+    final ResultSet rs = database.query("opencypher", "MATCH (a:Person {name:'A'})-[r:KNOWS]->(a) RETURN r");
+    assertThat(rs.hasNext()).isTrue();
+  }
+
+  @Test
+  void fewerThanTwoNodesThrows() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").save();
+    database.commit();
+
+    assertThatThrownBy(() -> database.command("opencypher",
+        "MATCH (a:Person {name:'A'}) CALL apoc.refactor.mergeNodes([a], {}) YIELD node RETURN node").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodesTest.java
@@ -141,6 +141,37 @@ class RefactorMergeNodesTest {
   }
 
   @Test
+  void unknownPropertiesPolicyThrows() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").save();
+    database.newVertex("Person").set("name", "B").save();
+    database.commit();
+
+    assertThatThrownBy(() -> database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) "
+            + "CALL apoc.refactor.mergeNodes([a,b], {properties: 'bogus'}) YIELD node RETURN node").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void combinePolicyAccumulatesAcrossMultipleAbsorbedNodes() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").set("tag", "x").save();
+    database.newVertex("Person").set("name", "B").set("tag", "y").save();
+    database.newVertex("Person").set("name", "C").set("tag", "z").save();
+    database.commit();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}), (c:Person {name:'C'}) "
+            + "CALL apoc.refactor.mergeNodes([a,b,c], {properties: 'combine'}) YIELD node RETURN node.tag AS tag");
+    final Object tag = rs.next().getProperty("tag");
+    database.commit();
+
+    assertThat(tag).isEqualTo(java.util.List.of("x", "y", "z"));
+  }
+
+  @Test
   void edgesFromAbsorbedNodeAreRewiredToSurvivor() {
     database.begin();
     final MutableVertex b = database.newVertex("Person").set("name", "B").save();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorMergeNodesTest.java
@@ -192,4 +192,67 @@ class RefactorMergeNodesTest {
         "MATCH (a:Person {name:'A'}) CALL apoc.refactor.mergeNodes([a], {}) YIELD node RETURN node").hasNext())
         .isInstanceOf(CommandSemanticException.class);
   }
+
+  @Test
+  void duplicateAbsorbedNodeInTheListIsDeduplicatedNotCrashed() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    database.commit();
+    final String aId = a.getIdentity().toString();
+
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}) CALL apoc.refactor.mergeNodes([a,b,b], {}) YIELD node RETURN node");
+    final String survivorId = rs.next().getVertex().get().getIdentity().toString();
+    database.commit();
+
+    assertThat(survivorId).isEqualTo(aId);
+    assertThatThrownBy(() -> database.lookupByRID(b.getIdentity(), true))
+        .isInstanceOf(RecordNotFoundException.class);
+  }
+
+  @Test
+  void nodesCollapsingToFewerThanTwoAfterDeduplicationThrows() {
+    database.begin();
+    database.newVertex("Person").set("name", "A").save();
+    database.commit();
+
+    assertThatThrownBy(() -> database.command("opencypher",
+        "MATCH (a:Person {name:'A'}) CALL apoc.refactor.mergeNodes([a,a], {}) YIELD node RETURN node").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void threeWayMergeRewiresEdgesFromEveryAbsorbedNode() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    final MutableVertex c = database.newVertex("Person").set("name", "C").save();
+    final MutableVertex d = database.newVertex("Person").set("name", "D").save();
+    b.newEdge("KNOWS", d, "since", 2020L).save();
+    c.newEdge("KNOWS", d, "since", 2021L).save();
+    database.commit();
+
+    // properties: 'discard' keeps the survivor's own 'name' - see edgesFromAbsorbedNodeAreRewiredToSurvivor
+    // above for why the default 'overwrite' policy would otherwise break the post-merge MATCH {name:'A'}.
+    database.begin();
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Person {name:'A'}), (b:Person {name:'B'}), (c:Person {name:'C'}) "
+            + "CALL apoc.refactor.mergeNodes([a,b,c], {properties: 'discard'}) YIELD node RETURN node");
+    final String survivorId = rs.next().getVertex().get().getIdentity().toString();
+    database.commit();
+
+    assertThat(survivorId).isEqualTo(a.getIdentity().toString());
+    assertThatThrownBy(() -> database.lookupByRID(b.getIdentity(), true)).isInstanceOf(RecordNotFoundException.class);
+    assertThatThrownBy(() -> database.lookupByRID(c.getIdentity(), true)).isInstanceOf(RecordNotFoundException.class);
+
+    final ResultSet rewiredEdges = database.query("opencypher",
+        "MATCH (a:Person {name:'A'})-[r:KNOWS]->(d:Person {name:'D'}) RETURN r.since AS since ORDER BY r.since");
+    assertThat(rewiredEdges.hasNext()).isTrue();
+    assertThat(rewiredEdges.next().<Long>getProperty("since")).isEqualTo(2020L);
+    assertThat(rewiredEdges.hasNext()).isTrue();
+    assertThat(rewiredEdges.next().<Long>getProperty("since")).isEqualTo(2021L);
+    assertThat(rewiredEdges.hasNext()).isFalse();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorProcedureArgsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/refactor/RefactorProcedureArgsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.refactor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the {@code (nodes, config)} argument parsing shared by the {@code refactor.*}
+ * procedures. Exercised directly (not through a Cypher CALL) since these are pure functions over
+ * already-evaluated procedure arguments.
+ */
+class RefactorProcedureArgsTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-refactor-procedure-args");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Person");
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void extractVerticesRejectsNonListArgument() {
+    assertThatThrownBy(() -> RefactorProcedureArgs.extractVertices("test.proc", "not-a-list"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("nodes must be a list");
+  }
+
+  @Test
+  void extractVerticesRejectsNullArgument() {
+    assertThatThrownBy(() -> RefactorProcedureArgs.extractVertices("test.proc", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("nodes must be a list");
+  }
+
+  @Test
+  void extractVerticesRejectsListWithNonVertexElement() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    database.commit();
+
+    assertThatThrownBy(() -> RefactorProcedureArgs.extractVertices("test.proc", List.of(a, "not-a-vertex")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("every element of nodes must be a node");
+  }
+
+  @Test
+  void extractVerticesDeduplicatesByIdentityKeepingFirstOccurrenceOrder() {
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "B").save();
+    database.commit();
+
+    final List<Vertex> result = RefactorProcedureArgs.extractVertices("test.proc", List.of(a, b, b, a));
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getIdentity()).isEqualTo(a.getIdentity());
+    assertThat(result.get(1).getIdentity()).isEqualTo(b.getIdentity());
+  }
+
+  @Test
+  void extractConfigReturnsEmptyMapForNull() {
+    assertThat(RefactorProcedureArgs.extractConfig("test.proc", null)).isEqualTo(Collections.emptyMap());
+  }
+
+  @Test
+  void extractConfigReturnsTheGivenMap() {
+    final Map<String, Object> config = Map.of("key", "value");
+    assertThat(RefactorProcedureArgs.extractConfig("test.proc", config)).isEqualTo(config);
+  }
+
+  @Test
+  void extractConfigRejectsNonMapArgument() {
+    assertThatThrownBy(() -> RefactorProcedureArgs.extractConfig("test.proc", "not-a-map"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("config must be a map");
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds the 3 remaining APOC-compatible refactor/control-flow procedures, following the existing `merge.node`/`merge.relationship` `CypherProcedure` pattern (`com.arcadedb.query.opencypher.procedures.merge`):

- **`apoc.do.when(condition, ifQuery, elseQuery, params)` YIELD value** - runs `ifQuery` when `condition` is true, `elseQuery` otherwise (both Cypher query strings), with `params` bound as named parameters. Dispatches to `database.query()` or `database.command()` based on `QueryEngine.analyze(query).isIdempotent()`, so both read and write sub-queries work without the caller having to say which. Each result row of the sub-query is yielded as a map under `value`.
- **`apoc.refactor.mergeNodes(nodes, config)` YIELD node** - merges a list of nodes into the first one (the survivor). `config.properties` controls how a property present on both the survivor and an absorbed node is resolved: `"overwrite"` (default, absorbed value wins), `"discard"` (survivor's value kept), or `"combine"` (both kept as a list). Every incoming/outgoing edge of the absorbed nodes is rewired onto the survivor via `MutableEdge.set("@out"/"@in", ...)` (which the engine's `GraphEngine.moveEdge` already handles correctly) - an edge that connected two nodes both being merged naturally becomes a self-relationship on the survivor. The absorbed nodes are then deleted.
- **`apoc.refactor.cloneNodesWithRelationships(nodes, config)` YIELD input, output, error** - clones each given node (new vertex, same type/properties, minus an optional `config.skipProperties` list) together with every relationship touching it in either direction. A relationship whose other endpoint is also being cloned reconnects the two clones rather than the originals; a relationship to a node outside the given list reconnects the clone to that same original node. A per-node clone failure surfaces via the `error` yield field instead of aborting the whole call. The source nodes and their relationships are left untouched.

All three are registered under both their plain and `apoc.`-prefixed names in `CypherProcedureRegistry`.

## Motivation

A customer migrating from Neo4j reported these among the APOC functions their query catalogue depends on (see #6059 for the full list; the other 7, simpler ones already shipped via #6058). These 3 were split out because they need deliberate semantics decisions matching real APOC config-flag behavior (property-conflict policy, self-relationship handling, clone-to-clone rewiring), plus dedicated regression tests per node/edge-count and property-conflict scenario, rather than being safe one-file/low-risk additions.

## Related issues

Closes #6060. Related to #6059 (tracking issue) and #6058 (the 7 simpler APOC functions already shipped).

## Additional Notes

Testing (TDD, tests written first): `DoWhenTest`, `RefactorMergeNodesTest`, `RefactorCloneNodesWithRelationshipsTest` - 19 tests total, all passing. Also re-ran the full `com.arcadedb.query.opencypher.procedures` package plus the registry/arity tests (`CypherProcedureRegistryTest`, `CypherBuiltInFunctionsTest`, `ProcedureRegistryTest`, `ProcedureArityIssue5627Test`) with no regressions.

One general-purpose finding surfaced while testing, worth flagging for reviewers: a write `CypherProcedure` (this includes the pre-existing `merge.node`/`merge.relationship`) is **not** auto-committed by the engine the way built-in write clauses like `SET`/`CREATE`/`DELETE` are - `CallStep.executeProcedure` runs lazily on the first `ResultSet` pull with no `begin()`/`commit()` wrapping, unlike those steps. A caller invoking a write procedure via `CALL` therefore needs its own explicit transaction around the call and its full consumption. Documented in `RefactorMergeNodesTest`'s class Javadoc since it isn't obvious and affects every existing write procedure, not just the new ones.

## Checklist

- [x] I have run the build using `mvn clean package` command (ran `mvn -pl engine -am compile` plus targeted `test` runs; full `mvn verify` not run for time)
- [x] My unit tests cover both failure and success scenarios