### PR TITLE
fix(#5587): exponential backoff with full jitter for transaction retries

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -460,8 +460,12 @@ public enum GlobalConfiguration {
   TX_RETRIES("arcadedb.txRetries", SCOPE.DATABASE, "Number of retries in case of MVCC exception", Integer.class, 3),
 
   TX_RETRY_DELAY("arcadedb.txRetryDelay", SCOPE.DATABASE,
-      "Maximum amount of milliseconds to compute a random number to wait for the next retry. This setting is helpful in case of high concurrency on the same pages (multi-thread insertion over the same bucket)",
+      "Cap in milliseconds on the random wait before the next transaction retry (issue #5587: exponential backoff with full jitter, min(this cap, TX_RETRY_DELAY_BASE * 2^attempt)). Helpful in case of high concurrency on the same pages (multi-thread insertion over the same bucket). Set to 0 to disable the delay entirely",
       Integer.class, 100),
+
+  TX_RETRY_DELAY_BASE("arcadedb.txRetryDelayBase", SCOPE.DATABASE,
+      "Starting size in milliseconds of the transaction retry backoff window, before doubling on each further attempt up to the TX_RETRY_DELAY cap (issue #5587). Kept small by default so light contention (which resolves in a handful of attempts) sees a shorter wait than before, while a long-running retry loop still saturates at the same worst-case cap as a single flat TX_RETRY_DELAY window",
+      Integer.class, 2),
 
   DELETE_TOLERATE_BROKEN_CHAIN("arcadedb.deleteTolerateBrokenChain", SCOPE.DATABASE,
       "When deleting a record whose own multi-page chunk chain is structurally broken, complete the deletion anyway instead of failing (for a vertex, this also disconnects its edges best-effort, which can leave dangling edges if some cannot be reached). Disabled by default: such a delete fails loudly instead, requiring an explicit CHECK DATABASE FIX to repair or remove the broken record deliberately - CHECK DATABASE FIX itself is unaffected by this setting either way, so the record is never permanently stuck (issues #4420/#4432). Enable only to restore the older behavior of a normal DELETE silently forcing through instead",

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -102,6 +102,7 @@ import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.LockException;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.RWLockContext;
+import com.arcadedb.utility.RetryBackoff;
 
 import java.io.File;
 import java.io.IOException;
@@ -125,7 +126,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
@@ -1417,6 +1417,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       attempts = 1;
 
     final int retryDelay = configuration.getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY);
+    final int retryDelayBase = configuration.getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY_BASE);
 
     boolean duplicatedKeyRetried = false;
 
@@ -1474,7 +1475,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         }
 
         if (retry < attempts - 1)
-          delayBetweenRetries(retryDelay);
+          delayBetweenRetries(retry, retryDelayBase, retryDelay);
 
       } catch (final Throwable e) {
         if (wrappedDatabaseInstance.isTransactionActive())
@@ -2675,17 +2676,24 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     }
   }
 
