### PR TITLE
fix(#5683): LSMTreeIndexCursor merge-loop minor-key grouping and array-based hasMoreSources

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -74,7 +74,6 @@ public class LSMTreeIndexCursor implements IndexCursor {
   private       Object[]                               currentKeys;
   private       RID[]                                  currentValues;
   private       int                                    currentValueIndex = 0;
-  private       int                                    validIterators;
   private       TempIndexCursor                        txCursor;
   private       Object[]                               txCursorKeys;
   /** Dead (tombstone-resolved) keys skipped by this scan; flushed to the main index stats at scan end. */
@@ -140,8 +139,6 @@ public class LSMTreeIndexCursor implements IndexCursor {
     lastConsumedPosition = new int[totalCursors];
     Arrays.fill(lastConsumedPageNumber, ascendingOrder ? Integer.MIN_VALUE : Integer.MAX_VALUE);
     Arrays.fill(lastConsumedPosition, ascendingOrder ? Integer.MIN_VALUE : Integer.MAX_VALUE);
-
-    validIterators = 0;
 
     for (int i = 0; i < compactedSeriesIterators.size(); ++i) {
       LSMTreeIndexUnderlyingCompactedSeriesCursor pageCursor = compactedSeriesIterators.get(i);
@@ -284,14 +281,12 @@ public class LSMTreeIndexCursor implements IndexCursor {
             }
 
           if (allFullKeyTomb) {
-            // #4944: never leave a cursor parked on a full-key tombstone. It would stay alive but
-            // uncounted in validIterators, while next() decrements the counter whenever ANY cursor
-            // is exhausted or leaves the range: the counter could reach zero with other cursors
-            // still holding valid rows, silently truncating the scan. Skip past tombstone-only keys
+            // #4944: never leave a cursor parked on a full-key tombstone - a page whose only entries left
+            // are dead weight would sit in pageCursors forever contributing nothing, and every round of
+            // fetchNext() would have to walk through it for no gain. Skip past tombstone-only keys
             // (recording them so older cursors skip their shadowed entries too: a newer re-add of
             // the same key always lives in an earlier-processed cursor, so this stays temporally
-            // correct) until a countable key is found or the cursor is exhausted. The invariant is:
-            // every cursor left alive by this constructor is counted in validIterators.
+            // correct) until a countable key is found or the cursor is exhausted.
             removedKeys.add(keys);
             if (pageCursor.hasNext()) {
               advanceCursor(i); // keeps the cursorKeys cache in sync with the advanced cursor
@@ -302,8 +297,6 @@ public class LSMTreeIndexCursor implements IndexCursor {
             cursorKeys[i] = null;
             break;
           }
-
-          validIterators++;
         }
         break;
       }
@@ -397,9 +390,20 @@ public class LSMTreeIndexCursor implements IndexCursor {
    * Whether any SOURCE of entries is left: a live underlying cursor, the RIDs of the key group currently loaded, or the
    * in-transaction overlay. This is what {@code hasNext()} used to answer directly - optimistic, because a live source
    * may still hold nothing but tombstones - and it is now only the loop condition of {@link #fetchNext()}.
+   * <p>
+   * Reads {@link #pageCursors} directly rather than a separately maintained live-count (#5683): a counter kept in
+   * lockstep with every site that nulls a slot is a standing invitation for the two to drift apart, and #4944 was
+   * exactly that - a counter/array drift bug whose failure mode was silent truncation (the scan reported itself
+   * exhausted while live page cursors remained). {@code pageCursors} is sized by the number of index components, not
+   * by data, so this walk is short and bounded - it runs once per merge round, not once per row.
    */
   private boolean hasMoreSources() {
-    return validIterators > 0 || (currentValues != null && currentValueIndex < currentValues.length) || txCursor != null;
+    if ((currentValues != null && currentValueIndex < currentValues.length) || txCursor != null)
+      return true;
+    for (final LSMTreeIndexUnderlyingAbstractCursor pageCursor : pageCursors)
+      if (pageCursor != null)
+        return true;
+    return false;
   }
 
   /**
@@ -439,6 +443,12 @@ public class LSMTreeIndexCursor implements IndexCursor {
       for (int p = 0; p < totalCursors; ++p) {
         if (pageCursors[p] != null) {
           if (minorKey == null) {
+            // #5683: clear before adding, exactly like every other transition into a new minor key below.
+            // Without it, a live cursor whose cached key is itself null (cursorKeys[p] == null) leaves
+            // minorKey == null after this branch, so the NEXT live cursor also lands here - and would be
+            // appended to a list that already holds the first (differently-keyed) cursor instead of
+            // starting a fresh one, folding two unrelated keys into one group.
+            minorKeyIndexes.clear();
             minorKey = cursorKeys[p];
             minorKeyIndexes.add(p);
           } else {
@@ -481,7 +491,6 @@ public class LSMTreeIndexCursor implements IndexCursor {
       }
 
       if (minorKey == null) {
-        validIterators = 0;
         flushScanStats();
         return;
       }
@@ -554,14 +563,12 @@ public class LSMTreeIndexCursor implements IndexCursor {
                 currentCursor.close();
                 pageCursors[minorKeyIndex] = null;
                 cursorKeys[minorKeyIndex] = null;
-                --validIterators;
               }
             }
           } else {
             currentCursor.close();
             pageCursors[minorKeyIndex] = null;
             cursorKeys[minorKeyIndex] = null;
-            --validIterators;
           }
         }
       }
@@ -726,7 +733,6 @@ public class LSMTreeIndexCursor implements IndexCursor {
         it.close();
     Arrays.fill(pageCursors, null);
     // a closed cursor is exhausted: drop the prefetched entry and the merge state so hasNext() cannot resurrect it
-    validIterators = 0;
     txCursor = null;
     txCursorKeys = null;
     currentValues = null;

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeCompactionCorrectnessTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeCompactionCorrectnessTest.java
@@ -44,9 +44,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * (ADD, REMOVE, ADD of the same key+RID across pages) kept its pre-tombstone position and the reader, which
  * treats the LAST position as the newest entry, resolved the tombstone as the winner: the row vanished from the
  * index after compaction.</li>
- * <li>#4944: the cursor constructor left a cursor parked on a full-key tombstone alive but uncounted in
- * {@code validIterators}, while {@code next()} decrements the counter when any cursor is exhausted: a range scan
- * could stop with valid cursors still holding rows.</li>
+ * <li>#4944: the cursor constructor left a cursor parked on a full-key tombstone alive but uncounted by the
+ * live-source tracking of the day (a separately maintained counter, replaced by #5683 with a direct read of the
+ * page-cursor array), which could reach zero with valid cursors still holding rows: a range scan could stop
+ * early.</li>
  * <li>#4945: {@code get()} on a non-unique index resurrected a deleted RID when a per-RID tombstone and the
  * original ADD lived in different pages, because the {@code deletedRIDs} set was page-local instead of threaded
  * across pages and the compacted sub-index (like {@code removedKeys}).</li>
@@ -280,10 +281,11 @@ class LSMTreeCompactionCorrectnessTest extends TestHelper {
   }
 
   // ---- #4944: a range scan must not be truncated when an older page's only in-range key is a full-key tombstone.
-  // The cursor constructor left a cursor parked on a full-key tombstone alive but NOT counted in validIterators,
-  // while next() decrements validIterators when ANY cursor is exhausted: the counter hit zero with valid cursors
-  // still holding rows, silently truncating the scan. Full-key tombstones come from Index.remove(keys) without a
-  // RID (public API, also used internally by the geospatial index). ----
+  // The cursor constructor left a cursor parked on a full-key tombstone alive but NOT counted by the live-source
+  // tracking of the day (a separately maintained counter, replaced by #5683 with a direct read of the page-cursor
+  // array): the counter hit zero with valid cursors still holding rows, silently truncating the scan. Full-key
+  // tombstones come from Index.remove(keys) without a RID (public API, also used internally by the geospatial
+  // index). ----
 
   @Test
   void rangeScanNotTruncatedByFullKeyTombstoneInOlderPage() {

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue5683LSMTreeIndexCursorTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue5683LSMTreeIndexCursorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #5683 item 1: a latent minor-key-grouping defect in {@link LSMTreeIndexCursor#fetchNext()},
+ * found while working on #5635 / #5662 / #5673 and re-confirmed there, but never reachable through the public API
+ * because the constructor's own invariants keep a live {@code pageCursors[p]} paired with a non-null
+ * {@code cursorKeys[p]}.
+ * <p>
+ * In the "FIND THE MINOR KEY" loop, the first live cursor whose cached key is {@code null} is added to
+ * {@code minorKeyIndexes} while {@code minorKey} stays {@code null}. Before the fix, a second live cursor that also
+ * reached the {@code minorKey == null} branch was appended to that SAME list instead of starting a fresh one, so the
+ * merge treated two cursors positioned at two genuinely different keys as though they shared one: the first cursor's
+ * RIDs were folded into a group labelled with the second cursor's key.
+ * <p>
+ * The test forces the otherwise-unreachable state directly via reflection on {@link LSMTreeIndexCursor}'s private
+ * {@code cursorKeys} cache - the only way to exercise code that is defensive-by-construction today - and checks only
+ * the FIRST merge round: once a slot's cached key is wiped, nothing in the class ever refreshes it for a cursor that
+ * is not chosen into a group, so a full drain would run into the separate (and, for the same reason, equally
+ * unreachable) question of what happens to a cursor whose key can never again compare equal to anything. That is out
+ * of scope for the grouping defect under test here.
+ */
+class Issue5683LSMTreeIndexCursorTest extends TestHelper {
+  private static final String TYPE_NAME = "Widget";
+  private static final int    PAGE_SIZE = 4096;
+
+  @Test
+  void nullCachedCursorKeyDoesNotMergeUnrelatedKeysTogether() throws Exception {
+    createSchema();
+    final LSMTreeIndexMutable mutable = bucketMutableIndex();
+    final int bucketId = database.getSchema().getType(TYPE_NAME).getFirstBucketId();
+
+    final int firstBatch = 300;
+    final int secondBatch = 300;
+    final int totalKeys = firstBatch + secondBatch;
+
+    // Two batches, each committed in its own transaction, so they land on separate (older/newer) mutable pages.
+    database.transaction(() -> {
+      for (int i = 0; i < firstBatch; ++i)
+        mutable.put(new Object[] { i }, new RID[] { new RID(bucketId, i) });
+    });
+    database.transaction(() -> {
+      for (int i = firstBatch; i < totalKeys; ++i)
+        mutable.put(new Object[] { i }, new RID[] { new RID(bucketId, i) });
+    });
+
+    database.transaction(() -> {
+      try {
+        assertThat(mutable.getTotalPages()).as("precondition: must span multiple pages to open multiple cursors")
+            .isGreaterThan(1);
+
+        final LSMTreeIndexCursor cursor = (LSMTreeIndexCursor) mutable.range(true, null, true, null, true);
+        try {
+          final Object[] pageCursors = readArrayField(cursor, "pageCursors");
+          final Object[][] cursorKeys = readArrayField(cursor, "cursorKeys");
+          assertThat(pageCursors[0]).as("precondition: slot 0 (the newest page) must be a live cursor").isNotNull();
+          assertThat(pageCursors[1]).as("precondition: slot 1 (an older page) must be a live cursor").isNotNull();
+
+          // Capture the REAL keys the two live cursors are positioned at before corrupting the cache, so the
+          // assertions below can tell "correctly processed p1's key" apart from "wrongly labelled with p0's key".
+          final int p0RealKey = (Integer) cursorKeys[0][0];
+          final int p1RealKey = (Integer) cursorKeys[1][0];
+          assertThat(p0RealKey).as("precondition: the two live cursors must start on different keys").isNotEqualTo(p1RealKey);
+
+          // Corrupt ONLY the cache: pageCursors[0] stays live and pointed at its real, correct data - it is the
+          // cached key the merge loop reads for grouping decisions that goes missing, exactly the "live cursor,
+          // unknown key" shape the issue describes as unreachable through the constructor alone.
+          cursorKeys[0] = null;
+
+          assertThat(cursor.hasNext()).as("a live cursor must still produce a first entry").isTrue();
+          final RID firstRid = cursor.next();
+          final int firstKey = (Integer) cursor.getKeys()[0];
+
+          // The fix: this round's group must be exactly p1's real key with p1's single RID - p0's null-keyed
+          // cursor must NOT have been folded in under either label.
+          assertThat(firstKey).as("the emitted key must be the cursor genuinely positioned there (p1), not p0's")
+              .isEqualTo(p1RealKey);
+          assertThat(firstRid).as("the RID must be p1's own, not merged with p0's unrelated entry")
+              .isEqualTo(new RID(bucketId, p1RealKey));
+        } finally {
+          cursor.close();
+        }
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private void createSchema() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+      type.createProperty("id", Integer.class);
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).withPageSize(PAGE_SIZE).create();
+    });
+  }
+
+  private LSMTreeIndexMutable bucketMutableIndex() {
+    final com.arcadedb.index.TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties("id").getFirst();
+    for (final com.arcadedb.index.Index bucketIndex : typeIndex.getIndexesOnBuckets())
+      if (bucketIndex instanceof LSMTreeIndex lsmIndex)
+        return lsmIndex.getMutableIndex();
+    throw new IllegalStateException("No LSM bucket index found for type " + TYPE_NAME);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T readArrayField(final LSMTreeIndexCursor cursor, final String fieldName) throws Exception {
+    final Field field = LSMTreeIndexCursor.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return (T) field.get(cursor);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes two latent defects in `LSMTreeIndexCursor`'s merge (`fetchNext()`), reported in #5683 while working on #5635, #5662 and #5673. Both were held back from those PRs because neither is reachable through the public API today - the constructor's own invariants keep a live `pageCursors[p]` paired with a non-null `cursorKeys[p]` - but they are the kind of defensive-by-construction bug that can silently start firing the moment a future change relaxes that invariant, so they are worth closing off now.

**1. A null `cursorKeys[p]` on a live `pageCursors[p]` could put two different keys in one "minor key group".**

In the "FIND THE MINOR KEY" loop of `fetchNext()`, the first live cursor whose cached key is `null` is added to `minorKeyIndexes` while `minorKey` stays `null`. A second live cursor that also reaches the `minorKey == null` branch was appended to the *same* list instead of starting a fresh one - unlike every other transition into a new minor key, which clears the list first. The fix adds the missing `minorKeyIndexes.clear()` so this branch behaves exactly like every other transition.

**2. `hasMoreSources()` trusted a separately maintained `validIterators` counter instead of the `pageCursors` array itself.**

`validIterators` was incremented/decremented at every site that changes a `pageCursors` slot, and every current site does keep the two in lockstep - no drift is reachable today. But #4944 was exactly this class of bug: a counter and an array drifting apart, with a failure mode of silent scan truncation (the scan reports itself exhausted while live page cursors remain). Rather than keep auditing every future call site for the same discipline, `hasMoreSources()` now walks `pageCursors` directly and the `validIterators` field is removed entirely, so the two can no longer disagree by construction. The array is sized by the number of index components, not by data, so the walk stays short and bounded.

## Motivation

Filed as #5683 by @lvca: "Neither is reachable today, which is why both were held back from those PRs; filing so they are not lost."

## Related issues

Closes #5683

Related: #5635 (the `hasNext()`/`next()` prefetch contract this merge loop implements), #4944 (the original counter/array drift bug that motivated `validIterators` in the first place - now made structurally impossible instead of merely fixed once).

## Testing

- New regression test `Issue5683LSMTreeIndexCursorTest#nullCachedCursorKeyDoesNotMergeUnrelatedKeysTogether` (`engine/src/test/java/com/arcadedb/index/lsm/Issue5683LSMTreeIndexCursorTest.java`). Since the null-cached-key state can't be reached through the public constructor, the test builds a real two-page cursor and uses reflection to wipe only the *cached* key (`cursorKeys[0]`) of the newest page's cursor after construction, leaving the underlying page cursor itself live and correct. It then asserts the first emitted merge round is labelled with the OTHER (still-cached) cursor's real key and carries only that cursor's RID - not a group mislabelled with the corrupted cursor's key, or one whose RIDs mix the two.
  - Verified this test fails without the fix: temporarily reverted just the `minorKeyIndexes.clear()` line and reran - the test failed with `expected: 0 but was: 381` (the group came out labelled with the corrupted cursor's real key instead of the correct one), then restored the fix and reran clean.
  - The test only asserts the first merge round, not a full drain: once a slot's cached key is wiped, nothing in the class ever refreshes it for a cursor that isn't chosen into a group, so a full-cursor drain runs into a separate (and, for the same "unreachable today" reason, out-of-scope) question about what a permanently-null-keyed cursor should do to overall scan completion. That is not part of this issue's report and isn't touched by this fix.
- `hasMoreSources()`'s rewrite has no dedicated new unit test: the property it establishes (the answer can no longer diverge from `pageCursors`, because there is no longer a second value to diverge from) is structural rather than behavioral, and there's no field left to inject a fake "drift" against once removed. Coverage is the existing comprehensive `LSMTreeIndexCursor` test suite below, all of which continues to exercise multi-page merges, tombstone runs, and compaction through this method.
- Updated two comments in `LSMTreeCompactionCorrectnessTest` (the `#4944` regression test) that described the old `validIterators` mechanism by name; reworded to describe the historical bug without referencing a field that no longer exists.
- Full targeted regression run (222 tests, engine module, `-Dmaven.repo.local` scoped to the worktree): `Issue5683LSMTreeIndexCursorTest`, `LSMTreeIndexCursorContractTest`, `LSMTreeIndexCursorTombstoneRunTest`, `LSMTreeIndexCountEntriesTombstoneTest`, `LSMTreeCompactionCorrectnessTest`, `LSMTreeIndexCursorStaleKeyTest`, `Issue5932RangeAutoDetectOverloadTest`, `LSMTreeIndexTest` (+ nested), `TypeLSMTreeIndexTest`, `LSMTreeIndexCompositeTest`, `LSMTreeSortedNonUniqueBuildTest`, `LSMTreeSortedUniqueBuildTest`, `LSMTreeIndexPolymorphicTest`, `LSMTreeCompositeNullKeyAdjacencyTest`, `LSMTreeIndexCompactionTest` (+ nested), `Issue4960LSMReloadCompactionCounterTest`, `LSMTreeIndexFullCompactionTest`, `LSMTreeCompactionAtomicityTest`, `LSMTreeIndexKeyOrderCheckTest`, `Issue5703LsmLinkKeyCompressedRidTest`, `Issue4960LSMCloseDuringCompactionTest`, `LSMTreeIndexBloomFilterTest`, `LSMTreeIndexCheckIntegrityConcurrencyTest`, `LSMTreeFullTextIndexTest`, `LSMTreeFullTextIndexMLTTest`, geospatial LSM cursor tests. **Result: Tests run: 222, Failures: 0, Errors: 0.**
- `engine` module compiles cleanly (`mvn compile`).

## Additional Notes

No public API changes. `validIterators` was a private field with no external references (confirmed with a repo-wide grep before removal); its removal is invisible outside this class.

## Checklist

- [x] I have run the build using `mvn clean package` command (module-scoped: `mvn -pl engine -am compile` and targeted `test`, per repo guidance to avoid a full-suite run for a scoped change)
- [x] My unit tests cover both failure and success scenarios
