### PR TITLE
fix(#6070): route batch() over the gRPC GraphBatchLoad RPC on a gRPC connection

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -705,7 +705,16 @@ already had to solve:
   and reach the caller through `getResult()`, which is readable after catching the failure - re-sending a load
   blindly would double everything that did get through.
 - **`vertex_batch_size` is configurable.** It was hardcoded at 10,000 with no option to change it, which a
-  replicated database needs, one buffer being one Raft entry. `commit_retries` and `commit_retry_delay_ms` were
-  added alongside it for parity with the HTTP endpoint's builder.
+  replicated database needs, one buffer being one Raft entry.
+- **The commit-retry knobs are reachable from the Java client.** `PostBatchHandler` had read `commitRetries` and
+  `commitRetryDelayMs` as query parameters since they were introduced, but `RemoteGraphBatch.Builder` never
+  exposed them, so no Java caller on either transport could set them. `withCommitRetries()` and
+  `withCommitRetryDelay()` were added to the shared builder, which closes the gap for HTTP as well. Both are
+  `optional` on the wire, because zero is a setting for each of them - no retries at all, and no back-off before
+  the first one - and not the same as leaving them alone, which a plain proto3 integer cannot express.
+
+The follower refusal runs *after* the caller has been resolved against the database it named, the way every
+other RPC on this service starts. Naming the leader is a fact about the cluster's layout, so a request that
+cannot reach the database it asked for is answered about that database rather than told where the leader lives.
 
 [#6070](https://github.com/ArcadeData/arcadedb/issues/6070)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -665,3 +665,47 @@ every joiner waiting on it, which `shutdownNow()` cannot do for a task already u
 rather than surfacing as a SEVERE "Error building graph from scratch" wrapped in an opaque `IndexException`.
 
 [#5872](https://github.com/ArcadeData/arcadedb/issues/5872)
+
+## `batch()` on a gRPC connection now uses the gRPC streaming RPC instead of JSONL over HTTP (#6070)
+
+`RemoteGrpcDatabase.batch()` inherited `RemoteDatabase`'s implementation and returned a loader that posted its
+payload as JSONL to `POST /api/v1/batch`, over plain HTTP, whatever protocol the connection spoke. A caller who
+opened a gRPC connection got the HTTP transport silently, and nothing on the API surface said so. Meanwhile the
+`GraphBatchLoad` client-streaming RPC had been defined in the proto and implemented in `ArcadeDbGrpcService`
+since the gRPC module landed, with no client anywhere in the codebase calling it.
+
+`RemoteGrpcDatabase.batch()` now returns `RemoteGrpcGraphBatch`, which carries the load over that RPC. The public
+API is unchanged - same methods, same builder options, same results - so the switch is transparent to anything
+that only uses `batch()`. What changes underneath is where temporary ids are resolved. Over HTTP each flush is an
+independent request the server does not remember, so the loader has to ask for the id mapping back and rewrite
+the references of later edges itself; over one stream the server holds the mapping for the whole load, so a
+temporary id crosses a chunk boundary untouched. That removes the per-flush round trip, the client-side mapping
+arrays, and the ceiling `flushEvery` had on the HTTP path past which the server stops echoing a mapping too large
+to consume. The new loader adds `withTimeout()` for the deadline of the whole stream, and applies backpressure
+rather than handing gRPC chunks faster than the transport drains them.
+
+Wiring a real client onto the RPC surfaced the gaps that had gone unnoticed while it had none, each of which
+only shows on a load big enough to be worth a streaming transport, and each of which the HTTP endpoint had
+already had to solve:
+
+- **A load aimed at a follower is now refused instead of taken.** The bulk path mutates state only the leader can
+  serialize - the schema dictionary above all - so running it on a follower races the local state-machine apply
+  in `Dictionary.getIdByName`, which is the corruption #4122 was about and the reason `PostBatchHandler` relays
+  the payload to the leader. `GraphBatchLoad` had no such guard. It cannot relay the way HTTP does, because the
+  HA plugin exposes the leader's HTTP address only and relaying a bulk load through a follower would double the
+  traffic of the transport chosen to avoid exactly that, so it fails with `FAILED_PRECONDITION` naming the
+  leader - before writing anything, so there is nothing to reconcile.
+- **The temporary-id mapping is no longer always echoed back in full.** A load of a few million vertices built a
+  response past the default 4 MB message limit and failed at the very end, with everything already committed. The
+  new `return_id_mapping` option is a tri-state mirroring the HTTP `idMapping` parameter: unset caps it and
+  reports `id_mapping_omitted` / `id_mapping_size` past the cap, `true` demands it whatever the size, `false`
+  never sends it. The streaming loader sets `false`, having no use for a mapping the server resolves itself.
+- **A failed load now reports what it had already committed.** The batch commits incrementally, so an error is
+  not a rollback, but a gRPC status carries no message body. The counters ride the trailers of the failed call
+  and reach the caller through `getResult()`, which is readable after catching the failure - re-sending a load
+  blindly would double everything that did get through.
+- **`vertex_batch_size` is configurable.** It was hardcoded at 10,000 with no option to change it, which a
+  replicated database needs, one buffer being one Raft entry. `commit_retries` and `commit_retry_delay_ms` were
+  added alongside it for parity with the HTTP endpoint's builder.
+
+[#6070](https://github.com/ArcadeData/arcadedb/issues/6070)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -703,7 +703,13 @@ already had to solve:
 - **A failed load now reports what it had already committed.** The batch commits incrementally, so an error is
   not a rollback, but a gRPC status carries no message body. The counters ride the trailers of the failed call
   and reach the caller through `getResult()`, which is readable after catching the failure - re-sending a load
-  blindly would double everything that did get through.
+  blindly would double everything that did get through. On that trailer the edge count is what the batch
+  *flushed*, not what it received: an edge is buffered when its record arrives and reaches the database in a
+  later `commitEvery`-sized flush, with the incoming direction connected at close, so counting received edges
+  would claim ones that never landed and lead a caller to re-send too little and lose them. The counter
+  advances a flush at a time, so a load that dies mid-flush under-reports rather than over-reports - a
+  duplicate on re-send is recoverable, a silently missing edge is not. Vertices need no such distinction,
+  being counted once their own commit returns.
 - **`vertex_batch_size` is configurable.** It was hardcoded at 10,000 with no option to change it, which a
   replicated database needs, one buffer being one Raft entry.
 - **The commit-retry knobs are reachable from the Java client.** `PostBatchHandler` had read `commitRetries` and

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/GraphBatchLoadStream.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/GraphBatchLoadStream.java
@@ -177,6 +177,10 @@ class GraphBatchLoadStream {
    * Ends the stream and waits for the server's totals.
    */
   GraphBatchResult complete() {
+    // A call the server has already failed is done: half-closing it would raise gRPC's own "call already
+    // closed" on top of the real failure and bury it. Report the failure the load actually died of instead.
+    failIfTerminated();
+
     request.onCompleted();
 
     final boolean finished;

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/GraphBatchLoadStream.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/GraphBatchLoadStream.java
@@ -61,6 +61,8 @@ class GraphBatchLoadStream {
   private static final long READY_WAIT_TIMEOUT_MS = 5 * 60 * 1000L;
 
   private final long timeoutMs;
+  /** Same as {@link #READY_WAIT_TIMEOUT_MS}, kept per-instance so a test can wait a plausible moment instead of five minutes. */
+  private final long readyWaitTimeoutMs;
 
   private final CountDownLatch                    done             = new CountDownLatch(1);
   private final AtomicReference<GraphBatchResult> resultRef        = new AtomicReference<>();
@@ -75,7 +77,12 @@ class GraphBatchLoadStream {
   private StreamObserver<GraphBatchChunk> request;
 
   GraphBatchLoadStream(final long timeoutMs) {
+    this(timeoutMs, READY_WAIT_TIMEOUT_MS);
+  }
+
+  GraphBatchLoadStream(final long timeoutMs, final long readyWaitTimeoutMs) {
     this.timeoutMs = timeoutMs;
+    this.readyWaitTimeoutMs = readyWaitTimeoutMs;
   }
 
   /**
@@ -139,7 +146,7 @@ class GraphBatchLoadStream {
       // never coming.
       return;
 
-    final long deadline = System.currentTimeMillis() + READY_WAIT_TIMEOUT_MS;
+    final long deadline = System.currentTimeMillis() + readyWaitTimeoutMs;
     synchronized (readyLock) {
       while (!stream.isReady()) {
         failIfTerminated();
@@ -147,7 +154,7 @@ class GraphBatchLoadStream {
         final long remaining = deadline - System.currentTimeMillis();
         if (remaining <= 0)
           throw new TimeoutException(
-              "Graph batch load timed out after " + READY_WAIT_TIMEOUT_MS + "ms waiting for the server to consume "
+              "Graph batch load timed out after " + readyWaitTimeoutMs + "ms waiting for the server to consume "
                   + "the records already sent");
         try {
           readyLock.wait(remaining);

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/GraphBatchLoadStream.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/GraphBatchLoadStream.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.remote.RemoteException;
+import com.arcadedb.server.grpc.GraphBatchChunk;
+import com.arcadedb.server.grpc.GraphBatchProtocol;
+import com.arcadedb.server.grpc.GraphBatchResult;
+import io.grpc.Metadata;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.StreamObserver;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The client end of one {@code GraphBatchLoad} call: chunks are pushed in, one {@link GraphBatchResult} comes
+ * back when the stream ends. Written for a bulk load rather than a handful of messages, which is what the two
+ * things it does beyond opening the stream are for (issue #6070).
+ * <p>
+ * The first is backpressure. A client-streaming RPC accepts every {@code onNext} whether or not the transport
+ * can carry it, buffering the excess in the channel, so a loader pushing millions of records as fast as it can
+ * build them runs the client out of heap long before the server is the bottleneck. {@link #send} therefore
+ * waits for the call to report itself ready, which is the only signal gRPC gives that the outbound buffer has
+ * drained.
+ * <p>
+ * The second is what happens when the server fails the load. The batch commits incrementally, so an error is
+ * not a rollback: the server reports what it had already committed on the trailers of the failed call, and that
+ * is folded into the exception message here rather than dropped, because a caller that only knows "the load
+ * failed" has no way to reconcile short of re-sending everything.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphBatchLoadStream {
+
+  /**
+   * How long {@link #send} waits for the call to become ready again before giving up. Generous because the
+   * server pulls a chunk at a time and a chunk can take a while to load; short enough that a connection that
+   * died without notifying leaves the caller with an error instead of a permanently parked thread.
+   */
+  private static final long READY_WAIT_TIMEOUT_MS = 5 * 60 * 1000L;
+
+  private final long timeoutMs;
+
+  private final CountDownLatch                    done             = new CountDownLatch(1);
+  private final AtomicReference<GraphBatchResult> resultRef        = new AtomicReference<>();
+  private final AtomicReference<GraphBatchResult> partialResultRef = new AtomicReference<>();
+  private final AtomicReference<Throwable>        errorRef         = new AtomicReference<>();
+
+  /** Guards the wait/notify pairing between a sender parked on readiness and the gRPC thread reporting it. */
+  private final Object readyLock = new Object();
+
+  private volatile ClientCallStreamObserver<GraphBatchChunk> requestStream;
+
+  private StreamObserver<GraphBatchChunk> request;
+
+  GraphBatchLoadStream(final long timeoutMs) {
+    this.timeoutMs = timeoutMs;
+  }
+
+  /**
+   * The observer handed to the stub. Captures the call so {@link #send} can see its readiness, and wakes any
+   * parked sender both when the call becomes ready and when it terminates.
+   */
+  ClientResponseObserver<GraphBatchChunk, GraphBatchResult> responseObserver() {
+    return new ClientResponseObserver<>() {
+      @Override
+      public void beforeStart(final ClientCallStreamObserver<GraphBatchChunk> stream) {
+        requestStream = stream;
+        stream.setOnReadyHandler(() -> {
+          synchronized (readyLock) {
+            readyLock.notifyAll();
+          }
+        });
+      }
+
+      @Override
+      public void onNext(final GraphBatchResult value) {
+        resultRef.set(value);
+      }
+
+      @Override
+      public void onError(final Throwable t) {
+        errorRef.set(t);
+        done.countDown();
+        // A sender parked waiting for readiness will never be woken by a call that just died.
+        synchronized (readyLock) {
+          readyLock.notifyAll();
+        }
+      }
+
+      @Override
+      public void onCompleted() {
+        done.countDown();
+        synchronized (readyLock) {
+          readyLock.notifyAll();
+        }
+      }
+    };
+  }
+
+  void start(final StreamObserver<GraphBatchChunk> request) {
+    this.request = request;
+  }
+
+  /**
+   * Pushes one chunk, waiting first for the call to be able to carry it.
+   */
+  void send(final GraphBatchChunk chunk) {
+    awaitReady();
+    request.onNext(chunk);
+  }
+
+  private void awaitReady() {
+    final ClientCallStreamObserver<GraphBatchChunk> stream = requestStream;
+    if (stream == null)
+      // beforeStart always runs before the stub returns the request observer, so this only happens if the call
+      // never started at all; let onNext fail with the real reason rather than block on a readiness that is
+      // never coming.
+      return;
+
+    final long deadline = System.currentTimeMillis() + READY_WAIT_TIMEOUT_MS;
+    synchronized (readyLock) {
+      while (!stream.isReady()) {
+        failIfTerminated();
+
+        final long remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0)
+          throw new TimeoutException(
+              "Graph batch load timed out after " + READY_WAIT_TIMEOUT_MS + "ms waiting for the server to consume "
+                  + "the records already sent");
+        try {
+          readyLock.wait(remaining);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RemoteException("Interrupted while sending a graph batch load chunk", e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Cancels the call without raising anything of its own, for an unwind that is already carrying a failure.
+   */
+  void cancelQuietly(final String reason) {
+    final ClientCallStreamObserver<GraphBatchChunk> stream = requestStream;
+    if (stream == null)
+      return;
+    try {
+      stream.cancel(reason, null);
+    } catch (final RuntimeException ignored) {
+      // The call was already terminated: nothing left to release.
+    }
+  }
+
+  /**
+   * Ends the stream and waits for the server's totals.
+   */
+  GraphBatchResult complete() {
+    request.onCompleted();
+
+    final boolean finished;
+    try {
+      finished = done.await(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RemoteException("Interrupted while waiting for the graph batch load to complete", e);
+    }
+
+    if (!finished) {
+      // Cancelling releases the server-side batch slot instead of leaving the load hanging on to it.
+      final ClientCallStreamObserver<GraphBatchChunk> stream = requestStream;
+      if (stream != null)
+        stream.cancel("graph batch load timed out on the client", null);
+      throw new TimeoutException("Graph batch load timed out after " + timeoutMs + "ms waiting for the server to "
+          + "complete. Raise the timeout with withTimeout() if the load legitimately takes longer");
+    }
+
+    failIfTerminated();
+
+    final GraphBatchResult result = resultRef.get();
+    if (result == null)
+      throw new RemoteException("The server completed the graph batch load without reporting its result");
+
+    return result;
+  }
+
+  /**
+   * What the server had already committed when the load failed, or null if the load did not fail or the server
+   * reported nothing. Survives the exception, so a caller can see how much of the load is durable.
+   */
+  GraphBatchResult getPartialResult() {
+    return partialResultRef.get();
+  }
+
+  /**
+   * Rethrows the failure the call ended with, if it ended with one, having first recorded whatever the server
+   * managed to commit before failing.
+   */
+  private void failIfTerminated() {
+    final Throwable error = errorRef.get();
+    if (error == null)
+      return;
+
+    // The exception keeps the type the rest of this client maps gRPC statuses onto, so a caller can switch on it
+    // exactly as for any other operation. The counters do not go in the message: they belong to the batch, which
+    // reports them through getResult() whether the load succeeded or died half-way.
+    partialResultRef.set(readPartialResult(error));
+    throw GrpcClientErrorMapper.toException(error);
+  }
+
+  /**
+   * Reads the partial-commit counters the server puts on the trailers of a failed load. A load that failed is
+   * not a load that rolled back: the batch commits incrementally, so whatever it had already flushed is durable
+   * and the caller has to be able to tell how much that was.
+   */
+  private static GraphBatchResult readPartialResult(final Throwable error) {
+    if (!(error instanceof StatusRuntimeException statusError))
+      return null;
+
+    final Metadata trailers = statusError.getTrailers();
+    if (trailers == null)
+      return null;
+
+    return trailers.get(GraphBatchProtocol.RESULT_TRAILER);
+  }
+}

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -1356,6 +1356,32 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     }
   }
 
+  /**
+   * Returns a builder for a batch graph import that travels over the {@code GraphBatchLoad} streaming RPC, the
+   * gRPC transport this connection was opened for, rather than as JSONL over HTTP the way the inherited
+   * implementation would (issue #6070). The builder and the loader it produces expose the same API as the HTTP
+   * ones, so this override is transparent to a caller that only uses {@code batch()}.
+   *
+   * @return a new {@link RemoteGrpcGraphBatch.Builder}
+   */
+  @Override
+  public RemoteGrpcGraphBatch.Builder batch() {
+    checkDatabaseIsOpen();
+    return new RemoteGrpcGraphBatch.Builder(this);
+  }
+
+  /**
+   * Opens one {@code GraphBatchLoad} call and returns its client end. Package-visible so
+   * {@link RemoteGrpcGraphBatch} can drive the stream without reaching for the stub itself.
+   */
+  GraphBatchLoadStream openGraphBatchLoadStream(final long timeoutMs) {
+    final GraphBatchLoadStream stream = new GraphBatchLoadStream(timeoutMs);
+    stream.start(callAsyncDuplex("GraphBatchLoad", timeoutMs,
+        (stub, responseObserver) -> stub.graphBatchLoad(responseObserver),
+        stream.responseObserver()));
+    return stream;
+  }
+
   // Convenience overload
   public InsertSummary ingestStreamAsListOfMaps(final InsertOptions options, final List<Map<String, Object>> rows,
                                                 final int chunkSize,

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcGraphBatch.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcGraphBatch.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.remote.RemoteGraphBatch;
+import com.arcadedb.remote.grpc.utils.ProtoUtils;
+import com.arcadedb.server.grpc.GraphBatchChunk;
+import com.arcadedb.server.grpc.GraphBatchOptions;
+import com.arcadedb.server.grpc.GraphBatchRecord;
+import com.arcadedb.server.grpc.GraphBatchResult;
+
+/**
+ * Batch graph importer that carries the load over the {@code GraphBatchLoad} streaming RPC, the gRPC transport
+ * a {@link RemoteGrpcDatabase} connection was chosen for. Obtained from {@code remoteGrpcDb.batch()}, and
+ * interchangeable with the JSONL-over-HTTP {@link RemoteGraphBatch} it extends: same methods, same
+ * {@link com.arcadedb.remote.RemoteGraphBatch.Builder} options, same results (issue #6070).
+ * <p>
+ * What the transport changes is where temporary ids are resolved. Over HTTP each flush is an independent
+ * request the server does not remember, so the loader asks for the id mapping back and rewrites the references
+ * of later edges itself. Here the whole load is one stream and the server keeps the mapping for its lifetime,
+ * so a temporary id stays a temporary id on the wire however many chunks separate the vertex from the edge that
+ * references it. That removes the per-flush round trip, the client-side mapping arrays, and the ceiling the
+ * HTTP loader has on {@code flushEvery} (past which the server stops echoing a mapping too large to consume).
+ * The mapping is not requested at all, which is also what keeps a load of millions of vertices from failing at
+ * the very end on the 4 MB default message limit, with everything already committed.
+ * <p>
+ * {@code flushEvery} therefore means chunk size here: the number of records per {@code GraphBatchChunk} pushed
+ * onto the open stream, not a round trip. {@link #flush()} closes the current chunk and sends it; the result is
+ * only complete once {@link #close()} has ended the stream and the server has answered.
+ * <p>
+ * As with the HTTP loader, all vertices must be created before any edge.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class RemoteGrpcGraphBatch extends RemoteGraphBatch {
+
+  /** Cap on how long the whole load may take, not a per-chunk timeout: the RPC is one stream from open to close. */
+  public static final long DEFAULT_TIMEOUT_MS = 6 * 60 * 60 * 1000L;
+
+  private final RemoteGrpcDatabase database;
+  private final GraphBatchOptions  options;
+  private final int                chunkSize;
+  private final long               timeoutMs;
+
+  private GraphBatchChunk.Builder chunk;
+  private int                     recordsInChunk;
+  private GraphBatchLoadStream    stream;
+  private boolean                 firstChunkSent;
+
+  RemoteGrpcGraphBatch(final RemoteGrpcDatabase database, final GraphBatchOptions options, final int chunkSize,
+      final long timeoutMs) {
+    super(database);
+    this.database = database;
+    this.options = options;
+    this.chunkSize = chunkSize;
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public String createVertex(final String typeName, final Object... properties) {
+    checkOpen();
+    if (hasEdges)
+      throw new IllegalStateException("Cannot add vertices after edges have been added");
+
+    final String tempId = "v" + vertexCounter++;
+
+    final GraphBatchRecord.Builder record = GraphBatchRecord.newBuilder()
+        .setKind(GraphBatchRecord.Kind.VERTEX)
+        .setTypeName(typeName)
+        .setTempId(tempId);
+    putProperties(record, properties);
+
+    addRecord(record.build());
+
+    return tempId;
+  }
+
+  @Override
+  public void createEdge(final String edgeTypeName, final String from, final String to, final Object... properties) {
+    checkOpen();
+    if (from == null || from.isEmpty() || to == null || to.isEmpty())
+      throw new IllegalArgumentException("Vertex reference cannot be null or empty");
+    hasEdges = true;
+
+    // No client-side resolution: the server holds the temporary-id map for the whole stream, so a reference to a
+    // vertex sent in an earlier chunk resolves there exactly as one sent in this chunk does.
+    final GraphBatchRecord.Builder record = GraphBatchRecord.newBuilder()
+        .setKind(GraphBatchRecord.Kind.EDGE)
+        .setTypeName(edgeTypeName)
+        .setFromRef(from)
+        .setToRef(to);
+    putProperties(record, properties);
+
+    addRecord(record.build());
+  }
+
+  /**
+   * Sends the records buffered so far as one chunk on the open stream, opening the stream if this is the first
+   * one. Unlike the HTTP loader this is not a round trip and returns nothing: the counters of the load are only
+   * known once {@link #close()} has ended the stream and the server has answered with the totals.
+   */
+  @Override
+  public void flush() {
+    if (recordsInChunk == 0)
+      return;
+
+    if (stream == null)
+      stream = database.openGraphBatchLoadStream(timeoutMs);
+
+    if (!firstChunkSent) {
+      // Database and options are read from the first chunk and ignored on the ones that follow.
+      chunk.setDatabase(database.getName()).setCredentials(database.buildCredentials()).setOptions(options);
+      firstChunkSent = true;
+    }
+
+    stream.send(chunk.build());
+    chunk = null;
+    recordsInChunk = 0;
+  }
+
+  /**
+   * Sends whatever is still buffered, ends the stream and waits for the server's totals. Idempotent.
+   * <p>
+   * A load that fails here is not a load that rolled back - the batch commits incrementally - so on the way out
+   * this records whatever the server reported as already committed. {@link #getResult()} is therefore worth
+   * reading after catching the failure: it says how much of the load is in the database, which is what a caller
+   * needs to reconcile instead of re-sending everything.
+   */
+  @Override
+  public void close() {
+    if (closed)
+      return;
+    closed = true;
+
+    try {
+      flush();
+    } catch (final RuntimeException e) {
+      // The call has to be released even though the load is failing: a server-side batch holds the database's
+      // batching slot for its lifetime, so an abandoned call would stop every later load until its deadline.
+      if (stream != null) {
+        stream.cancelQuietly("the graph batch load failed while sending its last chunk");
+        recordTotals(stream.getPartialResult());
+      }
+      throw e;
+    }
+
+    if (stream == null)
+      // Nothing was ever buffered: no stream was opened, so there is nothing to close and the totals stay zero.
+      return;
+
+    try {
+      recordTotals(stream.complete());
+    } catch (final RuntimeException e) {
+      recordTotals(stream.getPartialResult());
+      throw e;
+    }
+  }
+
+  private void recordTotals(final GraphBatchResult result) {
+    if (result == null)
+      return;
+    totalVerticesCreated = result.getVerticesCreated();
+    totalEdgesCreated = result.getEdgesCreated();
+    totalElapsedMs = result.getElapsedMs();
+  }
+
+  private void addRecord(final GraphBatchRecord record) {
+    if (chunk == null)
+      chunk = GraphBatchChunk.newBuilder();
+    chunk.addRecords(record);
+
+    if (++recordsInChunk >= chunkSize)
+      flush();
+  }
+
+  private static void putProperties(final GraphBatchRecord.Builder record, final Object[] properties) {
+    if (properties == null || properties.length == 0)
+      return;
+    if (properties.length % 2 != 0)
+      throw new IllegalArgumentException("Properties must be key-value pairs (even number of arguments)");
+
+    for (int i = 0; i < properties.length; i += 2)
+      record.putProperties((String) properties[i], ProtoUtils.toGrpcValue(properties[i + 1]));
+  }
+
+  /**
+   * Builder for a {@link RemoteGrpcGraphBatch}. Inherits every option of the HTTP loader's builder, which mean
+   * the same thing here, and translates them into the {@link GraphBatchOptions} the streaming RPC carries.
+   */
+  public static class Builder extends RemoteGraphBatch.Builder {
+    private long timeoutMs = DEFAULT_TIMEOUT_MS;
+
+    Builder(final RemoteGrpcDatabase database) {
+      super(database);
+    }
+
+    // The inherited setters are re-declared to narrow their return type. Without that, the first inherited call
+    // in a chain would hand back the base builder and nothing gRPC-specific could follow it, making
+    // withTimeout() usable only in first position. They carry no behaviour of their own.
+
+    @Override
+    public Builder withFlushEvery(final int flushEvery) {
+      super.withFlushEvery(flushEvery);
+      return this;
+    }
+
+    @Override
+    public Builder withBatchSize(final int batchSize) {
+      super.withBatchSize(batchSize);
+      return this;
+    }
+
+    @Override
+    public Builder withExpectedEdgeCount(final int expectedEdgeCount) {
+      super.withExpectedEdgeCount(expectedEdgeCount);
+      return this;
+    }
+
+    @Override
+    public Builder withEdgeListInitialSize(final int size) {
+      super.withEdgeListInitialSize(size);
+      return this;
+    }
+
+    @Deprecated
+    @Override
+    public Builder withLightEdges(final boolean lightEdges) {
+      super.withLightEdges(lightEdges);
+      return this;
+    }
+
+    @Override
+    public Builder withBidirectional(final boolean bidirectional) {
+      super.withBidirectional(bidirectional);
+      return this;
+    }
+
+    @Override
+    public Builder withCommitEvery(final int commitEvery) {
+      super.withCommitEvery(commitEvery);
+      return this;
+    }
+
+    @Override
+    public Builder withVertexBatchSize(final int vertexBatchSize) {
+      super.withVertexBatchSize(vertexBatchSize);
+      return this;
+    }
+
+    @Override
+    public Builder withWAL(final boolean useWAL) {
+      super.withWAL(useWAL);
+      return this;
+    }
+
+    @Override
+    public Builder withPreAllocateEdgeChunks(final boolean preAllocate) {
+      super.withPreAllocateEdgeChunks(preAllocate);
+      return this;
+    }
+
+    @Override
+    public Builder withParallelFlush(final boolean parallel) {
+      super.withParallelFlush(parallel);
+      return this;
+    }
+
+    /**
+     * Deadline for the whole load, from the first chunk to the server's answer, in milliseconds. Default: 6
+     * hours. It bounds the stream rather than any single chunk, so it has to cover the entire import.
+     */
+    public Builder withTimeout(final long timeoutMs) {
+      if (timeoutMs < 1)
+        throw new IllegalArgumentException("timeoutMs must be greater than 0");
+      this.timeoutMs = timeoutMs;
+      return this;
+    }
+
+    /** Renders the options the caller chose as the {@link GraphBatchOptions} of the first chunk. */
+    protected GraphBatchOptions toGraphBatchOptions() {
+      final GraphBatchOptions.Builder options = GraphBatchOptions.newBuilder();
+      if (batchSize != null)
+        options.setBatchSize(batchSize);
+      if (expectedEdgeCount != null)
+        options.setExpectedEdgeCount(expectedEdgeCount);
+      if (edgeListInitialSize != null)
+        options.setEdgeListInitialSize(edgeListInitialSize);
+      if (lightEdges != null)
+        options.setLightEdges(lightEdges);
+      if (bidirectional != null)
+        options.setBidirectional(bidirectional);
+      if (commitEvery != null)
+        options.setCommitEvery(commitEvery);
+      if (vertexBatchSize != null)
+        options.setVertexBatchSize(vertexBatchSize);
+      if (useWAL != null)
+        options.setWal(useWAL);
+      if (preAllocateEdgeChunks != null)
+        options.setPreAllocateEdgeChunks(preAllocateEdgeChunks);
+      if (parallelFlush != null)
+        options.setParallelFlush(parallelFlush);
+      // The server resolves temporary ids for the whole stream, so this loader never reads the mapping back.
+      // Saying so keeps a load of millions of vertices from building a response too large to send, which would
+      // fail the call at the very end with everything already committed.
+      options.setReturnIdMapping(false);
+      return options.build();
+    }
+
+    @Override
+    public RemoteGrpcGraphBatch build() {
+      final int effectiveChunkSize = flushEvery == 0 ? Integer.MAX_VALUE : flushEvery;
+      return new RemoteGrpcGraphBatch((RemoteGrpcDatabase) database, toGraphBatchOptions(), effectiveChunkSize,
+          timeoutMs);
+    }
+  }
+}

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcGraphBatch.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcGraphBatch.java
@@ -120,25 +120,27 @@ public class RemoteGrpcGraphBatch extends RemoteGraphBatch {
     if (recordsInChunk == 0)
       return;
 
-    if (stream == null)
-      stream = database.openGraphBatchLoadStream(timeoutMs);
-
-    if (!firstChunkSent) {
+    if (!firstChunkSent)
       // Database and options are read from the first chunk and ignored on the ones that follow.
       chunk.setDatabase(database.getName()).setCredentials(database.buildCredentials()).setOptions(options);
-      firstChunkSent = true;
-    }
 
-    // The buffer is handed over before the send rather than after it, so a send that fails leaves nothing
+    // The buffer is handed over before anything that can fail, so nothing this method throws leaves records
     // behind for a later flush to send a second time. An interior auto-flush raises its failure from inside
     // createVertex()/createEdge(), and the close() that follows - from a try-with-resources, which runs whether
-    // or not the body threw - would otherwise re-send this very chunk on a stream the failure had already
-    // terminated.
+    // or not the body threw - would otherwise repeat the whole attempt and answer with a second failure on top
+    // of the real one. Both of the things below can throw: opening the call, and sending on it.
     final GraphBatchChunk pending = chunk.build();
     chunk = null;
     recordsInChunk = 0;
 
+    if (stream == null)
+      stream = database.openGraphBatchLoadStream(timeoutMs);
+
     stream.send(pending);
+
+    // Only once a chunk is actually on the wire has the server been told the database and the options, so this
+    // stays false if the send above threw and the next attempt stamps them again.
+    firstChunkSent = true;
   }
 
   /**

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcGraphBatch.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcGraphBatch.java
@@ -129,9 +129,16 @@ public class RemoteGrpcGraphBatch extends RemoteGraphBatch {
       firstChunkSent = true;
     }
 
-    stream.send(chunk.build());
+    // The buffer is handed over before the send rather than after it, so a send that fails leaves nothing
+    // behind for a later flush to send a second time. An interior auto-flush raises its failure from inside
+    // createVertex()/createEdge(), and the close() that follows - from a try-with-resources, which runs whether
+    // or not the body threw - would otherwise re-send this very chunk on a stream the failure had already
+    // terminated.
+    final GraphBatchChunk pending = chunk.build();
     chunk = null;
     recordsInChunk = 0;
+
+    stream.send(pending);
   }
 
   /**
@@ -281,6 +288,18 @@ public class RemoteGrpcGraphBatch extends RemoteGraphBatch {
       return this;
     }
 
+    @Override
+    public Builder withCommitRetries(final int commitRetries) {
+      super.withCommitRetries(commitRetries);
+      return this;
+    }
+
+    @Override
+    public Builder withCommitRetryDelay(final long commitRetryDelayMs) {
+      super.withCommitRetryDelay(commitRetryDelayMs);
+      return this;
+    }
+
     /**
      * Deadline for the whole load, from the first chunk to the server's answer, in milliseconds. Default: 6
      * hours. It bounds the stream rather than any single chunk, so it has to cover the entire import.
@@ -315,6 +334,10 @@ public class RemoteGrpcGraphBatch extends RemoteGraphBatch {
         options.setPreAllocateEdgeChunks(preAllocateEdgeChunks);
       if (parallelFlush != null)
         options.setParallelFlush(parallelFlush);
+      if (commitRetries != null)
+        options.setCommitRetries(commitRetries);
+      if (commitRetryDelayMs != null)
+        options.setCommitRetryDelayMs(commitRetryDelayMs);
       // The server resolves temporary ids for the whole stream, so this loader never reads the mapping back.
       // Saying so keeps a load of millions of vertices from building a response too large to send, which would
       // fail the call at the very end with everything already committed.

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcGraphBatch.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcGraphBatch.java
@@ -38,7 +38,10 @@ import com.arcadedb.server.grpc.GraphBatchResult;
  * references it. That removes the per-flush round trip, the client-side mapping arrays, and the ceiling the
  * HTTP loader has on {@code flushEvery} (past which the server stops echoing a mapping too large to consume).
  * The mapping is not requested at all, which is also what keeps a load of millions of vertices from failing at
- * the very end on the 4 MB default message limit, with everything already committed.
+ * the very end on the 4 MB default message limit, with everything already committed. Nothing is lost by not
+ * asking: {@link com.arcadedb.remote.RemoteBatchResult} carries counters and elapsed time on either transport
+ * and has never exposed the mapping, so a caller wanting temporary ids resolved to RIDs queries the vertices
+ * back or calls the {@code GraphBatchLoad} RPC directly with {@code return_id_mapping} set.
  * <p>
  * {@code flushEvery} therefore means chunk size here: the number of records per {@code GraphBatchChunk} pushed
  * onto the open stream, not a round trip. {@link #flush()} closes the current chunk and sends it; the result is
@@ -305,6 +308,12 @@ public class RemoteGrpcGraphBatch extends RemoteGraphBatch {
     /**
      * Deadline for the whole load, from the first chunk to the server's answer, in milliseconds. Default: 6
      * hours. It bounds the stream rather than any single chunk, so it has to cover the entire import.
+     * <p>
+     * It is not the only limit in play, and raising it does not lift the other one: a single chunk also has a
+     * fixed five-minute ceiling on how long it may wait for the transport to drain before the load is given up
+     * on. That ceiling is deliberately not settable - it exists to tell a connection that died without saying
+     * so from one that is merely busy, and no legitimate load spends five minutes on one chunk's backpressure -
+     * but it does mean a link slow enough to breach it fails the load however much of this budget is left.
      */
     public Builder withTimeout(final long timeoutMs) {
       if (timeoutMs < 1)

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/GraphBatchLoadStreamTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/GraphBatchLoadStreamTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.remote.RemoteException;
+import com.arcadedb.server.grpc.GraphBatchChunk;
+import com.arcadedb.server.grpc.GraphBatchResult;
+import io.grpc.Status;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The parts of {@link GraphBatchLoadStream} an integration test cannot reach: what a sender parked waiting for
+ * the call to drain does when the call never drains, dies underneath it, or its thread is interrupted. Against a
+ * live server the readiness wait is either instant or never observed, so these paths - the ones that decide
+ * whether a bulk load fails or hangs - had no coverage at all.
+ * <p>
+ * Everything here drives the class against a hand-written {@link ClientCallStreamObserver} rather than a server,
+ * which is what makes "never becomes ready" and "fails while a sender is parked" expressible at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphBatchLoadStreamTest {
+
+  /** Long enough that a wait genuinely parks, short enough to be a test. */
+  private static final long READY_WAIT_MS      = 500;
+  /**
+   * Used where the test has to tell a sender that was woken from one that merely timed out. The readiness
+   * budget is set far above the time the assertion allows, so falling through it cannot be mistaken for a
+   * notification: only an actual wake-up finishes in time.
+   */
+  private static final long LONG_READY_WAIT_MS = 10_000;
+  private static final long PROMPT_MS          = 2_000;
+
+  @Test
+  void sendsStraightThroughWhileTheCallIsReady() {
+    final FakeCall call = new FakeCall(true);
+    final GraphBatchLoadStream stream = open(call);
+
+    stream.send(chunk());
+    stream.send(chunk());
+
+    assertThat(call.sent).as("a ready call carries every chunk without parking").hasSize(2);
+  }
+
+  /**
+   * The point of the readiness wait: a call that is not draining must hold the sender back rather than let it
+   * pile chunks into the channel's buffer, which is what runs a bulk load out of heap.
+   */
+  @Test
+  void aParkedSenderResumesWhenTheCallDrains() throws Exception {
+    final FakeCall call = new FakeCall(false);
+    final GraphBatchLoadStream stream = open(call, TimeUnit.SECONDS.toMillis(30), LONG_READY_WAIT_MS);
+
+    final CountDownLatch sent = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread sender = new Thread(() -> {
+      try {
+        stream.send(chunk());
+        sent.countDown();
+      } catch (final Throwable t) {
+        failure.set(t);
+        sent.countDown();
+      }
+    });
+    sender.start();
+
+    assertThat(sent.await(200, TimeUnit.MILLISECONDS)).as("a call that is not ready must hold the sender").isFalse();
+    assertThat(call.sent).isEmpty();
+
+    call.becomeReady();
+
+    assertThat(sent.await(PROMPT_MS, TimeUnit.MILLISECONDS))
+        .as("the sender must resume when the call drains, not sit out the readiness budget").isTrue();
+    assertThat(failure.get()).isNull();
+    assertThat(call.sent).hasSize(1);
+    sender.join(TimeUnit.SECONDS.toMillis(5));
+  }
+
+  /**
+   * A call that dies while a sender is parked wakes it with the reason. Without that the sender waits out the
+   * full readiness timeout on a call that is never coming back, and the caller waits with it.
+   */
+  @Test
+  void aParkedSenderIsWokenByTheCallFailing() throws Exception {
+    final FakeCall call = new FakeCall(false);
+    final GraphBatchLoadStream stream = open(call, TimeUnit.SECONDS.toMillis(30), LONG_READY_WAIT_MS);
+
+    final CountDownLatch finished = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread sender = new Thread(() -> {
+      try {
+        stream.send(chunk());
+      } catch (final Throwable t) {
+        failure.set(t);
+      } finally {
+        finished.countDown();
+      }
+    });
+    sender.start();
+
+    Thread.sleep(100); // let it park
+    call.observer.onError(Status.INTERNAL.withDescription("server said no").asRuntimeException());
+
+    assertThat(finished.await(PROMPT_MS, TimeUnit.MILLISECONDS))
+        .as("the failure must wake the sender, not leave it to fall out of the readiness budget").isTrue();
+    assertThat(failure.get()).as("and it must fail with the reason, not a timeout").isNotNull();
+    assertThat(failure.get()).isNotInstanceOf(TimeoutException.class);
+    assertThat(call.sent).as("nothing may be pushed onto a call that already failed").isEmpty();
+    sender.join(TimeUnit.SECONDS.toMillis(5));
+  }
+
+  /** A call that never drains has to end as a timeout rather than a thread parked for good. */
+  @Test
+  void aSenderGivesUpWhenTheCallNeverDrains() {
+    final FakeCall call = new FakeCall(false);
+    final GraphBatchLoadStream stream = open(call);
+
+    assertThatThrownBy(() -> stream.send(chunk()))
+        .isInstanceOf(TimeoutException.class)
+        .hasMessageContaining("waiting for the server to consume");
+
+    assertThat(call.sent).isEmpty();
+  }
+
+  /** Interrupting a parked sender must surface as a failure and leave the flag set for the caller above. */
+  @Test
+  void anInterruptedSenderFailsAndKeepsTheInterruptFlag() throws Exception {
+    final FakeCall call = new FakeCall(false);
+    final GraphBatchLoadStream stream = open(call, TimeUnit.SECONDS.toMillis(30), LONG_READY_WAIT_MS);
+
+    final CountDownLatch finished = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final AtomicBoolean stillInterrupted = new AtomicBoolean();
+    final Thread sender = new Thread(() -> {
+      try {
+        stream.send(chunk());
+      } catch (final Throwable t) {
+        failure.set(t);
+        stillInterrupted.set(Thread.currentThread().isInterrupted());
+      } finally {
+        finished.countDown();
+      }
+    });
+    sender.start();
+
+    Thread.sleep(100); // let it park
+    sender.interrupt();
+
+    assertThat(finished.await(PROMPT_MS, TimeUnit.MILLISECONDS))
+        .as("an interrupt must break the wait immediately, not wait out the readiness budget").isTrue();
+    assertThat(failure.get()).isInstanceOf(RemoteException.class);
+    assertThat(failure.get()).hasMessageContaining("Interrupted");
+    assertThat(stillInterrupted).as("the interrupt must not be swallowed on the way out").isTrue();
+    sender.join(TimeUnit.SECONDS.toMillis(5));
+  }
+
+  @Test
+  void completeReturnsTheServersResult() {
+    final FakeCall call = new FakeCall(true);
+    final GraphBatchLoadStream stream = open(call);
+
+    call.observer.onNext(GraphBatchResult.newBuilder().setVerticesCreated(7).setEdgesCreated(3).build());
+    call.observer.onCompleted();
+
+    final GraphBatchResult result = stream.complete();
+    assertThat(result.getVerticesCreated()).isEqualTo(7);
+    assertThat(result.getEdgesCreated()).isEqualTo(3);
+    assertThat(call.halfClosed).as("a healthy call is half-closed to end the load").isTrue();
+  }
+
+  /**
+   * Half-closing a call the server has already failed would raise gRPC's own complaint on top of the real
+   * failure and bury it. The failure is what the caller needs.
+   */
+  @Test
+  void completeReportsAFailedCallWithoutHalfClosingIt() {
+    final FakeCall call = new FakeCall(true);
+    final GraphBatchLoadStream stream = open(call);
+
+    call.observer.onError(Status.INTERNAL.withDescription("server said no").asRuntimeException());
+
+    assertThatThrownBy(stream::complete).isInstanceOf(RuntimeException.class);
+    assertThat(call.halfClosed).as("a call that already failed must not be half-closed again").isFalse();
+  }
+
+  /** A server that ends the stream without answering is a protocol failure, not an empty result. */
+  @Test
+  void completeRejectsAStreamThatEndedWithoutAResult() {
+    final FakeCall call = new FakeCall(true);
+    final GraphBatchLoadStream stream = open(call);
+
+    call.observer.onCompleted();
+
+    assertThatThrownBy(stream::complete)
+        .isInstanceOf(RemoteException.class)
+        .hasMessageContaining("without reporting its result");
+  }
+
+  /** The load's own deadline: a server that never answers must not park the caller for ever, and must be cut loose. */
+  @Test
+  void completeTimesOutAndCancelsTheCall() {
+    final FakeCall call = new FakeCall(true);
+    final GraphBatchLoadStream stream = open(call, 300);
+
+    assertThatThrownBy(stream::complete)
+        .isInstanceOf(TimeoutException.class)
+        .hasMessageContaining("withTimeout()");
+
+    assertThat(call.cancelled).as("a load given up on must release the server's batch slot").isTrue();
+  }
+
+  private GraphBatchLoadStream open(final FakeCall call) {
+    return open(call, TimeUnit.SECONDS.toMillis(30));
+  }
+
+  private GraphBatchLoadStream open(final FakeCall call, final long timeoutMs) {
+    return open(call, timeoutMs, READY_WAIT_MS);
+  }
+
+  private GraphBatchLoadStream open(final FakeCall call, final long timeoutMs, final long readyWaitMs) {
+    final GraphBatchLoadStream stream = new GraphBatchLoadStream(timeoutMs, readyWaitMs);
+    final ClientResponseObserver<GraphBatchChunk, GraphBatchResult> response = stream.responseObserver();
+    response.beforeStart(call);
+    // The fake call stands in for the server too: a test terminates the load through this.
+    call.observer = response;
+    stream.start(call);
+    return stream;
+  }
+
+  private static GraphBatchChunk chunk() {
+    return GraphBatchChunk.newBuilder().setDatabase("test").build();
+  }
+
+  /**
+   * A call whose readiness is decided by the test rather than by a transport. Doubles as the request observer,
+   * so what the loader pushes is recorded here too.
+   */
+  private static final class FakeCall extends ClientCallStreamObserver<GraphBatchChunk> {
+    private final    List<GraphBatchChunk>            sent     = new ArrayList<>();
+    private volatile boolean                          ready;
+    private volatile Runnable                         onReady;
+    private volatile boolean                          halfClosed;
+    private volatile boolean                          cancelled;
+    private volatile StreamObserver<GraphBatchResult> observer;
+
+    private FakeCall(final boolean ready) {
+      this.ready = ready;
+    }
+
+    private void becomeReady() {
+      ready = true;
+      final Runnable handler = onReady;
+      if (handler != null)
+        handler.run();
+    }
+
+    @Override
+    public boolean isReady() {
+      return ready;
+    }
+
+    @Override
+    public void setOnReadyHandler(final Runnable onReadyHandler) {
+      this.onReady = onReadyHandler;
+    }
+
+    @Override
+    public void cancel(final String message, final Throwable cause) {
+      cancelled = true;
+    }
+
+    @Override
+    public void onNext(final GraphBatchChunk value) {
+      sent.add(value);
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+    }
+
+    @Override
+    public void onCompleted() {
+      halfClosed = true;
+    }
+
+    @Override
+    public void disableAutoRequestWithInitial(final int request) {
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+    }
+
+    @Override
+    public void request(final int count) {
+    }
+
+    @Override
+    public void setMessageCompression(final boolean enable) {
+    }
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6070GrpcGraphBatchIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6070GrpcGraphBatchIT.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.remote.RemoteGraphBatch;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6070: {@code batch()} on a gRPC connection sent the load as JSONL over plain HTTP
+ * to {@code POST /api/v1/batch} instead of over the {@code GraphBatchLoad} streaming RPC that already existed
+ * and was implemented server-side. A caller who chose a gRPC connection got the HTTP transport silently, and
+ * nothing on the API surface said so.
+ *
+ * <p>The transport is asserted through the type {@code batch()} returns, which is the only thing that decides
+ * it: {@link RemoteGrpcGraphBatch} speaks the streaming RPC and nothing else, the inherited
+ * {@link RemoteGraphBatch} speaks HTTP and nothing else. The rest of the tests pin the behaviour the new
+ * transport has to keep identical to the HTTP one, and the one thing it does differently: temporary ids that
+ * survive a chunk boundary are resolved by the server, which holds them for the whole stream, rather than by
+ * the client round-tripping an id mapping per flush.
+ */
+public class Issue6070GrpcGraphBatchIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT = 50051;
+  private static final int    HTTP_PORT = 2480;
+  private static final String PERSON    = "Issue6070Person";
+  private static final String KNOWS     = "Issue6070Knows";
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase grpc;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void openAndPrepare() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    grpc = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, HTTP_PORT, getDatabaseName(), "root",
+        DEFAULT_PASSWORD_FOR_TESTS);
+
+    grpc.command("sql", "CREATE VERTEX TYPE `" + PERSON + "` IF NOT EXISTS");
+    grpc.command("sql", "CREATE EDGE TYPE `" + KNOWS + "` IF NOT EXISTS");
+    grpc.command("sql", "DELETE FROM `" + KNOWS + "`");
+    grpc.command("sql", "DELETE FROM `" + PERSON + "`");
+  }
+
+  @AfterEach
+  void closeClient() {
+    if (grpc != null) {
+      try {
+        grpc.command("sql", "DROP TYPE `" + KNOWS + "` IF EXISTS UNSAFE");
+        grpc.command("sql", "DROP TYPE `" + PERSON + "` IF EXISTS UNSAFE");
+      } catch (final Throwable ignore) {
+        // the server may already be going down; the base class drops the database anyway
+      }
+      grpc.close();
+    }
+    if (grpcServer != null)
+      grpcServer.close();
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Test
+  void batchOnAGrpcConnectionUsesTheStreamingRpcNotHttp() {
+    // The bug: this returned the inherited RemoteGraphBatch.Builder, whose loader posts JSONL over HTTP.
+    final RemoteGraphBatch.Builder builder = grpc.batch();
+    assertThat(builder).as("batch() on a gRPC connection must build the gRPC loader")
+        .isInstanceOf(RemoteGrpcGraphBatch.Builder.class);
+
+    try (final RemoteGraphBatch batch = builder.build()) {
+      assertThat(batch).as("the loader built on a gRPC connection must speak the GraphBatchLoad RPC")
+          .isInstanceOf(RemoteGrpcGraphBatch.class);
+    }
+  }
+
+  @Test
+  void loadsVerticesAndEdgesOverTheStreamingRpc() {
+    try (final RemoteGraphBatch batch = grpc.batch().build()) {
+      final String alice = batch.createVertex(PERSON, "name", "Alice", "age", 30);
+      final String bob = batch.createVertex(PERSON, "name", "Bob", "age", 25);
+      batch.createEdge(KNOWS, alice, bob, "since", 2020);
+
+      assertThatThrownBy(batch::getResult).as("counters are only known once the stream has ended")
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    assertThat(countOf(PERSON)).isEqualTo(2);
+    assertThat(countOf(KNOWS)).isEqualTo(1);
+
+    assertThat(grpc.query("sql", "SELECT name, age FROM `" + PERSON + "` ORDER BY name").stream()
+        .map(r -> r.getProperty("name") + ":" + r.<Object>getProperty("age"))
+        .toList()).containsExactly("Alice:30", "Bob:25");
+
+    // The edge connects the two vertices the temporary ids named...
+    assertThat(grpc.query("sql", "SELECT name, out(\"" + KNOWS + "\").name AS knows FROM `" + PERSON + "` ORDER BY name")
+        .stream().map(r -> r.getProperty("name") + "->" + r.<List<Object>>getProperty("knows")).toList())
+        .containsExactly("Alice->[Bob]", "Bob->[]");
+
+    // ...and carries its own properties, which land on the edge rather than on either endpoint.
+    assertThat(grpc.query("sql", "SELECT since FROM `" + KNOWS + "`").next().<Object>getProperty("since"))
+        .isEqualTo(2020);
+  }
+
+  @Test
+  void reportsTheServersTotalsAfterClose() {
+    final RemoteGraphBatch batch = grpc.batch().build();
+    final String a = batch.createVertex(PERSON, "name", "A");
+    final String b = batch.createVertex(PERSON, "name", "B");
+    final String c = batch.createVertex(PERSON, "name", "C");
+    batch.createEdge(KNOWS, a, b);
+    batch.createEdge(KNOWS, b, c);
+    batch.close();
+
+    assertThat(batch.getResult().getVerticesCreated()).isEqualTo(3);
+    assertThat(batch.getResult().getEdgesCreated()).isEqualTo(2);
+    assertThat(batch.getResult().getElapsedMs()).isGreaterThanOrEqualTo(0);
+  }
+
+  /**
+   * The one behaviour the streaming transport implements differently. Over HTTP each flush is an independent
+   * request, so an edge sent after the vertex it points at has already been flushed can only be connected
+   * because the client asked for the id mapping back and rewrote the reference itself. Here the whole load is
+   * one call and the server keeps the mapping for its lifetime, so the temporary id crosses the chunk boundary
+   * untouched. A chunk size of 2 puts every vertex in a chunk of its own, well before the edges arrive.
+   */
+  @Test
+  void resolvesTemporaryIdsAcrossChunkBoundaries() {
+    try (final RemoteGraphBatch batch = grpc.batch().withFlushEvery(2).build()) {
+      final String a = batch.createVertex(PERSON, "name", "A");
+      final String b = batch.createVertex(PERSON, "name", "B");
+      final String c = batch.createVertex(PERSON, "name", "C");
+      final String d = batch.createVertex(PERSON, "name", "D");
+
+      // Every one of these references a vertex sent in an earlier chunk.
+      batch.createEdge(KNOWS, a, b);
+      batch.createEdge(KNOWS, b, c);
+      batch.createEdge(KNOWS, c, d);
+      batch.createEdge(KNOWS, d, a);
+    }
+
+    assertThat(countOf(PERSON)).isEqualTo(4);
+    assertThat(countOf(KNOWS)).as("every cross-chunk reference must have been connected").isEqualTo(4);
+
+    // A dropped reference would leave a vertex without the edge rather than fail, so the shape is what proves it.
+    assertThat(grpc.query("sql", "SELECT name, out(\"" + KNOWS + "\").name AS knows FROM `" + PERSON + "` ORDER BY name")
+        .stream().map(r -> r.getProperty("name") + "->" + r.<List<?>>getProperty("knows")).toList())
+        .containsExactly("A->[B]", "B->[C]", "C->[D]", "D->[A]");
+  }
+
+  @Test
+  void connectsAnEdgeToAVertexAlreadyInTheDatabaseByRid() {
+    grpc.command("sql", "INSERT INTO `" + PERSON + "` SET name = 'Existing'");
+    final String existingRid = grpc.query("sql", "SELECT @rid AS rid FROM `" + PERSON + "` WHERE name = 'Existing'")
+        .next().getProperty("rid").toString();
+
+    try (final RemoteGraphBatch batch = grpc.batch().build()) {
+      final String fresh = batch.createVertex(PERSON, "name", "Fresh");
+      batch.createEdge(KNOWS, fresh, existingRid);
+    }
+
+    assertThat(grpc.query("sql", "SELECT out(\"" + KNOWS + "\").name AS knows FROM `" + PERSON + "` WHERE name = 'Fresh'")
+        .next().<List<Object>>getProperty("knows")).containsExactly("Existing");
+  }
+
+  @Test
+  void carriesTheBuilderOptionsToTheServer() {
+    // vertexBatchSize had no equivalent on the RPC before this fix, so a caller lowering it (which a replicated
+    // database needs, one batch being one Raft entry) was silently ignored. Set below the record count so the
+    // server has to honour it to load everything.
+    try (final RemoteGraphBatch batch = grpc.batch().withVertexBatchSize(2).withFlushEvery(3).withWAL(true).build()) {
+      for (int i = 0; i < 7; i++)
+        batch.createVertex(PERSON, "name", "P" + i);
+    }
+
+    assertThat(countOf(PERSON)).isEqualTo(7);
+  }
+
+  /**
+   * The gRPC-only options have to be reachable after the inherited ones. An inherited setter that handed back
+   * the base builder would compile only while {@code withTimeout} came first, which is not an ordering anyone
+   * would expect a builder to impose.
+   */
+  @Test
+  void buildsWithTheGrpcOptionsInAnyPositionOfTheChain() {
+    try (final RemoteGraphBatch batch = grpc.batch()
+        .withFlushEvery(10)
+        .withBatchSize(1000)
+        .withTimeout(60_000)
+        .withVertexBatchSize(5)
+        .build()) {
+      batch.createVertex(PERSON, "name", "Chained");
+    }
+
+    assertThat(countOf(PERSON)).isEqualTo(1);
+  }
+
+  @Test
+  void rejectsAVertexAddedAfterAnEdge() {
+    try (final RemoteGraphBatch batch = grpc.batch().build()) {
+      final String a = batch.createVertex(PERSON, "name", "A");
+      final String b = batch.createVertex(PERSON, "name", "B");
+      batch.createEdge(KNOWS, a, b);
+
+      assertThatThrownBy(() -> batch.createVertex(PERSON, "name", "TooLate"))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Cannot add vertices after edges");
+    }
+  }
+
+  @Test
+  void rejectsUseAfterClose() {
+    final RemoteGraphBatch batch = grpc.batch().build();
+    batch.createVertex(PERSON, "name", "A");
+    batch.close();
+
+    assertThatThrownBy(() -> batch.createVertex(PERSON, "name", "B")).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> batch.createEdge(KNOWS, "v0", "v0")).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void closingAnEmptyBatchNeitherOpensAStreamNorFails() {
+    final RemoteGraphBatch batch = grpc.batch().build();
+    batch.close();
+    batch.close(); // idempotent
+
+    assertThat(batch.getResult().getVerticesCreated()).isZero();
+    assertThat(batch.getResult().getEdgesCreated()).isZero();
+    assertThat(countOf(PERSON)).isZero();
+  }
+
+  /**
+   * The batch commits incrementally, so a load that fails is not a load that rolled back. What the server had
+   * already committed rides the trailers of the failed call and has to end up somewhere the caller can read it:
+   * re-sending the whole load blindly would double everything that did get through.
+   */
+  @Test
+  void aFailedLoadReportsWhatItAlreadyCommitted() {
+    grpc.command("sql", "CREATE PROPERTY `" + PERSON + "`.tag IF NOT EXISTS STRING (MANDATORY TRUE)");
+
+    final RemoteGraphBatch batch = grpc.batch().withVertexBatchSize(2).build();
+    for (int i = 0; i < 8; i++)
+      batch.createVertex(PERSON, "tag", "t" + i);
+    // The ninth has no 'tag', so the buffer holding it cannot be created and the load fails there.
+    batch.createVertex(PERSON);
+
+    assertThatThrownBy(batch::close).as("a load violating the schema must fail, not pass silently")
+        .isInstanceOf(RuntimeException.class);
+
+    assertThat(batch.getResult().getVerticesCreated())
+        .as("the counters must say how much of the load is durable, not zero")
+        .isEqualTo(8);
+    assertThat(countOf(PERSON)).as("and what they claim is durable really is").isEqualTo(8);
+  }
+
+  private long countOf(final String typeName) {
+    return grpc.query("sql", "SELECT count(*) AS c FROM `" + typeName + "`").next().<Number>getProperty("c").longValue();
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6070GrpcGraphBatchIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6070GrpcGraphBatchIT.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -227,6 +228,25 @@ public class Issue6070GrpcGraphBatchIT extends BaseGraphServerTest {
     assertThat(countOf(PERSON)).isEqualTo(1);
   }
 
+  /**
+   * The commit-retry knobs reach the server. Zero is the interesting value: it means "do not retry, fail on the
+   * first error", which is a setting and not an absence, so the two fields are {@code optional} on the wire -
+   * a plain proto3 int could not tell a caller who asked for no retries from one who asked for nothing.
+   */
+  @Test
+  void carriesTheCommitRetryOptionsIncludingZero() {
+    try (final RemoteGraphBatch batch = grpc.batch().withCommitRetries(0).withCommitRetryDelay(0).build()) {
+      batch.createVertex(PERSON, "name", "NoRetries");
+    }
+
+    assertThat(countOf(PERSON)).isEqualTo(1);
+
+    assertThatThrownBy(() -> grpc.batch().withCommitRetries(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> grpc.batch().withCommitRetryDelay(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
   @Test
   void rejectsAVertexAddedAfterAnEdge() {
     try (final RemoteGraphBatch batch = grpc.batch().build()) {
@@ -283,6 +303,56 @@ public class Issue6070GrpcGraphBatchIT extends BaseGraphServerTest {
         .as("the counters must say how much of the load is durable, not zero")
         .isEqualTo(8);
     assertThat(countOf(PERSON)).as("and what they claim is durable really is").isEqualTo(8);
+  }
+
+  /**
+   * The failure above arrives on the single flush that {@code close()} performs. This one arrives on an
+   * interior auto-flush, which is the shape a real bulk load has: the exception comes out of
+   * {@code createVertex()} in the middle of the body, and the {@code close()} that a try-with-resources runs
+   * afterwards must neither re-send the chunk that just failed nor bury the real failure under gRPC's own "call
+   * already closed".
+   * <p>
+   * The loader is written not to depend on which of those happens - it hands the buffer over before the send,
+   * and does not half-close a call the server has already failed - but this test does not distinguish the two
+   * implementations on its own: current grpc-java reports {@code isReady() == false} on a terminated call, so
+   * the readiness wait raises the real failure before a re-send could reach the wire either way. What it pins
+   * is the contract a caller sees, which must hold however grpc-java resolves that internally: the committed
+   * buffer survives exactly once, and {@code close()} adds no second, misleading failure.
+   */
+  @Test
+  void aFailureOnAnInteriorFlushIsNotResentByClose() {
+    grpc.command("sql", "CREATE PROPERTY `" + PERSON + "`.tag IF NOT EXISTS STRING (MANDATORY TRUE)");
+
+    final AtomicReference<Throwable> fromBody = new AtomicReference<>();
+
+    // Chunk and server-side buffer both 2, so the first two vertices are committed as a whole buffer before the
+    // buffer holding the bad one fails. The 400 that follow make sure the failure is observed by a later send
+    // in the body rather than only at close(), which is what puts an already-sent chunk at risk of a re-send.
+    try (final RemoteGraphBatch batch = grpc.batch().withFlushEvery(2).withVertexBatchSize(2).build()) {
+      try {
+        batch.createVertex(PERSON, "tag", "ok0");
+        batch.createVertex(PERSON, "tag", "ok1");
+        batch.createVertex(PERSON, "tag", "ok2");
+        batch.createVertex(PERSON); // no 'tag': the server fails the load on this buffer
+        for (int i = 0; i < 400; i++)
+          batch.createVertex(PERSON, "tag", "after" + i);
+      } catch (final RuntimeException e) {
+        fromBody.set(e);
+      }
+    } catch (final RuntimeException fromClose) {
+      // close() may re-raise the same failure; what it must not do is raise a different, misleading one on top
+      // of it, which is what half-closing or re-sending on a call the server already terminated produces.
+      assertThat(fromClose).as("close() must not invent a failure of its own on top of the real one")
+          .hasMessageNotContaining("call already closed")
+          .hasMessageNotContaining("already half-closed")
+          .hasMessageNotContaining("Stream is already completed");
+    }
+
+    assertThat(fromBody.get()).as("the load violates the schema, so it must fail during the body").isNotNull();
+
+    // The buffer that completed before the failure is durable, and exactly once: a chunk handed to a terminated
+    // stream and then sent again by close() would show up here as a duplicate.
+    assertThat(countOf(PERSON)).as("the committed buffer survives, and is not loaded twice").isEqualTo(2);
   }
 
   private long countOf(final String typeName) {

--- a/grpc/src/main/java/com/arcadedb/server/grpc/GraphBatchProtocol.java
+++ b/grpc/src/main/java/com/arcadedb/server/grpc/GraphBatchProtocol.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import io.grpc.Metadata;
+import io.grpc.protobuf.ProtoUtils;
+
+/**
+ * Wire constants of the {@code GraphBatchLoad} RPC that both ends have to agree on. They live in the module that
+ * owns the protocol definition rather than on either side of it, so the server writing a trailer and the client
+ * reading it cannot drift apart (issue #6070).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class GraphBatchProtocol {
+
+  /**
+   * Carries the partial-commit counters of a failed {@code GraphBatchLoad} on the trailers of the failed call.
+   * A gRPC error ends the stream with a status and no message, but the batch commits incrementally, so a load
+   * that failed part-way is not rolled back: without this the caller would be told that the load failed and
+   * nothing about how much of it is durable, leaving re-sending everything as the only safe option.
+   */
+  public static final Metadata.Key<GraphBatchResult> RESULT_TRAILER = Metadata.Key.of(
+      "arcadedb-graph-batch-result-bin", ProtoUtils.metadataMarshaller(GraphBatchResult.getDefaultInstance()));
+
+  private GraphBatchProtocol() {
+  }
+}

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -579,12 +579,20 @@ message GraphBatchResult {
   // empty one, so read id_mapping_omitted before concluding that no temp IDs were used. Left unset rather
   // than silently truncated, because a partial mapping would resolve some edge references and drop the rest.
   map<string, string> id_mapping = 4;
-  bool  id_mapping_omitted       = 5;  // the mapping was dropped: it exceeded the server-side cap
+  // The mapping is not in this message. On a successful load that means it exceeded the server-side cap while
+  // return_id_mapping was left unset; on the failure trailer described below it is always set, because a
+  // trailer is bounded far below a message and never carries the mapping at all. It is never set when the
+  // caller asked for no mapping: nothing was dropped that they wanted.
+  bool  id_mapping_omitted       = 5;
   int64 id_mapping_size          = 6;  // number of temp IDs mapped, reported whether or not the mapping travels
   // A load that failed part-way still committed everything the batch had already flushed: GraphBatch commits
   // incrementally (commit_every / vertex_batch_size), so an error is not a rollback. The server reports the
   // counts durable at the point of failure in the 'arcadedb-graph-batch-result-bin' trailer of the failed
   // call, with this flag set, so a caller can reconcile instead of blindly re-sending the whole load.
+  // On that trailer edges_created counts only edges whose flush committed: an edge is buffered when its record
+  // is received and reaches the database later, so counting received edges would overstate what survived and
+  // lead a caller to re-send too little. vertices_created needs no such distinction - a vertex is counted once
+  // its own commit has returned.
   bool  partial_commit           = 7;
 }
 

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -538,8 +538,11 @@ message GraphBatchOptions {
   // On a replicated database that transaction ships as one Raft entry, so lower it when the server warns
   // that a replicated entry approaches the maximum entry size. Mirrors the HTTP 'vertexBatchSize' parameter.
   int32  vertex_batch_size        = 10; // default 10000
-  int32  commit_retries           = 11; // default: engine default
-  int64  commit_retry_delay_ms    = 12; // default: engine default
+  // Optional, unlike the sizing fields above, because zero is a meaningful setting for both and not the same
+  // thing as leaving them alone: no retries at all (fail on the first error) and no back-off before the first
+  // retry. A plain int32 could not tell that apart from unset.
+  optional int32 commit_retries        = 11; // default 10; 0 disables retrying
+  optional int64 commit_retry_delay_ms = 12; // default 1000
   // Whether the server echoes the temp_id -> RID mapping back in GraphBatchResult. Unset means AUTO: the
   // mapping is returned only while it stays under the server-side cap, past which it is dropped and
   // reported through id_mapping_omitted / id_mapping_size. Set it to false when the caller does not need

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -534,6 +534,19 @@ message GraphBatchOptions {
   optional bool   bidirectional            = 7;  // default true (unset = true)
   int32  commit_every             = 8;  // default 50000
   int32  expected_edge_count      = 9;  // default 0
+  // Vertices accumulated before they are created and committed in a single transaction (default 10000).
+  // On a replicated database that transaction ships as one Raft entry, so lower it when the server warns
+  // that a replicated entry approaches the maximum entry size. Mirrors the HTTP 'vertexBatchSize' parameter.
+  int32  vertex_batch_size        = 10; // default 10000
+  int32  commit_retries           = 11; // default: engine default
+  int64  commit_retry_delay_ms    = 12; // default: engine default
+  // Whether the server echoes the temp_id -> RID mapping back in GraphBatchResult. Unset means AUTO: the
+  // mapping is returned only while it stays under the server-side cap, past which it is dropped and
+  // reported through id_mapping_omitted / id_mapping_size. Set it to false when the caller does not need
+  // the RIDs back: the server resolves temp IDs itself for the whole stream, so a single-stream loader
+  // never needs the mapping and dropping it removes the message-size ceiling entirely. Set it to true to
+  // demand the mapping whatever its size, accepting that a large one may exceed maxInboundMessageSize.
+  optional bool return_id_mapping = 13;
 }
 
 message GraphBatchRecord {
@@ -559,10 +572,17 @@ message GraphBatchResult {
   int64 vertices_created         = 1;
   int64 edges_created            = 2;
   int64 elapsed_ms               = 3;
-  map<string, string> id_mapping = 4;  // temp_id → RID string
-  // Note: for very large batches with many temp IDs, the id_mapping may exceed the default
-  // gRPC message size limit (4 MB). Callers importing millions of vertices with temp IDs should
-  // increase maxInboundMessageSize or avoid temp IDs when RID mapping is not needed.
+  // temp_id -> RID string. Subject to GraphBatchOptions.return_id_mapping: an omitted mapping is not an
+  // empty one, so read id_mapping_omitted before concluding that no temp IDs were used. Left unset rather
+  // than silently truncated, because a partial mapping would resolve some edge references and drop the rest.
+  map<string, string> id_mapping = 4;
+  bool  id_mapping_omitted       = 5;  // the mapping was dropped: it exceeded the server-side cap
+  int64 id_mapping_size          = 6;  // number of temp IDs mapped, reported whether or not the mapping travels
+  // A load that failed part-way still committed everything the batch had already flushed: GraphBatch commits
+  // incrementally (commit_every / vertex_batch_size), so an error is not a rollback. The server reports the
+  // counts durable at the point of failure in the 'arcadedb-graph-batch-result-bin' trailer of the failed
+  // call, with this flag set, so a caller can reconcile instead of blindly re-sending the whole load.
+  bool  partial_commit           = 7;
 }
 
 // -----------------------------------------------------------------------------

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2653,6 +2653,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             if (chunk.getDatabase().isEmpty())
               throw new IllegalArgumentException("First chunk must contain the database name");
 
+            // Authenticate first, exactly as every other RPC on this service does. The leadership check below
+            // answers with the cluster's topology, which is not something to hand to a caller that has not
+            // shown it may talk to this database at all.
+            final Database db = getDatabase(chunk.getDatabase(), chunk.getCredentials());
+
             // On a follower of a replicated database the load must not run here: the bulk path mutates shared
             // state (schema dictionary, type metadata) that only the leader can serialize, and running it on a
             // follower hits the race in Dictionary.getIdByName as the local state-machine apply runs
@@ -2673,7 +2678,6 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               return;
             }
 
-            final Database db = getDatabase(chunk.getDatabase(), chunk.getCredentials());
             dbRef.set(db);
             final GraphBatchOptions options = chunk.hasOptions() ? chunk.getOptions() : null;
             if (options != null) {
@@ -2893,9 +2897,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       builder.withCommitEvery(opts.getCommitEvery());
     if (opts.getExpectedEdgeCount() > 0)
       builder.withExpectedEdgeCount(opts.getExpectedEdgeCount());
-    if (opts.getCommitRetries() > 0)
+    // Zero is a setting here, not an absence: no retries, and no back-off before the first one.
+    if (opts.hasCommitRetries())
       builder.withCommitRetries(opts.getCommitRetries());
-    if (opts.getCommitRetryDelayMs() > 0)
+    if (opts.hasCommitRetryDelayMs())
       builder.withCommitRetryDelay(opts.getCommitRetryDelayMs());
   }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -139,6 +139,15 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    */
   private static final int GRAPH_BATCH_MAX_ID_MAPPING = 10_000;
 
+  /**
+   * Ceiling on the vertex buffer a caller may ask for. The buffer is a caller-supplied list length held for the
+   * whole stream, so without a bound a single request could name a size large enough to exhaust the server's
+   * heap before sending a second chunk. The cap is far above any legitimate setting: the reason to touch this
+   * option at all is to make the buffer smaller than the 10,000 default, not larger, one buffer being one Raft
+   * entry on a replicated database.
+   */
+  private static final int GRAPH_BATCH_MAX_VERTEX_BUFFER = 1_000_000;
+
   // Transaction management - now stores TransactionContext with executor for thread affinity
   private final Map<String, TransactionContext> activeTransactions = new ConcurrentHashMap<>();
 
@@ -2625,8 +2634,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final Map<String, RID> tempIdMap = new HashMap<>();
 
     // Vertex accumulation state
-    final List<Object[]> vertexPropsBatch = new ArrayList<>();
-    final List<String> vertexTempIds = new ArrayList<>();
+    final ArrayList<Object[]> vertexPropsBatch = new ArrayList<>();
+    final ArrayList<String> vertexTempIds = new ArrayList<>();
     final String[] currentType = { null };
     final long[] counts = new long[2]; // [0]=vertices, [1]=edges
     final boolean[] inEdgePhase = { false };
@@ -2682,10 +2691,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             final GraphBatchOptions options = chunk.hasOptions() ? chunk.getOptions() : null;
             if (options != null) {
               if (options.getVertexBatchSize() > 0)
-                vertexBatchSize[0] = options.getVertexBatchSize();
+                vertexBatchSize[0] = Math.min(options.getVertexBatchSize(), GRAPH_BATCH_MAX_VERTEX_BUFFER);
               if (options.hasReturnIdMapping())
                 returnIdMapping[0] = options.getReturnIdMapping();
             }
+            // Sized once the buffer is known, rather than at the default, so a load that asked for a different
+            // one does not spend the start of the stream growing two lists it keeps for the whole load.
+            vertexPropsBatch.ensureCapacity(vertexBatchSize[0]);
+            vertexTempIds.ensureCapacity(vertexBatchSize[0]);
             final GraphBatch.Builder builder = db.batch();
             configureGraphBatchOptions(builder, options);
             try {
@@ -2739,9 +2752,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           if (abandoned != null)
             abandoned.abandon();
           // What the batch already flushed is committed and stays committed: report it on the trailers so the
-          // caller can reconcile instead of re-sending a load that is partly in the database already.
+          // caller can reconcile instead of re-sending a load that is partly in the database already. The
+          // abandoned batch is still the one holding the flushed-edge count, and abandon() drops what was
+          // buffered without touching what it had already committed.
           out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage())
-              .asException(partialCommitTrailer(counts, tempIdMap, startedAt)));
+              .asException(partialCommitTrailer(abandoned, counts, tempIdMap, startedAt)));
           return;
         } finally {
           if (!cancelled.get() && !errorSent[0])
@@ -2796,8 +2811,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             out.onCompleted();
           }
         } catch (final Exception e) {
+          // close() is where the deferred incoming edges are connected, so a failure here can leave edges
+          // buffered that the counters must not claim: the batch is asked what it actually flushed.
           out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage())
-              .asException(partialCommitTrailer(counts, tempIdMap, startedAt)));
+              .asException(partialCommitTrailer(batchRef.get(), counts, tempIdMap, startedAt)));
           closeQuietly(batchRef.get());
         }
       }
@@ -2805,20 +2822,37 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   /**
-   * Builds the trailers that carry a failed load's partial-commit counters. The id mapping itself is never
-   * attached: trailers are bounded far below a message, and a caller reconciling a failed load re-reads the
-   * database rather than trusting a mapping the failure may have cut short.
+   * Builds the trailers that carry a failed load's partial-commit counters. The whole point of them is that a
+   * caller can reconcile instead of re-sending, so they have to count what is durable and nothing more.
+   * <p>
+   * That makes the edge count a different number from the one the success path reports. {@code counts[1]} is
+   * incremented when an edge record is <i>buffered</i>, and a buffered edge is not a created one: outgoing
+   * edges reach the database in {@code commitEvery}-sized flushes, and the incoming direction is connected at
+   * {@link GraphBatch#close()}. A load that dies before or during either still holds buffered edges that never
+   * landed, and reporting those as committed would make a caller re-send too little and lose them silently -
+   * exactly the failure these counters exist to prevent. The batch's own {@code totalEdgesCreated} advances
+   * only after a flush has committed, so it is what gets reported here. Vertices need no such care:
+   * {@code counts[0]} is only advanced by {@code createVertices}, which returns after its commit.
+   * <p>
+   * The id mapping itself is never attached - trailers are bounded far below a message, and a caller
+   * reconciling a failed load re-reads the database rather than trusting a mapping the failure may have cut
+   * short - so {@code id_mapping_omitted} is always set here, and means "not in this message" rather than the
+   * success path's narrower "dropped because it exceeded the cap".
+   *
+   * @param batch the batch the load was running on, or null if it never got one or has already been abandoned
    */
-  private static Metadata partialCommitTrailer(final long[] counts, final Map<String, RID> tempIdMap,
-      final long startedAt) {
+  private static Metadata partialCommitTrailer(final GraphBatch batch, final long[] counts,
+      final Map<String, RID> tempIdMap, final long startedAt) {
+    final long edgesCommitted = batch != null ? batch.getTotalEdgesCreated() : 0;
+
     final Metadata trailers = new Metadata();
     trailers.put(GraphBatchProtocol.RESULT_TRAILER, GraphBatchResult.newBuilder()
         .setVerticesCreated(counts[0])
-        .setEdgesCreated(counts[1])
+        .setEdgesCreated(edgesCommitted)
         .setElapsedMs(System.currentTimeMillis() - startedAt)
         .setIdMappingSize(tempIdMap.size())
         .setIdMappingOmitted(true)
-        .setPartialCommit(counts[0] > 0 || counts[1] > 0)
+        .setPartialCommit(counts[0] > 0 || edgesCommitted > 0)
         .build());
     return trailers;
   }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -54,6 +54,7 @@ import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.security.SecurityManager;
 import com.arcadedb.serializer.JsonSerializer;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.grpc.InsertOptions.ConflictMode;
 import com.arcadedb.server.grpc.InsertOptions.TransactionMode;
 import com.arcadedb.server.grpc.ProjectionSettings.ProjectionEncoding;
@@ -69,6 +70,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import io.grpc.Context;
+import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -126,6 +128,16 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       .setUseCollectionSizeForEdges(false).setUseCollectionSize(false);
 
   private static final int GRAPH_BATCH_VERTEX_BUFFER = 10_000;
+
+  /**
+   * Past this many temp IDs the mapping is dropped from {@link GraphBatchResult} instead of travelling with it,
+   * and the caller is told so through {@code id_mapping_omitted} / {@code id_mapping_size}. Mirrors the HTTP
+   * endpoint's {@code MAX_ID_MAPPING_IN_RESPONSE}: a mapping of a few million vertices is both larger than the
+   * default 4 MB gRPC message limit (which would fail the whole load at the very end, after everything was
+   * committed) and larger than any caller can usefully consume in one response. Callers that need it regardless
+   * set {@code return_id_mapping=true}; callers that never need it set false and lift the ceiling entirely.
+   */
+  private static final int GRAPH_BATCH_MAX_ID_MAPPING = 10_000;
 
   // Transaction management - now stores TransactionContext with executor for thread affinity
   private final Map<String, TransactionContext> activeTransactions = new ConcurrentHashMap<>();
@@ -2613,11 +2625,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final Map<String, RID> tempIdMap = new HashMap<>();
 
     // Vertex accumulation state
-    final List<Object[]> vertexPropsBatch = new ArrayList<>(GRAPH_BATCH_VERTEX_BUFFER);
-    final List<String> vertexTempIds = new ArrayList<>(GRAPH_BATCH_VERTEX_BUFFER);
+    final List<Object[]> vertexPropsBatch = new ArrayList<>();
+    final List<String> vertexTempIds = new ArrayList<>();
     final String[] currentType = { null };
     final long[] counts = new long[2]; // [0]=vertices, [1]=edges
     final boolean[] inEdgePhase = { false };
+    // Resolved from the first chunk's options, then fixed for the whole stream.
+    final int[] vertexBatchSize = { GRAPH_BATCH_VERTEX_BUFFER };
+    final Boolean[] returnIdMapping = { null };
 
     call.setOnCancelHandler(() -> {
       cancelled.set(true);
@@ -2637,10 +2652,38 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             // First chunk: initialize
             if (chunk.getDatabase().isEmpty())
               throw new IllegalArgumentException("First chunk must contain the database name");
+
+            // On a follower of a replicated database the load must not run here: the bulk path mutates shared
+            // state (schema dictionary, type metadata) that only the leader can serialize, and running it on a
+            // follower hits the race in Dictionary.getIdByName as the local state-machine apply runs
+            // concurrently with this thread (issue #4122). The HTTP endpoint relays the payload to the leader;
+            // this stream cannot, because the HA plugin exposes the leader's HTTP address only and relaying a
+            // bulk load through a follower would double the traffic of the transport chosen to avoid exactly
+            // that. It is refused before a single record is written, so the caller can redirect and retry
+            // without having to reconcile a partial load.
+            final HAServerPlugin ha = arcadeServer != null ? arcadeServer.getHA() : null;
+            if (ha != null && !ha.isLeader()) {
+              final String leader = ha.getLeaderAddress();
+              errorSent[0] = true;
+              out.onError(Status.FAILED_PRECONDITION.withDescription(
+                  "graphBatchLoad: this server is not the cluster leader and a graph batch load must run on the leader. "
+                      + (leader != null && !leader.isBlank() ?
+                      "Reconnect to the leader at '" + leader + "' (HTTP address; use its gRPC port) and retry" :
+                      "The leader is currently unknown, retry once the election has settled")).asException());
+              return;
+            }
+
             final Database db = getDatabase(chunk.getDatabase(), chunk.getCredentials());
             dbRef.set(db);
+            final GraphBatchOptions options = chunk.hasOptions() ? chunk.getOptions() : null;
+            if (options != null) {
+              if (options.getVertexBatchSize() > 0)
+                vertexBatchSize[0] = options.getVertexBatchSize();
+              if (options.hasReturnIdMapping())
+                returnIdMapping[0] = options.getReturnIdMapping();
+            }
             final GraphBatch.Builder builder = db.batch();
-            configureGraphBatchOptions(builder, chunk.hasOptions() ? chunk.getOptions() : null);
+            configureGraphBatchOptions(builder, options);
             try {
               batch = builder.build();
             } catch (final DatabaseOperationException e) {
@@ -2679,7 +2722,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               vertexPropsBatch.add(props);
               vertexTempIds.add(rec.getTempId().isEmpty() ? null : rec.getTempId());
 
-              if (vertexPropsBatch.size() >= GRAPH_BATCH_VERTEX_BUFFER)
+              if (vertexPropsBatch.size() >= vertexBatchSize[0])
                 counts[0] += flushVertexBatch(batch, currentType[0], vertexPropsBatch, vertexTempIds, tempIdMap);
             }
           }
@@ -2691,7 +2734,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           final GraphBatch abandoned = batchRef.getAndSet(null);
           if (abandoned != null)
             abandoned.abandon();
-          out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
+          // What the batch already flushed is committed and stays committed: report it on the trailers so the
+          // caller can reconcile instead of re-sending a load that is partly in the database already.
+          out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage())
+              .asException(partialCommitTrailer(counts, tempIdMap, startedAt)));
           return;
         } finally {
           if (!cancelled.get() && !errorSent[0])
@@ -2727,21 +2773,50 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           final GraphBatchResult.Builder result = GraphBatchResult.newBuilder()
               .setVerticesCreated(counts[0])
               .setEdgesCreated(counts[1])
-              .setElapsedMs(System.currentTimeMillis() - startedAt);
+              .setElapsedMs(System.currentTimeMillis() - startedAt)
+              .setIdMappingSize(tempIdMap.size());
 
-          for (final Map.Entry<String, RID> entry : tempIdMap.entrySet())
-            result.putIdMapping(entry.getKey(), entry.getValue().toString());
+          // AUTO (unset) returns the mapping only while it stays consumable; explicit true demands it whatever
+          // its size; explicit false never sends it. The mapping is all-or-nothing: a truncated one would
+          // resolve some of the caller's references and silently drop the rest.
+          if (returnIdMapping[0] == null ?
+              tempIdMap.size() <= GRAPH_BATCH_MAX_ID_MAPPING :
+              returnIdMapping[0]) {
+            for (final Map.Entry<String, RID> entry : tempIdMap.entrySet())
+              result.putIdMapping(entry.getKey(), entry.getValue().toString());
+          } else if (returnIdMapping[0] == null)
+            result.setIdMappingOmitted(true);
 
           if (!cancelled.get()) {
             out.onNext(result.build());
             out.onCompleted();
           }
         } catch (final Exception e) {
-          out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
+          out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage())
+              .asException(partialCommitTrailer(counts, tempIdMap, startedAt)));
           closeQuietly(batchRef.get());
         }
       }
     };
+  }
+
+  /**
+   * Builds the trailers that carry a failed load's partial-commit counters. The id mapping itself is never
+   * attached: trailers are bounded far below a message, and a caller reconciling a failed load re-reads the
+   * database rather than trusting a mapping the failure may have cut short.
+   */
+  private static Metadata partialCommitTrailer(final long[] counts, final Map<String, RID> tempIdMap,
+      final long startedAt) {
+    final Metadata trailers = new Metadata();
+    trailers.put(GraphBatchProtocol.RESULT_TRAILER, GraphBatchResult.newBuilder()
+        .setVerticesCreated(counts[0])
+        .setEdgesCreated(counts[1])
+        .setElapsedMs(System.currentTimeMillis() - startedAt)
+        .setIdMappingSize(tempIdMap.size())
+        .setIdMappingOmitted(true)
+        .setPartialCommit(counts[0] > 0 || counts[1] > 0)
+        .build());
+    return trailers;
   }
 
   private Object[] toPropertyArray(final Map<String, GrpcValue> properties) {
@@ -2818,6 +2893,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       builder.withCommitEvery(opts.getCommitEvery());
     if (opts.getExpectedEdgeCount() > 0)
       builder.withExpectedEdgeCount(opts.getExpectedEdgeCount());
+    if (opts.getCommitRetries() > 0)
+      builder.withCommitRetries(opts.getCommitRetries());
+    if (opts.getCommitRetryDelayMs() > 0)
+      builder.withCommitRetryDelay(opts.getCommitRetryDelayMs());
   }
 
   private void closeQuietly(final GraphBatch batch) {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
@@ -241,6 +241,32 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
     assertThat(countOf("Issue6070Node")).isEqualTo(4);
   }
 
+  /**
+   * Zero commit retries means "fail on the first error", not "no preference", so the two retry fields are
+   * {@code optional} on the wire. A plain proto3 int32 defaults to 0 when unset, so a server reading it with
+   * the usual {@code > 0} guard would silently ignore the one caller who explicitly asked not to retry - the
+   * caller with the strongest opinion about it. The HTTP endpoint gets this right (a query parameter is
+   * present or it is not), so the RPC has to as well.
+   */
+  @Test
+  void distinguishesZeroCommitRetriesFromUnset() throws Exception {
+    assertThat(GraphBatchOptions.newBuilder().build().hasCommitRetries())
+        .as("an untouched options message must not claim a retry setting").isFalse();
+    assertThat(GraphBatchOptions.newBuilder().setCommitRetries(0).build().hasCommitRetries())
+        .as("asking for zero retries must be distinguishable from asking for nothing").isTrue();
+    assertThat(GraphBatchOptions.newBuilder().setCommitRetryDelayMs(0).build().hasCommitRetryDelayMs())
+        .as("asking for no back-off must be distinguishable from asking for nothing").isTrue();
+
+    // And a load carrying them still runs.
+    final GraphBatchResult result = load(GraphBatchOptions.newBuilder()
+        .setCommitRetries(0)
+        .setCommitRetryDelayMs(0)
+        .build(), 3);
+
+    assertThat(result.getVerticesCreated()).isEqualTo(3);
+    assertThat(countOf("Issue6070Node")).isEqualTo(3);
+  }
+
   private GraphBatchResult loadWithIdMappingPreference(final Boolean returnIdMapping, final int vertices)
       throws Exception {
     final GraphBatchOptions.Builder options = GraphBatchOptions.newBuilder();

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
@@ -19,6 +19,8 @@
 package com.arcadedb.server.grpc;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.server.BaseGraphServerTest;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -267,6 +269,77 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
     assertThat(countOf("Issue6070Node")).isEqualTo(3);
   }
 
+  /**
+   * The counters must not claim an edge that never reached the database. An edge is buffered when its record
+   * arrives and is written in {@code commitEvery}-sized flushes, with the incoming direction connected at
+   * {@code close()}, so a load that dies at either point is still holding edges that did not land. Counting
+   * received edges rather than flushed ones would report those as committed, and a caller reconciling against
+   * that number re-sends too little and loses them - the exact failure the trailer exists to prevent.
+   * <p>
+   * The failure is arranged where the previous test cannot reach: past the vertex phase, on the edge flush that
+   * {@code close()} performs, by pointing an edge at a bucket that does not exist. The vertices are committed
+   * by then, so the trailer has to report some of the load as durable and none of the edges.
+   */
+  @Test
+  void countsOnlyFlushedEdgesOnTheTrailerOfALoadThatFailsClosing() throws Exception {
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+
+    final StreamObserver<GraphBatchChunk> observer = asyncAuthenticatedStub.graphBatchLoad(
+        observer(null, errorRef, done));
+
+    final GraphBatchChunk.Builder chunk = GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setOptions(GraphBatchOptions.newBuilder().setVertexBatchSize(2).build());
+    for (int i = 0; i < 4; i++)
+      chunk.addRecords(vertex("e" + i));
+
+    // Both edges are buffered and neither is flushed before close(). The second originates from a bucket that
+    // does not exist, and the outgoing side is written into the source vertex's own record, so the flush that
+    // close() runs fails there and takes the first edge of the same flush with it. (A bad destination would
+    // not do: the outgoing flush commits regardless and only the incoming connect fails afterwards, at which
+    // point those edges genuinely are created and counting them is right.)
+    chunk.addRecords(GraphBatchRecord.newBuilder()
+        .setKind(GraphBatchRecord.Kind.EDGE)
+        .setTypeName("Issue6070Link")
+        .setFromRef("e0")
+        .setToRef("e1"));
+    chunk.addRecords(GraphBatchRecord.newBuilder()
+        .setKind(GraphBatchRecord.Kind.EDGE)
+        .setTypeName("Issue6070Link")
+        .setFromRef("#31212:0")
+        .setToRef("e2"));
+
+    observer.onNext(chunk.build());
+    observer.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).as("an edge pointing at a bucket that does not exist must fail the load")
+        .isInstanceOf(StatusRuntimeException.class);
+
+    final Metadata trailers = ((StatusRuntimeException) errorRef.get()).getTrailers();
+    assertThat(trailers).isNotNull();
+    final GraphBatchResult partial = trailers.get(GraphBatchProtocol.RESULT_TRAILER);
+    assertThat(partial).as("a failed load must carry its counters").isNotNull();
+
+    assertThat(partial.getVerticesCreated()).as("the vertex buffers committed before the edges were flushed")
+        .isEqualTo(4);
+    assertThat(partial.getPartialCommit()).as("vertices are durable, so this is a partial commit").isTrue();
+
+    assertThat(countOf("Issue6070Node")).isEqualTo(4);
+
+    // The invariant that matters, and the one this counter exists to keep: never claim an edge the graph does
+    // not hold. The flush died part-way, so one of the two edges had in fact been written by then, while the
+    // counter advances a whole flush at a time and so reports none. Under-reporting costs a caller a duplicate
+    // on an edge it re-sends; over-reporting costs it the edge, silently - and counting received records
+    // instead of flushed ones did exactly that here, claiming both.
+    final long connected = connectedEdgeCount();
+    assertThat(partial.getEdgesCreated())
+        .as("the trailer must never report more edges than the graph actually holds")
+        .isLessThanOrEqualTo(connected);
+    assertThat(partial.getEdgesCreated()).as("no edge flush completed, so no edge is counted").isZero();
+  }
+
   private GraphBatchResult loadWithIdMappingPreference(final Boolean returnIdMapping, final int vertices)
       throws Exception {
     final GraphBatchOptions.Builder options = GraphBatchOptions.newBuilder();
@@ -326,6 +399,15 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
         done.countDown();
       }
     };
+  }
+
+  /** Edges actually reachable from the vertices, as opposed to edge records the failed flush left orphaned. */
+  private long connectedEdgeCount() {
+    final long[] connected = { 0 };
+    final Database db = getServerDatabase(0, getDatabaseName());
+    db.transaction(() -> db.iterateType("Issue6070Node", true)
+        .forEachRemaining(r -> connected[0] += r.asVertex().countEdges(Vertex.DIRECTION.OUT, "Issue6070Link")));
+    return connected[0];
   }
 
   private long countOf(final String typeName) {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Hardening of the {@code GraphBatchLoad} RPC, done as part of wiring a real client onto it (issue #6070). The
+ * RPC had been implemented and tested but never called by any client, and the gaps that had gone unnoticed are
+ * exactly the ones that only show on a load large enough to be worth a streaming transport:
+ * <ul>
+ *   <li>the temporary-id mapping was always echoed back in full, so a load of a few million vertices built a
+ *   response past the 4 MB default message limit and failed at the very end, with everything committed;</li>
+ *   <li>the vertex buffer was hardcoded at 10,000, so a caller could not lower it - which a replicated database
+ *   needs, one buffer being one Raft entry;</li>
+ *   <li>a failure reported nothing about what had already been committed, even though the batch commits
+ *   incrementally and an error is not a rollback.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user",
+      Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password",
+      Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database",
+      Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub         asyncAuthenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+    asyncAuthenticatedStub = ArcadeDbServiceGrpc.newStub(authenticatedChannel);
+
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX TYPE Issue6070Node IF NOT EXISTS")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE EDGE TYPE Issue6070Link IF NOT EXISTS")
+        .build());
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  /** Left unset, the mapping still travels: a load small enough to consume it must not lose it to the cap. */
+  @Test
+  void returnsTheIdMappingByDefaultForASmallLoad() throws Exception {
+    final GraphBatchResult result = loadWithIdMappingPreference(null, 5);
+
+    assertThat(result.getVerticesCreated()).isEqualTo(5);
+    assertThat(result.getIdMappingOmitted()).as("a mapping this size is well under the cap").isFalse();
+    assertThat(result.getIdMappingSize()).isEqualTo(5);
+    assertThat(result.getIdMappingMap()).hasSize(5);
+    assertThat(result.getIdMappingMap().get("n0")).as("the mapping resolves a temporary id to a RID")
+        .startsWith("#");
+  }
+
+  /**
+   * The whole reason the streaming client sets it: a loader that never reads the mapping should not make the
+   * server build one, which is what puts a large load's response over the message limit.
+   */
+  @Test
+  void omitsTheIdMappingWhenTheCallerDeclinesIt() throws Exception {
+    final GraphBatchResult result = loadWithIdMappingPreference(false, 5);
+
+    assertThat(result.getVerticesCreated()).isEqualTo(5);
+    assertThat(result.getIdMappingMap()).as("declined explicitly, so not sent").isEmpty();
+    // Not "omitted": nothing was dropped that the caller wanted. The count is still reported, which is what
+    // distinguishes this from a load that used no temporary ids at all.
+    assertThat(result.getIdMappingOmitted()).isFalse();
+    assertThat(result.getIdMappingSize()).isEqualTo(5);
+  }
+
+  /** Demanded explicitly, the mapping travels whatever the cap says. */
+  @Test
+  void returnsTheIdMappingWhenTheCallerDemandsIt() throws Exception {
+    final GraphBatchResult result = loadWithIdMappingPreference(true, 5);
+
+    assertThat(result.getIdMappingMap()).hasSize(5);
+    assertThat(result.getIdMappingOmitted()).isFalse();
+    assertThat(result.getIdMappingSize()).isEqualTo(5);
+  }
+
+  /**
+   * A caller lowering the vertex buffer must actually get it - which a replicated database needs, one buffer
+   * being one Raft entry. The buffer used to be hardcoded at 10,000 and the option did not exist.
+   * <p>
+   * A load that succeeds cannot tell the two apart: the same vertices land whether they went in two at a time
+   * or all at once. Where the boundary becomes visible is a load that fails in the middle of the vertex phase,
+   * because each buffer is committed as it is flushed. Nine vertices at a buffer of two, with a mandatory
+   * property missing on the ninth, commits the first eight and fails on the buffer holding the ninth. Ignore
+   * the requested buffer and nothing is flushed before that single failing flush at the end, so nothing
+   * survives.
+   */
+  @Test
+  void honoursTheRequestedVertexBatchSize() throws Exception {
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE PROPERTY Issue6070Node.tag IF NOT EXISTS STRING (MANDATORY TRUE)")
+        .build());
+
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+    final StreamObserver<GraphBatchChunk> observer = asyncAuthenticatedStub.graphBatchLoad(
+        observer(null, errorRef, done));
+
+    final GraphBatchChunk.Builder chunk = GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setOptions(GraphBatchOptions.newBuilder().setVertexBatchSize(2).build());
+    for (int i = 0; i < 8; i++)
+      chunk.addRecords(GraphBatchRecord.newBuilder()
+          .setKind(GraphBatchRecord.Kind.VERTEX)
+          .setTypeName("Issue6070Node")
+          .setTempId("t" + i)
+          .putProperties("tag", GrpcValue.newBuilder().setStringValue("t" + i).build())
+          .build());
+    // The ninth carries no 'tag', so the buffer holding it cannot be created.
+    chunk.addRecords(GraphBatchRecord.newBuilder()
+        .setKind(GraphBatchRecord.Kind.VERTEX)
+        .setTypeName("Issue6070Node")
+        .setTempId("t8")
+        .build());
+
+    observer.onNext(chunk.build());
+    observer.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).as("the mandatory property is missing, so the load must fail").isNotNull();
+
+    assertThat(countOf("Issue6070Node"))
+        .as("a buffer of 2 commits the first 8 before the 9th fails; ignoring it commits nothing at all")
+        .isEqualTo(8);
+  }
+
+  /**
+   * A load that fails part-way is not rolled back, because the batch commits incrementally. The counters of
+   * what is durable have to reach the caller, and a status carries no message, so they ride the trailers.
+   */
+  @Test
+  void reportsPartialCommitCountersOnTheTrailersOfAFailedLoad() throws Exception {
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+
+    final StreamObserver<GraphBatchChunk> observer = asyncAuthenticatedStub.graphBatchLoad(observer(null, errorRef, done));
+
+    // A first chunk that commits: vertexBatchSize 2 with 4 vertices forces two full buffers through before the
+    // failure, so there is something durable to report.
+    final GraphBatchChunk.Builder first = GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setOptions(GraphBatchOptions.newBuilder().setVertexBatchSize(2).build());
+    for (int i = 0; i < 4; i++)
+      first.addRecords(vertex("p" + i));
+    observer.onNext(first.build());
+
+    // Then an edge pointing at a temporary id nothing declared, which fails inside onNext.
+    observer.onNext(GraphBatchChunk.newBuilder()
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.EDGE)
+            .setTypeName("Issue6070Link")
+            .setFromRef("p0")
+            .setToRef("pNeverDeclared"))
+        .build());
+    observer.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).isInstanceOf(StatusRuntimeException.class);
+
+    final StatusRuntimeException failure = (StatusRuntimeException) errorRef.get();
+    final Metadata trailers = failure.getTrailers();
+    assertThat(trailers).as("a failed load must carry its counters").isNotNull();
+
+    final GraphBatchResult partial = trailers.get(GraphBatchProtocol.RESULT_TRAILER);
+    assertThat(partial).as("the partial-commit trailer must be present on a failed load").isNotNull();
+    assertThat(partial.getPartialCommit()).as("vertices were committed before the failure").isTrue();
+    assertThat(partial.getVerticesCreated())
+        .as("the counters must say how much of the load is durable, not zero")
+        .isEqualTo(4);
+
+    // ...and what the trailer claims is durable really is: the failure did not undo it.
+    assertThat(countOf("Issue6070Node")).isEqualTo(4);
+  }
+
+  private GraphBatchResult loadWithIdMappingPreference(final Boolean returnIdMapping, final int vertices)
+      throws Exception {
+    final GraphBatchOptions.Builder options = GraphBatchOptions.newBuilder();
+    if (returnIdMapping != null)
+      options.setReturnIdMapping(returnIdMapping);
+    return load(options.build(), vertices);
+  }
+
+  private GraphBatchResult load(final GraphBatchOptions options, final int vertices) throws Exception {
+    final AtomicReference<GraphBatchResult> resultRef = new AtomicReference<>();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+
+    final StreamObserver<GraphBatchChunk> observer = asyncAuthenticatedStub.graphBatchLoad(
+        observer(resultRef, errorRef, done));
+
+    final GraphBatchChunk.Builder chunk = GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setOptions(options);
+    for (int i = 0; i < vertices; i++)
+      chunk.addRecords(vertex("n" + i));
+
+    observer.onNext(chunk.build());
+    observer.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).as("the load must not fail").isNull();
+    return resultRef.get();
+  }
+
+  private GraphBatchRecord vertex(final String tempId) {
+    return GraphBatchRecord.newBuilder()
+        .setKind(GraphBatchRecord.Kind.VERTEX)
+        .setTypeName("Issue6070Node")
+        .setTempId(tempId)
+        .putProperties("name", GrpcValue.newBuilder().setStringValue(tempId).build())
+        .build();
+  }
+
+  private static StreamObserver<GraphBatchResult> observer(final AtomicReference<GraphBatchResult> resultRef,
+      final AtomicReference<Throwable> errorRef, final CountDownLatch done) {
+    return new StreamObserver<>() {
+      @Override
+      public void onNext(final GraphBatchResult result) {
+        if (resultRef != null)
+          resultRef.set(result);
+      }
+
+      @Override
+      public void onError(final Throwable t) {
+        errorRef.set(t);
+        done.countDown();
+      }
+
+      @Override
+      public void onCompleted() {
+        done.countDown();
+      }
+    };
+  }
+
+  private long countOf(final String typeName) {
+    return getServerDatabase(0, getDatabaseName()).countType(typeName, true);
+  }
+
+  private final class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadLeaderGuardIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadLeaderGuardIT.java
@@ -160,10 +160,44 @@ class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
   }
 
   /**
+   * The refusal names the leader, which is a fact about the cluster's layout. It must therefore come after the
+   * caller has been resolved against the database it asked for, the way every other RPC on this service starts.
+   * A follower asked to load into a database that cannot be reached has to answer about that database, not
+   * volunteer where the leader lives - and the difference is only observable on a follower, because that is the
+   * only place the leadership branch is reached at all.
+   */
+  @Test
+  void aFollowerResolvesTheDatabaseBeforeNamingTheLeader() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    int followerIndex = -1;
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leaderIndex) {
+        followerIndex = i;
+        break;
+      }
+    assertThat(followerIndex).as("At least one follower must exist").isGreaterThanOrEqualTo(0);
+
+    final Throwable refusal = loadOneVertexInto(followerIndex, "unauthorized", "Issue6070NoSuchDatabase");
+
+    assertThat(refusal).as("a load naming a database that cannot be reached must be refused").isNotNull();
+    assertThat(refusal.getMessage())
+        .as("the refusal must be about the database, not about where the leader is")
+        .doesNotContain("not the cluster leader")
+        .doesNotContain("Reconnect to the leader");
+  }
+
+  /**
    * Runs a one-vertex load against the given server and returns the failure it ended with, or null if it
    * succeeded.
    */
   private Throwable loadOneVertex(final int serverIndex, final String tempId) throws Exception {
+    return loadOneVertexInto(serverIndex, tempId, getDatabaseName());
+  }
+
+  private Throwable loadOneVertexInto(final int serverIndex, final String tempId, final String databaseName)
+      throws Exception {
     channel = ManagedChannelBuilder.forAddress("localhost", BASE_GRPC_PORT + serverIndex).usePlaintext().build();
     try {
       final Channel authenticated = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
@@ -190,7 +224,7 @@ class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
           });
 
       observer.onNext(GraphBatchChunk.newBuilder()
-          .setDatabase(getDatabaseName())
+          .setDatabase(databaseName)
           .setCredentials(DatabaseCredentials.newBuilder()
               .setUsername("root")
               .setPassword(DEFAULT_PASSWORD_FOR_TESTS)

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadLeaderGuardIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadLeaderGuardIT.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.ha.raft.BaseRaftHATest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A graph batch load must not run on a follower (issue #6070). The bulk path mutates state that only the leader
+ * can serialize - the schema dictionary above all - so running it on a follower races the local state-machine
+ * apply in {@code Dictionary.getIdByName}, which is the corruption issue #4122 was about and the reason the
+ * HTTP endpoint relays the payload to the leader instead of loading it locally.
+ * <p>
+ * {@code GraphBatchLoad} had no such guard: it took the load wherever the client happened to connect. It cannot
+ * relay the way HTTP does, because the HA plugin exposes the leader's HTTP address only and relaying a bulk load
+ * through a follower would double the traffic of the transport chosen to avoid exactly that, so it refuses -
+ * before writing anything, and naming the leader, so the caller can redirect rather than reconcile a load that
+ * got half-way.
+ * <p>
+ * What makes this worth a cluster test rather than a unit test is the second assertion: the same load, over the
+ * same RPC, must still succeed against the leader. A guard that refused everywhere would pass a test that only
+ * checked the follower.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
+
+  private static final int    BASE_GRPC_PORT = 51091;
+  private static final String VERTEX_TYPE    = "Issue6070LeaderGuardNode";
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user",
+      Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password",
+      Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database",
+      Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    final String serverName = config.getValueAsString(GlobalConfiguration.SERVER_NAME);
+    final int index = Integer.parseInt(serverName.substring(serverName.lastIndexOf('_') + 1));
+
+    config.setValue("arcadedb.grpc.enabled", "true");
+    config.setValue("arcadedb.grpc.port", String.valueOf(BASE_GRPC_PORT + index));
+    config.setValue("arcadedb.grpc.host", "localhost");
+    config.setValue("arcadedb.grpc.reflection.enabled", "false");
+    config.setValue("arcadedb.grpc.health.enabled", "false");
+
+    final String existingPlugins = config.getValueAsString(GlobalConfiguration.SERVER_PLUGINS);
+    final String pluginEntry = "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin";
+    if (existingPlugins == null || existingPlugins.isEmpty())
+      config.setValue(GlobalConfiguration.SERVER_PLUGINS, pluginEntry);
+    else if (!existingPlugins.contains(pluginEntry))
+      config.setValue(GlobalConfiguration.SERVER_PLUGINS, existingPlugins + "," + pluginEntry);
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+      channel = null;
+    }
+  }
+
+  @Test
+  void aLoadOnAFollowerIsRefusedAndTheSameLoadOnTheLeaderSucceeds() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    int followerIndex = -1;
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leaderIndex) {
+        followerIndex = i;
+        break;
+      }
+    assertThat(followerIndex).as("At least one follower must exist").isGreaterThanOrEqualTo(0);
+
+    // Schema through the leader, so the guard under test is the only thing the load depends on.
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE);
+    });
+    waitForAllServers();
+
+    // The follower refuses, and says where to go instead.
+    final Throwable refusal = loadOneVertex(followerIndex, "onFollower");
+    assertThat(refusal).as("a load aimed at a follower must be refused, not silently taken")
+        .isInstanceOf(StatusRuntimeException.class);
+
+    final StatusRuntimeException failure = (StatusRuntimeException) refusal;
+    assertThat(failure.getStatus().getCode()).as("the caller has to be able to tell this from an engine fault")
+        .isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertThat(failure.getStatus().getDescription()).contains("not the cluster leader");
+
+    // Refused before writing anything: nothing to reconcile anywhere in the cluster.
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
+          .as("server %d must hold nothing from the refused load", i)
+          .isZero();
+
+    // The very same load against the leader goes through, and replicates.
+    assertThat(loadOneVertex(leaderIndex, "onLeader")).as("the leader must still accept the load").isNull();
+
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
+          .as("server %d (leader=%d) must see the vertex loaded on the leader", i, leaderIndex)
+          .isEqualTo(1);
+  }
+
+  /**
+   * Runs a one-vertex load against the given server and returns the failure it ended with, or null if it
+   * succeeded.
+   */
+  private Throwable loadOneVertex(final int serverIndex, final String tempId) throws Exception {
+    channel = ManagedChannelBuilder.forAddress("localhost", BASE_GRPC_PORT + serverIndex).usePlaintext().build();
+    try {
+      final Channel authenticated = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+
+      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+      final CountDownLatch done = new CountDownLatch(1);
+
+      final StreamObserver<GraphBatchChunk> observer = ArcadeDbServiceGrpc.newStub(authenticated).graphBatchLoad(
+          new StreamObserver<>() {
+            @Override
+            public void onNext(final GraphBatchResult result) {
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+              errorRef.set(t);
+              done.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+              done.countDown();
+            }
+          });
+
+      observer.onNext(GraphBatchChunk.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(DatabaseCredentials.newBuilder()
+              .setUsername("root")
+              .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+              .build())
+          .addRecords(GraphBatchRecord.newBuilder()
+              .setKind(GraphBatchRecord.Kind.VERTEX)
+              .setTypeName(VERTEX_TYPE)
+              .setTempId(tempId)
+              .putProperties("name", GrpcValue.newBuilder().setStringValue(tempId).build()))
+          .build());
+      observer.onCompleted();
+
+      assertThat(done.await(30, TimeUnit.SECONDS)).as("the load must terminate one way or the other").isTrue();
+      return errorRef.get();
+    } finally {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+      channel = null;
+    }
+  }
+
+  private final class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+}

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -285,6 +285,11 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
   /**
    * Returns a builder for configuring a remote batch graph import.
    * The builder mirrors the server-side GraphBatch.Builder parameters.
+   * <p>
+   * The load travels over the same protocol as the connection it is started from: this class sends it as JSONL
+   * to {@code POST /api/v1/batch}, while a subclass speaking another protocol overrides this method to return a
+   * builder for its own loader - {@code RemoteGrpcDatabase} returns one backed by the {@code GraphBatchLoad}
+   * streaming RPC (issue #6070). Every option below means the same thing either way.
    *
    * @return a new {@link RemoteGraphBatch.Builder}
    */

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -52,6 +52,13 @@ import java.util.Map;
  * }
  * // batch.getResult().getVerticesCreated() == 2
  * </pre>