-  private void delayBetweenRetries(final int retryDelay) {
-    if (retryDelay > 0) {
+  /**
+   * Sleeps an exponential-backoff-with-full-jitter interval before the next transaction retry (issue #5587):
+   * the window widens with every failed {@code attempt} instead of staying flat, so a transaction that has
+   * already lost several races backs off further than one on its first attempt. See {@link RetryBackoff} for
+   * the shared policy.
+   *
+   * @param attempt        zero-based count of retries already performed in this transaction
+   * @param retryDelayBase the backoff window's starting size ({@link GlobalConfiguration#TX_RETRY_DELAY_BASE})
+   * @param retryDelayCap  the backoff window's cap, and the on/off switch ({@link
+   *                       GlobalConfiguration#TX_RETRY_DELAY})
+   */
+  private void delayBetweenRetries(final int attempt, final int retryDelayBase, final int retryDelayCap) {
+    if (retryDelayCap > 0) {
       LogManager.instance()
-          .log(this, Level.FINE, "Wait %d ms before the next retry for transaction commit (threadId=%d)", retryDelay,
-              Thread.currentThread().threadId());
+          .log(this, Level.FINE, "Wait up to %d ms before the next retry for transaction commit (attempt=%d, threadId=%d)",
+              RetryBackoff.windowMs(attempt, retryDelayBase, retryDelayCap), attempt + 1, Thread.currentThread().threadId());
 
-      try {
-        Thread.sleep(1 + ThreadLocalRandom.current().nextInt(retryDelay));
-      } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-      }
+      RetryBackoff.sleep(attempt, retryDelayBase, retryDelayCap);
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -25,9 +25,9 @@ import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.parser.Statement;
+import com.arcadedb.utility.RetryBackoff;
 
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 
 public class RetryStep extends AbstractExecutionStep {
@@ -36,6 +36,7 @@ public class RetryStep extends AbstractExecutionStep {
   public        boolean               elseFail;
   private final int                   retries;
   private final int                   retryDelay;
+  private final int                   retryDelayBase;
   private       ExecutionStepInternal finalResult = null;
 
   public RetryStep(List<Statement> statements, int retries, List<Statement> elseStatements, Boolean elseFail, CommandContext ctx,
@@ -45,21 +46,22 @@ public class RetryStep extends AbstractExecutionStep {
     this.retries = retries;
     this.elseBody = elseStatements;
     this.elseFail = !Boolean.FALSE.equals(elseFail);
-    this.retryDelay = readRetryDelay(ctx);
+    this.retryDelay = readRetrySetting(ctx, GlobalConfiguration.TX_RETRY_DELAY);
+    this.retryDelayBase = readRetrySetting(ctx, GlobalConfiguration.TX_RETRY_DELAY_BASE);
   }
 
   /**
-   * Resolves the backoff between retries from the database the script runs against. The setting is declared
-   * with database scope, so the database's own configuration is the authority and it already falls back to the
+   * Resolves a retry-backoff setting from the database the script runs against. The setting is declared with
+   * database scope, so the database's own configuration is the authority and it already falls back to the
    * global value when the database does not override it. The command context's configuration is deliberately
    * not used: the script engine is handed either an empty configuration (embedded API) or the server's one
    * (HTTP, Postgres and the replicated paths), and neither carries a per-database override.
    */
-  private static int readRetryDelay(final CommandContext ctx) {
+  private static int readRetrySetting(final CommandContext ctx, final GlobalConfiguration setting) {
     final DatabaseInternal database = ctx != null ? ctx.getDatabase() : null;
     return database != null ?
-        database.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY) :
-        GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+        database.getConfiguration().getValueAsInteger(setting) :
+        setting.getValueAsInteger();
   }
 
   // @VisibleForTesting
@@ -113,7 +115,7 @@ public class RetryStep extends AbstractExecutionStep {
           }
         }
 
-        delayBetweenRetries();
+        delayBetweenRetries(attempt);
       }
     }
 
@@ -132,17 +134,20 @@ public class RetryStep extends AbstractExecutionStep {
     return plan;
   }
 
-  private void delayBetweenRetries() {
+  /**
+   * Sleeps an exponential-backoff-with-full-jitter interval before the next {@code COMMIT RETRY} attempt
+   * (issue #5587). See {@link RetryBackoff} for the shared policy, also used by the programmatic retry loop in
+   * {@link com.arcadedb.database.LocalDatabase#transaction}.
+   *
+   * @param attempt zero-based count of retries already performed by this statement
+   */
+  private void delayBetweenRetries(final int attempt) {
     if (retryDelay > 0) {
       LogManager.instance()
-          .log(this, Level.FINE, "Wait %d ms before the next retry for transaction commit (threadId=%d)", retryDelay,
-              Thread.currentThread().threadId());
+          .log(this, Level.FINE, "Wait up to %d ms before the next retry for transaction commit (attempt=%d, threadId=%d)",
+              RetryBackoff.windowMs(attempt, retryDelayBase, retryDelay), attempt + 1, Thread.currentThread().threadId());
 
-      try {
-        Thread.sleep(1 + ThreadLocalRandom.current().nextInt(retryDelay));
-      } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-      }
+      RetryBackoff.sleep(attempt, retryDelayBase, retryDelay);
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/utility/RetryBackoff.java
+++ b/engine/src/main/java/com/arcadedb/utility/RetryBackoff.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Exponential backoff with full jitter for transaction-retry delays (issue #5587).
+ * <p>
+ * Before this class existed, every retry slept a flat {@code U(1, cap)} interval regardless of how many times
+ * it had already lost: attempt 1 and attempt 100 drew from the same distribution, so a transaction's odds of
+ * winning the next race never improved no matter how long it had already waited. That is the wrong shape under
+ * contention - backoff exists to thin the crowd for the transactions that have waited longest.
+ * <p>
+ * The window for attempt {@code n} (zero-based) is {@code min(cap, base * 2^n)}, and the actual sleep is drawn
+ * uniformly from {@code [1, window]} - full jitter, not equal or decorrelated jitter, because the failure mode
+ * here is synchronised re-entry (many threads losing the same page race and retrying together) and full jitter
+ * minimises the odds of the next collision. The cap keeps a long retry loop from turning into a multi-second
+ * stall.
+ * <p>
+ * Shared by {@link com.arcadedb.database.LocalDatabase#transaction} (the programmatic / embedded retry loop)
+ * and {@link com.arcadedb.query.sql.executor.RetryStep} (the SQL {@code COMMIT RETRY} statement) so the two
+ * copies of this policy cannot drift from each other.
+ */
+public class RetryBackoff {
+  private RetryBackoff() {
+  }
+
+  /**
+   * Computes the upper bound (inclusive) in milliseconds of the backoff window for the given zero-based
+   * attempt: {@code min(cap, base * 2^attempt)}.
+   * <p>
+   * A non-positive {@code capMs} disables backoff entirely and returns {@code 0}, matching the pre-#5587
+   * behaviour of a disabled retry delay. A non-positive {@code baseMs} falls back to {@code 1} ms rather than
+   * never widening the window. A negative {@code attempt} is treated as attempt {@code 0}. The exponent shift
+   * is clamped so a very large attempt count saturates at {@code capMs} instead of overflowing {@code long}
+   * arithmetic into a negative or wrapped value.
+   *
+   * @param attempt zero-based count of retries already performed
+   * @param baseMs  the window's starting size, before doubling
+   * @param capMs   the window's maximum size, and the whole backoff's on/off switch
+   *
+   * @return the inclusive upper bound in milliseconds for this attempt's random sleep, or {@code 0} if backoff
+   * is disabled
+   */
+  public static long windowMs(final int attempt, final long baseMs, final long capMs) {
+    if (capMs <= 0)
+      return 0;
+
+    final long effectiveBase = Math.max(1, baseMs);
+    final int shift = Math.min(Math.max(attempt, 0), 62); // 1L << 63 would overflow into a negative value
+    final long widened = effectiveBase << shift;
+
+    if (widened <= 0 || widened > capMs) // overflowed past Long.MAX_VALUE, or simply past the cap
+      return capMs;
+
+    return widened;
+  }
+
+  /**
+   * Sleeps a random duration in {@code [1, windowMs(attempt, baseMs, capMs)]} milliseconds. Returns
+   * immediately, without sleeping, when the window is {@code 0} (backoff disabled). Restores the thread's
+   * interrupt flag and returns early if interrupted during the sleep.
+   *
+   * @param attempt zero-based count of retries already performed
+   * @param baseMs  the window's starting size, before doubling
+   * @param capMs   the window's maximum size, and the whole backoff's on/off switch
+   */
+  public static void sleep(final int attempt, final long baseMs, final long capMs) {
+    final long window = windowMs(attempt, baseMs, capMs);
+    if (window <= 0)
+      return;
+
+    try {
+      Thread.sleep(1 + ThreadLocalRandom.current().nextLong(window));
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue5587TxRetryExponentialBackoffTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5587TxRetryExponentialBackoffTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.ConcurrentModificationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #5587: before this fix, every {@code database.transaction(...)} retry slept a flat
+ * {@code U(1, TX_RETRY_DELAY)} interval no matter how many times the transaction had already lost, so a
+ * transaction on attempt 50 had the same odds of winning the next race as one on attempt 1. This proves the
+ * per-attempt window now widens (exponential backoff with full jitter,
+ * {@code min(TX_RETRY_DELAY, TX_RETRY_DELAY_BASE * 2^attempt)}) instead of staying flat.
+ * <p>
+ * The {@code error} callback fires once per failed attempt, right before the backoff sleep, so the wall-clock
+ * gap between consecutive callback invocations is (up to negligible retry-loop overhead) that attempt's sleep.
+ * Comparing the sum of the first few gaps against the sum of the last few isolates the backoff's growth from
+ * the retry loop's own cost, the same in-run-comparison approach {@code Issue5693TxRetryDelayScopeTest} uses to
+ * avoid depending on an absolute wall-clock budget.
+ */
+public class Issue5587TxRetryExponentialBackoffTest extends TestHelper {
+  /** One more than the number of forced failures, so the last attempt succeeds. */
+  private static final int ATTEMPTS = 10;
+  /** Small enough that early windows (2, 4, 8, 16 ms) stay tiny... */
+  private static final int BASE_MS  = 2;
+  /** ...and large enough that the late windows (32, 64, 128, 256 ms) never saturate against it. */
+  private static final int CAP_MS   = 1_000;
+
+  @Test
+  void laterRetriesBackOffFurtherThanEarlierOnes() {
+    final int savedCap = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    final int savedBase = GlobalConfiguration.TX_RETRY_DELAY_BASE.getValueAsInteger();
+    database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, CAP_MS);
+    database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY_BASE, BASE_MS);
+    try {
+      final List<Long> failureTimestampsNanos = new ArrayList<>();
+      final AtomicInteger attempt = new AtomicInteger();
+
+      database.transaction(() -> {
+        if (attempt.incrementAndGet() < ATTEMPTS)
+          throw new ConcurrentModificationException("forced retry");
+      }, false, ATTEMPTS, null, e -> failureTimestampsNanos.add(System.nanoTime()));
+
+      assertThat(attempt.get()).isEqualTo(ATTEMPTS);
+      // one error callback per failed attempt, i.e. every attempt but the last
+      assertThat(failureTimestampsNanos).hasSize(ATTEMPTS - 1);
+
+      final List<Long> gapsMs = new ArrayList<>();
+      for (int i = 1; i < failureTimestampsNanos.size(); i++)
+        gapsMs.add((failureTimestampsNanos.get(i) - failureTimestampsNanos.get(i - 1)) / 1_000_000);
+
+      final int half = gapsMs.size() / 2;
+      final long earlyGapsSumMs = gapsMs.subList(0, half).stream().mapToLong(Long::longValue).sum();
+      final long lateGapsSumMs = gapsMs.subList(gapsMs.size() - half, gapsMs.size()).stream().mapToLong(Long::longValue).sum();
+
+      // Expected sums are ~17ms (early, windows 2/4/8/16) vs ~242ms (late, windows 32/64/128/256) - a flat
+      // delay (the pre-#5587 behaviour) would make the two statistically indistinguishable instead.
+      assertThat(lateGapsSumMs)
+          .as("later retries (gaps %s) should back off further than earlier ones (gaps %s)", gapsMs.subList(gapsMs.size() - half, gapsMs.size()),
+              gapsMs.subList(0, half))
+          .isGreaterThan(earlyGapsSumMs * 2);
+    } finally {
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, savedCap);
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY_BASE, savedBase);
+    }
+  }
+
+  @Test
+  void aZeroCapDisablesTheDelayEntirelyJustLikeBeforeTheFix() {
+    final int savedCap = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, 0);
+    try {
+      final AtomicInteger attempt = new AtomicInteger();
+      final long start = System.nanoTime();
+
+      database.transaction(() -> {
+        if (attempt.incrementAndGet() < ATTEMPTS)
+          throw new ConcurrentModificationException("forced retry");
+      }, false, ATTEMPTS);
+
+      final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+      assertThat(attempt.get()).isEqualTo(ATTEMPTS);
+      assertThat(elapsedMs).isLessThan(1_000);
+    } finally {
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, savedCap);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue5693TxRetryDelayScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5693TxRetryDelayScopeTest.java
@@ -34,6 +34,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The assertions compare an in-run baseline (the same retry loop with no backoff configured) against the same
  * loop with the backoff raised, so nothing depends on an absolute wall-clock budget. When the retry loop reads
  * the global static the two runs are indistinguishable and the gap collapses to zero.
+ * <p>
+ * Since #5587, the per-attempt window is {@code min(TX_RETRY_DELAY, TX_RETRY_DELAY_BASE * 2^attempt)} instead
+ * of a flat {@code TX_RETRY_DELAY}. Both settings are set to the same {@link #RAISED_DELAY_MS} here, which
+ * collapses that formula back to a flat window on every attempt ({@code min(x, x * 2^n) == x}) - the scope
+ * behaviour under test does not depend on the backoff shape, only on which configuration wins, so pinning the
+ * shape keeps this test's timing budget identical to before #5587.
  */
 public class Issue5693TxRetryDelayScopeTest extends TestHelper {
   /** One more than the number of forced failures, so the last attempt succeeds. */
@@ -46,6 +52,7 @@ public class Issue5693TxRetryDelayScopeTest extends TestHelper {
   @Test
   void theRetryLoopUsesTheDelayConfiguredOnThisDatabase() {
     final int savedGlobal = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    final int savedGlobalBase = GlobalConfiguration.TX_RETRY_DELAY_BASE.getValueAsInteger();
     GlobalConfiguration.TX_RETRY_DELAY.setValue(0);
     try {
       // BASELINE TAKEN IN-RUN: NO BACKOFF ANYWHERE, SO THIS IS THE COST OF THE RETRY LOOP ITSELF
@@ -54,6 +61,7 @@ public class Issue5693TxRetryDelayScopeTest extends TestHelper {
 
       // ONLY THE DATABASE IS RETUNED: THE GLOBAL STATIC STAYS AT 0
       database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, RAISED_DELAY_MS);
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY_BASE, RAISED_DELAY_MS);
       final long observedMs = timeForcedRetries();
 
       assertThat(database.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY)).isEqualTo(
@@ -61,6 +69,7 @@ public class Issue5693TxRetryDelayScopeTest extends TestHelper {
       assertThat(observedMs - baselineMs).isGreaterThan(MIN_GAP_MS);
     } finally {
       database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, savedGlobal);
+      database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY_BASE, savedGlobalBase);
       GlobalConfiguration.TX_RETRY_DELAY.setValue(savedGlobal);
     }
   }
@@ -68,17 +77,20 @@ public class Issue5693TxRetryDelayScopeTest extends TestHelper {
   @Test
   void theGlobalDelayStillAppliesWhenTheDatabaseDoesNotOverrideIt() {
     final int savedGlobal = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    final int savedGlobalBase = GlobalConfiguration.TX_RETRY_DELAY_BASE.getValueAsInteger();
     GlobalConfiguration.TX_RETRY_DELAY.setValue(0);
     try {
       final long baselineMs = timeForcedRetries();
 
       // NOTHING IS SET ON THE DATABASE, SO THE GLOBAL VALUE MUST STILL BE HONOURED
       GlobalConfiguration.TX_RETRY_DELAY.setValue(RAISED_DELAY_MS);
+      GlobalConfiguration.TX_RETRY_DELAY_BASE.setValue(RAISED_DELAY_MS);
       final long observedMs = timeForcedRetries();
 
       assertThat(observedMs - baselineMs).isGreaterThan(MIN_GAP_MS);
     } finally {
       GlobalConfiguration.TX_RETRY_DELAY.setValue(savedGlobal);
+      GlobalConfiguration.TX_RETRY_DELAY_BASE.setValue(savedGlobalBase);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/utility/RetryBackoffTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/RetryBackoffTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the exponential-backoff-with-full-jitter window computation added for #5587: the window widens with
+ * every failed attempt instead of staying flat, and saturates at the configured cap instead of growing
+ * unbounded.
+ */
+class RetryBackoffTest {
+
+  @Test
+  void windowDoublesWithEachAttemptUntilItHitsTheCap() {
+    final long base = 2;
+    final long cap = 1000;
+
+    assertThat(RetryBackoff.windowMs(0, base, cap)).isEqualTo(2);
+    assertThat(RetryBackoff.windowMs(1, base, cap)).isEqualTo(4);
+    assertThat(RetryBackoff.windowMs(2, base, cap)).isEqualTo(8);
+    assertThat(RetryBackoff.windowMs(3, base, cap)).isEqualTo(16);
+    assertThat(RetryBackoff.windowMs(4, base, cap)).isEqualTo(32);
+  }
+
+  @Test
+  void windowSaturatesAtTheCapAndNeverExceedsIt() {
+    final long base = 2;
+    final long cap = 100;
+
+    // 2 * 2^6 = 128 > 100, so attempt 6 is the first to saturate
+    assertThat(RetryBackoff.windowMs(6, base, cap)).isEqualTo(cap);
+    assertThat(RetryBackoff.windowMs(7, base, cap)).isEqualTo(cap);
+    assertThat(RetryBackoff.windowMs(50, base, cap)).isEqualTo(cap);
+  }
+
+  @Test
+  void windowNeverExceedsTheCapEvenForAVeryLargeAttemptCount() {
+    // A naive base << attempt overflows a long well before attempt reaches Integer.MAX_VALUE; the window
+    // must still saturate at the cap instead of wrapping to a negative or otherwise bogus value.
+    assertThat(RetryBackoff.windowMs(Integer.MAX_VALUE, 2, 500)).isEqualTo(500);
+    assertThat(RetryBackoff.windowMs(200, 2, 500)).isEqualTo(500);
+  }
+
+  @Test
+  void aNonPositiveCapMeansNoBackoffAtAll() {
+    assertThat(RetryBackoff.windowMs(0, 2, 0)).isEqualTo(0);
+    assertThat(RetryBackoff.windowMs(5, 2, -1)).isEqualTo(0);
+  }
+
+  @Test
+  void aNonPositiveBaseFallsBackToOneMillisecondInsteadOfNeverGrowing() {
+    assertThat(RetryBackoff.windowMs(0, 0, 1000)).isEqualTo(1);
+    assertThat(RetryBackoff.windowMs(3, -5, 1000)).isEqualTo(8);
+  }
+
+  @Test
+  void aNegativeAttemptIsTreatedAsTheFirstAttempt() {
+    assertThat(RetryBackoff.windowMs(-1, 2, 1000)).isEqualTo(RetryBackoff.windowMs(0, 2, 1000));
+  }
+
+  @Test
+  void sleepReturnsImmediatelyWhenTheCapIsNotPositive() {
+    final long start = System.nanoTime();
+    RetryBackoff.sleep(3, 2, 0);
+    final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+    assertThat(elapsedMs).isLessThan(50);
+  }
+
+  @Test
+  void sleepNeverWaitsLongerThanTheWindowForThatAttempt() {
+    final long base = 2;
+    final long cap = 200;
+    final int attempt = 2; // window = min(200, 2*2^2) = 8ms
+
+    final long start = System.nanoTime();
+    RetryBackoff.sleep(attempt, base, cap);
+    final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+    // Generous upper bound: the window is 8ms, so anything close to the cap (200ms) would indicate the
+    // implementation is not actually scaling the sleep down for an early attempt.
+    assertThat(elapsedMs).isLessThan(cap);
+  }
+
+  @Test
+  void sleepRestoresTheInterruptFlagInsteadOfSwallowingIt() throws InterruptedException {
+    final AtomicBoolean interruptedAfterSleep = new AtomicBoolean(false);
+    final Thread worker = new Thread(() -> {
+      Thread.currentThread().interrupt();
+      RetryBackoff.sleep(0, 2, 5_000);
+      interruptedAfterSleep.set(Thread.currentThread().isInterrupted());
+    });
+    worker.start();
+    worker.join(5_000);
+
+    assertThat(worker.isAlive()).isFalse();
+    assertThat(interruptedAfterSleep.get()).isTrue();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Replaces the flat, uniformly-random transaction-retry delay with exponential backoff with full jitter, so a transaction's odds of winning the next race actually improve the longer it has already been losing.

**Before:** every `database.transaction(block, join, attempts)` and every SQL `COMMIT RETRY n` slept `U(1, TX_RETRY_DELAY)` before each retry, drawn from the *same* distribution on every attempt. Attempt 1 and attempt 100 looked statistically identical to the retry loop.

**After:** the window for zero-based attempt `n` is `min(TX_RETRY_DELAY, TX_RETRY_DELAY_BASE * 2^n)`, and the actual sleep is drawn uniformly from `[1, window]` (full jitter). `TX_RETRY_DELAY` keeps its existing role as the cap, so worst-case per-attempt latency for a long retry loop is unchanged from before. The new `TX_RETRY_DELAY_BASE` (database-scoped, default `2` ms) is the window's starting size, so light contention that resolves in a handful of attempts now waits noticeably less on average than before, while a long-running retry loop still saturates at the same cap.

The two independent copies of the flat-delay method (`LocalDatabase.delayBetweenRetries` and `RetryStep.delayBetweenRetries`) now both delegate to a new shared `com.arcadedb.utility.RetryBackoff`, so the programmatic API and the SQL `COMMIT RETRY` statement cannot drift from each other again.

## Motivation

Closes #5587, split out of #5570 / PR #5572, which fixed a test symptom (`EdgeAppendMergeRaceTest` burning all 100 attempts and giving up on a slow CI runner) but deliberately left the underlying retry behavior alone.

With N writers contending on one page, the expected number of losers per round stays constant no matter how long the pile-up has been going, because the retry window never widened. A transaction that had already lost 50 times re-entered the exact same race, against the same crowd, after the same expected wait as a first attempt - retry exhaustion was reachable purely because of that missing backoff, not because the losing side was actually stale.

## Design decisions (from the issue's open questions)

1. **Config surface.** `TX_RETRY_DELAY` stays the cap (so existing tuning and deployments keep the same worst-case behavior); a new `TX_RETRY_DELAY_BASE` (default 2 ms) is the starting window size. This was the issue's own preferred option, since it keeps worst-case per-attempt latency identical to today while letting p50 under light contention improve.
2. **`TX_RETRIES` default.** Left untouched at `3` in this PR - the issue flagged it as "worth checking" separately, but changing it is an orthogonal tuning decision with its own blast radius and wasn't bundled in here.
3. **Deduplication.** Both retry loops now call the same `com.arcadedb.utility.RetryBackoff.windowMs()` / `.sleep()`, eliminating the byte-for-byte-identical copies that existed in `LocalDatabase` and `RetryStep`.
4. **Interrupt handling.** Preserved as before (interrupt flag restored, sleep returns early) - now centralized in `RetryBackoff.sleep()`.

## Related issues

Closes #5587
Related to #5570, #5572

## Additional Notes

- `RetryBackoff.windowMs()` is overflow-safe: the exponent shift is clamped so a very large attempt count saturates at the cap instead of wrapping into a negative or bogus `long`.
- A non-positive `TX_RETRY_DELAY` (the cap) still disables the delay entirely, matching pre-#5587 behavior for anyone who has it set to `0`.
- Existing tests that pin `TX_RETRY_DELAY` to a small value (e.g. `1`) purely to keep test runtime fast are unaffected: with a 1 ms cap the window is clamped to 1 ms regardless of attempt or base.
- `Issue5693TxRetryDelayScopeTest` (config-scope regression, unrelated to this change) pins both `TX_RETRY_DELAY` and the new `TX_RETRY_DELAY_BASE` to the same value in its "raised delay" cases, which collapses the exponential formula back to a flat window (`min(x, x*2^n) == x`) and keeps its wall-clock timing budget identical to before this PR.

### New/changed tests

- `RetryBackoffTest` - unit coverage of the windowing formula: growth, saturation at the cap, overflow safety, the `capMs <= 0` / `baseMs <= 0` / negative-attempt edge cases, and interrupt-flag restoration in `sleep()`.
- `Issue5587TxRetryExponentialBackoffTest` - end-to-end regression test against `LocalDatabase.transaction()`: forces 9 failures via the `error` callback, timestamps each failure, and asserts the second half of the inter-failure gaps sums to more than double the first half - which a flat delay cannot produce. Verified this test fails consistently (6/6 runs) when `RetryBackoff.windowMs()` is temporarily reverted to return a flat cap, and passes consistently (5/5 runs) against the real implementation. Also covers that a `0` cap still disables the delay.
- `Issue5693TxRetryDelayScopeTest` - updated (not behavior-changed) to also pin `TX_RETRY_DELAY_BASE` alongside `TX_RETRY_DELAY` so its timing-based assertions keep the same magnitude under the new formula.

### Test plan

- [x] `RetryBackoffTest` (9 tests) - pure unit tests of the backoff formula
- [x] `Issue5587TxRetryExponentialBackoffTest` (2 tests) - end-to-end proof the delay widens across attempts, and that a 0 cap still disables it
- [x] `Issue5693TxRetryDelayScopeTest` / `Issue5693RetryStepDelayScopeTest` (4 tests) - unrelated config-scope regression tests, updated and re-verified green under the new formula
- [x] Connected regression suite re-run green: `ScriptExecutionTest`, `ContextConfigurationTest`, `EdgeAppendMergeRaceTest` (the exact fixture cited in the issue), `ConcurrentEdgeAppendMergeTest`, `Issue5680VertexDeleteEdgeCollectionTest`, `SuperNodeStripingTest`, `Issue5670EdgeDeleteDanglingBackRefTest`, `Issue5725GhostEdgeOnAppendRaceTest`, `Issue5147SuperNodeChunkRaceTest`, `Issue5760VertexDeleteSelfSideSkipTest` - 103/103 passing
- [x] `engine` and `ha-raft` modules both compile clean (`ha-raft` reads `TX_RETRY_DELAY` in `ArcadeStateMachine` for its own, unrelated flat-delay Raft-apply retry, which this PR intentionally left untouched - it is a single sequential thread, not a many-writer contention scenario, so backing off there is a separate design question)

## Checklist

- [x] I have run the build using `mvn clean package` (targeted module builds; see test plan)
- [x] My unit tests cover both failure and success scenarios
