### PR TITLE
fix(#5697): exclude benchmark-tagged tests by default without breaking overrides

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -51,7 +51,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Benchmark Unit Tests with Coverage
-        run: ./mvnw verify --batch-mode --errors --fail-never --show-version -Dgroups=benchmark -Dsurefire.includes=**/*Benchmark.java
+        # pom.xml now excludes @Tag("benchmark") by default (issue #5697); clear excludedGroups here
+        # so -Dgroups=benchmark still selects the benchmark-tagged tests this lane exists to run.
+        run: ./mvnw verify --batch-mode --errors --fail-never --show-version -Dgroups=benchmark -DexcludedGroups= -Dsurefire.includes=**/*Benchmark.java
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -283,18 +283,20 @@ mvn test
 Some tests are tagged to indicate their cost:
 
 - `slow` - functional tests that take noticeably long (large batches, multi-second elapsed time, big payloads)
-- `benchmark` - microbenchmarks not intended for regular CI runs
+- `benchmark` - microbenchmarks not intended for regular CI runs; excluded by default (see below)
 
-To skip these and run only the fast tests:
+`benchmark`-tagged tests are excluded by default, so a plain `mvn test` already skips them. To also skip
+`slow` tests and run only the fast ones:
 
 ```bash
 mvn test -DexcludedGroups="slow,benchmark"
 ```
 
-To run only a specific tag (e.g. benchmark tests in isolation):
+To run only a specific tag (e.g. benchmark tests in isolation), clear the default exclusion or it
+cancels out the selection and nothing runs:
 
 ```bash
-mvn test -Dgroups="benchmark"
+mvn test -Dgroups="benchmark" -DexcludedGroups=
 ```
 
 #### Running Integration Tests:

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,20 @@
         <skipITs>true</skipITs>
         <skipTests>false</skipTests>
 
+        <!-- Default surefire tag exclusion (issue #5697): keep this as a property, not a literal
+             <excludedGroups> in the surefire <configuration> below. A literal there would win over
+             the same-named -D user property on the command line (plugin configuration beats -D),
+             silently defeating every CI lane that passes its own -DexcludedGroups=... or that relies
+             on -Dgroups=benchmark alone selecting benchmark-tagged tests. Keeping it a property lets
+             -DexcludedGroups=... on the command line override this default as expected. -->
+        <excludedGroups>benchmark</excludedGroups>
+        <!-- maven-failsafe-plugin's own excludedGroups parameter defaults to this SAME ${excludedGroups}
+             user property (confirmed via its plugin.xml), so without a parameter of its own it would
+             silently inherit the surefire-only "benchmark" default above and drop @Tag("benchmark")
+             integration tests (e.g. Issue5413DenseVectorServerLatencyIT) from every -Pintegration lane.
+             Give failsafe its own namespaced property, left empty by default, so ITs are unaffected. -->
+        <failsafe.excludedGroups></failsafe.excludedGroups>
+
         <itCoverageAgent></itCoverageAgent>
         <argLine></argLine>
 
@@ -222,8 +236,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <!-- ADD THIS LINE TO SKIP BENCHMARKS BY DEFAULT -->
-<!--                    <excludedGroups>benchmark</excludedGroups>-->
+                    <!-- Skip @Tag("benchmark") classes by default (issue #5697). Sourced from the
+                         ${excludedGroups} property above so -DexcludedGroups=... on the command line
+                         still overrides it, e.g. benchmark-tests.yml clears it to run benchmarks and
+                         mvn-test.yml widens it to slow,benchmark,vector for the default lane. -->
+                    <excludedGroups>${excludedGroups}</excludedGroups>
                     <properties>
                         <!-- Work around. Surefire does not include enough
                              information to disambiguate between different
@@ -280,6 +297,9 @@
                         <!--                        <exclude>**/*ReplicationServerLeaderDownIT</exclude>-->
                         <exclude>**/*ReplicationServerLeaderChanges3TimesIT</exclude>
                     </excludes>
+                    <!-- Explicit, namespaced override of failsafe's excludedGroups (issue #5697): keeps
+                         it independent of the surefire-only ${excludedGroups} default set above. -->
+                    <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
                     <skipTests>${skipITs}</skipTests>
                     <skipITs>${skipITs}</skipITs>
                     <excludeJUnit5Engines>


### PR DESCRIPTION
## What does this PR do?

Turns on the `@Tag("benchmark")` surefire exclusion in the root `pom.xml` that CLAUDE.md documents but that was left commented out, **without** breaking any CI lane that depends on `-Dgroups`/`-DexcludedGroups` still being overridable from the command line.

## Motivation

`mvn -pl engine test` currently runs every `@Tag("benchmark")` class because the surefire configuration that would exclude them is commented out (with a comment inviting someone to uncomment it). On a developer machine with anything else competing for memory, the heavyweight benchmark classes exhaust the heap and surefire loses the forked JVM:

```
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Process Exit Code: 143
```

Exit code 143 is SIGTERM, and the reported "crashed test" is whichever class happened to be in the fork when it died - a different class each run - so it reads as a flaky test in an unrelated area and is expensive to diagnose.

### Why not just uncomment the line

A `<excludedGroups>benchmark</excludedGroups>` **literal** in the surefire `<configuration>` beats the same-named `-D` user property on the command line (plugin configuration wins over `-D`). Uncommenting it as a literal would silently:

- make `.github/workflows/benchmark-tests.yml`'s `-Dgroups=benchmark` select **zero** tests (a tag exclusion cancels out the same tag's inclusion) - the benchmark lane would go green while running nothing;
- make `.github/workflows/mvn-test.yml`'s `-DexcludedGroups=slow,benchmark,vector` and `-DexcludedGroups=vector` stop taking effect, since the literal can't be overridden.

This is exactly what sank the only prior attempt at this issue (#5730, closed unmerged): its branch was cut correctly but got lost to a force-push on the contributor's fork, and it isn't recoverable to review as a diff - this PR reproduces and extends the same analysis from a fresh branch.

There's a second, less obvious collision: `maven-failsafe-plugin`'s own `excludedGroups` parameter defaults to that **same** `${excludedGroups}` user property (confirmed by inspecting its `plugin.xml`). Without a parameter of its own, giving surefire a default of `benchmark` would have silently made every `-Pintegration` lane drop the one `@Tag("benchmark")` integration test in the repo (`Issue5413DenseVectorServerLatencyIT`) - reducing IT coverage with nothing announcing it.

## Fix

- **`pom.xml`**: the default now lives in an `excludedGroups` project property (default `benchmark`) that the surefire configuration reads via `${excludedGroups}`, so `-DexcludedGroups=...` on the command line still overrides or clears it as before.
- **`pom.xml`**: `maven-failsafe-plugin` gets its own, independently-defaulted `failsafe.excludedGroups` property (default empty) wired into its `<excludedGroups>`, so integration-test lanes are unaffected by the new surefire-only default.
- **`.github/workflows/benchmark-tests.yml`**: the weekly benchmark lane now passes `-DexcludedGroups=` alongside `-Dgroups=benchmark` to clear the new default - otherwise the inclusion and exclusion cancel out and it runs zero benchmarks.
- **`README.md`**: the documented `mvn test -Dgroups="benchmark"` example is corrected the same way, and the "skip slow/benchmark" section now notes that `benchmark` is already excluded by default.

`mvn-test.yml`'s other surefire invocations (`-DexcludedGroups=slow,benchmark,vector`, `-Dgroups=slow -DexcludedGroups=vector`, `-Dgroups=vector`) were checked and need no change: the first two already pass their own `excludedGroups` override, and `-Dgroups=vector` picking up the new `benchmark` default has no effect because no test class carries both tags (verified by grep).

## Verification (manual, isolated `.m2` repo)

Ran real `mvn test` invocations against `engine`, using the lightweight `@Tag("benchmark")` class `performance.VarIntBenchmark` as the probe and checking for a surefire report:

| command | expectation | result |
|---|---|---|
| `mvn -pl engine test -Dtest=VarIntBenchmark` (plain default) | benchmark class **skipped** | no surefire report generated - confirmed skipped |
| `mvn -pl engine test -Dgroups=benchmark -DexcludedGroups= -Dtest=VarIntBenchmark` (fixed `benchmark-tests.yml`) | benchmark class **runs** | surefire report generated, test executed |
| `mvn -pl engine test -Dgroups=benchmark -Dtest=VarIntBenchmark` (negative control: old workflow line *without* this PR's `-DexcludedGroups=` clear, against the new pom default) | **zero** tests selected, reproducing the exact bug this PR avoids | no surefire report - confirmed the collision |
| `mvn -pl engine test -DexcludedGroups=slow,benchmark,vector -Dtest=VarIntBenchmark` (`mvn-test.yml` main lane) | benchmark class **skipped** | no surefire report - confirmed skipped |
| `mvn -pl engine test -Dtest=BinarySerializerTest` (ordinary, untagged test) | runs normally | 17/17 passed |

Also confirmed via `mvn help:effective-pom` that surefire's resolved `<excludedGroups>` is `benchmark` while failsafe's resolved `<excludedGroups>` is empty, i.e. the two plugins no longer share the default.

Full reactor `mvn compile` and `mvn -pl engine -am install -DskipTests` both succeed against the changed `pom.xml`.

## Related issues

Closes #5697. Related to the closed, unmerged #5730 (same fix, lost to a fork force-push before it could be reviewed).

## Additional Notes

Left `docs/release-26.8.1.md` untouched - its `-Dgroups=benchmark` mention is a historical record of the command used for a past measurement (accurate at the time it was run), not current usage guidance.

## Checklist

- [x] I have run the build using `mvn clean package` command (reactor `compile` + `engine -am install -DskipTests`, both green)
- [x] My unit tests cover both failure and success scenarios (manual verification table above covers the default-exclusion, override-clearing, and collision-reproduction cases; no new Java test class since this is a build-configuration change with no application code path to unit test)