+ * <p>
+ * This class is the JSONL-over-HTTP loader. A connection that speaks another protocol returns its own subclass
+ * from {@code batch()} and carries the load over that protocol instead: {@code RemoteGrpcDatabase} returns a
+ * loader backed by the {@code GraphBatchLoad} streaming RPC (issue #6070). The public API above is the same for
+ * either, and so is the meaning of every {@link Builder} option; what differs is that a transport holding one
+ * session for the whole load has the server resolve temporary ids, where this one resolves them client-side
+ * because each flush is an independent request the server does not remember.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -61,21 +68,21 @@ public class RemoteGraphBatch implements AutoCloseable {
   private static final int DEFAULT_BUFFER_SIZE = 8192;
   private static final int INITIAL_MAPPING_CAPACITY = 1024;
 
-  private final RemoteDatabase      database;
-  private final Map<String, String> queryParams;
-  private final int                 flushEvery;
-  private final StringBuilder       buffer;
-  private       int                 vertexCounter;
+  private final   RemoteDatabase      database;
+  private final   Map<String, String> queryParams;
+  private final   int                 flushEvery;
+  private final   StringBuilder       buffer;
+  protected       int                 vertexCounter;
   /** Position of the first vertex of the buffer being filled, i.e. what the server has to number this payload from. */
-  private       int                 bufferOrdinalBase;
-  private       int                 itemsInBuffer;
-  private       boolean             hasEdges;
-  private       boolean             closed;
+  private         int                 bufferOrdinalBase;
+  private         int                 itemsInBuffer;
+  protected       boolean             hasEdges;
+  protected       boolean             closed;
 
   // --- Aggregated result across all flushes ---
-  private long totalVerticesCreated;
-  private long totalEdgesCreated;
-  private long totalElapsedMs;
+  protected long totalVerticesCreated;
+  protected long totalEdgesCreated;
+  protected long totalElapsedMs;
 
   // --- Resolved temp ID mapping: flat arrays indexed by vertex counter ---
   // resolvedBucketIds[i] and resolvedPositions[i] hold the real RID for vertex "v<i>"
@@ -99,6 +106,23 @@ public class RemoteGraphBatch implements AutoCloseable {
     this.buffer = new StringBuilder(DEFAULT_BUFFER_SIZE);
     this.resolvedBucketIds = new int[INITIAL_MAPPING_CAPACITY];
     this.resolvedPositions = new long[INITIAL_MAPPING_CAPACITY];
+  }
+
+  /**
+   * Constructor for a subclass that carries the load over a different transport. None of the state this class
+   * keeps for the JSONL-over-HTTP path is allocated: the payload buffer, the flush accounting and the
+   * client-side temporary-id mapping all exist because each flush is an independent stateless request, and a
+   * transport that holds one session for the whole load has the server resolve references instead. A subclass
+   * using it must override {@link #createVertex}, {@link #createEdge} and {@link #flush}, which would otherwise
+   * dereference the buffer this constructor leaves null.
+   */
+  protected RemoteGraphBatch(final RemoteDatabase database) {
+    this.database = database;
+    this.queryParams = null;
+    this.flushEvery = Integer.MAX_VALUE;
+    this.buffer = null;
+    this.resolvedBucketIds = null;
+    this.resolvedPositions = null;
   }
 
   /**
@@ -238,7 +262,7 @@ public class RemoteGraphBatch implements AutoCloseable {
     flush();
   }
 
-  private void checkOpen() {
+  protected void checkOpen() {
     if (closed)
       throw new IllegalStateException("Batch is already closed");
   }
@@ -490,11 +514,26 @@ public class RemoteGraphBatch implements AutoCloseable {
    * the server-side GraphBatch.Builder options.
    */
   public static class Builder {
-    private final RemoteDatabase      database;
-    private final Map<String, String> queryParams = new HashMap<>();
-    private       int                 flushEvery  = DEFAULT_FLUSH_EVERY;
+    protected final RemoteDatabase database;
+    protected       int            flushEvery = DEFAULT_FLUSH_EVERY;
 
-    Builder(final RemoteDatabase database) {
+    // Options are held typed rather than pre-rendered into query-string entries so a subclass carrying the load
+    // over a transport that is not HTTP can read them back without parsing its own parameters (issue #6070).
+    // Boxed because "not set" and "set to the server default" are different: the server only overrides a default
+    // for an option the caller actually chose.
+    protected Integer batchSize;
+    protected Integer expectedEdgeCount;
+    protected Integer edgeListInitialSize;
+    protected Boolean lightEdges;
+    protected Boolean bidirectional;
+    protected Integer commitEvery;
+    protected Integer vertexBatchSize;
+    protected Boolean useWAL;
+    protected Boolean preAllocateEdgeChunks;
+    protected Boolean parallelFlush;
+
+    /** Not for direct use: a builder comes from {@link RemoteDatabase#batch()}, which picks the right one for its transport. */
+    protected Builder(final RemoteDatabase database) {
       this.database = database;
     }
 
@@ -512,19 +551,19 @@ public class RemoteGraphBatch implements AutoCloseable {
 
     /** Maximum number of edges buffered before an automatic flush on the server. Default: 100,000. */
     public Builder withBatchSize(final int batchSize) {
-      queryParams.put("batchSize", String.valueOf(batchSize));
+      this.batchSize = batchSize;
       return this;
     }
 
     /** Hint for expected total edge count, used for server-side auto-tuning. */
     public Builder withExpectedEdgeCount(final int expectedEdgeCount) {
-      queryParams.put("expectedEdgeCount", String.valueOf(expectedEdgeCount));
+      this.expectedEdgeCount = expectedEdgeCount;
       return this;
     }
 
     /** Initial size in bytes for new edge segments. Default: 2048. */
     public Builder withEdgeListInitialSize(final int size) {
-      queryParams.put("edgeListInitialSize", String.valueOf(size));
+      this.edgeListInitialSize = size;
       return this;
     }
 
@@ -535,19 +574,19 @@ public class RemoteGraphBatch implements AutoCloseable {
      */
     @Deprecated
     public Builder withLightEdges(final boolean lightEdges) {
-      queryParams.put("lightEdges", String.valueOf(lightEdges));
+      this.lightEdges = lightEdges;
       return this;
     }
 
     /** If true, incoming edges are also connected. Default: true. */
     public Builder withBidirectional(final boolean bidirectional) {
-      queryParams.put("bidirectional", String.valueOf(bidirectional));
+      this.bidirectional = bidirectional;
       return this;
     }
 
     /** Number of edges to process before committing within a server-side flush. Default: 50,000. */
     public Builder withCommitEvery(final int commitEvery) {
-      queryParams.put("commitEvery", String.valueOf(commitEvery));
+      this.commitEvery = commitEvery;
       return this;
     }
 
@@ -559,32 +598,53 @@ public class RemoteGraphBatch implements AutoCloseable {
     public Builder withVertexBatchSize(final int vertexBatchSize) {
       if (vertexBatchSize < 1)
         throw new IllegalArgumentException("vertexBatchSize must be greater than 0");
-      queryParams.put("vertexBatchSize", String.valueOf(vertexBatchSize));
+      this.vertexBatchSize = vertexBatchSize;
       return this;
     }
 
     /** If true, enables Write-Ahead Logging during import. Default: false. */
     public Builder withWAL(final boolean useWAL) {
-      queryParams.put("wal", String.valueOf(useWAL));
+      this.useWAL = useWAL;
       return this;
     }
 
     /** If true, pre-allocates empty edge segments at vertex creation. Default: true. */
     public Builder withPreAllocateEdgeChunks(final boolean preAllocate) {
-      queryParams.put("preAllocateEdgeChunks", String.valueOf(preAllocate));
+      this.preAllocateEdgeChunks = preAllocate;
       return this;
     }
 
     /** If true, edge connection during flush is parallelized. Default: true. */
     public Builder withParallelFlush(final boolean parallel) {
-      queryParams.put("parallelFlush", String.valueOf(parallel));
+      this.parallelFlush = parallel;
       return this;
+    }
+
+    /** Renders the options chosen by the caller as the query-string parameters of {@code POST /api/v1/batch}. */
+    protected Map<String, String> toQueryParams() {
+      final Map<String, String> queryParams = new HashMap<>();
+      putIfSet(queryParams, "batchSize", batchSize);
+      putIfSet(queryParams, "expectedEdgeCount", expectedEdgeCount);
+      putIfSet(queryParams, "edgeListInitialSize", edgeListInitialSize);
+      putIfSet(queryParams, "lightEdges", lightEdges);
+      putIfSet(queryParams, "bidirectional", bidirectional);
+      putIfSet(queryParams, "commitEvery", commitEvery);
+      putIfSet(queryParams, "vertexBatchSize", vertexBatchSize);
+      putIfSet(queryParams, "wal", useWAL);
+      putIfSet(queryParams, "preAllocateEdgeChunks", preAllocateEdgeChunks);
+      putIfSet(queryParams, "parallelFlush", parallelFlush);
+      return queryParams;
+    }
+
+    private static void putIfSet(final Map<String, String> queryParams, final String name, final Object value) {
+      if (value != null)
+        queryParams.put(name, value.toString());
     }
 
     /** Creates the {@link RemoteGraphBatch} ready for buffering vertices and edges. */
     public RemoteGraphBatch build() {
       final int effectiveFlushEvery = flushEvery == 0 ? Integer.MAX_VALUE : flushEvery;
-      return new RemoteGraphBatch(database, queryParams, effectiveFlushEvery);
+      return new RemoteGraphBatch(database, toQueryParams(), effectiveFlushEvery);
     }
   }
 }

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -531,6 +531,8 @@ public class RemoteGraphBatch implements AutoCloseable {
     protected Boolean useWAL;
     protected Boolean preAllocateEdgeChunks;
     protected Boolean parallelFlush;
+    protected Integer commitRetries;
+    protected Long    commitRetryDelayMs;
 
     /** Not for direct use: a builder comes from {@link RemoteDatabase#batch()}, which picks the right one for its transport. */
     protected Builder(final RemoteDatabase database) {
@@ -620,6 +622,29 @@ public class RemoteGraphBatch implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Number of times a vertex-creation commit is retried when it fails with a transient error, such as a
+     * quorum lost to a leader re-election on a replicated database. Default: 10. Set to 0 to fail on the first
+     * error instead of retrying.
+     */
+    public Builder withCommitRetries(final int commitRetries) {
+      if (commitRetries < 0)
+        throw new IllegalArgumentException("commitRetries must be >= 0");
+      this.commitRetries = commitRetries;
+      return this;
+    }
+
+    /**
+     * Initial back-off in milliseconds before the first vertex-commit retry; later retries back off
+     * exponentially from it. Default: 1000.
+     */
+    public Builder withCommitRetryDelay(final long commitRetryDelayMs) {
+      if (commitRetryDelayMs < 0)
+        throw new IllegalArgumentException("commitRetryDelayMs must be >= 0");
+      this.commitRetryDelayMs = commitRetryDelayMs;
+      return this;
+    }
+
     /** Renders the options chosen by the caller as the query-string parameters of {@code POST /api/v1/batch}. */
     protected Map<String, String> toQueryParams() {
       final Map<String, String> queryParams = new HashMap<>();
@@ -633,6 +658,8 @@ public class RemoteGraphBatch implements AutoCloseable {
       putIfSet(queryParams, "wal", useWAL);
       putIfSet(queryParams, "preAllocateEdgeChunks", preAllocateEdgeChunks);
       putIfSet(queryParams, "parallelFlush", parallelFlush);
+      putIfSet(queryParams, "commitRetries", commitRetries);
+      putIfSet(queryParams, "commitRetryDelayMs", commitRetryDelayMs);
       return queryParams;
     }
 


### PR DESCRIPTION
Fixes #6070.

## The problem

`RemoteGrpcDatabase.batch()` inherited `RemoteDatabase`'s implementation and returned a loader that posted its payload as JSONL to `POST /api/v1/batch`, over plain HTTP, whatever protocol the connection spoke. A caller who opened a gRPC connection got the HTTP transport silently, and nothing on the API surface said so.

Meanwhile `rpc GraphBatchLoad (stream GraphBatchChunk) returns (GraphBatchResult)` had been defined in the proto and implemented in `ArcadeDbGrpcService` since the gRPC module landed, with server-side tests, and **no client anywhere in the codebase calling it**.

## The fix

`RemoteGrpcDatabase.batch()` now returns `RemoteGrpcGraphBatch`, which carries the load over that RPC. The public API is unchanged - same methods, same builder options, same results - so the switch is transparent to anything that only uses `batch()`.

What changes underneath is where temporary ids are resolved. Over HTTP each flush is an independent request the server does not remember, so the loader asks for the id mapping back and rewrites the references of later edges itself. Over one stream the server holds the mapping for the whole load, so a temporary id crosses a chunk boundary untouched. That removes the per-flush round trip, the client-side mapping arrays, and the ceiling `flushEvery` had on the HTTP path past which the server stops echoing a mapping too large to consume. The new loader adds `withTimeout()` for the deadline of the whole stream, and applies backpressure rather than handing gRPC chunks faster than the transport drains them.

### Server-side hardening

Wiring a real client onto the RPC surfaced the gaps that had gone unnoticed while it had none. Each only shows on a load big enough to be worth a streaming transport, and each is something `PostBatchHandler` had already had to solve:

- **A load aimed at a follower is refused instead of taken.** The bulk path mutates state only the leader can serialize - the schema dictionary above all - so running it on a follower races the local state-machine apply in `Dictionary.getIdByName`, which is the corruption #4122 was about and the reason the HTTP endpoint relays the payload to the leader. `GraphBatchLoad` had no such guard. It cannot relay the way HTTP does, because `HAServerPlugin` exposes the leader's HTTP address only and relaying a bulk load through a follower would double the traffic of the transport chosen to avoid exactly that, so it fails with `FAILED_PRECONDITION` naming the leader - before writing anything, so there is nothing to reconcile.
- **The temporary-id mapping is no longer always echoed back in full.** A load of a few million vertices built a response past the default 4 MB message limit and failed at the very end, with everything already committed. The new `return_id_mapping` option is a tri-state mirroring the HTTP `idMapping` parameter: unset caps it and reports `id_mapping_omitted`/`id_mapping_size` past the cap, `true` demands it whatever the size, `false` never sends it. The streaming loader sets `false`, having no use for a mapping the server resolves itself.
- **A failed load reports what it had already committed.** The batch commits incrementally, so an error is not a rollback, but a gRPC status carries no message body. The counters ride the trailers of the failed call and reach the caller through `getResult()`, readable after catching the failure - re-sending blindly would double everything that did get through.
- **`vertex_batch_size` is configurable** (was hardcoded at 10,000, which a replicated database cannot use as one Raft entry), with `commit_retries` and `commit_retry_delay_ms` alongside it for parity.

## Design notes

- **No new module dependency.** `grpc-client` already depended on both `network` and `grpc`, so the loader lives there. `network` gains no gRPC/protobuf dependency and the wire-protocol isolation rule is untouched.
- **Shared wire constant.** The partial-commit trailer key lives in the `grpc` module (`GraphBatchProtocol`), which owns the protocol definition, so the server writing it and the client reading it cannot drift.
- `RemoteGraphBatch.Builder` now holds its options typed rather than pre-rendered as query-string entries, so a non-HTTP transport can read them back; one validated option API serves both. `RemoteGraphBatch` gains a `protected` constructor for a subclass that allocates none of the HTTP-only buffering state.
- The gRPC builder re-declares the inherited setters to narrow their return type, so `withTimeout()` works anywhere in the chain rather than only first.

## Testing

New:
- `Issue6070GrpcGraphBatchIT` (grpc-client, 11 tests) - the transport assertion that is the regression test for the issue, plus cross-chunk temp-id resolution, RID endpoints, edge properties, builder-option propagation, fluent-chain ordering, and the partial-commit path end to end.
- `Issue6070GraphBatchLoadHardeningIT` (grpcw, 5 tests) - the id-mapping tri-state, `vertexBatchSize`, and the partial-commit trailer.
- `Issue6070GraphBatchLoadLeaderGuardIT` (grpcw, Raft cluster) - a follower refuses; the same load on the leader succeeds and replicates.

Every new behaviour was mutation-checked: reverting each of the four server-side changes individually makes exactly the corresponding test fail. The first `vertexBatchSize` test written passed under mutation (a successful load cannot see the buffer boundary) and was replaced with one that fails part-way through the vertex phase, where the boundary decides how much is durable.

Regression suites, all green: network 448, grpcw 172, grpc-client 132, plus `RemoteGraphBatchIT` + `PostBatchHandlerIT` (41) for the HTTP path the builder refactor touches.
